### PR TITLE
fix(a11y): improve color contrast to meet WCAG AA standards

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -262,7 +262,7 @@ function LoginPageContent() {
               <div className="w-full border-t border-neutral-700"></div>
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-4 bg-neutral-900 text-neutral-500">
+              <span className="px-4 bg-neutral-900 text-neutral-400">
                 or continue with email
               </span>
             </div>
@@ -285,7 +285,7 @@ function LoginPageContent() {
                 required
                 aria-describedby={error ? "form-error" : undefined}
                 aria-invalid={error ? "true" : undefined}
-                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                 placeholder="you@example.com"
               />
             </div>
@@ -305,7 +305,7 @@ function LoginPageContent() {
                 required
                 aria-describedby={error ? "form-error" : undefined}
                 aria-invalid={error ? "true" : undefined}
-                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                 placeholder="Enter your password"
               />
             </div>

--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -1087,7 +1087,7 @@ function ProfilePageContent() {
                 </div>
               )}
 
-              <p className="text-neutral-500 text-sm mt-3">
+              <p className="text-neutral-400 text-sm mt-3">
                 Member since{" "}
                 {user.metadata.creationTime
                   ? new Date(user.metadata.creationTime).toLocaleDateString(
@@ -1477,7 +1477,7 @@ function ProfilePageContent() {
                         <p className="text-white text-sm truncate">
                           Registered for {reg.eventTitle}
                         </p>
-                        <p className="text-neutral-500 text-xs">
+                        <p className="text-neutral-400 text-xs">
                           {reg.registeredAt?.toDate
                             ? reg.registeredAt.toDate().toLocaleDateString()
                             : "Recently"}
@@ -1509,7 +1509,7 @@ function ProfilePageContent() {
                         <p className="text-white text-sm truncate">
                           Submitted talk: {talk.title}
                         </p>
-                        <p className="text-neutral-500 text-xs capitalize">
+                        <p className="text-neutral-400 text-xs capitalize">
                           Status: {talk.status || "pending"}
                         </p>
                       </div>
@@ -1793,7 +1793,7 @@ function ProfilePageContent() {
                     </div>
                     <div>
                       <p className="text-white text-sm">{user.email}</p>
-                      <p className="text-neutral-500 text-xs">Primary email</p>
+                      <p className="text-neutral-400 text-xs">Primary email</p>
                     </div>
                   </div>
                   <span className="px-2 py-1 bg-emerald-500/10 text-emerald-400 text-xs rounded-full">
@@ -1826,7 +1826,7 @@ function ProfilePageContent() {
                       </div>
                       <div>
                         <p className="text-white text-sm">{emailEntry.email}</p>
-                        <p className="text-neutral-500 text-xs">
+                        <p className="text-neutral-400 text-xs">
                           {emailEntry.verified ? "Verified" : "Pending verification"}
                         </p>
                       </div>
@@ -1865,7 +1865,7 @@ function ProfilePageContent() {
                     value={newEmail}
                     onChange={(e) => setNewEmail(e.target.value)}
                     placeholder="Enter email address"
-                    className="flex-1 px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent"
+                    className="flex-1 px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent"
                   />
                   <button
                     onClick={handleAddEmail}
@@ -2474,7 +2474,7 @@ function ProfilePageContent() {
                   >
                     Choose Photo
                   </button>
-                  <p className="text-neutral-500 text-xs mt-2">
+                  <p className="text-neutral-400 text-xs mt-2">
                     JPG, PNG or GIF. Max 5MB.
                   </p>
                 </div>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -194,7 +194,7 @@ function SignUpPageContent() {
               <div className="w-full border-t border-neutral-700"></div>
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="px-4 bg-neutral-900 text-neutral-500">
+              <span className="px-4 bg-neutral-900 text-neutral-400">
                 or continue with email
               </span>
             </div>
@@ -215,7 +215,7 @@ function SignUpPageContent() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 required
-                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                 placeholder="Your name"
               />
             </div>
@@ -233,7 +233,7 @@ function SignUpPageContent() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                 placeholder="you@example.com"
               />
             </div>
@@ -251,7 +251,7 @@ function SignUpPageContent() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                 placeholder="At least 6 characters"
               />
             </div>
@@ -269,7 +269,7 @@ function SignUpPageContent() {
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
-                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                 placeholder="Confirm your password"
               />
             </div>
@@ -283,7 +283,7 @@ function SignUpPageContent() {
             </button>
           </form>
 
-          <p className="mt-6 text-xs text-neutral-500 text-center">
+          <p className="mt-6 text-xs text-neutral-400 text-center">
             By creating an account, you agree to our terms of service and
             privacy policy.
           </p>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -36,7 +36,7 @@ export default function BlogPage() {
                   key={post.slug}
                   className="bg-white dark:bg-neutral-900 rounded-2xl p-8 border border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors"
                 >
-                  <div className="flex items-center gap-4 text-sm text-neutral-600 dark:text-neutral-500 mb-4">
+                  <div className="flex items-center gap-4 text-sm text-neutral-600 dark:text-neutral-400 mb-4">
                     <time dateTime={post.date}>
                       {new Date(post.date).toLocaleDateString("en-US", {
                         year: "numeric",

--- a/app/events/request/page.tsx
+++ b/app/events/request/page.tsx
@@ -248,7 +248,7 @@ export default function RequestEventPage() {
                     value={formData.name}
                     onChange={handleChange}
                     required
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="Jane Doe"
                   />
                 </div>
@@ -263,7 +263,7 @@ export default function RequestEventPage() {
                     value={formData.email}
                     onChange={handleChange}
                     required
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="jane@example.com"
                   />
                 </div>
@@ -277,7 +277,7 @@ export default function RequestEventPage() {
                     name="organization"
                     value={formData.organization}
                     onChange={handleChange}
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="MIT, Hult, Company name, etc."
                   />
                 </div>
@@ -330,7 +330,7 @@ export default function RequestEventPage() {
                     value={formData.title}
                     onChange={handleChange}
                     required
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="Cursor for Beginners, AI Hackathon, etc."
                   />
                 </div>
@@ -345,7 +345,7 @@ export default function RequestEventPage() {
                     onChange={handleChange}
                     required
                     rows={4}
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
                     placeholder="What's the event about? What would attendees learn or do?"
                   />
                 </div>
@@ -360,7 +360,7 @@ export default function RequestEventPage() {
                       name="proposedDate"
                       value={formData.proposedDate}
                       onChange={handleChange}
-                      className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                      className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                       placeholder="February 2026, flexible, etc."
                     />
                   </div>
@@ -395,7 +395,7 @@ export default function RequestEventPage() {
                     name="venue"
                     value={formData.venue}
                     onChange={handleChange}
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="We can host at..., Need help finding a venue, etc."
                   />
                 </div>
@@ -415,7 +415,7 @@ export default function RequestEventPage() {
                   value={formData.additionalInfo}
                   onChange={handleChange}
                   rows={3}
-                  className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
+                  className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
                   placeholder="Special requirements, collaboration ideas, etc."
                 />
               </div>

--- a/app/hackathons/team/page.tsx
+++ b/app/hackathons/team/page.tsx
@@ -536,7 +536,7 @@ function HackathonsTeamPageContent() {
                     value={profileName}
                     onChange={(e) => setProfileName(e.target.value)}
                     placeholder="e.g. Full Stack Crew"
-                    className="w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                    className="w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400"
                   />
                 </div>
                 <div>
@@ -549,7 +549,7 @@ function HackathonsTeamPageContent() {
                     value={profileLogoUrl}
                     onChange={(e) => setProfileLogoUrl(e.target.value)}
                     placeholder="https://…"
-                    className="w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                    className="w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400"
                   />
                 </div>
                 <button
@@ -633,7 +633,7 @@ function HackathonsTeamPageContent() {
                       value={repoUrl}
                       onChange={(e) => setRepoUrl(e.target.value)}
                       placeholder="https://github.com/owner/repo"
-                      className="w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                      className="w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400"
                     />
                   </div>
                   <button

--- a/app/talks/submit/page.tsx
+++ b/app/talks/submit/page.tsx
@@ -141,7 +141,7 @@ export default function SubmitTalkPage() {
               strokeWidth="1.5"
               strokeLinecap="round"
               strokeLinejoin="round"
-              className="text-neutral-500"
+              className="text-neutral-400"
             >
               <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
               <circle cx="12" cy="7" r="4" />
@@ -257,7 +257,7 @@ export default function SubmitTalkPage() {
                     value={formData.name}
                     onChange={handleChange}
                     required
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="Jane Doe"
                   />
                 </div>
@@ -272,7 +272,7 @@ export default function SubmitTalkPage() {
                     value={formData.email}
                     onChange={handleChange}
                     required
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="jane@example.com"
                   />
                 </div>
@@ -287,7 +287,7 @@ export default function SubmitTalkPage() {
                       name="linkedIn"
                       value={formData.linkedIn}
                       onChange={handleChange}
-                      className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                      className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                       placeholder="https://linkedin.com/in/..."
                     />
                   </div>
@@ -301,7 +301,7 @@ export default function SubmitTalkPage() {
                       name="twitter"
                       value={formData.twitter}
                       onChange={handleChange}
-                      className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                      className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                       placeholder="@username"
                     />
                   </div>
@@ -324,7 +324,7 @@ export default function SubmitTalkPage() {
                     value={formData.title}
                     onChange={handleChange}
                     required
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
                     placeholder="How I Built X with Cursor"
                   />
                 </div>
@@ -339,7 +339,7 @@ export default function SubmitTalkPage() {
                     onChange={handleChange}
                     required
                     rows={4}
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
                     placeholder="What will you cover? What will attendees learn?"
                   />
                 </div>
@@ -422,7 +422,7 @@ export default function SubmitTalkPage() {
                     value={formData.bio}
                     onChange={handleChange}
                     rows={3}
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
                     placeholder="Tell us a bit about yourself..."
                   />
                 </div>
@@ -436,7 +436,7 @@ export default function SubmitTalkPage() {
                     value={formData.previousTalks}
                     onChange={handleChange}
                     rows={2}
-                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
+                    className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent resize-none"
                     placeholder="Any previous talks or presentations (optional, first-time speakers welcome!)"
                   />
                 </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -229,7 +229,7 @@ export default function Footer() {
 
         {/* Bottom bar */}
         <div className="border-t border-neutral-200 dark:border-neutral-800 mt-8 pt-8 flex flex-col sm:flex-row justify-between items-center">
-          <p className="text-neutral-600 dark:text-neutral-500 text-sm">
+          <p className="text-neutral-600 dark:text-neutral-400 text-sm">
             © {new Date().getFullYear()} Cursor Boston
           </p>
           <a

--- a/components/ProfileRequirementsModal.tsx
+++ b/components/ProfileRequirementsModal.tsx
@@ -381,7 +381,7 @@ export default function ProfileRequirementsModal({
               value={displayNameInput}
               onChange={(e) => setDisplayNameInput(e.target.value)}
               placeholder="Enter your name"
-              className="px-3 py-1.5 bg-neutral-800 border border-neutral-700 rounded-lg text-sm text-white placeholder-neutral-500 focus:outline-none focus:border-neutral-500 w-40"
+              className="px-3 py-1.5 bg-neutral-800 border border-neutral-700 rounded-lg text-sm text-white placeholder-neutral-400 focus:outline-none focus:border-neutral-500 w-40"
               onKeyDown={(e) => {
                 if (e.key === "Enter") saveDisplayName();
                 if (e.key === "Escape") {

--- a/components/feed/CommunityFeed.tsx
+++ b/components/feed/CommunityFeed.tsx
@@ -81,7 +81,7 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
             value={feedSearchQuery}
             onChange={(e) => setFeedSearchQuery(e.target.value)}
             placeholder="Search messages..."
-            className="w-full pl-11 pr-4 py-3 bg-neutral-900 border border-neutral-800 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent"
+            className="w-full pl-11 pr-4 py-3 bg-neutral-900 border border-neutral-800 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent"
           />
           {feedSearchQuery && (
             <button

--- a/components/feed/MessageCard.tsx
+++ b/components/feed/MessageCard.tsx
@@ -294,7 +294,7 @@ export function MessageCard({
                 placeholder={`Reply to ${message.authorName}...`}
                 rows={2}
                 maxLength={500}
-                className="w-full bg-neutral-800 rounded-lg p-3 text-white placeholder-neutral-500 resize-none focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                className="w-full bg-neutral-800 rounded-lg p-3 text-white placeholder-neutral-400 resize-none focus:outline-none focus:ring-2 focus:ring-emerald-400"
               />
               <div className="flex items-center justify-between mt-2">
                 <span className={`text-xs ${

--- a/components/feed/PostComposer.tsx
+++ b/components/feed/PostComposer.tsx
@@ -70,7 +70,7 @@ export function PostComposer({
             placeholder={placeholder}
             rows={3}
             maxLength={maxLength}
-            className="w-full bg-transparent text-white placeholder-neutral-500 resize-none focus:outline-none"
+            className="w-full bg-transparent text-white placeholder-neutral-400 resize-none focus:outline-none"
           />
           <div className="flex items-center justify-between pt-3 border-t border-neutral-800">
             <span className={`text-xs ${

--- a/components/feed/RepostModal.tsx
+++ b/components/feed/RepostModal.tsx
@@ -43,7 +43,7 @@ export function RepostModal({
             placeholder="Add your comment..."
             rows={4}
             maxLength={maxLength}
-            className="w-full bg-neutral-800 rounded-lg p-3 text-white placeholder-neutral-500 resize-none focus:outline-none focus:ring-2 focus:ring-emerald-400"
+            className="w-full bg-neutral-800 rounded-lg p-3 text-white placeholder-neutral-400 resize-none focus:outline-none focus:ring-2 focus:ring-emerald-400"
           />
           <div className="flex items-center justify-between mt-2">
             <span className={`text-xs ${

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -59,10 +59,10 @@ export function MemberCard({ member }: MemberCardProps) {
             <p className="text-neutral-600 dark:text-neutral-400 text-sm truncate">{member.jobTitle}</p>
           )}
           {!isAgent && v?.showCompany && member.company && (
-            <p className="text-neutral-600 dark:text-neutral-500 text-sm truncate">{member.company}</p>
+            <p className="text-neutral-600 dark:text-neutral-400 text-sm truncate">{member.company}</p>
           )}
           {isAgent && member.owner?.displayName && v?.showOwner && (
-            <p className="text-neutral-600 dark:text-neutral-500 text-sm truncate">
+            <p className="text-neutral-600 dark:text-neutral-400 text-sm truncate">
               Owned by {member.owner.displayName}
             </p>
           )}
@@ -244,7 +244,7 @@ export function MemberCard({ member }: MemberCardProps) {
           </a>
         )}
         {v?.showMemberSince && member.createdAt && (
-          <span className="text-neutral-500 text-xs ml-auto">
+          <span className="text-neutral-400 text-xs ml-auto">
             Member since{" "}
             {member.createdAt.toDate().toLocaleDateString("en-US", {
               month: "short",

--- a/components/members/MemberDirectory.tsx
+++ b/components/members/MemberDirectory.tsx
@@ -66,7 +66,7 @@ export function MemberDirectory({ initialSearch = "" }: MemberDirectoryProps) {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search by name, location, job, bio..."
-                  className="w-full pl-11 pr-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg text-foreground placeholder-neutral-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent"
+                  className="w-full pl-11 pr-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg text-foreground placeholder-neutral-400 dark:placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent"
                 />
               </div>
 
@@ -288,7 +288,7 @@ export function MemberDirectory({ initialSearch = "" }: MemberDirectoryProps) {
             <p className="text-neutral-600 dark:text-neutral-400 text-lg mb-4">
               No public profiles yet.
             </p>
-            <p className="text-neutral-600 dark:text-neutral-500">
+            <p className="text-neutral-600 dark:text-neutral-400">
               Be the first to{" "}
               <Link
                 href="/profile"

--- a/components/ui/FormField.tsx
+++ b/components/ui/FormField.tsx
@@ -2,7 +2,7 @@ import type { InputHTMLAttributes, TextareaHTMLAttributes } from "react";
 
 // Shared input styling
 const inputClass =
-  "w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent";
+  "w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent";
 
 const labelClass = "block text-sm font-medium text-neutral-300 mb-2";
 


### PR DESCRIPTION
## Description

Audit and fix color contrast ratios across the site to meet WCAG 2.1 AA minimum of 4.5:1 for normal text.

All fixes bump `neutral-500` → `neutral-400` (#737373 → #a3a3a3). One shade lighter, no design disruption.

Changes:
- Replace `placeholder-neutral-500` with `placeholder-neutral-400` on all form inputs
- Replace `dark:text-neutral-500` with `dark:text-neutral-400` in Footer, MemberCard, MemberDirectory, and blog
- Replace `text-neutral-500` with `text-neutral-400` on dark-only pages where text sits on neutral-900 cards (auth, talks, profile)

Fixes the **🎨 Color Contrast Check** issue from ACTIVE_ISSUES.md

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility improvement

## How Has This Been Tested?

- [x] Tested locally
- [x] Tested on mobile devices
- [x] Tested accessibility (keyboard navigation, screen readers)

Verified all changed elements against WCAG 2.1 AA contrast ratios using the Tailwind neutral palette hex values. Spot-checked light mode and dark mode across affected pages (auth, talks, members, footer) — no visual regressions.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Only instances of `neutral-500` that fail contrast on their specific background were changed. Instances that already pass (e.g. `text-neutral-500` on white in light mode at 4.59:1) were intentionally left alone.