### PR TITLE
fix(a11y): add aria-label to PostComposer textarea

### DIFF
--- a/components/feed/PostComposer.tsx
+++ b/components/feed/PostComposer.tsx
@@ -68,6 +68,7 @@ export function PostComposer({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             placeholder={placeholder}
+            aria-label={placeholder}
             rows={3}
             maxLength={maxLength}
             className="w-full bg-transparent text-white placeholder-neutral-400 resize-none focus:outline-none"


### PR DESCRIPTION
## Description
Add aria-label to the PostComposer textarea using the placeholder prop value, so screen readers can announce the input's purpose.

## Type of Change
- [x] Bug fix

## Testing
- Use a screen reader on the members/feed page
- Verify the textarea announces "What's on your mind?" (or the custom placeholder) when focused

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings generated
- [x] Changes tested locally