### PR TITLE
fix: guard MemberCard against null/invalid createdAt field

### DIFF
--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -243,7 +243,7 @@ export function MemberCard({ member }: MemberCardProps) {
             </svg>
           </a>
         )}
-        {v?.showMemberSince && member.createdAt && (
+        {v?.showMemberSince && member.createdAt && typeof member.createdAt.toDate === "function" && (
           <span className="text-neutral-400 text-xs ml-auto">
             Member since{" "}
             {member.createdAt.toDate().toLocaleDateString("en-US", {


### PR DESCRIPTION
## Summary
- Fixes #116
- Adds a `typeof member.createdAt.toDate === "function"` check before calling `.toDate()`, preventing runtime crashes when a member document has a missing or malformed `createdAt` field.

## Test plan
- [ ] Verify MemberCard renders correctly for members with a valid `createdAt` Firestore Timestamp
- [ ] Verify MemberCard does not crash when `createdAt` is `null`, `undefined`, or a plain object without a `toDate` method
- [ ] Confirm the "Member since" label is hidden when `createdAt` is invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)