### PR TITLE
fix: use message param in GitHub OAuth error handler to show specific errors

### DIFF
--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -349,11 +349,21 @@ function ProfilePageContent() {
         }
       };
       saveGithub();
-    } else if (githubStatus === "error") {
-      const message = searchParams.get("message");
-      setGithubError("Failed to connect GitHub. Please try again.");
-      router.replace("/profile");
-    }
+   } else if (githubStatus === "error") {
+  const message = searchParams.get("message");
+  if (message === "invalid_state") {
+    setGithubError("Connection failed due to a security check. Please try again.");
+  } else if (message === "not_configured") {
+    setGithubError("GitHub connection is not configured. Please contact support.");
+  } else if (message === "token_failed") {
+    setGithubError("GitHub authorization was denied or expired. Please try again.");
+  } else if (message === "user_fetch_failed") {
+    setGithubError("Connected to GitHub but couldn't fetch your profile. Please try again.");
+  } else {
+    setGithubError("Failed to connect GitHub. Please try again.");
+  }
+  router.replace("/profile");
+   }
   }, [searchParams, user, router, loading]);
 
   const connectDiscord = () => {


### PR DESCRIPTION
Fixes #57

## Problem
In the GitHub OAuth callback `useEffect`, the `message` variable was 
declared but never used, always showing a generic error regardless 
of what went wrong.

## Solution
Reviewed the GitHub OAuth callback route (`app/api/github/callback/route.ts`) 
which sends 5 distinct error codes: `invalid_state`, `not_configured`, 
`token_failed`, `user_fetch_failed`, and `unknown`. The fix now handles 
each with a specific user-facing message, consistent with how the 
existing Discord error handler works.

## Changes
- `app/(auth)/profile/page.tsx` — GitHub error handler now uses the 
  `message` param to display specific error messages

## Test Plan
- Trigger a GitHub OAuth error and verify the correct message appears
- Verify the success flow still works correctly
- `npm run lint` passes with no warnings