### PR TITLE
fix: reject pair programming requests with past or invalid proposed times

### DIFF
--- a/app/api/pair/request/route.ts
+++ b/app/api/pair/request/route.ts
@@ -99,6 +99,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (proposedTime) {
+      const parsedTime = new Date(proposedTime);
+      if (isNaN(parsedTime.getTime())) {
+        return NextResponse.json(
+          { success: false, error: "Invalid proposed time format" },
+          { status: 400 }
+        );
+      }
+      if (parsedTime.getTime() < Date.now()) {
+        return NextResponse.json(
+          { success: false, error: "Proposed time must be in the future" },
+          { status: 400 }
+        );
+      }
+    }
+
     const requestId = await createPairRequestServer({
       fromUserId: user.uid,
       toUserId,


### PR DESCRIPTION
## Summary
- Adds validation for `proposedTime` in the pair programming request API (`POST /api/pair/request`)
- Returns 400 with `"Invalid proposed time format"` if the date string cannot be parsed
- Returns 400 with `"Proposed time must be in the future"` if the parsed date is in the past

Fixes #119

## Test plan
- [ ] Send a pair request with a past `proposedTime` and verify a 400 response with error `"Proposed time must be in the future"`
- [ ] Send a pair request with an invalid `proposedTime` string (e.g. `"not-a-date"`) and verify a 400 response with error `"Invalid proposed time format"`
- [ ] Send a pair request with a valid future `proposedTime` and verify it succeeds
- [ ] Send a pair request with no `proposedTime` and verify it still succeeds (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)