### PR TITLE
Add talk moderation API and tests

### DIFF
--- a/__tests__/app/api/talks/submission/moderate/route.test.ts
+++ b/__tests__/app/api/talks/submission/moderate/route.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/talks/submission/moderate/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  getClientIdentifier: jest.fn(() => "test-ip"),
+}));
+
+jest.mock("@/lib/rate-limit-server", () => ({
+  checkServerRateLimit: jest.fn(async () => ({ success: true, retryAfter: 0 })),
+  buildRateLimitHeaders: jest.fn(() => ({})),
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/talks/submission/moderate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/talks/submission/moderate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_EMAILS = "admin@example.com";
+    process.env.ADMIN_EMAIL = "";
+  });
+
+  it("requires approval before complete", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "talkSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({ exists: true, data: () => ({ status: "pending" }) })),
+            set: jest.fn(async () => undefined),
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await POST(makePostRequest({ submissionId: "t1", action: "complete" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("must be approved");
+  });
+
+  it("supports approve -> complete transition", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    let status: "pending" | "approved" | "completed" = "pending";
+    const setMock = jest.fn(async (payload: Record<string, unknown>) => {
+      if (payload.status === "approved") status = "approved";
+      if (payload.status === "completed") status = "completed";
+    });
+
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "talkSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({ exists: true, data: () => ({ status }) })),
+            set: setMock,
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const approveRes = await POST(makePostRequest({ submissionId: "t1", action: "approve" }));
+    const approveBody = await approveRes.json();
+    expect(approveRes.status).toBe(200);
+    expect(approveBody).toEqual(expect.objectContaining({ status: "approved", approved: true }));
+
+    const completeRes = await POST(makePostRequest({ submissionId: "t1", action: "complete" }));
+    const completeBody = await completeRes.json();
+    expect(completeRes.status).toBe(200);
+    expect(completeBody).toEqual(expect.objectContaining({ status: "completed", approved: true }));
+
+    expect(setMock).toHaveBeenCalledTimes(2);
+    expect(setMock.mock.calls[0][0]).toEqual(expect.objectContaining({ status: "approved" }));
+    expect(setMock.mock.calls[1][0]).toEqual(expect.objectContaining({ status: "completed" }));
+  });
+
+  it("completing an already completed talk is blocked", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const setMock = jest.fn(async () => undefined);
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "talkSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({ exists: true, data: () => ({ status: "completed" }) })),
+            set: setMock,
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await POST(makePostRequest({ submissionId: "t1", action: "complete" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("must be approved");
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("re-approving an already approved talk is idempotent", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const setMock = jest.fn(async () => undefined);
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "talkSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({ exists: true, data: () => ({ status: "approved" }) })),
+            set: setMock,
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await POST(makePostRequest({ submissionId: "t1", action: "approve" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(
+      expect.objectContaining({
+        alreadyApproved: true,
+        status: "approved",
+      })
+    );
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("approving an already completed talk is a no-op", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const setMock = jest.fn(async () => undefined);
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "talkSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({ exists: true, data: () => ({ status: "completed" }) })),
+            set: setMock,
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await POST(makePostRequest({ submissionId: "t1", action: "approve" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(
+      expect.objectContaining({
+        alreadyCompleted: true,
+        status: "completed",
+      })
+    );
+    expect(setMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/talks/submission/moderate/route.ts
+++ b/app/api/talks/submission/moderate/route.ts
@@ -1,0 +1,322 @@
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getClientIdentifier } from "@/lib/rate-limit";
+import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
+import { sanitizeDocId } from "@/lib/sanitize";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const TALK_SUBMISSION_MODERATE_GET_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 60 };
+const TALK_SUBMISSION_MODERATE_POST_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 30 };
+
+type TalkModerationAction = "approve" | "complete";
+type AdminDb = NonNullable<ReturnType<typeof getAdminDb>>;
+
+function toIsoDate(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const timestamp = value as { toDate?: () => Date };
+  if (typeof timestamp.toDate !== "function") return undefined;
+  return timestamp.toDate().toISOString();
+}
+
+function getPendingAgeBuckets(isoDates: Array<string | undefined>): Record<string, number> {
+  const now = Date.now();
+  const buckets = {
+    lt1d: 0,
+    d1to3: 0,
+    d3to7: 0,
+    d7plus: 0,
+    unknown: 0,
+  };
+
+  for (const iso of isoDates) {
+    if (!iso) {
+      buckets.unknown += 1;
+      continue;
+    }
+
+    const parsed = Date.parse(iso);
+    if (Number.isNaN(parsed)) {
+      buckets.unknown += 1;
+      continue;
+    }
+
+    const ageMs = Math.max(0, now - parsed);
+    const ageDays = ageMs / (1000 * 60 * 60 * 24);
+    if (ageDays < 1) {
+      buckets.lt1d += 1;
+    } else if (ageDays < 3) {
+      buckets.d1to3 += 1;
+    } else if (ageDays < 7) {
+      buckets.d3to7 += 1;
+    } else {
+      buckets.d7plus += 1;
+    }
+  }
+
+  return buckets;
+}
+
+async function logTalkPendingAgeSummary(
+  db: AdminDb,
+  source: "queue_read" | "moderation_approved" | "moderation_completed"
+) {
+  try {
+    const pendingSnapshot = await db
+      .collection("talkSubmissions")
+      .where("status", "==", "pending")
+      .limit(100)
+      .get();
+
+    const pendingDates = pendingSnapshot.docs.map((doc) => {
+      const data = doc.data() as { createdAt?: unknown };
+      return toIsoDate(data.createdAt);
+    });
+
+    logger.info("moderation_pending_age_summary", {
+      metric: "pending_age_distribution",
+      queue: "talk_submissions",
+      source,
+      pendingCount: pendingSnapshot.size,
+      ageBuckets: getPendingAgeBuckets(pendingDates),
+    });
+  } catch (error) {
+    logger.warn("moderation_pending_age_summary_failed", {
+      metric: "pending_age_distribution",
+      queue: "talk_submissions",
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "talk-submission-moderate-get",
+      windowMs: TALK_SUBMISSION_MODERATE_GET_RATE_LIMIT.windowMs,
+      maxRequests: TALK_SUBMISSION_MODERATE_GET_RATE_LIMIT.maxRequests,
+      identifier: `uid:${user.uid}|ip:${getClientIdentifier(request as unknown as Request)}`,
+      fallbackMode: "deny",
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        {
+          error:
+            rateResult.statusCode === 503
+              ? "Rate limit service unavailable"
+              : "Too many requests",
+          retryAfterSeconds: rateResult.retryAfter,
+        },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(
+            rateResult,
+            TALK_SUBMISSION_MODERATE_GET_RATE_LIMIT.maxRequests
+          ),
+        }
+      );
+    }
+
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const [pendingSnapshot, approvedSnapshot, completedSnapshot] = await Promise.all([
+      db.collection("talkSubmissions").where("status", "==", "pending").limit(100).get(),
+      db.collection("talkSubmissions").where("status", "==", "approved").limit(100).get(),
+      db.collection("talkSubmissions").where("status", "==", "completed").limit(100).get(),
+    ]);
+
+    const talkSubmissions = [...pendingSnapshot.docs, ...approvedSnapshot.docs, ...completedSnapshot.docs]
+      .map((doc) => {
+        const data = doc.data() as {
+          userId?: unknown;
+          title?: unknown;
+          status?: unknown;
+          createdAt?: unknown;
+        };
+        const status =
+          data.status === "approved"
+            ? "approved"
+            : data.status === "completed"
+            ? "completed"
+            : data.status === "pending"
+            ? "pending"
+            : "unknown";
+
+        return {
+          submissionId: doc.id,
+          userId: typeof data.userId === "string" ? data.userId : "",
+          title: typeof data.title === "string" ? data.title : "",
+          status,
+          createdAt: toIsoDate(data.createdAt),
+        };
+      });
+
+    await logTalkPendingAgeSummary(db, "queue_read");
+
+    return NextResponse.json({ talkSubmissions });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/talks/submission/moderate",
+      method: "GET",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "talk-submission-moderate-post",
+      windowMs: TALK_SUBMISSION_MODERATE_POST_RATE_LIMIT.windowMs,
+      maxRequests: TALK_SUBMISSION_MODERATE_POST_RATE_LIMIT.maxRequests,
+      identifier: `uid:${user.uid}|ip:${getClientIdentifier(request as unknown as Request)}`,
+      fallbackMode: "deny",
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        {
+          error:
+            rateResult.statusCode === 503
+              ? "Rate limit service unavailable"
+              : "Too many requests",
+          retryAfterSeconds: rateResult.retryAfter,
+        },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(
+            rateResult,
+            TALK_SUBMISSION_MODERATE_POST_RATE_LIMIT.maxRequests
+          ),
+        }
+      );
+    }
+
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const submissionId = sanitizeDocId(body.submissionId);
+    const action: TalkModerationAction = body.action === "complete" ? "complete" : "approve";
+    if (!submissionId) {
+      return NextResponse.json({ error: "Invalid submissionId" }, { status: 400 });
+    }
+
+    const submissionRef = db.collection("talkSubmissions").doc(submissionId);
+    const snapshot = await submissionRef.get();
+    if (!snapshot.exists) {
+      return NextResponse.json({ error: "Submission not found" }, { status: 404 });
+    }
+
+    const existing = snapshot.data() as { status?: unknown };
+
+    if (action === "approve") {
+      if (existing.status === "approved") {
+        return NextResponse.json({
+          approved: true,
+          alreadyApproved: true,
+          submissionId,
+          status: "approved",
+        });
+      }
+
+      if (existing.status === "completed") {
+        return NextResponse.json({
+          approved: true,
+          alreadyCompleted: true,
+          submissionId,
+          status: "completed",
+        });
+      }
+
+      await submissionRef.set(
+        {
+          status: "approved",
+          approvedAt: FieldValue.serverTimestamp(),
+          approvedBy: user.uid,
+        },
+        { merge: true }
+      );
+
+      logger.info("moderation_action", {
+        metric: "moderation_approval_throughput",
+        entityType: "talk_submission",
+        action: "approve",
+        resultStatus: "approved",
+        submissionId,
+        moderatorUid: user.uid,
+      });
+      await logTalkPendingAgeSummary(db, "moderation_approved");
+
+      return NextResponse.json({
+        approved: true,
+        submissionId,
+        status: "approved",
+      });
+    }
+
+    if (existing.status !== "approved") {
+      return NextResponse.json(
+        { error: "Talk submission must be approved before marking delivered." },
+        { status: 400 }
+      );
+    }
+
+    await submissionRef.set(
+      {
+        status: "completed",
+        completedAt: FieldValue.serverTimestamp(),
+        completedBy: user.uid,
+      },
+      { merge: true }
+    );
+
+    logger.info("moderation_action", {
+      metric: "moderation_approval_throughput",
+      entityType: "talk_submission",
+      action: "complete",
+      resultStatus: "completed",
+      submissionId,
+      moderatorUid: user.uid,
+    });
+    await logTalkPendingAgeSummary(db, "moderation_completed");
+
+    return NextResponse.json({
+      approved: true,
+      submissionId,
+      status: "completed",
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/talks/submission/moderate",
+      method: "POST",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Description
This PR adds the talk submission moderation API and its test coverage.
It includes:
the server route for talk submission moderation
tests covering moderation route behavior and state transitions
This PR builds on the shared server auth and rate limiting infrastructure and isolates the talk moderation backend into a focused review unit.

Fixes # 79

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally
- [x] Tested authentication flows

Commands used:
rm -rf .next
npm test
npm run type-check

Verified:
talk moderation route tests pass locally
route compiles cleanly with auth and rate-limit dependencies present
full local test suite and typecheck pass on this branch

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
This PR is part of the #79 restack and depends on pr2-auth-rate-limit. It contains only the talk moderation API and tests.