### PR TITLE
Unify profile visibility save behavior (auto-save)

### DIFF
--- a/components/ui/FormField.tsx
+++ b/components/ui/FormField.tsx
@@ -65,6 +65,7 @@ interface ToggleSwitchProps {
   size?: "sm" | "md";
   /** Accessible label for screen readers */
   label?: string;
+  disabled?: boolean;
 }
 
 export function ToggleSwitch({
@@ -72,6 +73,7 @@ export function ToggleSwitch({
   onChange,
   size = "sm",
   label,
+  disabled = false,
 }: ToggleSwitchProps) {
   const trackClass =
     size === "md"
@@ -79,10 +81,11 @@ export function ToggleSwitch({
       : "w-9 h-5 after:h-4 after:w-4";
 
   return (
-    <label className="relative inline-flex items-center cursor-pointer">
+    <label className={`relative inline-flex items-center ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}>
       <input
         type="checkbox"
         checked={checked}
+        disabled={disabled}
         onChange={(e) => onChange(e.target.checked)}
         className="sr-only peer"
         aria-label={label}


### PR DESCRIPTION
## Summary
Unifies all profile visibility settings to use auto-save on toggle, eliminating the inconsistency where the header toggle saved immediately to Firestore while the Settings tab only saved on button click.

## Changes
- **saveVisibility helper**: Uses `PATCH /api/profile/visibility` with `refreshUserProfile()` on success
- **Header toggle**: Saves immediately via API (replaces direct Firestore `updateDoc`)
- **Settings tab Public Profile toggle**: Saves immediately on change
- **Individual visibility toggles**: Each saves immediately on toggle
- **Show All / Hide All**: Sends all field updates in one API call
- **saveProfileSettings**: Visibility block removed; only saves bio, location, company, jobTitle, socialLinks
- **ToggleSwitch**: Added `disabled` prop for loading states

## Behavior
- All visibility changes use optimistic updates with revert on error
- `visibilitySaving` state prevents double-clicks during save
- Same save pattern everywhere—no more lost changes when navigating away

## Files
- `app/(auth)/profile/page.tsx`
- `components/ui/FormField.tsx`

Made with [Cursor](https://cursor.com)