### PR TITLE
fix(logo): improve visibility in light mode using brightness filter

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -27,7 +27,7 @@ export default function Logo({ size, className = "", priority = false }: LogoPro
         src={LOGO_SRC}
         alt={ALT}
         fill
-        className="object-contain"
+        className="object-contain dark:brightness-100 brightness-0"
         priority={priority}
         sizes={
           size === "heroHome"


### PR DESCRIPTION
## Description
The Cursor Boston logo was nearly invisible in light mode on the hero section. The logo is white/light colored which caused it to blend into the white background.

Applied a CSS brightness filter (`brightness-0`) in light mode and `brightness-100` in dark mode to ensure the logo is clearly visible in both themes.

Fixes #198

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<img width="1792" height="711" alt="Screenshot 2026-03-29 at 2 26 58 PM" src="https://github.com/user-attachments/assets/c110edd5-5f3a-45dc-a605-bf4c1621a65e" />
