### PR TITLE
docs(readme): clarify fork-first clone for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Each feature is **fully isolated** — new routes, new Firestore collections, no
 
 1. **Clone the repo**
    ```bash
-   git clone https://github.com/rogerSuperBuilderAlpha/cursor-boston.git
+   git clone https://github.com/your-username/cursor-boston.git
    cd cursor-boston
    ```
+   Fork the repository first if you plan to open a pull request, then use your fork URL above (replace `your-username`). To clone read-only without a fork, use `https://github.com/rogerSuperBuilderAlpha/cursor-boston.git`.
 
 2. **Install & Setup**
    ```bash


### PR DESCRIPTION
Made-with: Cursor

## Description

Update the Quick Start section so the clone example uses `your-username`, matches the fork-first flow in the Contributing Guide, and mentions the read-only upstream URL when not using a fork.

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- Viewed `README.md` on GitHub (rendered) and confirmed the Quick Start clone instructions are clear and consistent.
- Documentation-only change; no application code or runtime behavior affected.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (N/A — docs only; no code changes)

## Screenshots (if applicable)

N/A — text-only README change.

## Additional Notes

No linked issue; small contributor onboarding clarification.