### PR TITLE
feat(pair): implement pair programming matchmaker

### DIFF
--- a/app/api/pair/matches/route.ts
+++ b/app/api/pair/matches/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getPairProfileServer,
+  getAllActiveProfilesServer,
+} from "@/lib/pair-programming/data-server";
+import { getTopMatches } from "@/lib/pair-programming/matching";
+
+/**
+ * GET /api/pair/matches
+ * Get top matches for the authenticated user
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const userProfile = await getPairProfileServer(user.uid);
+    if (!userProfile || !userProfile.isActive) {
+      return NextResponse.json(
+        { success: false, error: "No active profile found. Create a profile first." },
+        { status: 404 }
+      );
+    }
+
+    const allProfiles = await getAllActiveProfilesServer();
+    const matches = await getTopMatches(userProfile, allProfiles, 20);
+
+    return NextResponse.json({
+      success: true,
+      matches,
+    });
+  } catch (error) {
+    console.error("Error fetching matches:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch matches" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pair/profile/route.ts
+++ b/app/api/pair/profile/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getPairProfileServer,
+  createOrUpdatePairProfileServer,
+} from "@/lib/pair-programming/data-server";
+import type { PairProfile, SessionType } from "@/lib/pair-programming/types";
+
+const VALID_SESSION_TYPES: SessionType[] = [
+  "teach-me",
+  "build-together",
+  "code-review",
+  "explore-topic",
+];
+
+const MAX_ARRAY_LENGTH = 20;
+const MAX_STRING_LENGTH = 500;
+
+/**
+ * GET /api/pair/profile
+ * Get the authenticated user's pair programming profile
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const profile = await getPairProfileServer(user.uid);
+    return NextResponse.json({
+      success: true,
+      profile: profile || null,
+    });
+  } catch (error) {
+    console.error("Error fetching pair profile:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch profile" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/pair/profile
+ * Create or update the authenticated user's pair programming profile
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const {
+      skillsCanTeach,
+      skillsWantToLearn,
+      preferredLanguages,
+      preferredFrameworks,
+      timezone,
+      availability,
+      sessionTypes,
+      bio,
+      isActive,
+    } = body;
+
+    // Validate arrays
+    if (!Array.isArray(skillsCanTeach) || !Array.isArray(skillsWantToLearn)) {
+      return NextResponse.json(
+        { success: false, error: "Skills arrays are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!timezone || typeof timezone !== "string") {
+      return NextResponse.json(
+        { success: false, error: "Timezone is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!Array.isArray(sessionTypes) || sessionTypes.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "At least one session type required" },
+        { status: 400 }
+      );
+    }
+
+    // Validate session types
+    if (!sessionTypes.every((t: string) => VALID_SESSION_TYPES.includes(t as SessionType))) {
+      return NextResponse.json(
+        { success: false, error: "Invalid session type" },
+        { status: 400 }
+      );
+    }
+
+    // Validate array lengths
+    const arrays = [skillsCanTeach, skillsWantToLearn, preferredLanguages || [], preferredFrameworks || []];
+    if (arrays.some((arr) => arr.length > MAX_ARRAY_LENGTH)) {
+      return NextResponse.json(
+        { success: false, error: `Arrays cannot exceed ${MAX_ARRAY_LENGTH} items` },
+        { status: 400 }
+      );
+    }
+
+    // Validate string items in arrays
+    const allStrings = [...skillsCanTeach, ...skillsWantToLearn, ...(preferredLanguages || []), ...(preferredFrameworks || [])];
+    if (!allStrings.every((s: unknown) => typeof s === "string" && s.length <= MAX_STRING_LENGTH)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid array items" },
+        { status: 400 }
+      );
+    }
+
+    // Validate bio length
+    if (bio && typeof bio === "string" && bio.length > 1000) {
+      return NextResponse.json(
+        { success: false, error: "Bio cannot exceed 1000 characters" },
+        { status: 400 }
+      );
+    }
+
+    const profile: Omit<PairProfile, "userId" | "createdAt" | "updatedAt"> = {
+      skillsCanTeach: skillsCanTeach.map((s: string) => s.trim()).filter(Boolean),
+      skillsWantToLearn: skillsWantToLearn.map((s: string) => s.trim()).filter(Boolean),
+      preferredLanguages: (preferredLanguages || []).map((s: string) => s.trim()).filter(Boolean),
+      preferredFrameworks: (preferredFrameworks || []).map((s: string) => s.trim()).filter(Boolean),
+      timezone: timezone.trim(),
+      availability: Array.isArray(availability) ? availability : [],
+      sessionTypes,
+      bio: bio ? String(bio).trim().slice(0, 1000) : undefined,
+      isActive: isActive !== undefined ? Boolean(isActive) : true,
+    };
+
+    await createOrUpdatePairProfileServer(user.uid, profile);
+
+    return NextResponse.json({
+      success: true,
+      message: "Profile updated successfully",
+    });
+  } catch (error) {
+    console.error("Error updating pair profile:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to update profile" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pair/request/route.ts
+++ b/app/api/pair/request/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  createPairRequestServer,
+  getPairRequestsForUserServer,
+} from "@/lib/pair-programming/data-server";
+import type { SessionType } from "@/lib/pair-programming/types";
+
+const VALID_SESSION_TYPES: SessionType[] = [
+  "teach-me",
+  "build-together",
+  "code-review",
+  "explore-topic",
+];
+
+const MAX_MESSAGE_LENGTH = 1000;
+
+/**
+ * GET /api/pair/request
+ * Get pair requests for the authenticated user (sent and received)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get("type") === "sent" ? "sent" : "received";
+
+    const requests = await getPairRequestsForUserServer(user.uid, type);
+
+    return NextResponse.json({
+      success: true,
+      requests,
+    });
+  } catch (error) {
+    console.error("Error fetching pair requests:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch requests" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/pair/request
+ * Create a new pair programming request
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { toUserId, sessionType, message, proposedTime } = body;
+
+    if (!toUserId || typeof toUserId !== "string") {
+      return NextResponse.json(
+        { success: false, error: "toUserId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!sessionType || !VALID_SESSION_TYPES.includes(sessionType)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid session type" },
+        { status: 400 }
+      );
+    }
+
+    if (!message || typeof message !== "string" || message.trim().length === 0) {
+      return NextResponse.json(
+        { success: false, error: "Message is required" },
+        { status: 400 }
+      );
+    }
+
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return NextResponse.json(
+        { success: false, error: `Message cannot exceed ${MAX_MESSAGE_LENGTH} characters` },
+        { status: 400 }
+      );
+    }
+
+    if (toUserId === user.uid) {
+      return NextResponse.json(
+        { success: false, error: "Cannot send request to yourself" },
+        { status: 400 }
+      );
+    }
+
+    const requestId = await createPairRequestServer({
+      fromUserId: user.uid,
+      toUserId,
+      sessionType,
+      message: message.trim(),
+      proposedTime: proposedTime ? new Date(proposedTime) : undefined,
+    });
+
+    return NextResponse.json({
+      success: true,
+      requestId,
+      message: "Pair request sent successfully",
+    });
+  } catch (error) {
+    console.error("Error creating pair request:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to create request" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pair/respond/route.ts
+++ b/app/api/pair/respond/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { respondToPairRequestServer } from "@/lib/pair-programming/data-server";
+
+/**
+ * POST /api/pair/respond
+ * Accept or decline a pair programming request (uses transaction to prevent races)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { requestId, action } = body;
+
+    if (!requestId || typeof requestId !== "string") {
+      return NextResponse.json(
+        { success: false, error: "requestId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (action !== "accept" && action !== "decline") {
+      return NextResponse.json(
+        { success: false, error: "Action must be 'accept' or 'decline'" },
+        { status: 400 }
+      );
+    }
+
+    const result = await respondToPairRequestServer(requestId, user.uid, action);
+
+    return NextResponse.json({
+      success: true,
+      status: result.status,
+      sessionId: result.sessionId,
+      message: action === "accept" ? "Request accepted - session created" : "Request declined",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to respond to request";
+
+    if (message === "Request not found") {
+      return NextResponse.json({ success: false, error: message }, { status: 404 });
+    }
+    if (message === "Unauthorized") {
+      return NextResponse.json(
+        { success: false, error: "You can only respond to requests sent to you" },
+        { status: 403 }
+      );
+    }
+    if (message === "Request has already been responded to") {
+      return NextResponse.json({ success: false, error: message }, { status: 400 });
+    }
+
+    console.error("Error responding to pair request:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to respond to request" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/pair/[sessionId]/page.tsx
+++ b/app/pair/[sessionId]/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { doc, getDoc, updateDoc, serverTimestamp } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { PairSession, SessionNotes } from "@/lib/pair-programming/types";
+
+interface PublicUser {
+  uid: string;
+  displayName: string | null;
+  photoURL: string | null;
+}
+
+export default function SessionDetailPage() {
+  const { user, loading: authLoading } = useAuth();
+  const params = useParams();
+  const router = useRouter();
+  const sessionId = params.sessionId as string;
+  const [session, setSession] = useState<PairSession | null>(null);
+  const [otherUser, setOtherUser] = useState<PublicUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notes, setNotes] = useState<SessionNotes>({
+    whatWeWorkedOn: "",
+    whatILearned: "",
+    nextSteps: "",
+  });
+  const [savingNotes, setSavingNotes] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchSession() {
+      if (!user || !db || !sessionId) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const sessionDoc = await getDoc(doc(db, "pair_sessions", sessionId));
+        if (!sessionDoc.exists()) {
+          setLoading(false);
+          return;
+        }
+
+        const sessionData = { id: sessionDoc.id, ...sessionDoc.data() } as PairSession;
+
+        // Verify user is a participant
+        if (!sessionData.participantIds.includes(user.uid)) {
+          router.push("/pair");
+          return;
+        }
+
+        setSession(sessionData);
+
+        // Fetch other participant's profile
+        const otherUserId = sessionData.participantIds.find((id) => id !== user.uid);
+        if (otherUserId) {
+          const userDoc = await getDoc(doc(db, "users", otherUserId));
+          if (userDoc.exists()) {
+            const userData = userDoc.data();
+            setOtherUser({
+              uid: otherUserId,
+              displayName: userData.displayName || null,
+              photoURL: userData.photoURL || null,
+            });
+          }
+        }
+
+        // Load user's notes if they exist
+        const userNotes = sessionData.notes?.[user.uid];
+        if (userNotes) {
+          setNotes(userNotes);
+        }
+      } catch (error) {
+        console.error("Error fetching session:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (!authLoading && user) {
+      fetchSession();
+    }
+  }, [user, authLoading, sessionId, router]);
+
+  const handleStartSession = async () => {
+    if (!db || !sessionId) return;
+
+    try {
+      await updateDoc(doc(db, "pair_sessions", sessionId), {
+        status: "in-progress",
+        startedAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+      setSession((prev) => prev ? { ...prev, status: "in-progress" } : null);
+    } catch (error) {
+      console.error("Error starting session:", error);
+      setStatusMessage("Failed to start session");
+    }
+  };
+
+  const handleCompleteSession = async () => {
+    if (!db || !sessionId || !user) return;
+    if (!notes.whatWeWorkedOn.trim() || !notes.whatILearned.trim()) {
+      setStatusMessage("Please fill in session notes before completing");
+      return;
+    }
+
+    try {
+      await updateDoc(doc(db, "pair_sessions", sessionId), {
+        status: "completed",
+        completedAt: serverTimestamp(),
+        [`notes.${user.uid}`]: notes,
+        updatedAt: serverTimestamp(),
+      });
+      setSession((prev) => prev ? { ...prev, status: "completed" } : null);
+      setStatusMessage("Session completed!");
+    } catch (error) {
+      console.error("Error completing session:", error);
+      setStatusMessage("Failed to complete session");
+    }
+  };
+
+  const handleSaveNotes = async () => {
+    if (!db || !sessionId || !user) return;
+
+    setSavingNotes(true);
+    try {
+      await updateDoc(doc(db, "pair_sessions", sessionId), {
+        [`notes.${user.uid}`]: notes,
+        updatedAt: serverTimestamp(),
+      });
+      setStatusMessage("Notes saved!");
+      setTimeout(() => setStatusMessage(null), 3000);
+    } catch (error) {
+      console.error("Error saving notes:", error);
+      setStatusMessage("Failed to save notes");
+    } finally {
+      setSavingNotes(false);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-emerald-500" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md w-full text-center">
+          <h1 className="text-2xl font-bold mb-4">Session Details</h1>
+          <p className="text-neutral-600 dark:text-neutral-300 mb-6">
+            Sign in to view session details.
+          </p>
+          <Link
+            href="/login"
+            className="inline-block px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+          >
+            Sign In
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md w-full text-center">
+          <h1 className="text-2xl font-bold mb-4">Session Not Found</h1>
+          <Link
+            href="/pair"
+            className="text-emerald-600 dark:text-emerald-400 hover:underline"
+          >
+            &larr; Back to Pair Programming
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const sessionTypeLabels: Record<PairSession["sessionType"], string> = {
+    "teach-me": "Teach Me",
+    "build-together": "Build Together",
+    "code-review": "Code Review Swap",
+    "explore-topic": "Explore a Topic",
+  };
+
+  return (
+    <div className="min-h-screen py-12 px-6">
+      <div className="max-w-4xl mx-auto">
+        <Link
+          href="/pair"
+          className="text-emerald-600 dark:text-emerald-400 hover:underline mb-6 inline-block"
+        >
+          &larr; Back to Pair Programming
+        </Link>
+
+        <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6 mb-6">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h1 className="text-2xl font-bold mb-2">Pair Programming Session</h1>
+              <p className="text-neutral-600 dark:text-neutral-300">
+                {sessionTypeLabels[session.sessionType]}
+              </p>
+            </div>
+            <span
+              className={`px-3 py-1 rounded-full text-sm font-medium ${
+                session.status === "scheduled"
+                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                  : session.status === "in-progress"
+                    ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
+                    : session.status === "completed"
+                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                      : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+              }`}
+            >
+              {session.status}
+            </span>
+          </div>
+
+          {/* Partner Info */}
+          {otherUser && (
+            <div className="flex items-center gap-4 mb-6 p-4 bg-neutral-50 dark:bg-neutral-800 rounded-lg">
+              {otherUser.photoURL ? (
+                <Image
+                  src={otherUser.photoURL}
+                  alt={otherUser.displayName || "Partner"}
+                  width={64}
+                  height={64}
+                  className="w-16 h-16 rounded-full"
+                />
+              ) : (
+                <div className="w-16 h-16 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
+                  <span className="text-2xl text-neutral-500">
+                    {otherUser.displayName?.[0]?.toUpperCase() || "?"}
+                  </span>
+                </div>
+              )}
+              <div>
+                <h3 className="font-semibold text-lg">
+                  {otherUser.displayName || "Anonymous User"}
+                </h3>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">Your Pair Partner</p>
+              </div>
+            </div>
+          )}
+
+          {/* Status Message */}
+          {statusMessage && (
+            <div className="mb-4 p-3 bg-neutral-100 dark:bg-neutral-800 rounded-lg text-sm">
+              {statusMessage}
+            </div>
+          )}
+
+          {/* Session Actions */}
+          {session.status === "scheduled" && (
+            <button
+              onClick={handleStartSession}
+              className="w-full px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors mb-6"
+            >
+              Start Session
+            </button>
+          )}
+
+          {/* Session Notes */}
+          {(session.status === "in-progress" || session.status === "completed") && (
+            <div className="space-y-4">
+              <h2 className="text-xl font-semibold">Session Notes</h2>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="notes-worked-on" className="block text-sm font-medium mb-2">
+                    What We Worked On
+                  </label>
+                  <textarea
+                    id="notes-worked-on"
+                    value={notes.whatWeWorkedOn}
+                    onChange={(e) =>
+                      setNotes((prev) => ({ ...prev, whatWeWorkedOn: e.target.value }))
+                    }
+                    rows={4}
+                    className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+                    placeholder="Describe what you worked on together..."
+                    disabled={session.status === "completed"}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="notes-learned" className="block text-sm font-medium mb-2">
+                    What I Learned
+                  </label>
+                  <textarea
+                    id="notes-learned"
+                    value={notes.whatILearned}
+                    onChange={(e) =>
+                      setNotes((prev) => ({ ...prev, whatILearned: e.target.value }))
+                    }
+                    rows={4}
+                    className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+                    placeholder="What did you learn from this session?"
+                    disabled={session.status === "completed"}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="notes-next-steps" className="block text-sm font-medium mb-2">
+                    Next Steps (Optional)
+                  </label>
+                  <textarea
+                    id="notes-next-steps"
+                    value={notes.nextSteps || ""}
+                    onChange={(e) =>
+                      setNotes((prev) => ({ ...prev, nextSteps: e.target.value }))
+                    }
+                    rows={3}
+                    className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+                    placeholder="Any follow-up actions or topics to explore..."
+                    disabled={session.status === "completed"}
+                  />
+                </div>
+              </div>
+              {session.status === "in-progress" && (
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleSaveNotes}
+                    disabled={savingNotes}
+                    className="px-6 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors disabled:opacity-50"
+                  >
+                    {savingNotes ? "Saving..." : "Save Notes"}
+                  </button>
+                  <button
+                    onClick={handleCompleteSession}
+                    className="px-6 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+                  >
+                    Complete Session
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/pair/page.tsx
+++ b/app/pair/page.tsx
@@ -1,0 +1,698 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import Link from "next/link";
+import type {
+  PairProfile,
+  MatchScore,
+  PairRequest,
+  SessionType,
+} from "@/lib/pair-programming/types";
+import Image from "next/image";
+import { getPairProfile, getAllActiveProfiles } from "@/lib/pair-programming/data";
+import { getTopMatches } from "@/lib/pair-programming/matching";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+
+interface PublicUser {
+  uid: string;
+  displayName: string | null;
+  photoURL: string | null;
+}
+
+export default function PairProgrammingPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [profile, setProfile] = useState<PairProfile | null>(null);
+  const [matches, setMatches] = useState<MatchScore[]>([]);
+  const [requests, setRequests] = useState<PairRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showProfileForm, setShowProfileForm] = useState(false);
+  const [userProfiles, setUserProfiles] = useState<Record<string, PublicUser>>({});
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Fetch user's pair profile
+  useEffect(() => {
+    async function fetchProfile() {
+      if (!user || !db) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const userProfile = await getPairProfile(user.uid);
+        setProfile(userProfile);
+        setShowProfileForm(!userProfile);
+      } catch (error) {
+        console.error("Error fetching profile:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (!authLoading && user) {
+      fetchProfile();
+    }
+  }, [user, authLoading, refreshKey]);
+
+  // Fetch matches
+  useEffect(() => {
+    async function fetchMatches() {
+      if (!user || !profile || !profile.isActive || !db) return;
+
+      try {
+        const allProfiles = await getAllActiveProfiles();
+        const topMatches = await getTopMatches(profile, allProfiles, 20);
+        setMatches(topMatches);
+
+        // Fetch user profiles for display names/photos
+        const userIds = topMatches.map((m) => m.userId);
+        const profilePromises = userIds.map(async (uid) => {
+          if (!db) return { uid, displayName: null, photoURL: null };
+          const userDoc = await getDoc(doc(db, "users", uid));
+          if (userDoc.exists()) {
+            const data = userDoc.data();
+            return {
+              uid,
+              displayName: data.displayName || null,
+              photoURL: data.photoURL || null,
+            };
+          }
+          return { uid, displayName: null, photoURL: null };
+        });
+        const profiles = await Promise.all(profilePromises);
+        const profileMap: Record<string, PublicUser> = {};
+        profiles.forEach((p) => {
+          profileMap[p.uid] = p;
+        });
+        setUserProfiles(profileMap);
+      } catch (error) {
+        console.error("Error fetching matches:", error);
+      }
+    }
+
+    if (profile && profile.isActive) {
+      fetchMatches();
+    }
+  }, [user, profile]);
+
+  // Fetch requests
+  useEffect(() => {
+    async function fetchRequests() {
+      if (!user) return;
+
+      try {
+        const token = await user.getIdToken();
+        const response = await fetch("/api/pair/request?type=received", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        const data = await response.json();
+        if (data.success) {
+          setRequests(data.requests || []);
+        }
+      } catch (error) {
+        console.error("Error fetching requests:", error);
+      }
+    }
+
+    if (user) {
+      fetchRequests();
+    }
+  }, [user]);
+
+  const handleSendRequest = useCallback(
+    async (toUserId: string, sessionType: SessionType, message: string) => {
+      if (!user) return;
+
+      try {
+        const token = await user.getIdToken();
+        const response = await fetch("/api/pair/request", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            toUserId,
+            sessionType,
+            message,
+          }),
+        });
+
+        const data = await response.json();
+        if (data.success) {
+          alert("Pair request sent successfully!");
+        } else {
+          alert(`Error: ${data.error}`);
+        }
+      } catch (error) {
+        console.error("Error sending request:", error);
+        alert("Failed to send request. Please try again.");
+      }
+    },
+    [user]
+  );
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-emerald-500"></div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md w-full text-center">
+          <h1 className="text-2xl font-bold mb-4">Pair Programming Matchmaker</h1>
+          <p className="text-neutral-600 dark:text-neutral-300 mb-6">
+            Sign in to find your perfect pair programming partner.
+          </p>
+          <Link
+            href="/login"
+            className="inline-block px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+          >
+            Sign In
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!profile || showProfileForm) {
+    return (
+      <div className="min-h-screen py-12 px-6">
+        <div className="max-w-2xl mx-auto">
+          <h1 className="text-3xl font-bold mb-6">Create Your Pair Programming Profile</h1>
+          <ProfileForm
+            user={user}
+            existingProfile={profile}
+            onSave={() => {
+              setShowProfileForm(false);
+              setRefreshKey((k) => k + 1);
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen py-12 px-6">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-bold mb-2">Pair Programming Matchmaker</h1>
+            <p className="text-neutral-600 dark:text-neutral-300">
+              Find your perfect coding partner based on complementary skills
+            </p>
+          </div>
+          <button
+            onClick={() => setShowProfileForm(true)}
+            className="px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+          >
+            Edit Profile
+          </button>
+        </div>
+
+        {/* Pending Requests */}
+        {requests.length > 0 && (
+          <div className="mb-8 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+            <h2 className="font-semibold mb-2">You have {requests.length} pending request(s)</h2>
+            <Link
+              href="/pair/requests"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              View requests →
+            </Link>
+          </div>
+        )}
+
+        {/* Matches Grid */}
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {matches.map((match) => {
+            const userProfile = userProfiles[match.userId];
+            return (
+              <MatchCard
+                key={match.userId}
+                match={match}
+                userProfile={userProfile}
+                onSendRequest={(sessionType, message) =>
+                  handleSendRequest(match.userId, sessionType, message)
+                }
+              />
+            );
+          })}
+        </div>
+
+        {matches.length === 0 && (
+          <div className="text-center py-12 text-neutral-600 dark:text-neutral-300">
+            <p>No matches found yet. Check back later or update your profile!</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MatchCard({
+  match,
+  userProfile,
+  onSendRequest,
+}: {
+  match: MatchScore;
+  userProfile?: PublicUser;
+  onSendRequest: (sessionType: SessionType, message: string) => void;
+}) {
+  const [showRequestForm, setShowRequestForm] = useState(false);
+  const [sessionType, setSessionType] = useState<SessionType>("build-together");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = () => {
+    if (!message.trim()) {
+      alert("Please enter a message");
+      return;
+    }
+    onSendRequest(sessionType, message);
+    setShowRequestForm(false);
+    setMessage("");
+  };
+
+  return (
+    <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6">
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-center gap-3">
+          {userProfile?.photoURL ? (
+            <Image
+              src={userProfile.photoURL}
+              alt={userProfile.displayName || "User"}
+              width={48}
+              height={48}
+              className="w-12 h-12 rounded-full"
+            />
+          ) : (
+            <div className="w-12 h-12 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
+              <span className="text-neutral-500">
+                {userProfile?.displayName?.[0]?.toUpperCase() || "?"}
+              </span>
+            </div>
+          )}
+          <div>
+            <h3 className="font-semibold">
+              {userProfile?.displayName || "Anonymous User"}
+            </h3>
+            <div className="flex items-center gap-2 mt-1">
+              <div
+                className={`px-2 py-1 rounded-full text-xs font-medium ${
+                  match.score >= 80
+                    ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                    : match.score >= 60
+                      ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                      : "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
+                }`}
+              >
+                {match.score}% match
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-2">
+          Why you match:
+        </p>
+        <ul className="text-sm space-y-1">
+          {match.reasons.slice(0, 3).map((reason, idx) => (
+            <li key={idx} className="text-neutral-700 dark:text-neutral-300">
+              • {reason}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {showRequestForm ? (
+        <div className="space-y-3">
+          <select
+            value={sessionType}
+            onChange={(e) => setSessionType(e.target.value as SessionType)}
+            className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+          >
+            <option value="teach-me">Teach Me</option>
+            <option value="build-together">Build Together</option>
+            <option value="code-review">Code Review Swap</option>
+            <option value="explore-topic">Explore a Topic</option>
+          </select>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Send a message..."
+            className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+            rows={3}
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={handleSubmit}
+              className="flex-1 px-4 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+            >
+              Send Request
+            </button>
+            <button
+              onClick={() => setShowRequestForm(false)}
+              className="px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => setShowRequestForm(true)}
+          className="w-full px-4 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+        >
+          Send Pair Request
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ProfileForm({
+  user,
+  existingProfile,
+  onSave,
+}: {
+  user: { getIdToken: () => Promise<string> };
+  existingProfile: PairProfile | null;
+  onSave: () => void;
+}) {
+  const [skillsCanTeach, setSkillsCanTeach] = useState<string[]>(
+    existingProfile?.skillsCanTeach || []
+  );
+  const [skillsWantToLearn, setSkillsWantToLearn] = useState<string[]>(
+    existingProfile?.skillsWantToLearn || []
+  );
+  const [preferredLanguages, setPreferredLanguages] = useState<string[]>(
+    existingProfile?.preferredLanguages || []
+  );
+  const [preferredFrameworks, setPreferredFrameworks] = useState<string[]>(
+    existingProfile?.preferredFrameworks || []
+  );
+  const [timezone, setTimezone] = useState(existingProfile?.timezone || "America/New_York");
+  const [sessionTypes, setSessionTypes] = useState<SessionType[]>(
+    existingProfile?.sessionTypes || []
+  );
+  const [bio, setBio] = useState(existingProfile?.bio || "");
+  const [isActive, setIsActive] = useState(existingProfile?.isActive ?? true);
+  const [saving, setSaving] = useState(false);
+
+  const [newSkillTeach, setNewSkillTeach] = useState("");
+  const [newSkillLearn, setNewSkillLearn] = useState("");
+  const [newLanguage, setNewLanguage] = useState("");
+  const [newFramework, setNewFramework] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (sessionTypes.length === 0) {
+      alert("Please select at least one session type");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch("/api/pair/profile", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          skillsCanTeach,
+          skillsWantToLearn,
+          preferredLanguages,
+          preferredFrameworks,
+          timezone,
+          availability: existingProfile?.availability || [],
+          sessionTypes,
+          bio,
+          isActive,
+        }),
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        onSave();
+      } else {
+        alert(`Error: ${data.error}`);
+      }
+    } catch (error) {
+      console.error("Error saving profile:", error);
+      alert("Failed to save profile. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Skills Can Teach */}
+      <div>
+        <label className="block text-sm font-medium mb-2">Skills I Can Teach</label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type="text"
+            value={newSkillTeach}
+            onChange={(e) => setNewSkillTeach(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                if (newSkillTeach.trim() && !skillsCanTeach.includes(newSkillTeach.trim())) {
+                  setSkillsCanTeach([...skillsCanTeach, newSkillTeach.trim()]);
+                  setNewSkillTeach("");
+                }
+              }
+            }}
+            placeholder="Add skill (press Enter)"
+            className="flex-1 px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {skillsCanTeach.map((skill, idx) => (
+            <span
+              key={idx}
+              className="px-3 py-1 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full text-sm flex items-center gap-2"
+            >
+              {skill}
+              <button
+                type="button"
+                onClick={() => setSkillsCanTeach(skillsCanTeach.filter((_, i) => i !== idx))}
+                className="hover:text-emerald-900"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Skills Want to Learn */}
+      <div>
+        <label className="block text-sm font-medium mb-2">Skills I Want to Learn</label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type="text"
+            value={newSkillLearn}
+            onChange={(e) => setNewSkillLearn(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                if (newSkillLearn.trim() && !skillsWantToLearn.includes(newSkillLearn.trim())) {
+                  setSkillsWantToLearn([...skillsWantToLearn, newSkillLearn.trim()]);
+                  setNewSkillLearn("");
+                }
+              }
+            }}
+            placeholder="Add skill (press Enter)"
+            className="flex-1 px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {skillsWantToLearn.map((skill, idx) => (
+            <span
+              key={idx}
+              className="px-3 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full text-sm flex items-center gap-2"
+            >
+              {skill}
+              <button
+                type="button"
+                onClick={() => setSkillsWantToLearn(skillsWantToLearn.filter((_, i) => i !== idx))}
+                className="hover:text-blue-900"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Languages & Frameworks */}
+      <div className="grid md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-2">Preferred Languages</label>
+          <div className="flex gap-2 mb-2">
+            <input
+              type="text"
+              value={newLanguage}
+              onChange={(e) => setNewLanguage(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  if (newLanguage.trim() && !preferredLanguages.includes(newLanguage.trim())) {
+                    setPreferredLanguages([...preferredLanguages, newLanguage.trim()]);
+                    setNewLanguage("");
+                  }
+                }
+              }}
+              placeholder="e.g., TypeScript"
+              className="flex-1 px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {preferredLanguages.map((lang, idx) => (
+              <span
+                key={idx}
+                className="px-2 py-1 bg-neutral-100 dark:bg-neutral-800 rounded text-sm"
+              >
+                {lang}
+                <button
+                  type="button"
+                  onClick={() => setPreferredLanguages(preferredLanguages.filter((_, i) => i !== idx))}
+                  className="ml-1"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-2">Preferred Frameworks</label>
+          <div className="flex gap-2 mb-2">
+            <input
+              type="text"
+              value={newFramework}
+              onChange={(e) => setNewFramework(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  if (newFramework.trim() && !preferredFrameworks.includes(newFramework.trim())) {
+                    setPreferredFrameworks([...preferredFrameworks, newFramework.trim()]);
+                    setNewFramework("");
+                  }
+                }
+              }}
+              placeholder="e.g., Next.js"
+              className="flex-1 px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {preferredFrameworks.map((fw, idx) => (
+              <span
+                key={idx}
+                className="px-2 py-1 bg-neutral-100 dark:bg-neutral-800 rounded text-sm"
+              >
+                {fw}
+                <button
+                  type="button"
+                  onClick={() => setPreferredFrameworks(preferredFrameworks.filter((_, i) => i !== idx))}
+                  className="ml-1"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Timezone */}
+      <div>
+        <label className="block text-sm font-medium mb-2">Timezone</label>
+        <select
+          value={timezone}
+          onChange={(e) => setTimezone(e.target.value)}
+          className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+        >
+          <option value="America/New_York">Eastern Time (ET)</option>
+          <option value="America/Chicago">Central Time (CT)</option>
+          <option value="America/Denver">Mountain Time (MT)</option>
+          <option value="America/Los_Angeles">Pacific Time (PT)</option>
+          <option value="UTC">UTC</option>
+        </select>
+      </div>
+
+      {/* Session Types */}
+      <div>
+        <label className="block text-sm font-medium mb-2">Session Types I&apos;m Interested In</label>
+        <div className="space-y-2">
+          {(["teach-me", "build-together", "code-review", "explore-topic"] as SessionType[]).map(
+            (type) => (
+              <label key={type} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={sessionTypes.includes(type)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setSessionTypes([...sessionTypes, type]);
+                    } else {
+                      setSessionTypes(sessionTypes.filter((t) => t !== type));
+                    }
+                  }}
+                />
+                <span className="capitalize">{type.replace("-", " ")}</span>
+              </label>
+            )
+          )}
+        </div>
+      </div>
+
+      {/* Bio */}
+      <div>
+        <label className="block text-sm font-medium mb-2">Bio (Optional)</label>
+        <textarea
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          rows={4}
+          className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg"
+          placeholder="Tell potential partners about yourself..."
+        />
+      </div>
+
+      {/* Active Toggle */}
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="isActive"
+          checked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        />
+        <label htmlFor="isActive" className="text-sm">
+          Make my profile active (visible to others)
+        </label>
+      </div>
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="w-full px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors disabled:opacity-50"
+      >
+        {saving ? "Saving..." : "Save Profile"}
+      </button>
+    </form>
+  );
+}

--- a/app/pair/requests/page.tsx
+++ b/app/pair/requests/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import Link from "next/link";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import type { PairRequest, SessionType } from "@/lib/pair-programming/types";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+
+interface PublicUser {
+  uid: string;
+  displayName: string | null;
+  photoURL: string | null;
+}
+
+export default function PairRequestsPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [sentRequests, setSentRequests] = useState<PairRequest[]>([]);
+  const [receivedRequests, setReceivedRequests] = useState<PairRequest[]>([]);
+  const [userProfiles, setUserProfiles] = useState<Record<string, PublicUser>>({});
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<"sent" | "received">("received");
+  const [refreshKey, setRefreshKey] = useState(0);
+  const router = useRouter();
+
+  useEffect(() => {
+    async function fetchRequests() {
+      if (!user || !db) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const token = await user.getIdToken();
+
+        // Fetch sent requests
+        const sentResponse = await fetch("/api/pair/request?type=sent", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const sentData = await sentResponse.json();
+        if (sentData.success) {
+          setSentRequests(sentData.requests || []);
+        }
+
+        // Fetch received requests
+        const receivedResponse = await fetch("/api/pair/request?type=received", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const receivedData = await receivedResponse.json();
+        if (receivedData.success) {
+          setReceivedRequests(receivedData.requests || []);
+        }
+
+        // Fetch user profiles
+        const allUserIds = [
+          ...(sentData.requests || []).map((r: PairRequest) => r.toUserId),
+          ...(receivedData.requests || []).map((r: PairRequest) => r.fromUserId),
+        ];
+        const uniqueIds = [...new Set(allUserIds)];
+        const profilePromises = uniqueIds.map(async (uid: string) => {
+          if (!db) return { uid, displayName: null, photoURL: null };
+          const userDoc = await getDoc(doc(db, "users", uid));
+          if (userDoc.exists()) {
+            const data = userDoc.data();
+            return {
+              uid,
+              displayName: data.displayName || null,
+              photoURL: data.photoURL || null,
+            };
+          }
+          return { uid, displayName: null, photoURL: null };
+        });
+        const profiles = await Promise.all(profilePromises);
+        const profileMap: Record<string, PublicUser> = {};
+        profiles.forEach((p) => {
+          profileMap[p.uid] = p;
+        });
+        setUserProfiles(profileMap);
+      } catch (error) {
+        console.error("Error fetching requests:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (!authLoading && user) {
+      fetchRequests();
+    }
+  }, [user, authLoading, refreshKey]);
+
+  const handleRespond = async (requestId: string, action: "accept" | "decline") => {
+    if (!user) return;
+
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch("/api/pair/respond", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ requestId, action }),
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        if (action === "accept" && data.sessionId) {
+          router.push(`/pair/${data.sessionId}`);
+          return;
+        }
+        setRefreshKey((k) => k + 1);
+      }
+    } catch (error) {
+      console.error("Error responding to request:", error);
+      alert("Failed to respond. Please try again.");
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-emerald-500"></div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md w-full text-center">
+          <h1 className="text-2xl font-bold mb-4">Pair Requests</h1>
+          <p className="text-neutral-600 dark:text-neutral-300 mb-6">
+            Sign in to view your pair programming requests.
+          </p>
+          <Link
+            href="/login"
+            className="inline-block px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+          >
+            Sign In
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const requests = activeTab === "sent" ? sentRequests : receivedRequests;
+
+  return (
+    <div className="min-h-screen py-12 px-6">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-bold">Pair Requests</h1>
+          <Link
+            href="/pair"
+            className="text-emerald-600 dark:text-emerald-400 hover:underline"
+          >
+            ← Back to Matches
+          </Link>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-4 mb-6 border-b border-neutral-200 dark:border-neutral-800">
+          <button
+            onClick={() => setActiveTab("received")}
+            className={`px-4 py-2 font-medium border-b-2 transition-colors ${
+              activeTab === "received"
+                ? "border-emerald-500 text-emerald-600 dark:text-emerald-400"
+                : "border-transparent text-neutral-600 dark:text-neutral-400"
+            }`}
+          >
+            Received ({receivedRequests.length})
+          </button>
+          <button
+            onClick={() => setActiveTab("sent")}
+            className={`px-4 py-2 font-medium border-b-2 transition-colors ${
+              activeTab === "sent"
+                ? "border-emerald-500 text-emerald-600 dark:text-emerald-400"
+                : "border-transparent text-neutral-600 dark:text-neutral-400"
+            }`}
+          >
+            Sent ({sentRequests.length})
+          </button>
+        </div>
+
+        {/* Requests List */}
+        <div className="space-y-4">
+          {requests.length === 0 ? (
+            <div className="text-center py-12 text-neutral-600 dark:text-neutral-300">
+              <p>No {activeTab} requests yet.</p>
+            </div>
+          ) : (
+            requests.map((request) => {
+              const otherUser =
+                activeTab === "sent"
+                  ? userProfiles[request.toUserId]
+                  : userProfiles[request.fromUserId];
+              return (
+                <RequestCard
+                  key={request.id}
+                  request={request}
+                  otherUser={otherUser}
+                  isReceived={activeTab === "received"}
+                  onRespond={handleRespond}
+                />
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RequestCard({
+  request,
+  otherUser,
+  isReceived,
+  onRespond,
+}: {
+  request: PairRequest;
+  otherUser?: PublicUser;
+  isReceived: boolean;
+  onRespond: (requestId: string, action: "accept" | "decline") => void;
+}) {
+  const sessionTypeLabels: Record<SessionType, string> = {
+    "teach-me": "Teach Me",
+    "build-together": "Build Together",
+    "code-review": "Code Review Swap",
+    "explore-topic": "Explore a Topic",
+  };
+
+  return (
+    <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6">
+      <div className="flex items-start gap-4">
+        {otherUser?.photoURL ? (
+          <Image
+            src={otherUser.photoURL}
+            alt={otherUser.displayName || "User"}
+            width={48}
+            height={48}
+            className="w-12 h-12 rounded-full"
+          />
+        ) : (
+          <div className="w-12 h-12 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
+            <span className="text-neutral-500">
+              {otherUser?.displayName?.[0]?.toUpperCase() || "?"}
+            </span>
+          </div>
+        )}
+        <div className="flex-1">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="font-semibold">
+              {otherUser?.displayName || "Anonymous User"}
+            </h3>
+            <span
+              className={`px-2 py-1 rounded-full text-xs font-medium ${
+                request.status === "pending"
+                  ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
+                  : request.status === "accepted"
+                    ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                    : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+              }`}
+            >
+              {request.status}
+            </span>
+          </div>
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-2">
+            Session Type: {sessionTypeLabels[request.sessionType]}
+          </p>
+          <p className="text-neutral-700 dark:text-neutral-300 mb-4">{request.message}</p>
+          {isReceived && request.status === "pending" && (
+            <div className="flex gap-2">
+              <button
+                onClick={() => onRespond(request.id!, "accept")}
+                className="px-4 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+              >
+                Accept
+              </button>
+              <button
+                onClick={() => onRespond(request.id!, "decline")}
+                className="px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              >
+                Decline
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -62,6 +62,9 @@ export default function Navigation() {
           <Link href="/showcase" className="text-neutral-600 dark:text-neutral-300 hover:text-black dark:hover:text-white text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
             Showcase
           </Link>
+          <Link href="/pair" className="text-neutral-600 dark:text-neutral-300 hover:text-black dark:hover:text-white text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
+            Pair Programming
+          </Link>
           <Link href="/about" className="text-neutral-600 dark:text-neutral-300 hover:text-black dark:hover:text-white text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
             About
           </Link>
@@ -150,6 +153,9 @@ export default function Navigation() {
               </Link>
               <Link href="/showcase" onClick={() => setMobileMenuOpen(false)} className="text-neutral-600 dark:text-neutral-300 hover:text-black dark:hover:text-white py-3 text-base font-medium transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
                 Showcase
+              </Link>
+              <Link href="/pair" onClick={() => setMobileMenuOpen(false)} className="text-neutral-600 dark:text-neutral-300 hover:text-black dark:hover:text-white py-3 text-base font-medium transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
+                Pair Programming
               </Link>
               <Link href="/about" onClick={() => setMobileMenuOpen(false)} className="text-neutral-600 dark:text-neutral-300 hover:text-black dark:hover:text-white py-3 text-base font-medium transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
                 About

--- a/config/firebase/firestore.indexes.json
+++ b/config/firebase/firestore.indexes.json
@@ -114,6 +114,38 @@
         { "fieldPath": "eventId", "order": "ASCENDING" },
         { "fieldPath": "userId", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "pair_profiles",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isActive", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "pair_requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "fromUserId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "pair_requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "toUserId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "pair_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participantIds", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -150,5 +150,33 @@ service cloud.firestore {
       allow read: if request.auth != null;
       allow write: if false; // Only server-side writes for data integrity
     }
+
+    // Pair Programming - Profiles: users can create/update their own profile, read active profiles
+    match /pair_profiles/{userId} {
+      allow read: if request.auth != null && (resource.data.isActive == true || request.auth.uid == userId);
+      allow create: if request.auth != null && request.auth.uid == userId;
+      allow update: if request.auth != null && request.auth.uid == userId;
+      allow delete: if false; // Profiles should be deactivated, not deleted
+    }
+
+    // Pair Programming - Requests: create by fromUserId, read by participants, update by toUserId
+    match /pair_requests/{requestId} {
+      allow create: if request.auth != null && request.resource.data.fromUserId == request.auth.uid;
+      allow read: if request.auth != null && (
+        resource.data.fromUserId == request.auth.uid || resource.data.toUserId == request.auth.uid
+      );
+      allow update: if request.auth != null && resource.data.toUserId == request.auth.uid;
+      allow delete: if request.auth != null && (
+        resource.data.fromUserId == request.auth.uid || resource.data.toUserId == request.auth.uid
+      );
+    }
+
+    // Pair Programming - Sessions: read/update by participants
+    match /pair_sessions/{sessionId} {
+      allow read: if request.auth != null && request.auth.uid in resource.data.participantIds;
+      allow create: if false; // Created server-side when request is accepted
+      allow update: if request.auth != null && request.auth.uid in resource.data.participantIds;
+      allow delete: if false; // Sessions should not be deleted
+    }
   }
 }

--- a/lib/pair-programming/data-server.ts
+++ b/lib/pair-programming/data-server.ts
@@ -1,0 +1,146 @@
+import { getAdminDb } from "@/lib/firebase-admin";
+import type {
+  PairProfile,
+  PairRequest,
+  RequestStatus,
+} from "./types";
+
+// Collection names
+const COLLECTIONS = {
+  PROFILES: "pair_profiles",
+  REQUESTS: "pair_requests",
+  SESSIONS: "pair_sessions",
+} as const;
+
+// ─── Server-side operations (for API routes) ────────────────────────────────
+
+export async function getPairProfileServer(userId: string): Promise<PairProfile | null> {
+  const adminDb = getAdminDb();
+  if (!adminDb) return null;
+  const docRef = adminDb.collection(COLLECTIONS.PROFILES).doc(userId);
+  const docSnap = await docRef.get();
+  if (!docSnap.exists) return null;
+  return { ...docSnap.data(), userId: docSnap.id } as PairProfile;
+}
+
+export async function getAllActiveProfilesServer(): Promise<PairProfile[]> {
+  const adminDb = getAdminDb();
+  if (!adminDb) return [];
+  const snapshot = await adminDb
+    .collection(COLLECTIONS.PROFILES)
+    .where("isActive", "==", true)
+    .orderBy("updatedAt", "desc")
+    .get();
+  return snapshot.docs.map((d) => ({
+    ...d.data(),
+    userId: d.id,
+  })) as PairProfile[];
+}
+
+export async function createOrUpdatePairProfileServer(
+  userId: string,
+  profile: Omit<PairProfile, "userId" | "createdAt" | "updatedAt">
+): Promise<void> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+
+  const docRef = adminDb.collection(COLLECTIONS.PROFILES).doc(userId);
+  const existing = await docRef.get();
+
+  if (existing.exists) {
+    await docRef.update({
+      ...profile,
+      updatedAt: new Date(),
+    });
+  } else {
+    await docRef.set({
+      ...profile,
+      userId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+}
+
+export async function createPairRequestServer(
+  request: Omit<PairRequest, "id" | "createdAt" | "updatedAt" | "status">
+): Promise<string> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+  const docRef = await adminDb.collection(COLLECTIONS.REQUESTS).add({
+    ...request,
+    status: "pending" as RequestStatus,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return docRef.id;
+}
+
+export async function getPairRequestsForUserServer(
+  userId: string,
+  type: "sent" | "received"
+): Promise<PairRequest[]> {
+  const adminDb = getAdminDb();
+  if (!adminDb) return [];
+  const field = type === "sent" ? "fromUserId" : "toUserId";
+  const snapshot = await adminDb
+    .collection(COLLECTIONS.REQUESTS)
+    .where(field, "==", userId)
+    .orderBy("createdAt", "desc")
+    .get();
+  return snapshot.docs.map((d) => ({
+    id: d.id,
+    ...d.data(),
+  })) as PairRequest[];
+}
+
+export async function respondToPairRequestServer(
+  requestId: string,
+  userId: string,
+  action: "accept" | "decline"
+): Promise<{ status: RequestStatus; sessionId?: string }> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+
+  // Use a transaction to prevent race conditions
+  return adminDb.runTransaction(async (transaction) => {
+    const requestRef = adminDb.collection(COLLECTIONS.REQUESTS).doc(requestId);
+    const requestDoc = await transaction.get(requestRef);
+
+    if (!requestDoc.exists) {
+      throw new Error("Request not found");
+    }
+
+    const requestData = requestDoc.data()!;
+
+    if (requestData.toUserId !== userId) {
+      throw new Error("Unauthorized");
+    }
+
+    if (requestData.status !== "pending") {
+      throw new Error("Request has already been responded to");
+    }
+
+    const newStatus: RequestStatus = action === "accept" ? "accepted" : "declined";
+    transaction.update(requestRef, {
+      status: newStatus,
+      updatedAt: new Date(),
+    });
+
+    let sessionId: string | undefined;
+    if (action === "accept") {
+      const sessionRef = adminDb.collection(COLLECTIONS.SESSIONS).doc();
+      transaction.set(sessionRef, {
+        participantIds: [requestData.fromUserId, userId],
+        sessionType: requestData.sessionType,
+        status: "scheduled",
+        scheduledTime: requestData.proposedTime || null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      sessionId = sessionRef.id;
+    }
+
+    return { status: newStatus, sessionId };
+  });
+}

--- a/lib/pair-programming/data.ts
+++ b/lib/pair-programming/data.ts
@@ -1,0 +1,72 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  updateDoc,
+  query,
+  where,
+  orderBy,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type {
+  PairProfile,
+  PairSession,
+} from "./types";
+
+// Collection names
+const COLLECTIONS = {
+  PROFILES: "pair_profiles",
+  SESSIONS: "pair_sessions",
+} as const;
+
+// ─── Client-side Firestore operations ───────────────────────────────────────
+
+export async function getPairProfile(userId: string): Promise<PairProfile | null> {
+  if (!db) return null;
+  const docRef = doc(db, COLLECTIONS.PROFILES, userId);
+  const docSnap = await getDoc(docRef);
+  if (!docSnap.exists()) return null;
+  return { ...docSnap.data(), userId: docSnap.id } as PairProfile;
+}
+
+export async function getAllActiveProfiles(): Promise<PairProfile[]> {
+  if (!db) return [];
+  const q = query(
+    collection(db, COLLECTIONS.PROFILES),
+    where("isActive", "==", true),
+    orderBy("updatedAt", "desc")
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => ({
+    ...d.data(),
+    userId: d.id,
+  })) as PairProfile[];
+}
+
+export async function getPairSessionsForUser(userId: string): Promise<PairSession[]> {
+  if (!db) return [];
+  const q = query(
+    collection(db, COLLECTIONS.SESSIONS),
+    where("participantIds", "array-contains", userId),
+    orderBy("createdAt", "desc")
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => ({
+    id: d.id,
+    ...d.data(),
+  })) as PairSession[];
+}
+
+export async function updatePairSession(
+  sessionId: string,
+  updates: Partial<PairSession>
+): Promise<void> {
+  if (!db) throw new Error("Firestore not initialized");
+  const docRef = doc(db, COLLECTIONS.SESSIONS, sessionId);
+  await updateDoc(docRef, {
+    ...updates,
+    updatedAt: serverTimestamp(),
+  });
+}

--- a/lib/pair-programming/matching.ts
+++ b/lib/pair-programming/matching.ts
@@ -1,0 +1,207 @@
+import type { PairProfile, MatchScore } from "./types";
+
+/**
+ * Calculate match score between two profiles based on complementary skills
+ * Returns a score from 0-100 and reasons for the match
+ */
+export function calculateMatchScore(
+  profile1: PairProfile,
+  profile2: PairProfile
+): MatchScore {
+  let score = 0;
+  const reasons: string[] = [];
+
+  // Skill complementarity (highest weight)
+  // Check if profile1 can teach what profile2 wants to learn
+  const teachMatches = profile1.skillsCanTeach.filter((skill) =>
+    profile2.skillsWantToLearn.some((wanted) =>
+      normalizeSkill(skill) === normalizeSkill(wanted)
+    )
+  );
+  // Check if profile2 can teach what profile1 wants to learn
+  const learnMatches = profile2.skillsCanTeach.filter((skill) =>
+    profile1.skillsWantToLearn.some((wanted) =>
+      normalizeSkill(skill) === normalizeSkill(wanted)
+    )
+  );
+
+  const totalMatches = teachMatches.length + learnMatches.length;
+  const skillScore = Math.min(50, totalMatches * 10); // Max 50 points
+  score += skillScore;
+
+  if (teachMatches.length > 0) {
+    reasons.push(
+      `You can teach ${teachMatches.join(", ")} - they want to learn it`
+    );
+  }
+  if (learnMatches.length > 0) {
+    reasons.push(
+      `They can teach ${learnMatches.join(", ")} - you want to learn it`
+    );
+  }
+
+  // Language/framework overlap (medium weight)
+  const languageOverlap = profile1.preferredLanguages.filter((lang) =>
+    profile2.preferredLanguages.includes(lang)
+  ).length;
+  const frameworkOverlap = profile1.preferredFrameworks.filter((fw) =>
+    profile2.preferredFrameworks.includes(fw)
+  ).length;
+  const overlapScore = Math.min(20, (languageOverlap + frameworkOverlap) * 5);
+  score += overlapScore;
+
+  if (languageOverlap > 0 || frameworkOverlap > 0) {
+    const common = [
+      ...profile1.preferredLanguages.filter((l) =>
+        profile2.preferredLanguages.includes(l)
+      ),
+      ...profile1.preferredFrameworks.filter((f) =>
+        profile2.preferredFrameworks.includes(f)
+      ),
+    ];
+    if (common.length > 0) {
+      reasons.push(`Shared interests: ${common.join(", ")}`);
+    }
+  }
+
+  // Session type overlap (low weight)
+  const sessionTypeOverlap = profile1.sessionTypes.filter((type) =>
+    profile2.sessionTypes.includes(type)
+  ).length;
+  const sessionScore = Math.min(15, sessionTypeOverlap * 5);
+  score += sessionScore;
+
+  if (sessionTypeOverlap > 0) {
+    const commonTypes = profile1.sessionTypes.filter((type) =>
+      profile2.sessionTypes.includes(type)
+    );
+    reasons.push(`Both interested in: ${commonTypes.join(", ")}`);
+  }
+
+  // Timezone compatibility (low weight)
+  // Simple check: same timezone = bonus, different = small penalty
+  if (profile1.timezone === profile2.timezone) {
+    score += 10;
+    reasons.push("Same timezone - easier scheduling");
+  } else {
+    // Check if timezones are close (within 3 hours)
+    const tzDiff = getTimezoneDifference(profile1.timezone, profile2.timezone);
+    if (tzDiff !== null && Math.abs(tzDiff) <= 3) {
+      score += 5;
+      reasons.push("Similar timezone - scheduling should work");
+    }
+  }
+
+  // Availability overlap (medium weight)
+  const availabilityScore = calculateAvailabilityOverlap(
+    profile1.availability,
+    profile2.availability
+  );
+  score += availabilityScore;
+
+  if (availabilityScore > 0) {
+    reasons.push("Overlapping availability windows");
+  }
+
+  // Cap at 100
+  score = Math.min(100, Math.round(score));
+
+  return {
+    userId: profile2.userId,
+    score,
+    reasons: reasons.length > 0 ? reasons : ["Potential match based on profiles"],
+  };
+}
+
+/**
+ * Normalize skill names for comparison (case-insensitive, trim whitespace)
+ */
+function normalizeSkill(skill: string): string {
+  return skill.toLowerCase().trim();
+}
+
+/**
+ * Get timezone difference in hours (simplified - doesn't handle DST)
+ * Returns null if timezones can't be parsed
+ */
+function getTimezoneDifference(tz1: string, tz2: string): number | null {
+  try {
+    // Simple approach: extract UTC offset if present
+    // This is a simplified version - in production you'd use a proper timezone library
+    const now = new Date();
+    const date1 = new Date(
+      now.toLocaleString("en-US", { timeZone: tz1 })
+    );
+    const date2 = new Date(
+      now.toLocaleString("en-US", { timeZone: tz2 })
+    );
+    return (date2.getTime() - date1.getTime()) / (1000 * 60 * 60);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calculate availability overlap score (0-15 points)
+ */
+function calculateAvailabilityOverlap(
+  avail1: PairProfile["availability"],
+  avail2: PairProfile["availability"]
+): number {
+  if (avail1.length === 0 || avail2.length === 0) return 0;
+
+  let overlapCount = 0;
+  for (const window1 of avail1) {
+    for (const window2 of avail2) {
+      if (window1.dayOfWeek === window2.dayOfWeek) {
+        // Check if time ranges overlap
+        if (timeRangesOverlap(window1.startTime, window1.endTime, window2.startTime, window2.endTime)) {
+          overlapCount++;
+        }
+      }
+    }
+  }
+
+  // Score based on number of overlapping windows
+  return Math.min(15, overlapCount * 3);
+}
+
+/**
+ * Check if two time ranges overlap
+ */
+function timeRangesOverlap(
+  start1: string,
+  end1: string,
+  start2: string,
+  end2: string
+): boolean {
+  const [h1, m1] = start1.split(":").map(Number);
+  const [h2, m2] = end1.split(":").map(Number);
+  const [h3, m3] = start2.split(":").map(Number);
+  const [h4, m4] = end2.split(":").map(Number);
+
+  const time1Start = h1 * 60 + m1;
+  const time1End = h2 * 60 + m2;
+  const time2Start = h3 * 60 + m3;
+  const time2End = h4 * 60 + m4;
+
+  return time1Start < time2End && time2Start < time1End;
+}
+
+/**
+ * Get top matches for a user profile
+ */
+export async function getTopMatches(
+  userProfile: PairProfile,
+  allProfiles: PairProfile[],
+  limit: number = 10
+): Promise<MatchScore[]> {
+  const matches = allProfiles
+    .filter((p) => p.userId !== userProfile.userId && p.isActive)
+    .map((profile) => calculateMatchScore(userProfile, profile))
+    .filter((match) => match.score > 0) // Only include matches with score > 0
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  return matches;
+}

--- a/lib/pair-programming/types.ts
+++ b/lib/pair-programming/types.ts
@@ -1,0 +1,74 @@
+import type { Timestamp } from "firebase/firestore";
+
+export type SessionType = "teach-me" | "build-together" | "code-review" | "explore-topic";
+
+export type RequestStatus = "pending" | "accepted" | "declined" | "cancelled";
+
+export interface PairProfile {
+  userId: string;
+  // Skills user can teach
+  skillsCanTeach: string[];
+  // Skills user wants to learn
+  skillsWantToLearn: string[];
+  // Preferred languages/frameworks
+  preferredLanguages: string[];
+  preferredFrameworks: string[];
+  // Timezone (e.g., "America/New_York")
+  timezone: string;
+  // Availability windows (day of week + time ranges)
+  availability: AvailabilityWindow[];
+  // Session types user is interested in
+  sessionTypes: SessionType[];
+  // Optional bio/notes
+  bio?: string;
+  // When profile was created/updated
+  createdAt: Timestamp | Date;
+  updatedAt: Timestamp | Date;
+  // Whether profile is active (opt-in)
+  isActive: boolean;
+}
+
+export interface AvailabilityWindow {
+  dayOfWeek: number; // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+  startTime: string; // HH:mm format (e.g., "09:00")
+  endTime: string; // HH:mm format (e.g., "17:00")
+}
+
+export interface PairRequest {
+  id?: string;
+  fromUserId: string;
+  toUserId: string;
+  sessionType: SessionType;
+  message: string;
+  status: RequestStatus;
+  createdAt: Timestamp | Date;
+  updatedAt: Timestamp | Date;
+  // Optional proposed time
+  proposedTime?: Timestamp | Date;
+}
+
+export interface PairSession {
+  id?: string;
+  participantIds: string[]; // Array of 2 user IDs
+  sessionType: SessionType;
+  status: "scheduled" | "in-progress" | "completed" | "cancelled";
+  scheduledTime?: Timestamp | Date;
+  startedAt?: Timestamp | Date;
+  completedAt?: Timestamp | Date;
+  // Per-participant session notes keyed by participantId
+  notes?: Record<string, SessionNotes>;
+  createdAt: Timestamp | Date;
+  updatedAt: Timestamp | Date;
+}
+
+export interface SessionNotes {
+  whatWeWorkedOn: string;
+  whatILearned: string;
+  nextSteps?: string;
+}
+
+export interface MatchScore {
+  userId: string;
+  score: number; // 0-100
+  reasons: string[]; // Why they matched (e.g., "You teach React, they want to learn React")
+}


### PR DESCRIPTION
## Summary
- Implements pair programming matchmaker feature with skill-based matching, request system, and session management (addresses #80)
- Separates client and server data layers to prevent firebase-admin from bundling into client components
- All API routes use server-side firebase-admin SDK with proper auth verification
- Respond route uses Firestore transaction to prevent race conditions on concurrent accept/decline
- Per-participant session notes (both users can independently save their notes)

Supersedes #95 — reimplemented with critical fixes for security, architecture, and code quality.

### Key fixes from PR #95 review:
- **Security**: API routes no longer use client-side Firestore; all mutations go through firebase-admin
- **Race conditions**: Accept/decline uses Firestore transaction
- **Input validation**: Max lengths, type checking, array bounds on all API routes
- **Code quality**: `img` → `next/image`, `onKeyPress` → `onKeyDown`, `window.location.reload()` → React state, removed dead code
- **Architecture**: Split `data.ts` (client) / `data-server.ts` (server) to fix Next.js build errors

## Test plan
- [ ] Create pair programming profile with skills, languages, frameworks
- [ ] View matches based on complementary skills
- [ ] Send pair request with message and session type
- [ ] Accept/decline received requests
- [ ] Start and complete pair sessions with notes
- [ ] Navigation link appears in desktop and mobile menus
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)