### PR TITLE
Add badge UI and profile badge surfaces

### DIFF
--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -23,6 +23,21 @@ import {
   EyeIcon,
   EyeOffIcon,
 } from "@/components/icons";
+import {
+  getBadgeEligibilityData,
+  type BadgeEligibilityDataStatus,
+} from "@/lib/badges/getBadgeEligibilityInput";
+import { evaluateBadgeEligibility } from "@/lib/badges/eligibility";
+import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
+import {
+  ensureUserBadgesForEligibleWithStatus,
+  getUserBadgeMap,
+  type BadgeAwardPersistenceStatus,
+  type UserBadgeMap,
+} from "@/lib/badges/data";
+import type { BadgeDefinition, BadgeEligibilityMap } from "@/lib/badges/types";
+import { getEarnedBadgeIds } from "@/lib/badges/utils";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
 
 // Hooks
 import { useDiscordConnection } from "./_hooks/useDiscordConnection";
@@ -93,6 +108,18 @@ function ProfilePageContent() {
   const [loadingData, setLoadingData] = useState(true);
   const [connectedAgents, setConnectedAgents] = useState<ConnectedAgent[]>([]);
   const [loadingAgents, setLoadingAgents] = useState(false);
+  const [badgeEligibilityMap, setBadgeEligibilityMap] = useState<BadgeEligibilityMap | undefined>(undefined);
+  const [userBadgeMap, setUserBadgeMap] = useState<UserBadgeMap>({});
+  const [loadingBadges, setLoadingBadges] = useState(false);
+  const [badgeDefinitions, setBadgeDefinitions] = useState<BadgeDefinition[]>(BADGE_DEFINITIONS);
+  const [usingFallbackDefinitions, setUsingFallbackDefinitions] = useState(false);
+  const [badgeDataStatus, setBadgeDataStatus] = useState<BadgeEligibilityDataStatus>({
+    state: "failed",
+    isAuthoritative: false,
+    failedSources: [],
+  });
+  const [badgePersistenceStatus, setBadgePersistenceStatus] =
+    useState<BadgeAwardPersistenceStatus>({ state: "complete" });
 
   // ── Password state (kept here because it needs user from auth context) ────
   const [passwordSaving, setPasswordSaving] = useState(false);
@@ -214,6 +241,87 @@ function ProfilePageContent() {
     })();
   }, [user]);
 
+  // ── Fetch Firestore-backed badge definitions ──────────────────────────────
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await fetch("/api/badges/definitions", { cache: "no-store" });
+        if (!response.ok) {
+          setUsingFallbackDefinitions(true);
+          return;
+        }
+        const data = (await response.json()) as {
+          definitions?: BadgeDefinition[];
+          source?: "firestore" | "seeded-fallback" | "local-fallback";
+        };
+        if (Array.isArray(data.definitions) && data.definitions.length > 0) {
+          setBadgeDefinitions(data.definitions);
+        }
+        setUsingFallbackDefinitions(data.source !== "firestore");
+      } catch {
+        // Keep local fallback definitions
+        setUsingFallbackDefinitions(true);
+      }
+    })();
+  }, []);
+
+  // ── Fetch badge eligibility input and evaluate badges ─────────────────────
+  useEffect(() => {
+    if (!user) {
+      setBadgeEligibilityMap(undefined);
+      setUserBadgeMap({});
+      setBadgeDataStatus({
+        state: "failed",
+        isAuthoritative: false,
+        failedSources: [],
+      });
+      setBadgePersistenceStatus({ state: "complete" });
+      return;
+    }
+
+    setLoadingBadges(true);
+    (async () => {
+      try {
+        const badgeData = await getBadgeEligibilityData({
+          uid: user.uid,
+          displayName: userProfile?.displayName ?? user.displayName ?? null,
+          visibility: userProfile?.visibility ?? null,
+          bio: userProfile?.bio ?? null,
+          photoURL: userProfile?.photoURL ?? user.photoURL ?? null,
+          discord: userProfile?.discord,
+          github: userProfile?.github,
+        });
+        const evaluated = evaluateBadgeEligibility(badgeData.input);
+        const persisted = await getUserBadgeMap(user.uid);
+        const persistenceResult = await ensureUserBadgesForEligibleWithStatus(
+          user.uid,
+          evaluated,
+          persisted
+        );
+        setBadgeEligibilityMap(evaluated);
+        setUserBadgeMap(persistenceResult.userBadgeMap);
+        setBadgeDataStatus(badgeData.status);
+        setBadgePersistenceStatus(persistenceResult.status);
+      } catch (err) {
+        console.error("Error evaluating badge eligibility:", err);
+        setBadgeEligibilityMap(evaluateBadgeEligibility({}));
+        setUserBadgeMap({});
+        setBadgeDataStatus({
+          state: "failed",
+          isAuthoritative: false,
+          failedSources: [],
+          message: "Badge data could not be loaded right now.",
+        });
+        setBadgePersistenceStatus({
+          state: "failed",
+          message: "Badge awards could not be saved right now.",
+        });
+      } finally {
+        setLoadingBadges(false);
+      }
+    })();
+  }, [user, userProfile]);
+
   // ── Handlers ──────────────────────────────────────────────────────────────
   const handleSignOut = async () => {
     setSignOutError(null);
@@ -261,6 +369,14 @@ function ProfilePageContent() {
 
   const discordInfo = discord.discordInfo;
   const githubInfo = github.githubInfo;
+  const earnedBadgeIds = getEarnedBadgeIds(
+    badgeDefinitions,
+    badgeEligibilityMap,
+    userBadgeMap
+  );
+  const earnedBadgeDefinitions = badgeDefinitions.filter((definition) =>
+    earnedBadgeIds.includes(definition.id)
+  );
 
   return (
     <div className="min-h-[80vh] px-6 py-8 md:py-12">
@@ -451,6 +567,80 @@ function ProfilePageContent() {
               <p className="text-neutral-500 dark:text-neutral-400 text-sm">{label}</p>
             </div>
           ))}
+        </div>
+        <p className="text-xs text-neutral-500 mb-6">
+          Contributor badge progress is based on merged pull requests in this repository.
+        </p>
+
+        {/* ── Achievement Badges ───────────────────────────────────── */}
+        <div className="bg-neutral-900 rounded-2xl p-6 border border-neutral-800 mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-white">Earned Badges</h2>
+            <Link
+              href="/badges"
+              className="text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
+            >
+              View all badges
+            </Link>
+          </div>
+
+          {loadingBadges ? (
+            <span className="text-xs text-neutral-400">Updating...</span>
+          ) : earnedBadgeDefinitions.length === 0 ? (
+            <div className="text-sm text-neutral-400">
+              No badges earned yet. Complete milestones to unlock your first one.
+            </div>
+          ) : (
+            <BadgeGrid
+              definitions={earnedBadgeDefinitions}
+              eligibilityMap={badgeEligibilityMap}
+              earnedBadgeIds={earnedBadgeIds}
+              userBadgeMap={userBadgeMap}
+              compact
+              layout="horizontal"
+              isAuthoritative={badgeDataStatus.isAuthoritative}
+            />
+          )}
+
+          {badgeDataStatus.state !== "complete" && (
+            <div
+              className={`mt-4 rounded-lg border px-3 py-2 text-xs ${
+                badgeDataStatus.state === "failed"
+                  ? "border-red-500/30 bg-red-500/10 text-red-300"
+                  : "border-amber-500/30 bg-amber-500/10 text-amber-300"
+              }`}
+            >
+              {badgeDataStatus.message ||
+                "Badge data is partially unavailable. Some badge statuses may be unverified."}
+              {process.env.NODE_ENV !== "production" &&
+                badgeDataStatus.failedSources.length > 0 && (
+                  <p className="mt-1 text-[11px] opacity-80">
+                    Debug: failed badge sources: {badgeDataStatus.failedSources.join(", ")}
+                  </p>
+                )}
+            </div>
+          )}
+
+          {badgePersistenceStatus.state !== "complete" && (
+            <div
+              className={`mt-3 rounded-lg border px-3 py-2 text-xs ${
+                badgePersistenceStatus.state === "failed"
+                  ? "border-red-500/30 bg-red-500/10 text-red-300"
+                  : "border-amber-500/30 bg-amber-500/10 text-amber-300"
+              }`}
+            >
+              {badgePersistenceStatus.message ||
+                (badgePersistenceStatus.state === "failed"
+                  ? "We couldn’t save some badge updates. Earned dates may be missing. Please refresh or try again."
+                  : "Some badge updates are still syncing. Earned dates may appear shortly.")}
+            </div>
+          )}
+
+          {usingFallbackDefinitions && (
+            <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+              Badge definitions are using fallback data right now.
+            </div>
+          )}
         </div>
 
         {/* ── Tabs ──────────────────────────────────────────────────────── */}

--- a/app/badges/page.tsx
+++ b/app/badges/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  getBadgeEligibilityData,
+  type BadgeEligibilityDataStatus,
+} from "@/lib/badges/getBadgeEligibilityInput";
+import { evaluateBadgeEligibility } from "@/lib/badges/eligibility";
+import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
+import {
+  ensureUserBadgesForEligibleWithStatus,
+  getUserBadgeMap,
+  type BadgeAwardPersistenceStatus,
+  type UserBadgeMap,
+} from "@/lib/badges/data";
+import type { BadgeEligibilityMap } from "@/lib/badges/types";
+import { getEarnedBadgeIds } from "@/lib/badges/utils";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import type { BadgeDefinition } from "@/lib/badges/types";
+
+export default function BadgesPage() {
+  const { user, userProfile, loading } = useAuth();
+  const router = useRouter();
+  const [eligibilityMap, setEligibilityMap] = useState<BadgeEligibilityMap | undefined>(undefined);
+  const [userBadgeMap, setUserBadgeMap] = useState<UserBadgeMap>({});
+  const [loadingBadges, setLoadingBadges] = useState(false);
+  const [badgeDefinitions, setBadgeDefinitions] = useState<BadgeDefinition[]>(BADGE_DEFINITIONS);
+  const [usingFallbackDefinitions, setUsingFallbackDefinitions] = useState(false);
+  const [badgeDataStatus, setBadgeDataStatus] = useState<BadgeEligibilityDataStatus>({
+    state: "failed",
+    isAuthoritative: false,
+    failedSources: [],
+  });
+  const [badgePersistenceStatus, setBadgePersistenceStatus] =
+    useState<BadgeAwardPersistenceStatus>({ state: "complete" });
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login?redirect=/badges");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await fetch("/api/badges/definitions", { cache: "no-store" });
+        if (!response.ok) {
+          setUsingFallbackDefinitions(true);
+          return;
+        }
+        const data = (await response.json()) as {
+          definitions?: BadgeDefinition[];
+          source?: "firestore" | "seeded-fallback" | "local-fallback";
+        };
+        if (Array.isArray(data.definitions) && data.definitions.length > 0) {
+          setBadgeDefinitions(data.definitions);
+        }
+        setUsingFallbackDefinitions(data.source !== "firestore");
+      } catch {
+        // Keep local fallback definitions
+        setUsingFallbackDefinitions(true);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setEligibilityMap(undefined);
+      setUserBadgeMap({});
+      setBadgeDataStatus({
+        state: "failed",
+        isAuthoritative: false,
+        failedSources: [],
+      });
+      setBadgePersistenceStatus({ state: "complete" });
+      return;
+    }
+
+    setLoadingBadges(true);
+    (async () => {
+      try {
+        const badgeData = await getBadgeEligibilityData({
+          uid: user.uid,
+          displayName: userProfile?.displayName ?? user.displayName ?? null,
+          visibility: userProfile?.visibility ?? null,
+          bio: userProfile?.bio ?? null,
+          photoURL: userProfile?.photoURL ?? user.photoURL ?? null,
+          discord: userProfile?.discord,
+          github: userProfile?.github,
+        });
+        const evaluated = evaluateBadgeEligibility(badgeData.input);
+        const persisted = await getUserBadgeMap(user.uid);
+        const persistenceResult = await ensureUserBadgesForEligibleWithStatus(
+          user.uid,
+          evaluated,
+          persisted
+        );
+        setEligibilityMap(evaluated);
+        setUserBadgeMap(persistenceResult.userBadgeMap);
+        setBadgeDataStatus(badgeData.status);
+        setBadgePersistenceStatus(persistenceResult.status);
+      } catch (err) {
+        console.error("Error loading badge eligibility:", err);
+        setEligibilityMap(evaluateBadgeEligibility({}));
+        setUserBadgeMap({});
+        setBadgeDataStatus({
+          state: "failed",
+          isAuthoritative: false,
+          failedSources: [],
+          message: "Badge data could not be loaded right now.",
+        });
+        setBadgePersistenceStatus({
+          state: "failed",
+          message: "Badge awards could not be saved right now.",
+        });
+      } finally {
+        setLoadingBadges(false);
+      }
+    })();
+  }, [user, userProfile]);
+
+  const earnedBadgeIds = getEarnedBadgeIds(
+    badgeDefinitions,
+    eligibilityMap,
+    userBadgeMap
+  );
+  const earnedCount = earnedBadgeIds.length;
+  const totalCount = badgeDefinitions.length;
+
+  if (loading || !user) {
+    return (
+      <div className="min-h-[80vh] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900 dark:border-white" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[80vh] px-6 py-8 md:py-12">
+      <div className="max-w-6xl mx-auto">
+        <section className="mb-6">
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-2">Achievement Badges</h1>
+          <p className="text-neutral-600 dark:text-neutral-400 max-w-2xl">
+            Track your milestones across profile completion, community participation, events, and contributions.
+          </p>
+        </section>
+
+        <section className="mb-4">
+          <div className="inline-flex items-center gap-2 rounded-full border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-3 py-1.5 text-sm">
+            <span className="text-foreground font-medium">{earnedCount}</span>
+            <span className="text-neutral-600 dark:text-neutral-400">earned</span>
+            <span className="text-neutral-400">/</span>
+            <span className="text-neutral-600 dark:text-neutral-400">{totalCount} total</span>
+          </div>
+        </section>
+
+        {usingFallbackDefinitions && (
+          <section className="mb-4">
+            <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-300">
+              Badge definitions are using fallback data right now.
+            </div>
+          </section>
+        )}
+
+        {badgeDataStatus.state !== "complete" && (
+          <section className="mb-4">
+            <div
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                badgeDataStatus.state === "failed"
+                  ? "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+                  : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+              }`}
+            >
+              {badgeDataStatus.message ||
+                "Badge data is partially unavailable. Some badge statuses may be unverified."}
+              {process.env.NODE_ENV !== "production" &&
+                badgeDataStatus.failedSources.length > 0 && (
+                  <p className="mt-1 text-[11px] opacity-80">
+                    Debug: failed badge sources: {badgeDataStatus.failedSources.join(", ")}
+                  </p>
+                )}
+            </div>
+          </section>
+        )}
+
+        {badgePersistenceStatus.state !== "complete" && (
+          <section className="mb-4">
+            <div
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                badgePersistenceStatus.state === "failed"
+                  ? "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+                  : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+              }`}
+            >
+              {badgePersistenceStatus.message ||
+                (badgePersistenceStatus.state === "failed"
+                  ? "We couldn’t save some badge updates. Earned dates may be missing. Please refresh or try again."
+                  : "Some badge updates are still syncing. Earned dates may appear shortly.")}
+            </div>
+          </section>
+        )}
+
+        <section className="bg-white dark:bg-neutral-900 rounded-2xl p-6 border border-neutral-200 dark:border-neutral-800">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-foreground">Your Progress</h2>
+            {loadingBadges && <span className="text-xs text-neutral-400">Updating...</span>}
+          </div>
+
+          <BadgeGrid
+            definitions={badgeDefinitions}
+            eligibilityMap={eligibilityMap}
+            earnedBadgeIds={earnedBadgeIds}
+            userBadgeMap={userBadgeMap}
+            isAuthoritative={badgeDataStatus.isAuthoritative}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/badges/BadgeCard.tsx
+++ b/components/badges/BadgeCard.tsx
@@ -1,0 +1,321 @@
+import { useRef, useState, type KeyboardEvent, type SVGProps } from "react";
+import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
+import { cn } from "@/lib/utils";
+import { BadgePopover } from "./BadgePopover";
+
+interface BadgeCardProps {
+  definition: BadgeDefinition;
+  eligibility?: BadgeEligibilityResult;
+  earned?: boolean;
+  awardedAt?: string;
+  isAuthoritative?: boolean;
+  compact?: boolean;
+  className?: string;
+}
+
+function SparklesIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3Z" />
+      <path d="M19 14l.8 2.2L22 17l-2.2.8L19 20l-.8-2.2L16 17l2.2-.8L19 14Z" />
+      <path d="M5 14l.8 2.2L8 17l-2.2.8L5 20l-.8-2.2L2 17l2.2-.8L5 14Z" />
+    </svg>
+  );
+}
+
+function LinkIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="M10 13a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 1 0-7.07-7.07L11 4" />
+      <path d="M14 11a5 5 0 0 0-7.07 0L4.1 13.83a5 5 0 1 0 7.07 7.07L13 20" />
+    </svg>
+  );
+}
+
+function MicIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <rect x="9" y="2" width="6" height="11" rx="3" />
+      <path d="M5 10a7 7 0 0 0 14 0" />
+      <path d="M12 17v5" />
+      <path d="M8 22h8" />
+    </svg>
+  );
+}
+
+function CodeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="m8 16-4-4 4-4" />
+      <path d="m16 8 4 4-4 4" />
+      <path d="m14 4-4 16" />
+    </svg>
+  );
+}
+
+function StarIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="m12 3 2.9 5.9 6.6 1-4.8 4.7 1.1 6.6L12 18l-5.8 3.2 1.1-6.6-4.8-4.7 6.6-1L12 3Z" />
+    </svg>
+  );
+}
+
+function MessageSquareIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}
+
+function CalendarCheckIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M16 2v4M8 2v4M3 10h18" />
+      <path d="m9 16 2 2 4-4" />
+    </svg>
+  );
+}
+
+function GraduationCapIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="m2 10 10-5 10 5-10 5-10-5Z" />
+      <path d="M6 12v4c0 1.7 2.7 3 6 3s6-1.3 6-3v-4" />
+    </svg>
+  );
+}
+
+function GitPullRequestIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <circle cx="6" cy="6" r="3" />
+      <circle cx="18" cy="18" r="3" />
+      <path d="M6 9v9" />
+      <path d="M18 15V9a3 3 0 0 0-3-3H9" />
+    </svg>
+  );
+}
+
+function FallbackAwardIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <circle cx="12" cy="8" r="5" />
+      <path d="m8.5 13.5-2 7 5.5-2.5 5.5 2.5-2-7" />
+    </svg>
+  );
+}
+
+function BadgeIcon({
+  iconKey,
+  ...props
+}: { iconKey?: string } & SVGProps<SVGSVGElement>) {
+  switch (iconKey) {
+    case "sparkles":
+      return <SparklesIcon {...props} />;
+    case "link":
+      return <LinkIcon {...props} />;
+    case "mic":
+      return <MicIcon {...props} />;
+    case "code":
+      return <CodeIcon {...props} />;
+    case "star":
+      return <StarIcon {...props} />;
+    case "message-square":
+      return <MessageSquareIcon {...props} />;
+    case "calendar-check":
+      return <CalendarCheckIcon {...props} />;
+    case "graduation-cap":
+      return <GraduationCapIcon {...props} />;
+    case "git-pull-request":
+      return <GitPullRequestIcon {...props} />;
+    default:
+      return <FallbackAwardIcon {...props} />;
+  }
+}
+
+export function BadgeCard({
+  definition,
+  eligibility,
+  earned,
+  awardedAt,
+  isAuthoritative = true,
+  compact = false,
+  className,
+}: BadgeCardProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const triggerRef = useRef<HTMLElement>(null);
+  const isEarned = earned ?? eligibility?.isEligible ?? false;
+  const showcaseApprovalNote =
+    definition.id === "showcase-star" && isEarned
+      ? "Showcase Star is only awarded after at least one showcase submission is approved."
+      : undefined;
+  const statusText = isEarned
+    ? "Earned"
+    : isAuthoritative
+    ? eligibility?.reason || "Not earned yet"
+    : "Badge data is partially unavailable. Some badge statuses may be unverified.";
+  const earnedDate = awardedAt ? new Date(awardedAt) : null;
+  const earnedDateLabel =
+    isEarned && earnedDate && !Number.isNaN(earnedDate.getTime())
+      ? earnedDate.toLocaleDateString("en-US", {
+          month: "short",
+          year: "numeric",
+        })
+      : null;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setIsPopoverOpen(true);
+    }
+  };
+
+  const closePopover = () => {
+    setIsPopoverOpen(false);
+    requestAnimationFrame(() => {
+      triggerRef.current?.focus();
+    });
+  };
+
+  return (
+    <>
+      <article
+        ref={triggerRef}
+        className={cn(
+          "rounded-xl border transition-colors cursor-pointer",
+          "bg-white dark:bg-neutral-900",
+          isEarned
+            ? "border-emerald-300/70 dark:border-emerald-500/40"
+            : "border-neutral-200 dark:border-neutral-800",
+          !compact && "hover:border-neutral-300 dark:hover:border-neutral-700",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400",
+          compact ? "p-3" : "p-4",
+          className
+        )}
+        aria-label={definition.name}
+        aria-haspopup="dialog"
+        aria-expanded={isPopoverOpen}
+        role="button"
+        tabIndex={0}
+        onClick={() => setIsPopoverOpen(true)}
+        onKeyDown={handleKeyDown}
+      >
+        <div className={cn("flex items-start", compact ? "gap-3" : "gap-4")}>
+          <div
+            className={cn(
+              "shrink-0 rounded-full border flex items-center justify-center",
+              compact ? "h-9 w-9" : "h-11 w-11",
+              isEarned
+                ? "bg-emerald-500/10 border-emerald-500/30 text-emerald-600 dark:text-emerald-400"
+                : "bg-neutral-100 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-700 text-neutral-500 dark:text-neutral-400"
+            )}
+          >
+            <BadgeIcon
+              iconKey={definition.iconKey}
+              width={compact ? 16 : 18}
+              height={compact ? 16 : 18}
+              aria-hidden="true"
+            />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <h3
+                className={cn(
+                  "font-semibold text-foreground truncate",
+                  compact ? "text-sm" : "text-base"
+                )}
+              >
+                {definition.name}
+              </h3>
+              <span
+                className={cn(
+                  "shrink-0 px-2 py-0.5 rounded-full text-xs font-medium",
+                  isEarned
+                    ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                    : "bg-neutral-200/80 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400"
+                )}
+              >
+                {isEarned ? "Earned" : isAuthoritative ? "Locked" : "Unverified data"}
+              </span>
+            </div>
+
+            <p
+              className={cn(
+                "text-neutral-600 dark:text-neutral-400",
+                compact ? "text-xs" : "text-sm"
+              )}
+            >
+              {definition.description}
+            </p>
+
+            {!isEarned && (
+              <p
+                className={cn(
+                  "text-neutral-500 dark:text-neutral-400 mt-1",
+                  compact ? "text-xs" : "text-sm"
+                )}
+              >
+                {statusText}
+              </p>
+            )}
+
+            {isEarned && earnedDateLabel && (
+              <p
+                className={cn(
+                  "text-neutral-500 dark:text-neutral-400 mt-1",
+                  compact ? "text-xs" : "text-sm"
+                )}
+              >
+                Earned {earnedDateLabel}
+              </p>
+            )}
+
+            {eligibility?.progress && (
+              <div className={cn("mt-2", compact ? "text-xs" : "text-sm")}>
+                <p className="text-neutral-500 dark:text-neutral-400 mb-1">
+                  Progress: {eligibility.progress.current}/{eligibility.progress.target}
+                  {eligibility.progress.unit ? ` ${eligibility.progress.unit}` : ""}
+                </p>
+                <div className="h-1.5 rounded-full bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
+                  <div
+                    className={cn(
+                      "h-full rounded-full",
+                      isEarned ? "bg-emerald-500" : "bg-neutral-500 dark:bg-neutral-500"
+                    )}
+                    style={{
+                      width: `${Math.min(
+                        100,
+                        (eligibility.progress.current / eligibility.progress.target) * 100
+                      )}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+
+            <p
+              className={cn(
+                "mt-2 text-neutral-500 dark:text-neutral-400",
+                compact ? "text-[11px]" : "text-xs"
+              )}
+            >
+              Click for details
+            </p>
+          </div>
+        </div>
+      </article>
+
+      <BadgePopover
+        definition={definition}
+        eligibility={eligibility}
+        isOpen={isPopoverOpen}
+        onClose={closePopover}
+        showcaseApprovalNote={showcaseApprovalNote}
+      />
+    </>
+  );
+}

--- a/components/badges/BadgeGrid.tsx
+++ b/components/badges/BadgeGrid.tsx
@@ -1,0 +1,68 @@
+import type { BadgeDefinition, BadgeEligibilityMap, BadgeId } from "@/lib/badges/types";
+import { cn } from "@/lib/utils";
+import { BadgeCard } from "./BadgeCard";
+
+interface BadgeGridProps {
+  definitions: BadgeDefinition[];
+  eligibilityMap?: BadgeEligibilityMap;
+  earnedBadgeIds?: BadgeId[];
+  userBadgeMap?: Partial<Record<BadgeId, { awardedAt?: string }>>;
+  isAuthoritative?: boolean;
+  compact?: boolean;
+  layout?: "grid" | "horizontal";
+  className?: string;
+}
+
+export function BadgeGrid({
+  definitions,
+  eligibilityMap,
+  earnedBadgeIds,
+  userBadgeMap,
+  isAuthoritative = true,
+  compact = false,
+  layout = "grid",
+  className,
+}: BadgeGridProps) {
+  const isHorizontal = layout === "horizontal";
+
+  return (
+    <section className={cn(className)}>
+      <div
+        className={cn(
+          isHorizontal
+            ? "flex gap-4 overflow-x-auto pb-1 pr-2"
+            : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+        )}
+      >
+        {definitions.map((definition) => {
+          const eligibility = eligibilityMap?.[definition.id];
+          const earned = earnedBadgeIds
+            ? earnedBadgeIds.includes(definition.id)
+            : undefined;
+
+          const card = (
+            <BadgeCard
+              key={definition.id}
+              definition={definition}
+              eligibility={eligibility}
+              earned={earned}
+              awardedAt={userBadgeMap?.[definition.id]?.awardedAt}
+              isAuthoritative={isAuthoritative}
+              compact={compact}
+            />
+          );
+
+          if (isHorizontal) {
+            return (
+              <div key={definition.id} className="min-w-[260px] shrink-0">
+                {card}
+              </div>
+            );
+          }
+
+          return card;
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/badges/BadgePopover.tsx
+++ b/components/badges/BadgePopover.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef } from "react";
+import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
+import { cn } from "@/lib/utils";
+
+interface BadgePopoverProps {
+  definition: BadgeDefinition;
+  eligibility?: BadgeEligibilityResult;
+  isOpen: boolean;
+  onClose: () => void;
+  anchorLabel?: string;
+  showcaseApprovalNote?: string;
+}
+
+export function BadgePopover({
+  definition,
+  eligibility,
+  isOpen,
+  onClose,
+  anchorLabel,
+  showcaseApprovalNote,
+}: BadgePopoverProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const container = dialogRef.current;
+      if (!container) return;
+
+      const focusable = container.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const isEarned = eligibility?.isEligible ?? false;
+  const headingId = `badge-popover-title-${definition.id}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+      aria-label={anchorLabel || `${definition.name} details`}
+    >
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40"
+        aria-label="Close"
+        onClick={onClose}
+      />
+
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-sm rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-3 p-4 border-b border-neutral-200 dark:border-neutral-800">
+          <div className="min-w-0">
+            <h3 id={headingId} className="text-base font-semibold text-foreground truncate">
+              {definition.name}
+            </h3>
+            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+              {anchorLabel || "Achievement badge"}
+            </p>
+          </div>
+          <span
+            className={cn(
+              "shrink-0 px-2 py-0.5 rounded-full text-xs font-medium",
+              isEarned
+                ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                : "bg-neutral-200/80 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400"
+            )}
+          >
+            {isEarned ? "Earned" : "Locked"}
+          </span>
+        </div>
+
+        <div className="p-4 space-y-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+              Description
+            </p>
+            <p className="text-sm text-neutral-700 dark:text-neutral-300">
+              {definition.description}
+            </p>
+          </div>
+
+          <div>
+            <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+              How to earn
+            </p>
+            <p className="text-sm text-neutral-700 dark:text-neutral-300">
+              {definition.howToEarn}
+            </p>
+          </div>
+
+          {eligibility?.progress && (
+            <div>
+              <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+                Progress
+              </p>
+              <p className="text-sm text-neutral-700 dark:text-neutral-300 mb-2">
+                {eligibility.progress.current}/{eligibility.progress.target}
+                {eligibility.progress.unit ? ` ${eligibility.progress.unit}` : ""}
+              </p>
+              <div className="h-1.5 rounded-full bg-neutral-200 dark:bg-neutral-800 overflow-hidden">
+                <div
+                  className={cn(
+                    "h-full rounded-full",
+                    isEarned ? "bg-emerald-500" : "bg-neutral-500 dark:bg-neutral-500"
+                  )}
+                  style={{
+                    width: `${Math.min(
+                      100,
+                      (eligibility.progress.current / eligibility.progress.target) * 100
+                    )}%`,
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {!isEarned && eligibility?.reason && (
+            <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-800/40 p-3">
+              <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+                Next step
+              </p>
+              <p className="text-sm text-neutral-700 dark:text-neutral-300">
+                {eligibility.reason}
+              </p>
+            </div>
+          )}
+
+          {showcaseApprovalNote && (
+            <div className="rounded-lg border border-emerald-300/40 dark:border-emerald-500/30 bg-emerald-50/80 dark:bg-emerald-500/10 p-3">
+              <p className="text-xs uppercase tracking-wide text-emerald-700 dark:text-emerald-300 mb-1">
+                Verification
+              </p>
+              <p className="text-sm text-emerald-800 dark:text-emerald-200">
+                {showcaseApprovalNote}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="p-4 pt-0">
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="w-full px-3 py-2 rounded-lg bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/badges/index.ts
+++ b/components/badges/index.ts
@@ -1,0 +1,3 @@
+export { BadgeCard } from "./BadgeCard";
+export { BadgeGrid } from "./BadgeGrid";
+export { BadgePopover } from "./BadgePopover";

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -2,6 +2,12 @@ import Image from "next/image";
 import type { PublicMember } from "@/types/members";
 import { getInitials } from "@/lib/utils";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
+import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
+import { evaluateBadgeEligibility } from "@/lib/badges/eligibility";
+import type { BadgeEligibilityInput, BadgeId } from "@/lib/badges/types";
+import { getBaseBadgeEligibilityInput } from "@/lib/badges/getBadgeEligibilityInput";
+import { getEarnedBadgeIds } from "@/lib/badges/utils";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
 
 interface MemberCardProps {
   member: PublicMember;
@@ -10,6 +16,40 @@ interface MemberCardProps {
 export function MemberCard({ member }: MemberCardProps) {
   const v = member.visibility;
   const isAgent = member.memberType === "agent";
+  const badgeInput = {
+    ...getBaseBadgeEligibilityInput({
+      displayName: member.displayName,
+      bio: member.bio ?? null,
+      photoURL: member.photoURL,
+      discord: member.discord,
+      github: member.github,
+    }),
+    eventsAttendedCount: member.eventsAttended ?? 0,
+    talksGivenCount: member.talksGiven ?? 0,
+    pullRequestsCount: member.pullRequestsCount ?? 0,
+  } satisfies BadgeEligibilityInput;
+
+  const badgeEligibilityMap = evaluateBadgeEligibility(badgeInput);
+  const persistedBadgeOverlay = (member.earnedBadgeIds || []).reduce<
+    Partial<Record<BadgeId, true>>
+  >((acc, badgeId) => {
+    const matchingDefinition = BADGE_DEFINITIONS.find(
+      (definition) => definition.id === badgeId
+    );
+    if (matchingDefinition) {
+      acc[matchingDefinition.id] = true;
+    }
+    return acc;
+  }, {});
+  const earnedBadgeIds = getEarnedBadgeIds(
+    BADGE_DEFINITIONS,
+    badgeEligibilityMap,
+    persistedBadgeOverlay
+  );
+  const previewDefinitions = [
+    ...BADGE_DEFINITIONS.filter((definition) => earnedBadgeIds.includes(definition.id)),
+    ...BADGE_DEFINITIONS.filter((definition) => !earnedBadgeIds.includes(definition.id)),
+  ].slice(0, 3);
 
   return (
     <div className="bg-white dark:bg-neutral-900 rounded-xl p-6 border border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors">
@@ -131,6 +171,18 @@ export function MemberCard({ member }: MemberCardProps) {
             Hack-a-Sprint &apos;26
           </span>
         )}
+      </div>
+
+      <div className="mb-4">
+        <p className="mb-2 text-xs text-neutral-500 dark:text-neutral-400">
+          Preview only. Final badge status appears on profile.
+        </p>
+        <BadgeGrid
+          definitions={previewDefinitions}
+          eligibilityMap={badgeEligibilityMap}
+          earnedBadgeIds={earnedBadgeIds}
+          compact
+        />
       </div>
 
       {/* Social Links */}

--- a/types/members.ts
+++ b/types/members.ts
@@ -41,6 +41,7 @@ export interface PublicMember {
   talksGiven?: number;
   pullRequestsCount?: number;
   hackASprint2026ShowcaseBadge?: boolean;
+  earnedBadgeIds?: string[];
   github?: {
     login: string;
     html_url: string;


### PR DESCRIPTION
## Description
This PR adds the badge UI layer, including reusable badge components, the badges page, and badge-related profile/member display surfaces.
It includes:
reusable badge UI components
badge grid and popover presentation
the badges page
profile and member badge display surfaces
This PR intentionally excludes badge backend logic and APIs, which were isolated in the prior badge system PR.

Fixes # 79

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally
- [x] Tested authentication flows

Commands used:
rm -rf .next
npm test
npm run type-check

Verified:
badge UI components render and compile correctly
badge page and profile/member surfaces pass local tests
full local test suite and typecheck pass on this branch

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
N/A

## Additional Notes
This PR is part of the #79 restack and depends on pr3-badge-system. It contains only badge UI and badge display surfaces.