### PR TITLE
[codex] chore(contributors): replace samblouir email mapping

### DIFF
--- a/.github-usernames
+++ b/.github-usernames
@@ -15,4 +15,4 @@ JKaroki@student.hult.edu JoyNKaroki
 joaquin.moyano.rugby@gmail.com joaquinmoyanorugby-png
 Join@4goodvibes.shop Kissprisonblock2018
 dungarani.j@northeastern.edu 17-jd
-scblouir+github@gmail.com samblouir
+scblouir@gmail.com samblouir


### PR DESCRIPTION
## What changed
- replace `scblouir+github@gmail.com` with `scblouir@gmail.com` in `.github-usernames`

## Why
- PR #331 merged before the corrected author email rewrite could propagate
- this follow-up keeps the contributor mapping aligned with the intended email address

## User impact
- future contributor tooling will resolve Sam Blouir from `scblouir@gmail.com`
- no runtime or product behavior changes

## Validation
- `git diff --check`
