### PR TITLE
fix(a11y): add descriptive alt text to team logo images

### DIFF
--- a/app/hackathons/pool/page.tsx
+++ b/app/hackathons/pool/page.tsx
@@ -626,7 +626,7 @@ function HackathonsPoolPageContent() {
                           // eslint-disable-next-line @next/next/no-img-element
                           <img
                             src={t.logoUrl}
-                            alt=""
+                            alt={`${teamDisplayName(t)} logo`}
                             width={20}
                             height={20}
                             className="rounded-full object-cover w-5 h-5"

--- a/app/hackathons/teams/page.tsx
+++ b/app/hackathons/teams/page.tsx
@@ -269,7 +269,7 @@ function TeamsPageContent() {
                             // eslint-disable-next-line @next/next/no-img-element
                             <img
                               src={t.logoUrl}
-                              alt=""
+                              alt={`${teamDisplayName(t)} logo`}
                               width={28}
                               height={28}
                               className="rounded-full object-cover w-7 h-7"
@@ -386,7 +386,7 @@ function TeamsPageContent() {
                             // eslint-disable-next-line @next/next/no-img-element
                             <img
                               src={t.logoUrl}
-                              alt=""
+                              alt={`${teamDisplayName(t)} logo`}
                               width={24}
                               height={24}
                               className="rounded-full object-cover w-6 h-6"


### PR DESCRIPTION
## Summary
- Replace empty `alt=""` with `alt={`${teamDisplayName(t)} logo`}` on team logo `<img>` elements
- Affected files: `app/hackathons/teams/page.tsx` (2 instances), `app/hackathons/pool/page.tsx` (1 instance)
- Empty alt text on non-decorative images fails WCAG 2.1 SC 1.1.1 (Non-text Content)

## Test plan
- [ ] Verify screen reader announces team name when focusing team logo
- [ ] Confirm no visual regression on `/hackathons/teams` and `/hackathons/pool` pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)