### PR TITLE
feat: add sm size variant to Logo component

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -122,6 +122,16 @@ git checkout develop
 git merge upstream/develop
 ```
 
+Before you open a pull request, rebase your feature branch onto the latest `develop` so your PR contains only your intended changes and CI compares the right commit range:
+
+```bash
+git fetch upstream
+git checkout your-branch
+git rebase upstream/develop
+```
+
+If GitHub shows merge conflicts or your branch falls behind after review starts, rebase again and push the updated branch to the same PR.
+
 ## Claiming an Issue
 
 ### Step 1 — Find an issue
@@ -363,16 +373,25 @@ If you've modified forms:
    npm run build     # Verify the app builds
    ```
 
-2. **Update documentation**
+2. **Rebase onto the latest `develop`**
+   ```bash
+   git fetch upstream
+   git checkout your-branch
+   git rebase upstream/develop
+   ```
+
+   This keeps your PR focused, avoids unrelated commits in the diff, and helps CI run against the correct base.
+
+3. **Update documentation**
    - Update README.md if you've changed setup instructions
    - Add JSDoc comments for new functions
    - Update type definitions if needed
 
-3. **Test your changes**
+4. **Test your changes**
    - Follow the [Testing](#testing) checklist above
    - Test edge cases and error scenarios
 
-4. **Pre-commit hooks run automatically** when you commit:
+5. **Pre-commit hooks run automatically** when you commit:
    - **gitleaks** — scans staged files for accidentally committed secrets
    - **lint-staged** — runs `tsc --noEmit` and `eslint --fix --max-warnings=0` on staged files
    - **commitlint** — validates commit message format ([Conventional Commits](https://www.conventionalcommits.org/))

--- a/__tests__/lib/github-merged-pr-reconcile.test.ts
+++ b/__tests__/lib/github-merged-pr-reconcile.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ */
+
+import { reconcileMergedPrCreditForUser } from "@/lib/github-merged-pr-reconcile";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: jest.fn(() => ({
+    owner: "rogerSuperBuilderAlpha",
+    repo: "cursor-boston",
+  })),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "serverTimestamp"),
+  },
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+describe("reconcileMergedPrCreditForUser", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            number: 281,
+            title: "Fix event page",
+            html_url: "https://github.com/rogerSuperBuilderAlpha/cursor-boston/pull/281",
+            created_at: "2026-04-06T20:00:00.000Z",
+            updated_at: "2026-04-06T21:00:00.000Z",
+            closed_at: "2026-04-06T21:10:00.000Z",
+            user: { login: "Shreyas0786" },
+          },
+        ],
+      }),
+    })) as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("syncs GitHub PRs and preserves the trusted Firestore count", async () => {
+    const batchSet = jest.fn();
+    const batchCommit = jest.fn(async () => undefined);
+    const userSet = jest.fn(async () => undefined);
+
+    const pullRequestsRef = {
+      doc: jest.fn((id: string) => ({ id })),
+      where: jest.fn().mockReturnThis(),
+      get: jest.fn(async () => ({
+        docs: [
+          {
+            data: () => ({
+              repository: "rogerSuperBuilderAlpha/cursor-boston",
+            }),
+          },
+          {
+            data: () => ({
+              repository: "rogerSuperBuilderAlpha/cursor-boston",
+            }),
+          },
+          {
+            data: () => ({
+              repository: "other-owner/other-repo",
+            }),
+          },
+        ],
+      })),
+    };
+
+    const usersRef = {
+      doc: jest.fn(() => ({
+        set: userSet,
+      })),
+    };
+
+    const db = {
+      batch: jest.fn(() => ({
+        set: batchSet,
+        commit: batchCommit,
+      })),
+      collection: jest.fn((name: string) => {
+        if (name === "pullRequests") return pullRequestsRef;
+        if (name === "users") return usersRef;
+        throw new Error(`Unexpected collection: ${name}`);
+      }),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const result = await reconcileMergedPrCreditForUser("user-1", "Shreyas0786");
+
+    expect(result).toEqual({
+      mergedPrCount: 2,
+      syncedPrCount: 1,
+    });
+    expect(batchSet).toHaveBeenCalledWith(
+      { id: "pr-281" },
+      expect.objectContaining({
+        prNumber: 281,
+        userId: "user-1",
+        authorLogin: "Shreyas0786",
+        repository: "rogerSuperBuilderAlpha/cursor-boston",
+        backfillSource: "github-connect-reconcile",
+      }),
+      { merge: true }
+    );
+    expect(userSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pullRequestsCount: 2,
+        github: { login: "Shreyas0786" },
+      }),
+      { merge: true }
+    );
+  });
+});

--- a/__tests__/lib/registrations.test.ts
+++ b/__tests__/lib/registrations.test.ts
@@ -1,0 +1,64 @@
+import { getUserStats } from "@/lib/registrations";
+import { getDocs, getDoc } from "firebase/firestore";
+
+jest.mock("@/lib/firebase", () => ({
+  db: { mocked: true },
+}));
+
+jest.mock("firebase/firestore", () => ({
+  collection: jest.fn((...args) => ({ kind: "collection", args })),
+  doc: jest.fn((...args) => ({ kind: "doc", args })),
+  setDoc: jest.fn(),
+  getDoc: jest.fn(),
+  getDocs: jest.fn(),
+  query: jest.fn((...args) => ({ kind: "query", args })),
+  where: jest.fn((...args) => ({ kind: "where", args })),
+  serverTimestamp: jest.fn(() => "serverTimestamp"),
+  Timestamp: class Timestamp {},
+}));
+
+const mockGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
+const mockGetDoc = getDoc as jest.MockedFunction<typeof getDoc>;
+
+describe("getUserStats", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("counts merged PRs from pullRequests documents", async () => {
+    mockGetDocs
+      .mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ status: "registered" }) },
+          { data: () => ({ status: "attended" }) },
+        ],
+      } as never)
+      .mockResolvedValueOnce({
+        size: 2,
+        docs: [
+          { data: () => ({ status: "pending" }) },
+          { data: () => ({ status: "completed" }) },
+        ],
+      } as never)
+      .mockResolvedValueOnce({
+        size: 3,
+        docs: [
+          { data: () => ({ state: "merged" }) },
+          { data: () => ({ state: "merged" }) },
+          { data: () => ({ state: "merged" }) },
+        ],
+      } as never);
+
+    const stats = await getUserStats("user-123");
+
+    expect(stats).toEqual({
+      eventsRegistered: 2,
+      eventsAttended: 1,
+      talksSubmitted: 2,
+      talksGiven: 1,
+      pullRequestsCount: 3,
+    });
+    expect(mockGetDocs).toHaveBeenCalledTimes(3);
+    expect(mockGetDoc).not.toHaveBeenCalled();
+  });
+});

--- a/app/(auth)/profile/_components/ActivitySection.tsx
+++ b/app/(auth)/profile/_components/ActivitySection.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { useProfileContext } from "../_contexts/ProfileContext";
+
+export function ActivitySection() {
+  const {
+    data: { registrations, talkSubmissions, loadingData },
+  } = useProfileContext();
+
+  if (loadingData) {
+    return (
+      <div className="mb-8">
+        <h2 className="text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3">
+          Activity
+        </h2>
+        <div className="bg-neutral-900 rounded-xl p-6 border border-neutral-800 text-center">
+          <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-neutral-400 mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  const hasEvents = registrations.length > 0;
+  const hasTalks = talkSubmissions.length > 0;
+
+  if (!hasEvents && !hasTalks) {
+    return (
+      <div className="mb-8">
+        <h2 className="text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3">
+          Activity
+        </h2>
+        <div className="bg-neutral-900 rounded-xl p-8 border border-neutral-800 text-center">
+          <p className="text-neutral-400 text-sm mb-3">No activity yet</p>
+          <div className="flex justify-center gap-3">
+            <Link
+              href="/events"
+              className="px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors"
+            >
+              Browse Events
+            </Link>
+            <Link
+              href="/talks/submit"
+              className="px-4 py-2 bg-neutral-800 text-white rounded-lg text-sm font-medium hover:bg-neutral-700 transition-colors"
+            >
+              Submit a Talk
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const statusColor = (status: string) => {
+    switch (status.toLowerCase()) {
+      case "attended":
+      case "approved":
+      case "completed":
+        return "bg-emerald-500/10 text-emerald-400";
+      case "cancelled":
+      case "rejected":
+        return "bg-red-500/10 text-red-400";
+      case "registered":
+        return "bg-blue-500/10 text-blue-400";
+      default:
+        return "bg-amber-500/10 text-amber-400";
+    }
+  };
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3">
+        Activity
+      </h2>
+      <div className="bg-neutral-900 rounded-xl border border-neutral-800 divide-y divide-neutral-800">
+        {/* Events */}
+        {hasEvents && (
+          <div className="p-5">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-medium text-neutral-300">Events</h3>
+              <Link href="/events" className="text-xs text-emerald-400 hover:text-emerald-300">
+                Browse all
+              </Link>
+            </div>
+            <div className="space-y-2">
+              {registrations.slice(0, 5).map((reg) => (
+                <div key={reg.id} className="flex items-center justify-between py-1.5">
+                  <div className="min-w-0">
+                    <p className="text-sm text-white truncate">{reg.eventTitle}</p>
+                    {reg.eventDate && (
+                      <p className="text-xs text-neutral-500">{reg.eventDate}</p>
+                    )}
+                  </div>
+                  <span className={`shrink-0 ml-3 px-2 py-0.5 text-xs rounded-full ${statusColor(reg.status)}`}>
+                    {reg.status}
+                  </span>
+                </div>
+              ))}
+              {registrations.length > 5 && (
+                <p className="text-xs text-neutral-500 pt-1">
+                  +{registrations.length - 5} more event{registrations.length - 5 > 1 ? "s" : ""}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Talks */}
+        {hasTalks && (
+          <div className="p-5">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-medium text-neutral-300">Talks</h3>
+              <Link href="/talks/submit" className="text-xs text-emerald-400 hover:text-emerald-300">
+                Submit a talk
+              </Link>
+            </div>
+            <div className="space-y-2">
+              {talkSubmissions.slice(0, 5).map((talk) => (
+                <div key={talk.id} className="flex items-center justify-between py-1.5">
+                  <div className="min-w-0">
+                    <p className="text-sm text-white truncate">{talk.title}</p>
+                    {talk.submittedAt && (
+                      <p className="text-xs text-neutral-500">
+                        {talk.submittedAt.toDate().toLocaleDateString()}
+                      </p>
+                    )}
+                  </div>
+                  <span className={`shrink-0 ml-3 px-2 py-0.5 text-xs rounded-full ${statusColor(talk.status)}`}>
+                    {talk.status}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/profile/_components/ConnectionsSection.tsx
+++ b/app/(auth)/profile/_components/ConnectionsSection.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  DiscordIcon,
+  GitHubIcon,
+  UserCardIcon,
+} from "@/components/icons";
+import { useProfileContext } from "../_contexts/ProfileContext";
+
+export function ConnectionsSection() {
+  const {
+    userProfile,
+    data: { connectedAgents },
+    discord,
+    github,
+  } = useProfileContext();
+
+  const discordInfo = discord.discordInfo;
+  const githubInfo = github.githubInfo;
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3">
+        Connections
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {/* GitHub */}
+        <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-neutral-800 flex items-center justify-center">
+              <GitHubIcon size={18} />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-white">GitHub</p>
+              {githubInfo ? (
+                <p className="text-xs text-neutral-400">{githubInfo.login}</p>
+              ) : (
+                <p className="text-xs text-neutral-500">Not connected</p>
+              )}
+            </div>
+          </div>
+          {githubInfo ? (
+            <button
+              onClick={github.disconnect}
+              disabled={github.disconnecting}
+              className="text-xs text-neutral-400 hover:text-red-400 transition-colors disabled:opacity-50"
+            >
+              {github.disconnecting ? "..." : "Disconnect"}
+            </button>
+          ) : (
+            <button
+              onClick={github.connect}
+              disabled={github.connecting}
+              className="text-xs text-emerald-400 hover:text-emerald-300 font-medium transition-colors disabled:opacity-50"
+            >
+              {github.connecting ? "..." : "Connect"}
+            </button>
+          )}
+        </div>
+
+        {/* Discord */}
+        <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-[#5865F2]/10 flex items-center justify-center">
+              <DiscordIcon size={18} className="text-[#5865F2]" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-white">Discord</p>
+              {discordInfo ? (
+                <p className="text-xs text-neutral-400">{discordInfo.username}</p>
+              ) : (
+                <p className="text-xs text-neutral-500">Not connected</p>
+              )}
+            </div>
+          </div>
+          {discordInfo ? (
+            <button
+              onClick={discord.disconnect}
+              disabled={discord.disconnecting}
+              className="text-xs text-neutral-400 hover:text-red-400 transition-colors disabled:opacity-50"
+            >
+              {discord.disconnecting ? "..." : "Disconnect"}
+            </button>
+          ) : (
+            <button
+              onClick={discord.connect}
+              disabled={discord.connecting}
+              className="text-xs text-emerald-400 hover:text-emerald-300 font-medium transition-colors disabled:opacity-50"
+            >
+              {discord.connecting ? "..." : "Connect"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Status badges */}
+      {(connectedAgents.length > 0 ||
+        userProfile?.eduBadge ||
+        userProfile?.additionalEmails?.some((e) => e.verified && e.email.toLowerCase().endsWith(".edu")) ||
+        userProfile?.hackASprint2026ShowcaseBadge) && (
+        <div className="flex flex-wrap gap-2 mt-3">
+          {connectedAgents.length > 0 && (
+            <span className="px-3 py-1 bg-purple-500/10 text-purple-400 text-xs rounded-full inline-flex items-center gap-1">
+              <UserCardIcon size={12} />
+              {connectedAgents.length} Agent{connectedAgents.length > 1 ? "s" : ""}
+            </span>
+          )}
+          {(userProfile?.eduBadge ||
+            userProfile?.additionalEmails?.some((e) => e.verified && e.email.toLowerCase().endsWith(".edu"))) && (
+            <span className="px-3 py-1 bg-amber-500/10 text-amber-400 text-xs rounded-full">.edu verified</span>
+          )}
+          {userProfile?.hackASprint2026ShowcaseBadge && (
+            <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 text-xs rounded-full">Hack-a-Sprint &apos;26</span>
+          )}
+        </div>
+      )}
+
+      {(discord.error || github.error) && (
+        <p className="text-red-400 text-xs mt-2">{discord.error || github.error}</p>
+      )}
+    </div>
+  );
+}

--- a/app/(auth)/profile/_components/EarnedBadgesSection.tsx
+++ b/app/(auth)/profile/_components/EarnedBadgesSection.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import { useProfileContext } from "../_contexts/ProfileContext";
+
+export function EarnedBadgesSection() {
+  const { badges } = useProfileContext();
+  const {
+    eligibilityMap,
+    userBadgeMap,
+    earnedIds,
+    earnedDefinitions,
+    loading,
+    dataStatus,
+    persistenceStatus,
+    usingFallback,
+  } = badges;
+
+  return (
+    <div className="bg-neutral-900 rounded-2xl p-6 border border-neutral-800 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-white">Earned Badges</h2>
+        <Link
+          href="/badges"
+          className="text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
+        >
+          View all badges
+        </Link>
+      </div>
+
+      {loading ? (
+        <span className="text-xs text-neutral-400">Updating...</span>
+      ) : earnedDefinitions.length === 0 ? (
+        <div className="text-sm text-neutral-400">
+          No badges earned yet. Complete milestones to unlock your first one.
+        </div>
+      ) : (
+        <BadgeGrid
+          definitions={earnedDefinitions}
+          eligibilityMap={eligibilityMap}
+          earnedBadgeIds={earnedIds}
+          userBadgeMap={userBadgeMap}
+          compact
+          layout="horizontal"
+          isAuthoritative={dataStatus.isAuthoritative}
+        />
+      )}
+
+      {dataStatus.state !== "complete" && (
+        <div
+          className={`mt-4 rounded-lg border px-3 py-2 text-xs ${
+            dataStatus.state === "failed"
+              ? "border-red-500/30 bg-red-500/10 text-red-300"
+              : "border-amber-500/30 bg-amber-500/10 text-amber-300"
+          }`}
+        >
+          {dataStatus.message ||
+            "Badge data is partially unavailable. Some badge statuses may be unverified."}
+          {process.env.NODE_ENV !== "production" &&
+            dataStatus.failedSources.length > 0 && (
+              <p className="mt-1 text-[11px] opacity-80">
+                Debug: failed badge sources: {dataStatus.failedSources.join(", ")}
+              </p>
+            )}
+        </div>
+      )}
+
+      {persistenceStatus.state !== "complete" && (
+        <div
+          className={`mt-3 rounded-lg border px-3 py-2 text-xs ${
+            persistenceStatus.state === "failed"
+              ? "border-red-500/30 bg-red-500/10 text-red-300"
+              : "border-amber-500/30 bg-amber-500/10 text-amber-300"
+          }`}
+        >
+          {persistenceStatus.message ||
+            (persistenceStatus.state === "failed"
+              ? "We couldn't save some badge updates. Earned dates may be missing. Please refresh or try again."
+              : "Some badge updates are still syncing. Earned dates may appear shortly.")}
+        </div>
+      )}
+
+      {usingFallback && (
+        <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+          Badge definitions are using fallback data right now.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(auth)/profile/_components/OnboardingChecklist.tsx
+++ b/app/(auth)/profile/_components/OnboardingChecklist.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { useProfileContext } from "../_contexts/ProfileContext";
+
+interface ChecklistItem {
+  label: string;
+  done: boolean;
+  action?: () => void;
+  href?: string;
+  description: string;
+}
+
+export function OnboardingChecklist() {
+  const {
+    user,
+    userProfile,
+    data: { stats },
+    discord,
+    github,
+    profileSettings,
+  } = useProfileContext();
+
+  const items: ChecklistItem[] = [
+    {
+      label: "Create your account",
+      done: true,
+      description: "You're in!",
+    },
+    {
+      label: "Add a profile photo",
+      done: Boolean(user.photoURL),
+      description: "Help the community recognize you",
+    },
+    {
+      label: "Write a short bio",
+      done: Boolean(userProfile?.bio?.trim()),
+      description: "Tell people what you're building",
+    },
+    {
+      label: "Connect GitHub",
+      done: Boolean(github.githubInfo),
+      action: github.githubInfo ? undefined : github.connect,
+      description: github.githubInfo
+        ? `Connected as ${github.githubInfo.login}`
+        : "Link your GitHub to track contributions",
+    },
+    {
+      label: "Connect Discord",
+      done: Boolean(discord.discordInfo),
+      action: discord.discordInfo ? undefined : discord.connect,
+      description: discord.discordInfo
+        ? `Connected as ${discord.discordInfo.username}`
+        : "Join the Cursor Boston community server",
+    },
+    {
+      label: "Make your profile public",
+      done: profileSettings.settings.visibility.isPublic,
+      action: profileSettings.settings.visibility.isPublic
+        ? undefined
+        : () => profileSettings.togglePublic(true),
+      description: "Show up on the Members page",
+    },
+    {
+      label: "Submit a pull request",
+      done: (stats?.pullRequestsCount ?? 0) > 0,
+      href: "https://github.com/rogerSuperBuilderAlpha/cursor-boston",
+      description: "Contribute to the community repo",
+    },
+  ];
+
+  const completed = items.filter((i) => i.done).length;
+  const total = items.length;
+  const allDone = completed === total;
+
+  if (allDone) return null;
+
+  const pct = Math.round((completed / total) * 100);
+
+  return (
+    <div className="bg-neutral-900 rounded-2xl p-6 border border-neutral-800 mb-8">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-white">Get Started</h2>
+        <span className="text-sm text-neutral-400">
+          {completed}/{total} complete
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-2 bg-neutral-800 rounded-full mb-5 overflow-hidden">
+        <div
+          className="h-full bg-emerald-500 rounded-full transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      {/* Checklist */}
+      <div className="space-y-1">
+        {items.map((item) => {
+          const content = (
+            <div
+              className={`flex items-start gap-3 p-3 rounded-xl transition-colors ${
+                item.done
+                  ? "opacity-60"
+                  : "hover:bg-neutral-800/60 cursor-pointer"
+              }`}
+            >
+              {/* Checkbox */}
+              <div
+                className={`shrink-0 mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors ${
+                  item.done
+                    ? "bg-emerald-500 border-emerald-500"
+                    : "border-neutral-600"
+                }`}
+              >
+                {item.done && (
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <p className={`text-sm font-medium ${item.done ? "text-neutral-400 line-through" : "text-white"}`}>
+                  {item.label}
+                </p>
+                <p className="text-xs text-neutral-500 mt-0.5">{item.description}</p>
+              </div>
+
+              {!item.done && (item.action || item.href) && (
+                <span className="shrink-0 text-xs text-emerald-400 font-medium mt-0.5">
+                  {item.href ? "Open" : "Connect"} &rarr;
+                </span>
+              )}
+            </div>
+          );
+
+          if (!item.done && item.href) {
+            return (
+              <Link key={item.label} href={item.href} target="_blank" rel="noopener noreferrer">
+                {content}
+              </Link>
+            );
+          }
+
+          if (!item.done && item.action) {
+            return (
+              <button key={item.label} onClick={item.action} className="w-full text-left">
+                {content}
+              </button>
+            );
+          }
+
+          return <div key={item.label}>{content}</div>;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/profile/_components/OverviewTab.tsx
+++ b/app/(auth)/profile/_components/OverviewTab.tsx
@@ -4,20 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { CalendarIcon, DiscordIcon, LayersIcon, PlusIcon, UserCardIcon } from "@/components/icons";
 import { EventRegistration } from "@/lib/registrations";
-
-interface TalkSubmission {
-  id: string;
-  title: string;
-  status: string;
-  submittedAt: { toDate: () => Date } | null;
-}
-
-interface ConnectedAgent {
-  id: string;
-  name: string;
-  description?: string;
-  avatarUrl?: string;
-}
+import type { TalkSubmission, ConnectedAgent } from "../_types";
 
 interface OverviewTabProps {
   registrations: EventRegistration[];

--- a/app/(auth)/profile/_components/ProfileHeader.tsx
+++ b/app/(auth)/profile/_components/ProfileHeader.tsx
@@ -1,14 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import Avatar from "@/components/Avatar";
-import {
-  DiscordIcon,
-  GitHubIcon,
-  UserCardIcon,
-  EyeIcon,
-  EyeOffIcon,
-} from "@/components/icons";
+import { EyeIcon, EyeOffIcon } from "@/components/icons";
 import { useProfileContext } from "../_contexts/ProfileContext";
 
 interface ProfileHeaderProps {
@@ -18,31 +11,24 @@ interface ProfileHeaderProps {
 export function ProfileHeader({ onEditProfile }: ProfileHeaderProps) {
   const {
     user,
-    userProfile,
-    data: { connectedAgents },
-    discord,
-    github,
     profileSettings,
     handleSignOut,
     isSigningOut,
     signOutError,
   } = useProfileContext();
 
-  const discordInfo = discord.discordInfo;
-  const githubInfo = github.githubInfo;
-
   return (
-    <div className="bg-neutral-900 rounded-2xl p-6 md:p-8 border border-neutral-800 mb-6">
-      <div className="flex flex-col md:flex-row gap-6 items-center md:items-start">
+    <div className="bg-neutral-900 rounded-2xl p-6 border border-neutral-800 mb-8">
+      <div className="flex items-center gap-5">
         {/* Avatar */}
         <button
           onClick={onEditProfile}
-          className="shrink-0 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 rounded-full"
+          className="shrink-0 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 rounded-full"
           aria-label="Edit profile photo"
         >
           <Avatar src={user.photoURL} name={user.displayName} email={user.email} size="xl" />
           <div className="absolute inset-0 bg-black/60 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-white" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-white" aria-hidden="true">
               <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
               <path d="m15 5 4 4" />
             </svg>
@@ -50,121 +36,28 @@ export function ProfileHeader({ onEditProfile }: ProfileHeaderProps) {
         </button>
 
         {/* Info */}
-        <div className="flex-1 text-center md:text-left">
-          <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4 mb-1">
-            <h1 className="text-2xl md:text-3xl font-bold text-white">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 mb-1">
+            <h1 className="text-xl md:text-2xl font-bold text-white truncate">
               {user.displayName || "Community Member"}
             </h1>
             <button
               onClick={() => profileSettings.togglePublic(!profileSettings.settings.visibility.isPublic)}
-              className={`inline-flex items-center gap-1.5 px-3 py-1 text-sm rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 ${
+              className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-0.5 text-xs rounded-full transition-colors ${
                 profileSettings.settings.visibility.isPublic
-                  ? "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30 focus-visible:ring-emerald-400"
-                  : "bg-neutral-700 text-neutral-400 hover:bg-neutral-600 focus-visible:ring-neutral-400"
+                  ? "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30"
+                  : "bg-neutral-700 text-neutral-400 hover:bg-neutral-600"
               }`}
             >
               {profileSettings.settings.visibility.isPublic ? (
-                <><EyeIcon /> Public Profile</>
+                <><EyeIcon /> Public</>
               ) : (
-                <><EyeOffIcon /> Private Profile</>
+                <><EyeOffIcon /> Private</>
               )}
             </button>
           </div>
-
-          <p className="text-neutral-400 mb-3">{user.email}</p>
-
-          {/* Badge pills */}
-          <div className="flex flex-wrap gap-2 justify-center md:justify-start">
-            <span className="px-3 py-1 bg-emerald-500/10 text-emerald-400 text-sm rounded-full">Community Member</span>
-            {userProfile?.provider && (
-              <span className="px-3 py-1 bg-neutral-800 text-neutral-300 text-sm rounded-full capitalize">
-                {userProfile.provider} Account
-              </span>
-            )}
-            {discordInfo ? (
-              <button
-                onClick={discord.disconnect}
-                disabled={discord.disconnecting}
-                className="px-3 py-1 bg-[#5865F2]/10 text-[#5865F2] text-sm rounded-full inline-flex items-center gap-1 hover:bg-[#5865F2]/20 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2] group"
-              >
-                <DiscordIcon size={14} aria-hidden="true" />
-                <span className="group-hover:hidden">{discordInfo.username}</span>
-                <span className="hidden group-hover:inline">{discord.disconnecting ? "Disconnecting..." : "Disconnect"}</span>
-              </button>
-            ) : (
-              <button
-                onClick={discord.connect}
-                disabled={discord.connecting}
-                className="px-3 py-1 bg-[#5865F2] text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-[#4752C4] transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]"
-              >
-                <DiscordIcon size={14} aria-hidden="true" />
-                {discord.connecting ? "Connecting..." : "Connect Discord"}
-              </button>
-            )}
-            {githubInfo ? (
-              <button
-                onClick={github.disconnect}
-                disabled={github.disconnecting}
-                className="px-3 py-1 bg-neutral-800/50 text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-neutral-700 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white group"
-              >
-                <GitHubIcon size={14} aria-hidden="true" />
-                <span className="group-hover:hidden">{githubInfo.login}</span>
-                <span className="hidden group-hover:inline">{github.disconnecting ? "Disconnecting..." : "Disconnect"}</span>
-              </button>
-            ) : (
-              <button
-                onClick={github.connect}
-                disabled={github.connecting}
-                className="px-3 py-1 bg-neutral-800 text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-neutral-700 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-              >
-                <GitHubIcon size={14} aria-hidden="true" />
-                {github.connecting ? "Connecting..." : "Connect GitHub"}
-              </button>
-            )}
-            {connectedAgents.length > 0 && (
-              <span className="px-3 py-1 bg-purple-500/10 text-purple-400 text-sm rounded-full inline-flex items-center gap-1">
-                <UserCardIcon size={14} />
-                {connectedAgents.length} Agent{connectedAgents.length > 1 ? "s" : ""}
-              </span>
-            )}
-            {(userProfile?.eduBadge ||
-              userProfile?.additionalEmails?.some(
-                (e) => e.verified && e.email.toLowerCase().endsWith(".edu")
-              )) && (
-              <span className="px-3 py-1 bg-amber-500/10 text-amber-400 text-sm rounded-full">
-                .edu
-              </span>
-            )}
-            {userProfile?.hackASprint2026ShowcaseBadge && (
-              <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 text-sm rounded-full">
-                Hack-a-Sprint &apos;26 showcase
-              </span>
-            )}
-          </div>
-
-          {discord.error && <p className="text-red-400 text-xs mt-2">{discord.error}</p>}
-          {github.error && <p className="text-red-400 text-xs mt-2">{github.error}</p>}
-
-          {github.hasGithubConnection && (
-            <div className="mt-4 p-4 bg-neutral-800/60 rounded-xl border border-neutral-700">
-              <h2 className="text-sm font-semibold text-white mb-2">Contribute to the Open Source</h2>
-              <ol className="list-decimal list-inside space-y-1 text-neutral-300 text-sm">
-                <li>Pick an issue labeled &quot;good first issue&quot;.</li>
-                <li>Fork the repo, make your change, and open a PR.</li>
-                <li>Add a short test plan to your PR.</li>
-              </ol>
-              <div className="mt-3 flex flex-wrap gap-2">
-                <Link href="https://github.com/rogerSuperBuilderAlpha/cursor-boston" target="_blank" rel="noopener noreferrer" className="px-3 py-2 bg-neutral-700 text-white rounded-lg text-xs font-medium hover:bg-neutral-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
-                  Visit GitHub Repo
-                </Link>
-                <Link href="https://github.com/rogerSuperBuilderAlpha/cursor-boston?tab=contributing-ov-file#readme" target="_blank" rel="noopener noreferrer" className="px-3 py-2 bg-emerald-500 text-white rounded-lg text-xs font-medium hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400">
-                  Contributing Guide
-                </Link>
-              </div>
-            </div>
-          )}
-
-          <p className="text-neutral-400 text-sm mt-3">
+          <p className="text-neutral-400 text-sm truncate">{user.email}</p>
+          <p className="text-neutral-500 text-xs mt-1">
             Member since{" "}
             {user.metadata.creationTime
               ? new Date(user.metadata.creationTime).toLocaleDateString("en-US", { year: "numeric", month: "long" })
@@ -173,25 +66,25 @@ export function ProfileHeader({ onEditProfile }: ProfileHeaderProps) {
         </div>
 
         {/* Actions */}
-        <div className="shrink-0 flex flex-col gap-2">
+        <div className="shrink-0 flex items-center gap-2">
           <button
             onClick={onEditProfile}
-            className="px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+            className="px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors"
           >
-            Edit Profile
+            Edit
           </button>
           <button
             onClick={handleSignOut}
             disabled={isSigningOut}
-            className="px-4 py-2 bg-neutral-800 text-white rounded-lg text-sm font-medium hover:bg-neutral-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+            className="px-4 py-2 bg-neutral-800 text-neutral-300 rounded-lg text-sm font-medium hover:bg-neutral-700 transition-colors disabled:opacity-50"
           >
-            {isSigningOut ? "Signing out..." : "Sign Out"}
+            {isSigningOut ? "..." : "Sign Out"}
           </button>
         </div>
       </div>
 
       {signOutError && (
-        <div className="mt-4 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+        <div className="mt-3 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
           {signOutError}
         </div>
       )}

--- a/app/(auth)/profile/_components/ProfileHeader.tsx
+++ b/app/(auth)/profile/_components/ProfileHeader.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import Link from "next/link";
+import Avatar from "@/components/Avatar";
+import {
+  DiscordIcon,
+  GitHubIcon,
+  UserCardIcon,
+  EyeIcon,
+  EyeOffIcon,
+} from "@/components/icons";
+import { useProfileContext } from "../_contexts/ProfileContext";
+
+interface ProfileHeaderProps {
+  onEditProfile: () => void;
+}
+
+export function ProfileHeader({ onEditProfile }: ProfileHeaderProps) {
+  const {
+    user,
+    userProfile,
+    data: { connectedAgents },
+    discord,
+    github,
+    profileSettings,
+    handleSignOut,
+    isSigningOut,
+    signOutError,
+  } = useProfileContext();
+
+  const discordInfo = discord.discordInfo;
+  const githubInfo = github.githubInfo;
+
+  return (
+    <div className="bg-neutral-900 rounded-2xl p-6 md:p-8 border border-neutral-800 mb-6">
+      <div className="flex flex-col md:flex-row gap-6 items-center md:items-start">
+        {/* Avatar */}
+        <button
+          onClick={onEditProfile}
+          className="shrink-0 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 rounded-full"
+          aria-label="Edit profile photo"
+        >
+          <Avatar src={user.photoURL} name={user.displayName} email={user.email} size="xl" />
+          <div className="absolute inset-0 bg-black/60 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-white" aria-hidden="true">
+              <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+              <path d="m15 5 4 4" />
+            </svg>
+          </div>
+        </button>
+
+        {/* Info */}
+        <div className="flex-1 text-center md:text-left">
+          <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4 mb-1">
+            <h1 className="text-2xl md:text-3xl font-bold text-white">
+              {user.displayName || "Community Member"}
+            </h1>
+            <button
+              onClick={() => profileSettings.togglePublic(!profileSettings.settings.visibility.isPublic)}
+              className={`inline-flex items-center gap-1.5 px-3 py-1 text-sm rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 ${
+                profileSettings.settings.visibility.isPublic
+                  ? "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30 focus-visible:ring-emerald-400"
+                  : "bg-neutral-700 text-neutral-400 hover:bg-neutral-600 focus-visible:ring-neutral-400"
+              }`}
+            >
+              {profileSettings.settings.visibility.isPublic ? (
+                <><EyeIcon /> Public Profile</>
+              ) : (
+                <><EyeOffIcon /> Private Profile</>
+              )}
+            </button>
+          </div>
+
+          <p className="text-neutral-400 mb-3">{user.email}</p>
+
+          {/* Badge pills */}
+          <div className="flex flex-wrap gap-2 justify-center md:justify-start">
+            <span className="px-3 py-1 bg-emerald-500/10 text-emerald-400 text-sm rounded-full">Community Member</span>
+            {userProfile?.provider && (
+              <span className="px-3 py-1 bg-neutral-800 text-neutral-300 text-sm rounded-full capitalize">
+                {userProfile.provider} Account
+              </span>
+            )}
+            {discordInfo ? (
+              <button
+                onClick={discord.disconnect}
+                disabled={discord.disconnecting}
+                className="px-3 py-1 bg-[#5865F2]/10 text-[#5865F2] text-sm rounded-full inline-flex items-center gap-1 hover:bg-[#5865F2]/20 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2] group"
+              >
+                <DiscordIcon size={14} aria-hidden="true" />
+                <span className="group-hover:hidden">{discordInfo.username}</span>
+                <span className="hidden group-hover:inline">{discord.disconnecting ? "Disconnecting..." : "Disconnect"}</span>
+              </button>
+            ) : (
+              <button
+                onClick={discord.connect}
+                disabled={discord.connecting}
+                className="px-3 py-1 bg-[#5865F2] text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-[#4752C4] transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]"
+              >
+                <DiscordIcon size={14} aria-hidden="true" />
+                {discord.connecting ? "Connecting..." : "Connect Discord"}
+              </button>
+            )}
+            {githubInfo ? (
+              <button
+                onClick={github.disconnect}
+                disabled={github.disconnecting}
+                className="px-3 py-1 bg-neutral-800/50 text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-neutral-700 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white group"
+              >
+                <GitHubIcon size={14} aria-hidden="true" />
+                <span className="group-hover:hidden">{githubInfo.login}</span>
+                <span className="hidden group-hover:inline">{github.disconnecting ? "Disconnecting..." : "Disconnect"}</span>
+              </button>
+            ) : (
+              <button
+                onClick={github.connect}
+                disabled={github.connecting}
+                className="px-3 py-1 bg-neutral-800 text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-neutral-700 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+              >
+                <GitHubIcon size={14} aria-hidden="true" />
+                {github.connecting ? "Connecting..." : "Connect GitHub"}
+              </button>
+            )}
+            {connectedAgents.length > 0 && (
+              <span className="px-3 py-1 bg-purple-500/10 text-purple-400 text-sm rounded-full inline-flex items-center gap-1">
+                <UserCardIcon size={14} />
+                {connectedAgents.length} Agent{connectedAgents.length > 1 ? "s" : ""}
+              </span>
+            )}
+            {(userProfile?.eduBadge ||
+              userProfile?.additionalEmails?.some(
+                (e) => e.verified && e.email.toLowerCase().endsWith(".edu")
+              )) && (
+              <span className="px-3 py-1 bg-amber-500/10 text-amber-400 text-sm rounded-full">
+                .edu
+              </span>
+            )}
+            {userProfile?.hackASprint2026ShowcaseBadge && (
+              <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 text-sm rounded-full">
+                Hack-a-Sprint &apos;26 showcase
+              </span>
+            )}
+          </div>
+
+          {discord.error && <p className="text-red-400 text-xs mt-2">{discord.error}</p>}
+          {github.error && <p className="text-red-400 text-xs mt-2">{github.error}</p>}
+
+          {github.hasGithubConnection && (
+            <div className="mt-4 p-4 bg-neutral-800/60 rounded-xl border border-neutral-700">
+              <h2 className="text-sm font-semibold text-white mb-2">Contribute to the Open Source</h2>
+              <ol className="list-decimal list-inside space-y-1 text-neutral-300 text-sm">
+                <li>Pick an issue labeled &quot;good first issue&quot;.</li>
+                <li>Fork the repo, make your change, and open a PR.</li>
+                <li>Add a short test plan to your PR.</li>
+              </ol>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Link href="https://github.com/rogerSuperBuilderAlpha/cursor-boston" target="_blank" rel="noopener noreferrer" className="px-3 py-2 bg-neutral-700 text-white rounded-lg text-xs font-medium hover:bg-neutral-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
+                  Visit GitHub Repo
+                </Link>
+                <Link href="https://github.com/rogerSuperBuilderAlpha/cursor-boston?tab=contributing-ov-file#readme" target="_blank" rel="noopener noreferrer" className="px-3 py-2 bg-emerald-500 text-white rounded-lg text-xs font-medium hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400">
+                  Contributing Guide
+                </Link>
+              </div>
+            </div>
+          )}
+
+          <p className="text-neutral-400 text-sm mt-3">
+            Member since{" "}
+            {user.metadata.creationTime
+              ? new Date(user.metadata.creationTime).toLocaleDateString("en-US", { year: "numeric", month: "long" })
+              : "Unknown"}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="shrink-0 flex flex-col gap-2">
+          <button
+            onClick={onEditProfile}
+            className="px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+          >
+            Edit Profile
+          </button>
+          <button
+            onClick={handleSignOut}
+            disabled={isSigningOut}
+            className="px-4 py-2 bg-neutral-800 text-white rounded-lg text-sm font-medium hover:bg-neutral-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+          >
+            {isSigningOut ? "Signing out..." : "Sign Out"}
+          </button>
+        </div>
+      </div>
+
+      {signOutError && (
+        <div className="mt-4 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+          {signOutError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(auth)/profile/_components/ProfileTabs.tsx
+++ b/app/(auth)/profile/_components/ProfileTabs.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { Tab } from "../_types";
+import { TAB_LABELS } from "../_types";
+
+interface ProfileTabsProps {
+  activeTab: Tab;
+  setActiveTab: (tab: Tab) => void;
+}
+
+export function ProfileTabs({ activeTab, setActiveTab }: ProfileTabsProps) {
+  return (
+    <div className="border-b border-neutral-200 dark:border-neutral-800 mb-6">
+      <nav className="flex gap-6 overflow-x-auto" aria-label="Profile sections">
+        {TAB_LABELS.map(({ id, label }) => (
+          <button
+            key={id}
+            onClick={() => setActiveTab(id)}
+            className={`pb-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:text-foreground whitespace-nowrap ${
+              activeTab === id
+                ? "text-foreground border-b-2 border-emerald-500"
+                : "text-neutral-500 dark:text-neutral-400 hover:text-foreground"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/app/(auth)/profile/_components/SecurityTab.tsx
+++ b/app/(auth)/profile/_components/SecurityTab.tsx
@@ -8,17 +8,11 @@ import { useGithubConnection } from "../_hooks/useGithubConnection";
 import { useGoogleConnection } from "../_hooks/useGoogleConnection";
 import { useMfaEnrollment } from "../_hooks/useMfaEnrollment";
 import { useEmailManagement } from "../_hooks/useEmailManagement";
+import type { ConnectedAgent } from "../_types";
 
 interface AdditionalEmail {
   email: string;
   verified: boolean;
-}
-
-interface ConnectedAgent {
-  id: string;
-  name: string;
-  description?: string;
-  avatarUrl?: string;
 }
 
 interface SecurityTabProps {

--- a/app/(auth)/profile/_components/SettingsTab.tsx
+++ b/app/(auth)/profile/_components/SettingsTab.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { FormInput, FormTextarea, ToggleSwitch } from "@/components/ui/FormField";
+import { useAuth } from "@/contexts/AuthContext";
 import { ProfileSettings } from "../_hooks/useProfileSettings";
 
 interface SettingsTabProps {
@@ -15,14 +16,20 @@ interface SettingsTabProps {
 }
 
 function useEmailSubscription() {
+  const { user } = useAuth();
   const [onList, setOnList] = useState(false);
   const [subscribed, setSubscribed] = useState(false);
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
 
   useEffect(() => {
+    if (!user) return;
     let cancelled = false;
-    fetch("/api/profile/subscription")
+    user.getIdToken().then((token) =>
+      fetch("/api/profile/subscription", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    )
       .then((r) => r.json())
       .then((data: { onList?: boolean; subscribed?: boolean }) => {
         if (cancelled) return;
@@ -32,16 +39,21 @@ function useEmailSubscription() {
       .catch(() => {})
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, []);
+  }, [user]);
 
   const toggle = useCallback(async (value: boolean) => {
+    if (!user) return;
     setToggling(true);
     const prev = subscribed;
     setSubscribed(value);
     try {
+      const token = await user.getIdToken();
       const res = await fetch("/api/profile/subscription", {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ subscribed: value }),
       });
       if (!res.ok) setSubscribed(prev);
@@ -50,7 +62,7 @@ function useEmailSubscription() {
     } finally {
       setToggling(false);
     }
-  }, [subscribed]);
+  }, [user, subscribed]);
 
   return { onList, subscribed, loading, toggling, toggle };
 }

--- a/app/(auth)/profile/_components/SettingsTab.tsx
+++ b/app/(auth)/profile/_components/SettingsTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { FormInput, FormTextarea, ToggleSwitch } from "@/components/ui/FormField";
 import { ProfileSettings } from "../_hooks/useProfileSettings";
 
@@ -11,6 +12,47 @@ interface SettingsTabProps {
   success: boolean;
   onSave: () => Promise<void>;
   onToggleAllVisibility: (show: boolean) => void;
+}
+
+function useEmailSubscription() {
+  const [onList, setOnList] = useState(false);
+  const [subscribed, setSubscribed] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/profile/subscription")
+      .then((r) => r.json())
+      .then((data: { onList?: boolean; subscribed?: boolean }) => {
+        if (cancelled) return;
+        setOnList(data.onList ?? false);
+        setSubscribed(data.subscribed ?? false);
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggle = useCallback(async (value: boolean) => {
+    setToggling(true);
+    const prev = subscribed;
+    setSubscribed(value);
+    try {
+      const res = await fetch("/api/profile/subscription", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subscribed: value }),
+      });
+      if (!res.ok) setSubscribed(prev);
+    } catch {
+      setSubscribed(prev);
+    } finally {
+      setToggling(false);
+    }
+  }, [subscribed]);
+
+  return { onList, subscribed, loading, toggling, toggle };
 }
 
 const VISIBILITY_FIELDS: { key: keyof ProfileSettings["visibility"]; label: string }[] = [
@@ -49,6 +91,8 @@ export function SettingsTab({
   const updateVisibility = (key: keyof ProfileSettings["visibility"], value: boolean) =>
     setSettings((prev) => ({ ...prev, visibility: { ...prev.visibility, [key]: value } }));
 
+  const emailSub = useEmailSubscription();
+
   return (
     <div className="space-y-6">
       {/* Profile Visibility Toggle */}
@@ -68,6 +112,27 @@ export function SettingsTab({
             : "Your profile is hidden from the Members page"}
         </p>
       </div>
+
+      {/* Email Subscription Toggle */}
+      {!emailSub.loading && emailSub.onList && (
+        <div className="bg-neutral-900 rounded-2xl p-6 border border-neutral-800">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-lg font-semibold text-white">Event Email Updates</h2>
+            <ToggleSwitch
+              size="md"
+              label="Event email updates"
+              checked={emailSub.subscribed}
+              onChange={(checked) => emailSub.toggle(checked)}
+              disabled={emailSub.toggling}
+            />
+          </div>
+          <p className="text-neutral-400 text-sm">
+            {emailSub.subscribed
+              ? "You\u2019ll receive emails about upcoming events and community updates"
+              : "You\u2019ve opted out of event update emails"}
+          </p>
+        </div>
+      )}
 
       {/* Profile Information */}
       <div className="bg-neutral-900 rounded-2xl p-6 border border-neutral-800">

--- a/app/(auth)/profile/_components/StatsGrid.tsx
+++ b/app/(auth)/profile/_components/StatsGrid.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useProfileContext } from "../_contexts/ProfileContext";
+
+export function StatsGrid() {
+  const { data: { stats, loadingData } } = useProfileContext();
+
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
+        {[
+          { label: "Events Registered", value: stats?.eventsRegistered },
+          { label: "Events Attended", value: stats?.eventsAttended },
+          { label: "Talks Submitted", value: stats?.talksSubmitted },
+          { label: "Talks Given", value: stats?.talksGiven },
+          { label: "Pull Requests", value: stats?.pullRequestsCount },
+        ].map(({ label, value }) => (
+          <div key={label} className="bg-white dark:bg-neutral-900 rounded-xl p-4 border border-neutral-200 dark:border-neutral-800 text-center">
+            <p className="text-3xl font-bold text-foreground">{loadingData ? "-" : value || 0}</p>
+            <p className="text-neutral-500 dark:text-neutral-400 text-sm">{label}</p>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-neutral-500 mb-6">
+        Contributor badge progress is based on merged pull requests in this repository.
+      </p>
+    </>
+  );
+}

--- a/app/(auth)/profile/_components/TalksTab.tsx
+++ b/app/(auth)/profile/_components/TalksTab.tsx
@@ -2,13 +2,7 @@
 
 import Link from "next/link";
 import { StackIcon } from "@/components/icons";
-
-interface TalkSubmission {
-  id: string;
-  title: string;
-  status: string;
-  submittedAt: { toDate: () => Date } | null;
-}
+import type { TalkSubmission } from "../_types";
 
 interface TalksTabProps {
   talkSubmissions: TalkSubmission[];

--- a/app/(auth)/profile/_contexts/ProfileContext.tsx
+++ b/app/(auth)/profile/_contexts/ProfileContext.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+import type { User } from "firebase/auth";
+import { EmailAuthProvider, linkWithCredential, updatePassword } from "firebase/auth";
+import { auth } from "@/lib/firebase";
+import { useAuth } from "@/contexts/AuthContext";
+import type { UserProfile } from "@/contexts/AuthContext";
+
+import { useProfileData } from "../_hooks/useProfileData";
+import { useBadges } from "../_hooks/useBadges";
+import { useDiscordConnection } from "../_hooks/useDiscordConnection";
+import { useGithubConnection } from "../_hooks/useGithubConnection";
+import { useGoogleConnection } from "../_hooks/useGoogleConnection";
+import { useMfaEnrollment } from "../_hooks/useMfaEnrollment";
+import { useEmailManagement } from "../_hooks/useEmailManagement";
+import { useProfileSettings } from "../_hooks/useProfileSettings";
+
+interface PasswordState {
+  saving: boolean;
+  error: string | null;
+  success: boolean;
+  setPassword: (password: string) => Promise<void>;
+}
+
+export interface ProfileContextValue {
+  user: User;
+  userProfile: UserProfile | null;
+  refreshUserProfile: () => Promise<void>;
+
+  data: ReturnType<typeof useProfileData>;
+  badges: ReturnType<typeof useBadges>;
+
+  discord: ReturnType<typeof useDiscordConnection>;
+  github: ReturnType<typeof useGithubConnection>;
+  google: ReturnType<typeof useGoogleConnection>;
+  mfa: ReturnType<typeof useMfaEnrollment>;
+  email: ReturnType<typeof useEmailManagement>;
+  profileSettings: ReturnType<typeof useProfileSettings>;
+  password: PasswordState;
+
+  signOut: () => Promise<void>;
+  signOutError: string | null;
+  isSigningOut: boolean;
+  handleSignOut: () => Promise<void>;
+}
+
+const ProfileContext = createContext<ProfileContextValue | null>(null);
+
+export function useProfileContext() {
+  const ctx = useContext(ProfileContext);
+  if (!ctx) throw new Error("useProfileContext must be used within ProfileProvider");
+  return ctx;
+}
+
+export function ProfileProvider({
+  user,
+  children,
+}: {
+  user: User;
+  children: React.ReactNode;
+}) {
+  const {
+    userProfile,
+    signOut,
+    sendAddEmailVerification,
+    removeAdditionalEmail,
+    changePrimaryEmail,
+    refreshUserProfile,
+  } = useAuth();
+
+  // Data hooks
+  const data = useProfileData(user);
+  const badges = useBadges(user, userProfile);
+
+  // Connection hooks
+  const discord = useDiscordConnection(user, userProfile?.discord);
+  const github = useGithubConnection(user, userProfile?.github, userProfile?.provider);
+  const google = useGoogleConnection(user);
+  const mfa = useMfaEnrollment(user);
+  const emailMgmt = useEmailManagement({
+    user,
+    sendAddEmailVerification,
+    removeAdditionalEmail,
+    changePrimaryEmail,
+  });
+  const profileSettings = useProfileSettings(user, userProfile, refreshUserProfile);
+
+  // Password state
+  const [passwordSaving, setPasswordSaving] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordSuccess, setPasswordSuccess] = useState(false);
+
+  const setPassword = async (pw: string) => {
+    if (!user || !auth) return;
+    setPasswordError(null);
+    setPasswordSuccess(false);
+    if (!user.email) {
+      setPasswordError("No email is associated with this account.");
+      return;
+    }
+    setPasswordSaving(true);
+    try {
+      if (google.hasPasswordProvider) {
+        await updatePassword(user, pw);
+      } else {
+        const credential = EmailAuthProvider.credential(user.email, pw);
+        await linkWithCredential(user, credential);
+      }
+      setPasswordSuccess(true);
+      setTimeout(() => setPasswordSuccess(false), 3000);
+    } catch {
+      setPasswordError("Failed to set password. Please re-authenticate and try again.");
+    } finally {
+      setPasswordSaving(false);
+    }
+  };
+
+  // Sign out
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const [signOutError, setSignOutError] = useState<string | null>(null);
+
+  const handleSignOut = async () => {
+    setSignOutError(null);
+    setIsSigningOut(true);
+    try {
+      await signOut();
+    } catch (err) {
+      setSignOutError(
+        err instanceof Error ? err.message : "Failed to sign out. Please try again."
+      );
+      setIsSigningOut(false);
+    }
+  };
+
+  const value: ProfileContextValue = {
+    user,
+    userProfile,
+    refreshUserProfile,
+    data,
+    badges,
+    discord,
+    github,
+    google,
+    mfa,
+    email: emailMgmt,
+    profileSettings,
+    password: {
+      saving: passwordSaving,
+      error: passwordError,
+      success: passwordSuccess,
+      setPassword,
+    },
+    signOut,
+    signOutError,
+    isSigningOut,
+    handleSignOut,
+  };
+
+  return (
+    <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>
+  );
+}

--- a/app/(auth)/profile/_contexts/ProfileContext.tsx
+++ b/app/(auth)/profile/_contexts/ProfileContext.tsx
@@ -70,12 +70,17 @@ export function ProfileProvider({
   } = useAuth();
 
   // Data hooks
-  const data = useProfileData(user);
+  const data = useProfileData(user, userProfile?.github?.login);
   const badges = useBadges(user, userProfile);
 
   // Connection hooks
   const discord = useDiscordConnection(user, userProfile?.discord);
-  const github = useGithubConnection(user, userProfile?.github, userProfile?.provider);
+  const github = useGithubConnection(
+    user,
+    userProfile?.github,
+    userProfile?.provider,
+    refreshUserProfile
+  );
   const google = useGoogleConnection(user);
   const mfa = useMfaEnrollment(user);
   const emailMgmt = useEmailManagement({

--- a/app/(auth)/profile/_hooks/useBadges.ts
+++ b/app/(auth)/profile/_hooks/useBadges.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { User } from "firebase/auth";
+import type { UserProfile } from "@/contexts/AuthContext";
+import {
+  getBadgeEligibilityData,
+  type BadgeEligibilityDataStatus,
+} from "@/lib/badges/getBadgeEligibilityInput";
+import { evaluateBadgeEligibility } from "@/lib/badges/eligibility";
+import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
+import {
+  ensureUserBadgesForEligibleWithStatus,
+  getUserBadgeMap,
+  type BadgeAwardPersistenceStatus,
+  type UserBadgeMap,
+} from "@/lib/badges/data";
+import type { BadgeDefinition, BadgeEligibilityMap } from "@/lib/badges/types";
+import { getEarnedBadgeIds } from "@/lib/badges/utils";
+
+export function useBadges(user: User | null, userProfile: UserProfile | null) {
+  const [eligibilityMap, setEligibilityMap] = useState<BadgeEligibilityMap | undefined>(undefined);
+  const [userBadgeMap, setUserBadgeMap] = useState<UserBadgeMap>({});
+  const [loading, setLoading] = useState(false);
+  const [definitions, setDefinitions] = useState<BadgeDefinition[]>(BADGE_DEFINITIONS);
+  const [usingFallback, setUsingFallback] = useState(false);
+  const [dataStatus, setDataStatus] = useState<BadgeEligibilityDataStatus>({
+    state: "failed",
+    isAuthoritative: false,
+    failedSources: [],
+  });
+  const [persistenceStatus, setPersistenceStatus] =
+    useState<BadgeAwardPersistenceStatus>({ state: "complete" });
+
+  // Fetch Firestore-backed badge definitions
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await fetch("/api/badges/definitions", { cache: "no-store" });
+        if (!response.ok) {
+          setUsingFallback(true);
+          return;
+        }
+        const data = (await response.json()) as {
+          definitions?: BadgeDefinition[];
+          source?: "firestore" | "seeded-fallback" | "local-fallback";
+        };
+        if (Array.isArray(data.definitions) && data.definitions.length > 0) {
+          setDefinitions(data.definitions);
+        }
+        setUsingFallback(data.source !== "firestore");
+      } catch {
+        setUsingFallback(true);
+      }
+    })();
+  }, []);
+
+  // Evaluate eligibility and persist awards
+  useEffect(() => {
+    if (!user) {
+      setEligibilityMap(undefined);
+      setUserBadgeMap({});
+      setDataStatus({ state: "failed", isAuthoritative: false, failedSources: [] });
+      setPersistenceStatus({ state: "complete" });
+      return;
+    }
+
+    setLoading(true);
+    (async () => {
+      try {
+        const badgeData = await getBadgeEligibilityData({
+          uid: user.uid,
+          displayName: userProfile?.displayName ?? user.displayName ?? null,
+          visibility: userProfile?.visibility ?? null,
+          bio: userProfile?.bio ?? null,
+          photoURL: userProfile?.photoURL ?? user.photoURL ?? null,
+          discord: userProfile?.discord,
+          github: userProfile?.github,
+        });
+        const evaluated = evaluateBadgeEligibility(badgeData.input);
+        const persisted = await getUserBadgeMap(user.uid);
+        const persistenceResult = await ensureUserBadgesForEligibleWithStatus(
+          user.uid,
+          evaluated,
+          persisted
+        );
+        setEligibilityMap(evaluated);
+        setUserBadgeMap(persistenceResult.userBadgeMap);
+        setDataStatus(badgeData.status);
+        setPersistenceStatus(persistenceResult.status);
+      } catch (err) {
+        console.error("Error evaluating badge eligibility:", err);
+        setEligibilityMap(evaluateBadgeEligibility({}));
+        setUserBadgeMap({});
+        setDataStatus({
+          state: "failed",
+          isAuthoritative: false,
+          failedSources: [],
+          message: "Badge data could not be loaded right now.",
+        });
+        setPersistenceStatus({
+          state: "failed",
+          message: "Badge awards could not be saved right now.",
+        });
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [user, userProfile]);
+
+  // Derived values
+  const earnedIds = getEarnedBadgeIds(definitions, eligibilityMap, userBadgeMap);
+  const earnedDefinitions = definitions.filter((d) => earnedIds.includes(d.id));
+
+  return {
+    definitions,
+    eligibilityMap,
+    userBadgeMap,
+    earnedIds,
+    earnedDefinitions,
+    loading,
+    dataStatus,
+    persistenceStatus,
+    usingFallback,
+  };
+}

--- a/app/(auth)/profile/_hooks/useGithubConnection.ts
+++ b/app/(auth)/profile/_hooks/useGithubConnection.ts
@@ -14,7 +14,12 @@ export interface GithubInfo {
   html_url: string;
 }
 
-export function useGithubConnection(user: User | null, userProfileGithub?: GithubInfo | null, userProvider?: string) {
+export function useGithubConnection(
+  user: User | null,
+  userProfileGithub?: GithubInfo | null,
+  userProvider?: string,
+  refreshUserProfile?: () => Promise<void>
+) {
   const router = useRouter();
   const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
@@ -69,6 +74,24 @@ export function useGithubConnection(user: User | null, userProfileGithub?: Githu
       await updateDoc(userRef, {
         github: { ...githubUserInfo, connectedAt: serverTimestamp() },
       });
+
+      try {
+        const token = await user.getIdToken();
+        const response = await fetch("/api/profile/github/reconcile", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!response.ok) {
+          setError("GitHub connected, but merged PR history could not be synced yet.");
+        }
+      } catch {
+        setError("GitHub connected, but merged PR history could not be synced yet.");
+      }
+
+      await refreshUserProfile?.();
       setConnectedInfo(githubUserInfo);
       setWasDisconnected(false);
       router.replace("/profile", { scroll: false });

--- a/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
+++ b/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect } from "react";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import type { useDiscordConnection } from "./useDiscordConnection";
+import type { useGithubConnection } from "./useGithubConnection";
+import type { useEmailManagement } from "./useEmailManagement";
+import type { Tab } from "../_types";
+
+interface OAuthCallbackDeps {
+  loading: boolean;
+  searchParams: ReadonlyURLSearchParams;
+  router: AppRouterInstance;
+  discord: ReturnType<typeof useDiscordConnection>;
+  github: ReturnType<typeof useGithubConnection>;
+  email: ReturnType<typeof useEmailManagement>;
+  refreshUserProfile: () => Promise<void>;
+  setActiveTab: (tab: Tab) => void;
+}
+
+export function useOAuthCallbacks({
+  loading,
+  searchParams,
+  router,
+  discord,
+  github,
+  email,
+  refreshUserProfile,
+  setActiveTab,
+}: OAuthCallbackDeps) {
+  useEffect(() => {
+    if (loading) return;
+
+    // Discord callback
+    const discordStatus = searchParams.get("discord");
+    if (discordStatus) {
+      const data = searchParams.get("data");
+      if (discordStatus === "success" && data) {
+        discord.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
+      } else if (discordStatus === "error") {
+        discord.handleOAuthError(searchParams.get("message"));
+      }
+    }
+
+    // GitHub callback
+    const githubStatus = searchParams.get("github");
+    if (githubStatus) {
+      const data = searchParams.get("data");
+      if (githubStatus === "success" && data) {
+        github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
+      } else if (githubStatus === "error") {
+        github.handleOAuthError();
+      }
+    }
+
+    // Email verification callback
+    const emailVerification = searchParams.get("emailVerification");
+    if (emailVerification) {
+      const message = searchParams.get("message");
+      const tab = searchParams.get("tab");
+
+      if (emailVerification === "success") {
+        email.setVerificationStatus({
+          type: "success",
+          message: "Email verified and added to your account successfully!",
+        });
+        refreshUserProfile();
+        if (tab === "security") setActiveTab("security");
+      } else if (emailVerification === "error") {
+        const errorMessages: Record<string, string> = {
+          missing_token: "Invalid verification link.",
+          invalid_token:
+            "This verification link is invalid or has already been used.",
+          token_expired:
+            "This verification link has expired. Please request a new one.",
+          email_taken:
+            "This email is already associated with another account.",
+          server_error: "An error occurred. Please try again.",
+        };
+        email.setVerificationStatus({
+          type: "error",
+          message: errorMessages[message || ""] || "Failed to verify email.",
+        });
+        setActiveTab("security");
+      }
+
+      router.replace("/profile", { scroll: false });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, loading]);
+}

--- a/app/(auth)/profile/_hooks/useProfileData.ts
+++ b/app/(auth)/profile/_hooks/useProfileData.ts
@@ -12,7 +12,7 @@ import {
 import type { User } from "firebase/auth";
 import type { TalkSubmission, ConnectedAgent } from "../_types";
 
-export function useProfileData(user: User | null) {
+export function useProfileData(user: User | null, githubLogin?: string | null) {
   const [stats, setStats] = useState<UserStats | null>(null);
   const [registrations, setRegistrations] = useState<EventRegistration[]>([]);
   const [talkSubmissions, setTalkSubmissions] = useState<TalkSubmission[]>([]);
@@ -28,10 +28,28 @@ export function useProfileData(user: User | null) {
     }
     (async () => {
       try {
-        const [userStats, userRegistrations] = await Promise.all([
+        let [userStats, userRegistrations] = await Promise.all([
           getUserStats(user.uid),
           getUserRegistrations(user.uid),
         ]);
+
+        if (githubLogin && userStats.pullRequestsCount === 0) {
+          try {
+            const response = await fetch("/api/profile/github/reconcile", {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${await user.getIdToken()}`,
+              },
+            });
+
+            if (response.ok) {
+              userStats = await getUserStats(user.uid);
+            }
+          } catch (reconcileError) {
+            console.error("Error reconciling GitHub PR history:", reconcileError);
+          }
+        }
+
         setStats(userStats);
         setRegistrations(userRegistrations);
 
@@ -51,7 +69,7 @@ export function useProfileData(user: User | null) {
         setLoadingData(false);
       }
     })();
-  }, [user]);
+  }, [user, githubLogin]);
 
   // Fetch connected agents
   useEffect(() => {

--- a/app/(auth)/profile/_hooks/useProfileData.ts
+++ b/app/(auth)/profile/_hooks/useProfileData.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { collection, query, where, getDocs } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import {
+  getUserRegistrations,
+  getUserStats,
+  type EventRegistration,
+  type UserStats,
+} from "@/lib/registrations";
+import type { User } from "firebase/auth";
+import type { TalkSubmission, ConnectedAgent } from "../_types";
+
+export function useProfileData(user: User | null) {
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [registrations, setRegistrations] = useState<EventRegistration[]>([]);
+  const [talkSubmissions, setTalkSubmissions] = useState<TalkSubmission[]>([]);
+  const [loadingData, setLoadingData] = useState(true);
+  const [connectedAgents, setConnectedAgents] = useState<ConnectedAgent[]>([]);
+  const [loadingAgents, setLoadingAgents] = useState(false);
+
+  // Fetch stats, registrations, and talks
+  useEffect(() => {
+    if (!user) {
+      setLoadingData(false);
+      return;
+    }
+    (async () => {
+      try {
+        const [userStats, userRegistrations] = await Promise.all([
+          getUserStats(user.uid),
+          getUserRegistrations(user.uid),
+        ]);
+        setStats(userStats);
+        setRegistrations(userRegistrations);
+
+        if (db) {
+          const talksQuery = query(
+            collection(db, "talkSubmissions"),
+            where("userId", "==", user.uid)
+          );
+          const snap = await getDocs(talksQuery);
+          setTalkSubmissions(
+            snap.docs.map((d) => ({ id: d.id, ...d.data() })) as TalkSubmission[]
+          );
+        }
+      } catch (err) {
+        console.error("Error fetching user data:", err);
+      } finally {
+        setLoadingData(false);
+      }
+    })();
+  }, [user]);
+
+  // Fetch connected agents
+  useEffect(() => {
+    if (!user) return;
+    setLoadingAgents(true);
+    (async () => {
+      try {
+        const res = await fetch("/api/agents/user", {
+          headers: { Authorization: `Bearer ${await user.getIdToken()}` },
+        });
+        const data = await res.json();
+        if (data.success && data.agents) setConnectedAgents(data.agents);
+      } catch (err) {
+        console.error("Error fetching connected agents:", err);
+      } finally {
+        setLoadingAgents(false);
+      }
+    })();
+  }, [user]);
+
+  return { stats, registrations, talkSubmissions, connectedAgents, loadingData, loadingAgents };
+}

--- a/app/(auth)/profile/_types/index.ts
+++ b/app/(auth)/profile/_types/index.ts
@@ -1,0 +1,24 @@
+export type Tab = "overview" | "events" | "talks" | "security" | "settings";
+
+export interface TalkSubmission {
+  id: string;
+  title: string;
+  status: string;
+  submittedAt: { toDate: () => Date } | null;
+}
+
+export interface ConnectedAgent {
+  id: string;
+  name: string;
+  description?: string;
+  avatarUrl?: string;
+  claimedAt?: { _seconds: number };
+}
+
+export const TAB_LABELS: { id: Tab; label: string }[] = [
+  { id: "overview", label: "Overview" },
+  { id: "events", label: "My Events" },
+  { id: "talks", label: "My Talks" },
+  { id: "security", label: "Security" },
+  { id: "settings", label: "Public Profile" },
+];

--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -5,18 +5,15 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
-import type { Tab } from "./_types";
-import { TAB_LABELS } from "./_types";
 import { useOAuthCallbacks } from "./_hooks/useOAuthCallbacks";
 import { ProfileProvider, useProfileContext } from "./_contexts/ProfileContext";
 
 import { ProfileHeader } from "./_components/ProfileHeader";
+import { OnboardingChecklist } from "./_components/OnboardingChecklist";
+import { ConnectionsSection } from "./_components/ConnectionsSection";
 import { StatsGrid } from "./_components/StatsGrid";
 import { EarnedBadgesSection } from "./_components/EarnedBadgesSection";
-import { ProfileTabs } from "./_components/ProfileTabs";
-import { OverviewTab } from "./_components/OverviewTab";
-import { EventsTab } from "./_components/EventsTab";
-import { TalksTab } from "./_components/TalksTab";
+import { ActivitySection } from "./_components/ActivitySection";
 import { SecurityTab } from "./_components/SecurityTab";
 import { SettingsTab } from "./_components/SettingsTab";
 import { EditProfileModal } from "./_components/EditProfileModal";
@@ -26,7 +23,7 @@ function ProfilePageContent() {
   const {
     user,
     userProfile,
-    data: { registrations, talkSubmissions, connectedAgents, loadingData, loadingAgents },
+    data: { connectedAgents, loadingAgents },
     discord,
     github,
     google,
@@ -38,11 +35,10 @@ function ProfilePageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const initialTab = (searchParams.get("tab") as Tab) || "overview";
-  const [activeTab, setActiveTab] = useState<Tab>(
-    TAB_LABELS.some((t) => t.id === initialTab) ? initialTab : "overview"
-  );
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const initialSection = searchParams.get("section");
+  const [settingsOpen, setSettingsOpen] = useState(initialSection === "settings");
+  const [securityOpen, setSecurityOpen] = useState(initialSection === "security");
 
   // Google reconnection reset
   useEffect(() => {
@@ -61,61 +57,81 @@ function ProfilePageContent() {
     github,
     email: ctx.email,
     refreshUserProfile: ctx.refreshUserProfile,
-    setActiveTab,
+    setActiveTab: (tab) => {
+      if (tab === "security") setSecurityOpen(true);
+    },
   });
 
   return (
     <div className="min-h-[80vh] px-6 py-8 md:py-12">
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-3xl mx-auto">
         <ProfileHeader onEditProfile={() => setIsEditModalOpen(true)} />
+        <OnboardingChecklist />
+        <ConnectionsSection />
         <StatsGrid />
         <EarnedBadgesSection />
-        <ProfileTabs activeTab={activeTab} setActiveTab={setActiveTab} />
+        <ActivitySection />
 
-        {activeTab === "overview" && (
-          <OverviewTab
-            registrations={registrations}
-            talkSubmissions={talkSubmissions}
-            connectedAgents={connectedAgents}
-            loadingData={loadingData}
-            loadingAgents={loadingAgents}
-          />
-        )}
-        {activeTab === "events" && (
-          <EventsTab registrations={registrations} loadingData={loadingData} />
-        )}
-        {activeTab === "talks" && (
-          <TalksTab talkSubmissions={talkSubmissions} loadingData={loadingData} />
-        )}
-        {activeTab === "security" && (
-          <SecurityTab
-            discord={discord}
-            github={github}
-            google={google}
-            mfa={ctx.mfa}
-            email={ctx.email}
-            primaryEmail={user.email}
-            additionalEmails={userProfile?.additionalEmails || []}
-            hasPasswordProvider={google.hasPasswordProvider}
-            connectedAgents={connectedAgents}
-            loadingAgents={loadingAgents}
-            onSetPassword={password.setPassword}
-            passwordSaving={password.saving}
-            passwordError={password.error}
-            passwordSuccess={password.success}
-          />
-        )}
-        {activeTab === "settings" && (
-          <SettingsTab
-            settings={profileSettings.settings}
-            setSettings={profileSettings.setSettings}
-            saving={profileSettings.saving}
-            error={profileSettings.error}
-            success={profileSettings.success}
-            onSave={profileSettings.save}
-            onToggleAllVisibility={profileSettings.toggleAllVisibility}
-          />
-        )}
+        {/* Settings — collapsible */}
+        <div className="mb-8">
+          <button
+            onClick={() => setSettingsOpen(!settingsOpen)}
+            className="w-full flex items-center justify-between text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3 hover:text-neutral-300 transition-colors"
+          >
+            <span>Profile Settings</span>
+            <svg
+              className={`w-4 h-4 transition-transform ${settingsOpen ? "rotate-180" : ""}`}
+              fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {settingsOpen && (
+            <SettingsTab
+              settings={profileSettings.settings}
+              setSettings={profileSettings.setSettings}
+              saving={profileSettings.saving}
+              error={profileSettings.error}
+              success={profileSettings.success}
+              onSave={profileSettings.save}
+              onToggleAllVisibility={profileSettings.toggleAllVisibility}
+            />
+          )}
+        </div>
+
+        {/* Security — collapsible */}
+        <div className="mb-8">
+          <button
+            onClick={() => setSecurityOpen(!securityOpen)}
+            className="w-full flex items-center justify-between text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3 hover:text-neutral-300 transition-colors"
+          >
+            <span>Security</span>
+            <svg
+              className={`w-4 h-4 transition-transform ${securityOpen ? "rotate-180" : ""}`}
+              fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {securityOpen && (
+            <SecurityTab
+              discord={discord}
+              github={github}
+              google={google}
+              mfa={ctx.mfa}
+              email={ctx.email}
+              primaryEmail={user.email}
+              additionalEmails={userProfile?.additionalEmails || []}
+              hasPasswordProvider={google.hasPasswordProvider}
+              connectedAgents={connectedAgents}
+              loadingAgents={loadingAgents}
+              onSetPassword={password.setPassword}
+              passwordSaving={password.saving}
+              passwordError={password.error}
+              passwordSuccess={password.success}
+            />
+          )}
+        </div>
       </div>
 
       {isEditModalOpen && (

--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -2,52 +2,18 @@
 
 import { useEffect, Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
-import { EmailAuthProvider, linkWithCredential, updatePassword } from "firebase/auth";
-import { auth } from "@/lib/firebase";
 import { useAuth } from "@/contexts/AuthContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import Avatar from "@/components/Avatar";
-import {
-  getUserRegistrations,
-  getUserStats,
-  EventRegistration,
-  UserStats,
-} from "@/lib/registrations";
-import { collection, query, where, getDocs } from "firebase/firestore";
-import { db } from "@/lib/firebase";
-import {
-  DiscordIcon,
-  GitHubIcon,
-  UserCardIcon,
-  EyeIcon,
-  EyeOffIcon,
-} from "@/components/icons";
-import {
-  getBadgeEligibilityData,
-  type BadgeEligibilityDataStatus,
-} from "@/lib/badges/getBadgeEligibilityInput";
-import { evaluateBadgeEligibility } from "@/lib/badges/eligibility";
-import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
-import {
-  ensureUserBadgesForEligibleWithStatus,
-  getUserBadgeMap,
-  type BadgeAwardPersistenceStatus,
-  type UserBadgeMap,
-} from "@/lib/badges/data";
-import type { BadgeDefinition, BadgeEligibilityMap } from "@/lib/badges/types";
-import { getEarnedBadgeIds } from "@/lib/badges/utils";
-import { BadgeGrid } from "@/components/badges/BadgeGrid";
 
-// Hooks
-import { useDiscordConnection } from "./_hooks/useDiscordConnection";
-import { useGithubConnection } from "./_hooks/useGithubConnection";
-import { useGoogleConnection } from "./_hooks/useGoogleConnection";
-import { useMfaEnrollment } from "./_hooks/useMfaEnrollment";
-import { useEmailManagement } from "./_hooks/useEmailManagement";
-import { useProfileSettings } from "./_hooks/useProfileSettings";
+import type { Tab } from "./_types";
+import { TAB_LABELS } from "./_types";
+import { useOAuthCallbacks } from "./_hooks/useOAuthCallbacks";
+import { ProfileProvider, useProfileContext } from "./_contexts/ProfileContext";
 
-// Components
+import { ProfileHeader } from "./_components/ProfileHeader";
+import { StatsGrid } from "./_components/StatsGrid";
+import { EarnedBadgesSection } from "./_components/EarnedBadgesSection";
+import { ProfileTabs } from "./_components/ProfileTabs";
 import { OverviewTab } from "./_components/OverviewTab";
 import { EventsTab } from "./_components/EventsTab";
 import { TalksTab } from "./_components/TalksTab";
@@ -55,614 +21,57 @@ import { SecurityTab } from "./_components/SecurityTab";
 import { SettingsTab } from "./_components/SettingsTab";
 import { EditProfileModal } from "./_components/EditProfileModal";
 
-type Tab = "overview" | "events" | "talks" | "security" | "settings";
-
-interface TalkSubmission {
-  id: string;
-  title: string;
-  status: string;
-  submittedAt: { toDate: () => Date } | null;
-}
-
-interface ConnectedAgent {
-  id: string;
-  name: string;
-  description?: string;
-  avatarUrl?: string;
-  claimedAt?: { _seconds: number };
-}
-
-const TAB_LABELS: { id: Tab; label: string }[] = [
-  { id: "overview", label: "Overview" },
-  { id: "events", label: "My Events" },
-  { id: "talks", label: "My Talks" },
-  { id: "security", label: "Security" },
-  { id: "settings", label: "Public Profile" },
-];
-
 function ProfilePageContent() {
+  const ctx = useProfileContext();
   const {
     user,
     userProfile,
-    loading,
-    signOut,
-    updateUserProfile,
-    sendAddEmailVerification,
-    removeAdditionalEmail,
-    changePrimaryEmail,
-    refreshUserProfile,
-  } = useAuth();
+    data: { registrations, talkSubmissions, connectedAgents, loadingData, loadingAgents },
+    discord,
+    github,
+    google,
+    profileSettings,
+    password,
+  } = ctx;
+
+  const { updateUserProfile } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // ── UI state ──────────────────────────────────────────────────────────────
-  const [activeTab, setActiveTab] = useState<Tab>("overview");
+  const initialTab = (searchParams.get("tab") as Tab) || "overview";
+  const [activeTab, setActiveTab] = useState<Tab>(
+    TAB_LABELS.some((t) => t.id === initialTab) ? initialTab : "overview"
+  );
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [isSigningOut, setIsSigningOut] = useState(false);
-  const [signOutError, setSignOutError] = useState<string | null>(null);
 
-  // ── Data state ────────────────────────────────────────────────────────────
-  const [stats, setStats] = useState<UserStats | null>(null);
-  const [registrations, setRegistrations] = useState<EventRegistration[]>([]);
-  const [talkSubmissions, setTalkSubmissions] = useState<TalkSubmission[]>([]);
-  const [loadingData, setLoadingData] = useState(true);
-  const [connectedAgents, setConnectedAgents] = useState<ConnectedAgent[]>([]);
-  const [loadingAgents, setLoadingAgents] = useState(false);
-  const [badgeEligibilityMap, setBadgeEligibilityMap] = useState<BadgeEligibilityMap | undefined>(undefined);
-  const [userBadgeMap, setUserBadgeMap] = useState<UserBadgeMap>({});
-  const [loadingBadges, setLoadingBadges] = useState(false);
-  const [badgeDefinitions, setBadgeDefinitions] = useState<BadgeDefinition[]>(BADGE_DEFINITIONS);
-  const [usingFallbackDefinitions, setUsingFallbackDefinitions] = useState(false);
-  const [badgeDataStatus, setBadgeDataStatus] = useState<BadgeEligibilityDataStatus>({
-    state: "failed",
-    isAuthoritative: false,
-    failedSources: [],
-  });
-  const [badgePersistenceStatus, setBadgePersistenceStatus] =
-    useState<BadgeAwardPersistenceStatus>({ state: "complete" });
-
-  // ── Password state (kept here because it needs user from auth context) ────
-  const [passwordSaving, setPasswordSaving] = useState(false);
-  const [passwordError, setPasswordError] = useState<string | null>(null);
-  const [passwordSuccess, setPasswordSuccess] = useState(false);
-
-  // ── Custom hooks ──────────────────────────────────────────────────────────
-  const discord = useDiscordConnection(user, userProfile?.discord);
-  const github = useGithubConnection(user, userProfile?.github, userProfile?.provider);
-  const google = useGoogleConnection(user);
-  const mfa = useMfaEnrollment(user);
-  const email = useEmailManagement({ user, sendAddEmailVerification, removeAdditionalEmail, changePrimaryEmail });
-  const profileSettings = useProfileSettings(user, userProfile, refreshUserProfile);
-
-  // ── Redirect if not authed ────────────────────────────────────────────────
-  useEffect(() => {
-    if (!loading && !user) router.push("/login?redirect=/profile");
-  }, [user, loading, router]);
-
-  // ── Reset Google disconnected flag when provider reappears ────────────────
+  // Google reconnection reset
   useEffect(() => {
     google.resetIfReconnected();
   }, [user?.providerData]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Cleanup recaptcha on unmount ──────────────────────────────────────────
-  useEffect(() => () => mfa.clearRecaptcha(), []); // eslint-disable-line react-hooks/exhaustive-deps
+  // Cleanup recaptcha on unmount
+  useEffect(() => () => ctx.mfa.clearRecaptcha(), []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Handle Discord OAuth callback ─────────────────────────────────────────
-  useEffect(() => {
-    if (loading) return;
-    const status = searchParams.get("discord");
-    const data = searchParams.get("data");
-    if (status === "success" && data) {
-      discord.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
-    } else if (status === "error") {
-      discord.handleOAuthError(searchParams.get("message"));
-    }
-  }, [searchParams, loading]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // ── Handle GitHub OAuth callback ──────────────────────────────────────────
-  useEffect(() => {
-    if (loading) return;
-    const status = searchParams.get("github");
-    const data = searchParams.get("data");
-    if (status === "success" && data) {
-      github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
-    } else if (status === "error") {
-      github.handleOAuthError();
-    }
-  }, [searchParams, loading]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // ── Handle email verification callback ────────────────────────────────────
-  useEffect(() => {
-    if (loading) return;
-    const emailVerification = searchParams.get("emailVerification");
-    const message = searchParams.get("message");
-    const tab = searchParams.get("tab");
-
-    if (emailVerification === "success") {
-      email.setVerificationStatus({ type: "success", message: "Email verified and added to your account successfully!" });
-      refreshUserProfile();
-      if (tab === "security") setActiveTab("security");
-      router.replace("/profile", { scroll: false });
-    } else if (emailVerification === "error") {
-      const errorMessages: Record<string, string> = {
-        missing_token: "Invalid verification link.",
-        invalid_token: "This verification link is invalid or has already been used.",
-        token_expired: "This verification link has expired. Please request a new one.",
-        email_taken: "This email is already associated with another account.",
-        server_error: "An error occurred. Please try again.",
-      };
-      email.setVerificationStatus({ type: "error", message: errorMessages[message || ""] || "Failed to verify email." });
-      setActiveTab("security");
-      router.replace("/profile", { scroll: false });
-    }
-  }, [searchParams, loading]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // ── Fetch user data ───────────────────────────────────────────────────────
-  useEffect(() => {
-    if (!user) { setLoadingData(false); return; }
-    (async () => {
-      try {
-        const [userStats, userRegistrations] = await Promise.all([
-          getUserStats(user.uid),
-          getUserRegistrations(user.uid),
-        ]);
-        setStats(userStats);
-        setRegistrations(userRegistrations);
-
-        if (db) {
-          const talksQuery = query(collection(db, "talkSubmissions"), where("userId", "==", user.uid));
-          const snap = await getDocs(talksQuery);
-          setTalkSubmissions(snap.docs.map((d) => ({ id: d.id, ...d.data() })) as TalkSubmission[]);
-        }
-      } catch (err) {
-        console.error("Error fetching user data:", err);
-      } finally {
-        setLoadingData(false);
-      }
-    })();
-  }, [user]);
-
-  // ── Fetch connected agents ────────────────────────────────────────────────
-  useEffect(() => {
-    if (!user) return;
-    setLoadingAgents(true);
-    (async () => {
-      try {
-        const res = await fetch("/api/agents/user", {
-          headers: { Authorization: `Bearer ${await user.getIdToken()}` },
-        });
-        const data = await res.json();
-        if (data.success && data.agents) setConnectedAgents(data.agents);
-      } catch (err) {
-        console.error("Error fetching connected agents:", err);
-      } finally {
-        setLoadingAgents(false);
-      }
-    })();
-  }, [user]);
-
-  // ── Fetch Firestore-backed badge definitions ──────────────────────────────
-  useEffect(() => {
-    (async () => {
-      try {
-        const response = await fetch("/api/badges/definitions", { cache: "no-store" });
-        if (!response.ok) {
-          setUsingFallbackDefinitions(true);
-          return;
-        }
-        const data = (await response.json()) as {
-          definitions?: BadgeDefinition[];
-          source?: "firestore" | "seeded-fallback" | "local-fallback";
-        };
-        if (Array.isArray(data.definitions) && data.definitions.length > 0) {
-          setBadgeDefinitions(data.definitions);
-        }
-        setUsingFallbackDefinitions(data.source !== "firestore");
-      } catch {
-        // Keep local fallback definitions
-        setUsingFallbackDefinitions(true);
-      }
-    })();
-  }, []);
-
-  // ── Fetch badge eligibility input and evaluate badges ─────────────────────
-  useEffect(() => {
-    if (!user) {
-      setBadgeEligibilityMap(undefined);
-      setUserBadgeMap({});
-      setBadgeDataStatus({
-        state: "failed",
-        isAuthoritative: false,
-        failedSources: [],
-      });
-      setBadgePersistenceStatus({ state: "complete" });
-      return;
-    }
-
-    setLoadingBadges(true);
-    (async () => {
-      try {
-        const badgeData = await getBadgeEligibilityData({
-          uid: user.uid,
-          displayName: userProfile?.displayName ?? user.displayName ?? null,
-          visibility: userProfile?.visibility ?? null,
-          bio: userProfile?.bio ?? null,
-          photoURL: userProfile?.photoURL ?? user.photoURL ?? null,
-          discord: userProfile?.discord,
-          github: userProfile?.github,
-        });
-        const evaluated = evaluateBadgeEligibility(badgeData.input);
-        const persisted = await getUserBadgeMap(user.uid);
-        const persistenceResult = await ensureUserBadgesForEligibleWithStatus(
-          user.uid,
-          evaluated,
-          persisted
-        );
-        setBadgeEligibilityMap(evaluated);
-        setUserBadgeMap(persistenceResult.userBadgeMap);
-        setBadgeDataStatus(badgeData.status);
-        setBadgePersistenceStatus(persistenceResult.status);
-      } catch (err) {
-        console.error("Error evaluating badge eligibility:", err);
-        setBadgeEligibilityMap(evaluateBadgeEligibility({}));
-        setUserBadgeMap({});
-        setBadgeDataStatus({
-          state: "failed",
-          isAuthoritative: false,
-          failedSources: [],
-          message: "Badge data could not be loaded right now.",
-        });
-        setBadgePersistenceStatus({
-          state: "failed",
-          message: "Badge awards could not be saved right now.",
-        });
-      } finally {
-        setLoadingBadges(false);
-      }
-    })();
-  }, [user, userProfile]);
-
-  // ── Handlers ──────────────────────────────────────────────────────────────
-  const handleSignOut = async () => {
-    setSignOutError(null);
-    setIsSigningOut(true);
-    try {
-      await signOut();
-      router.push("/");
-    } catch (err) {
-      setSignOutError(err instanceof Error ? err.message : "Failed to sign out. Please try again.");
-      setIsSigningOut(false);
-    }
-  };
-
-  const handleSetPassword = async (password: string) => {
-    if (!user || !auth) return;
-    setPasswordError(null);
-    setPasswordSuccess(false);
-    if (!user.email) { setPasswordError("No email is associated with this account."); return; }
-    setPasswordSaving(true);
-    try {
-      if (google.hasPasswordProvider) {
-        await updatePassword(user, password);
-      } else {
-        const credential = EmailAuthProvider.credential(user.email, password);
-        await linkWithCredential(user, credential);
-      }
-      setPasswordSuccess(true);
-      setTimeout(() => setPasswordSuccess(false), 3000);
-    } catch {
-      setPasswordError("Failed to set password. Please re-authenticate and try again.");
-    } finally {
-      setPasswordSaving(false);
-    }
-  };
-
-  // ── Loading / auth guard ──────────────────────────────────────────────────
-  if (loading) {
-    return (
-      <div className="min-h-[80vh] flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-white" />
-      </div>
-    );
-  }
-  if (!user) return null;
-
-  const discordInfo = discord.discordInfo;
-  const githubInfo = github.githubInfo;
-  const earnedBadgeIds = getEarnedBadgeIds(
-    badgeDefinitions,
-    badgeEligibilityMap,
-    userBadgeMap
-  );
-  const earnedBadgeDefinitions = badgeDefinitions.filter((definition) =>
-    earnedBadgeIds.includes(definition.id)
-  );
+  // OAuth callbacks
+  useOAuthCallbacks({
+    loading: false,
+    searchParams,
+    router,
+    discord,
+    github,
+    email: ctx.email,
+    refreshUserProfile: ctx.refreshUserProfile,
+    setActiveTab,
+  });
 
   return (
     <div className="min-h-[80vh] px-6 py-8 md:py-12">
       <div className="max-w-4xl mx-auto">
+        <ProfileHeader onEditProfile={() => setIsEditModalOpen(true)} />
+        <StatsGrid />
+        <EarnedBadgesSection />
+        <ProfileTabs activeTab={activeTab} setActiveTab={setActiveTab} />
 
-        {/* ── Profile Header ─────────────────────────────────────────────── */}
-        <div className="bg-neutral-900 rounded-2xl p-6 md:p-8 border border-neutral-800 mb-6">
-          <div className="flex flex-col md:flex-row gap-6 items-center md:items-start">
-            {/* Avatar */}
-            <button
-              onClick={() => setIsEditModalOpen(true)}
-              className="shrink-0 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 rounded-full"
-              aria-label="Edit profile photo"
-            >
-              <Avatar src={user.photoURL} name={user.displayName} email={user.email} size="xl" />
-              <div className="absolute inset-0 bg-black/60 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-white" aria-hidden="true">
-                  <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-                  <path d="m15 5 4 4" />
-                </svg>
-              </div>
-            </button>
-
-            {/* Info */}
-            <div className="flex-1 text-center md:text-left">
-              <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4 mb-1">
-                <h1 className="text-2xl md:text-3xl font-bold text-white">
-                  {user.displayName || "Community Member"}
-                </h1>
-                {/* Public/Private badge */}
-                <button
-                  onClick={() => profileSettings.togglePublic(!profileSettings.settings.visibility.isPublic)}
-                  className={`inline-flex items-center gap-1.5 px-3 py-1 text-sm rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 ${
-                    profileSettings.settings.visibility.isPublic
-                      ? "bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30 focus-visible:ring-emerald-400"
-                      : "bg-neutral-700 text-neutral-400 hover:bg-neutral-600 focus-visible:ring-neutral-400"
-                  }`}
-                >
-                  {profileSettings.settings.visibility.isPublic ? (
-                    <><EyeIcon /> Public Profile</>
-                  ) : (
-                    <><EyeOffIcon /> Private Profile</>
-                  )}
-                </button>
-              </div>
-
-              <p className="text-neutral-400 mb-3">{user.email}</p>
-
-              {/* Badges */}
-              <div className="flex flex-wrap gap-2 justify-center md:justify-start">
-                <span className="px-3 py-1 bg-emerald-500/10 text-emerald-400 text-sm rounded-full">Community Member</span>
-                {userProfile?.provider && (
-                  <span className="px-3 py-1 bg-neutral-800 text-neutral-300 text-sm rounded-full capitalize">
-                    {userProfile.provider} Account
-                  </span>
-                )}
-                {/* Discord badge */}
-                {discordInfo ? (
-                  <button
-                    onClick={discord.disconnect}
-                    disabled={discord.disconnecting}
-                    className="px-3 py-1 bg-[#5865F2]/10 text-[#5865F2] text-sm rounded-full inline-flex items-center gap-1 hover:bg-[#5865F2]/20 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2] group"
-                  >
-                    <DiscordIcon size={14} aria-hidden="true" />
-                    <span className="group-hover:hidden">{discordInfo.username}</span>
-                    <span className="hidden group-hover:inline">{discord.disconnecting ? "Disconnecting..." : "Disconnect"}</span>
-                  </button>
-                ) : (
-                  <button
-                    onClick={discord.connect}
-                    disabled={discord.connecting}
-                    className="px-3 py-1 bg-[#5865F2] text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-[#4752C4] transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]"
-                  >
-                    <DiscordIcon size={14} aria-hidden="true" />
-                    {discord.connecting ? "Connecting..." : "Connect Discord"}
-                  </button>
-                )}
-                {/* GitHub badge */}
-                {githubInfo ? (
-                  <button
-                    onClick={github.disconnect}
-                    disabled={github.disconnecting}
-                    className="px-3 py-1 bg-neutral-800/50 text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-neutral-700 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white group"
-                  >
-                    <GitHubIcon size={14} aria-hidden="true" />
-                    <span className="group-hover:hidden">{githubInfo.login}</span>
-                    <span className="hidden group-hover:inline">{github.disconnecting ? "Disconnecting..." : "Disconnect"}</span>
-                  </button>
-                ) : (
-                  <button
-                    onClick={github.connect}
-                    disabled={github.connecting}
-                    className="px-3 py-1 bg-neutral-800 text-white text-sm rounded-full inline-flex items-center gap-1 hover:bg-neutral-700 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                  >
-                    <GitHubIcon size={14} aria-hidden="true" />
-                    {github.connecting ? "Connecting..." : "Connect GitHub"}
-                  </button>
-                )}
-                {connectedAgents.length > 0 && (
-                  <span className="px-3 py-1 bg-purple-500/10 text-purple-400 text-sm rounded-full inline-flex items-center gap-1">
-                    <UserCardIcon size={14} />
-                    {connectedAgents.length} Agent{connectedAgents.length > 1 ? "s" : ""}
-                  </span>
-                )}
-                {/* .edu badge - verified institutional email */}
-                {(userProfile?.eduBadge ||
-                  userProfile?.additionalEmails?.some(
-                    (e) => e.verified && e.email.toLowerCase().endsWith(".edu")
-                  )) && (
-                  <span className="px-3 py-1 bg-amber-500/10 text-amber-400 text-sm rounded-full">
-                    .edu
-                  </span>
-                )}
-                {userProfile?.hackASprint2026ShowcaseBadge && (
-                  <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 text-sm rounded-full">
-                    Hack-a-Sprint &apos;26 showcase
-                  </span>
-                )}
-              </div>
-
-              {discord.error && <p className="text-red-400 text-xs mt-2">{discord.error}</p>}
-              {github.error && <p className="text-red-400 text-xs mt-2">{github.error}</p>}
-
-              {/* GitHub open source callout */}
-              {github.hasGithubConnection && (
-                <div className="mt-4 p-4 bg-neutral-800/60 rounded-xl border border-neutral-700">
-                  <h2 className="text-sm font-semibold text-white mb-2">Contribute to the Open Source</h2>
-                  <ol className="list-decimal list-inside space-y-1 text-neutral-300 text-sm">
-                    <li>Pick an issue labeled &quot;good first issue&quot;.</li>
-                    <li>Fork the repo, make your change, and open a PR.</li>
-                    <li>Add a short test plan to your PR.</li>
-                  </ol>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <Link href="https://github.com/rogerSuperBuilderAlpha/cursor-boston" target="_blank" rel="noopener noreferrer" className="px-3 py-2 bg-neutral-700 text-white rounded-lg text-xs font-medium hover:bg-neutral-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
-                      Visit GitHub Repo
-                    </Link>
-                    <Link href="https://github.com/rogerSuperBuilderAlpha/cursor-boston?tab=contributing-ov-file#readme" target="_blank" rel="noopener noreferrer" className="px-3 py-2 bg-emerald-500 text-white rounded-lg text-xs font-medium hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400">
-                      Contributing Guide
-                    </Link>
-                  </div>
-                </div>
-              )}
-
-              <p className="text-neutral-400 text-sm mt-3">
-                Member since{" "}
-                {user.metadata.creationTime
-                  ? new Date(user.metadata.creationTime).toLocaleDateString("en-US", { year: "numeric", month: "long" })
-                  : "Unknown"}
-              </p>
-            </div>
-
-            {/* Actions */}
-            <div className="shrink-0 flex flex-col gap-2">
-              <button
-                onClick={() => setIsEditModalOpen(true)}
-                className="px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
-              >
-                Edit Profile
-              </button>
-              <button
-                onClick={handleSignOut}
-                disabled={isSigningOut}
-                className="px-4 py-2 bg-neutral-800 text-white rounded-lg text-sm font-medium hover:bg-neutral-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
-              >
-                {isSigningOut ? "Signing out..." : "Sign Out"}
-              </button>
-            </div>
-          </div>
-
-          {signOutError && (
-            <div className="mt-4 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
-              {signOutError}
-            </div>
-          )}
-        </div>
-
-        {/* ── Stats ─────────────────────────────────────────────────────── */}
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
-          {[
-            { label: "Events Registered", value: stats?.eventsRegistered },
-            { label: "Events Attended", value: stats?.eventsAttended },
-            { label: "Talks Submitted", value: stats?.talksSubmitted },
-            { label: "Talks Given", value: stats?.talksGiven },
-            { label: "Pull Requests", value: stats?.pullRequestsCount },
-          ].map(({ label, value }) => (
-            <div key={label} className="bg-white dark:bg-neutral-900 rounded-xl p-4 border border-neutral-200 dark:border-neutral-800 text-center">
-              <p className="text-3xl font-bold text-foreground">{loadingData ? "-" : value || 0}</p>
-              <p className="text-neutral-500 dark:text-neutral-400 text-sm">{label}</p>
-            </div>
-          ))}
-        </div>
-        <p className="text-xs text-neutral-500 mb-6">
-          Contributor badge progress is based on merged pull requests in this repository.
-        </p>
-
-        {/* ── Achievement Badges ───────────────────────────────────── */}
-        <div className="bg-neutral-900 rounded-2xl p-6 border border-neutral-800 mb-6">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-white">Earned Badges</h2>
-            <Link
-              href="/badges"
-              className="text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
-            >
-              View all badges
-            </Link>
-          </div>
-
-          {loadingBadges ? (
-            <span className="text-xs text-neutral-400">Updating...</span>
-          ) : earnedBadgeDefinitions.length === 0 ? (
-            <div className="text-sm text-neutral-400">
-              No badges earned yet. Complete milestones to unlock your first one.
-            </div>
-          ) : (
-            <BadgeGrid
-              definitions={earnedBadgeDefinitions}
-              eligibilityMap={badgeEligibilityMap}
-              earnedBadgeIds={earnedBadgeIds}
-              userBadgeMap={userBadgeMap}
-              compact
-              layout="horizontal"
-              isAuthoritative={badgeDataStatus.isAuthoritative}
-            />
-          )}
-
-          {badgeDataStatus.state !== "complete" && (
-            <div
-              className={`mt-4 rounded-lg border px-3 py-2 text-xs ${
-                badgeDataStatus.state === "failed"
-                  ? "border-red-500/30 bg-red-500/10 text-red-300"
-                  : "border-amber-500/30 bg-amber-500/10 text-amber-300"
-              }`}
-            >
-              {badgeDataStatus.message ||
-                "Badge data is partially unavailable. Some badge statuses may be unverified."}
-              {process.env.NODE_ENV !== "production" &&
-                badgeDataStatus.failedSources.length > 0 && (
-                  <p className="mt-1 text-[11px] opacity-80">
-                    Debug: failed badge sources: {badgeDataStatus.failedSources.join(", ")}
-                  </p>
-                )}
-            </div>
-          )}
-
-          {badgePersistenceStatus.state !== "complete" && (
-            <div
-              className={`mt-3 rounded-lg border px-3 py-2 text-xs ${
-                badgePersistenceStatus.state === "failed"
-                  ? "border-red-500/30 bg-red-500/10 text-red-300"
-                  : "border-amber-500/30 bg-amber-500/10 text-amber-300"
-              }`}
-            >
-              {badgePersistenceStatus.message ||
-                (badgePersistenceStatus.state === "failed"
-                  ? "We couldn’t save some badge updates. Earned dates may be missing. Please refresh or try again."
-                  : "Some badge updates are still syncing. Earned dates may appear shortly.")}
-            </div>
-          )}
-
-          {usingFallbackDefinitions && (
-            <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
-              Badge definitions are using fallback data right now.
-            </div>
-          )}
-        </div>
-
-        {/* ── Tabs ──────────────────────────────────────────────────────── */}
-        <div className="border-b border-neutral-200 dark:border-neutral-800 mb-6">
-          <nav className="flex gap-6 overflow-x-auto" aria-label="Profile sections">
-            {TAB_LABELS.map(({ id, label }) => (
-              <button
-                key={id}
-                onClick={() => setActiveTab(id)}
-                className={`pb-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:text-foreground whitespace-nowrap ${
-                  activeTab === id
-                    ? "text-foreground border-b-2 border-emerald-500"
-                    : "text-neutral-500 dark:text-neutral-400 hover:text-foreground"
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </nav>
-        </div>
-
-        {/* ── Tab Content ───────────────────────────────────────────────── */}
         {activeTab === "overview" && (
           <OverviewTab
             registrations={registrations}
@@ -683,17 +92,17 @@ function ProfilePageContent() {
             discord={discord}
             github={github}
             google={google}
-            mfa={mfa}
-            email={email}
+            mfa={ctx.mfa}
+            email={ctx.email}
             primaryEmail={user.email}
             additionalEmails={userProfile?.additionalEmails || []}
             hasPasswordProvider={google.hasPasswordProvider}
             connectedAgents={connectedAgents}
             loadingAgents={loadingAgents}
-            onSetPassword={handleSetPassword}
-            passwordSaving={passwordSaving}
-            passwordError={passwordError}
-            passwordSuccess={passwordSuccess}
+            onSetPassword={password.setPassword}
+            passwordSaving={password.saving}
+            passwordError={password.error}
+            passwordSuccess={password.success}
           />
         )}
         {activeTab === "settings" && (
@@ -709,7 +118,6 @@ function ProfilePageContent() {
         )}
       </div>
 
-      {/* ── Edit Profile Modal ──────────────────────────────────────────── */}
       {isEditModalOpen && (
         <EditProfileModal
           user={user}
@@ -718,6 +126,30 @@ function ProfilePageContent() {
         />
       )}
     </div>
+  );
+}
+
+function ProfilePageShell() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login?redirect=/profile");
+  }, [user, loading, router]);
+
+  if (loading) {
+    return (
+      <div className="min-h-[80vh] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-white" />
+      </div>
+    );
+  }
+  if (!user) return null;
+
+  return (
+    <ProfileProvider user={user}>
+      <ProfilePageContent />
+    </ProfileProvider>
   );
 }
 
@@ -731,7 +163,7 @@ export default function ProfilePage() {
           </div>
         }
       >
-        <ProfilePageContent />
+        <ProfilePageShell />
       </Suspense>
     </ErrorBoundary>
   );

--- a/app/api/notifications/unsubscribe/route.ts
+++ b/app/api/notifications/unsubscribe/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { verifyUnsubscribeToken } from "@/lib/unsubscribe-token";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { FieldValue } from "firebase-admin/firestore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE = { windowMs: 15 * 60 * 1000, maxRequests: 20 };
+
+/**
+ * GET /api/notifications/unsubscribe?email=...&token=...
+ *
+ * Validates the HMAC token and marks the contact as unsubscribed in Firestore,
+ * then redirects to a confirmation page.
+ */
+export async function GET(request: NextRequest) {
+  const clientId = getClientIdentifier(request as unknown as Request);
+  const rateResult = checkRateLimit(`unsub:${clientId}`, RATE);
+  if (!rateResult.success) {
+    return NextResponse.redirect(
+      new URL("/unsubscribe?status=rate-limited", request.url)
+    );
+  }
+
+  const email = request.nextUrl.searchParams.get("email")?.toLowerCase().trim();
+  const token = request.nextUrl.searchParams.get("token");
+
+  if (!email || !token) {
+    return NextResponse.redirect(
+      new URL("/unsubscribe?status=invalid", request.url)
+    );
+  }
+
+  if (!/^[a-f0-9]{64}$/i.test(token)) {
+    return NextResponse.redirect(
+      new URL("/unsubscribe?status=invalid", request.url)
+    );
+  }
+
+  if (!verifyUnsubscribeToken(email, token)) {
+    return NextResponse.redirect(
+      new URL("/unsubscribe?status=invalid", request.url)
+    );
+  }
+
+  try {
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.redirect(
+        new URL("/unsubscribe?status=error", request.url)
+      );
+    }
+
+    const docRef = db.collection("eventContacts").doc(email);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      // Contact not found — still show success (don't leak membership info)
+      return NextResponse.redirect(
+        new URL("/unsubscribe?status=success", request.url)
+      );
+    }
+
+    await docRef.update({
+      unsubscribed: true,
+      unsubscribedAt: FieldValue.serverTimestamp(),
+    });
+
+    return NextResponse.redirect(
+      new URL("/unsubscribe?status=success", request.url)
+    );
+  } catch {
+    return NextResponse.redirect(
+      new URL("/unsubscribe?status=error", request.url)
+    );
+  }
+}

--- a/app/api/profile/github/reconcile/route.ts
+++ b/app/api/profile/github/reconcile/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getClientIdentifier, checkRateLimit } from "@/lib/rate-limit";
+import { reconcileMergedPrCreditForUser } from "@/lib/github-merged-pr-reconcile";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
+
+export async function POST(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`profile-github-reconcile:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const userSnap = await db.collection("users").doc(user.uid).get();
+    if (!userSnap.exists) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+
+    const github =
+      userSnap.data()?.github && typeof userSnap.data()?.github === "object" ?
+        (userSnap.data()?.github as { login?: string })
+      : null;
+    const githubLogin =
+      typeof github?.login === "string" && github.login.trim() ? github.login.trim() : null;
+
+    if (!githubLogin) {
+      return NextResponse.json({ error: "GitHub is not connected" }, { status: 400 });
+    }
+
+    const result = await reconcileMergedPrCreditForUser(user.uid, githubLogin);
+
+    return NextResponse.json({
+      success: true,
+      githubLogin,
+      mergedPrCount: result.mergedPrCount,
+      syncedPrCount: result.syncedPrCount,
+    });
+  } catch (error) {
+    console.error("[profile/github/reconcile]", error);
+    return NextResponse.json(
+      { error: "Failed to reconcile GitHub pull requests" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/profile/subscription/route.ts
+++ b/app/api/profile/subscription/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 20 };
+
+/**
+ * Find the eventContacts doc for a user by checking their primary email
+ * and any additional verified emails.
+ */
+async function findContactDoc(
+  db: FirebaseFirestore.Firestore,
+  uid: string,
+  primaryEmail: string | null
+) {
+  // Try primary email first
+  if (primaryEmail) {
+    const ref = db.collection("eventContacts").doc(primaryEmail.toLowerCase());
+    const snap = await ref.get();
+    if (snap.exists) return { ref, data: snap.data()! };
+  }
+
+  // Try additional emails from the user doc
+  const userDoc = await db.collection("users").doc(uid).get();
+  const userData = userDoc.data();
+  const additionalEmails: { email: string; verified: boolean }[] =
+    userData?.additionalEmails || [];
+
+  for (const entry of additionalEmails) {
+    if (!entry.verified || !entry.email) continue;
+    const ref = db
+      .collection("eventContacts")
+      .doc(entry.email.toLowerCase());
+    const snap = await ref.get();
+    if (snap.exists) return { ref, data: snap.data()! };
+  }
+
+  return null;
+}
+
+/**
+ * GET /api/profile/subscription
+ * Returns the user's email subscription status.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`profile-sub:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests" },
+        { status: 429 }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const result = await findContactDoc(db, user.uid, user.email ?? null);
+
+    if (!result) {
+      // User has no eventContacts record — they're not on the list
+      return NextResponse.json({ onList: false, subscribed: false });
+    }
+
+    return NextResponse.json({
+      onList: true,
+      subscribed: result.data.unsubscribed !== true,
+    });
+  } catch {
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/profile/subscription
+ * Body: { subscribed: boolean }
+ * Updates the user's subscription preference in eventContacts.
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`profile-sub:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests" },
+        { status: 429 }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    let body: { subscribed?: boolean };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (typeof body.subscribed !== "boolean") {
+      return NextResponse.json(
+        { error: "subscribed must be a boolean" },
+        { status: 400 }
+      );
+    }
+
+    const result = await findContactDoc(db, user.uid, user.email ?? null);
+
+    if (!result) {
+      return NextResponse.json(
+        { error: "No event contact record found for your email" },
+        { status: 404 }
+      );
+    }
+
+    if (body.subscribed) {
+      await result.ref.update({
+        unsubscribed: false,
+        unsubscribedAt: FieldValue.delete(),
+        resubscribedAt: FieldValue.serverTimestamp(),
+      });
+    } else {
+      await result.ref.update({
+        unsubscribed: true,
+        unsubscribedAt: FieldValue.serverTimestamp(),
+      });
+    }
+
+    return NextResponse.json({ subscribed: body.subscribed });
+  } catch {
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,0 +1,98 @@
+import { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Unsubscribe - Cursor Boston",
+  description: "Manage your Cursor Boston email preferences.",
+};
+
+export default async function UnsubscribePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const { status } = await searchParams;
+
+  return (
+    <div className="flex flex-col">
+      <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="max-w-xl mx-auto text-center">
+          {status === "success" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                You&apos;ve been unsubscribed
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                You won&apos;t receive any more event update emails from Cursor
+                Boston. If you change your mind, just register for a future event
+                on Luma and let us know.
+              </p>
+            </>
+          )}
+          {status === "invalid" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Invalid link
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                This unsubscribe link is invalid or has already been used. If you
+                need help, email{" "}
+                <a
+                  href="mailto:hello@cursorboston.com"
+                  className="underline"
+                >
+                  hello@cursorboston.com
+                </a>
+                .
+              </p>
+            </>
+          )}
+          {status === "rate-limited" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Too many requests
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                Please wait a few minutes and try again.
+              </p>
+            </>
+          )}
+          {status === "error" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Something went wrong
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                We couldn&apos;t process your request. Please try again or email{" "}
+                <a
+                  href="mailto:hello@cursorboston.com"
+                  className="underline"
+                >
+                  hello@cursorboston.com
+                </a>
+                .
+              </p>
+            </>
+          )}
+          {!status && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Email preferences
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                Use the link in your email to manage your subscription
+                preferences.
+              </p>
+            </>
+          )}
+          <Link
+            href="/"
+            className="text-sm text-neutral-500 hover:text-foreground transition-colors"
+          >
+            &larr; Back to cursorboston.com
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -4,6 +4,7 @@ const LOGO_SRC = "/cursor-boston-logo.png";
 const ALT = "Cursor Boston";
 
 const sizeClasses = {
+  sm: "w-8 h-8",
   header: "w-12 h-12",
   footer: "w-12 h-12",
   hero: "w-28 h-28",
@@ -34,7 +35,9 @@ export default function Logo({ size, className = "", priority = false }: LogoPro
             ? "(min-width: 768px) 192px, 160px"
             : size === "hero"
               ? "112px"
-              : "48px"
+              : size === "sm"
+                ? "32px"
+                : "48px"
         }
       />
     </div>

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -278,5 +278,10 @@ service cloud.firestore {
     match /hackathonEventSignups/{docId} {
       allow read, write: if false;
     }
+
+    // Consolidated event contact list — Admin SDK only
+    match /eventContacts/{docId} {
+      allow read, write: if false;
+    }
   }
 }

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -93,6 +93,16 @@ type(scope): short description
 
 ## Step 6: Push and Open a Pull Request
 
+Before you push or open the PR, rebase your branch onto the latest `develop` so the diff stays clean and review only includes your work:
+
+```bash
+git fetch upstream
+git checkout docs/fix-typo-in-readme
+git rebase upstream/develop
+```
+
+If you already opened the PR and `develop` moved, rebase again and push the updated branch to the same PR.
+
 ```bash
 git push origin docs/fix-typo-in-readme
 ```
@@ -124,6 +134,7 @@ Then on GitHub:
 |---------|-----|
 | Forgot `-s` on commit | `git commit --amend -s` to add sign-off to the last commit |
 | PR targets `main` instead of `develop` | Edit the PR on GitHub and change the base branch to `develop` |
+| PR includes unrelated commits from an outdated branch | `git fetch upstream && git checkout your-branch && git rebase upstream/develop`, then push the rebased branch |
 | Pre-commit hook rejects commit | Run `npm run lint` and `npm run type-check` to see errors, fix them, and try again |
 | Commit message rejected by commitlint | Use the format `type(scope): description` — see the types table above |
 | Merge conflicts with `develop` | `git checkout develop && git pull upstream develop && git checkout your-branch && git rebase develop` |

--- a/lib/github-merged-pr-reconcile.ts
+++ b/lib/github-merged-pr-reconcile.ts
@@ -1,0 +1,183 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { logger } from "@/lib/logger";
+
+type SearchMergedPrItem = {
+  number: number;
+  title: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  user?: { login?: string } | null;
+};
+
+const SEARCH_PER_PAGE = 100;
+const SEARCH_MAX_PAGES = 10;
+const BATCH_WRITE_LIMIT = 400;
+
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export async function fetchMergedPullRequestsForAuthor(
+  githubLogin: string
+): Promise<SearchMergedPrItem[]> {
+  const login = githubLogin.trim();
+  if (!login) return [];
+
+  const { owner, repo } = getGithubRepoPair();
+  const query = `repo:${owner}/${repo} type:pr is:merged author:${login}`;
+  const headers = githubHeaders();
+  const items: SearchMergedPrItem[] = [];
+
+  for (let page = 1; page <= SEARCH_MAX_PAGES; page += 1) {
+    const url = new URL("https://api.github.com/search/issues");
+    url.searchParams.set("q", query);
+    url.searchParams.set("per_page", String(SEARCH_PER_PAGE));
+    url.searchParams.set("page", String(page));
+
+    const response = await fetch(url.toString(), {
+      headers,
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `GitHub merged PR search failed for ${login}: ${response.status} ${body}`
+      );
+    }
+
+    const data = (await response.json()) as { items?: SearchMergedPrItem[] };
+    const pageItems = Array.isArray(data.items) ? data.items : [];
+    if (pageItems.length === 0) break;
+
+    items.push(...pageItems);
+
+    if (pageItems.length < SEARCH_PER_PAGE) break;
+  }
+
+  return items;
+}
+
+async function countMergedRepoPullRequestsForUser(userId: string): Promise<number> {
+  const db = getAdminDb();
+  if (!db) {
+    throw new Error("Firebase Admin is not configured");
+  }
+
+  const { owner, repo } = getGithubRepoPair();
+  const expectedRepo = `${owner}/${repo}`;
+  const snapshot = await db
+    .collection("pullRequests")
+    .where("userId", "==", userId)
+    .where("state", "==", "merged")
+    .get();
+
+  let count = 0;
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const repository = data.repository;
+    if (
+      typeof repository === "string" &&
+      repository.length > 0 &&
+      repository !== expectedRepo
+    ) {
+      continue;
+    }
+    count += 1;
+  }
+
+  return count;
+}
+
+export async function reconcileMergedPrCreditForUser(
+  userId: string,
+  githubLogin: string
+): Promise<{ mergedPrCount: number; syncedPrCount: number }> {
+  const db = getAdminDb();
+  if (!db) {
+    throw new Error("Firebase Admin is not configured");
+  }
+
+  const login = githubLogin.trim();
+  if (!login) {
+    throw new Error("GitHub login is required");
+  }
+
+  const { owner, repo } = getGithubRepoPair();
+  const repository = `${owner}/${repo}`;
+  const mergedPrs = await fetchMergedPullRequestsForAuthor(login);
+
+  let batch = db.batch();
+  let writes = 0;
+
+  const flush = async () => {
+    if (writes === 0) return;
+    await batch.commit();
+    batch = db.batch();
+    writes = 0;
+  };
+
+  for (const pr of mergedPrs) {
+    batch.set(
+      db.collection("pullRequests").doc(`pr-${pr.number}`),
+      {
+        prNumber: pr.number,
+        title: pr.title,
+        state: "merged",
+        authorLogin: pr.user?.login ?? login,
+        userId,
+        url: pr.html_url,
+        repository,
+        createdAt: new Date(pr.created_at),
+        updatedAt: new Date(pr.updated_at),
+        mergedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+        isConnected: true,
+        lastProcessedAt: FieldValue.serverTimestamp(),
+        backfillSource: "github-connect-reconcile",
+      },
+      { merge: true }
+    );
+    writes += 1;
+
+    if (writes >= BATCH_WRITE_LIMIT) {
+      await flush();
+    }
+  }
+
+  await flush();
+
+  const mergedPrCount = await countMergedRepoPullRequestsForUser(userId);
+  await db.collection("users").doc(userId).set(
+    {
+      pullRequestsCount: mergedPrCount,
+      github: {
+        login,
+      },
+    },
+    { merge: true }
+  );
+
+  logger.info("Reconciled merged PR credit for user", {
+    userId,
+    githubLogin: login,
+    syncedPrCount: mergedPrs.length,
+    mergedPrCount,
+  });
+
+  return {
+    mergedPrCount,
+    syncedPrCount: mergedPrs.length,
+  };
+}

--- a/lib/registrations.ts
+++ b/lib/registrations.ts
@@ -117,10 +117,15 @@ export async function getUserStats(userId: string): Promise<UserStats> {
     (doc) => doc.data().status === "completed"
   ).length;
 
-  // Get PR count from user profile
-  const userRef = doc(db, "users", userId);
-  const userSnap = await getDoc(userRef);
-  const pullRequestsCount = userSnap.data()?.pullRequestsCount || 0;
+  // Count trusted merged PR records instead of relying only on a cached user field.
+  const pullRequestsRef = collection(db, "pullRequests");
+  const pullRequestsQuery = query(
+    pullRequestsRef,
+    where("userId", "==", userId),
+    where("state", "==", "merged")
+  );
+  const pullRequestsSnapshot = await getDocs(pullRequestsQuery);
+  const pullRequestsCount = pullRequestsSnapshot.size;
 
   return {
     eventsRegistered,

--- a/lib/unsubscribe-token.ts
+++ b/lib/unsubscribe-token.ts
@@ -1,0 +1,31 @@
+import { createHmac } from "crypto";
+
+const SECRET =
+  process.env.UNSUBSCRIBE_SECRET || process.env.NEXTAUTH_SECRET || "cursor-boston-unsub";
+
+/** Generate a deterministic HMAC token for an email address. */
+export function generateUnsubscribeToken(email: string): string {
+  return createHmac("sha256", SECRET)
+    .update(email.toLowerCase().trim())
+    .digest("hex");
+}
+
+/** Verify that a token matches the expected HMAC for the email. */
+export function verifyUnsubscribeToken(
+  email: string,
+  token: string
+): boolean {
+  const expected = generateUnsubscribeToken(email);
+  return expected === token;
+}
+
+/** Build a full unsubscribe URL for a given email. */
+export function buildUnsubscribeUrl(email: string): string {
+  const origin =
+    (process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com").replace(
+      /\/$/,
+      ""
+    );
+  const token = generateUnsubscribeToken(email);
+  return `${origin}/api/notifications/unsubscribe?email=${encodeURIComponent(email)}&token=${token}`;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -37,12 +37,13 @@ const nextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://embed.lu.ma",
+              // Firebase/Google OAuth popup flows load Google-hosted scripts.
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://embed.lu.ma https://apis.google.com https://accounts.google.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: blob: https://firebasestorage.googleapis.com https://*.googleusercontent.com https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://*.cartocdn.com https://unpkg.com",
               "font-src 'self'",
-              "connect-src 'self' https://*.firebaseio.com https://*.firebaseapp.com https://*.googleapis.com https://*.cartocdn.com https://unpkg.com",
-              "frame-src https://lu.ma https://luma.com",
+              "connect-src 'self' https://*.firebaseio.com https://*.firebaseapp.com https://*.googleapis.com https://accounts.google.com https://*.cartocdn.com https://unpkg.com",
+              "frame-src https://lu.ma https://luma.com https://accounts.google.com https://*.firebaseapp.com",
               "object-src 'none'",
               "base-uri 'self'",
               "form-action 'self'",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "rate-limit-cleanup": "tsx scripts/run-rate-limit-cleanup.ts",
     "backfill-merge-credit": "tsx scripts/backfill-merge-credit.ts",
     "send-hack-a-sprint-emails": "tsx scripts/send-hack-a-sprint-emails.ts",
+    "sync-event-contacts": "tsx scripts/sync-event-contacts.ts",
+    "send-contact-list-email": "tsx scripts/send-contact-list-email.ts",
     "prebuild": "npm run validate-env",
     "prepare": "husky install"
   },

--- a/scripts/send-contact-list-email.ts
+++ b/scripts/send-contact-list-email.ts
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Send a one-time announcement to all eventContacts informing them about
+ * the email list, listing which events they registered for, and giving
+ * them an unsubscribe link.
+ *
+ * Usage:
+ *   npx tsx scripts/send-contact-list-email.ts --dry-run
+ *   npx tsx scripts/send-contact-list-email.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const SITE_ORIGIN = (
+  process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com"
+).replace(/\/$/, "");
+
+// ---------------------------------------------------------------------------
+// Email template
+// ---------------------------------------------------------------------------
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+  events: {
+    eventName: string;
+    checkedIn: boolean;
+    approvalStatus: string;
+  }[];
+}
+
+function buildEmail(contact: ContactData): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
+  );
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  // Event list
+  const eventLines = contact.events.map((e) => {
+    const status = e.checkedIn ? "Attended" : e.approvalStatus === "approved" ? "Registered" : "Registered";
+    return `<li><strong>${escapeHtml(e.eventName)}</strong> — ${status}</li>`;
+  });
+
+  const eventTextLines = contact.events.map((e) => {
+    const status = e.checkedIn ? "Attended" : "Registered";
+    return `  - ${e.eventName} (${status})`;
+  });
+
+  const subject = "Cursor Boston — Your event history & community updates";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Thank you for being part of the Cursor Boston community! We're putting together a contact list so we can keep you posted on upcoming events, workshops, and community news.</p>
+
+<p><strong>Your Cursor Boston events:</strong></p>
+<ul>
+${eventLines.join("\n")}
+</ul>
+
+<p>This email list is built from your Luma event registrations. Going forward, we'll send occasional updates about new events, community highlights, and opportunities. We'll keep it useful and infrequent — no spam.</p>
+
+<p><strong>Upcoming:</strong></p>
+<ul>
+<li><strong>Hack-a-Sprint</strong> — April 13, 2026, 4:00–8:00 PM ET, Back Bay, Boston (<a href="https://luma.com/uixo8hl6">Luma</a>)</li>
+<li><strong>Open Source Workshop</strong> — May 30, 2026, 12:00–5:00 PM ET, Boston (<a href="https://luma.com/w4gvg7fl">Luma</a>)</li>
+</ul>
+
+<p>Visit <a href="${escapeHtml(SITE_ORIGIN)}">${escapeHtml(SITE_ORIGIN)}</a> to see all events, join the community, and connect your GitHub profile.</p>
+
+<p>See you at the next one!</p>
+
+<p>— The Cursor Boston Team</p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you registered for a Cursor Boston event on Luma.<br/>
+Don't want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"},
+
+Thank you for being part of the Cursor Boston community! We're putting together a contact list so we can keep you posted on upcoming events, workshops, and community news.
+
+Your Cursor Boston events:
+${eventTextLines.join("\n")}
+
+This email list is built from your Luma event registrations. Going forward, we'll send occasional updates about new events, community highlights, and opportunities.
+
+Upcoming:
+  - Hack-a-Sprint — April 13, 2026, 4:00-8:00 PM ET, Back Bay, Boston (https://luma.com/uixo8hl6)
+  - Open Source Workshop — May 30, 2026, 12:00-5:00 PM ET, Boston (https://luma.com/w4gvg7fl)
+
+Visit ${SITE_ORIGIN} to see all events and join the community.
+
+See you at the next one!
+— The Cursor Boston Team
+
+You're receiving this because you registered for a Cursor Boston event on Luma.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+  let skippedDeclinedOnly = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+
+    // Skip unsubscribed contacts
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+
+    const events: ContactData["events"] = (data.events || []).map(
+      (e: { eventName?: string; checkedIn?: boolean; approvalStatus?: string }) => ({
+        eventName: e.eventName || "",
+        checkedIn: e.checkedIn || false,
+        approvalStatus: e.approvalStatus || "",
+      })
+    );
+
+    // Count declined-only for reporting but still include them
+    if (events.length > 0 && events.every((e) => e.approvalStatus === "declined")) {
+      skippedDeclinedOnly++;
+    }
+
+    contacts.push({
+      email: data.email || doc.id,
+      name: data.name || "",
+      firstName: data.firstName || "",
+      events,
+    });
+  }
+
+  console.log(
+    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed} | Declined-only (still included): ${skippedDeclinedOnly}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+
+    // Show sample
+    const sample = contacts[0];
+    if (sample) {
+      const { subject, html } = buildEmail(sample);
+      console.log(`Sample email to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`Events: ${sample.events.map((e) => e.eventName).join(", ")}`);
+      console.log(`\nHTML preview:\n---\n${html.slice(0, 600)}…\n---`);
+    }
+
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  // Send emails
+  let sent = 0;
+  let failed = 0;
+
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 50 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(
+    `\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed + skippedDeclinedOnly}.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/sync-event-contacts.ts
+++ b/scripts/sync-event-contacts.ts
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+/**
+ * Sync Luma CSV exports into the Firestore `eventContacts` collection.
+ *
+ * Reads one or more Luma guest-export CSVs, deduplicates by email, and
+ * upserts each contact into Firestore. Existing documents are merged so
+ * re-running the script with new event exports is safe and additive.
+ *
+ * Usage:
+ *   npx tsx scripts/sync-event-contacts.ts --dry-run <csv1> [csv2 ...]
+ *   npx tsx scripts/sync-event-contacts.ts --write  <csv1> [csv2 ...]
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ */
+import { readFileSync } from "fs";
+import { basename } from "path";
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type CsvRow = Record<string, string>;
+
+interface EventAttendance {
+  eventName: string;
+  csvFile: string;
+  registeredAt: string;
+  approvalStatus: string;
+  checkedIn: boolean;
+  checkedInAt: string | null;
+  ticketType: string | null;
+}
+
+interface ContactRecord {
+  email: string;
+  name: string;
+  firstName: string;
+  lastName: string;
+  events: EventAttendance[];
+  eventNames: string[];
+  totalEvents: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  updatedAt: FieldValue;
+}
+
+// ---------------------------------------------------------------------------
+// CSV parser (reused from send-hack-a-sprint-emails.ts)
+// ---------------------------------------------------------------------------
+
+function parseCsv(content: string): CsvRow[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      /* ignore */
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((cell) => cell.length > 0)) {
+    rows.push(row);
+  }
+
+  if (rows.length < 2) return [];
+
+  const header = rows[0]!.map((h) => h.trim());
+  const out: CsvRow[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const line = rows[r]!;
+    const obj: CsvRow = {};
+    for (let j = 0; j < header.length; j++) {
+      obj[header[j]!] = (line[j] ?? "").trim();
+    }
+    out.push(obj);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Event name inference from CSV filename
+// ---------------------------------------------------------------------------
+
+/** Infer event name from a Luma CSV filename like
+ *  "Cursor Boston Hack-a-Sprint - Guests - 2026-04-06-13-49-16.csv"
+ *  → "Cursor Boston Hack-a-Sprint" */
+function inferEventName(csvPath: string): string {
+  const base = basename(csvPath, ".csv");
+  const guestsIdx = base.indexOf(" - Guests");
+  if (guestsIdx > 0) return base.slice(0, guestsIdx).trim();
+  return base.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Build contact map from CSVs
+// ---------------------------------------------------------------------------
+
+function buildContactMap(
+  csvPaths: string[]
+): Map<string, { name: string; firstName: string; lastName: string; events: EventAttendance[] }> {
+  const contacts = new Map<
+    string,
+    { name: string; firstName: string; lastName: string; events: EventAttendance[] }
+  >();
+
+  for (const csvPath of csvPaths) {
+    let raw: string;
+    try {
+      raw = readFileSync(csvPath, "utf8");
+    } catch (e) {
+      console.error(`Cannot read CSV: ${csvPath}`, e);
+      process.exit(1);
+    }
+
+    // Strip BOM
+    if (raw.charCodeAt(0) === 0xfeff) {
+      raw = raw.slice(1);
+    }
+
+    const rows = parseCsv(raw);
+    if (rows.length === 0) {
+      console.warn(`[warn] No data rows in ${csvPath}, skipping.`);
+      continue;
+    }
+
+    const eventName = inferEventName(csvPath);
+    const csvFile = basename(csvPath);
+    console.log(`  ${csvFile}: ${rows.length} rows → "${eventName}"`);
+
+    for (const row of rows) {
+      const emailRaw = row.email?.trim();
+      if (!emailRaw) continue;
+      const email = emailRaw.toLowerCase();
+
+      const firstName = row.first_name?.trim() || "";
+      const lastName = row.last_name?.trim() || "";
+      const name = row.name?.trim() || [firstName, lastName].filter(Boolean).join(" ");
+
+      const attendance: EventAttendance = {
+        eventName,
+        csvFile,
+        registeredAt: row.created_at?.trim() || "",
+        approvalStatus: (row.approval_status || "").trim().toLowerCase(),
+        checkedIn: !!(row.checked_in_at?.trim()),
+        checkedInAt: row.checked_in_at?.trim() || null,
+        ticketType: row.ticket_name?.trim() || null,
+      };
+
+      const existing = contacts.get(email);
+      if (existing) {
+        // Avoid duplicate event entries for the same event
+        const alreadyHasEvent = existing.events.some(
+          (e) => e.eventName === eventName
+        );
+        if (alreadyHasEvent) {
+          // Merge: prefer the entry with a check-in if current one doesn't have it
+          const idx = existing.events.findIndex((e) => e.eventName === eventName);
+          if (idx >= 0 && attendance.checkedIn && !existing.events[idx]!.checkedIn) {
+            existing.events[idx] = attendance;
+          }
+        } else {
+          existing.events.push(attendance);
+        }
+        // Update name if we have a better one
+        if (!existing.name && name) {
+          existing.name = name;
+          existing.firstName = firstName;
+          existing.lastName = lastName;
+        }
+      } else {
+        contacts.set(email, {
+          name,
+          firstName,
+          lastName,
+          events: [attendance],
+        });
+      }
+    }
+  }
+
+  return contacts;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]) {
+  const dryRun = argv.includes("--dry-run");
+  const write = argv.includes("--write");
+
+  if ((dryRun && write) || (!dryRun && !write)) {
+    console.error("Specify exactly one of: --dry-run | --write");
+    process.exit(1);
+  }
+
+  const csvPaths = argv.filter((a) => !a.startsWith("--"));
+  if (csvPaths.length === 0) {
+    console.error("Provide at least one CSV file path.");
+    process.exit(1);
+  }
+
+  return { dryRun, write, csvPaths };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const COLLECTION = "eventContacts";
+const BATCH_SIZE = 500; // Firestore batch limit
+
+async function main() {
+  const { dryRun, csvPaths } = parseArgs(process.argv.slice(2));
+
+  console.log(`\nParsing ${csvPaths.length} CSV file(s)…`);
+  const contacts = buildContactMap(csvPaths);
+  console.log(`\nUnique emails: ${contacts.size}`);
+
+  // Summary table
+  const eventCounts = new Map<string, number>();
+  for (const [, c] of contacts) {
+    for (const e of c.events) {
+      eventCounts.set(e.eventName, (eventCounts.get(e.eventName) ?? 0) + 1);
+    }
+  }
+  console.log("\nPer-event breakdown:");
+  for (const [name, count] of [...eventCounts.entries()].sort()) {
+    console.log(`  ${name}: ${count} registrants`);
+  }
+
+  // Multi-event contacts
+  const multiEvent = [...contacts.values()].filter((c) => c.events.length > 1);
+  console.log(`\nContacts at 2+ events: ${multiEvent.length}`);
+
+  // Checked-in stats
+  const checkedInAny = [...contacts.values()].filter((c) =>
+    c.events.some((e) => e.checkedIn)
+  );
+  console.log(`Contacts who checked in at least once: ${checkedInAny.length}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no Firestore writes. Preview:\n");
+    const sorted = [...contacts.entries()].sort((a, b) =>
+      b[1].events.length - a[1].events.length || a[0].localeCompare(b[0])
+    );
+    const pad = (s: string, n: number) => s.slice(0, n).padEnd(n);
+    for (const [email, c] of sorted) {
+      const events = c.events.map((e) => {
+        const check = e.checkedIn ? "✓" : "○";
+        return `${check} ${e.eventName}`;
+      });
+      console.log(
+        `${pad(email, 42)} ${pad(c.name || "(no name)", 25)} [${events.join(", ")}]`
+      );
+    }
+    console.log(`\nTotal: ${contacts.size} unique contacts`);
+    return;
+  }
+
+  // Write to Firestore
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nWriting ${contacts.size} contacts to Firestore "${COLLECTION}"…`);
+
+  const entries = [...contacts.entries()];
+  let written = 0;
+  let updated = 0;
+
+  for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+    const chunk = entries.slice(i, i + BATCH_SIZE);
+    const batch = db.batch();
+
+    for (const [email, c] of chunk) {
+      const docRef = db.collection(COLLECTION).doc(email);
+      const existing = await docRef.get();
+
+      const allDates = c.events
+        .map((e) => e.registeredAt)
+        .filter(Boolean)
+        .sort();
+      const firstSeenAt = allDates[0] || "";
+      const lastSeenAt = allDates[allDates.length - 1] || "";
+
+      if (existing.exists) {
+        // Merge: append new events, update metadata
+        const data = existing.data()!;
+        const existingEvents: EventAttendance[] = data.events || [];
+
+        const mergedEvents = [...existingEvents];
+        for (const newEvt of c.events) {
+          const idx = mergedEvents.findIndex(
+            (e) => e.eventName === newEvt.eventName
+          );
+          if (idx >= 0) {
+            // Prefer entry with check-in data
+            if (newEvt.checkedIn && !mergedEvents[idx]!.checkedIn) {
+              mergedEvents[idx] = newEvt;
+            }
+          } else {
+            mergedEvents.push(newEvt);
+          }
+        }
+
+        const mergedEventNames = [
+          ...new Set(mergedEvents.map((e) => e.eventName)),
+        ];
+
+        const mergedDates = mergedEvents
+          .map((e) => e.registeredAt)
+          .filter(Boolean)
+          .sort();
+
+        batch.update(docRef, {
+          name: c.name || data.name || "",
+          firstName: c.firstName || data.firstName || "",
+          lastName: c.lastName || data.lastName || "",
+          events: mergedEvents,
+          eventNames: mergedEventNames,
+          totalEvents: mergedEventNames.length,
+          firstSeenAt: mergedDates[0] || data.firstSeenAt || "",
+          lastSeenAt: mergedDates[mergedDates.length - 1] || data.lastSeenAt || "",
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+        updated++;
+      } else {
+        const eventNames = [...new Set(c.events.map((e) => e.eventName))];
+        const record: ContactRecord = {
+          email,
+          name: c.name,
+          firstName: c.firstName,
+          lastName: c.lastName,
+          events: c.events,
+          eventNames,
+          totalEvents: eventNames.length,
+          firstSeenAt,
+          lastSeenAt,
+          updatedAt: FieldValue.serverTimestamp(),
+        };
+        batch.set(docRef, record);
+        written++;
+      }
+    }
+
+    await batch.commit();
+    console.log(
+      `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${chunk.length} docs committed`
+    );
+  }
+
+  console.log(
+    `\nDone. Created ${written}, updated ${updated} (total ${contacts.size} contacts in "${COLLECTION}").`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a small (`sm`, 32×32) size to `Logo` for use in compact contexts like notifications, mobile chips, or icon-only buttons.

## Changes
- `components/Logo.tsx`: Add `sm` to `sizeClasses` and handle it in the `sizes` attribute

## Test plan
- [ ] `<Logo size="sm" />` renders a 32×32 logo
- [ ] All existing size variants are unaffected