### PR TITLE
fix: prevent getInitials crash on whitespace-only names

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -32,15 +32,17 @@ function getInitials(
   name: string | null | undefined,
   email: string | null | undefined
 ): string {
-  if (name) {
-    const parts = name.trim().split(/\s+/);
+  const trimmedName = name?.trim();
+  if (trimmedName) {
+    const parts = trimmedName.split(/\s+/);
     if (parts.length >= 2) {
       return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
     }
-    return name[0].toUpperCase();
+    return trimmedName[0].toUpperCase();
   }
-  if (email) {
-    return email[0].toUpperCase();
+  const trimmedEmail = email?.trim();
+  if (trimmedEmail) {
+    return trimmedEmail[0].toUpperCase();
   }
   return "?";
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,14 +12,13 @@ export function cn(...classes: (string | undefined | null | false)[]): string {
  * Returns first letter of first and last name, or single letter if only one word.
  */
 export function getInitials(name: string | null | undefined): string {
-  if (name) {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length >= 2) {
-      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-    }
-    return name[0].toUpperCase();
+  const trimmed = name?.trim();
+  if (!trimmed) return "?";
+  const parts = trimmed.split(/\s+/);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
   }
-  return "?";
+  return trimmed[0].toUpperCase();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes #117. Trims the name before checking truthiness, preventing crashes when name is whitespace-only (truthy but empty after trim).
- Fixed in both `lib/utils.ts` and `components/Avatar.tsx`.
- Also added trimming for the email fallback in `Avatar.tsx` for consistency.

## Test plan
- [ ] Pass `"   "` (whitespace-only string) as `name` to `getInitials()` — should return `"?"` instead of crashing
- [ ] Pass `""` (empty string) — should return `"?"`
- [ ] Pass `null` / `undefined` — should return `"?"`
- [ ] Pass normal names like `"John Doe"` — should return `"JD"`
- [ ] Pass single-word name like `"Alice"` — should return `"A"`
- [ ] Verify Avatar component renders fallback initials correctly with whitespace-only names

🤖 Generated with [Claude Code](https://claude.com/claude-code)