### PR TITLE
Add server auth and rate limiting infrastructure

### DIFF
--- a/__tests__/lib/server-auth.test.ts
+++ b/__tests__/lib/server-auth.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminAuth } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminAuth: jest.fn(),
+}));
+
+const mockGetAdminAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/test", {
+    headers: { Authorization: "Bearer test-token" },
+  });
+}
+
+describe("getVerifiedUser admin authorization bridge", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_EMAILS = "legacy-admin@example.com";
+    process.env.ADMIN_EMAIL = "";
+  });
+
+  it("allows admin via explicit claim", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => ({
+        uid: "u1",
+        email: "member@example.com",
+        admin: true,
+      })),
+    } as never);
+
+    const user = await getVerifiedUser(makeRequest());
+
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("allows fallback email admin when no explicit admin claim fields exist", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => ({
+        uid: "u2",
+        email: "legacy-admin@example.com",
+      })),
+    } as never);
+
+    const user = await getVerifiedUser(makeRequest());
+
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("does not override explicit non-admin claim with fallback email", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => ({
+        uid: "u3",
+        email: "legacy-admin@example.com",
+        role: "member",
+      })),
+    } as never);
+
+    const user = await getVerifiedUser(makeRequest());
+
+    expect(user?.isAdmin).toBe(false);
+  });
+
+  it("denies admin when no explicit claim and no fallback email match", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => ({
+        uid: "u4",
+        email: "member@example.com",
+      })),
+    } as never);
+
+    const user = await getVerifiedUser(makeRequest());
+
+    expect(user?.isAdmin).toBe(false);
+  });
+});
+

--- a/lib/rate-limit-server.ts
+++ b/lib/rate-limit-server.ts
@@ -1,0 +1,218 @@
+import { createHash } from "crypto";
+import { Timestamp } from "firebase-admin/firestore";
+import { getAdminDb } from "./firebase-admin";
+import { checkRateLimit, getClientIdentifier } from "./rate-limit";
+import { logger } from "./logger";
+
+interface ServerRateLimitOptions {
+  scope: string;
+  windowMs: number;
+  maxRequests: number;
+  identifier?: string;
+  fallbackMode?: "strict-memory" | "memory" | "deny";
+  fallbackMaxRequests?: number;
+  successSampleRate?: number;
+}
+
+export interface ServerRateLimitResult {
+  success: boolean;
+  remaining: number;
+  resetTime: number;
+  retryAfter?: number;
+  source: "firestore" | "memory-fallback" | "fail-closed";
+  statusCode?: number;
+}
+
+function hashIdentifier(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function toRetryAfter(resetTime: number, now: number): number {
+  return Math.max(1, Math.ceil((resetTime - now) / 1000));
+}
+
+/**
+ * Production-oriented server rate limit.
+ *
+ * Uses Firestore transactions for cross-instance consistency when Admin DB is available.
+ * Fallback behavior is explicit per endpoint:
+ * - "strict-memory" (default): bounded in-memory fallback with tighter limits.
+ * - "memory": in-memory fallback with same limits.
+ * - "deny": fail closed (503) when distributed limiter is unavailable.
+ *
+ * NOTE: Any memory fallback is resilience-only and not equivalent to distributed protection.
+ */
+export async function checkServerRateLimit(
+  request: Request,
+  options: ServerRateLimitOptions
+): Promise<ServerRateLimitResult> {
+  const now = Date.now();
+  const identifier = options.identifier || getClientIdentifier(request) || "unknown";
+  const resetTime = Math.floor(now / options.windowMs) * options.windowMs + options.windowMs;
+  const bucket = Math.floor(now / options.windowMs);
+  const fallbackMode = options.fallbackMode ?? "strict-memory";
+  const successSampleRate = Math.max(1, options.successSampleRate ?? 100);
+  const fallbackMaxRequests = Math.max(
+    1,
+    options.fallbackMaxRequests ??
+      (fallbackMode === "strict-memory"
+        ? Math.min(options.maxRequests, 10)
+        : options.maxRequests)
+  );
+
+  const db = getAdminDb();
+  const fallback = (): ServerRateLimitResult => {
+    if (fallbackMode === "deny") {
+      return {
+        success: false,
+        remaining: 0,
+        resetTime,
+        retryAfter: toRetryAfter(resetTime, now),
+        source: "fail-closed",
+        statusCode: 503,
+      };
+    }
+
+    const memoryFallback = checkRateLimit(
+      `fallback:${options.scope}:${identifier}`,
+      { windowMs: options.windowMs, maxRequests: fallbackMaxRequests }
+    );
+    return {
+      ...memoryFallback,
+      source: "memory-fallback",
+    };
+  };
+
+  if (!db) {
+    const fallbackResult = fallback();
+    logger.warn("rate_limit_observation", {
+      metric: "rate_limit_source_mix",
+      scope: options.scope,
+      source: fallbackResult.source,
+      success: fallbackResult.success,
+      statusCode: fallbackResult.statusCode ?? null,
+      fallbackMode,
+      reason: "admin_db_unavailable",
+    });
+    return fallbackResult;
+  }
+
+  const identifierHash = hashIdentifier(identifier);
+  const docId = `${options.scope}:${bucket}:${identifierHash}`;
+  const docRef = db.collection("apiRateLimits").doc(docId);
+  const shouldSampleSuccess = parseInt(identifierHash.slice(0, 8), 16) % successSampleRate === 0;
+
+  try {
+    const txResult = await db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      const currentCount = snap.exists ? Number(snap.data()?.count || 0) : 0;
+
+      if (currentCount >= options.maxRequests) {
+        return {
+          allowed: false,
+          count: currentCount,
+        };
+      }
+
+      const nextCount = currentCount + 1;
+      const basePayload = {
+        count: nextCount,
+        updatedAt: Timestamp.now(),
+      };
+
+      if (!snap.exists) {
+        tx.set(docRef, {
+          ...basePayload,
+          scope: options.scope,
+          identifierHash,
+          bucket,
+          windowMs: options.windowMs,
+          resetTimeMs: resetTime,
+          // Keep for operational cleanup / optional Firestore TTL.
+          // Cleanup route: POST /api/internal/rate-limits/cleanup (CRON_SECRET protected).
+          expiresAt: Timestamp.fromMillis(resetTime + options.windowMs),
+        });
+      } else {
+        // Existing buckets only need count/updatedAt to reduce write payload pressure.
+        tx.set(docRef, basePayload, { merge: true });
+      }
+
+      return {
+        allowed: true,
+        count: nextCount,
+      };
+    });
+
+    if (!txResult.allowed) {
+      const deniedResult: ServerRateLimitResult = {
+        success: false,
+        remaining: 0,
+        resetTime,
+        retryAfter: toRetryAfter(resetTime, now),
+        source: "firestore",
+      };
+      logger.warn("rate_limit_observation", {
+        metric: "rate_limit_source_mix",
+        scope: options.scope,
+        source: deniedResult.source,
+        success: deniedResult.success,
+        statusCode: deniedResult.statusCode ?? 429,
+        fallbackMode,
+        reason: "quota_exceeded",
+      });
+      return deniedResult;
+    }
+
+    const successResult: ServerRateLimitResult = {
+      success: true,
+      remaining: Math.max(0, options.maxRequests - txResult.count),
+      resetTime,
+      source: "firestore",
+    };
+    if (shouldSampleSuccess) {
+      logger.info("rate_limit_observation", {
+        metric: "rate_limit_source_mix",
+        scope: options.scope,
+        source: successResult.source,
+        success: successResult.success,
+        statusCode: 200,
+        fallbackMode,
+        reason: "allowed_sampled",
+        sampleRate: successSampleRate,
+      });
+    }
+
+    return successResult;
+  } catch (error) {
+    const fallbackResult = fallback();
+    logger.warn("rate_limit_observation", {
+      metric: "rate_limit_source_mix",
+      scope: options.scope,
+      source: fallbackResult.source,
+      success: fallbackResult.success,
+      statusCode: fallbackResult.statusCode ?? null,
+      fallbackMode,
+      reason: "firestore_transaction_error",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return fallbackResult;
+  }
+}
+
+export function buildRateLimitHeaders(
+  result: ServerRateLimitResult,
+  maxRequests: number
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-RateLimit-Limit": String(maxRequests),
+    "X-RateLimit-Remaining": String(result.remaining),
+    "X-RateLimit-Reset": String(result.resetTime),
+    "X-RateLimit-Source": result.source,
+  };
+
+  if (result.retryAfter) {
+    headers["Retry-After"] = String(result.retryAfter);
+  }
+
+  return headers;
+}

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -6,6 +6,52 @@ export interface VerifiedUser {
   name?: string;
   email?: string;
   picture?: string;
+  isAdmin?: boolean;
+  role?: string;
+  roles?: string[];
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function hasAdminClaim(decoded: Record<string, unknown>): boolean {
+  if (decoded.admin === true || decoded.isAdmin === true) {
+    return true;
+  }
+
+  const role = typeof decoded.role === "string" ? decoded.role : undefined;
+  if (role === "admin") {
+    return true;
+  }
+
+  const roles = toStringArray(decoded.roles);
+  return roles.includes("admin");
+}
+
+function hasExplicitAdminClaimFields(decoded: Record<string, unknown>): boolean {
+  return (
+    Object.prototype.hasOwnProperty.call(decoded, "admin") ||
+    Object.prototype.hasOwnProperty.call(decoded, "isAdmin") ||
+    Object.prototype.hasOwnProperty.call(decoded, "role") ||
+    Object.prototype.hasOwnProperty.call(decoded, "roles")
+  );
+}
+
+function getLegacyAdminEmailSet(): Set<string> {
+  const csv = process.env.ADMIN_EMAILS || process.env.ADMIN_EMAIL || "";
+  return new Set(
+    csv
+      .split(",")
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function isLegacyAdminEmail(email?: string): boolean {
+  if (!email) return false;
+  return getLegacyAdminEmailSet().has(email.trim().toLowerCase());
 }
 
 export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUser | null> {
@@ -26,10 +72,21 @@ export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUse
 
   // checkRevoked=false: revocation check can fail (tenant/API issues).
   const decoded = await adminAuth.verifyIdToken(token, false);
+  const role = typeof decoded.role === "string" ? decoded.role : undefined;
+  const roles = toStringArray(decoded.roles);
+  const hasExplicitAdminClaims = hasExplicitAdminClaimFields(decoded);
+  const claimAdmin = hasAdminClaim(decoded);
+  // Migration bridge: claim-based admin is authoritative; legacy email fallback
+  // only applies when token has no explicit admin-role claim fields.
+  const isAdmin = claimAdmin || (!hasExplicitAdminClaims && isLegacyAdminEmail(decoded.email));
+
   return {
     uid: decoded.uid,
     name: decoded.name,
     email: decoded.email,
     picture: decoded.picture,
+    isAdmin,
+    role,
+    roles,
   };
 }


### PR DESCRIPTION
## Description
This PR adds shared backend infrastructure for server-side authentication and rate limiting.
It includes:
a server-auth helper for consistent auth and admin enforcement in server routes
shared server-side rate limiting infrastructure to support later API protections
unit test coverage for the new server auth helper
This PR is part of the #79 restack and intentionally isolates backend infrastructure so later feature PRs can stay smaller and more reviewable.

Fixes # 79

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally
- [x] Tested authentication flows

Commands used:
rm -rf .next
npm test
npm run type-check
Verified:
server auth helper behavior passes local tests
full local test suite passes on this branch
TypeScript compilation passes after clearing stale generated .next artifacts 

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A

## Additional Notes
This PR intentionally contains only shared server auth and rate limiting infrastructure from the broader #79 work. It does not include badge system, badge UI, showcase flows, or moderation routes.