### PR TITLE
refactor(rate-limit): centralize hackathon presets

### DIFF
--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.test.ts
@@ -8,10 +8,14 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
 
-jest.mock("@/lib/rate-limit", () => ({
-  getClientIdentifier: jest.fn(() => "test-ip"),
-  checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
-}));
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -124,5 +124,47 @@ describe('Rate Limiting', () => {
       expect(rateLimitConfigs.standard.windowMs).toBe(60 * 1000);
       expect(rateLimitConfigs.standard.maxRequests).toBe(60);
     });
+
+    it('should preserve hackathon presets from the route-local values', () => {
+      expect(rateLimitConfigs.hackathonMutation).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 10,
+      });
+      expect(rateLimitConfigs.hackathonAction).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 20,
+      });
+      expect(rateLimitConfigs.hackathonEligibility).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 30,
+      });
+      expect(rateLimitConfigs.hackathonEventSignup).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 40,
+      });
+    });
+
+    it('should keep distinct showcase presets where the behavior differs', () => {
+      expect(rateLimitConfigs.hackathonShowcaseAiScore).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 30,
+      });
+      expect(rateLimitConfigs.hackathonShowcaseJudgeScore).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 40,
+      });
+      expect(rateLimitConfigs.hackathonShowcaseUnlock).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 20,
+      });
+      expect(rateLimitConfigs.hackathonShowcaseUnlockAttempts).toEqual({
+        windowMs: 5 * 60 * 1000,
+        maxRequests: 15,
+      });
+      expect(rateLimitConfigs.hackathonShowcaseVote).toEqual({
+        windowMs: 60 * 1000,
+        maxRequests: 30,
+      });
+    });
   });
 });

--- a/app/api/hackathons/eligibility/route.ts
+++ b/app/api/hackathons/eligibility/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getCurrentVirtualHackathonId } from "@/lib/hackathons";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 30 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonEligibility;
 
 /**
  * GET /api/hackathons/eligibility

--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -14,12 +14,12 @@ import {
 } from "@/lib/hackathon-event-signup";
 import { fetchMergedPrCountsForLogins } from "@/lib/github-merged-pr-count";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const RATE = { windowMs: 60 * 1000, maxRequests: 40 };
+const RATE = rateLimitConfigs.hackathonEventSignup;
 
 function signedUpAtToMs(value: unknown): number {
   if (

--- a/app/api/hackathons/invites/accept/route.ts
+++ b/app/api/hackathons/invites/accept/route.ts
@@ -2,13 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { sanitizeDocId } from "@/lib/sanitize";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 20 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonAction;
 
 /**
  * POST /api/hackathons/invites/accept

--- a/app/api/hackathons/pool/join/route.ts
+++ b/app/api/hackathons/pool/join/route.ts
@@ -3,12 +3,12 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getCurrentVirtualHackathonId } from "@/lib/hackathons";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 20 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonAction;
 
 /**
  * POST /api/hackathons/pool/join

--- a/app/api/hackathons/requests/accept/route.ts
+++ b/app/api/hackathons/requests/accept/route.ts
@@ -2,13 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { sanitizeDocId } from "@/lib/sanitize";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 20 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonAction;
 
 /**
  * POST /api/hackathons/requests/accept

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
@@ -7,12 +7,12 @@ import {
   fetchShowcaseSubmissionsFromGitHub,
 } from "@/lib/hackathon-showcase";
 import { hackASprint2026ScoreDocId } from "@/lib/hackathon-asprint-2026-state";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const RATE = { windowMs: 60 * 1000, maxRequests: 30 };
+const RATE = rateLimitConfigs.hackathonShowcaseAiScore;
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
@@ -9,12 +9,12 @@ import {
 import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
 import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
 import { hackASprint2026ScoreDocId } from "@/lib/hackathon-asprint-2026-state";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const RATE = { windowMs: 60 * 1000, maxRequests: 40 };
+const RATE = rateLimitConfigs.hackathonShowcaseJudgeScore;
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.ts
@@ -5,12 +5,12 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
 import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
 import { hackathonEventSignupDocId } from "@/lib/hackathon-event-signup";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const RATE = { windowMs: 60 * 1000, maxRequests: 20 };
+const RATE = rateLimitConfigs.hackathonShowcaseUnlock;
 
 function passcodesMatch(expected: string, provided: string): boolean {
   if (expected.length !== provided.length) return false;
@@ -70,10 +70,10 @@ export async function POST(request: NextRequest) {
     const body = await request.json().catch(() => ({}));
     const provided = String((body as { passcode?: string }).passcode ?? "").trim();
 
-    const uidRate = checkRateLimit(`hack-asprint-unlock-uid:${user.uid}`, {
-      windowMs: 5 * 60 * 1000,
-      maxRequests: 15,
-    });
+    const uidRate = checkRateLimit(
+      `hack-asprint-unlock-uid:${user.uid}`,
+      rateLimitConfigs.hackathonShowcaseUnlockAttempts
+    );
     if (!uidRate.success) {
       return NextResponse.json(
         { error: "Too many attempts", retryAfterSeconds: uidRate.retryAfter },

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
@@ -12,12 +12,12 @@ import {
   hackASprint2026ScoreDocId,
   userHasHackASprint2026Signup,
 } from "@/lib/hackathon-asprint-2026-state";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const VOTE_RATE = { windowMs: 60 * 1000, maxRequests: 30 };
+const VOTE_RATE = rateLimitConfigs.hackathonShowcaseVote;
 
 function normalizeIds(raw: unknown): string[] | null {
   if (!Array.isArray(raw)) return null;

--- a/app/api/hackathons/submissions/register/route.ts
+++ b/app/api/hackathons/submissions/register/route.ts
@@ -3,13 +3,13 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getCurrentVirtualHackathonId, getVirtualMonthStartEndUtc, isVirtualHackathonId } from "@/lib/hackathons";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonMutation;
 
 /**
  * Parse repo URL to owner/repo (e.g. https://github.com/owner/repo -> owner/repo).

--- a/app/api/hackathons/submissions/submit/route.ts
+++ b/app/api/hackathons/submissions/submit/route.ts
@@ -7,12 +7,12 @@ import {
   getSubmissionCutoffForMonth,
   isVirtualHackathonId,
 } from "@/lib/hackathons";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonMutation;
 
 /**
  * POST /api/hackathons/submissions/submit

--- a/app/api/hackathons/team/leave/route.ts
+++ b/app/api/hackathons/team/leave/route.ts
@@ -2,13 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { sanitizeDocId } from "@/lib/sanitize";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonMutation;
 
 /**
  * POST /api/hackathons/team/leave

--- a/app/api/hackathons/team/profile/route.ts
+++ b/app/api/hackathons/team/profile/route.ts
@@ -2,13 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { sanitizeName, sanitizeUrl, sanitizeDocId } from "@/lib/sanitize";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const HACKATHON_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 20 };
+const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonAction;
 
 /**
  * PATCH /api/hackathons/team/profile

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -195,4 +195,45 @@ export const rateLimitConfigs = {
     windowMs: 60 * 1000, // 1 minute
     maxRequests: 100, // 100 requests per minute
   },
+  // Strict rate limit for hackathon mutations that change team or submission state.
+  hackathonMutation: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 10, // 10 requests per minute
+  },
+  // Standard rate limit for hackathon pool, invite, request, and team profile actions.
+  hackathonAction: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 20, // 20 requests per minute
+  },
+  // Eligibility checks are read-heavy but still authenticated.
+  hackathonEligibility: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 30, // 30 requests per minute
+  },
+  // Event signup is used by GET/POST/DELETE on the same endpoint.
+  hackathonEventSignup: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 40, // 40 requests per minute
+  },
+  // Showcase-specific presets intentionally remain distinct from other hackathon flows.
+  hackathonShowcaseAiScore: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 30, // 30 requests per minute
+  },
+  hackathonShowcaseJudgeScore: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 40, // 40 requests per minute
+  },
+  hackathonShowcaseUnlock: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 20, // 20 requests per minute
+  },
+  hackathonShowcaseUnlockAttempts: {
+    windowMs: 5 * 60 * 1000, // 5 minutes
+    maxRequests: 15, // 15 attempts per 5 minutes
+  },
+  hackathonShowcaseVote: {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 30, // 30 requests per minute
+  },
 };


### PR DESCRIPTION
Summary
- move hackathon route rate-limit configs into lib/rate-limit.ts
- preserve the existing thresholds exactly while replacing route-local literals
- add coverage for the new hackathon presets and update the unlock route test mock

Closes #247

Verification
- rg -n "windowMs:|maxRequests:" app/api/hackathons
- npm run lint
- npm run type-check
- npm test -- --runInBand
- npm run build

Notes
- npm run lint still reports one pre-existing warning in postcss.config.mjs unrelated to this change.