### PR TITLE
Hackathon: public teams list, invite creates team, seed script, eligibility guidance

### DIFF
--- a/app/hackathons/page.tsx
+++ b/app/hackathons/page.tsx
@@ -41,6 +41,12 @@ export default function HackathonsPage() {
               Find a team
             </Link>
             <Link
+              href="/hackathons/teams"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-neutral-800 text-white rounded-lg text-sm font-semibold hover:bg-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            >
+              Teams
+            </Link>
+            <Link
               href="/hackathons/team"
               className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-neutral-800 text-white rounded-lg text-sm font-semibold hover:bg-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >

--- a/app/hackathons/teams/page.tsx
+++ b/app/hackathons/teams/page.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState, useCallback, Suspense } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  getDoc,
+  doc,
+  addDoc,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { useAuth } from "@/contexts/AuthContext";
+import { getCurrentVirtualHackathonId } from "@/lib/hackathons";
+
+interface HackathonTeam {
+  id: string;
+  hackathonId: string;
+  memberIds: string[];
+  name?: string;
+  createdBy: string;
+  createdAt: unknown;
+}
+
+function TeamsPageContent() {
+  const { user, loading: authLoading } = useAuth();
+  const searchParams = useSearchParams();
+  const hackathonId = searchParams.get("hackathonId") || getCurrentVirtualHackathonId();
+  const [teams, setTeams] = useState<HackathonTeam[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [inPool, setInPool] = useState(false);
+  const [myTeamId, setMyTeamId] = useState<string | null>(null);
+  const [requesting, setRequesting] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!db) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const teamsRef = collection(db, "hackathonTeams");
+      const q = query(teamsRef, where("hackathonId", "==", hackathonId));
+      const snap = await getDocs(q);
+      const list = snap.docs.map((d) => ({ id: d.id, ...d.data() } as HackathonTeam));
+      setTeams(list);
+
+      if (user) {
+        const myTeam = list.find((t) => t.memberIds.includes(user.uid));
+        setMyTeamId(myTeam?.id ?? null);
+
+        const poolRef = doc(db, "hackathonPool", `${user.uid}_${hackathonId}`);
+        const poolSnap = await getDoc(poolRef);
+        setInPool(poolSnap.exists());
+      } else {
+        setMyTeamId(null);
+        setInPool(false);
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  }, [hackathonId, user]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    fetchData();
+  }, [authLoading, fetchData]);
+
+  const handleRequestToJoin = async (teamId: string) => {
+    if (!db || !user) return;
+    setRequesting(teamId);
+    try {
+      await addDoc(collection(db, "hackathonJoinRequests"), {
+        fromUserId: user.uid,
+        teamId,
+        status: "pending",
+        createdAt: serverTimestamp(),
+      });
+      await fetchData();
+    } catch (e) {
+      console.error(e);
+      alert("Failed to send request");
+    } finally {
+      setRequesting(null);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-white" />
+      </div>
+    );
+  }
+
+  const teamsWithSlots = teams.filter((t) => t.memberIds.length < 3);
+  const fullTeams = teams.filter((t) => t.memberIds.length === 3);
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-10">
+      <div className="mb-8">
+        <Link
+          href="/hackathons"
+          className="text-neutral-400 hover:text-white text-sm font-medium"
+        >
+          ← Hackathons
+        </Link>
+        <h1 className="text-3xl font-bold text-white mt-2">Teams</h1>
+        <p className="text-neutral-400 mt-1">
+          Hackathon: <span className="text-white font-medium">{hackathonId}</span>
+        </p>
+      </div>
+
+      <p className="text-neutral-400 mb-6">
+        Teams of 3 can participate. Join the{" "}
+        <Link href="/hackathons/pool" className="text-emerald-400 hover:underline">
+          pool
+        </Link>{" "}
+        to invite others or request to join a team below.
+      </p>
+
+      {teams.length === 0 ? (
+        <section className="bg-neutral-900 rounded-xl p-6 border border-neutral-800">
+          <p className="text-neutral-500">No teams yet for this hackathon.</p>
+          <p className="text-neutral-500 text-sm mt-2">
+            Invite someone from the pool to form a team, or they can request to join once you have a team.
+          </p>
+          <Link
+            href="/hackathons/pool"
+            className="inline-block mt-4 px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400"
+          >
+            Find a team
+          </Link>
+        </section>
+      ) : (
+        <>
+          {teamsWithSlots.length > 0 && (
+            <section className="bg-neutral-900 rounded-xl p-6 border border-neutral-800 mb-8">
+              <h2 className="text-lg font-semibold text-white mb-4">
+                Teams with open slots ({teamsWithSlots.length})
+              </h2>
+              <ul className="space-y-4">
+                {teamsWithSlots.map((t) => {
+                  const openSlots = 3 - t.memberIds.length;
+                  const isMyTeam = t.id === myTeamId;
+                  const canRequest = user && inPool && !isMyTeam && !t.memberIds.includes(user.uid);
+                  return (
+                    <li
+                      key={t.id}
+                      className="flex items-center justify-between gap-4 py-3 border-b border-neutral-800 last:border-0"
+                    >
+                      <div>
+                        <span className="text-white font-medium">
+                          {t.name || `Team ${t.id.slice(0, 8)}`}
+                        </span>
+                        <span className="text-neutral-500 text-sm ml-2">
+                          {t.memberIds.length}/3 members · {openSlots} open slot{openSlots !== 1 ? "s" : ""}
+                        </span>
+                        {isMyTeam && (
+                          <span className="text-emerald-400 text-sm ml-2">(your team)</span>
+                        )}
+                      </div>
+                      {canRequest && (
+                        <button
+                          onClick={() => handleRequestToJoin(t.id)}
+                          disabled={requesting === t.id}
+                          className="px-4 py-2 bg-emerald-500/20 text-emerald-400 rounded-lg text-sm font-medium hover:bg-emerald-500/30 disabled:opacity-50"
+                        >
+                          {requesting === t.id ? "Sending…" : "Request to join"}
+                        </button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+
+          {fullTeams.length > 0 && (
+            <section className="bg-neutral-900 rounded-xl p-6 border border-neutral-800">
+              <h2 className="text-lg font-semibold text-white mb-4">
+                Full teams ({fullTeams.length})
+              </h2>
+              <ul className="space-y-2">
+                {fullTeams.map((t) => {
+                  const isMyTeam = t.id === myTeamId;
+                  return (
+                    <li
+                      key={t.id}
+                      className="flex items-center justify-between py-2 border-b border-neutral-800 last:border-0 text-neutral-400 text-sm"
+                    >
+                      <span>
+                        {t.name || `Team ${t.id.slice(0, 8)}`} · 3/3
+                        {isMyTeam && " (your team)"}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function HackathonsTeamsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-[60vh] flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-white" />
+        </div>
+      }
+    >
+      <TeamsPageContent />
+    </Suspense>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:watch": "jest --watch --config config/jest.config.js",
     "test:coverage": "jest --coverage --config config/jest.config.js",
     "validate-env": "tsx scripts/validate-env.ts",
+    "seed-hackathon-teams": "tsx scripts/seed-hackathon-teams.ts",
     "prebuild": "npm run validate-env",
     "prepare": "husky install"
   },

--- a/scripts/seed-hackathon-teams.ts
+++ b/scripts/seed-hackathon-teams.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Seed mock hackathon teams for the current virtual month.
+ * Creates 3 teams: one full (3/3), one with 1 open spot (2/3), one with 2 open spots (1/3).
+ * Uses placeholder member IDs so any user can "Request to join" the teams with open slots.
+ *
+ * Usage: npx tsx scripts/seed-hackathon-teams.ts
+ */
+
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getCurrentVirtualHackathonId } from "../lib/hackathons";
+import { getAdminDb } from "../lib/firebase-admin";
+
+const MOCK_PREFIX = "mock-member-";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured. Set FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS.");
+    process.exit(1);
+  }
+
+  const hackathonId = getCurrentVirtualHackathonId();
+  console.log("Seeding mock teams for hackathon:", hackathonId);
+
+  const teamsRef = db.collection("hackathonTeams");
+
+  const teams = [
+    { name: "Full Stack Crew", memberIds: [MOCK_PREFIX + "1", MOCK_PREFIX + "2", MOCK_PREFIX + "3"] },
+    { name: "Open Slot Squad", memberIds: [MOCK_PREFIX + "4", MOCK_PREFIX + "5"] },
+    { name: "Solo Starter", memberIds: [MOCK_PREFIX + "6"] },
+  ];
+
+  for (const team of teams) {
+    const docRef = await teamsRef.add({
+      hackathonId,
+      memberIds: team.memberIds,
+      name: team.name,
+      createdBy: team.memberIds[0],
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    console.log("Created team:", team.name, "id:", docRef.id, "members:", team.memberIds.length + "/3");
+  }
+
+  console.log("Done. View teams at /hackathons/teams");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- **Public teams list** at /hackathons/teams – lists all teams for the current hackathon with open slots and "Request to join"
- **Invite creates team** – removed separate "Create team" button; inviting someone from the pool creates your team if you don't have one
- **Seed script** `npm run seed-hackathon-teams` – creates mock teams (one full, one with 1 open spot, one with 2 open slots) for testing
- **Eligibility guidance** – when user can't join pool (missing GitHub/Discord), shows clear instructions and "Go to Profile" link
- **Teams link** on Hackathons landing page
- **Firestore rules** – null-safe checks for invite/join-request rules when team doc is missing