### PR TITLE
fix: README cleanup, focus ring theme, and QR Image container

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,3 @@ Each feature is **fully isolated** — new routes, new Firestore collections, no
   <strong>Made with ❤️ in Boston.</strong><br />
   Join us on <a href="https://discord.gg/Wsncg8YYqc">Discord</a> or <a href="https://lu.ma/cursor-boston">Luma</a>.
 </p>
-# Webhook test Tue Jan 27 14:03:34 EST 2026

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -206,7 +206,7 @@ export default function Home() {
                 className="object-contain"
               />
               {/* QR Code Overlay */}
-              <div className="absolute bottom-[2%] right-[3%] w-[15%] aspect-square bg-white p-1 rounded border border-neutral-200 dark:border-none shadow-sm">
+              <div className="absolute bottom-[2%] right-[3%] w-[15%] aspect-square bg-white p-1 rounded border border-neutral-200 dark:border-none shadow-sm relative">
                 <Image
                   src="/luma-qr.png"
                   alt="Scan to register"
@@ -407,7 +407,7 @@ export default function Home() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Subscribe on Luma (opens in new tab)"
-            className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             Subscribe on Luma
             <svg


### PR DESCRIPTION
Small fixes from site review:

- **README**: Remove accidental webhook test line at end of file
- **Home page (a11y/theme)**: Use `ring-offset-background` on Luma CTA so focus ring is theme-consistent (was `ring-offset-black`)
- **Home page (Next.js Image)**: Add `relative` to QR overlay div so `<Image fill />` is correctly scoped to that container

Made with [Cursor](https://cursor.com)