### PR TITLE
fix: penalize empty profiles in pair programming matching algorithm

### DIFF
--- a/lib/pair-programming/matching.ts
+++ b/lib/pair-programming/matching.ts
@@ -103,6 +103,15 @@ export function calculateMatchScore(
     reasons.push("Overlapping availability windows");
   }
 
+  // Penalize empty profiles — profiles with no skills listed get reduced scores
+  const profile2SkillCount = profile2.skillsCanTeach.length + profile2.skillsWantToLearn.length;
+  if (profile2SkillCount === 0) {
+    score = Math.round(score * 0.3); // 70% penalty for completely empty skill profiles
+    reasons.push("Limited profile — fewer skills listed");
+  } else if (profile2SkillCount < 2) {
+    score = Math.round(score * 0.6); // 40% penalty for very sparse profiles
+  }
+
   // Cap at 100
   score = Math.min(100, Math.round(score));
 


### PR DESCRIPTION
## Summary
- Fixes #118. Adds a profile completeness penalty to the pair programming matching algorithm.
- Profiles with **no skills** listed (both `skillsCanTeach` and `skillsWantToLearn` empty) receive a **70% score reduction**.
- Profiles with **fewer than 2 skills** total receive a **40% score reduction**.
- This prevents empty profiles from ranking higher than detailed ones based solely on timezone/availability bonuses.

## Test plan
- [ ] Verify that a profile with 0 skills gets its score multiplied by 0.3 and a "Limited profile" reason is added
- [ ] Verify that a profile with exactly 1 skill gets its score multiplied by 0.6
- [ ] Verify that profiles with 2+ skills are unaffected by the penalty
- [ ] Verify the score cap at 100 still applies after the penalty
- [ ] Run existing matching tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)