### PR TITLE
[codex] chore(contributors): map samblouir github username

### DIFF
--- a/.github-usernames
+++ b/.github-usernames
@@ -15,3 +15,4 @@ JKaroki@student.hult.edu JoyNKaroki
 joaquin.moyano.rugby@gmail.com joaquinmoyanorugby-png
 Join@4goodvibes.shop Kissprisonblock2018
 dungarani.j@northeastern.edu 17-jd
+scblouir+github@gmail.com samblouir


### PR DESCRIPTION
## What changed
- add `scblouir+github@gmail.com samblouir` to `.github-usernames`

## Why
- this repository uses `.github-usernames` to map non-noreply commit emails to GitHub usernames for contributor tooling
- adding this mapping ensures future merged commits from this email resolve cleanly to `@samblouir`

## User impact
- improves contributor attribution for Sam Blouir
- no runtime or product behavior changes

## Validation
- `git diff --check`
