### PR TITLE
fix(profile): resolve Firebase auth error when saving profile settings

### DIFF
--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -109,9 +109,20 @@ function ProfilePageContent() {
   const hasGoogleProvider = !wasGoogleDisconnected && providerIds.some((id) => id === "google.com");
   const hasPasswordProvider = providerIds.some((id) => id === "password");
   const canDisconnectGoogle = hasGoogleProvider && providerIds.length > 1;
-  const enrolledFactors = user ? multiFactor(user).enrolledFactors : [];
+
+  // Safely get enrolled factors with error handling using useMemo
+  const enrolledFactors = useMemo(() => {
+    try {
+      if (!user) return [];
+      return multiFactor(user).enrolledFactors;
+    } catch (error) {
+      // Silently handle error - multiFactor may not be available yet
+      return [];
+    }
+  }, [user]);
+
   const hasPhoneMfa = enrolledFactors.some(
-    (factor) => factor.factorId === PhoneMultiFactorGenerator.FACTOR_ID
+    (factor) => factor?.factorId === PhoneMultiFactorGenerator.FACTOR_ID
   );
 
   const [googleDisconnecting, setGoogleDisconnecting] = useState(false);
@@ -455,34 +466,58 @@ function ProfilePageContent() {
   }, [userProfile]);
 
   const saveProfileSettings = async () => {
-    if (!user || !db) return;
+    if (!user) return;
 
     setSavingSettings(true);
     setSettingsError(null);
     setSettingsSuccess(false);
 
     try {
-      const userRef = doc(db, "users", user.uid);
-      await updateDoc(userRef, {
-        bio: profileSettings.bio.trim(),
-        location: profileSettings.location.trim(),
-        company: profileSettings.company.trim(),
-        jobTitle: profileSettings.jobTitle.trim(),
-        socialLinks: {
-          website: profileSettings.socialLinks.website.trim(),
-          linkedIn: profileSettings.socialLinks.linkedIn.trim(),
-          twitter: profileSettings.socialLinks.twitter.trim(),
-          github: profileSettings.socialLinks.github.trim(),
-          substack: profileSettings.socialLinks.substack.trim(),
+      // Use API route instead of direct Firestore update
+      const token = await user.getIdToken();
+      const response = await fetch("/api/profile/update", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
         },
-        visibility: profileSettings.visibility,
-        updatedAt: serverTimestamp(),
+        body: JSON.stringify({
+          bio: profileSettings.bio.trim(),
+          location: profileSettings.location.trim(),
+          company: profileSettings.company.trim(),
+          jobTitle: profileSettings.jobTitle.trim(),
+          socialLinks: {
+            website: profileSettings.socialLinks.website.trim(),
+            linkedIn: profileSettings.socialLinks.linkedIn.trim(),
+            twitter: profileSettings.socialLinks.twitter.trim(),
+            github: profileSettings.socialLinks.github.trim(),
+            substack: profileSettings.socialLinks.substack.trim(),
+          },
+        }),
       });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to save settings");
+      }
+
+      // Save visibility settings separately (not handled by API yet)
+      if (db) {
+        const userRef = doc(db, "users", user.uid);
+        await updateDoc(userRef, {
+          visibility: profileSettings.visibility,
+          updatedAt: serverTimestamp(),
+        });
+      }
+
+      // Refresh user profile to get updated data
+      await refreshUserProfile();
+
       setSettingsSuccess(true);
       setTimeout(() => setSettingsSuccess(false), 3000);
     } catch (error) {
       console.error("Error saving profile settings:", error);
-      setSettingsError("Failed to save settings. Please try again.");
+      setSettingsError(error instanceof Error ? error.message : "Failed to save settings. Please try again.");
     } finally {
       setSavingSettings(false);
     }


### PR DESCRIPTION
## Description

Fixes Firebase authentication error that occurred when saving profile settings (bio, location, company, job title, social links).

The issue was caused by direct Firestore writes from the client, which created a race condition with Firebase Auth token refresh. The fix uses the existing API route `/api/profile/update` instead of direct Firestore updates.

Fixes #49

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Accessibility improvement

## How Has This Been Tested?

- [x] Tested locally
- [x] Tested authentication flows
- [x] Tested form submissions

**Testing Details:**
- Created test Firebase project and configured all services
- Signed up and logged in successfully
- Tested saving profile settings (bio, location, company, job title, social links)
- Verified no Firebase auth errors appear after saving
- Confirmed data persists correctly in Firestore
- Verified profile data refreshes properly after save

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Commits are signed off with DCO (`-s` flag)

## Changes Made

1. **Modified `saveProfileSettings` function** in `app/(auth)/profile/page.tsx`:
   - Changed from direct Firestore `updateDoc` to API route `/api/profile/update`
   - Added proper authentication token handling
   - Added `refreshUserProfile()` call after successful save
   - Improved error handling and user feedback

2. **Added error handling for `multiFactor` auth checks**:
   - Wrapped in `useMemo` with try-catch to prevent runtime errors
   - Ensures graceful handling when multiFactor is unavailable

## Additional Notes

The existing API route `/api/profile/update` already had all the necessary validation and security checks, so this change improves consistency and prevents auth conflicts without requiring new backend code.

