### PR TITLE
fix(a11y): add aria-hidden to decorative SVG icon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -415,6 +415,7 @@ export default function Home() {
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
+              aria-hidden="true"
             >
               <path d="M7 17l9.2-9.2M17 17V7H7" />
             </svg>


### PR DESCRIPTION
## Summary
- Adds `aria-hidden="true"` to the decorative arrow SVG icon in the final CTA section of the homepage
- This prevents screen readers from announcing the purely decorative icon, improving accessibility

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan
- [x] Verified the SVG is decorative (accompanies "Subscribe on Luma" link text)
- [x] Confirmed other SVGs in the codebase already use `aria-hidden="true"` — this brings consistency