### PR TITLE
Add showcase submission and moderation flow

### DIFF
--- a/__tests__/app/api/showcase/submission/approve/route.test.ts
+++ b/__tests__/app/api/showcase/submission/approve/route.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/showcase/submission/approve/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  getClientIdentifier: jest.fn(() => "test-ip"),
+}));
+
+jest.mock("@/lib/rate-limit-server", () => ({
+  checkServerRateLimit: jest.fn(async () => ({ success: true, retryAfter: 0 })),
+  buildRateLimitHeaders: jest.fn(() => ({})),
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/showcase/submission/approve", { method: "GET" });
+}
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/showcase/submission/approve", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/showcase/submission/approve", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_EMAILS = "admin@example.com";
+    process.env.ADMIN_EMAIL = "";
+  });
+
+  it("rejects non-admin moderation access", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "u1",
+      email: "member@example.com",
+      isAdmin: false,
+    });
+
+    const res = await GET(makeGetRequest());
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows admin to reject and approve pending submissions", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const setMock = jest.fn(async () => undefined);
+    const docGetMock = jest.fn(async () => ({ exists: true, data: () => ({ status: "pending" }) }));
+
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "showcaseSubmissions") throw new Error("unexpected collection");
+        return {
+          where: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          get: jest.fn(async () => ({ docs: [] })),
+          doc: jest.fn(() => ({
+            get: docGetMock,
+            set: setMock,
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const rejectRes = await POST(makePostRequest({ submissionId: "s1", action: "reject" }));
+    const rejectBody = await rejectRes.json();
+    expect(rejectRes.status).toBe(200);
+    expect(rejectBody).toEqual(expect.objectContaining({ status: "rejected", rejected: true }));
+
+    const approveRes = await POST(makePostRequest({ submissionId: "s1", action: "approve" }));
+    const approveBody = await approveRes.json();
+    expect(approveRes.status).toBe(200);
+    expect(approveBody).toEqual(expect.objectContaining({ status: "approved", approved: true }));
+
+    expect(setMock).toHaveBeenCalledTimes(2);
+    expect(setMock.mock.calls[0][0]).toEqual(expect.objectContaining({ status: "rejected" }));
+    expect(setMock.mock.calls[1][0]).toEqual(expect.objectContaining({ status: "approved" }));
+  });
+
+  it("re-approving an already approved submission is idempotent", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const setMock = jest.fn(async () => undefined);
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "showcaseSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({
+              exists: true,
+              data: () => ({
+                status: "approved",
+                approvedAt: { toDate: () => new Date("2026-03-01T00:00:00.000Z") },
+                approvedBy: "admin-prev",
+                decisionSource: "manual",
+              }),
+            })),
+            set: setMock,
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await POST(makePostRequest({ submissionId: "s1", action: "approve" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(
+      expect.objectContaining({
+        alreadyApproved: true,
+        status: "approved",
+        submissionId: "s1",
+      })
+    );
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("rejecting an already approved submission does not transition state", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const setMock = jest.fn(async () => undefined);
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "showcaseSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({
+              exists: true,
+              data: () => ({ status: "approved" }),
+            })),
+            set: setMock,
+          })),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await POST(makePostRequest({ submissionId: "s1", action: "reject" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(
+      expect.objectContaining({
+        alreadyApproved: true,
+        status: "approved",
+      })
+    );
+    expect(setMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/showcase/submission/route.test.ts
+++ b/__tests__/app/api/showcase/submission/route.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/showcase/submission/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/content/showcase.json", () => ({
+  projects: [{ id: "project-1" }],
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  getClientIdentifier: jest.fn(() => "test-ip"),
+}));
+
+jest.mock("@/lib/rate-limit-server", () => ({
+  checkServerRateLimit: jest.fn(async () => ({ success: true, retryAfter: 0 })),
+  buildRateLimitHeaders: jest.fn(() => ({})),
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/showcase/submission", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/showcase/submission", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_EMAILS = "";
+    process.env.ADMIN_EMAIL = "";
+  });
+
+  it("returns authenticated user's submissions on GET", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@example.com" });
+
+    const db = {
+      collection: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn(async () => ({
+          docs: [
+            { data: () => ({ projectId: "project-1", status: "approved" }) },
+            { data: () => ({ projectId: "project-2", status: "rejected" }) },
+          ],
+        })),
+      })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(new NextRequest("http://localhost/api/showcase/submission"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.submissions).toEqual([
+      { projectId: "project-1", status: "approved" },
+      { projectId: "project-2", status: "rejected" },
+    ]);
+  });
+
+  it("creates a pending submission and supports rejected -> pending resubmission", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@example.com" });
+
+    let existingStatus: "missing" | "rejected" = "missing";
+    const setMock = jest.fn(async (payload: Record<string, unknown>) => {
+      if (payload.status === "pending") {
+        existingStatus = "rejected";
+      }
+    });
+
+    const submissionRef = {
+      get: jest.fn(async () =>
+        existingStatus === "missing"
+          ? { exists: false }
+          : { exists: true, data: () => ({ status: "rejected" }) }
+      ),
+      set: setMock,
+    };
+
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "showcaseSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => submissionRef),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const createRes = await POST(makePostRequest({ projectId: "project-1" }));
+    const createBody = await createRes.json();
+    expect(createRes.status).toBe(200);
+    expect(createBody).toEqual(
+      expect.objectContaining({ created: true, status: "pending", projectId: "project-1" })
+    );
+
+    const resubmitRes = await POST(makePostRequest({ projectId: "project-1" }));
+    const resubmitBody = await resubmitRes.json();
+    expect(resubmitRes.status).toBe(200);
+    expect(resubmitBody).toEqual(
+      expect.objectContaining({ resubmitted: true, status: "pending", projectId: "project-1" })
+    );
+
+    expect(setMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats repeated submission while already pending as idempotent no-op", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@example.com" });
+
+    const setMock = jest.fn(async () => undefined);
+    const submissionRef = {
+      get: jest.fn(async () => ({ exists: true, data: () => ({ status: "pending" }) })),
+      set: setMock,
+    };
+
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name !== "showcaseSubmissions") throw new Error("unexpected collection");
+        return {
+          doc: jest.fn(() => submissionRef),
+        };
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await POST(makePostRequest({ projectId: "project-1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(
+      expect.objectContaining({
+        created: false,
+        status: "pending",
+        projectId: "project-1",
+      })
+    );
+    expect(body.resubmitted).toBeUndefined();
+    expect(setMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/showcase/page.moderation.test.tsx
+++ b/__tests__/app/showcase/page.moderation.test.tsx
@@ -1,0 +1,232 @@
+/* eslint-disable @next/next/no-img-element */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as AuthContext from "@/contexts/AuthContext";
+import ShowcasePage from "@/app/showcase/page";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+jest.mock("@/content/showcase.json", () => ({
+  projects: [
+    {
+      id: "project-1",
+      name: "Project One",
+      description: "A project",
+      image: "/showcase/project-1.png",
+      categories: ["AI"],
+      contact: {},
+      submittedBy: "Member",
+      submittedDate: "2026-03-10",
+    },
+  ],
+}));
+
+jest.mock("firebase/auth", () => ({
+  getIdToken: jest.fn(async () => "test-token"),
+}));
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(() => ({ user: null })),
+}));
+
+type PendingSubmission = {
+  submissionId: string;
+  userId: string;
+  projectId: string;
+  createdAt?: string;
+  resubmittedAt?: string;
+};
+
+type TalkSubmission = {
+  submissionId: string;
+  userId: string;
+  title: string;
+  status: "pending" | "approved" | "completed" | "unknown";
+  createdAt?: string;
+};
+
+const mockUser = {
+  uid: "user-1",
+  email: "member@example.com",
+  displayName: "Member",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response);
+}
+
+function setupFetch(options?: {
+  admin?: boolean;
+  pendingSubmissions?: PendingSubmission[];
+  talkSubmissions?: TalkSubmission[];
+}) {
+  const {
+    admin = false,
+    pendingSubmissions = [],
+    talkSubmissions = [],
+  } = options || {};
+
+  const fetchMock = jest.fn((input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method || "GET").toUpperCase();
+
+    if (url.includes("/api/showcase/vote") && method === "GET") {
+      return jsonResponse({ votes: {}, userVotes: {} });
+    }
+
+    if (url.includes("/api/showcase/submission") && !url.includes("/approve") && method === "GET") {
+      return jsonResponse({ submissions: [] });
+    }
+
+    if (url.includes("/api/showcase/submission/approve") && method === "GET") {
+      return admin
+        ? jsonResponse({ pendingSubmissions })
+        : jsonResponse({ error: "Forbidden" }, 403);
+    }
+
+    if (url.includes("/api/talks/submission/moderate") && method === "GET") {
+      return admin
+        ? jsonResponse({ talkSubmissions })
+        : jsonResponse({ error: "Forbidden" }, 403);
+    }
+
+    if (url.includes("/api/showcase/submission/approve") && method === "POST") {
+      return jsonResponse({ approved: true, status: "approved" });
+    }
+
+    if (url.includes("/api/talks/submission/moderate") && method === "POST") {
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      return jsonResponse({
+        approved: true,
+        status: body.action === "complete" ? "completed" : "approved",
+      });
+    }
+
+    return Promise.reject(new Error(`Unexpected fetch: ${method} ${url}`));
+  });
+
+  global.fetch = fetchMock as jest.Mock;
+  return fetchMock;
+}
+
+describe("ShowcasePage moderation controls", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    (AuthContext.useAuth as jest.Mock).mockReturnValue({ user: mockUser });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not render moderation controls for non-admin users", async () => {
+    setupFetch({ admin: false });
+
+    render(<ShowcasePage />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/showcase/submission/approve",
+        expect.objectContaining({ headers: expect.any(Object) })
+      );
+    });
+
+    expect(screen.queryByText("Submission Moderation")).not.toBeInTheDocument();
+  });
+
+  it("renders moderation controls for admins", async () => {
+    setupFetch({
+      admin: true,
+      pendingSubmissions: [{ submissionId: "s1", userId: "u1", projectId: "project-1" }],
+      talkSubmissions: [{ submissionId: "t1", userId: "u2", title: "Talk A", status: "pending" }],
+    });
+
+    render(<ShowcasePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Submission Moderation")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Talk Moderation")).toBeInTheDocument();
+  });
+
+  it("renders strict status-based talk moderation actions", async () => {
+    setupFetch({
+      admin: true,
+      pendingSubmissions: [],
+      talkSubmissions: [
+        { submissionId: "t-p", userId: "u1", title: "Pending Talk", status: "pending" },
+        { submissionId: "t-a", userId: "u2", title: "Approved Talk", status: "approved" },
+        { submissionId: "t-c", userId: "u3", title: "Completed Talk", status: "completed" },
+        { submissionId: "t-u", userId: "u4", title: "Unknown Talk", status: "unknown" },
+      ],
+    });
+
+    render(<ShowcasePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Talk Moderation")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByRole("button", { name: "Approve" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Mark Delivered" })).toHaveLength(1);
+    expect(screen.getByText("Resolved")).toBeInTheDocument();
+    expect(screen.getByText("No action")).toBeInTheDocument();
+  });
+
+  it("wires showcase and talk moderation button actions to expected endpoints", async () => {
+    const fetchMock = setupFetch({
+      admin: true,
+      pendingSubmissions: [{ submissionId: "s-approve", userId: "u1", projectId: "project-1" }],
+      talkSubmissions: [{
+        submissionId: "t-complete",
+        userId: "u2",
+        title: "Approved Talk",
+        status: "approved",
+      }],
+    });
+
+    const user = userEvent.setup();
+    render(<ShowcasePage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Mark Delivered" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    await user.click(screen.getByRole("button", { name: "Mark Delivered" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Talk marked as delivered.")).toBeInTheDocument();
+    });
+
+    const postCalls = fetchMock.mock.calls.filter(([, init]) => (init?.method || "GET") === "POST");
+
+    const showcasePostCall = postCalls.find(([url]) =>
+      String(url).includes("/api/showcase/submission/approve")
+    );
+    expect(showcasePostCall).toBeDefined();
+    expect(JSON.parse(String(showcasePostCall?.[1]?.body))).toEqual(
+      expect.objectContaining({ submissionId: "s-approve", action: "approve" })
+    );
+
+    const talkPostCall = postCalls.find(([url]) =>
+      String(url).includes("/api/talks/submission/moderate")
+    );
+    expect(talkPostCall).toBeDefined();
+    expect(JSON.parse(String(talkPostCall?.[1]?.body))).toEqual(
+      expect.objectContaining({ submissionId: "t-complete", action: "complete" })
+    );
+  });
+});

--- a/app/api/showcase/submission/approve/route.ts
+++ b/app/api/showcase/submission/approve/route.ts
@@ -1,0 +1,352 @@
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getClientIdentifier } from "@/lib/rate-limit";
+import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
+import { sanitizeDocId } from "@/lib/sanitize";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const SHOWCASE_SUBMISSION_APPROVE_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 30 };
+const SHOWCASE_SUBMISSION_APPROVE_GET_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 60 };
+type ShowcaseDecisionAction = "submitted" | "approved" | "rejected" | "resubmitted";
+type ShowcaseDecisionSource = "manual" | "auto" | "user";
+type AdminDb = NonNullable<ReturnType<typeof getAdminDb>>;
+
+function historyEntry(params: {
+  action: ShowcaseDecisionAction;
+  source: ShowcaseDecisionSource;
+  by: string;
+  reason?: string;
+}) {
+  return {
+    action: params.action,
+    at: Timestamp.now(),
+    by: params.by,
+    source: params.source,
+    ...(params.reason ? { reason: params.reason } : {}),
+  };
+}
+
+function toIsoDate(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const timestamp = value as { toDate?: () => Date };
+  if (typeof timestamp.toDate !== "function") return undefined;
+  return timestamp.toDate().toISOString();
+}
+
+function getPendingAgeBuckets(isoDates: Array<string | undefined>): Record<string, number> {
+  const now = Date.now();
+  const buckets = {
+    lt1d: 0,
+    d1to3: 0,
+    d3to7: 0,
+    d7plus: 0,
+    unknown: 0,
+  };
+
+  for (const iso of isoDates) {
+    if (!iso) {
+      buckets.unknown += 1;
+      continue;
+    }
+
+    const parsed = Date.parse(iso);
+    if (Number.isNaN(parsed)) {
+      buckets.unknown += 1;
+      continue;
+    }
+
+    const ageMs = Math.max(0, now - parsed);
+    const ageDays = ageMs / (1000 * 60 * 60 * 24);
+    if (ageDays < 1) {
+      buckets.lt1d += 1;
+    } else if (ageDays < 3) {
+      buckets.d1to3 += 1;
+    } else if (ageDays < 7) {
+      buckets.d3to7 += 1;
+    } else {
+      buckets.d7plus += 1;
+    }
+  }
+
+  return buckets;
+}
+
+async function logShowcasePendingAgeSummary(
+  db: AdminDb,
+  source: "queue_read" | "moderation_approved" | "moderation_rejected"
+) {
+  try {
+    const pendingSnapshot = await db
+      .collection("showcaseSubmissions")
+      .where("status", "==", "pending")
+      .limit(100)
+      .get();
+
+    const pendingDates = pendingSnapshot.docs.map((doc) => {
+      const data = doc.data() as { createdAt?: unknown; resubmittedAt?: unknown };
+      return toIsoDate(data.resubmittedAt) || toIsoDate(data.createdAt);
+    });
+
+    logger.info("moderation_pending_age_summary", {
+      metric: "pending_age_distribution",
+      queue: "showcase_submissions",
+      source,
+      pendingCount: pendingSnapshot.size,
+      ageBuckets: getPendingAgeBuckets(pendingDates),
+    });
+  } catch (error) {
+    logger.warn("moderation_pending_age_summary_failed", {
+      metric: "pending_age_distribution",
+      queue: "showcase_submissions",
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "showcase-submission-approve-get",
+      windowMs: SHOWCASE_SUBMISSION_APPROVE_GET_RATE_LIMIT.windowMs,
+      maxRequests: SHOWCASE_SUBMISSION_APPROVE_GET_RATE_LIMIT.maxRequests,
+      identifier: `uid:${user.uid}|ip:${getClientIdentifier(request as unknown as Request)}`,
+      fallbackMode: "deny",
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        {
+          error:
+            rateResult.statusCode === 503
+              ? "Rate limit service unavailable"
+              : "Too many requests",
+          retryAfterSeconds: rateResult.retryAfter,
+        },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(
+            rateResult,
+            SHOWCASE_SUBMISSION_APPROVE_GET_RATE_LIMIT.maxRequests
+          ),
+        }
+      );
+    }
+
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const pendingSnapshot = await db
+      .collection("showcaseSubmissions")
+      .where("status", "==", "pending")
+      .limit(100)
+      .get();
+
+    const pendingSubmissions = pendingSnapshot.docs.map((doc) => {
+      const data = doc.data() as {
+        userId?: unknown;
+        projectId?: unknown;
+        createdAt?: unknown;
+        resubmittedAt?: unknown;
+      };
+      return {
+        submissionId: doc.id,
+        userId: typeof data.userId === "string" ? data.userId : "",
+        projectId: typeof data.projectId === "string" ? data.projectId : "",
+        createdAt: toIsoDate(data.createdAt),
+        resubmittedAt: toIsoDate(data.resubmittedAt),
+      };
+    });
+
+    await logShowcasePendingAgeSummary(db, "queue_read");
+
+    return NextResponse.json({ pendingSubmissions });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/showcase/submission/approve",
+      method: "GET",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "showcase-submission-approve-post",
+      windowMs: SHOWCASE_SUBMISSION_APPROVE_RATE_LIMIT.windowMs,
+      maxRequests: SHOWCASE_SUBMISSION_APPROVE_RATE_LIMIT.maxRequests,
+      identifier: `uid:${user.uid}|ip:${getClientIdentifier(request as unknown as Request)}`,
+      fallbackMode: "deny",
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        {
+          error:
+            rateResult.statusCode === 503
+              ? "Rate limit service unavailable"
+              : "Too many requests",
+          retryAfterSeconds: rateResult.retryAfter,
+        },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(
+            rateResult,
+            SHOWCASE_SUBMISSION_APPROVE_RATE_LIMIT.maxRequests
+          ),
+        }
+      );
+    }
+
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const submissionId = sanitizeDocId(body.submissionId);
+    const action = body.action === "reject" ? "reject" : "approve";
+    const reason =
+      typeof body.reason === "string" && body.reason.trim()
+        ? body.reason.trim()
+        : undefined;
+    if (!submissionId) {
+      return NextResponse.json({ error: "Invalid submissionId" }, { status: 400 });
+    }
+
+    const submissionRef = db.collection("showcaseSubmissions").doc(submissionId);
+    const snapshot = await submissionRef.get();
+    if (!snapshot.exists) {
+      return NextResponse.json({ error: "Submission not found" }, { status: 404 });
+    }
+
+    const existing = snapshot.data() as {
+      status?: unknown;
+      approvedAt?: unknown;
+      decisionSource?: unknown;
+      approvalSource?: unknown;
+      approvedBy?: unknown;
+    };
+    if (existing.status === "approved") {
+      return NextResponse.json({
+        approved: true,
+        alreadyApproved: true,
+        submissionId,
+        status: "approved",
+        approvedAt:
+          existing.approvedAt && typeof existing.approvedAt === "object" &&
+          typeof (existing.approvedAt as { toDate?: () => Date }).toDate === "function"
+            ? (existing.approvedAt as { toDate: () => Date }).toDate().toISOString()
+            : undefined,
+        decisionSource:
+          typeof existing.decisionSource === "string"
+            ? existing.decisionSource
+            : typeof existing.approvalSource === "string"
+            ? existing.approvalSource
+            : undefined,
+        approvedBy:
+          typeof existing.approvedBy === "string" ? existing.approvedBy : undefined,
+      });
+    }
+
+    if (action === "reject") {
+      await submissionRef.set(
+        {
+          status: "rejected",
+          rejectedAt: FieldValue.serverTimestamp(),
+          rejectedBy: user.uid,
+          decisionSource: "manual",
+          decisionHistory: FieldValue.arrayUnion(
+            historyEntry({
+              action: "rejected",
+              source: "manual",
+              by: user.uid,
+              reason,
+            })
+          ),
+        },
+        { merge: true }
+      );
+
+      logger.info("moderation_action", {
+        metric: "moderation_approval_throughput",
+        entityType: "showcase_submission",
+        action: "reject",
+        resultStatus: "rejected",
+        submissionId,
+        moderatorUid: user.uid,
+      });
+      await logShowcasePendingAgeSummary(db, "moderation_rejected");
+
+      return NextResponse.json({
+        approved: false,
+        rejected: true,
+        submissionId,
+        status: "rejected",
+      });
+    }
+
+    await submissionRef.set(
+      {
+        status: "approved",
+        approvedAt: FieldValue.serverTimestamp(),
+        decisionSource: "manual",
+        approvedBy: user.uid,
+        decisionHistory: FieldValue.arrayUnion(
+          historyEntry({
+            action: "approved",
+            source: "manual",
+            by: user.uid,
+            reason,
+          })
+        ),
+      },
+      { merge: true }
+    );
+
+    logger.info("moderation_action", {
+      metric: "moderation_approval_throughput",
+      entityType: "showcase_submission",
+      action: "approve",
+      resultStatus: "approved",
+      submissionId,
+      moderatorUid: user.uid,
+    });
+    await logShowcasePendingAgeSummary(db, "moderation_approved");
+
+    return NextResponse.json({
+      approved: true,
+      submissionId,
+      status: "approved",
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/showcase/submission/approve",
+      method: "POST",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/showcase/submission/route.ts
+++ b/app/api/showcase/submission/route.ts
@@ -1,0 +1,324 @@
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getClientIdentifier } from "@/lib/rate-limit";
+import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
+import { sanitizeDocId } from "@/lib/sanitize";
+import { logger } from "@/lib/logger";
+import showcaseData from "@/content/showcase.json";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SHOWCASE_SUBMISSION_POST_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 20 };
+const SHOWCASE_SUBMISSION_GET_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 60 };
+type ShowcaseSubmissionStatus = "pending" | "approved" | "rejected";
+type ShowcaseDecisionAction = "submitted" | "approved" | "rejected" | "resubmitted";
+type ShowcaseDecisionSource = "manual" | "auto" | "user";
+type AdminDb = NonNullable<ReturnType<typeof getAdminDb>>;
+
+function historyEntry(params: {
+  action: ShowcaseDecisionAction;
+  source: ShowcaseDecisionSource;
+  by: string;
+  reason?: string;
+}) {
+  return {
+    action: params.action,
+    at: Timestamp.now(),
+    by: params.by,
+    source: params.source,
+    ...(params.reason ? { reason: params.reason } : {}),
+  };
+}
+
+function toIsoDate(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const timestamp = value as { toDate?: () => Date };
+  if (typeof timestamp.toDate !== "function") return undefined;
+  return timestamp.toDate().toISOString();
+}
+
+function getPendingAgeBuckets(isoDates: Array<string | undefined>): Record<string, number> {
+  const now = Date.now();
+  const buckets = {
+    lt1d: 0,
+    d1to3: 0,
+    d3to7: 0,
+    d7plus: 0,
+    unknown: 0,
+  };
+
+  for (const iso of isoDates) {
+    if (!iso) {
+      buckets.unknown += 1;
+      continue;
+    }
+
+    const parsed = Date.parse(iso);
+    if (Number.isNaN(parsed)) {
+      buckets.unknown += 1;
+      continue;
+    }
+
+    const ageMs = Math.max(0, now - parsed);
+    const ageDays = ageMs / (1000 * 60 * 60 * 24);
+    if (ageDays < 1) {
+      buckets.lt1d += 1;
+    } else if (ageDays < 3) {
+      buckets.d1to3 += 1;
+    } else if (ageDays < 7) {
+      buckets.d3to7 += 1;
+    } else {
+      buckets.d7plus += 1;
+    }
+  }
+
+  return buckets;
+}
+
+async function logShowcasePendingAgeSummary(
+  db: AdminDb,
+  source: "submission_created" | "submission_resubmitted"
+) {
+  try {
+    const pendingSnapshot = await db
+      .collection("showcaseSubmissions")
+      .where("status", "==", "pending")
+      .limit(100)
+      .get();
+
+    const pendingDates = pendingSnapshot.docs.map((doc) => {
+      const data = doc.data() as { createdAt?: unknown; resubmittedAt?: unknown };
+      return toIsoDate(data.resubmittedAt) || toIsoDate(data.createdAt);
+    });
+
+    logger.info("moderation_pending_age_summary", {
+      metric: "pending_age_distribution",
+      queue: "showcase_submissions",
+      source,
+      pendingCount: pendingSnapshot.size,
+      ageBuckets: getPendingAgeBuckets(pendingDates),
+    });
+  } catch (error) {
+    logger.warn("moderation_pending_age_summary_failed", {
+      metric: "pending_age_distribution",
+      queue: "showcase_submissions",
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "showcase-submission-get",
+      windowMs: SHOWCASE_SUBMISSION_GET_RATE_LIMIT.windowMs,
+      maxRequests: SHOWCASE_SUBMISSION_GET_RATE_LIMIT.maxRequests,
+      identifier: `uid:${user.uid}|ip:${getClientIdentifier(request as unknown as Request)}`,
+      fallbackMode: "strict-memory",
+      fallbackMaxRequests: 20,
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(
+            rateResult,
+            SHOWCASE_SUBMISSION_GET_RATE_LIMIT.maxRequests
+          ),
+        }
+      );
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const snapshot = await db
+      .collection("showcaseSubmissions")
+      .where("userId", "==", user.uid)
+      .get();
+
+    const submissions = snapshot.docs
+      .map((doc) => {
+        const data = doc.data() as {
+          projectId?: unknown;
+          status?: unknown;
+        };
+        if (typeof data.projectId !== "string") return null;
+
+        const status: ShowcaseSubmissionStatus =
+          data.status === "approved"
+            ? "approved"
+            : data.status === "rejected"
+            ? "rejected"
+            : "pending";
+        return {
+          projectId: data.projectId,
+          status,
+        };
+      })
+      .filter((submission): submission is { projectId: string; status: ShowcaseSubmissionStatus } => submission !== null);
+
+    return NextResponse.json({ submissions });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/showcase/submission",
+      method: "GET",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "showcase-submission-post",
+      windowMs: SHOWCASE_SUBMISSION_POST_RATE_LIMIT.windowMs,
+      maxRequests: SHOWCASE_SUBMISSION_POST_RATE_LIMIT.maxRequests,
+      identifier: `ip:${clientId}`,
+      fallbackMode: "strict-memory",
+      fallbackMaxRequests: 5,
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(
+            rateResult,
+            SHOWCASE_SUBMISSION_POST_RATE_LIMIT.maxRequests
+          ),
+        }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const sanitizedProjectId = sanitizeDocId(body.projectId);
+    if (!sanitizedProjectId) {
+      return NextResponse.json({ error: "Invalid projectId" }, { status: 400 });
+    }
+
+    const projectExists = (showcaseData.projects || []).some(
+      (project) => project.id === sanitizedProjectId
+    );
+    if (!projectExists) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const docId = `${user.uid}_${sanitizedProjectId}`;
+    const submissionRef = db.collection("showcaseSubmissions").doc(docId);
+    const existing = await submissionRef.get();
+
+    if (existing.exists) {
+      const existingData = existing.data() as { status?: unknown } | undefined;
+      const status: ShowcaseSubmissionStatus =
+        existingData?.status === "approved"
+          ? "approved"
+          : existingData?.status === "rejected"
+          ? "rejected"
+          : "pending";
+
+      if (status === "rejected") {
+        await submissionRef.set(
+          {
+            status: "pending",
+            updatedAt: FieldValue.serverTimestamp(),
+            resubmittedAt: FieldValue.serverTimestamp(),
+            decisionSource: "user",
+            decisionHistory: FieldValue.arrayUnion(
+              historyEntry({
+                action: "resubmitted",
+                source: "user",
+                by: user.uid,
+              })
+            ),
+          },
+          { merge: true }
+        );
+        await logShowcasePendingAgeSummary(db, "submission_resubmitted");
+
+        return NextResponse.json({
+          created: false,
+          resubmitted: true,
+          projectId: sanitizedProjectId,
+          status: "pending" as ShowcaseSubmissionStatus,
+        });
+      }
+
+      return NextResponse.json({
+        created: false,
+        projectId: sanitizedProjectId,
+        status,
+      });
+    }
+
+    const autoApproved = Boolean(user.isAdmin);
+    const submittedEvent = historyEntry({
+      action: "submitted",
+      source: "user",
+      by: user.uid,
+    });
+    const approvedEvent = autoApproved
+      ? historyEntry({
+          action: "approved",
+          source: "auto",
+          by: user.uid,
+        })
+      : null;
+
+    await submissionRef.set({
+      userId: user.uid,
+      projectId: sanitizedProjectId,
+      status: autoApproved ? "approved" : "pending",
+      createdAt: FieldValue.serverTimestamp(),
+      decisionHistory: approvedEvent
+        ? [submittedEvent, approvedEvent]
+        : [submittedEvent],
+      ...(autoApproved
+        ? {
+            approvedAt: FieldValue.serverTimestamp(),
+            decisionSource: "auto",
+            approvedBy: user.uid,
+          }
+        : {}),
+    });
+
+    if (!autoApproved) {
+      await logShowcasePendingAgeSummary(db, "submission_created");
+    }
+
+    return NextResponse.json({
+      created: true,
+      projectId: sanitizedProjectId,
+      status: (autoApproved ? "approved" : "pending") as ShowcaseSubmissionStatus,
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/showcase/submission",
+      method: "POST",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/showcase/page.tsx
+++ b/app/showcase/page.tsx
@@ -32,6 +32,32 @@ interface UserVotes {
   [projectId: string]: string;
 }
 
+interface SubmissionFeedback {
+  type: "success" | "error";
+  message: string;
+}
+
+type SubmissionStatus = "pending" | "approved" | "rejected";
+type TalkModerationStatus = "pending" | "approved" | "completed" | "unknown";
+type ShowcaseModerationAction = "approve" | "reject";
+type TalkModerationAction = "approve" | "complete";
+
+interface PendingSubmission {
+  submissionId: string;
+  userId: string;
+  projectId: string;
+  createdAt?: string;
+  resubmittedAt?: string;
+}
+
+interface TalkModerationSubmission {
+  submissionId: string;
+  userId: string;
+  title: string;
+  status: TalkModerationStatus;
+  createdAt?: string;
+}
+
 function getNetScore(votes: VoteCounts, projectId: string): number {
   const v = votes[projectId];
   if (!v) return 0;
@@ -43,7 +69,18 @@ export default function ShowcasePage() {
   const [votes, setVotes] = useState<VoteCounts>({});
   const [userVotes, setUserVotes] = useState<UserVotes>({});
   const [votingId, setVotingId] = useState<string | null>(null);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const [submittedProjects, setSubmittedProjects] = useState<Record<string, SubmissionStatus>>({});
   const [instructionsOpen, setInstructionsOpen] = useState(false);
+  const [submissionFeedback, setSubmissionFeedback] = useState<SubmissionFeedback | null>(null);
+  const [adminFeedback, setAdminFeedback] = useState<SubmissionFeedback | null>(null);
+  const [isAdminOperator, setIsAdminOperator] = useState(false);
+  const [loadingPendingSubmissions, setLoadingPendingSubmissions] = useState(false);
+  const [pendingSubmissions, setPendingSubmissions] = useState<PendingSubmission[]>([]);
+  const [talkModerationSubmissions, setTalkModerationSubmissions] = useState<
+    TalkModerationSubmission[]
+  >([]);
+  const [moderatingSubmissionId, setModeratingSubmissionId] = useState<string | null>(null);
 
   // Fetch vote data
   useEffect(() => {
@@ -113,6 +150,305 @@ export default function ShowcasePage() {
       }
     },
     [user, votingId]
+  );
+
+  const handleMarkSubmitted = useCallback(
+    async (projectId: string) => {
+      if (!user || submittingId) return;
+
+      setSubmittingId(projectId);
+      setSubmissionFeedback(null);
+      try {
+        const { getIdToken } = await import("firebase/auth");
+        const token = await getIdToken(user);
+        const res = await fetch("/api/showcase/submission", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ projectId }),
+        });
+
+        const payload = (await res.json().catch(() => ({}))) as {
+          created?: boolean;
+          resubmitted?: boolean;
+          error?: string;
+          status?: SubmissionStatus;
+        };
+
+        if (!res.ok) {
+          setSubmissionFeedback({
+            type: "error",
+            message: payload.error || "Could not record submission. Please try again.",
+          });
+          return;
+        }
+
+        const status =
+          payload.status === "approved"
+            ? "approved"
+            : payload.status === "rejected"
+            ? "rejected"
+            : "pending";
+        setSubmittedProjects((prev) => ({ ...prev, [projectId]: status }));
+        setSubmissionFeedback({
+          type: "success",
+          message: payload.resubmitted
+            ? "Submission re-sent for review. It does not count toward Showcase Star until approved."
+            : payload.created
+            ? "Submission received. It is pending review and does not count toward Showcase Star until approved."
+            : status === "approved"
+            ? "This submission is already approved."
+            : status === "rejected"
+            ? "This submission was rejected. You can resubmit after making changes."
+            : "This submission is already pending review.",
+        });
+      } catch {
+        setSubmissionFeedback({
+          type: "error",
+          message: "Could not record submission. Please try again.",
+        });
+      } finally {
+        setSubmittingId(null);
+      }
+    },
+    [user, submittingId]
+  );
+
+  useEffect(() => {
+    if (!user) {
+      setSubmittedProjects({});
+      return;
+    }
+
+    let active = true;
+    (async () => {
+      try {
+        const { getIdToken } = await import("firebase/auth");
+        const token = await getIdToken(user);
+        const res = await fetch("/api/showcase/submission", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (!res.ok) {
+          throw new Error("Failed to fetch showcase submission state.");
+        }
+
+        const data = (await res.json()) as {
+          submissions?: Array<{ projectId: string; status: SubmissionStatus }>;
+        };
+        if (!active) return;
+
+        const submittedMap = (data.submissions || []).reduce<Record<string, SubmissionStatus>>(
+          (acc, submission) => {
+            acc[submission.projectId] = submission.status;
+            return acc;
+          },
+          {}
+        );
+        setSubmittedProjects(submittedMap);
+      } catch {
+        if (!active) return;
+        setSubmissionFeedback({
+          type: "error",
+          message: "Could not load your showcase submission statuses.",
+        });
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) {
+      setIsAdminOperator(false);
+      setPendingSubmissions([]);
+      setTalkModerationSubmissions([]);
+      setAdminFeedback(null);
+      return;
+    }
+
+    let active = true;
+    setLoadingPendingSubmissions(true);
+    (async () => {
+      try {
+        const { getIdToken } = await import("firebase/auth");
+        const token = await getIdToken(user);
+        const res = await fetch("/api/showcase/submission/approve", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (res.status === 403) {
+          if (!active) return;
+          setIsAdminOperator(false);
+          setPendingSubmissions([]);
+          setTalkModerationSubmissions([]);
+          return;
+        }
+
+        if (!res.ok) {
+          throw new Error("Failed to fetch pending showcase submissions.");
+        }
+
+        const payload = (await res.json()) as {
+          pendingSubmissions?: PendingSubmission[];
+        };
+
+        if (!active) return;
+        setIsAdminOperator(true);
+        setPendingSubmissions(
+          Array.isArray(payload.pendingSubmissions) ? payload.pendingSubmissions : []
+        );
+
+        const talkRes = await fetch("/api/talks/submission/moderate", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (talkRes.ok) {
+          const talkPayload = (await talkRes.json()) as {
+            talkSubmissions?: TalkModerationSubmission[];
+          };
+          setTalkModerationSubmissions(
+            Array.isArray(talkPayload.talkSubmissions) ? talkPayload.talkSubmissions : []
+          );
+        } else {
+          setTalkModerationSubmissions([]);
+        }
+      } catch {
+        if (!active) return;
+        setIsAdminOperator(false);
+      } finally {
+        if (active) {
+          setLoadingPendingSubmissions(false);
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  const handleModerationAction = useCallback(
+    async (submissionId: string, action: ShowcaseModerationAction) => {
+      if (!user || !isAdminOperator || moderatingSubmissionId) return;
+
+      setModeratingSubmissionId(submissionId);
+      setAdminFeedback(null);
+
+      try {
+        const { getIdToken } = await import("firebase/auth");
+        const token = await getIdToken(user);
+        const res = await fetch("/api/showcase/submission/approve", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ submissionId, action }),
+        });
+
+        const payload = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+
+        if (!res.ok) {
+          setAdminFeedback({
+            type: "error",
+            message: payload.error || "Could not update submission status. Please try again.",
+          });
+          return;
+        }
+
+        setPendingSubmissions((prev) =>
+          prev.filter((submission) => submission.submissionId !== submissionId)
+        );
+        setAdminFeedback({
+          type: "success",
+          message: action === "approve"
+            ? "Submission approved."
+            : "Submission rejected.",
+        });
+      } catch {
+        setAdminFeedback({
+          type: "error",
+          message: "Could not update submission status. Please try again.",
+        });
+      } finally {
+        setModeratingSubmissionId(null);
+      }
+    },
+    [isAdminOperator, moderatingSubmissionId, user]
+  );
+
+  const handleTalkModerationAction = useCallback(
+    async (submissionId: string, action: TalkModerationAction) => {
+      if (!user || !isAdminOperator || moderatingSubmissionId) return;
+
+      setModeratingSubmissionId(submissionId);
+      setAdminFeedback(null);
+
+      try {
+        const { getIdToken } = await import("firebase/auth");
+        const token = await getIdToken(user);
+        const res = await fetch("/api/talks/submission/moderate", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ submissionId, action }),
+        });
+
+        const payload = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+
+        if (!res.ok) {
+          setAdminFeedback({
+            type: "error",
+            message: payload.error || "Could not update talk status. Please try again.",
+          });
+          return;
+        }
+
+        if (action === "approve") {
+          setTalkModerationSubmissions((prev) =>
+            prev.map((submission) =>
+              submission.submissionId === submissionId
+                ? { ...submission, status: "approved" }
+                : submission
+            )
+          );
+          setAdminFeedback({
+            type: "success",
+            message: "Talk submission approved.",
+          });
+        } else {
+          setTalkModerationSubmissions((prev) =>
+            prev.map((submission) =>
+              submission.submissionId === submissionId
+                ? { ...submission, status: "completed" }
+                : submission
+            )
+          );
+          setAdminFeedback({
+            type: "success",
+            message: "Talk marked as delivered.",
+          });
+        }
+      } catch {
+        setAdminFeedback({
+          type: "error",
+          message: "Could not update talk status. Please try again.",
+        });
+      } finally {
+        setModeratingSubmissionId(null);
+      }
+    },
+    [isAdminOperator, moderatingSubmissionId, user]
   );
 
   // Sort projects by net votes (descending)
@@ -275,6 +611,169 @@ export default function ShowcasePage() {
             </span>
           </div>
 
+          {submissionFeedback && (
+            <div
+              role={submissionFeedback.type === "error" ? "alert" : "status"}
+              className={`mb-6 rounded-xl border px-4 py-3 text-sm ${
+                submissionFeedback.type === "error"
+                  ? "border-red-500/30 bg-red-500/10 text-red-300"
+                  : "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+              }`}
+            >
+              {submissionFeedback.message}
+            </div>
+          )}
+
+          {isAdminOperator && (
+            <div className="mb-6 rounded-xl border border-neutral-800 bg-neutral-900 p-4">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <h3 className="text-sm font-semibold text-white">Submission Moderation</h3>
+                {loadingPendingSubmissions && (
+                  <span className="text-xs text-neutral-400">Loading pending...</span>
+                )}
+              </div>
+
+              {adminFeedback && (
+                <div
+                  role={adminFeedback.type === "error" ? "alert" : "status"}
+                  className={`mb-3 rounded-lg border px-3 py-2 text-xs ${
+                    adminFeedback.type === "error"
+                      ? "border-red-500/30 bg-red-500/10 text-red-300"
+                      : "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                  }`}
+                >
+                  {adminFeedback.message}
+                </div>
+              )}
+
+              {pendingSubmissions.length === 0 ? (
+                <p className="text-xs text-neutral-400">No pending submissions.</p>
+              ) : (
+                <div className="space-y-2">
+                  {pendingSubmissions.map((submission) => (
+                    <div
+                      key={submission.submissionId}
+                      className="rounded-lg border border-neutral-800 bg-neutral-950 p-3"
+                    >
+                      <p className="text-sm text-white mb-1">
+                        {submission.projectId || "(unknown project)"}
+                      </p>
+                      <p className="text-xs text-neutral-400 mb-2">
+                        User: {submission.userId || "(unknown user)"}
+                        {submission.resubmittedAt
+                          ? ` • Resubmitted ${new Date(
+                              submission.resubmittedAt
+                            ).toLocaleDateString("en-US", {
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            })}`
+                          : submission.createdAt
+                          ? ` • Submitted ${new Date(
+                              submission.createdAt
+                            ).toLocaleDateString("en-US", {
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            })}`
+                          : ""}
+                      </p>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            handleModerationAction(submission.submissionId, "approve")
+                          }
+                          disabled={moderatingSubmissionId === submission.submissionId}
+                          className="px-3 py-1.5 rounded-md text-xs font-medium bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20 disabled:opacity-60 disabled:cursor-not-allowed"
+                        >
+                          Approve
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            handleModerationAction(submission.submissionId, "reject")
+                          }
+                          disabled={moderatingSubmissionId === submission.submissionId}
+                          className="px-3 py-1.5 rounded-md text-xs font-medium bg-red-500/10 text-red-300 hover:bg-red-500/20 disabled:opacity-60 disabled:cursor-not-allowed"
+                        >
+                          Reject
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="mt-4 pt-4 border-t border-neutral-800">
+                <h4 className="text-xs font-semibold text-neutral-300 mb-2">Talk Moderation</h4>
+                {talkModerationSubmissions.length === 0 ? (
+                  <p className="text-xs text-neutral-400">No talks requiring moderation.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {talkModerationSubmissions.map((submission) => (
+                      <div
+                        key={submission.submissionId}
+                        className="rounded-lg border border-neutral-800 bg-neutral-950 p-3"
+                      >
+                        <p className="text-sm text-white mb-1">
+                          {submission.title || "(untitled talk)"}
+                        </p>
+                        <p className="text-xs text-neutral-400 mb-2">
+                          User: {submission.userId || "(unknown user)"}
+                          {submission.createdAt
+                            ? ` • Submitted ${new Date(submission.createdAt).toLocaleDateString(
+                                "en-US",
+                                {
+                                  month: "short",
+                                  day: "numeric",
+                                  year: "numeric",
+                                }
+                              )}`
+                            : ""}
+                          {` • ${submission.status}`}
+                        </p>
+                        <div className="flex gap-2">
+                          {submission.status === "pending" ? (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                handleTalkModerationAction(submission.submissionId, "approve")
+                              }
+                              disabled={moderatingSubmissionId === submission.submissionId}
+                              className="px-3 py-1.5 rounded-md text-xs font-medium bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20 disabled:opacity-60 disabled:cursor-not-allowed"
+                            >
+                              Approve
+                            </button>
+                          ) : submission.status === "approved" ? (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                handleTalkModerationAction(submission.submissionId, "complete")
+                              }
+                              disabled={moderatingSubmissionId === submission.submissionId}
+                              className="px-3 py-1.5 rounded-md text-xs font-medium bg-blue-500/10 text-blue-300 hover:bg-blue-500/20 disabled:opacity-60 disabled:cursor-not-allowed"
+                            >
+                              Mark Delivered
+                            </button>
+                          ) : submission.status === "completed" ? (
+                            <span className="px-3 py-1.5 rounded-md text-xs font-medium bg-neutral-800 text-neutral-400">
+                              Resolved
+                            </span>
+                          ) : (
+                            <span className="px-3 py-1.5 rounded-md text-xs font-medium bg-neutral-800 text-neutral-400">
+                              No action
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
           {sortedProjects.length === 0 ? (
             <div className="text-center py-20">
               <p className="text-neutral-400 text-lg">
@@ -291,7 +790,10 @@ export default function ShowcasePage() {
                   userVote={userVotes[project.id]}
                   isLoggedIn={!!user}
                   isVoting={votingId === project.id}
+                  isSubmitting={submittingId === project.id}
+                  submissionStatus={submittedProjects[project.id]}
                   onVote={handleVote}
+                  onMarkSubmitted={handleMarkSubmitted}
                 />
               ))}
             </div>
@@ -308,19 +810,30 @@ function ProjectCard({
   userVote,
   isLoggedIn,
   isVoting,
+  isSubmitting,
+  submissionStatus,
   onVote,
+  onMarkSubmitted,
 }: {
   project: Project;
   votes?: { upCount: number; downCount: number };
   userVote?: string;
   isLoggedIn: boolean;
   isVoting: boolean;
+  isSubmitting: boolean;
+  submissionStatus?: SubmissionStatus;
   onVote: (projectId: string, type: "up" | "down") => void;
+  onMarkSubmitted: (projectId: string) => void;
 }) {
   const upCount = votes?.upCount || 0;
   const downCount = votes?.downCount || 0;
   const netScore = upCount - downCount;
   const [imgError, setImgError] = useState(false);
+
+  const isSubmitted = Boolean(submissionStatus);
+  const isPending = submissionStatus === "pending";
+  const isApproved = submissionStatus === "approved";
+  const isRejected = submissionStatus === "rejected";
 
   return (
     <div className="bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-800 flex flex-col hover:border-neutral-700 transition-colors">
@@ -491,6 +1004,32 @@ function ProjectCard({
             </button>
           </div>
         </div>
+
+        <button
+          type="button"
+          onClick={() => onMarkSubmitted(project.id)}
+          disabled={!isLoggedIn || isSubmitting || isApproved || isPending}
+          title={isLoggedIn ? "Mark this project as your submission" : "Sign in to mark submissions"}
+          className={`mt-3 w-full px-3 py-2 rounded-lg text-xs font-medium transition-colors ${
+            isApproved
+              ? "bg-emerald-500/10 text-emerald-400"
+              : isRejected
+              ? "bg-red-500/10 text-red-300 hover:bg-red-500/20"
+              : isSubmitted
+              ? "bg-amber-500/10 text-amber-300"
+              : "bg-neutral-800 text-neutral-300 hover:bg-neutral-700"
+          } disabled:opacity-60 disabled:cursor-not-allowed`}
+        >
+          {isApproved
+            ? "Submission Approved"
+            : isRejected
+            ? "Resubmit for Review"
+            : isSubmitted
+            ? "Pending Review"
+            : isSubmitting
+            ? "Recording..."
+            : "Submit for Review"}
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
This PR adds the showcase submission and moderation flow, including the submission API, admin approval API, showcase page, and related test coverage.
It includes:
showcase submission route
showcase approval/moderation route
showcase page UI
API and page-level tests for submission and moderation behavior
This PR builds on the talk moderation and shared backend infrastructure already split into earlier PRs, and isolates the showcase flow into a focused review unit.

Fixes # 79

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally
- [x] Tested authentication flows
- [x] Tested form submissions

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
This PR is part of the #79 restack and depends on pr5-talk-moderation. It contains only the showcase submission and moderation flow.
