### PR TITLE
fix: use typed error classes instead of string matching in pair respond handler

### DIFF
--- a/lib/pair-programming/data-server.ts
+++ b/lib/pair-programming/data-server.ts
@@ -5,6 +5,17 @@ import type {
   RequestStatus,
 } from "./types";
 
+/** Custom error classes for typed error handling in API routes */
+export class PairRequestNotFoundError extends Error {
+  constructor() { super("Request not found"); this.name = "PairRequestNotFoundError"; }
+}
+export class PairRequestUnauthorizedError extends Error {
+  constructor() { super("Unauthorized"); this.name = "PairRequestUnauthorizedError"; }
+}
+export class PairRequestAlreadyRespondedError extends Error {
+  constructor() { super("Request has already been responded to"); this.name = "PairRequestAlreadyRespondedError"; }
+}
+
 // Collection names
 const COLLECTIONS = {
   PROFILES: "pair_profiles",
@@ -108,17 +119,17 @@ export async function respondToPairRequestServer(
     const requestDoc = await transaction.get(requestRef);
 
     if (!requestDoc.exists) {
-      throw new Error("Request not found");
+      throw new PairRequestNotFoundError();
     }
 
     const requestData = requestDoc.data()!;
 
     if (requestData.toUserId !== userId) {
-      throw new Error("Unauthorized");
+      throw new PairRequestUnauthorizedError();
     }
 
     if (requestData.status !== "pending") {
-      throw new Error("Request has already been responded to");
+      throw new PairRequestAlreadyRespondedError();
     }
 
     const newStatus: RequestStatus = action === "accept" ? "accepted" : "declined";


### PR DESCRIPTION
## Summary
- Adds custom error classes (`PairRequestNotFoundError`, `PairRequestUnauthorizedError`, `PairRequestAlreadyRespondedError`) to `lib/pair-programming/data-server.ts`
- Replaces fragile string-based error message matching in the `app/api/pair/respond/route.ts` catch block with `instanceof` checks

Fixes #126.

## Test plan
- [ ] Verify that responding to a non-existent pair request returns 404
- [ ] Verify that responding to another user's request returns 403
- [ ] Verify that responding to an already-responded request returns 400
- [ ] Verify that unexpected errors still return 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)