### PR TITLE
fix(nav): rebalance header spacing and prevent horizontal overflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,12 +19,18 @@
 
 html {
   scroll-behavior: smooth;
+  max-width: 100%;
+  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 body {
   background-color: var(--background);
   color: var(--foreground);
   font-feature-settings: "rlig" 1, "calt" 1;
+  max-width: 100%;
+  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* Selection color */
@@ -109,10 +115,6 @@ img {
     min-height: 44px;
   }
   
-  /* Prevent horizontal scroll */
-  body {
-    overflow-x: hidden;
-  }
 }
 
 /* Prevent iOS zoom on input focus (requires 16px font) */

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -26,7 +26,7 @@ export default function Navigation() {
 
   return (
     <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-neutral-200 dark:border-neutral-800 transition-colors duration-300">
-      <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
+      <div className="w-full px-4 md:px-6 h-16 flex items-center">
         {/* Logo: 44px min touch target (WCAG 2.1) */}
         <Link
           href="/"
@@ -54,7 +54,7 @@ export default function Navigation() {
         </Link>
 
         {/* Desktop Nav */}
-        <nav aria-label="Main" className="hidden xl:flex items-center space-x-8 ml-12">
+        <nav aria-label="Main" className="hidden xl:flex items-center gap-6 ml-8 flex-1 min-w-0">
           <Link href="/events" className={buildNavClass("/events")}>Events</Link>
           <Link href="/map" className={buildNavClass("/map")}>Map</Link>
           <Link href="/talks" className={buildNavClass("/talks")}>Talks</Link>
@@ -68,11 +68,8 @@ export default function Navigation() {
           <Link href="/about" className={buildNavClass("/about")}>About</Link>
         </nav>
 
-        {/* Spacer */}
-        <div className="hidden xl:block flex-1" />
-
         {/* Desktop Auth */}
-        <div className="hidden xl:flex items-center shrink-0 gap-4">
+        <div className="hidden xl:flex items-center shrink-0 gap-4 pl-6">
           <ThemeToggle />
           {loading ? (
             <div className="w-8 h-8 rounded-full bg-neutral-200 dark:bg-neutral-800 animate-pulse" />
@@ -104,7 +101,7 @@ export default function Navigation() {
         </div>
 
         {/* Mobile menu button */}
-        <div className="flex items-center gap-4 xl:hidden">
+        <div className="ml-auto flex items-center gap-4 xl:hidden">
           <ThemeToggle />
           <button
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
@@ -129,7 +126,7 @@ export default function Navigation() {
       {/* Mobile menu */}
       {mobileMenuOpen && (
         <div id="mobile-menu" className="xl:hidden border-t border-neutral-200 dark:border-neutral-800 bg-background">
-          <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="w-full px-4 md:px-6 py-4">
             {/* Menu closes via the pathname useEffect — onClick handlers not needed on nav links */}
             <nav aria-label="Mobile" className="flex flex-col space-y-1">
               <Link href="/events" className={buildNavClass("/events", true)}>Events</Link>


### PR DESCRIPTION
## Summary
This PR fixes two UX/layout issues:
- Rebalances desktop header spacing so nav is not crowded on the right.
- Prevents page-level horizontal overflow by guarding overflow-x at the root.

## Changes
- Updated components/Navigation.tsx:
  - Made the header row full-width and left-anchored.
  - Made desktop nav the flexible middle lane (flex-1 min-w-0).
  - Removed spacer-driven skew and tuned right-side auth spacing.
  - Kept mobile controls aligned using ml-auto.
  - Matched mobile menu container width/padding strategy.
- Updated app/globals.css:
  - Added root-level horizontal overflow protection on html and body.
  - Included overflow-x: hidden fallback plus overflow-x: clip.
  - Removed redundant mobile-only body overflow rule.

## Validation
- Local type-check/lint hooks passed on commit.
- Dev server starts and layout changes are available at localhost:3000.

## Issue Context
This repository currently has GitHub Issues disabled, so no issue could be created programmatically. This PR includes full problem statement and acceptance criteria from the requested issue flow.

## Acceptance Criteria
- No page-level horizontal scrollbar on desktop/mobile for normal routes.
- Header appears balanced with nav links not congested on the right.
- Mobile menu behavior remains intact.
- Intentional local horizontal scrollers remain functional.
