### PR TITLE
feat: logo standards, shared Logo component, and design doc

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,17 @@
+# Design and logo usage
+
+## Logo size scale
+
+Use these canonical sizes for the Cursor Boston brand logo (`/cursor-boston-logo.png`) so the site stays consistent.
+
+| Context | Size (px) | Tailwind | Use |
+|--------|-----------|----------|-----|
+| **Header / Footer** | 44–48 | `w-11 h-11` (44px) or `w-12 h-12` (48px) | Nav bar and footer brand link. Minimum 44×44px clickable area (WCAG touch target). |
+| **Page hero (secondary)** | 96–112 | `w-24 h-24` (96px) or `w-28 h-28` (112px) | About, about-cursor, and other non-homepage heroes. |
+| **Homepage hero** | 160 base, 192 md+ | `w-40 h-40 md:w-48 md:h-48` | Main hero on the homepage only. |
+
+## Implementation
+
+- Use the shared `Logo` component in `components/Logo.tsx` with size prop `header` | `footer` | `hero` | `heroHome`.
+- All logo links (header, footer) must have a minimum 44×44px touch target: use `min-h-[44px] min-w-[44px]` or padding so the interactive area meets WCAG 2.1.
+- Prefer Next.js `Image` without `unoptimized` where the asset works with the image optimizer.

--- a/app/about-cursor/page.tsx
+++ b/app/about-cursor/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import Image from "next/image";
+import Logo from "@/components/Logo";
 
 export const metadata: Metadata = {
   title: "About Cursor & Our Affiliation",
@@ -221,15 +221,7 @@ export default function AboutCursorPage() {
       <section className="py-12 md:py-16 px-6 border-b border-neutral-800">
         <div className="max-w-4xl mx-auto">
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-12 h-12 relative">
-              <Image
-                src="/cursor-boston-logo.png"
-                alt="Cursor Boston"
-                fill
-                unoptimized
-                className="object-contain"
-              />
-            </div>
+            <Logo size="footer" />
             <h2 className="text-3xl font-bold text-white">Cursor Boston&apos;s Relationship with Cursor</h2>
           </div>
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import Image from "next/image";
+import Logo from "@/components/Logo";
 
 export const metadata: Metadata = {
   title: "About",
@@ -41,15 +41,7 @@ export default function AboutPage() {
       {/* Hero */}
       <section className="py-16 md:py-24 px-6 border-b border-neutral-800">
         <div className="max-w-4xl mx-auto text-center">
-          <div className="w-24 h-24 relative mx-auto mb-6">
-            <Image
-              src="/cursor-boston-logo.png"
-              unoptimized
-              alt="Cursor Boston"
-              fill
-              className="object-contain"
-            />
-          </div>
+          <Logo size="hero" className="mx-auto mb-6" />
           <h1 className="text-4xl md:text-5xl font-bold text-white mb-6">
             About Cursor Boston
           </h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import Logo from "@/components/Logo";
 
 export const metadata: Metadata = {
   title: "Cursor Boston - AI Coding Community",
@@ -138,16 +139,7 @@ export default function Home() {
       {/* Hero Section */}
       <section className="py-16 md:py-24 px-6">
         <div className="max-w-4xl mx-auto text-center">
-          <div className="w-32 h-32 md:w-40 md:h-40 relative mx-auto mb-6">
-            <Image
-              src="/cursor-boston-logo.png"
-              alt="Cursor Boston"
-              fill
-              priority
-              unoptimized
-              className="object-contain"
-            />
-          </div>
+          <Logo size="heroHome" className="mx-auto mb-6" priority />
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-4 tracking-tight">
             Boston&apos;s Cursor Community
           </h1>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import Logo from "@/components/Logo";
 
 export default function Footer() {
   return (
@@ -9,16 +10,11 @@ export default function Footer() {
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12">
           {/* Brand column */}
           <div className="lg:col-span-4">
-            <Link href="/" className="inline-flex items-center mb-4 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950">
-              <div className="w-8 h-8 relative">
-                <Image
-                  src="/cursor-boston-logo.png"
-                  alt="Cursor Boston"
-                  fill
-                  unoptimized
-                  className="object-contain"
-                />
-              </div>
+            <Link
+              href="/"
+              className="inline-flex items-center min-h-[44px] min-w-[44px] mb-4 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
+            >
+              <Logo size="footer" />
               <span className="font-semibold text-white ml-3">Cursor Boston</span>
             </Link>
             <p className="text-neutral-400 text-sm leading-relaxed mb-6 max-w-xs">

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,42 @@
+import Image from "next/image";
+
+const LOGO_SRC = "/cursor-boston-logo.png";
+const ALT = "Cursor Boston";
+
+const sizeClasses = {
+  header: "w-12 h-12",
+  footer: "w-12 h-12",
+  hero: "w-28 h-28",
+  heroHome: "w-40 h-40 md:w-48 md:h-48",
+} as const;
+
+export type LogoSize = keyof typeof sizeClasses;
+
+type LogoProps = {
+  size: LogoSize;
+  className?: string;
+  priority?: boolean;
+};
+
+export default function Logo({ size, className = "", priority = false }: LogoProps) {
+  const dimensionClasses = sizeClasses[size];
+
+  return (
+    <div className={`relative ${dimensionClasses} ${className}`.trim()}>
+      <Image
+        src={LOGO_SRC}
+        alt={ALT}
+        fill
+        className="object-contain"
+        priority={priority}
+        sizes={
+          size === "heroHome"
+            ? "(min-width: 768px) 192px, 160px"
+            : size === "hero"
+              ? "112px"
+              : "48px"
+        }
+      />
+    </div>
+  );
+}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import Avatar from "@/components/Avatar";
@@ -13,15 +12,19 @@ export default function Navigation() {
   return (
     <header className="sticky top-0 z-50 bg-black border-b border-neutral-800">
       <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-        {/* Logo */}
-        <Link href="/" className="flex items-center gap-2 flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-lg">
-          <div className="w-8 h-8 bg-black border border-neutral-700 rounded-md flex items-center justify-center">
+        {/* Logo: 44px min touch target (WCAG 2.1) */}
+        <Link
+          href="/"
+          className="flex items-center gap-2 flex-shrink-0 min-h-[44px] min-w-[44px] py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded-lg"
+        >
+          <div className="w-8 h-8 bg-black border border-neutral-700 rounded-md flex items-center justify-center flex-shrink-0">
             <svg
               width="18"
               height="18"
               viewBox="0 0 24 24"
               fill="none"
               style={{ transform: "rotate(-45deg)" }}
+              aria-hidden
             >
               <path
                 d="M5 3l14 9-6 2-3 6-5-17z"

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -19,6 +19,13 @@ const firebaseConfig = {
 // Check if Firebase config is available
 const isConfigured = firebaseConfig.apiKey && firebaseConfig.projectId;
 
+// Skip Analytics when using placeholder env (avoids "API key not valid" console errors)
+const isPlaceholderKey =
+  !firebaseConfig.apiKey ||
+  firebaseConfig.apiKey.startsWith("your-") ||
+  firebaseConfig.apiKey === "your-api-key" ||
+  (firebaseConfig.projectId?.startsWith("your-") ?? false);
+
 let app: FirebaseApp | undefined;
 let auth: Auth | undefined;
 let db: Firestore | undefined;
@@ -33,13 +40,15 @@ if (isConfigured && typeof window !== "undefined") {
   db = getFirestore(app);
   rtdb = getDatabase(app);
   storage = getStorage(app);
-  
-  // Initialize analytics only if supported
-  isSupported().then((supported) => {
-    if (supported && app) {
-      analytics = getAnalytics(app);
-    }
-  });
+
+  // Initialize analytics only when we have real credentials (not .env.example placeholders)
+  if (!isPlaceholderKey) {
+    isSupported().then((supported) => {
+      if (supported && app) {
+        analytics = getAnalytics(app);
+      }
+    });
+  }
 }
 
 export { app, auth, db, rtdb, storage, analytics };

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,12 @@
 const nextConfig = {
   // Enable standalone output for Docker deployments
   output: 'standalone',
-  
+
+  // Use this project as the Turbopack root (fixes multi-lockfile warning)
+  turbopack: {
+    root: __dirname,
+  },
+
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- Add **DESIGN.md** with logo size scale and usage notes
- Add shared **Logo** component (`header` | `footer` | `hero` | `heroHome`)
- **Homepage hero:** larger logo (160/192px), use Logo, remove unoptimized
- **About hero:** use Logo at hero size (112px)
- **About-cursor:** use Logo in relationship section
- **Footer:** use Logo at 48px, 44px touch target
- **Navigation:** keep green-arrow SVG, add 44px touch target (WCAG 2.1)
- **Firebase:** skip Analytics when env has placeholder API key (fixes console error)
- **next.config:** set `turbopack.root` to fix multi-lockfile warning

Made with [Cursor](https://cursor.com)