### PR TITLE
fix(a11y): use theme-aware colors in ErrorBoundary

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -34,10 +34,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       return (
         <div className="min-h-[60vh] flex items-center justify-center p-8">
           <div className="text-center max-w-md">
-            <h2 className="text-xl font-semibold text-white mb-2">
+            <h2 className="text-xl font-semibold text-foreground mb-2">
               Something went wrong
             </h2>
-            <p className="text-neutral-400 mb-6">
+            <p className="text-neutral-600 dark:text-neutral-400 mb-6">
               An unexpected error occurred. Please try reloading the page.
             </p>
             <button


### PR DESCRIPTION
## Description
Replace hardcoded `text-white` and `text-neutral-400` in the ErrorBoundary fallback UI with `text-foreground` and `text-neutral-600 dark:text-neutral-400` so the error screen is readable in both light and dark themes.

## Type of Change
- [x] Bug fix

## Testing
- Trigger an error boundary (e.g., throw in a child component) and verify the fallback UI is readable in both light and dark mode

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings generated
- [x] Changes tested locally