### PR TITLE
Add rate limit cleanup utility and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ Each feature is **fully isolated** — new routes, new Firestore collections, no
    npm run dev
    ```
 
+## 🧰 Operations
+
+### Rate-limit cleanup (internal maintenance)
+
+Run the internal `apiRateLimits` cleanup endpoint from this repo:
+
+```bash
+CRON_SECRET=your-secret npm run rate-limit-cleanup
+```
+
+Optional environment variables:
+- `RATE_LIMIT_CLEANUP_BASE_URL` (default: `http://localhost:3000`)
+- `RATE_LIMIT_CLEANUP_DRY_RUN` (`true` for no-delete simulation)
+- `RATE_LIMIT_CLEANUP_BATCH_SIZE` (clamped to `1-500`)
+- `RATE_LIMIT_CLEANUP_MAX_BATCHES` (clamped to `1-20`)
+
+Examples:
+
+```bash
+# Dry run against production URL
+CRON_SECRET=your-secret RATE_LIMIT_CLEANUP_BASE_URL=https://cursorboston.com RATE_LIMIT_CLEANUP_DRY_RUN=true npm run rate-limit-cleanup
+
+# Real cleanup with tighter bounds
+CRON_SECRET=your-secret RATE_LIMIT_CLEANUP_BATCH_SIZE=200 RATE_LIMIT_CLEANUP_MAX_BATCHES=3 npm run rate-limit-cleanup
+```
+
 ---
 
 ## 🗺️ Roadmap

--- a/app/api/internal/rate-limits/cleanup/route.ts
+++ b/app/api/internal/rate-limits/cleanup/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Timestamp } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CRON_SECRET = process.env.CRON_SECRET;
+const DEFAULT_BATCH_SIZE = 500;
+const MAX_BATCH_SIZE = 500;
+const DEFAULT_MAX_BATCHES = 5;
+const MAX_MAX_BATCHES = 20;
+
+function getCronSecret(request: NextRequest): string | null {
+  return (
+    request.headers.get("x-cron-secret") ||
+    request.headers.get("authorization")?.replace("Bearer ", "") ||
+    null
+  );
+}
+
+// Internal maintenance endpoint. Use cron/job runner with CRON_SECRET.
+export async function POST(request: NextRequest) {
+  try {
+    const invocationId = crypto.randomUUID();
+    if (!CRON_SECRET) {
+      logger.error("Rate limit cleanup rejected: CRON_SECRET missing", {
+        endpoint: "/api/internal/rate-limits/cleanup",
+        invocationId,
+      });
+      return NextResponse.json(
+        { error: "Server not configured: CRON_SECRET not set" },
+        { status: 500 }
+      );
+    }
+
+    const cronSecret = getCronSecret(request);
+    if (!cronSecret || cronSecret !== CRON_SECRET) {
+      logger.warn("Rate limit cleanup unauthorized invocation", {
+        endpoint: "/api/internal/rate-limits/cleanup",
+        invocationId,
+      });
+      return NextResponse.json(
+        { error: "Unauthorized: Invalid or missing cron secret" },
+        { status: 401 }
+      );
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      logger.error("Rate limit cleanup failed: admin db unavailable", {
+        endpoint: "/api/internal/rate-limits/cleanup",
+        invocationId,
+      });
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const batchSize = Math.min(
+      Math.max(Number(request.nextUrl.searchParams.get("batchSize")) || DEFAULT_BATCH_SIZE, 1),
+      MAX_BATCH_SIZE
+    );
+    const maxBatches = Math.min(
+      Math.max(Number(request.nextUrl.searchParams.get("maxBatches")) || DEFAULT_MAX_BATCHES, 1),
+      MAX_MAX_BATCHES
+    );
+    const dryRun = request.nextUrl.searchParams.get("dryRun") === "true";
+
+    const now = Timestamp.now();
+    let totalDeleted = 0;
+    let totalMatched = 0;
+    let batchesProcessed = 0;
+    let hasMore = false;
+
+    for (let i = 0; i < maxBatches; i++) {
+      const snapshot = await db
+        .collection("apiRateLimits")
+        .where("expiresAt", "<=", now)
+        .orderBy("expiresAt", "asc")
+        .limit(batchSize)
+        .get();
+
+      if (snapshot.empty) {
+        hasMore = false;
+        break;
+      }
+
+      batchesProcessed++;
+      totalMatched += snapshot.size;
+
+      if (!dryRun) {
+        const batch = db.batch();
+        snapshot.docs.forEach((doc) => batch.delete(doc.ref));
+        await batch.commit();
+      }
+
+      totalDeleted += dryRun ? 0 : snapshot.size;
+      hasMore = snapshot.size === batchSize;
+
+      if (snapshot.size < batchSize) {
+        hasMore = false;
+        break;
+      }
+    }
+
+    const response = {
+      success: true,
+      invocationId,
+      dryRun,
+      totalMatched,
+      totalDeleted,
+      batchesProcessed,
+      batchSize,
+      maxBatches,
+      hasMore,
+      cleanedAt: new Date().toISOString(),
+    };
+    logger.info("Rate limit cleanup completed", {
+      endpoint: "/api/internal/rate-limits/cleanup",
+      ...response,
+    });
+    return NextResponse.json(response);
+  } catch {
+    logger.error("Rate limit cleanup failed with exception", {
+      endpoint: "/api/internal/rate-limits/cleanup",
+    });
+    return NextResponse.json({ error: "Failed to clean rate limit records" }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  return NextResponse.json(
+    { error: "Method not allowed. Use POST for internal maintenance cleanup." },
+    { status: 405 }
+  );
+}

--- a/scripts/run-rate-limit-cleanup.ts
+++ b/scripts/run-rate-limit-cleanup.ts
@@ -1,0 +1,100 @@
+/**
+ * Operator script to invoke internal API rate-limit cleanup.
+ *
+ * Usage:
+ *   CRON_SECRET=... npm run rate-limit-cleanup
+ *
+ * Optional env vars:
+ *   RATE_LIMIT_CLEANUP_BASE_URL (default: http://localhost:3000)
+ *   RATE_LIMIT_CLEANUP_DRY_RUN   ("true" | "false", default: false)
+ *   RATE_LIMIT_CLEANUP_BATCH_SIZE (1-500, optional)
+ *   RATE_LIMIT_CLEANUP_MAX_BATCHES (1-20, optional)
+ */
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+function loadDotEnvLocal() {
+  const envPath = resolve(process.cwd(), ".env.local");
+  if (!existsSync(envPath)) return;
+
+  const content = readFileSync(envPath, "utf-8");
+  for (const line of content.split("\n")) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) continue;
+    const key = match[1];
+    if (process.env[key]) continue;
+    const value = match[2].replace(/^["']|["']$/g, "").trim();
+    process.env[key] = value;
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+async function main() {
+  loadDotEnvLocal();
+
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    console.error("Missing CRON_SECRET. Set it in env or .env.local.");
+    process.exit(1);
+  }
+
+  const baseUrl = (process.env.RATE_LIMIT_CLEANUP_BASE_URL || "http://localhost:3000").replace(
+    /\/$/,
+    ""
+  );
+
+  const dryRun = process.env.RATE_LIMIT_CLEANUP_DRY_RUN === "true";
+  const batchSizeRaw = process.env.RATE_LIMIT_CLEANUP_BATCH_SIZE;
+  const maxBatchesRaw = process.env.RATE_LIMIT_CLEANUP_MAX_BATCHES;
+
+  const search = new URLSearchParams();
+  if (dryRun) search.set("dryRun", "true");
+
+  if (batchSizeRaw) {
+    const parsed = Number(batchSizeRaw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      search.set("batchSize", String(clamp(Math.floor(parsed), 1, 500)));
+    }
+  }
+
+  if (maxBatchesRaw) {
+    const parsed = Number(maxBatchesRaw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      search.set("maxBatches", String(clamp(Math.floor(parsed), 1, 20)));
+    }
+  }
+
+  const cleanupUrl = `${baseUrl}/api/internal/rate-limits/cleanup${
+    search.toString() ? `?${search.toString()}` : ""
+  }`;
+
+  const res = await fetch(cleanupUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-cron-secret": cronSecret,
+    },
+  });
+
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    console.error("Rate-limit cleanup failed.", {
+      status: res.status,
+      statusText: res.statusText,
+      body,
+    });
+    process.exit(1);
+  }
+
+  console.log("Rate-limit cleanup completed.", body);
+}
+
+main().catch((error) => {
+  console.error("Rate-limit cleanup script crashed.", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

This PR adds the rate-limit cleanup utility, including the internal cleanup route, the operator script, and related documentation updates.
It includes:
an internal route for rate-limit cleanup
a script to invoke the cleanup flow
documentation updates for using the cleanup utility
This PR builds on the shared rate limiting infrastructure and isolates the cleanup utility into a focused review unit.

Fixes # 79

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally

Commands used:
rm -rf .next
npm test
npm run type-check

Verified:
cleanup route compiles cleanly with rate-limit infrastructure present
operator script is included with the intended route flow
full local test suite and typecheck pass on this branch

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A
## Additional Notes
This PR is part of the #79 restack and depends on pr2-auth-rate-limit. It contains only the rate-limit cleanup utility, script, and related documentation.