### PR TITLE
fix(api): return 400 for invalid JSON bodies

### DIFF
--- a/__tests__/app/api/live/session/route.test.ts
+++ b/__tests__/app/api/live/session/route.test.ts
@@ -27,6 +27,14 @@ function makeRequest(body: Record<string, unknown>) {
   });
 }
 
+function makeInvalidJsonRequest() {
+  return new NextRequest("http://localhost/api/live/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{",
+  });
+}
+
 describe("POST /api/live/session", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -161,6 +169,21 @@ describe("POST /api/live/session", () => {
 
     expect(res.status).toBe(400);
     expect(body.error).toContain("Title must be a string");
+    expect(mockCreateLiveSessionServer).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+
+    const res = await POST(makeInvalidJsonRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: "Invalid JSON in request body" });
     expect(mockCreateLiveSessionServer).not.toHaveBeenCalled();
   });
 });

--- a/app/api/events/[eventId]/coworking/register/route.ts
+++ b/app/api/events/[eventId]/coworking/register/route.ts
@@ -56,8 +56,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
 
     // Get session ID from body
-    const body = await request.json().catch(() => ({}));
-    const sessionId = sanitizeDocId(body.sessionId);
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json(
+        { success: false, error: "Invalid JSON in request body" },
+        { status: 400 }
+      );
+    }
+    const sessionId = sanitizeDocId(
+      typeof body.sessionId === "string" ? body.sessionId : ""
+    );
     if (!sessionId) {
       return NextResponse.json(
         { success: false, error: "Session ID is required" },

--- a/app/api/hackathons/invites/accept/route.ts
+++ b/app/api/hackathons/invites/accept/route.ts
@@ -37,10 +37,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { inviteId } = await request.json().catch(() => ({}));
+    let body: { inviteId?: unknown };
+    try {
+      body = (await request.json()) as { inviteId?: unknown };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const { inviteId } = body;
     
     // Validate and sanitize inviteId
-    const sanitizedInviteId = sanitizeDocId(inviteId);
+    const sanitizedInviteId = sanitizeDocId(typeof inviteId === "string" ? inviteId : "");
     if (!sanitizedInviteId) {
       return NextResponse.json({ error: "Invalid inviteId format" }, { status: 400 });
     }

--- a/app/api/hackathons/pool/join/route.ts
+++ b/app/api/hackathons/pool/join/route.ts
@@ -37,7 +37,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const hackathonId = (body.hackathonId as string) || getCurrentVirtualHackathonId();
 
     const userRef = db.collection("users").doc(user.uid);

--- a/app/api/hackathons/requests/accept/route.ts
+++ b/app/api/hackathons/requests/accept/route.ts
@@ -37,10 +37,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { requestId } = await request.json().catch(() => ({}));
+    let body: { requestId?: unknown };
+    try {
+      body = (await request.json()) as { requestId?: unknown };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const { requestId } = body;
     
     // Validate and sanitize requestId
-    const sanitizedRequestId = sanitizeDocId(requestId);
+    const sanitizedRequestId = sanitizeDocId(
+      typeof requestId === "string" ? requestId : ""
+    );
     if (!sanitizedRequestId) {
       return NextResponse.json({ error: "Invalid requestId format" }, { status: 400 });
     }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
@@ -30,13 +30,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: { submissionId?: string; aiScore?: number };
+    try {
+      body = (await request.json()) as { submissionId?: string; aiScore?: number };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const submissionId = String(
-      (body as { submissionId?: string }).submissionId ?? ""
+      body.submissionId ?? ""
     )
       .trim()
       .toLowerCase();
-    const aiScore = Number((body as { aiScore?: number }).aiScore);
+    const aiScore = Number(body.aiScore);
 
     if (!submissionId || !Number.isInteger(aiScore) || aiScore < 1 || aiScore > 10) {
       return NextResponse.json(

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
@@ -50,13 +50,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Not a judge" }, { status: 403 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: { submissionId?: string; score?: number };
+    try {
+      body = (await request.json()) as { submissionId?: string; score?: number };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const submissionId = String(
-      (body as { submissionId?: string }).submissionId ?? ""
+      body.submissionId ?? ""
     )
       .trim()
       .toLowerCase();
-    const score = Number((body as { score?: number }).score);
+    const score = Number(body.score);
 
     if (!submissionId || !Number.isInteger(score) || score < 1 || score > 10) {
       return NextResponse.json(

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.ts
@@ -67,8 +67,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json().catch(() => ({}));
-    const provided = String((body as { passcode?: string }).passcode ?? "").trim();
+    let body: { passcode?: string };
+    try {
+      body = (await request.json()) as { passcode?: string };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const provided = String(body.passcode ?? "").trim();
 
     const uidRate = checkRateLimit(
       `hack-asprint-unlock-uid:${user.uid}`,

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
@@ -71,8 +71,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json().catch(() => ({}));
-    const ids = normalizeIds((body as { submissionIds?: unknown }).submissionIds);
+    let body: { submissionIds?: unknown };
+    try {
+      body = (await request.json()) as { submissionIds?: unknown };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const ids = normalizeIds(body.submissionIds);
     if (!ids || ids.length !== 6) {
       return NextResponse.json(
         { error: "Submit exactly 6 distinct project picks." },

--- a/app/api/hackathons/submissions/register/route.ts
+++ b/app/api/hackathons/submissions/register/route.ts
@@ -53,7 +53,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const repoUrl = (body.repoUrl as string)?.trim();
     const hackathonId = (body.hackathonId as string) || getCurrentVirtualHackathonId();
 

--- a/app/api/hackathons/submissions/submit/route.ts
+++ b/app/api/hackathons/submissions/submit/route.ts
@@ -42,7 +42,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const hackathonId = (body.hackathonId as string) || getCurrentVirtualHackathonId();
 
     if (!isVirtualHackathonId(hackathonId)) {

--- a/app/api/hackathons/team/leave/route.ts
+++ b/app/api/hackathons/team/leave/route.ts
@@ -37,10 +37,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { teamId } = await request.json().catch(() => ({}));
+    let body: { teamId?: unknown };
+    try {
+      body = (await request.json()) as { teamId?: unknown };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const { teamId } = body;
     
     // Validate and sanitize teamId
-    const sanitizedTeamId = sanitizeDocId(teamId);
+    const sanitizedTeamId = sanitizeDocId(typeof teamId === "string" ? teamId : "");
     if (!sanitizedTeamId) {
       return NextResponse.json({ error: "Invalid teamId format" }, { status: 400 });
     }

--- a/app/api/hackathons/team/profile/route.ts
+++ b/app/api/hackathons/team/profile/route.ts
@@ -37,11 +37,16 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const { teamId, name, logoUrl } = body;
     
     // Validate and sanitize teamId
-    const sanitizedTeamId = sanitizeDocId(teamId);
+    const sanitizedTeamId = sanitizeDocId(typeof teamId === "string" ? teamId : "");
     if (!sanitizedTeamId) {
       return NextResponse.json({ error: "Invalid teamId format" }, { status: 400 });
     }

--- a/app/api/live/[sessionId]/control/route.ts
+++ b/app/api/live/[sessionId]/control/route.ts
@@ -33,11 +33,20 @@ export async function POST(
     }
 
     const { sessionId } = await context.params;
-    const body = (await request.json().catch(() => ({}))) as {
+    let body: {
       action?: unknown;
       entryId?: unknown;
       targetIndex?: unknown;
     };
+    try {
+      body = (await request.json()) as {
+        action?: unknown;
+        entryId?: unknown;
+        targetIndex?: unknown;
+      };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
 
     if (!VALID_ACTIONS.includes(body.action as LiveSessionControlAction)) {
       return NextResponse.json({ error: "Invalid action" }, { status: 400 });

--- a/app/api/live/[sessionId]/queue/route.ts
+++ b/app/api/live/[sessionId]/queue/route.ts
@@ -55,10 +55,18 @@ export async function POST(
       return NextResponse.json({ error: "Session ID is required" }, { status: 400 });
     }
 
-    const body = (await request.json().catch(() => ({}))) as {
+    let body: {
       talkTitle?: unknown;
       durationMinutes?: unknown;
     };
+    try {
+      body = (await request.json()) as {
+        talkTitle?: unknown;
+        durationMinutes?: unknown;
+      };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
 
     const talkTitle = normalizeTalkTitle(body.talkTitle);
     const durationMinutes = normalizeDuration(body.durationMinutes);

--- a/app/api/live/session/route.ts
+++ b/app/api/live/session/route.ts
@@ -41,7 +41,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const body = (await request.json().catch(() => ({}))) as { title?: unknown };
+    let body: { title?: unknown };
+    try {
+      body = (await request.json()) as { title?: unknown };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const title = normalizeSessionTitle(body.title);
 
     if (!title) {

--- a/app/api/profile/update/route.ts
+++ b/app/api/profile/update/route.ts
@@ -36,7 +36,12 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     const updates: Record<string, unknown> = {};
 
     // Display name

--- a/app/api/profile/visibility/route.ts
+++ b/app/api/profile/visibility/route.ts
@@ -36,7 +36,12 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
     
     // Allowed visibility fields to update
     const allowedFields = [

--- a/app/api/showcase/submission/approve/route.ts
+++ b/app/api/showcase/submission/approve/route.ts
@@ -226,8 +226,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
-    const submissionId = sanitizeDocId(body.submissionId);
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const submissionId = sanitizeDocId(
+      typeof body.submissionId === "string" ? body.submissionId : ""
+    );
     const action = body.action === "reject" ? "reject" : "approve";
     const reason =
       typeof body.reason === "string" && body.reason.trim()

--- a/app/api/showcase/submission/route.ts
+++ b/app/api/showcase/submission/route.ts
@@ -214,8 +214,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
-    const sanitizedProjectId = sanitizeDocId(body.projectId);
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const sanitizedProjectId = sanitizeDocId(
+      typeof body.projectId === "string" ? body.projectId : ""
+    );
     if (!sanitizedProjectId) {
       return NextResponse.json({ error: "Invalid projectId" }, { status: 400 });
     }

--- a/app/api/talks/submission/moderate/route.ts
+++ b/app/api/talks/submission/moderate/route.ts
@@ -221,8 +221,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const body = await request.json().catch(() => ({}));
-    const submissionId = sanitizeDocId(body.submissionId);
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+    }
+    const submissionId = sanitizeDocId(
+      typeof body.submissionId === "string" ? body.submissionId : ""
+    );
     const action: TalkModerationAction = body.action === "complete" ? "complete" : "approve";
     if (!submissionId) {
       return NextResponse.json({ error: "Invalid submissionId" }, { status: 400 });


### PR DESCRIPTION
Summary
- replace silent `request.json().catch(() => ({}))` fallbacks with explicit JSON parse handling in the affected API routes
- return `400` with `Invalid JSON in request body` when request-body parsing fails
- add focused coverage for malformed JSON on the live session route

Closes #250

Verification
- rg -n "request\.json\(\)\.catch\(\(\) => \(\{\}\)\)" app/api
- npm run lint
- npm run type-check
- npm test -- --runInBand
- npm run build

Notes
- `npm run lint` still reports one pre-existing warning in `postcss.config.mjs` unrelated to this change.