### PR TITLE
fix: fall back to initials when Avatar image fails to load

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Image from "next/image";
 
 interface AvatarProps {
@@ -66,11 +67,12 @@ export default function Avatar({
   size = "xl",
   className = "",
 }: AvatarProps) {
+  const [imgError, setImgError] = useState(false);
   const identifier = email || name || "user";
   const initials = getInitials(name, email);
   const gradient = getGradient(identifier);
 
-  if (src) {
+  if (src && !imgError) {
     return (
       <Image
         src={src}
@@ -78,6 +80,7 @@ export default function Avatar({
         width={imageSizes[size]}
         height={imageSizes[size]}
         className={`rounded-full object-cover ${sizeClasses[size].split(" ").slice(0, 2).join(" ")} ${className}`}
+        onError={() => setImgError(true)}
       />
     );
   }


### PR DESCRIPTION
## Summary
- Adds `useState` hook to track image load errors in the `Avatar` component
- Attaches an `onError` handler to the `<Image>` element that sets the error flag
- When an image fails to load, the component gracefully falls back to showing initials instead of a broken image icon

Fixes #124

## Test plan
- [ ] Verify Avatar renders correctly with a valid image URL
- [ ] Verify Avatar falls back to initials when given an invalid/broken image URL
- [ ] Verify Avatar still shows initials when no `src` prop is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)