### PR TITLE
fix(seo): disallow private routes in robots.txt

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/hackathons/team/', '/hackathons/pool/'],
+        disallow: ['/api/', '/hackathons/team/', '/hackathons/pool/', '/profile', '/hackathons/hack-a-sprint-2026/signup', '/agents/claim/'],
       },
     ],
     sitemap: 'https://cursorboston.com/sitemap.xml',


### PR DESCRIPTION
## Description
Add /profile, /hackathons/hack-a-sprint-2026/signup, and /agents/claim/ to the robots.txt disallow list. These auth-gated and token-based routes should not be indexed by search engines.

## Type of Change
- [x] Bug fix

## Testing
- Visit /robots.txt and verify the three new disallow entries appear
- Confirm public routes are still allowed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings generated
- [x] Changes tested locally