### PR TITLE
fix: reject requests without Origin/Referer in production CSRF check

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -35,13 +35,8 @@ export function isOriginAllowed(request: NextRequest): boolean {
 
   // If no origin header, check referer (some browsers don't send origin)
   if (!origin && !referer) {
-    // Allow requests without origin/referer in development
-    if (process.env.NODE_ENV === "development") {
-      return true;
-    }
-    // In production, requests from the same origin may not have origin header
-    // This is less restrictive but acceptable for API routes using Bearer tokens
-    return true;
+    // Allow requests without origin/referer in development only
+    return process.env.NODE_ENV === "development";
   }
 
   // Check if origin matches allowed list


### PR DESCRIPTION
## Summary
- Fixes #106
- In production, requests to state-changing API routes that lack both Origin and Referer headers are now rejected instead of silently allowed.
- Development mode continues to allow such requests for local testing convenience.

## Test plan
- [ ] Verify that POST/PUT/DELETE requests without Origin and Referer headers are rejected (403) in production
- [ ] Verify that such requests still succeed in development (NODE_ENV=development)
- [ ] Verify that requests with valid Origin or Referer headers continue to work in all environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)