### PR TITLE
fix(theme-toggle): open dropdown to prevent overflow in sidebar

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -132,7 +132,7 @@ export function ThemeToggle() {
           role="menu"
           aria-label="Theme selection"
           onKeyDown={handleMenuKeyDown}
-          className="absolute right-0 mt-2 w-36 rounded-md bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 shadow-lg ring-1 ring-black ring-opacity-5 z-50"
+          className="absolute left-full bottom-0 ml-2 w-36 rounded-md bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 shadow-lg ring-1 ring-black ring-opacity-5 z-50"
         >
           <div className="py-1" role="none">
             {themeOptions.map((option, index) => {


### PR DESCRIPTION
## Description
The theme switcher dropdown was rendering downward and overflowing off screen since the button sits at the bottom of the sidebar. Fixed by repositioning the dropdown to open to the right of the button so all options are fully visible.

Fixes #222

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<img width="379" height="292" alt="Screenshot 2026-04-05 at 4 09 51 PM" src="https://github.com/user-attachments/assets/bbb4f39d-5a63-4783-a634-633c4abc425b" />