### PR TITLE
chore: add GPL-3.0 copyright headers to source files + Pre commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # Scan for secrets in staged files (if gitleaks is installed)
-if command -v gitleaks &> /dev/null; then
+if command -v gitleaks > /dev/null 2>&1; then
   echo "🔍 Scanning for secrets..."
   gitleaks protect --staged --verbose
   if [ $? -ne 0 ]; then
@@ -12,5 +12,12 @@ if command -v gitleaks &> /dev/null; then
   echo "✅ No secrets detected"
 fi
 
-# Run lint-staged
+# Add GPL headers where missing
+echo "📝 Ensuring GPL headers are present..."
+npm run add:gpl-headers
+
+# Re-stage files that may have been modified by the header script
+git add app lib components hooks contexts types
+
+# Run lint-staged on final staged content
 npx lint-staged

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, Suspense } from "react";

--- a/app/(auth)/profile/_components/ActivitySection.tsx
+++ b/app/(auth)/profile/_components/ActivitySection.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/app/(auth)/profile/_components/ConnectionsSection.tsx
+++ b/app/(auth)/profile/_components/ConnectionsSection.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import {

--- a/app/(auth)/profile/_components/EarnedBadgesSection.tsx
+++ b/app/(auth)/profile/_components/EarnedBadgesSection.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/app/(auth)/profile/_components/EditProfileModal.tsx
+++ b/app/(auth)/profile/_components/EditProfileModal.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useRef, useState } from "react";

--- a/app/(auth)/profile/_components/EventsTab.tsx
+++ b/app/(auth)/profile/_components/EventsTab.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/app/(auth)/profile/_components/OnboardingChecklist.tsx
+++ b/app/(auth)/profile/_components/OnboardingChecklist.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/app/(auth)/profile/_components/OverviewTab.tsx
+++ b/app/(auth)/profile/_components/OverviewTab.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/app/(auth)/profile/_components/ProfileHeader.tsx
+++ b/app/(auth)/profile/_components/ProfileHeader.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Avatar from "@/components/Avatar";

--- a/app/(auth)/profile/_components/ProfileTabs.tsx
+++ b/app/(auth)/profile/_components/ProfileTabs.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import type { Tab } from "../_types";

--- a/app/(auth)/profile/_components/SecurityTab.tsx
+++ b/app/(auth)/profile/_components/SecurityTab.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Image from "next/image";

--- a/app/(auth)/profile/_components/SettingsTab.tsx
+++ b/app/(auth)/profile/_components/SettingsTab.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useCallback, useEffect, useState } from "react";

--- a/app/(auth)/profile/_components/StatsGrid.tsx
+++ b/app/(auth)/profile/_components/StatsGrid.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useProfileContext } from "../_contexts/ProfileContext";

--- a/app/(auth)/profile/_components/TalksTab.tsx
+++ b/app/(auth)/profile/_components/TalksTab.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/app/(auth)/profile/_contexts/ProfileContext.tsx
+++ b/app/(auth)/profile/_contexts/ProfileContext.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { createContext, useContext, useState } from "react";

--- a/app/(auth)/profile/_hooks/useBadges.ts
+++ b/app/(auth)/profile/_hooks/useBadges.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/app/(auth)/profile/_hooks/useDiscordConnection.ts
+++ b/app/(auth)/profile/_hooks/useDiscordConnection.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { doc, updateDoc, serverTimestamp, deleteField } from "firebase/firestore";

--- a/app/(auth)/profile/_hooks/useEmailManagement.ts
+++ b/app/(auth)/profile/_hooks/useEmailManagement.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useState } from "react";
 import { User } from "firebase/auth";
 

--- a/app/(auth)/profile/_hooks/useGithubConnection.ts
+++ b/app/(auth)/profile/_hooks/useGithubConnection.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { doc, updateDoc, serverTimestamp, deleteField } from "firebase/firestore";

--- a/app/(auth)/profile/_hooks/useGoogleConnection.ts
+++ b/app/(auth)/profile/_hooks/useGoogleConnection.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useMemo, useState } from "react";
 import { unlink, User } from "firebase/auth";
 import { auth } from "@/lib/firebase";

--- a/app/(auth)/profile/_hooks/useMfaEnrollment.ts
+++ b/app/(auth)/profile/_hooks/useMfaEnrollment.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useMemo, useRef, useState } from "react";
 import {
   PhoneAuthProvider,

--- a/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
+++ b/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect } from "react";

--- a/app/(auth)/profile/_hooks/useProfileData.ts
+++ b/app/(auth)/profile/_hooks/useProfileData.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/app/(auth)/profile/_hooks/useProfileSettings.ts
+++ b/app/(auth)/profile/_hooks/useProfileSettings.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useEffect, useState } from "react";
 import { doc, updateDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";

--- a/app/(auth)/profile/_types/index.ts
+++ b/app/(auth)/profile/_types/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 export type Tab = "overview" | "events" | "talks" | "security" | "settings";
 
 export interface TalkSubmission {

--- a/app/(auth)/profile/layout.tsx
+++ b/app/(auth)/profile/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, Suspense, useState } from "react";

--- a/app/(auth)/signup/layout.tsx
+++ b/app/(auth)/signup/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, Suspense } from "react";

--- a/app/about-cursor/page.tsx
+++ b/app/about-cursor/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 import Logo from "@/components/Logo";

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Logo from "@/components/Logo";
 import { DiscordIcon } from "@/components/icons";

--- a/app/accessibility/page.tsx
+++ b/app/accessibility/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/agents/claim/[token]/layout.tsx
+++ b/app/agents/claim/[token]/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/agents/claim/[token]/page.tsx
+++ b/app/agents/claim/[token]/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, use, useCallback } from "react";

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import AnalyticsDashboard from "@/components/AnalyticsDashboard";
 

--- a/app/api/agents/claim/[token]/route.ts
+++ b/app/api/agents/claim/[token]/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAgentByClaimToken, claimAgent } from "@/lib/agents";
 import { getVerifiedUser } from "@/lib/server-auth";

--- a/app/api/agents/me/route.ts
+++ b/app/api/agents/me/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import {
   getVerifiedAgent,

--- a/app/api/agents/register/route.ts
+++ b/app/api/agents/register/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { createAgent, getVerifiedAgent } from "@/lib/agents";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";

--- a/app/api/agents/user/route.ts
+++ b/app/api/agents/user/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAgentsByOwner } from "@/lib/agents";

--- a/app/api/analytics/summary/route.ts
+++ b/app/api/analytics/summary/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { logger } from "@/lib/logger";

--- a/app/api/auth/change-primary-email/route.ts
+++ b/app/api/auth/change-primary-email/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";

--- a/app/api/auth/remove-email/route.ts
+++ b/app/api/auth/remove-email/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/auth/resolve-email/route.ts
+++ b/app/api/auth/resolve-email/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
 

--- a/app/api/auth/send-email-verification/route.ts
+++ b/app/api/auth/send-email-verification/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "crypto";
 import { getVerifiedUser } from "@/lib/server-auth";

--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";

--- a/app/api/badges/awards/route.ts
+++ b/app/api/badges/awards/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/badges/definitions/route.ts
+++ b/app/api/badges/definitions/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";

--- a/app/api/cfp/send-edu-code/route.ts
+++ b/app/api/cfp/send-edu-code/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { randomInt } from "crypto";
 import { getVerifiedUser } from "@/lib/server-auth";

--- a/app/api/cfp/verify-edu-code/route.ts
+++ b/app/api/cfp/verify-edu-code/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/community/delete/route.ts
+++ b/app/api/community/delete/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";

--- a/app/api/community/post/route.ts
+++ b/app/api/community/post/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/community/reaction/route.ts
+++ b/app/api/community/reaction/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/community/reply/route.ts
+++ b/app/api/community/reply/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/community/repost/route.ts
+++ b/app/api/community/repost/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/cookbook/entries/route.ts
+++ b/app/api/cookbook/entries/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import type {
   DocumentSnapshot,

--- a/app/api/cookbook/vote/route.ts
+++ b/app/api/cookbook/vote/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/discord/authorize/route.ts
+++ b/app/api/discord/authorize/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { randomBytes } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 

--- a/app/api/discord/callback/route.ts
+++ b/app/api/discord/callback/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import { logger } from "@/lib/logger";

--- a/app/api/events/[eventId]/coworking/eligibility/route.ts
+++ b/app/api/events/[eventId]/coworking/eligibility/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { checkCoworkingEligibility } from "@/lib/coworking";

--- a/app/api/events/[eventId]/coworking/register/route.ts
+++ b/app/api/events/[eventId]/coworking/register/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {

--- a/app/api/events/[eventId]/coworking/slots/route.ts
+++ b/app/api/events/[eventId]/coworking/slots/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getSessionsWithStatus } from "@/lib/coworking";

--- a/app/api/github/authorize/route.ts
+++ b/app/api/github/authorize/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { randomBytes } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import { logger } from "@/lib/logger";

--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import {

--- a/app/api/hackathons/eligibility/route.ts
+++ b/app/api/hackathons/eligibility/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";

--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";

--- a/app/api/hackathons/invites/accept/route.ts
+++ b/app/api/hackathons/invites/accept/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/pool/join/route.ts
+++ b/app/api/hackathons/pool/join/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/requests/accept/route.ts
+++ b/app/api/hackathons/requests/accept/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import type { DocumentData } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/me/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/me/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/submissions/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/submissions/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import type { DocumentData } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/unlock/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/vote/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/submissions/check-disqualified/route.ts
+++ b/app/api/hackathons/submissions/check-disqualified/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/submissions/register/route.ts
+++ b/app/api/hackathons/submissions/register/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/submissions/submit/route.ts
+++ b/app/api/hackathons/submissions/submit/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/team/leave/route.ts
+++ b/app/api/hackathons/team/leave/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/hackathons/team/profile/route.ts
+++ b/app/api/hackathons/team/profile/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextResponse } from 'next/server';
 
 /**

--- a/app/api/internal/rate-limits/cleanup/route.ts
+++ b/app/api/internal/rate-limits/cleanup/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { Timestamp } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/live/[sessionId]/control/route.ts
+++ b/app/api/live/[sessionId]/control/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {

--- a/app/api/live/[sessionId]/queue/route.ts
+++ b/app/api/live/[sessionId]/queue/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { sanitizeText } from "@/lib/sanitize";

--- a/app/api/live/session/route.ts
+++ b/app/api/live/session/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { sanitizeText } from "@/lib/sanitize";

--- a/app/api/notifications/unsubscribe/route.ts
+++ b/app/api/notifications/unsubscribe/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { verifyUnsubscribeToken } from "@/lib/unsubscribe-token";

--- a/app/api/notify-admin/cfp/route.ts
+++ b/app/api/notify-admin/cfp/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { sendEmail } from "@/lib/mailgun";
 

--- a/app/api/notify-admin/event/route.ts
+++ b/app/api/notify-admin/event/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { sendEmail } from "@/lib/mailgun";
 

--- a/app/api/notify-admin/talk/route.ts
+++ b/app/api/notify-admin/talk/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { sendEmail } from "@/lib/mailgun";
 

--- a/app/api/pair/matches/route.ts
+++ b/app/api/pair/matches/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {

--- a/app/api/pair/profile/route.ts
+++ b/app/api/pair/profile/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {

--- a/app/api/pair/request/route.ts
+++ b/app/api/pair/request/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {

--- a/app/api/pair/respond/route.ts
+++ b/app/api/pair/respond/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {

--- a/app/api/profile/github/reconcile/route.ts
+++ b/app/api/profile/github/reconcile/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/profile/subscription/route.ts
+++ b/app/api/profile/subscription/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/profile/update/route.ts
+++ b/app/api/profile/update/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/profile/visibility/route.ts
+++ b/app/api/profile/visibility/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/showcase/submission/approve/route.ts
+++ b/app/api/showcase/submission/approve/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/showcase/submission/route.ts
+++ b/app/api/showcase/submission/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/showcase/vote/route.ts
+++ b/app/api/showcase/vote/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/api/talks/submission/moderate/route.ts
+++ b/app/api/talks/submission/moderate/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { ImageResponse } from "next/og";
 
 export const runtime = "edge";

--- a/app/badges/page.tsx
+++ b/app/badges/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 import { getAllPosts } from "@/lib/blog";

--- a/app/cfp/page.tsx
+++ b/app/cfp/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, useCallback } from "react";

--- a/app/code-of-conduct/page.tsx
+++ b/app/code-of-conduct/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 

--- a/app/cookbook/layout.tsx
+++ b/app/cookbook/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { Metadata } from "next";
 
 const title = "Prompt & Rules Cookbook | Cursor Boston";

--- a/app/cookbook/page.tsx
+++ b/app/cookbook/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, useCallback } from "react";

--- a/app/cookies/page.tsx
+++ b/app/cookies/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 'use client';
 
 import { useEffect } from 'react';

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";

--- a/app/events/request/layout.tsx
+++ b/app/events/request/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/events/request/page.tsx
+++ b/app/events/request/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, useCallback } from "react";

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { getAllPosts } from '@/lib/blog';
 
 export async function GET() {

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 'use client';
 
 import { useEffect } from 'react';

--- a/app/hackathons/hack-a-sprint-2026/admin/layout.tsx
+++ b/app/hackathons/hack-a-sprint-2026/admin/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/hackathons/hack-a-sprint-2026/admin/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/admin/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useCallback, useEffect, useState } from "react";

--- a/app/hackathons/hack-a-sprint-2026/instructions/layout.tsx
+++ b/app/hackathons/hack-a-sprint-2026/instructions/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/hackathons/hack-a-sprint-2026/instructions/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/instructions/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import Link from "next/link";
 import { CURSOR_CREDIT_TOP_N } from "@/lib/hackathon-event-signup";
 

--- a/app/hackathons/hack-a-sprint-2026/layout.tsx
+++ b/app/hackathons/hack-a-sprint-2026/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/hackathons/hack-a-sprint-2026/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useCallback, useEffect, useState } from "react";

--- a/app/hackathons/hack-a-sprint-2026/signup/layout.tsx
+++ b/app/hackathons/hack-a-sprint-2026/signup/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/hackathons/hack-a-sprint-2026/signup/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/signup/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import React, { useCallback, useEffect, useState } from "react";

--- a/app/hackathons/page.tsx
+++ b/app/hackathons/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 import { getCurrentVirtualHackathonId, getMonthEndFromVirtualId } from "@/lib/hackathons";

--- a/app/hackathons/pool/layout.tsx
+++ b/app/hackathons/pool/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/hackathons/pool/page.tsx
+++ b/app/hackathons/pool/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState, useCallback, Suspense } from "react";

--- a/app/hackathons/team/layout.tsx
+++ b/app/hackathons/team/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/hackathons/team/page.tsx
+++ b/app/hackathons/team/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState, useCallback, Suspense } from "react";

--- a/app/hackathons/teams/layout.tsx
+++ b/app/hackathons/teams/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/hackathons/teams/page.tsx
+++ b/app/hackathons/teams/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState, useCallback, Suspense } from "react";

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { ImageResponse } from "next/og";
 
 export const runtime = "edge";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { Metadata } from "next";
 import "./globals.css";
 import AppShell from "@/components/AppShell";

--- a/app/live/[sessionId]/emcee/page.tsx
+++ b/app/live/[sessionId]/emcee/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Image from "next/image";

--- a/app/live/[sessionId]/page.tsx
+++ b/app/live/[sessionId]/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState } from "react";

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 export async function GET() {
   const baseUrl = "https://cursorboston.com";
 

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 import eventsData from "@/content/events.json";

--- a/app/members/layout.tsx
+++ b/app/members/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, Suspense } from "react";

--- a/app/open-source/page.tsx
+++ b/app/open-source/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 import { DiscordIcon } from "@/components/icons";

--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import opportunitiesData from "@/content/opportunities.json";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";

--- a/app/pair/[sessionId]/page.tsx
+++ b/app/pair/[sessionId]/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/app/pair/page.tsx
+++ b/app/pair/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState, useCallback } from "react";

--- a/app/pair/requests/page.tsx
+++ b/app/pair/requests/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {

--- a/app/showcase/page.tsx
+++ b/app/showcase/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Image from "next/image";

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { MetadataRoute } from 'next';
 import { getAllPostSlugs } from '@/lib/blog';
 

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import talksData from "@/content/talks.json";
 import articlesData from "@/content/articles.json";

--- a/app/talks/submit/layout.tsx
+++ b/app/talks/submit/layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/talks/submit/page.tsx
+++ b/app/talks/submit/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, useCallback } from "react";

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 

--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Metadata } from "next";
 import Link from "next/link";
 

--- a/components/AnalyticsDashboard.tsx
+++ b/components/AnalyticsDashboard.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useRef, useState } from "react";

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Link from "next/link";

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState } from "react";

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { Component, ReactNode } from "react";

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import Link from "next/link";
 import Image from "next/image";
 import Logo from "@/components/Logo";

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import Image from "next/image";
 
 const LOGO_SRC = "/cursor-boston-logo.png";

--- a/components/LumaCheckoutTracker.tsx
+++ b/components/LumaCheckoutTracker.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect } from "react";

--- a/components/ProfileRequirementsModal.tsx
+++ b/components/ProfileRequirementsModal.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, useCallback, type KeyboardEvent as ReactKeyboardEvent } from "react";

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { ThemeProvider as NextThemesProvider } from "next-themes";

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import * as React from "react";

--- a/components/WelcomeModal.tsx
+++ b/components/WelcomeModal.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";

--- a/components/badges/BadgeCard.tsx
+++ b/components/badges/BadgeCard.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useRef, useState, type KeyboardEvent, type SVGProps } from "react";
 import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
 import { cn } from "@/lib/utils";

--- a/components/badges/BadgeGrid.tsx
+++ b/components/badges/BadgeGrid.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { BadgeDefinition, BadgeEligibilityMap, BadgeId } from "@/lib/badges/types";
 import { cn } from "@/lib/utils";
 import { BadgeCard } from "./BadgeCard";

--- a/components/badges/BadgePopover.tsx
+++ b/components/badges/BadgePopover.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { useEffect, useRef } from "react";
 import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
 import { cn } from "@/lib/utils";

--- a/components/badges/index.ts
+++ b/components/badges/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 export { BadgeCard } from "./BadgeCard";
 export { BadgeGrid } from "./BadgeGrid";
 export { BadgePopover } from "./BadgePopover";

--- a/components/cookbook/CookbookEntries.tsx
+++ b/components/cookbook/CookbookEntries.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import type { CookbookEntry } from "@/types/cookbook";

--- a/components/cookbook/CookbookEntryCard.tsx
+++ b/components/cookbook/CookbookEntryCard.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState } from "react";

--- a/components/cookbook/EntryDetailModal.tsx
+++ b/components/cookbook/EntryDetailModal.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, type KeyboardEvent as ReactKeyboardEvent } from "react";

--- a/components/cookbook/PromptMarkdown.tsx
+++ b/components/cookbook/PromptMarkdown.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import ReactMarkdown from "react-markdown";

--- a/components/cookbook/SubmitForm.tsx
+++ b/components/cookbook/SubmitForm.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState } from "react";

--- a/components/events/CoworkingSlots.tsx
+++ b/components/events/CoworkingSlots.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useEffect, useCallback } from "react";

--- a/components/feed/CommunityFeed.tsx
+++ b/components/feed/CommunityFeed.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { User } from "firebase/auth";

--- a/components/feed/MessageCard.tsx
+++ b/components/feed/MessageCard.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState } from "react";

--- a/components/feed/PostComposer.tsx
+++ b/components/feed/PostComposer.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import Image from "next/image";

--- a/components/feed/ReplyCard.tsx
+++ b/components/feed/ReplyCard.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState } from "react";

--- a/components/feed/RepostModal.tsx
+++ b/components/feed/RepostModal.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { type KeyboardEvent as ReactKeyboardEvent } from "react";

--- a/components/home/OpenSourceFeedSection.tsx
+++ b/components/home/OpenSourceFeedSection.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import Link from "next/link";
 import { Suspense } from "react";
 import { GitHubIcon } from "@/components/icons";

--- a/components/icons/index.tsx
+++ b/components/icons/index.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { SVGProps } from "react";
 
 type IconProps = SVGProps<SVGSVGElement> & {

--- a/components/map/EventMap.tsx
+++ b/components/map/EventMap.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState, useMemo, useEffect } from "react";

--- a/components/members/FilterCheckbox.tsx
+++ b/components/members/FilterCheckbox.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 interface FilterCheckboxProps {
   checked: boolean;
   onChange: (checked: boolean) => void;

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import Image from "next/image";
 import type { PublicMember } from "@/types/members";
 import { getInitials } from "@/lib/utils";

--- a/components/members/MemberDirectory.tsx
+++ b/components/members/MemberDirectory.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useState } from "react";

--- a/components/skeletons/AuthFormSkeleton.tsx
+++ b/components/skeletons/AuthFormSkeleton.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { Skeleton } from "@/components/ui/Skeleton";

--- a/components/skeletons/FeedMessageSkeleton.tsx
+++ b/components/skeletons/FeedMessageSkeleton.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { Skeleton } from "@/components/ui/Skeleton";

--- a/components/skeletons/HackathonPageSkeleton.tsx
+++ b/components/skeletons/HackathonPageSkeleton.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { Skeleton } from "@/components/ui/Skeleton";

--- a/components/skeletons/MemberCardSkeleton.tsx
+++ b/components/skeletons/MemberCardSkeleton.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { Skeleton } from "@/components/ui/Skeleton";

--- a/components/skeletons/MembersPageSkeleton.tsx
+++ b/components/skeletons/MembersPageSkeleton.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { Skeleton } from "@/components/ui/Skeleton";

--- a/components/ui/FormField.tsx
+++ b/components/ui/FormField.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { InputHTMLAttributes, TextareaHTMLAttributes } from "react";
 
 // Shared input styling

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { cn } from "@/lib/utils";

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import {

--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState, useCallback, useMemo } from "react";

--- a/hooks/useMembers.ts
+++ b/hooks/useMembers.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useEffect, useState, useMemo } from "react";

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { createHash, randomBytes } from "crypto";
 import { NextRequest } from "next/server";
 import { getAdminDb } from "./firebase-admin";

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextResponse } from "next/server";
 
 /**

--- a/lib/badges/admin-badge-awards.ts
+++ b/lib/badges/admin-badge-awards.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { BADGE_IDS } from "@/lib/badges/definitions";

--- a/lib/badges/data.ts
+++ b/lib/badges/data.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import {
   collection,
   getDocs,

--- a/lib/badges/definitions.ts
+++ b/lib/badges/definitions.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { BadgeDefinition, BadgeId } from "./types";
 
 export const BADGE_DEFINITIONS: BadgeDefinition[] = [

--- a/lib/badges/eligibility.ts
+++ b/lib/badges/eligibility.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { BadgeEligibilityInput, BadgeEligibilityMap } from "./types";
 
 type NormalizedBadgeEligibilityInput = Required<BadgeEligibilityInput>;

--- a/lib/badges/getBadgeEligibilityInput.ts
+++ b/lib/badges/getBadgeEligibilityInput.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { collection, getDocs, query, where } from "firebase/firestore";
 import { db } from "../firebase";
 import { getUserStats } from "../registrations";

--- a/lib/badges/types.ts
+++ b/lib/badges/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 export type BadgeId =
   | "first-steps"
   | "connected"

--- a/lib/badges/utils.ts
+++ b/lib/badges/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { BadgeDefinition, BadgeEligibilityMap, BadgeId } from "./types";
 
 export function getEarnedBadgeIds(

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";

--- a/lib/cfp-submissions.ts
+++ b/lib/cfp-submissions.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { doc, setDoc, getDoc, serverTimestamp, Timestamp } from "firebase/firestore";
 import { db } from "./firebase";
 import { sanitizeText, sanitizeName } from "./sanitize";

--- a/lib/cookbook-labels.ts
+++ b/lib/cookbook-labels.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { CookbookCategory } from "@/types/cookbook";
 
 /** Human-readable display labels for each cookbook category. */

--- a/lib/cookbook-search.ts
+++ b/lib/cookbook-search.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 /** Returns true if any search term matches the entry's title, description, or tags (case-insensitive). */
 export function matchesCookbookSearchTerms(
   title: string,

--- a/lib/coworking.ts
+++ b/lib/coworking.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Coworking Slots Management
  * 
  * Handles coworking session registration for events like Cafe Cursor.

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Discord webhook integration for sending notifications
  */
 import { logger } from "./logger";

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { cert, getApps, initializeApp, App } from "firebase-admin/app";
 import { getAuth, Auth } from "firebase-admin/auth";
 import { getDatabase, Database } from "firebase-admin/database";

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { initializeApp, getApps, FirebaseApp } from "firebase/app";
 import { getAuth, Auth } from "firebase/auth";
 import { getFirestore, Firestore } from "firebase/firestore";

--- a/lib/format-cookbook-date.ts
+++ b/lib/format-cookbook-date.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 /** Formats an ISO date string into a short locale date (e.g. "Mar 5, 2026"). */
 export function formatCookbookDate(iso: string): string {
   if (!iso) return "";

--- a/lib/github-merged-pr-count.ts
+++ b/lib/github-merged-pr-count.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
 import { logger } from "@/lib/logger";
 

--- a/lib/github-merged-pr-reconcile.ts
+++ b/lib/github-merged-pr-reconcile.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";

--- a/lib/github-recent-merged-prs.ts
+++ b/lib/github-recent-merged-prs.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { logger } from "@/lib/logger";
 
 const DEFAULT_OWNER = "rogerSuperBuilderAlpha";

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { createHmac, timingSafeEqual } from "crypto";
 import { FieldValue } from "firebase-admin/firestore";
 import { getGithubRepoPair } from "./github-recent-merged-prs";

--- a/lib/hackathon-asprint-2026-schedule.ts
+++ b/lib/hackathon-asprint-2026-schedule.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Hack-a-Sprint April 13, 2026 — America/New_York schedule (single source for UI + API).
  */
 

--- a/lib/hackathon-asprint-2026-scores.ts
+++ b/lib/hackathon-asprint-2026-scores.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";

--- a/lib/hackathon-asprint-2026-state.ts
+++ b/lib/hackathon-asprint-2026-state.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { Firestore } from "firebase-admin/firestore";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
 import { hackathonEventSignupDocId } from "@/lib/hackathon-event-signup";

--- a/lib/hackathon-event-signup.ts
+++ b/lib/hackathon-event-signup.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
 
 /** In-person / special events with website signup (separate from Luma). */

--- a/lib/hackathon-showcase-admin.ts
+++ b/lib/hackathon-showcase-admin.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { FieldValue } from "firebase-admin/firestore";
 import type { Firestore } from "firebase-admin/firestore";
 import { getAdminDb } from "./firebase-admin";

--- a/lib/hackathon-showcase.ts
+++ b/lib/hackathon-showcase.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
 
 export const HACK_A_SPRINT_2026_EVENT_ID = "hack-a-sprint-2026";

--- a/lib/hackathons.ts
+++ b/lib/hackathons.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Hackathon helpers: virtual month IDs (Boston time), eligibility, etc.
  */
 

--- a/lib/live-sessions/client.ts
+++ b/lib/live-sessions/client.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/lib/live-sessions/data-server.ts
+++ b/lib/live-sessions/data-server.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { getAdminDb, getAdminRtdb } from "@/lib/firebase-admin";
 import type {
   ControlLiveSessionInput,

--- a/lib/live-sessions/types.ts
+++ b/lib/live-sessions/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 export const LIVE_TALK_DURATIONS = [3, 5] as const;
 
 export type LiveTalkDurationMinutes = (typeof LIVE_TALK_DURATIONS)[number];

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Request Logging Utility
  * 
  * Provides structured logging for API requests and responses.

--- a/lib/luma-event.ts
+++ b/lib/luma-event.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { Event } from "@/types/events";
 
 /** Id passed to Luma checkout (`data-luma-event-id`). */

--- a/lib/mailgun.ts
+++ b/lib/mailgun.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Mailgun email sending - direct API, no Firebase extension.
  *
  * Required env vars:

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Next.js Middleware Utilities
  * 
  * Wrappers for rate limiting, logging, and CSRF protection that work with Next.js API routes

--- a/lib/pair-programming/data-server.ts
+++ b/lib/pair-programming/data-server.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { getAdminDb } from "@/lib/firebase-admin";
 import type {
   PairProfile,

--- a/lib/pair-programming/data.ts
+++ b/lib/pair-programming/data.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import {
   collection,
   doc,

--- a/lib/pair-programming/matching.ts
+++ b/lib/pair-programming/matching.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { PairProfile, MatchScore } from "./types";
 
 /**

--- a/lib/pair-programming/types.ts
+++ b/lib/pair-programming/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import type { Timestamp } from "firebase/firestore";
 
 export type SessionType = "teach-me" | "build-together" | "code-review" | "explore-topic";

--- a/lib/rate-limit-server.ts
+++ b/lib/rate-limit-server.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { createHash } from "crypto";
 import { Timestamp } from "firebase-admin/firestore";
 import { getAdminDb } from "./firebase-admin";

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Rate Limiting Utility
  * 
  * Simple in-memory rate limiter for API routes.

--- a/lib/registrations.ts
+++ b/lib/registrations.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import {
   collection,
   doc,

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Input Sanitization Utilities
  * 
  * Provides functions to sanitize user input to prevent XSS and other injection attacks.

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { NextRequest } from "next/server";
 import { getAdminAuth } from "./firebase-admin";
 

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "./firebase";
 

--- a/lib/unsubscribe-token.ts
+++ b/lib/unsubscribe-token.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { createHmac } from "crypto";
 
 const SECRET =

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Timestamp } from "firebase/firestore";
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,6 +218,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1158,6 +1159,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1181,6 +1183,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1202,7 +1205,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
       "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-tools": {
       "version": "0.2.21",
@@ -1962,6 +1966,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.10.tgz",
       "integrity": "sha512-PlPhdtjgWUra+LImQTnXOUqUa/jcufZhizdR93ZjlQSS3ahCtDTG6pJw7j0OwFal18DQjICXfeVNsUUrcNisfA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -2028,6 +2033,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.10.tgz",
       "integrity": "sha512-tFmBuZL0/v1h6eyKRgWI58ucft6dEJmAi9nhPUXoAW4ZbPSTlnsh31AuEwUoRTz+wwRk9gmgss9GZV05ZM9Kug==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.10",
         "@firebase/component": "0.7.2",
@@ -2043,7 +2049,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.4",
@@ -2507,6 +2514,7 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -5140,6 +5148,7 @@
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5318,6 +5327,7 @@
       "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
       "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
       "license": "Hippocratic-2.1",
+      "peer": true,
       "peerDependencies": {
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
@@ -5788,6 +5798,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6263,6 +6274,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6284,6 +6296,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6435,6 +6448,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -6991,6 +7005,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7730,6 +7745,7 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -8138,6 +8154,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9399,6 +9416,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -10617,6 +10635,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -10798,6 +10817,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11418,6 +11438,7 @@
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -13312,6 +13333,7 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -15671,6 +15693,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -16041,7 +16064,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",
@@ -16987,6 +17011,7 @@
       "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -19475,6 +19500,7 @@
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -20352,6 +20378,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -20364,6 +20391,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -20384,6 +20412,7 @@
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
       "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
       "license": "Hippocratic-2.1",
+      "peer": true,
       "dependencies": {
         "@react-leaflet/core": "^3.0.0"
       },
@@ -20441,6 +20470,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -20588,7 +20618,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -22765,6 +22796,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23188,6 +23220,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24308,6 +24341,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "seed-luma-registrants": "tsx scripts/seed-luma-registrants.ts",
     "generate-contributors": "bash scripts/generate-contributors.sh",
     "prebuild": "npm run validate-env",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "add:gpl-headers": "node scripts/add-gpl-headers.js"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.2",

--- a/scripts/add-gpl-headers.js
+++ b/scripts/add-gpl-headers.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT_DIRS = ["app", "lib", "components", "hooks", "contexts", "types"];
+
+const HEADER = `/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+`;
+
+function hasHeader(content) {
+  return content.includes("licensed under GPL-3.0");
+}
+
+function processFile(filePath) {
+  const content = fs.readFileSync(filePath, "utf8");
+
+  if (hasHeader(content)) {
+    return;
+  }
+
+  const updated = HEADER + "\n" + content;
+  fs.writeFileSync(filePath, updated, "utf8");
+
+  console.log(`✔ Added header: ${filePath}`);
+}
+
+function walkDir(dir) {
+  if (!fs.existsSync(dir)) return;
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      walkDir(fullPath);
+    } else if (
+      entry.isFile() &&
+      (fullPath.endsWith(".ts") || fullPath.endsWith(".tsx"))
+    ) {
+      processFile(fullPath);
+    }
+  }
+}
+
+function main() {
+  ROOT_DIRS.forEach((dir) => walkDir(path.resolve(process.cwd(), dir)));
+}
+
+main();

--- a/types/cookbook.ts
+++ b/types/cookbook.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 export const COOKBOOK_CATEGORIES = [
   "debugging",
   "refactoring",

--- a/types/events.ts
+++ b/types/events.ts
@@ -1,4 +1,10 @@
 /**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
  * Event type definitions for the Cursor Boston community events
  */
 

--- a/types/feed.ts
+++ b/types/feed.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 import { Timestamp } from "firebase/firestore";
 
 export type ReactionType = "like" | "dislike" | "bookmark";

--- a/types/members.ts
+++ b/types/members.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 export type MemberType = "human" | "agent";
 
 export interface PublicMember {

--- a/types/qrcode.d.ts
+++ b/types/qrcode.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
 declare module "qrcode" {
   interface ToDataURLOptions {
     margin?: number;


### PR DESCRIPTION
## Description
Adds the GPL-3.0 copyright header to relevant `.ts` and `.tsx` source files to improve per-file license clarity. Also added the script as a pre commit hook via husky.

Closes #238

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- Ran `npm run lint` -> unrelated warnings
- Ran `npm run build` -> unrelated warnings
- Manually verified 7 headers were added to relevant source files

## Screenshots
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated
- [x] No new warnings generated
- [x] Changes tested locally