### PR TITLE
fix(error-boundary): add root and global error boundaries with retry support

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[Error Boundary]', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center p-8">
+      <div className="text-center max-w-md">
+        <h2 className="text-xl font-semibold text-foreground mb-2">
+          Something went wrong
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+          An unexpected error occurred. You can try again or reload the page.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={reset}
+            className="px-6 py-3 bg-emerald-500 text-white rounded-lg font-medium hover:bg-emerald-400 transition-colors"
+          >
+            Try again
+          </button>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-6 py-3 border border-neutral-300 dark:border-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg font-medium hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+          >
+            Reload page
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[Global Error Boundary]', error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <div className="min-h-screen flex items-center justify-center p-8">
+          <div className="text-center max-w-md">
+            <h2 className="text-xl font-semibold mb-2">
+              Something went wrong
+            </h2>
+            <p className="text-neutral-600 mb-6">
+              A critical error occurred. You can try again or reload the page.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <button
+                onClick={reset}
+                className="px-6 py-3 bg-emerald-500 text-white rounded-lg font-medium hover:bg-emerald-400 transition-colors"
+              >
+                Try again
+              </button>
+              <button
+                onClick={() => window.location.reload()}
+                className="px-6 py-3 border border-neutral-300 text-neutral-700 rounded-lg font-medium hover:bg-neutral-100 transition-colors"
+              >
+                Reload page
+              </button>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -38,17 +38,22 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               Something went wrong
             </h2>
             <p className="text-neutral-600 dark:text-neutral-400 mb-6">
-              An unexpected error occurred. Please try reloading the page.
+              An unexpected error occurred. You can try again or reload the page.
             </p>
-            <button
-              onClick={() => {
-                this.setState({ hasError: false });
-                window.location.reload();
-              }}
-              className="px-6 py-3 bg-emerald-500 text-white rounded-lg font-medium hover:bg-emerald-400 transition-colors"
-            >
-              Reload Page
-            </button>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <button
+                onClick={() => this.setState({ hasError: false })}
+                className="px-6 py-3 bg-emerald-500 text-white rounded-lg font-medium hover:bg-emerald-400 transition-colors"
+              >
+                Try again
+              </button>
+              <button
+                onClick={() => window.location.reload()}
+                className="px-6 py-3 border border-neutral-300 dark:border-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg font-medium hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              >
+                Reload page
+              </button>
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
## Description
The application had no global error recovery mechanism. If a React component threw during render, the entire page would crash with no user-facing recovery path. This PR adds a root-level error boundary via Next.js `app/error.tsx`, a global error boundary via `app/global-error.tsx`, and updates the existing `ErrorBoundary` component with a retry action alongside the reload option. Errors are logged to the console for debugging.

Fixes #251

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally by throwing a test error in `app/events/page.tsx` and confirming the fallback UI renders with working "Try again" and "Reload page" buttons

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Screenshot
<img width="1792" height="608" alt="Screenshot 2026-04-08 at 9 40 14 PM" src="https://github.com/user-attachments/assets/2ae27862-482a-4915-8c4c-e98117a54b22" />
