### PR TITLE
feat(live): add realtime lightning talk sessions

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -24,6 +24,9 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
 NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
 NEXT_PUBLIC_FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
+# Optional server-side override for Admin SDK RTDB access.
+# Defaults to NEXT_PUBLIC_FIREBASE_DATABASE_URL when omitted.
+# FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
 
 # Optional: Firebase Analytics Measurement ID
 # NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/__tests__/app/api/live/control/route.test.ts
+++ b/__tests__/app/api/live/control/route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/live/[sessionId]/control/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  controlLiveSessionServer,
+  LiveSessionInvalidActionError,
+  LiveSessionNotFoundError,
+  LiveSessionUnauthorizedError,
+} from "@/lib/live-sessions/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/live-sessions/data-server", () => ({
+  controlLiveSessionServer: jest.fn(),
+  LiveSessionNotFoundError: class LiveSessionNotFoundError extends Error {},
+  LiveSessionUnauthorizedError: class LiveSessionUnauthorizedError extends Error {},
+  LiveSessionInvalidActionError: class LiveSessionInvalidActionError extends Error {},
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockControlLiveSessionServer =
+  controlLiveSessionServer as jest.MockedFunction<typeof controlLiveSessionServer>;
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/live/session-1/control", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/live/[sessionId]/control", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requires authentication", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ action: "start-next" }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("validates actions", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin-1" });
+    const res = await POST(makeRequest({ action: "unknown" }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("dispatches valid actions", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin-1" });
+    mockControlLiveSessionServer.mockResolvedValue({
+      session: {
+        status: "live",
+        timer: { status: "running" },
+        currentSpeaker: { speakerName: "A", talkTitle: "B", entryId: "entry-1" },
+      },
+      queue: { order: [], items: {}, updatedAtMs: 1 },
+      historyRecord: null,
+    } as never);
+
+    const res = await POST(makeRequest({ action: "start-next" }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockControlLiveSessionServer).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      emceeUid: "admin-1",
+      action: "start-next",
+      entryId: undefined,
+      targetIndex: undefined,
+    });
+  });
+
+  it("maps domain errors", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin-1" });
+
+    mockControlLiveSessionServer.mockRejectedValueOnce(new LiveSessionNotFoundError());
+    const notFound = await POST(makeRequest({ action: "start-next" }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(notFound.status).toBe(404);
+
+    mockControlLiveSessionServer.mockRejectedValueOnce(new LiveSessionUnauthorizedError());
+    const forbidden = await POST(makeRequest({ action: "start-next" }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(forbidden.status).toBe(403);
+
+    mockControlLiveSessionServer.mockRejectedValueOnce(
+      new LiveSessionInvalidActionError("bad")
+    );
+    const badRequest = await POST(makeRequest({ action: "start-next" }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(badRequest.status).toBe(400);
+  });
+});

--- a/__tests__/app/api/live/queue/route.test.ts
+++ b/__tests__/app/api/live/queue/route.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/live/[sessionId]/queue/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  enqueueSpeakerServer,
+  LiveSessionClosedError,
+  LiveSessionDuplicateSpeakerError,
+  LiveSessionNotFoundError,
+} from "@/lib/live-sessions/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/live-sessions/data-server", () => ({
+  enqueueSpeakerServer: jest.fn(),
+  LiveSessionNotFoundError: class LiveSessionNotFoundError extends Error {},
+  LiveSessionClosedError: class LiveSessionClosedError extends Error {},
+  LiveSessionDuplicateSpeakerError: class LiveSessionDuplicateSpeakerError extends Error {},
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockEnqueueSpeakerServer =
+  enqueueSpeakerServer as jest.MockedFunction<typeof enqueueSpeakerServer>;
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/live/session-1/queue", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/live/[sessionId]/queue", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requires authentication", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("validates talk title and duration", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "user-1",
+      email: "user@example.com",
+    });
+
+    const res = await POST(makeRequest({ talkTitle: "", durationMinutes: 9 }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockEnqueueSpeakerServer).not.toHaveBeenCalled();
+  });
+
+  it("enqueues a speaker", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "user-1",
+      email: "user@example.com",
+      name: "Queue User",
+      picture: "https://example.com/avatar.png",
+    });
+    mockEnqueueSpeakerServer.mockResolvedValue({
+      id: "entry-1",
+      sessionId: "session-1",
+      userId: "user-1",
+      speakerName: "Queue User",
+      speakerPhotoUrl: "https://example.com/avatar.png",
+      talkTitle: "Building Fast",
+      durationMinutes: 5,
+      status: "queued",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    });
+
+    const res = await POST(makeRequest({ talkTitle: " Building Fast ", durationMinutes: 5 }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockEnqueueSpeakerServer).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      userId: "user-1",
+      speakerName: "Queue User",
+      speakerPhotoUrl: "https://example.com/avatar.png",
+      talkTitle: "Building Fast",
+      durationMinutes: 5,
+    });
+    expect(body).toEqual({
+      entryId: "entry-1",
+      sessionId: "session-1",
+      talkTitle: "Building Fast",
+      durationMinutes: 5,
+      status: "queued",
+    });
+  });
+
+  it("maps live-session domain errors to HTTP statuses", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "user-1",
+      email: "user@example.com",
+    });
+    mockEnqueueSpeakerServer.mockRejectedValueOnce(new LiveSessionNotFoundError());
+
+    const notFoundRes = await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "missing" }),
+    });
+    expect(notFoundRes.status).toBe(404);
+
+    mockEnqueueSpeakerServer.mockRejectedValueOnce(new LiveSessionClosedError());
+    const closedRes = await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "closed" }),
+    });
+    expect(closedRes.status).toBe(409);
+
+    mockEnqueueSpeakerServer.mockRejectedValueOnce(new LiveSessionDuplicateSpeakerError());
+    const duplicateRes = await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "duplicate" }),
+    });
+    expect(duplicateRes.status).toBe(409);
+  });
+});

--- a/__tests__/app/api/live/session/route.test.ts
+++ b/__tests__/app/api/live/session/route.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/live/session/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/live-sessions/data-server", () => ({
+  createLiveSessionServer: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCreateLiveSessionServer =
+  createLiveSessionServer as jest.MockedFunction<typeof createLiveSessionServer>;
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/live/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/live/session", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("requires authentication", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ title: "Demo Night" }));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("requires admin privileges", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "user-1",
+      email: "member@example.com",
+      isAdmin: false,
+    });
+
+    const res = await POST(makeRequest({ title: "Demo Night" }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("creates a live session for admins", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      name: "Host User",
+      isAdmin: true,
+    });
+    mockCreateLiveSessionServer.mockResolvedValue({
+      sessionId: "session-123",
+      session: {
+        id: "session-123",
+        status: "pending",
+        title: "Demo Night",
+        createdAtMs: 100,
+        updatedAtMs: 100,
+        emceeUid: "admin-1",
+        emceeName: "Host User",
+        audiencePath: "/live/session-123",
+        emceePath: "/live/session-123/emcee",
+        currentSpeaker: {
+          entryId: null,
+          speakerName: null,
+          talkTitle: null,
+        },
+        timer: {
+          status: "idle",
+          durationSeconds: 0,
+          remainingSeconds: 0,
+          startedAtMs: null,
+          pausedAtMs: null,
+          warningThresholds: [60, 30],
+        },
+      },
+    });
+
+    const res = await POST(makeRequest({ title: " Demo Night " }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockCreateLiveSessionServer).toHaveBeenCalledWith({
+      title: "Demo Night",
+      emceeUid: "admin-1",
+      emceeName: "Host User",
+    });
+    expect(body).toEqual({
+      sessionId: "session-123",
+      title: "Demo Night",
+      audiencePath: "/live/session-123",
+      emceePath: "/live/session-123/emcee",
+      status: "pending",
+    });
+  });
+
+  it("defaults the title when omitted", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+    mockCreateLiveSessionServer.mockResolvedValue({
+      sessionId: "session-456",
+      session: {
+        id: "session-456",
+        status: "pending",
+        title: "Lightning Talks",
+        createdAtMs: 100,
+        updatedAtMs: 100,
+        emceeUid: "admin-1",
+        emceeName: "admin@example.com",
+        audiencePath: "/live/session-456",
+        emceePath: "/live/session-456/emcee",
+        currentSpeaker: {
+          entryId: null,
+          speakerName: null,
+          talkTitle: null,
+        },
+        timer: {
+          status: "idle",
+          durationSeconds: 0,
+          remainingSeconds: 0,
+          startedAtMs: null,
+          pausedAtMs: null,
+          warningThresholds: [60, 30],
+        },
+      },
+    });
+
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(200);
+    expect(mockCreateLiveSessionServer).toHaveBeenCalledWith({
+      title: "Lightning Talks",
+      emceeUid: "admin-1",
+      emceeName: "admin@example.com",
+    });
+  });
+
+  it("rejects invalid titles", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const res = await POST(makeRequest({ title: "x".repeat(121) }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("Title must be a string");
+    expect(mockCreateLiveSessionServer).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/live-sessions/data-server.test.ts
+++ b/__tests__/lib/live-sessions/data-server.test.ts
@@ -1,0 +1,523 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  controlLiveSessionServer,
+  createLiveSessionServer,
+  enqueueSpeakerServer,
+  LiveSessionClosedError,
+  LiveSessionDuplicateSpeakerError,
+  LiveSessionInvalidActionError,
+  LiveSessionNotFoundError,
+  LiveSessionUnauthorizedError,
+} from "@/lib/live-sessions/data-server";
+import { getAdminDb, getAdminRtdb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+  getAdminRtdb: jest.fn(),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockGetAdminRtdb = getAdminRtdb as jest.MockedFunction<typeof getAdminRtdb>;
+
+describe("createLiveSessionServer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates firestore archive and realtime session records", async () => {
+    const setFirestore = jest.fn(async () => undefined);
+    const setRtdb = jest.fn(async () => undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          id: "live-session-1",
+          set: setFirestore,
+        })),
+      })),
+    } as never);
+
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn(() => ({
+        set: setRtdb,
+      })),
+    } as never);
+
+    const result = await createLiveSessionServer({
+      title: "Cursor Boston Demo Night",
+      emceeUid: "admin-1",
+      emceeName: "Admin User",
+    });
+
+    expect(result.sessionId).toBe("live-session-1");
+    expect(result.session).toEqual(
+      expect.objectContaining({
+        id: "live-session-1",
+        title: "Cursor Boston Demo Night",
+        status: "pending",
+        emceeUid: "admin-1",
+        emceeName: "Admin User",
+        audiencePath: "/live/live-session-1",
+        emceePath: "/live/live-session-1/emcee",
+      })
+    );
+
+    expect(setFirestore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "live-session-1",
+        title: "Cursor Boston Demo Night",
+        status: "pending",
+        createdBy: {
+          uid: "admin-1",
+          name: "Admin User",
+        },
+      })
+    );
+
+    expect(setRtdb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "live-session-1",
+        title: "Cursor Boston Demo Night",
+      })
+    );
+    expect(setRtdb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        order: [],
+        items: {},
+      })
+    );
+  });
+
+  it("fails if firestore or realtime database admin clients are unavailable", async () => {
+    mockGetAdminDb.mockReturnValue(null);
+    mockGetAdminRtdb.mockReturnValue(null);
+
+    await expect(
+      createLiveSessionServer({
+        title: "Lightning Talks",
+        emceeUid: "admin-1",
+        emceeName: "Admin User",
+      })
+    ).rejects.toThrow("Firebase Admin is not fully initialized");
+  });
+});
+
+describe("enqueueSpeakerServer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("appends a queued speaker entry and persists an archive record", async () => {
+    const queueSet = jest.fn(async () => undefined);
+    const queueTransaction = jest.fn(async (updater: (value: unknown) => unknown) => {
+      const nextValue = updater({
+        order: [],
+        items: {},
+        updatedAtMs: 1,
+      });
+      return { committed: true, snapshot: { val: () => nextValue } };
+    });
+    const queueGet = jest.fn(async () => ({
+      exists: () => true,
+      val: () => ({ status: "pending" }),
+    }));
+    const queueRef = jest.fn((path: string) => {
+      if (path === "live_sessions/session-1") {
+        return { get: queueGet };
+      }
+      if (path === "live_queue_entries/session-1") {
+        return { set: queueSet, transaction: queueTransaction };
+      }
+      throw new Error(`unexpected ref path: ${path}`);
+    });
+    const firestoreSet = jest.fn(async () => undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name !== "live_queue_entries") {
+          throw new Error(`unexpected collection: ${name}`);
+        }
+        return {
+          doc: jest.fn(() => ({
+            id: "entry-1",
+            set: firestoreSet,
+          })),
+        };
+      }),
+    } as never);
+    mockGetAdminRtdb.mockReturnValue({
+      ref: queueRef,
+    } as never);
+
+    const result = await enqueueSpeakerServer({
+      sessionId: "session-1",
+      userId: "user-1",
+      speakerName: "Queue User",
+      talkTitle: "Realtime Demos",
+      durationMinutes: 3,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: "entry-1",
+        sessionId: "session-1",
+        userId: "user-1",
+        speakerName: "Queue User",
+        talkTitle: "Realtime Demos",
+        durationMinutes: 3,
+        status: "queued",
+      })
+    );
+    expect(queueTransaction).toHaveBeenCalled();
+    expect(firestoreSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "entry-1",
+        sessionId: "session-1",
+        userId: "user-1",
+      })
+    );
+  });
+
+  it("throws when the session does not exist", async () => {
+    mockGetAdminDb.mockReturnValue({} as never);
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn(() => ({
+        get: jest.fn(async () => ({
+          exists: () => false,
+        })),
+      })),
+    } as never);
+
+    await expect(
+      enqueueSpeakerServer({
+        sessionId: "missing",
+        userId: "user-1",
+        speakerName: "Queue User",
+        talkTitle: "Realtime Demos",
+        durationMinutes: 3,
+      })
+    ).rejects.toBeInstanceOf(LiveSessionNotFoundError);
+  });
+
+  it("throws when the session is closed", async () => {
+    mockGetAdminDb.mockReturnValue({} as never);
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn(() => ({
+        get: jest.fn(async () => ({
+          exists: () => true,
+          val: () => ({ status: "completed" }),
+        })),
+      })),
+    } as never);
+
+    await expect(
+      enqueueSpeakerServer({
+        sessionId: "closed",
+        userId: "user-1",
+        speakerName: "Queue User",
+        talkTitle: "Realtime Demos",
+        durationMinutes: 3,
+      })
+    ).rejects.toBeInstanceOf(LiveSessionClosedError);
+  });
+
+  it("throws when the speaker is already queued", async () => {
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          id: "entry-1",
+          set: jest.fn(async () => undefined),
+        })),
+      })),
+    } as never);
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn((path: string) => {
+        if (path === "live_sessions/session-1") {
+          return {
+            get: jest.fn(async () => ({
+              exists: () => true,
+              val: () => ({ status: "pending" }),
+            })),
+          };
+        }
+        if (path === "live_queue_entries/session-1") {
+          return {
+            transaction: jest.fn(async () => ({ committed: false })),
+          };
+        }
+        throw new Error(`unexpected ref path: ${path}`);
+      }),
+    } as never);
+
+    await expect(
+      enqueueSpeakerServer({
+        sessionId: "session-1",
+        userId: "user-1",
+        speakerName: "Queue User",
+        talkTitle: "Realtime Demos",
+        durationMinutes: 3,
+      })
+    ).rejects.toBeInstanceOf(LiveSessionDuplicateSpeakerError);
+  });
+});
+
+describe("controlLiveSessionServer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("starts the next queued speaker", async () => {
+    const sessionSet = jest.fn(async () => undefined);
+    const queueSet = jest.fn(async () => undefined);
+    const archiveGet = jest.fn(async () => ({
+      exists: true,
+      data: () => ({
+        sessionId: "session-1",
+        history: [],
+      }),
+    }));
+    const archiveSet = jest.fn(async () => undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name === "live_sessions") {
+          return {
+            doc: jest.fn(() => ({
+              get: archiveGet,
+              set: archiveSet,
+            })),
+          };
+        }
+        return {
+          doc: jest.fn(() => ({
+            set: jest.fn(async () => undefined),
+          })),
+        };
+      }),
+    } as never);
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn((path: string) => {
+        if (path === "live_sessions/session-1") {
+          return {
+            get: jest.fn(async () => ({
+              exists: () => true,
+              val: () => ({
+                emceeUid: "admin-1",
+                status: "pending",
+                timer: {
+                  status: "idle",
+                  durationSeconds: 0,
+                  remainingSeconds: 0,
+                  startedAtMs: null,
+                  pausedAtMs: null,
+                  warningThresholds: [60, 30],
+                },
+                currentSpeaker: {
+                  entryId: null,
+                  speakerName: null,
+                  talkTitle: null,
+                },
+              }),
+            })),
+            set: sessionSet,
+          };
+        }
+        if (path === "live_queue_entries/session-1") {
+          return {
+            get: jest.fn(async () => ({
+              val: () => ({
+                order: ["entry-1"],
+                items: {
+                  "entry-1": {
+                    id: "entry-1",
+                    sessionId: "session-1",
+                    userId: "user-1",
+                    speakerName: "Queue User",
+                    speakerPhotoUrl: null,
+                    talkTitle: "Realtime Demos",
+                    durationMinutes: 3,
+                    status: "queued",
+                    createdAtMs: 1,
+                    updatedAtMs: 1,
+                  },
+                },
+                updatedAtMs: 1,
+              }),
+            })),
+            set: queueSet,
+          };
+        }
+        throw new Error(`unexpected ref path: ${path}`);
+      }),
+    } as never);
+
+    const result = await controlLiveSessionServer({
+      sessionId: "session-1",
+      emceeUid: "admin-1",
+      action: "start-next",
+    });
+
+    expect(result.session.status).toBe("live");
+    expect(result.session.currentSpeaker.entryId).toBe("entry-1");
+    expect(result.session.timer.status).toBe("running");
+    expect(queueSet).toHaveBeenCalled();
+  });
+
+  it("completes the current speaker and appends history", async () => {
+    const entrySet = jest.fn(async () => undefined);
+    const archiveSet = jest.fn(async () => undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name === "live_sessions") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn(async () => ({
+                exists: true,
+                data: () => ({ sessionId: "session-1", history: [] }),
+              })),
+              set: archiveSet,
+            })),
+          };
+        }
+        if (name === "live_queue_entries") {
+          return {
+            doc: jest.fn(() => ({
+              set: entrySet,
+            })),
+          };
+        }
+        throw new Error(`unexpected collection: ${name}`);
+      }),
+    } as never);
+
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn((path: string) => {
+        if (path === "live_sessions/session-1") {
+          return {
+            get: jest.fn(async () => ({
+              exists: () => true,
+              val: () => ({
+                emceeUid: "admin-1",
+                status: "live",
+                timer: {
+                  status: "running",
+                  durationSeconds: 180,
+                  remainingSeconds: 120,
+                  startedAtMs: 100,
+                  pausedAtMs: null,
+                  warningThresholds: [60, 30],
+                },
+                currentSpeaker: {
+                  entryId: "entry-1",
+                  speakerName: "Queue User",
+                  talkTitle: "Realtime Demos",
+                },
+              }),
+            })),
+            set: jest.fn(async () => undefined),
+          };
+        }
+        if (path === "live_queue_entries/session-1") {
+          return {
+            get: jest.fn(async () => ({
+              val: () => ({
+                order: ["entry-1"],
+                items: {
+                  "entry-1": {
+                    id: "entry-1",
+                    sessionId: "session-1",
+                    userId: "user-1",
+                    speakerName: "Queue User",
+                    speakerPhotoUrl: null,
+                    talkTitle: "Realtime Demos",
+                    durationMinutes: 3,
+                    status: "live",
+                    createdAtMs: 1,
+                    updatedAtMs: 1,
+                  },
+                },
+                updatedAtMs: 1,
+              }),
+            })),
+            set: jest.fn(async () => undefined),
+          };
+        }
+        throw new Error(`unexpected ref path: ${path}`);
+      }),
+    } as never);
+
+    const result = await controlLiveSessionServer({
+      sessionId: "session-1",
+      emceeUid: "admin-1",
+      action: "complete-current",
+    });
+
+    expect(result.historyRecord?.outcome).toBe("completed");
+    expect(result.session.currentSpeaker.entryId).toBeNull();
+    expect(result.session.timer.status).toBe("idle");
+    expect(archiveSet).toHaveBeenCalled();
+    expect(entrySet).toHaveBeenCalled();
+  });
+
+  it("blocks non-emcee control", async () => {
+    mockGetAdminDb.mockReturnValue({ collection: jest.fn() } as never);
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn(() => ({
+        get: jest.fn(async () => ({
+          exists: () => true,
+          val: () => ({
+            emceeUid: "admin-1",
+            timer: { status: "idle", durationSeconds: 0, remainingSeconds: 0, startedAtMs: null, pausedAtMs: null, warningThresholds: [60, 30] },
+            currentSpeaker: { entryId: null, speakerName: null, talkTitle: null },
+          }),
+        })),
+      })),
+    } as never);
+
+    await expect(
+      controlLiveSessionServer({
+        sessionId: "session-1",
+        emceeUid: "admin-2",
+        action: "start-next",
+      })
+    ).rejects.toBeInstanceOf(LiveSessionUnauthorizedError);
+  });
+
+  it("rejects invalid action states", async () => {
+    mockGetAdminDb.mockReturnValue({ collection: jest.fn() } as never);
+    mockGetAdminRtdb.mockReturnValue({
+      ref: jest.fn((path: string) => {
+        if (path === "live_sessions/session-1") {
+          return {
+            get: jest.fn(async () => ({
+              exists: () => true,
+              val: () => ({
+                emceeUid: "admin-1",
+                status: "pending",
+                timer: { status: "idle", durationSeconds: 0, remainingSeconds: 0, startedAtMs: null, pausedAtMs: null, warningThresholds: [60, 30] },
+                currentSpeaker: { entryId: null, speakerName: null, talkTitle: null },
+              }),
+            })),
+          };
+        }
+        return {
+          get: jest.fn(async () => ({
+            val: () => ({ order: [], items: {}, updatedAtMs: 1 }),
+          })),
+        };
+      }),
+    } as never);
+
+    await expect(
+      controlLiveSessionServer({
+        sessionId: "session-1",
+        emceeUid: "admin-1",
+        action: "pause-timer",
+      })
+    ).rejects.toBeInstanceOf(LiveSessionInvalidActionError);
+  });
+});

--- a/app/api/live/[sessionId]/control/route.ts
+++ b/app/api/live/[sessionId]/control/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  controlLiveSessionServer,
+  LiveSessionInvalidActionError,
+  LiveSessionNotFoundError,
+  LiveSessionUnauthorizedError,
+} from "@/lib/live-sessions/data-server";
+import type { LiveSessionControlAction } from "@/lib/live-sessions/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const VALID_ACTIONS: LiveSessionControlAction[] = [
+  "start-next",
+  "pause-timer",
+  "resume-timer",
+  "complete-current",
+  "skip-current",
+  "remove-entry",
+  "move-entry",
+  "end-session",
+];
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ sessionId: string }> }
+) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { sessionId } = await context.params;
+    const body = (await request.json().catch(() => ({}))) as {
+      action?: unknown;
+      entryId?: unknown;
+      targetIndex?: unknown;
+    };
+
+    if (!VALID_ACTIONS.includes(body.action as LiveSessionControlAction)) {
+      return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+    }
+
+    const result = await controlLiveSessionServer({
+      sessionId,
+      emceeUid: user.uid,
+      action: body.action as LiveSessionControlAction,
+      entryId: typeof body.entryId === "string" ? body.entryId : undefined,
+      targetIndex: typeof body.targetIndex === "number" ? body.targetIndex : undefined,
+    });
+
+    return NextResponse.json({
+      status: result.session.status,
+      timerStatus: result.session.timer.status,
+      currentSpeaker: result.session.currentSpeaker,
+      historyRecord: result.historyRecord,
+    });
+  } catch (error) {
+    if (error instanceof LiveSessionNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof LiveSessionUnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    if (error instanceof LiveSessionInvalidActionError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    console.error("Error controlling live session:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/live/[sessionId]/queue/route.ts
+++ b/app/api/live/[sessionId]/queue/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { sanitizeText } from "@/lib/sanitize";
+import {
+  enqueueSpeakerServer,
+  LiveSessionClosedError,
+  LiveSessionDuplicateSpeakerError,
+  LiveSessionNotFoundError,
+} from "@/lib/live-sessions/data-server";
+import {
+  LIVE_TALK_DURATIONS,
+  type LiveTalkDurationMinutes,
+} from "@/lib/live-sessions/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_TALK_TITLE_LENGTH = 140;
+
+function normalizeTalkTitle(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const sanitized = sanitizeText(value);
+  if (!sanitized || sanitized.length > MAX_TALK_TITLE_LENGTH) {
+    return null;
+  }
+
+  return sanitized;
+}
+
+function normalizeDuration(value: unknown): LiveTalkDurationMinutes | null {
+  if (typeof value !== "number") {
+    return null;
+  }
+
+  return LIVE_TALK_DURATIONS.includes(value as LiveTalkDurationMinutes)
+    ? (value as LiveTalkDurationMinutes)
+    : null;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ sessionId: string }> }
+) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { sessionId } = await context.params;
+    if (!sessionId?.trim()) {
+      return NextResponse.json({ error: "Session ID is required" }, { status: 400 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as {
+      talkTitle?: unknown;
+      durationMinutes?: unknown;
+    };
+
+    const talkTitle = normalizeTalkTitle(body.talkTitle);
+    const durationMinutes = normalizeDuration(body.durationMinutes);
+
+    if (!talkTitle) {
+      return NextResponse.json(
+        { error: `Talk title must be a string up to ${MAX_TALK_TITLE_LENGTH} characters` },
+        { status: 400 }
+      );
+    }
+
+    if (!durationMinutes) {
+      return NextResponse.json(
+        { error: `Duration must be one of: ${LIVE_TALK_DURATIONS.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    const speakerName =
+      typeof user.name === "string" && user.name.trim()
+        ? user.name.trim()
+        : typeof user.email === "string" && user.email.trim()
+        ? user.email.trim()
+        : "Speaker";
+
+    const entry = await enqueueSpeakerServer({
+      sessionId: sessionId.trim(),
+      userId: user.uid,
+      speakerName,
+      speakerPhotoUrl: user.picture ?? null,
+      talkTitle,
+      durationMinutes,
+    });
+
+    return NextResponse.json({
+      entryId: entry.id,
+      sessionId: entry.sessionId,
+      talkTitle: entry.talkTitle,
+      durationMinutes: entry.durationMinutes,
+      status: entry.status,
+    });
+  } catch (error) {
+    if (error instanceof LiveSessionNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof LiveSessionClosedError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    if (error instanceof LiveSessionDuplicateSpeakerError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+
+    console.error("Error joining live queue:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/live/session/route.ts
+++ b/app/api/live/session/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { sanitizeText } from "@/lib/sanitize";
+import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_SESSION_TITLE = "Lightning Talks";
+const MAX_TITLE_LENGTH = 120;
+
+function normalizeSessionTitle(value: unknown): string | null {
+  if (value == null || value === "") {
+    return DEFAULT_SESSION_TITLE;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const sanitized = sanitizeText(value);
+  if (!sanitized) {
+    return DEFAULT_SESSION_TITLE;
+  }
+
+  if (sanitized.length > MAX_TITLE_LENGTH) {
+    return null;
+  }
+
+  return sanitized;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as { title?: unknown };
+    const title = normalizeSessionTitle(body.title);
+
+    if (!title) {
+      return NextResponse.json(
+        { error: `Title must be a string up to ${MAX_TITLE_LENGTH} characters` },
+        { status: 400 }
+      );
+    }
+
+    const emceeName =
+      typeof user.name === "string" && user.name.trim()
+        ? user.name.trim()
+        : typeof user.email === "string" && user.email.trim()
+        ? user.email.trim()
+        : "Emcee";
+
+    const { sessionId, session } = await createLiveSessionServer({
+      title,
+      emceeUid: user.uid,
+      emceeName,
+    });
+
+    return NextResponse.json({
+      sessionId,
+      title: session.title,
+      audiencePath: session.audiencePath,
+      emceePath: session.emceePath,
+      status: session.status,
+    });
+  } catch (error) {
+    console.error("Error creating live session:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/live/[sessionId]/emcee/page.tsx
+++ b/app/live/[sessionId]/emcee/page.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import QRCode from "qrcode";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  getLiveRemainingSeconds,
+  useLiveSession,
+  useLiveTimerAudioAlerts,
+} from "@/lib/live-sessions/client";
+import type { LiveSessionControlAction } from "@/lib/live-sessions/types";
+
+function formatClock(totalSeconds: number) {
+  const safe = Math.max(0, totalSeconds);
+  const minutes = Math.floor(safe / 60);
+  const seconds = safe % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function formatTimestamp(timestampMs: number) {
+  return new Date(timestampMs).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function EmceeLiveSessionPage({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>;
+}) {
+  const { user, loading: authLoading } = useAuth();
+  const [sessionId, setSessionId] = useState("");
+  const { session, queue, loading, error } = useLiveSession(sessionId);
+  const [remainingSeconds, setRemainingSeconds] = useState(0);
+  const [qrCodeUrl, setQrCodeUrl] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [draggedEntryId, setDraggedEntryId] = useState<string | null>(null);
+
+  useEffect(() => {
+    params.then((resolved) => setSessionId(resolved.sessionId));
+  }, [params]);
+
+  useEffect(() => {
+    setRemainingSeconds(getLiveRemainingSeconds(session));
+    const interval = window.setInterval(() => {
+      setRemainingSeconds(getLiveRemainingSeconds(session));
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [session]);
+
+  useEffect(() => {
+    if (!sessionId || typeof window === "undefined") return;
+
+    const url = `${window.location.origin}/live/${sessionId}`;
+    QRCode.toDataURL(url, {
+      margin: 1,
+      width: 320,
+      color: {
+        dark: "#ffffff",
+        light: "#00000000",
+      },
+    })
+      .then(setQrCodeUrl)
+      .catch(() => setQrCodeUrl(null));
+  }, [sessionId]);
+
+  const queuedEntries = useMemo(
+    () => queue.filter((entry) => entry.status === "queued"),
+    [queue]
+  );
+
+  const isEmcee = Boolean(user && session && user.uid === session.emceeUid);
+  const timerAlert =
+    remainingSeconds === 0 && session?.timer.status === "running"
+      ? "Time is up"
+      : remainingSeconds <= 30 && session?.timer.status === "running"
+      ? "30 second warning"
+      : remainingSeconds <= 60 && session?.timer.status === "running"
+      ? "1 minute warning"
+      : null;
+  const { audioEnabled, audioSupported, enableAudio } = useLiveTimerAudioAlerts(
+    session,
+    remainingSeconds
+  );
+
+  async function runAction(
+    action: LiveSessionControlAction,
+    extra?: { entryId?: string; targetIndex?: number }
+  ) {
+    if (!user || !sessionId) return;
+
+    setPendingAction(`${action}:${extra?.entryId || ""}:${extra?.targetIndex ?? ""}`);
+    setActionError(null);
+    setActionMessage(null);
+
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/live/${sessionId}/control`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          action,
+          ...extra,
+        }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        throw new Error(payload.error || "Could not update live session.");
+      }
+
+      setActionMessage(
+        action === "start-next"
+          ? "Started the next speaker."
+          : action === "pause-timer"
+          ? "Timer paused."
+          : action === "resume-timer"
+          ? "Timer resumed."
+          : action === "complete-current"
+          ? "Speaker marked complete."
+          : action === "skip-current"
+          ? "Speaker skipped."
+          : action === "end-session"
+          ? "Session ended."
+          : action === "remove-entry"
+          ? "Speaker removed from queue."
+          : "Queue updated."
+      );
+    } catch (controlError) {
+      setActionError(
+        controlError instanceof Error ? controlError.message : "Could not update live session."
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  function handleDragStart(entryId: string) {
+    setDraggedEntryId(entryId);
+  }
+
+  function handleDragEnd() {
+    setDraggedEntryId(null);
+  }
+
+  function handleDrop(targetIndex: number) {
+    if (!draggedEntryId || pendingAction !== null) return;
+    void runAction("move-entry", { entryId: draggedEntryId, targetIndex });
+    setDraggedEntryId(null);
+  }
+
+  if (authLoading || loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-500 border-t-white" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-3xl font-semibold text-white">Emcee Controls</h1>
+        <p className="mt-3 text-neutral-400">Sign in to manage this live session.</p>
+        <Link
+          href={`/login?redirect=/live/${sessionId}/emcee`}
+          className="mt-6 inline-flex rounded-xl bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-neutral-200"
+        >
+          Sign In
+        </Link>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-3xl font-semibold text-white">Session not found</h1>
+        <p className="mt-3 text-neutral-400">{error || "This live session does not exist."}</p>
+        <Link
+          href="/live"
+          className="mt-6 inline-flex rounded-xl bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-neutral-200"
+        >
+          Create a Session
+        </Link>
+      </div>
+    );
+  }
+
+  if (!isEmcee) {
+    return (
+      <div className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-3xl font-semibold text-white">Read-only access</h1>
+        <p className="mt-3 text-neutral-400">
+          Only the session creator can use emcee controls. You can still watch the audience view.
+        </p>
+        <Link
+          href={`/live/${sessionId}`}
+          className="mt-6 inline-flex rounded-xl bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-neutral-200"
+        >
+          Open Audience View
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[linear-gradient(180deg,_#050505_0%,_#0b1510_100%)] px-4 py-8 text-white">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <section className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+          <div className="rounded-[2rem] border border-emerald-500/20 bg-emerald-500/5 p-6">
+            <p className="text-xs uppercase tracking-[0.35em] text-emerald-300">Emcee Panel</p>
+            <h1 className="mt-3 text-3xl font-semibold">{session.title}</h1>
+            <p className="mt-3 text-neutral-300">
+              Audience view:{" "}
+              <Link className="text-emerald-300 underline underline-offset-4" href={session.audiencePath}>
+                {session.audiencePath}
+              </Link>
+            </p>
+            <div className="mt-8 grid gap-4 md:grid-cols-2">
+              <div className="rounded-[1.5rem] border border-white/10 bg-black/40 p-5">
+                <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Current Timer</p>
+                <div className="mt-4 text-5xl font-semibold tabular-nums text-emerald-300">
+                  {formatClock(remainingSeconds)}
+                </div>
+                <p className="mt-3 text-sm text-neutral-400">
+                  Timer state: {session.timer.status}
+                </p>
+                {timerAlert ? (
+                  <div className="mt-3 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-white">
+                    {timerAlert}
+                  </div>
+                ) : null}
+                {audioSupported ? (
+                  <button
+                    type="button"
+                    onClick={() => void enableAudio()}
+                    className="mt-4 rounded-full border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 transition hover:border-white/30"
+                  >
+                    {audioEnabled ? "Sound Cues On" : "Enable Sound Cues"}
+                  </button>
+                ) : null}
+              </div>
+              <div className="rounded-[1.5rem] border border-white/10 bg-black/40 p-5">
+                <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Current Speaker</p>
+                <div className="mt-4 text-xl font-medium">
+                  {session.currentSpeaker.speakerName || "No speaker active"}
+                </div>
+                <p className="mt-2 text-neutral-400">
+                  {session.currentSpeaker.talkTitle || "Start a queue control action next."}
+                </p>
+              </div>
+            </div>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => runAction("start-next")}
+                disabled={pendingAction !== null}
+                className="rounded-xl bg-emerald-400 px-4 py-3 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:opacity-60"
+              >
+                Start Next
+              </button>
+              <button
+                type="button"
+                onClick={() => runAction("pause-timer")}
+                disabled={pendingAction !== null}
+                className="rounded-xl border border-white/10 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/30 disabled:opacity-60"
+              >
+                Pause
+              </button>
+              <button
+                type="button"
+                onClick={() => runAction("resume-timer")}
+                disabled={pendingAction !== null}
+                className="rounded-xl border border-white/10 px-4 py-3 text-sm font-semibold text-white transition hover:border-white/30 disabled:opacity-60"
+              >
+                Resume
+              </button>
+              <button
+                type="button"
+                onClick={() => runAction("complete-current")}
+                disabled={pendingAction !== null}
+                className="rounded-xl border border-emerald-500/40 px-4 py-3 text-sm font-semibold text-emerald-300 transition hover:border-emerald-400 disabled:opacity-60"
+              >
+                Complete
+              </button>
+              <button
+                type="button"
+                onClick={() => runAction("skip-current")}
+                disabled={pendingAction !== null}
+                className="rounded-xl border border-amber-500/40 px-4 py-3 text-sm font-semibold text-amber-300 transition hover:border-amber-400 disabled:opacity-60"
+              >
+                Skip
+              </button>
+              <button
+                type="button"
+                onClick={() => runAction("end-session")}
+                disabled={pendingAction !== null}
+                className="rounded-xl border border-rose-500/40 px-4 py-3 text-sm font-semibold text-rose-300 transition hover:border-rose-400 disabled:opacity-60"
+              >
+                End Session
+              </button>
+            </div>
+            {actionError ? <p className="mt-4 text-sm text-rose-400">{actionError}</p> : null}
+            {actionMessage ? <p className="mt-4 text-sm text-emerald-300">{actionMessage}</p> : null}
+          </div>
+
+            <div className="rounded-[2rem] border border-white/10 bg-white/5 p-6">
+            <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Join QR</p>
+            <div className="mt-5 rounded-[1.5rem] border border-dashed border-white/10 bg-black/40 p-5">
+              {qrCodeUrl ? (
+                <Image
+                  src={qrCodeUrl}
+                  alt="QR code for audience live queue"
+                  width={224}
+                  height={224}
+                  unoptimized
+                  className="mx-auto h-56 w-56"
+                />
+              ) : (
+                <div className="flex h-56 items-center justify-center text-neutral-500">Generating QR code...</div>
+              )}
+            </div>
+            <p className="mt-4 break-all text-sm text-neutral-400">
+              {typeof window !== "undefined" ? `${window.location.origin}/live/${sessionId}` : session.audiencePath}
+            </p>
+            <p className="mt-3 text-xs uppercase tracking-[0.24em] text-neutral-500">
+              Drag queue cards to reorder
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-[2rem] border border-white/10 bg-white/5 p-6">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Speaker Queue</p>
+              <h2 className="mt-2 text-2xl font-semibold">Queued speakers</h2>
+            </div>
+            <div className="rounded-full border border-white/10 px-4 py-2 text-sm text-neutral-300">
+              {queuedEntries.length} waiting
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-3">
+            {queuedEntries.length === 0 ? (
+              <div className="rounded-[1.5rem] border border-dashed border-white/10 px-5 py-8 text-neutral-500">
+                No one is queued yet. Share the audience link or QR code to start filling the list.
+              </div>
+            ) : (
+              queuedEntries.map((entry, index) => (
+                <div
+                  key={entry.id}
+                  draggable={pendingAction === null}
+                  onDragStart={() => handleDragStart(entry.id)}
+                  onDragEnd={handleDragEnd}
+                  onDragOver={(event) => event.preventDefault()}
+                  onDrop={() => handleDrop(index)}
+                  className={`flex items-center justify-between gap-4 rounded-[1.5rem] border px-5 py-4 ${
+                    draggedEntryId === entry.id
+                      ? "border-emerald-400/60 bg-emerald-500/10"
+                      : "border-white/10 bg-black/40"
+                  }`}
+                >
+                  <div>
+                    <p className="text-sm text-neutral-500">#{index + 1}</p>
+                    <p className="mt-1 text-lg font-medium text-white">{entry.talkTitle}</p>
+                    <p className="mt-1 text-sm text-neutral-400">{entry.speakerName}</p>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    <div className="rounded-full border border-white/10 px-3 py-1 text-sm text-neutral-300">
+                      {entry.durationMinutes} min
+                    </div>
+                    <div className="rounded-full border border-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-neutral-400">
+                      Drag
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => runAction("move-entry", { entryId: entry.id, targetIndex: Math.max(0, index - 1) })}
+                      disabled={pendingAction !== null || index === 0}
+                      className="rounded-lg border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 disabled:opacity-40"
+                    >
+                      Up
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        runAction("move-entry", {
+                          entryId: entry.id,
+                          targetIndex: Math.min(queuedEntries.length - 1, index + 1),
+                        })
+                      }
+                      disabled={pendingAction !== null || index === queuedEntries.length - 1}
+                      className="rounded-lg border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 disabled:opacity-40"
+                    >
+                      Down
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => runAction("remove-entry", { entryId: entry.id })}
+                      disabled={pendingAction !== null}
+                      className="rounded-lg border border-rose-500/30 px-3 py-2 text-xs font-semibold text-rose-300 disabled:opacity-40"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-[2rem] border border-white/10 bg-white/5 p-6">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Session History</p>
+              <h2 className="mt-2 text-2xl font-semibold">Completed talks</h2>
+            </div>
+            <div className="rounded-full border border-white/10 px-4 py-2 text-sm text-neutral-300">
+              {session.history.length} logged
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-3">
+            {session.history.length === 0 ? (
+              <div className="rounded-[1.5rem] border border-dashed border-white/10 px-5 py-8 text-neutral-500">
+                Finished talks will appear here with timestamps.
+              </div>
+            ) : (
+              [...session.history].reverse().map((item) => (
+                <div
+                  key={`${item.entryId}-${item.finishedAtMs}`}
+                  className="flex items-center justify-between gap-4 rounded-[1.5rem] border border-white/10 bg-black/40 px-5 py-4"
+                >
+                  <div>
+                    <p className="text-sm text-neutral-500">{formatTimestamp(item.finishedAtMs)}</p>
+                    <p className="mt-1 text-lg font-medium text-white">{item.talkTitle}</p>
+                    <p className="mt-1 text-sm text-neutral-400">{item.speakerName}</p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <div className="rounded-full border border-white/10 px-3 py-1 text-sm text-neutral-300">
+                      {item.durationMinutes} min
+                    </div>
+                    <div className="rounded-full border border-white/10 px-3 py-1 text-sm text-neutral-300">
+                      {item.outcome}
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/live/[sessionId]/page.tsx
+++ b/app/live/[sessionId]/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  getLiveRemainingSeconds,
+  useLiveSession,
+  useLiveTimerAudioAlerts,
+} from "@/lib/live-sessions/client";
+
+function formatClock(totalSeconds: number) {
+  const safe = Math.max(0, totalSeconds);
+  const minutes = Math.floor(safe / 60);
+  const seconds = safe % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export default function AudienceLiveSessionPage({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>;
+}) {
+  const { user, loading: authLoading } = useAuth();
+  const [sessionId, setSessionId] = useState("");
+  const { session, queue, loading, error } = useLiveSession(sessionId);
+  const [talkTitle, setTalkTitle] = useState("");
+  const [durationMinutes, setDurationMinutes] = useState<3 | 5>(3);
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState<string | null>(null);
+  const [remainingSeconds, setRemainingSeconds] = useState(0);
+
+  useEffect(() => {
+    params.then((resolved) => setSessionId(resolved.sessionId));
+  }, [params]);
+
+  useEffect(() => {
+    setRemainingSeconds(getLiveRemainingSeconds(session));
+    const interval = window.setInterval(() => {
+      setRemainingSeconds(getLiveRemainingSeconds(session));
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [session]);
+
+  const currentSpeakerLabel = useMemo(() => {
+    if (!session?.currentSpeaker.speakerName) {
+      return "Waiting for the next speaker";
+    }
+    return `${session.currentSpeaker.speakerName}${session.currentSpeaker.talkTitle ? `, ${session.currentSpeaker.talkTitle}` : ""}`;
+  }, [session]);
+
+  const upcomingQueue = queue.filter((entry) => entry.status === "queued");
+  const userIsQueued = user ? upcomingQueue.some((entry) => entry.userId === user.uid) : false;
+  const timerAlert =
+    remainingSeconds === 0 && session?.timer.status === "running"
+      ? "Time is up"
+      : remainingSeconds <= 30 && session?.timer.status === "running"
+      ? "30 second warning"
+      : remainingSeconds <= 60 && session?.timer.status === "running"
+      ? "1 minute warning"
+      : null;
+  const { audioEnabled, audioSupported, enableAudio } = useLiveTimerAudioAlerts(
+    session,
+    remainingSeconds
+  );
+
+  async function handleJoinQueue(event: React.FormEvent) {
+    event.preventDefault();
+    if (!user || !sessionId || submitting) return;
+
+    setSubmitting(true);
+    setFormError(null);
+    setFormSuccess(null);
+
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/live/${sessionId}/queue`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          talkTitle,
+          durationMinutes,
+        }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+
+      if (!res.ok) {
+        throw new Error(payload.error || "Could not join the queue.");
+      }
+
+      setTalkTitle("");
+      setDurationMinutes(3);
+      setFormSuccess("You are in the queue. Keep this page open to watch the session.");
+    } catch (joinError) {
+      setFormError(joinError instanceof Error ? joinError.message : "Could not join the queue.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_35%),linear-gradient(180deg,_#050505_0%,_#0b0b0b_100%)] px-4 py-8 text-white">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[2rem] border border-white/10 bg-white/5 p-6 backdrop-blur-md">
+          <p className="text-xs uppercase tracking-[0.35em] text-emerald-300">Live Queue</p>
+          <h1 className="mt-3 text-3xl font-semibold">
+            {session?.title || (loading ? "Loading session..." : "Live session")}
+          </h1>
+          <p className="mt-3 text-neutral-300">{error || currentSpeakerLabel}</p>
+
+          <div className="mt-8 grid gap-4 md:grid-cols-[1.4fr_0.8fr]">
+            <div className="rounded-[1.5rem] border border-white/10 bg-black/40 p-6">
+              <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Now Speaking</p>
+              <div className="mt-4 text-2xl font-medium">
+                {session?.currentSpeaker.talkTitle || "Queue forming"}
+              </div>
+              <div className="mt-2 text-neutral-400">
+                {session?.currentSpeaker.speakerName || "Emcee will start the first speaker soon"}
+              </div>
+            </div>
+
+            <div className="rounded-[1.5rem] border border-white/10 bg-black p-6 text-center">
+              <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Timer</p>
+              <div
+                className={`mt-4 text-6xl font-semibold tabular-nums ${
+                  remainingSeconds <= 30
+                    ? "text-rose-400"
+                    : remainingSeconds <= 60
+                    ? "text-amber-300"
+                    : "text-emerald-300"
+                }`}
+              >
+                {formatClock(remainingSeconds)}
+              </div>
+              <div className="mt-3 text-sm text-neutral-400">
+                {session?.timer.status ? `Status: ${session.timer.status}` : "Waiting for emcee"}
+              </div>
+              {timerAlert ? (
+                <div className="mt-3 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-white">
+                  {timerAlert}
+                </div>
+              ) : null}
+              {audioSupported ? (
+                <button
+                  type="button"
+                  onClick={() => void enableAudio()}
+                  className="mt-4 rounded-full border border-white/10 px-3 py-2 text-xs font-semibold text-neutral-200 transition hover:border-white/30"
+                >
+                  {audioEnabled ? "Sound Cues On" : "Enable Sound Cues"}
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+          <div className="rounded-[2rem] border border-white/10 bg-white/5 p-6">
+            <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Up Next</p>
+            <ol className="mt-5 space-y-3">
+              {upcomingQueue.length === 0 ? (
+                <li className="rounded-2xl border border-dashed border-white/10 px-4 py-5 text-neutral-500">
+                  No speakers queued yet.
+                </li>
+              ) : (
+                upcomingQueue.map((entry, index) => (
+                  <li
+                    key={entry.id}
+                    className="flex items-center justify-between rounded-2xl border border-white/10 bg-black/40 px-4 py-4"
+                  >
+                    <div>
+                      <p className="text-sm text-neutral-400">#{index + 1}</p>
+                      <p className="mt-1 font-medium text-white">{entry.talkTitle}</p>
+                      <p className="mt-1 text-sm text-neutral-400">{entry.speakerName}</p>
+                    </div>
+                    <div className="rounded-full border border-white/10 px-3 py-1 text-sm text-neutral-300">
+                      {entry.durationMinutes} min
+                    </div>
+                  </li>
+                ))
+              )}
+            </ol>
+          </div>
+
+          <div className="rounded-[2rem] border border-white/10 bg-white/5 p-6">
+            <p className="text-sm uppercase tracking-[0.28em] text-neutral-400">Join Queue</p>
+            {authLoading ? (
+              <p className="mt-5 text-neutral-400">Checking your sign-in status...</p>
+            ) : !user ? (
+              <div className="mt-5 rounded-2xl border border-white/10 bg-black/40 p-5">
+                <p className="text-neutral-300">
+                  Sign in to add your lightning talk to the queue.
+                </p>
+                <Link
+                  href={`/login?redirect=/live/${sessionId}`}
+                  className="mt-4 inline-flex rounded-xl bg-white px-4 py-3 text-sm font-semibold text-black transition hover:bg-neutral-200"
+                >
+                  Sign In
+                </Link>
+              </div>
+            ) : (
+              <form className="mt-5 space-y-4" onSubmit={handleJoinQueue}>
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-neutral-300" htmlFor="talk-title">
+                    Talk title
+                  </label>
+                  <input
+                    id="talk-title"
+                    value={talkTitle}
+                    onChange={(event) => setTalkTitle(event.target.value)}
+                    maxLength={140}
+                    required
+                    disabled={userIsQueued}
+                    className="w-full rounded-2xl border border-white/10 bg-black/50 px-4 py-3 text-white outline-none transition focus:border-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+                    placeholder="What are you demoing?"
+                  />
+                </div>
+
+                <div>
+                  <p className="mb-2 text-sm font-medium text-neutral-300">Duration</p>
+                  <div className="flex gap-3">
+                    {[3, 5].map((value) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => setDurationMinutes(value as 3 | 5)}
+                        disabled={userIsQueued}
+                        className={`rounded-xl border px-4 py-3 text-sm font-medium transition ${
+                          durationMinutes === value
+                            ? "border-emerald-400 bg-emerald-400 text-black"
+                            : "border-white/10 bg-black/40 text-neutral-200 hover:border-white/30"
+                        } disabled:cursor-not-allowed disabled:opacity-60`}
+                      >
+                        {value} min
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {formError ? (
+                  <p className="text-sm text-rose-400" role="alert">
+                    {formError}
+                  </p>
+                ) : null}
+                {formSuccess ? (
+                  <p className="text-sm text-emerald-300" role="status">
+                    {formSuccess}
+                  </p>
+                ) : null}
+
+                <button
+                  type="submit"
+                  disabled={submitting || userIsQueued}
+                  className="inline-flex rounded-2xl bg-emerald-400 px-5 py-3 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {userIsQueued ? "Already in Queue" : submitting ? "Joining..." : "Join Queue"}
+                </button>
+              </form>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useAuth } from "@/contexts/AuthContext";
+
+export default function LiveSessionsPage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+  const [title, setTitle] = useState("Lightning Talks");
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreateSession() {
+    if (!user || isCreating) return;
+
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/live/session", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ title }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as {
+        sessionId?: string;
+        error?: string;
+      };
+
+      if (!res.ok || !payload.sessionId) {
+        throw new Error(payload.error || "Could not create live session.");
+      }
+
+      router.push(`/live/${payload.sessionId}/emcee`);
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : "Could not create live session.");
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-500 border-t-white" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-3xl font-semibold text-white">Live Session Control Room</h1>
+        <p className="mt-3 text-neutral-400">
+          Sign in with an admin account to launch a lightning-talk session and open the emcee controls.
+        </p>
+        <Link
+          href="/login?redirect=/live"
+          className="mt-6 inline-flex rounded-xl bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-neutral-200"
+        >
+          Sign In
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-3xl flex-col px-6 py-12">
+      <div className="rounded-[2rem] border border-neutral-800 bg-neutral-950 p-8 shadow-2xl shadow-black/30">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-400">Live Events</p>
+        <h1 className="mt-4 text-4xl font-semibold text-white">Launch a lightning-talk session</h1>
+        <p className="mt-4 max-w-2xl text-base text-neutral-400">
+          This creates a realtime queue and an emcee control room. Audience members can join from their phones once you share the session link or QR code.
+        </p>
+
+        <div className="mt-8 space-y-4">
+          <label className="block text-sm font-medium text-neutral-300" htmlFor="session-title">
+            Session title
+          </label>
+          <input
+            id="session-title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            maxLength={120}
+            className="w-full rounded-2xl border border-neutral-800 bg-black px-4 py-3 text-white outline-none transition focus:border-emerald-500"
+            placeholder="Lightning Talks"
+          />
+          {error ? (
+            <p className="text-sm text-rose-400" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={handleCreateSession}
+            disabled={isCreating}
+            className="inline-flex rounded-2xl bg-emerald-400 px-5 py-3 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isCreating ? "Creating..." : "Create Session"}
+          </button>
+          <Link
+            href="/talks"
+            className="inline-flex rounded-2xl border border-neutral-700 px-5 py-3 text-sm font-semibold text-neutral-200 transition hover:border-neutral-500 hover:text-white"
+          >
+            Back to Talks
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/config/firebase/database.rules.json
+++ b/config/firebase/database.rules.json
@@ -1,0 +1,18 @@
+{
+  "rules": {
+    ".read": false,
+    ".write": false,
+    "live_sessions": {
+      "$sessionId": {
+        ".read": true,
+        ".write": false
+      }
+    },
+    "live_queue_entries": {
+      "$sessionId": {
+        ".read": true,
+        ".write": false
+      }
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,9 @@
     "rules": "config/firebase/firestore.rules",
     "indexes": "config/firebase/firestore.indexes.json"
   },
+  "database": {
+    "rules": "config/firebase/database.rules.json"
+  },
   "storage": {
     "rules": "config/firebase/storage.rules"
   }

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -1,9 +1,11 @@
 import { cert, getApps, initializeApp, App } from "firebase-admin/app";
 import { getAuth, Auth } from "firebase-admin/auth";
+import { getDatabase, Database } from "firebase-admin/database";
 import { getFirestore, Firestore } from "firebase-admin/firestore";
 
 let adminDb: Firestore | null = null;
 let adminAuth: Auth | null = null;
+let adminRtdb: Database | null = null;
 
 function parseServiceAccount() {
   const raw = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
@@ -31,12 +33,17 @@ function getAdminApp(): App | null {
     return initializeApp({
       credential: cert(serviceAccount),
       projectId: serviceAccount.project_id,
+      databaseURL:
+        process.env.FIREBASE_DATABASE_URL || process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
     });
   }
 
   if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
     console.log("[Firebase Admin] Initializing with GOOGLE_APPLICATION_CREDENTIALS");
-    return initializeApp();
+    return initializeApp({
+      databaseURL:
+        process.env.FIREBASE_DATABASE_URL || process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
+    });
   }
 
   console.warn("[Firebase Admin] No credentials found - FIREBASE_SERVICE_ACCOUNT_JSON not set");
@@ -69,4 +76,18 @@ export function getAdminAuth(): Auth | null {
 
   adminAuth = getAuth(app);
   return adminAuth;
+}
+
+export function getAdminRtdb(): Database | null {
+  if (adminRtdb) {
+    return adminRtdb;
+  }
+
+  const app = getAdminApp();
+  if (!app) {
+    return null;
+  }
+
+  adminRtdb = getDatabase(app);
+  return adminRtdb;
 }

--- a/lib/live-sessions/client.ts
+++ b/lib/live-sessions/client.ts
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { onValue, ref } from "firebase/database";
+import { rtdb } from "@/lib/firebase";
+import type { LiveQueueEntryRecord, LiveSessionRealtimeRecord } from "./types";
+
+interface LiveQueueState {
+  order: string[];
+  items: Record<string, LiveQueueEntryRecord>;
+  updatedAtMs?: number;
+}
+
+export interface UseLiveSessionResult {
+  session: LiveSessionRealtimeRecord | null;
+  queue: LiveQueueEntryRecord[];
+  loading: boolean;
+  error: string | null;
+}
+
+function normalizeQueue(snapshotValue: unknown): LiveQueueEntryRecord[] {
+  if (!snapshotValue || typeof snapshotValue !== "object") {
+    return [];
+  }
+
+  const queueState = snapshotValue as LiveQueueState;
+  const order = Array.isArray(queueState.order)
+    ? queueState.order.filter((value): value is string => typeof value === "string")
+    : [];
+  const items =
+    queueState.items && typeof queueState.items === "object" ? queueState.items : {};
+
+  return order
+    .map((entryId) => items[entryId])
+    .filter((entry): entry is LiveQueueEntryRecord => Boolean(entry));
+}
+
+export function getLiveRemainingSeconds(session: LiveSessionRealtimeRecord | null): number {
+  if (!session) return 0;
+
+  const timer = session.timer;
+  if (timer.status === "idle" || timer.status === "completed") {
+    return timer.remainingSeconds;
+  }
+
+  if (timer.status === "paused" || !timer.startedAtMs) {
+    return timer.remainingSeconds;
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((Date.now() - timer.startedAtMs) / 1000));
+  return Math.max(0, timer.remainingSeconds - elapsedSeconds);
+}
+
+export function useLiveSession(sessionId: string): UseLiveSessionResult {
+  const [session, setSession] = useState<LiveSessionRealtimeRecord | null>(null);
+  const [queue, setQueue] = useState<LiveQueueEntryRecord[]>([]);
+  const [loadedSessionId, setLoadedSessionId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    !sessionId ? null : !rtdb ? "Firebase Realtime Database is not configured." : null
+  );
+  const loading = Boolean(sessionId && rtdb && loadedSessionId !== sessionId);
+
+  useEffect(() => {
+    if (!sessionId || !rtdb) {
+      return;
+    }
+
+    const sessionRef = ref(rtdb, `live_sessions/${sessionId}`);
+    const queueRef = ref(rtdb, `live_queue_entries/${sessionId}`);
+
+    const unsubscribeSession = onValue(
+      sessionRef,
+      (snapshot) => {
+        setSession(snapshot.exists() ? (snapshot.val() as LiveSessionRealtimeRecord) : null);
+        setLoadedSessionId(sessionId);
+        setError(null);
+      },
+      () => {
+        setError("Could not load live session state.");
+        setLoadedSessionId(sessionId);
+      }
+    );
+
+    const unsubscribeQueue = onValue(
+      queueRef,
+      (snapshot) => {
+        setQueue(normalizeQueue(snapshot.val()));
+      },
+      () => {
+        setError("Could not load live queue state.");
+      }
+    );
+
+    return () => {
+      unsubscribeSession();
+      unsubscribeQueue();
+    };
+  }, [sessionId]);
+
+  return useMemo(
+    () => ({
+      session,
+      queue,
+      loading,
+      error,
+    }),
+    [session, queue, loading, error]
+  );
+}
+
+type AudioPattern = Array<{ durationMs: number; frequency: number; gapMs?: number }>;
+
+async function playAudioPattern(audioContext: AudioContext, pattern: AudioPattern) {
+  let startAt = audioContext.currentTime;
+
+  for (const tone of pattern) {
+    const oscillator = audioContext.createOscillator();
+    const gainNode = audioContext.createGain();
+
+    oscillator.type = "sine";
+    oscillator.frequency.value = tone.frequency;
+    gainNode.gain.setValueAtTime(0.0001, startAt);
+    gainNode.gain.exponentialRampToValueAtTime(0.12, startAt + 0.01);
+    gainNode.gain.exponentialRampToValueAtTime(
+      0.0001,
+      startAt + tone.durationMs / 1000
+    );
+
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+    oscillator.start(startAt);
+    oscillator.stop(startAt + tone.durationMs / 1000);
+
+    startAt += tone.durationMs / 1000 + (tone.gapMs ?? 120) / 1000;
+  }
+}
+
+export function useLiveTimerAudioAlerts(
+  session: LiveSessionRealtimeRecord | null,
+  remainingSeconds: number
+) {
+  const [audioEnabled, setAudioEnabled] = useState(false);
+  const audioSupported =
+    typeof window !== "undefined" && typeof window.AudioContext !== "undefined";
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const previousRemainingRef = useRef<number | null>(null);
+
+  const enableAudio = useCallback(async () => {
+    if (typeof window === "undefined" || typeof window.AudioContext === "undefined") {
+      return false;
+    }
+
+    if (!audioContextRef.current) {
+      audioContextRef.current = new window.AudioContext();
+    }
+
+    if (audioContextRef.current.state === "suspended") {
+      await audioContextRef.current.resume();
+    }
+
+    setAudioEnabled(true);
+    return true;
+  }, []);
+
+  useEffect(() => {
+    const previousRemaining = previousRemainingRef.current;
+    previousRemainingRef.current = remainingSeconds;
+
+    if (!audioEnabled || !audioContextRef.current || session?.timer.status !== "running") {
+      return;
+    }
+
+    const shouldPlayOneMinute =
+      previousRemaining !== null && previousRemaining > 60 && remainingSeconds <= 60;
+    const shouldPlayThirtySeconds =
+      previousRemaining !== null && previousRemaining > 30 && remainingSeconds <= 30;
+    const shouldPlayTimeUp =
+      previousRemaining !== null && previousRemaining > 0 && remainingSeconds === 0;
+
+    if (shouldPlayTimeUp) {
+      void playAudioPattern(audioContextRef.current, [
+        { frequency: 880, durationMs: 260 },
+        { frequency: 880, durationMs: 260 },
+        { frequency: 880, durationMs: 420 },
+      ]);
+      return;
+    }
+
+    if (shouldPlayThirtySeconds) {
+      void playAudioPattern(audioContextRef.current, [
+        { frequency: 740, durationMs: 220 },
+        { frequency: 740, durationMs: 220 },
+      ]);
+      return;
+    }
+
+    if (shouldPlayOneMinute) {
+      void playAudioPattern(audioContextRef.current, [
+        { frequency: 620, durationMs: 220 },
+      ]);
+    }
+  }, [audioEnabled, remainingSeconds, session?.timer.status]);
+
+  return {
+    audioEnabled,
+    audioSupported,
+    enableAudio,
+  };
+}

--- a/lib/live-sessions/data-server.ts
+++ b/lib/live-sessions/data-server.ts
@@ -1,0 +1,528 @@
+import { getAdminDb, getAdminRtdb } from "@/lib/firebase-admin";
+import type {
+  ControlLiveSessionInput,
+  CreateLiveSessionInput,
+  CreatedLiveSession,
+  EnqueueSpeakerInput,
+  LiveSessionArchiveRecord,
+  LiveQueueEntryRecord,
+  LiveSessionHistoryRecord,
+  LiveSessionRealtimeRecord,
+  LiveSessionStatus,
+} from "./types";
+
+const FIRESTORE_COLLECTIONS = {
+  SESSIONS: "live_sessions",
+  QUEUE_ENTRIES: "live_queue_entries",
+} as const;
+
+const RTDB_ROOTS = {
+  SESSIONS: "live_sessions",
+  QUEUE: "live_queue_entries",
+} as const;
+
+export function buildLiveSessionPaths(sessionId: string) {
+  return {
+    audiencePath: `/live/${sessionId}`,
+    emceePath: `/live/${sessionId}/emcee`,
+    sessionRtdbPath: `${RTDB_ROOTS.SESSIONS}/${sessionId}`,
+    queueRtdbPath: `${RTDB_ROOTS.QUEUE}/${sessionId}`,
+  };
+}
+
+export class LiveSessionNotFoundError extends Error {
+  constructor() {
+    super("Live session not found");
+    this.name = "LiveSessionNotFoundError";
+  }
+}
+
+export class LiveSessionClosedError extends Error {
+  constructor() {
+    super("Live session is not accepting speakers");
+    this.name = "LiveSessionClosedError";
+  }
+}
+
+export class LiveSessionDuplicateSpeakerError extends Error {
+  constructor() {
+    super("Speaker is already in the queue for this live session");
+    this.name = "LiveSessionDuplicateSpeakerError";
+  }
+}
+
+export class LiveSessionUnauthorizedError extends Error {
+  constructor() {
+    super("Only the emcee can control this live session");
+    this.name = "LiveSessionUnauthorizedError";
+  }
+}
+
+export class LiveSessionInvalidActionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LiveSessionInvalidActionError";
+  }
+}
+
+function buildInitialRealtimeRecord(
+  sessionId: string,
+  input: CreateLiveSessionInput,
+  nowMs: number
+): LiveSessionRealtimeRecord {
+  const paths = buildLiveSessionPaths(sessionId);
+
+  return {
+    id: sessionId,
+    status: "pending",
+    title: input.title,
+    createdAtMs: nowMs,
+    updatedAtMs: nowMs,
+    emceeUid: input.emceeUid,
+    emceeName: input.emceeName,
+    audiencePath: paths.audiencePath,
+    emceePath: paths.emceePath,
+    currentSpeaker: {
+      entryId: null,
+      speakerName: null,
+      talkTitle: null,
+    },
+    timer: {
+      status: "idle",
+      durationSeconds: 0,
+      remainingSeconds: 0,
+      startedAtMs: null,
+      pausedAtMs: null,
+      warningThresholds: [60, 30],
+    },
+    history: [],
+  };
+}
+
+function buildArchiveRecord(
+  sessionId: string,
+  session: LiveSessionRealtimeRecord,
+  createdAt: Date
+): LiveSessionArchiveRecord {
+  return {
+    sessionId,
+    title: session.title,
+    status: session.status,
+    createdAt,
+    updatedAt: createdAt,
+    createdBy: {
+      uid: session.emceeUid,
+      name: session.emceeName,
+    },
+    audiencePath: session.audiencePath,
+    emceePath: session.emceePath,
+    history: [],
+  };
+}
+
+export async function createLiveSessionServer(
+  input: CreateLiveSessionInput
+): Promise<CreatedLiveSession> {
+  const adminDb = getAdminDb();
+  const adminRtdb = getAdminRtdb();
+
+  if (!adminDb || !adminRtdb) {
+    throw new Error("Firebase Admin is not fully initialized");
+  }
+
+  const sessionRef = adminDb.collection(FIRESTORE_COLLECTIONS.SESSIONS).doc();
+  const sessionId = sessionRef.id;
+  const now = new Date();
+  const nowMs = now.getTime();
+  const session = buildInitialRealtimeRecord(sessionId, input, nowMs);
+  const archiveRecord = buildArchiveRecord(sessionId, session, now);
+  const paths = buildLiveSessionPaths(sessionId);
+
+  await Promise.all([
+    sessionRef.set(archiveRecord),
+    adminRtdb.ref(paths.sessionRtdbPath).set(session),
+    adminRtdb.ref(paths.queueRtdbPath).set({
+      order: [],
+      items: {},
+      updatedAtMs: nowMs,
+    }),
+  ]);
+
+  return {
+    sessionId,
+    session,
+  };
+}
+
+function buildQueueEntry(
+  entryId: string,
+  input: EnqueueSpeakerInput,
+  nowMs: number
+): LiveQueueEntryRecord {
+  return {
+    id: entryId,
+    sessionId: input.sessionId,
+    userId: input.userId,
+    speakerName: input.speakerName,
+    speakerPhotoUrl: input.speakerPhotoUrl ?? null,
+    talkTitle: input.talkTitle,
+    durationMinutes: input.durationMinutes,
+    status: "queued",
+    createdAtMs: nowMs,
+    updatedAtMs: nowMs,
+  };
+}
+
+export async function enqueueSpeakerServer(
+  input: EnqueueSpeakerInput
+): Promise<LiveQueueEntryRecord> {
+  const adminDb = getAdminDb();
+  const adminRtdb = getAdminRtdb();
+
+  if (!adminDb || !adminRtdb) {
+    throw new Error("Firebase Admin is not fully initialized");
+  }
+
+  const paths = buildLiveSessionPaths(input.sessionId);
+  const sessionSnapshot = await adminRtdb.ref(paths.sessionRtdbPath).get();
+
+  if (!sessionSnapshot.exists()) {
+    throw new LiveSessionNotFoundError();
+  }
+
+  const session = sessionSnapshot.val() as LiveSessionRealtimeRecord;
+  if (session.status === "completed" || session.status === "cancelled") {
+    throw new LiveSessionClosedError();
+  }
+
+  const queueRootRef = adminRtdb.ref(paths.queueRtdbPath);
+  const entryRef = adminDb.collection(FIRESTORE_COLLECTIONS.QUEUE_ENTRIES).doc();
+  const entryId = entryRef.id;
+  const now = new Date();
+  const nowMs = now.getTime();
+  const entry = buildQueueEntry(entryId, input, nowMs);
+
+  const transactionResult = await queueRootRef.transaction((current) => {
+    const order = Array.isArray(current?.order)
+      ? current.order.filter((value: unknown): value is string => typeof value === "string")
+      : [];
+    const items =
+      current && typeof current.items === "object" && current.items !== null
+        ? (current.items as Record<string, LiveQueueEntryRecord>)
+        : {};
+
+    const duplicate = Object.values(items).some(
+      (value) => value?.userId === input.userId && ["queued", "live"].includes(value.status)
+    );
+    if (duplicate) {
+      return;
+    }
+
+    return {
+      order: [...order, entryId],
+      items: {
+        ...items,
+        [entryId]: entry,
+      },
+      updatedAtMs: nowMs,
+    };
+  });
+
+  if (!transactionResult.committed) {
+    throw new LiveSessionDuplicateSpeakerError();
+  }
+
+  await entryRef.set({
+    ...entry,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return entry;
+}
+
+function assertEmcee(session: LiveSessionRealtimeRecord, emceeUid: string) {
+  if (session.emceeUid !== emceeUid) {
+    throw new LiveSessionUnauthorizedError();
+  }
+}
+
+function cloneQueueState(current: unknown): {
+  order: string[];
+  items: Record<string, LiveQueueEntryRecord>;
+  updatedAtMs: number;
+} {
+  if (!current || typeof current !== "object") {
+    return { order: [], items: {}, updatedAtMs: 0 };
+  }
+
+  const record = current as {
+    order?: unknown;
+    items?: unknown;
+    updatedAtMs?: unknown;
+  };
+
+  return {
+    order: Array.isArray(record.order)
+      ? record.order.filter((value): value is string => typeof value === "string")
+      : [],
+    items:
+      record.items && typeof record.items === "object"
+        ? ({ ...record.items } as Record<string, LiveQueueEntryRecord>)
+        : {},
+    updatedAtMs: typeof record.updatedAtMs === "number" ? record.updatedAtMs : 0,
+  };
+}
+
+function buildHistoryRecord(
+  entry: LiveQueueEntryRecord,
+  outcome: "completed" | "skipped" | "removed",
+  startedAtMs: number | null,
+  finishedAtMs: number
+): LiveSessionHistoryRecord {
+  return {
+    entryId: entry.id,
+    userId: entry.userId,
+    speakerName: entry.speakerName,
+    talkTitle: entry.talkTitle,
+    durationMinutes: entry.durationMinutes,
+    outcome,
+    startedAtMs,
+    finishedAtMs,
+  };
+}
+
+async function appendHistoryAndUpdateSessionArchive(
+  sessionId: string,
+  updates: Partial<LiveSessionArchiveRecord>,
+  historyRecord?: LiveSessionHistoryRecord
+) {
+  const adminDb = getAdminDb();
+  if (!adminDb) {
+    throw new Error("Firebase Admin is not fully initialized");
+  }
+
+  const sessionRef = adminDb.collection(FIRESTORE_COLLECTIONS.SESSIONS).doc(sessionId);
+  const snapshot = await sessionRef.get();
+  const existing = snapshot.exists ? (snapshot.data() as LiveSessionArchiveRecord) : null;
+
+  await sessionRef.set(
+    {
+      ...(existing || {}),
+      ...updates,
+      updatedAt: new Date(),
+      history: historyRecord ? [...(existing?.history || []), historyRecord] : existing?.history || [],
+    },
+    { merge: true }
+  );
+}
+
+function setCurrentSpeakerFromEntry(
+  session: LiveSessionRealtimeRecord,
+  entry: LiveQueueEntryRecord | null,
+  nowMs: number
+): LiveSessionRealtimeRecord {
+  if (!entry) {
+    return {
+      ...session,
+      status: "pending",
+      updatedAtMs: nowMs,
+      currentSpeaker: {
+        entryId: null,
+        speakerName: null,
+        talkTitle: null,
+      },
+      timer: {
+        ...session.timer,
+        status: "idle",
+        durationSeconds: 0,
+        remainingSeconds: 0,
+        startedAtMs: null,
+        pausedAtMs: null,
+      },
+    };
+  }
+
+  const durationSeconds = entry.durationMinutes * 60;
+
+  return {
+    ...session,
+    status: "live",
+    updatedAtMs: nowMs,
+    currentSpeaker: {
+      entryId: entry.id,
+      speakerName: entry.speakerName,
+      talkTitle: entry.talkTitle,
+    },
+    timer: {
+      ...session.timer,
+      status: "running",
+      durationSeconds,
+      remainingSeconds: durationSeconds,
+      startedAtMs: nowMs,
+      pausedAtMs: null,
+    },
+  };
+}
+
+export async function controlLiveSessionServer(input: ControlLiveSessionInput) {
+  const adminDb = getAdminDb();
+  const adminRtdb = getAdminRtdb();
+
+  if (!adminDb || !adminRtdb) {
+    throw new Error("Firebase Admin is not fully initialized");
+  }
+
+  const paths = buildLiveSessionPaths(input.sessionId);
+  const sessionRef = adminRtdb.ref(paths.sessionRtdbPath);
+  const queueRef = adminRtdb.ref(paths.queueRtdbPath);
+  const nowMs = Date.now();
+
+  const [sessionSnapshot, queueSnapshot] = await Promise.all([sessionRef.get(), queueRef.get()]);
+
+  if (!sessionSnapshot.exists()) {
+    throw new LiveSessionNotFoundError();
+  }
+
+  const session = sessionSnapshot.val() as LiveSessionRealtimeRecord;
+  assertEmcee(session, input.emceeUid);
+  const queueState = cloneQueueState(queueSnapshot.val());
+  const currentEntryId = session.currentSpeaker.entryId;
+  const currentEntry = currentEntryId ? queueState.items[currentEntryId] || null : null;
+
+  let nextSession: LiveSessionRealtimeRecord = { ...session };
+  const nextQueueState = {
+    order: [...queueState.order],
+    items: { ...queueState.items },
+    updatedAtMs: nowMs,
+  };
+  let historyRecord: LiveSessionHistoryRecord | undefined;
+  let archiveStatus: LiveSessionStatus | undefined;
+
+  if (input.action === "start-next") {
+    if (currentEntry && session.timer.status !== "completed" && session.timer.status !== "idle") {
+      throw new LiveSessionInvalidActionError("Finish or skip the current speaker first.");
+    }
+    const nextEntryId = nextQueueState.order.find((entryId) => nextQueueState.items[entryId]?.status === "queued");
+    const nextEntry = nextEntryId ? nextQueueState.items[nextEntryId] : null;
+    if (!nextEntry) {
+      throw new LiveSessionInvalidActionError("No queued speakers remain.");
+    }
+    nextQueueState.items[nextEntry.id] = { ...nextEntry, status: "live", updatedAtMs: nowMs };
+    nextSession = setCurrentSpeakerFromEntry(session, nextQueueState.items[nextEntry.id], nowMs);
+  } else if (input.action === "pause-timer") {
+    if (session.timer.status !== "running") {
+      throw new LiveSessionInvalidActionError("Timer is not running.");
+    }
+    const elapsedSeconds = session.timer.startedAtMs
+      ? Math.max(0, Math.floor((nowMs - session.timer.startedAtMs) / 1000))
+      : 0;
+    nextSession = {
+      ...session,
+      updatedAtMs: nowMs,
+      timer: {
+        ...session.timer,
+        status: "paused",
+        remainingSeconds: Math.max(0, session.timer.remainingSeconds - elapsedSeconds),
+        startedAtMs: null,
+        pausedAtMs: nowMs,
+      },
+    };
+  } else if (input.action === "resume-timer") {
+    if (session.timer.status !== "paused") {
+      throw new LiveSessionInvalidActionError("Timer is not paused.");
+    }
+    nextSession = {
+      ...session,
+      updatedAtMs: nowMs,
+      timer: {
+        ...session.timer,
+        status: "running",
+        startedAtMs: nowMs,
+        pausedAtMs: null,
+      },
+    };
+  } else if (input.action === "complete-current" || input.action === "skip-current") {
+    if (!currentEntry) {
+      throw new LiveSessionInvalidActionError("There is no active speaker.");
+    }
+    const outcome = input.action === "complete-current" ? "completed" : "skipped";
+    nextQueueState.items[currentEntry.id] = {
+      ...currentEntry,
+      status: outcome,
+      updatedAtMs: nowMs,
+    };
+    historyRecord = buildHistoryRecord(currentEntry, outcome, session.timer.startedAtMs, nowMs);
+    nextSession = setCurrentSpeakerFromEntry(session, null, nowMs);
+  } else if (input.action === "remove-entry") {
+    if (!input.entryId || !nextQueueState.items[input.entryId]) {
+      throw new LiveSessionInvalidActionError("Queue entry not found.");
+    }
+    const entry = nextQueueState.items[input.entryId];
+    nextQueueState.items[input.entryId] = { ...entry, status: "removed", updatedAtMs: nowMs };
+    nextQueueState.order = nextQueueState.order.filter((entryId) => entryId !== input.entryId);
+    historyRecord = buildHistoryRecord(entry, "removed", null, nowMs);
+  } else if (input.action === "move-entry") {
+    if (!input.entryId || !nextQueueState.items[input.entryId]) {
+      throw new LiveSessionInvalidActionError("Queue entry not found.");
+    }
+    if (typeof input.targetIndex !== "number" || input.targetIndex < 0 || input.targetIndex >= nextQueueState.order.length) {
+      throw new LiveSessionInvalidActionError("Target index is invalid.");
+    }
+    nextQueueState.order = nextQueueState.order.filter((entryId) => entryId !== input.entryId);
+    nextQueueState.order.splice(input.targetIndex, 0, input.entryId);
+  } else if (input.action === "end-session") {
+    nextSession = {
+      ...session,
+      status: "completed",
+      updatedAtMs: nowMs,
+      timer: {
+        ...session.timer,
+        status: "completed",
+        remainingSeconds: 0,
+        startedAtMs: null,
+        pausedAtMs: null,
+      },
+    };
+    archiveStatus = "completed";
+  } else {
+    throw new LiveSessionInvalidActionError("Unsupported action.");
+  }
+
+  if (historyRecord) {
+    nextSession = {
+      ...nextSession,
+      history: [...(session.history || []), historyRecord],
+    };
+  }
+
+  await Promise.all([
+    sessionRef.set(nextSession),
+    queueRef.set(nextQueueState),
+    appendHistoryAndUpdateSessionArchive(
+      input.sessionId,
+      archiveStatus ? { status: archiveStatus } : { status: nextSession.status },
+      historyRecord
+    ),
+    ...(historyRecord
+      ? [
+          adminDb
+            .collection(FIRESTORE_COLLECTIONS.QUEUE_ENTRIES)
+            .doc(historyRecord.entryId)
+            .set(
+              {
+                status: historyRecord.outcome,
+                updatedAt: new Date(),
+              },
+              { merge: true }
+            ),
+        ]
+      : []),
+  ]);
+
+  return {
+    session: nextSession,
+    queue: nextQueueState,
+    historyRecord: historyRecord || null,
+  };
+}

--- a/lib/live-sessions/types.ts
+++ b/lib/live-sessions/types.ts
@@ -1,0 +1,113 @@
+export const LIVE_TALK_DURATIONS = [3, 5] as const;
+
+export type LiveTalkDurationMinutes = (typeof LIVE_TALK_DURATIONS)[number];
+
+export type LiveSessionStatus = "pending" | "live" | "completed" | "cancelled";
+export type LiveTimerStatus = "idle" | "running" | "paused" | "completed";
+export type LiveQueueEntryStatus = "queued" | "live" | "completed" | "skipped" | "removed";
+export type LiveSessionControlAction =
+  | "start-next"
+  | "pause-timer"
+  | "resume-timer"
+  | "complete-current"
+  | "skip-current"
+  | "remove-entry"
+  | "move-entry"
+  | "end-session";
+
+export interface LiveSessionTimerState {
+  status: LiveTimerStatus;
+  durationSeconds: number;
+  remainingSeconds: number;
+  startedAtMs: number | null;
+  pausedAtMs: number | null;
+  warningThresholds: number[];
+}
+
+export interface LiveSessionCurrentSpeaker {
+  entryId: string | null;
+  speakerName: string | null;
+  talkTitle: string | null;
+}
+
+export interface LiveSessionRealtimeRecord {
+  id: string;
+  status: LiveSessionStatus;
+  title: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+  emceeUid: string;
+  emceeName: string;
+  audiencePath: string;
+  emceePath: string;
+  currentSpeaker: LiveSessionCurrentSpeaker;
+  timer: LiveSessionTimerState;
+  history: LiveSessionHistoryRecord[];
+}
+
+export interface LiveSessionArchiveRecord {
+  sessionId: string;
+  title: string;
+  status: LiveSessionStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: {
+    uid: string;
+    name: string;
+  };
+  audiencePath: string;
+  emceePath: string;
+  history: LiveSessionHistoryRecord[];
+}
+
+export interface LiveQueueEntryRecord {
+  id: string;
+  sessionId: string;
+  userId: string;
+  speakerName: string;
+  speakerPhotoUrl: string | null;
+  talkTitle: string;
+  durationMinutes: LiveTalkDurationMinutes;
+  status: LiveQueueEntryStatus;
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+export interface CreateLiveSessionInput {
+  title: string;
+  emceeUid: string;
+  emceeName: string;
+}
+
+export interface CreatedLiveSession {
+  sessionId: string;
+  session: LiveSessionRealtimeRecord;
+}
+
+export interface EnqueueSpeakerInput {
+  sessionId: string;
+  userId: string;
+  speakerName: string;
+  speakerPhotoUrl?: string | null;
+  talkTitle: string;
+  durationMinutes: LiveTalkDurationMinutes;
+}
+
+export interface LiveSessionHistoryRecord {
+  entryId: string;
+  userId: string;
+  speakerName: string;
+  talkTitle: string;
+  durationMinutes: LiveTalkDurationMinutes;
+  outcome: Extract<LiveQueueEntryStatus, "completed" | "skipped" | "removed">;
+  startedAtMs: number | null;
+  finishedAtMs: number;
+}
+
+export interface ControlLiveSessionInput {
+  sessionId: string;
+  emceeUid: string;
+  action: LiveSessionControlAction;
+  entryId?: string;
+  targetIndex?: number;
+}

--- a/types/qrcode.d.ts
+++ b/types/qrcode.d.ts
@@ -1,0 +1,15 @@
+declare module "qrcode" {
+  interface ToDataURLOptions {
+    margin?: number;
+    width?: number;
+    color?: {
+      dark?: string;
+      light?: string;
+    };
+  }
+
+  export function toDataURL(
+    text: string,
+    options?: ToDataURLOptions
+  ): Promise<string>;
+}


### PR DESCRIPTION
## Summary
- add a realtime live-session feature for lightning talks under 
- add audience and emcee pages with queueing, QR join, drag reordering, timer controls, alerts, and session history
- add server routes, RTDB config, and tests for session create, queue join, and emcee controls

## Testing
- npm test -- --runTestsByPath __tests__/app/api/live/session/route.test.ts __tests__/app/api/live/queue/route.test.ts __tests__/app/api/live/control/route.test.ts __tests__/lib/live-sessions/data-server.test.ts
- npm run type-check

Closes #83