### PR TITLE
fix(signup): correct password placeholder mismatch

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -249,7 +249,7 @@ function SignUpPageContent() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 className="w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-white/20 focus:border-transparent"
-                placeholder="At least 6 characters"
+                placeholder="At least 8 characters"
               />
             </div>
 


### PR DESCRIPTION
## Description
The password field placeholder says "At least 6 characters" but the validation logic requires `password.length >= 8`. Update the placeholder to "At least 8 characters" to match the actual requirement.

## Type of Change
- [x] Bug fix

## Testing
- Visit `/signup` and verify the password field placeholder reads "At least 8 characters"
- Confirm validation still rejects passwords shorter than 8 characters

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings generated
- [x] Changes tested locally