### PR TITLE
fix: expose error state from useFeed hook for UI feedback

### DIFF
--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -23,6 +23,9 @@ export function useFeed(user: User | null, isActive: boolean) {
   const [repostingMessage, setRepostingMessage] = useState<Message | null>(null);
   const [repostComment, setRepostComment] = useState("");
 
+  const [error, setError] = useState<string | null>(null);
+  const clearError = useCallback(() => setError(null), []);
+
   // Subscribe to real-time messages when feed tab is active
   useEffect(() => {
     if (!isActive || !db) return;
@@ -128,6 +131,7 @@ export function useFeed(user: User | null, isActive: boolean) {
       ]);
       setNewMessage("");
     } catch (error) {
+      setError("Failed to post message. Please try again.");
       console.error("Error posting message:", error);
     } finally {
       setPosting(false);
@@ -149,6 +153,7 @@ export function useFeed(user: User | null, isActive: boolean) {
         return updated;
       });
     } catch (error) {
+      setError("Failed to delete message. Please try again.");
       console.error("Error deleting message:", error);
     }
   };
@@ -312,6 +317,7 @@ export function useFeed(user: User | null, isActive: boolean) {
       setReplyingTo(null);
       setExpandedReplies((prev) => new Set([...Array.from(prev), parentId]));
     } catch (error) {
+      setError("Failed to post reply. Please try again.");
       console.error("Error posting reply:", error);
     } finally {
       setPostingReply(false);
@@ -361,6 +367,7 @@ export function useFeed(user: User | null, isActive: boolean) {
       setRepostingMessage(null);
       setRepostComment("");
     } catch (error) {
+      setError("Failed to repost. Please try again.");
       console.error("Error reposting:", error);
     } finally {
       setPosting(false);
@@ -382,6 +389,8 @@ export function useFeed(user: User | null, isActive: boolean) {
   return {
     messages,
     loading,
+    error,
+    clearError,
     newMessage,
     setNewMessage,
     posting,


### PR DESCRIPTION
## Summary
- Adds `error` state (`string | null`) and `clearError` callback to the `useFeed` hook
- Sets descriptive error messages in the `catch` blocks of `postMessage`, `deleteMessage`, `postReply`, and `repostMessage`
- Exposes `error` and `clearError` in the hook's return object so consuming UI components can display and dismiss error messages

Fixes #115

## Test plan
- [ ] Simulate a network failure or API error during post, delete, reply, and repost operations
- [ ] Verify the `error` state is set with the correct message for each operation
- [ ] Verify calling `clearError()` resets the error state to `null`
- [ ] Verify that successful operations do not set error state
- [ ] Verify TypeScript compilation passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)