### PR TITLE
feat: add editedAt and isPinned fields to Message type

### DIFF
--- a/types/feed.ts
+++ b/types/feed.ts
@@ -23,6 +23,8 @@ export interface Message {
   dislikeCount?: number;
   replyCount?: number;
   repostCount?: number;
+  editedAt?: Timestamp;
+  isPinned?: boolean;
 }
 
 export interface Reaction {


### PR DESCRIPTION
Adds two optional fields to the `Message` interface to support future edit history and pinned message features.

## Changes
- `editedAt?: Timestamp` — tracks when a message was last edited
- `isPinned?: boolean` — marks a message as pinned in a channel

## Files changed
- `types/feed.ts`

## Test plan
- [ ] Existing messages without these fields are unaffected (both optional)
- [ ] TypeScript compiles without errors