### PR TITLE
fix(submissions): return 409 when duplicate submission detected

### DIFF
--- a/app/api/hackathons/submissions/submit/route.ts
+++ b/app/api/hackathons/submissions/submit/route.ts
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest) {
     if (sub.submittedAt) {
       return NextResponse.json(
         { error: "Already submitted", submittedAt: sub.submittedAt },
-        { status: 200 }
+        { status: 409 }
       );
     }
 


### PR DESCRIPTION
## Description
Changed status code from `200` to `409` when a duplicate hackathon submission is detected in `app/api/hackathons/submissions/submit/route.ts`. Returning `200 OK` on a rejected operation is misleading to clients — `409 Conflict` correctly signals the request failed due to an existing submission.

Fixes #195

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings