### PR TITLE
Add badge foundation: types, definitions, data contract, and eligibility logic

### DIFF
--- a/__tests__/lib/badges/eligibility.test.ts
+++ b/__tests__/lib/badges/eligibility.test.ts
@@ -1,0 +1,127 @@
+import {
+  normalizeBadgeEligibilityInput,
+  evaluateBadgeEligibility,
+} from "@/lib/badges/eligibility";
+
+describe("badge eligibility", () => {
+  describe("normalizeBadgeEligibilityInput", () => {
+    it("normalizes missing fields to false/0", () => {
+      expect(normalizeBadgeEligibilityInput({})).toEqual({
+        hasDisplayName: false,
+        isPublicProfile: false,
+        hasDiscordConnected: false,
+        hasGithubConnected: false,
+        eventsAttendedCount: 0,
+        talksGivenCount: 0,
+        pullRequestsCount: 0,
+        communityPostsCount: 0,
+        hackathonParticipationCount: 0,
+        showcaseSubmissionsCount: 0,
+        mentorMatchesCount: 0,
+      });
+    });
+  });
+
+  describe("first-steps", () => {
+    it("is eligible when display name and public profile are both true", () => {
+      const result = evaluateBadgeEligibility({
+        hasDisplayName: true,
+        isPublicProfile: true,
+      });
+
+      expect(result["first-steps"].isEligible).toBe(true);
+    });
+
+    it("is ineligible with partial completion and reports 1/2 progress + reason", () => {
+      const result = evaluateBadgeEligibility({
+        hasDisplayName: true,
+        isPublicProfile: false,
+      });
+
+      expect(result["first-steps"].isEligible).toBe(false);
+      expect(result["first-steps"].progress).toEqual({
+        current: 1,
+        target: 2,
+        unit: "steps",
+      });
+      expect(result["first-steps"].reason).toBe(
+        "Add a display name and make your profile public."
+      );
+    });
+  });
+
+  describe("connected", () => {
+    it("is eligible only when both Discord and GitHub are connected", () => {
+      expect(
+        evaluateBadgeEligibility({
+          hasDiscordConnected: true,
+          hasGithubConnected: true,
+        }).connected.isEligible
+      ).toBe(true);
+
+      expect(
+        evaluateBadgeEligibility({
+          hasDiscordConnected: true,
+          hasGithubConnected: false,
+        }).connected.isEligible
+      ).toBe(false);
+    });
+
+    it("reports 1/2 progress for partial connection", () => {
+      const result = evaluateBadgeEligibility({
+        hasDiscordConnected: true,
+        hasGithubConnected: false,
+      });
+
+      expect(result.connected.progress).toEqual({
+        current: 1,
+        target: 2,
+        unit: "connections",
+      });
+    });
+  });
+
+  describe("speaker", () => {
+    it("is eligible at 1 talk and caps progress at 1", () => {
+      const eligible = evaluateBadgeEligibility({ talksGivenCount: 1 });
+      const capped = evaluateBadgeEligibility({ talksGivenCount: 5 });
+
+      expect(eligible.speaker.isEligible).toBe(true);
+      expect(capped.speaker.progress).toEqual({
+        current: 1,
+        target: 1,
+        unit: "talks",
+      });
+    });
+  });
+
+  describe("regular", () => {
+    it("is ineligible at 2 events and eligible at 3 with target 3", () => {
+      const atTwo = evaluateBadgeEligibility({ eventsAttendedCount: 2 });
+      const atThree = evaluateBadgeEligibility({ eventsAttendedCount: 3 });
+
+      expect(atTwo.regular.isEligible).toBe(false);
+      expect(atThree.regular.isEligible).toBe(true);
+      expect(atTwo.regular.progress?.target).toBe(3);
+    });
+  });
+
+  describe("contributor", () => {
+    it("is eligible at 1 pull request and has no reason when eligible", () => {
+      const result = evaluateBadgeEligibility({ pullRequestsCount: 1 });
+
+      expect(result.contributor.isEligible).toBe(true);
+      expect(result.contributor.reason).toBeUndefined();
+    });
+  });
+
+  describe("default input safety", () => {
+    it("does not accidentally award badges for missing values", () => {
+      const result = evaluateBadgeEligibility({});
+
+      expect(Object.values(result).every((badge) => badge.isEligible === false)).toBe(
+        true
+      );
+    });
+  });
+});

--- a/lib/badges/data.ts
+++ b/lib/badges/data.ts
@@ -1,0 +1,81 @@
+import {
+  BadgeDefinition,
+  BadgeId,
+  BadgeCategory,
+  BadgeAwardSource,
+  UserBadge,
+} from "./types";
+
+/**
+ * Firestore collection names
+ */
+export const BADGES_COLLECTION = "badges";
+export const USER_BADGES_COLLECTION = "user_badges";
+
+/**
+ * Firestore document shapes
+ * (kept identical to domain types for PR 1 simplicity)
+ */
+export interface BadgeDefinitionDocument {
+  id: BadgeId;
+  name: string;
+  description: string;
+  category: BadgeCategory;
+  howToEarn: string;
+  sortOrder: number;
+  iconKey?: string;
+}
+
+export interface UserBadgeDocument {
+  id: string;
+  userId: string;
+  badgeId: BadgeId;
+  awardedAt: string;
+  awardSource: BadgeAwardSource;
+  awardedBy?: string;
+}
+
+/**
+ * Deterministic document ID helpers
+ */
+export function getBadgeDocumentId(badgeId: BadgeId): string {
+  return badgeId;
+}
+
+export function getUserBadgeDocumentId(
+  userId: string,
+  badgeId: BadgeId
+): string {
+  return `${userId}_${badgeId}`;
+}
+
+/**
+ * Mapping helpers (domain -> storage)
+ * Pure functions, no Firebase usage
+ */
+export function toBadgeDefinitionDocument(
+  definition: BadgeDefinition
+): BadgeDefinitionDocument {
+  return {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    category: definition.category,
+    howToEarn: definition.howToEarn,
+    sortOrder: definition.sortOrder,
+    iconKey: definition.iconKey,
+  };
+}
+
+export function toUserBadgeDocument(
+  userBadge: UserBadge
+): UserBadgeDocument {
+  return {
+    id: userBadge.id,
+    userId: userBadge.userId,
+    badgeId: userBadge.badgeId,
+    awardedAt: userBadge.awardedAt,
+    awardSource: userBadge.awardSource,
+    awardedBy: userBadge.awardedBy,
+  };
+}

--- a/lib/badges/definitions.ts
+++ b/lib/badges/definitions.ts
@@ -1,0 +1,95 @@
+import { BadgeDefinition, BadgeId } from "./types";
+
+export const BADGE_DEFINITIONS: BadgeDefinition[] = [
+  {
+    id: "first-steps",
+    name: "First Steps",
+    category: "onboarding",
+    description: "Completed the basics to start participating in the community.",
+    howToEarn: "Add a display name and make your profile public.",
+    sortOrder: 1,
+    iconKey: "sparkles",
+  },
+  {
+    id: "connected",
+    name: "Connected",
+    category: "onboarding",
+    description: "Connected your community accounts.",
+    howToEarn: "Connect both Discord and GitHub.",
+    sortOrder: 2,
+    iconKey: "link",
+  },
+  {
+    id: "speaker",
+    name: "Speaker",
+    category: "events",
+    description: "Shared knowledge with the community.",
+    howToEarn: "Give at least 1 talk.",
+    sortOrder: 3,
+    iconKey: "mic",
+  },
+  {
+    id: "hacker",
+    name: "Hacker",
+    category: "events",
+    description: "Joined a hackathon or build event.",
+    howToEarn: "Participate in at least 1 hackathon.",
+    sortOrder: 4,
+    iconKey: "code",
+  },
+  {
+    id: "showcase-star",
+    name: "Showcase Star",
+    category: "community",
+    description: "Shared a project or community showcase.",
+    howToEarn: "Submit at least 1 showcase project.",
+    sortOrder: 5,
+    iconKey: "star",
+  },
+  {
+    id: "conversation-starter",
+    name: "Conversation Starter",
+    category: "community",
+    description: "Started a conversation in the community.",
+    howToEarn: "Create at least 1 community post.",
+    sortOrder: 6,
+    iconKey: "message-square",
+  },
+  {
+    id: "regular",
+    name: "Regular",
+    category: "community",
+    description: "Showed up consistently at community events.",
+    howToEarn: "Attend at least 3 events.",
+    sortOrder: 7,
+    iconKey: "calendar-check",
+  },
+  {
+    id: "mentor",
+    name: "Mentor",
+    category: "mentorship",
+    description: "Supported another member through mentorship.",
+    howToEarn: "Complete at least 1 mentor match.",
+    sortOrder: 8,
+    iconKey: "graduation-cap",
+  },
+  {
+    id: "contributor",
+    name: "Contributor",
+    category: "contributions",
+    description: "Contributed code to the community project.",
+    howToEarn: "Have at least 1 counted pull request.",
+    sortOrder: 9,
+    iconKey: "git-pull-request",
+  },
+];
+
+export const BADGE_IDS: BadgeId[] = BADGE_DEFINITIONS.map(
+  (badge) => badge.id
+);
+
+export const BADGE_DEFINITIONS_BY_ID: Record<BadgeId, BadgeDefinition> =
+  BADGE_DEFINITIONS.reduce((acc, badge) => {
+    acc[badge.id] = badge;
+    return acc;
+  }, {} as Record<BadgeId, BadgeDefinition>);

--- a/lib/badges/eligibility.ts
+++ b/lib/badges/eligibility.ts
@@ -1,0 +1,146 @@
+import type { BadgeEligibilityInput, BadgeEligibilityMap } from "./types";
+
+type NormalizedBadgeEligibilityInput = Required<BadgeEligibilityInput>;
+
+export function normalizeBadgeEligibilityInput(
+  input: BadgeEligibilityInput
+): NormalizedBadgeEligibilityInput {
+  return {
+    hasDisplayName: input.hasDisplayName ?? false,
+    isPublicProfile: input.isPublicProfile ?? false,
+    hasDiscordConnected: input.hasDiscordConnected ?? false,
+    hasGithubConnected: input.hasGithubConnected ?? false,
+    eventsAttendedCount: input.eventsAttendedCount ?? 0,
+    talksGivenCount: input.talksGivenCount ?? 0,
+    pullRequestsCount: input.pullRequestsCount ?? 0,
+    communityPostsCount: input.communityPostsCount ?? 0,
+    hackathonParticipationCount: input.hackathonParticipationCount ?? 0,
+    showcaseSubmissionsCount: input.showcaseSubmissionsCount ?? 0,
+    mentorMatchesCount: input.mentorMatchesCount ?? 0,
+  };
+}
+
+function cap(current: number, target: number): number {
+  return Math.min(current, target);
+}
+
+export function evaluateBadgeEligibility(
+  input: BadgeEligibilityInput
+): BadgeEligibilityMap {
+  const n = normalizeBadgeEligibilityInput(input);
+
+  const firstStepsCurrent = Number(n.hasDisplayName) + Number(n.isPublicProfile);
+  const firstStepsEligible = firstStepsCurrent >= 2;
+
+  const connectedCurrent = Number(n.hasDiscordConnected) + Number(n.hasGithubConnected);
+  const connectedEligible = connectedCurrent >= 2;
+
+  const speakerEligible = n.talksGivenCount >= 1;
+  const hackerEligible = n.hackathonParticipationCount >= 1;
+  const showcaseStarEligible = n.showcaseSubmissionsCount >= 1;
+  const conversationStarterEligible = n.communityPostsCount >= 1;
+  const regularEligible = n.eventsAttendedCount >= 3;
+  const mentorEligible = n.mentorMatchesCount >= 1;
+  const contributorEligible = n.pullRequestsCount >= 1;
+
+  return {
+    "first-steps": {
+      badgeId: "first-steps",
+      isEligible: firstStepsEligible,
+      progress: {
+        current: firstStepsCurrent,
+        target: 2,
+        unit: "steps",
+      },
+      reason: firstStepsEligible
+        ? undefined
+        : "Add a display name and make your profile public.",
+    },
+    connected: {
+      badgeId: "connected",
+      isEligible: connectedEligible,
+      progress: {
+        current: connectedCurrent,
+        target: 2,
+        unit: "connections",
+      },
+      reason: connectedEligible ? undefined : "Connect both Discord and GitHub.",
+    },
+    speaker: {
+      badgeId: "speaker",
+      isEligible: speakerEligible,
+      progress: {
+        current: cap(n.talksGivenCount, 1),
+        target: 1,
+        unit: "talks",
+      },
+      reason: speakerEligible ? undefined : "Give at least 1 talk.",
+    },
+    hacker: {
+      badgeId: "hacker",
+      isEligible: hackerEligible,
+      progress: {
+        current: cap(n.hackathonParticipationCount, 1),
+        target: 1,
+        unit: "hackathons",
+      },
+      reason: hackerEligible ? undefined : "Participate in at least 1 hackathon.",
+    },
+    "showcase-star": {
+      badgeId: "showcase-star",
+      isEligible: showcaseStarEligible,
+      progress: {
+        current: cap(n.showcaseSubmissionsCount, 1),
+        target: 1,
+        unit: "showcases",
+      },
+      reason: showcaseStarEligible
+        ? undefined
+        : "Submit at least 1 showcase project.",
+    },
+    "conversation-starter": {
+      badgeId: "conversation-starter",
+      isEligible: conversationStarterEligible,
+      progress: {
+        current: cap(n.communityPostsCount, 1),
+        target: 1,
+        unit: "posts",
+      },
+      reason: conversationStarterEligible
+        ? undefined
+        : "Create at least 1 community post.",
+    },
+    regular: {
+      badgeId: "regular",
+      isEligible: regularEligible,
+      progress: {
+        current: cap(n.eventsAttendedCount, 3),
+        target: 3,
+        unit: "events",
+      },
+      reason: regularEligible ? undefined : "Attend at least 3 events.",
+    },
+    mentor: {
+      badgeId: "mentor",
+      isEligible: mentorEligible,
+      progress: {
+        current: cap(n.mentorMatchesCount, 1),
+        target: 1,
+        unit: "matches",
+      },
+      reason: mentorEligible ? undefined : "Complete at least 1 mentor match.",
+    },
+    contributor: {
+      badgeId: "contributor",
+      isEligible: contributorEligible,
+      progress: {
+        current: cap(n.pullRequestsCount, 1),
+        target: 1,
+        unit: "pull requests",
+      },
+      reason: contributorEligible
+        ? undefined
+        : "Have at least 1 counted pull request.",
+    },
+  };
+}

--- a/lib/badges/types.ts
+++ b/lib/badges/types.ts
@@ -1,0 +1,67 @@
+export type BadgeId =
+  | "first-steps"
+  | "connected"
+  | "speaker"
+  | "hacker"
+  | "showcase-star"
+  | "conversation-starter"
+  | "regular"
+  | "mentor"
+  | "contributor";
+
+export type BadgeCategory =
+  | "onboarding"
+  | "community"
+  | "events"
+  | "contributions"
+  | "mentorship";
+
+export interface BadgeDefinition {
+  id: BadgeId;
+  name: string;
+  description: string;
+  category: BadgeCategory;
+  howToEarn: string;
+  sortOrder: number;
+  iconKey?: string;
+}
+
+export type BadgeAwardSource = "manual" | "on-demand" | "migration" | "system";
+
+export interface UserBadge {
+  id: string;
+  userId: string;
+  badgeId: BadgeId;
+  awardedAt: string;
+  awardSource: BadgeAwardSource;
+  awardedBy?: string;
+}
+
+export interface BadgeEligibilityInput {
+  hasDisplayName?: boolean;
+  isPublicProfile?: boolean;
+  hasDiscordConnected?: boolean;
+  hasGithubConnected?: boolean;
+  eventsAttendedCount?: number;
+  talksGivenCount?: number;
+  pullRequestsCount?: number;
+  communityPostsCount?: number;
+  hackathonParticipationCount?: number;
+  showcaseSubmissionsCount?: number;
+  mentorMatchesCount?: number;
+}
+
+export interface BadgeProgress {
+  current: number;
+  target: number;
+  unit?: string;
+}
+
+export interface BadgeEligibilityResult {
+  badgeId: BadgeId;
+  isEligible: boolean;
+  progress?: BadgeProgress;
+  reason?: string;
+}
+
+export type BadgeEligibilityMap = Record<BadgeId, BadgeEligibilityResult>;


### PR DESCRIPTION
Part of #79

This PR adds the foundation for the achievement badge system.

Included:
- badge domain types in `lib/badges/types.ts`
- starter badge definitions in `lib/badges/definitions.ts`
- Firestore-ready collection/data contract helpers in `lib/badges/data.ts`
- pure eligibility evaluation in `lib/badges/eligibility.ts`
- focused Jest coverage for badge eligibility rules

Badge coverage in this PR:
- First Steps
- Connected
- Speaker
- Hacker
- Showcase Star
- Conversation Starter
- Regular
- Mentor
- Contributor

Validation completed:
- badge eligibility test suite passes
- `npm run lint` passes with only a pre-existing warning in `postcss.config.mjs`
- `npm run build` passes successfully

Not included in this PR:
- badge UI components
- `/badges` route
- profile/member card rendering
- live Firestore reads/writes
- award automation / Cloud Functions

Follow-up work:
- PR 2: reusable badge UI (`BadgeCard`, `BadgeGrid`, `BadgePopover`)
- PR 3: app integration (`/badges` page, profile/member card rendering, repo-aligned awarding flow)