### PR TITLE
fix: add standardized API error/success response helpers

### DIFF
--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Standard error codes for API responses.
+ */
+export const ErrorCode = {
+  UNAUTHORIZED: "UNAUTHORIZED",
+  FORBIDDEN: "FORBIDDEN",
+  NOT_FOUND: "NOT_FOUND",
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  RATE_LIMITED: "RATE_LIMITED",
+  CONFLICT: "CONFLICT",
+  SERVER_ERROR: "SERVER_ERROR",
+  NOT_CONFIGURED: "NOT_CONFIGURED",
+} as const;
+
+export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/**
+ * Create a standardized error response.
+ */
+export function apiError(
+  message: string,
+  status: number,
+  code?: ErrorCodeType
+): NextResponse {
+  return NextResponse.json(
+    {
+      success: false,
+      error: {
+        message,
+        code: code ?? inferErrorCode(status),
+      },
+    },
+    { status }
+  );
+}
+
+/**
+ * Create a standardized success response.
+ */
+export function apiSuccess<T extends Record<string, unknown>>(
+  data: T,
+  status: number = 200
+): NextResponse {
+  return NextResponse.json({ success: true, ...data }, { status });
+}
+
+function inferErrorCode(status: number): ErrorCodeType {
+  switch (status) {
+    case 401:
+      return ErrorCode.UNAUTHORIZED;
+    case 403:
+      return ErrorCode.FORBIDDEN;
+    case 404:
+      return ErrorCode.NOT_FOUND;
+    case 409:
+      return ErrorCode.CONFLICT;
+    case 429:
+      return ErrorCode.RATE_LIMITED;
+    default:
+      return status >= 400 && status < 500
+        ? ErrorCode.VALIDATION_ERROR
+        : ErrorCode.SERVER_ERROR;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #120
- Adds `lib/api-response.ts` with `apiError()` and `apiSuccess()` helpers that enforce a consistent JSON response format across all API routes
- Includes a standard `ErrorCode` enum and automatic status-to-code inference
- New routes should use these helpers; existing routes can be migrated incrementally

## Test plan
- [ ] Verify `apiError()` returns `{ success: false, error: { message, code } }` with the correct HTTP status
- [ ] Verify `apiSuccess()` returns `{ success: true, ...data }` with the correct HTTP status
- [ ] Verify `inferErrorCode()` maps status codes to the expected error codes
- [ ] Confirm TypeScript compilation passes (`tsc --noEmit`)
- [ ] Confirm ESLint passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)