### PR TITLE
fix(firestore): remove unsafe data assertions

### DIFF
--- a/__tests__/lib/pair-programming/data-server.test.ts
+++ b/__tests__/lib/pair-programming/data-server.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  PairRequestNotFoundError,
+  respondToPairRequestServer,
+} from "@/lib/pair-programming/data-server";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+describe("respondToPairRequestServer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("treats an undefined transaction payload as not found", async () => {
+    const requestRef = { id: "request-1" };
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => ({
+        doc: jest.fn(() =>
+          name === "pair_requests"
+            ? requestRef
+            : { id: "session-1" }
+        ),
+      })),
+      runTransaction: jest.fn(async (callback: (transaction: { get: jest.Mock }) => unknown) =>
+        callback({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => undefined,
+          })),
+        })
+      ),
+    } as never);
+
+    await expect(
+      respondToPairRequestServer("request-1", "user-1", "accept")
+    ).rejects.toBeInstanceOf(PairRequestNotFoundError);
+  });
+});

--- a/app/api/hackathons/invites/accept/route.ts
+++ b/app/api/hackathons/invites/accept/route.ts
@@ -51,7 +51,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invite not found" }, { status: 404 });
     }
 
-    const invite = inviteSnap.data()!;
+    const invite = inviteSnap.data();
+    if (!invite) {
+      return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+    }
     if (invite.toUserId !== user.uid) {
       return NextResponse.json({ error: "Not your invite" }, { status: 403 });
     }
@@ -65,7 +68,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Team not found" }, { status: 404 });
     }
 
-    const team = teamSnap.data()!;
+    const team = teamSnap.data();
+    if (!team) {
+      return NextResponse.json({ error: "Team not found" }, { status: 404 });
+    }
     const memberIds: string[] = team.memberIds || [];
     if (memberIds.length >= 3) {
       return NextResponse.json({ error: "Team is full" }, { status: 400 });

--- a/app/api/hackathons/requests/accept/route.ts
+++ b/app/api/hackathons/requests/accept/route.ts
@@ -51,7 +51,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Request not found" }, { status: 404 });
     }
 
-    const reqData = reqSnap.data()!;
+    const reqData = reqSnap.data();
+    if (!reqData) {
+      return NextResponse.json({ error: "Request not found" }, { status: 404 });
+    }
     const fromUserId = reqData.fromUserId;
     const teamId = reqData.teamId;
     if (reqData.status !== "pending") {
@@ -64,7 +67,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Team not found" }, { status: 404 });
     }
 
-    const team = teamSnap.data()!;
+    const team = teamSnap.data();
+    if (!team) {
+      return NextResponse.json({ error: "Team not found" }, { status: 404 });
+    }
     const memberIds: string[] = team.memberIds || [];
     if (!memberIds.includes(user.uid)) {
       return NextResponse.json({ error: "You are not a member of this team" }, { status: 403 });

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
@@ -55,7 +55,8 @@ export async function POST(request: NextRequest) {
     }
 
     const userSnap = await db.collection("users").doc(user.uid).get();
-    if (userSnap.data()?.hackASprint2026Unlocked !== true) {
+    const userData = userSnap.data();
+    if (userData?.hackASprint2026Unlocked !== true) {
       return NextResponse.json(
         { error: "Enter the event passcode first." },
         { status: 403 }
@@ -95,9 +96,13 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const githubData =
+      userData?.github && typeof userData.github === "object"
+        ? (userData.github as { login?: string })
+        : undefined;
     const ghLogin =
-      typeof userSnap.data()?.github?.login === "string"
-        ? userSnap.data()!.github!.login.trim().toLowerCase()
+      typeof githubData?.login === "string"
+        ? githubData.login.trim().toLowerCase()
         : "";
     if (ghLogin && ids.some((id) => id === ghLogin)) {
       return NextResponse.json(
@@ -119,8 +124,10 @@ export async function POST(request: NextRequest) {
       .doc(hackASprint2026PeerVoteDocId(user.uid));
     await db.runTransaction(async (tx) => {
       const prevSnap = await tx.get(voteRef);
-      const oldIds: string[] = Array.isArray(prevSnap.data()?.submissionIds)
-        ? (prevSnap.data()!.submissionIds as string[]).map((x) =>
+      const prevData = prevSnap.data();
+      const prevSubmissionIds = prevData?.submissionIds;
+      const oldIds: string[] = Array.isArray(prevSubmissionIds)
+        ? (prevSubmissionIds as string[]).map((x) =>
             String(x).toLowerCase()
           )
         : [];

--- a/app/api/hackathons/submissions/submit/route.ts
+++ b/app/api/hackathons/submissions/submit/route.ts
@@ -87,7 +87,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const sub = submissionSnap.data()!;
+    const sub = submissionSnap.data();
+    if (!sub) {
+      return NextResponse.json(
+        { error: "Register a repo first before submitting" },
+        { status: 400 }
+      );
+    }
     if (sub.submittedAt) {
       return NextResponse.json(
         { error: "Already submitted", submittedAt: sub.submittedAt },

--- a/app/api/hackathons/team/leave/route.ts
+++ b/app/api/hackathons/team/leave/route.ts
@@ -51,7 +51,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Team not found" }, { status: 404 });
     }
 
-    const team = teamSnap.data()!;
+    const team = teamSnap.data();
+    if (!team) {
+      return NextResponse.json({ error: "Team not found" }, { status: 404 });
+    }
     const memberIds: string[] = team.memberIds || [];
     if (!memberIds.includes(user.uid)) {
       return NextResponse.json({ error: "You are not on this team" }, { status: 403 });

--- a/app/api/hackathons/team/profile/route.ts
+++ b/app/api/hackathons/team/profile/route.ts
@@ -52,7 +52,10 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Team not found" }, { status: 404 });
     }
 
-    const team = teamSnap.data()!;
+    const team = teamSnap.data();
+    if (!team) {
+      return NextResponse.json({ error: "Team not found" }, { status: 404 });
+    }
     const memberIds: string[] = team.memberIds || [];
     if (!memberIds.includes(user.uid)) {
       return NextResponse.json({ error: "You are not a member of this team" }, { status: 403 });

--- a/lib/pair-programming/data-server.ts
+++ b/lib/pair-programming/data-server.ts
@@ -122,7 +122,10 @@ export async function respondToPairRequestServer(
       throw new PairRequestNotFoundError();
     }
 
-    const requestData = requestDoc.data()!;
+    const requestData = requestDoc.data();
+    if (!requestData) {
+      throw new PairRequestNotFoundError();
+    }
 
     if (requestData.toUserId !== userId) {
       throw new PairRequestUnauthorizedError();


### PR DESCRIPTION
Summary
- replace remaining Firestore data() non-null assertions with explicit null-safe handling
- preserve the existing route-specific 404/400 responses where document data is unexpectedly missing
- add focused coverage for the pair request transaction edge case

Closes #245

Verification
- rg -n "\.data\(\)!" app lib
- npm run lint
- npm run type-check
- npm test -- --runInBand
- npm run build

Notes
- npm run lint still reports one pre-existing warning in postcss.config.mjs unrelated to this change.