### PR TITLE
fix: raise test coverage threshold from 0% to 5% baseline

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -31,13 +31,13 @@ const customJestConfig = {
     '**/__tests__/**/*.[jt]s?(x)',
     '**/?(*.)+(spec|test).[jt]s?(x)',
   ],
-  // Coverage thresholds - set to current baseline; increase as tests are added
+  // Coverage thresholds - enforce a minimum baseline; increase as tests are added
   coverageThreshold: {
     global: {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0,
+      branches: 5,
+      functions: 5,
+      lines: 5,
+      statements: 5,
     },
   },
   // Generate JSON summary for CI coverage checks


### PR DESCRIPTION
Fixes #121. Raises coverage thresholds from 0% to 5% as a starting baseline. This ensures the test suite will fail if coverage drops below the minimum, preventing silent regression. The threshold should be ratcheted up as more tests are added.