### PR TITLE
feat: freeze confirmed top 50 with static confirmedAt

### DIFF
--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -141,6 +141,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       mergedPrCount: number;
       displayName: string | null;
       githubLogin: string | null;
+      confirmedAt: number | null;
     }[] = [];
 
     const userIds = snap.docs.map((d) => d.data().userId as string).filter(Boolean);
@@ -180,6 +181,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         displayName:
           typeof profile?.displayName === "string" ? profile.displayName : null,
         githubLogin,
+        confirmedAt: data.confirmedAt ? signedUpAtToMs(data.confirmedAt) : null,
       });
     }
 
@@ -206,6 +208,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       githubLogin: string | null;
       lumaCreatedAt: string;
       mergedPrCount: number;
+      confirmedAt: number | null;
     };
     const lumaRows: LumaRow[] = [];
 
@@ -221,6 +224,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         githubLogin: ghLogin,
         lumaCreatedAt: typeof d.lumaCreatedAt === "string" ? d.lumaCreatedAt : "",
         mergedPrCount: 0,
+        confirmedAt: d.confirmedAt ? signedUpAtToMs(d.confirmedAt) : null,
       });
     }
 
@@ -245,6 +249,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       signedUpAtMs: number;
       signedUpAtIso: string;
       source: EntrySource;
+      confirmedAt: number | null;
     };
     const unified: UnifiedRow[] = [];
 
@@ -257,6 +262,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         signedUpAtMs: r.signedUpAtMs,
         signedUpAtIso: new Date(r.signedUpAtMs).toISOString(),
         source: "website",
+        confirmedAt: r.confirmedAt,
       });
     }
     for (const lr of lumaRows) {
@@ -268,24 +274,28 @@ export async function GET(request: NextRequest, context: RouteContext) {
         signedUpAtMs: lr.lumaCreatedAt ? new Date(lr.lumaCreatedAt).getTime() : 0,
         signedUpAtIso: lr.lumaCreatedAt,
         source: "luma_only",
+        confirmedAt: lr.confirmedAt,
       });
     }
 
-    // Sort everyone together: PR count desc, then signup time asc
+    // Frozen confirmed first; within each group: PRs desc → website before luma → registration time asc
     unified.sort((a, b) => {
+      const ac = a.confirmedAt != null ? 1 : 0;
+      const bc = b.confirmedAt != null ? 1 : 0;
+      if (bc !== ac) return bc - ac;
       if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
+      const aWeb = a.source === "website" ? 1 : 0;
+      const bWeb = b.source === "website" ? 1 : 0;
+      if (bWeb !== aWeb) return bWeb - aWeb;
       return a.signedUpAtMs - b.signedUpAtMs;
     });
 
-    // Build ranked entries — top N are confirmed, rest waitlisted
+    // Build ranked entries — status driven by confirmedAt field
     type EntryStatus = "confirmed" | "waitlisted";
     const websiteCount = rows.length;
     const entries = unified.map((u, i) => {
       const rank = i + 1;
-      const isLumaOnly = u.source === "luma_only";
-      const status: EntryStatus = rank <= CURSOR_CREDIT_TOP_N && !isLumaOnly
-        ? "confirmed"
-        : "waitlisted";
+      const isConfirmed = u.confirmedAt != null;
       return {
         rank,
         userId: u.userId,
@@ -293,8 +303,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
         githubLogin: u.githubLogin,
         mergedPrCount: u.mergedPrCount,
         signedUpAt: u.signedUpAtIso,
-        creditEligible: rank <= CURSOR_CREDIT_TOP_N && !isLumaOnly,
-        status,
+        creditEligible: isConfirmed,
+        status: (isConfirmed ? "confirmed" : "waitlisted") as EntryStatus,
       };
     });
 

--- a/scripts/freeze-confirmed-top50.ts
+++ b/scripts/freeze-confirmed-top50.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * Freeze the top 50 registrants as permanently confirmed by setting
+ * `confirmedAt` on their Firestore docs (website signups OR Luma-only).
+ *
+ * Ranking: PRs desc → website signup before Luma → registration time asc.
+ * Top 50 from that combined list are confirmed. Everyone else is waitlisted.
+ *
+ * Also clears `confirmedAt` from anyone outside the top 50 who has it
+ * (e.g. from a previous run with different logic).
+ *
+ * Usage:
+ *   npx tsx scripts/freeze-confirmed-top50.ts --dry-run
+ *   npx tsx scripts/freeze-confirmed-top50.ts --write
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * and GITHUB_TOKEN (for accurate PR counts). Load from .env.local.
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import type { DocumentData, Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { CURSOR_CREDIT_TOP_N } from "../lib/hackathon-event-signup";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "../lib/hackathon-showcase";
+import { fetchMergedPrCountsForLogins } from "../lib/github-merged-pr-count";
+import { getAdminDb } from "../lib/firebase-admin";
+
+const EVENT_ID = HACK_A_SPRINT_2026_EVENT_ID;
+
+function signedUpAtToMs(value: unknown): number {
+  if (
+    value &&
+    typeof value === "object" &&
+    "toMillis" in value &&
+    typeof (value as { toMillis: () => number }).toMillis === "function"
+  ) {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  if (value instanceof Date) return value.getTime();
+  return 0;
+}
+
+async function fetchUserDataMap(
+  db: Firestore,
+  userIds: string[]
+): Promise<Map<string, DocumentData>> {
+  const map = new Map<string, DocumentData>();
+  const unique = [...new Set(userIds)];
+  for (let i = 0; i < unique.length; i += 10) {
+    const chunk = unique.slice(i, i + 10);
+    const snap = await db.collection("users").where("__name__", "in", chunk).get();
+    for (const doc of snap.docs) map.set(doc.id, doc.data());
+  }
+  return map;
+}
+
+async function countMergedCommunityPrsByUserIds(
+  db: Firestore,
+  userIds: string[]
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  const unique = [...new Set(userIds)];
+  for (let i = 0; i < unique.length; i += 10) {
+    const chunk = unique.slice(i, i + 10);
+    const snap = await db
+      .collection("pullRequests")
+      .where("userId", "in", chunk)
+      .where("status", "==", "merged")
+      .get();
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      const uid = data.userId as string | undefined;
+      if (!uid) continue;
+      counts.set(uid, (counts.get(uid) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+type UnifiedEntry = {
+  collection: "hackathonEventSignups" | "hackathonLumaRegistrants";
+  docId: string;
+  displayName: string | null;
+  githubLogin: string | null;
+  mergedPrCount: number;
+  signedUpAtMs: number;
+  source: "website" | "luma_only";
+  alreadyConfirmed: boolean;
+};
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const write = process.argv.includes("--write");
+  if (!dryRun && !write) {
+    console.error("Specify exactly one of: --dry-run | --write");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // ── Website signups ──
+  console.log(`Fetching signups for ${EVENT_ID}…`);
+  const snap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+
+  const userIds = snap.docs.map((d) => d.data().userId as string).filter(Boolean);
+  console.log(`Found ${userIds.length} website signups.`);
+
+  const userMap = await fetchUserDataMap(db, userIds);
+  const firestoreMergedCounts = await countMergedCommunityPrsByUserIds(db, userIds);
+
+  const websiteGithubLogins: string[] = [];
+  const websiteEmails = new Set<string>();
+  const websiteGhSet = new Set<string>();
+  for (const uid of userIds) {
+    const profile = userMap.get(uid);
+    if (typeof profile?.email === "string") websiteEmails.add(profile.email.toLowerCase());
+    const login =
+      profile?.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login
+        : undefined;
+    if (typeof login === "string" && login.trim()) {
+      websiteGithubLogins.push(login.trim());
+      websiteGhSet.add(login.trim().toLowerCase());
+    }
+  }
+  const githubMergedByLogin = await fetchMergedPrCountsForLogins(websiteGithubLogins);
+
+  const unified: UnifiedEntry[] = [];
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const userId = data.userId as string;
+    if (!userId) continue;
+    const profile = userMap.get(userId);
+    const gh =
+      profile?.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login
+        : undefined;
+    const githubLogin = typeof gh === "string" ? gh : null;
+    let pr = firestoreMergedCounts.get(userId) ?? 0;
+    if (githubLogin) {
+      const fromApi = githubMergedByLogin.get(githubLogin.toLowerCase());
+      if (fromApi !== undefined) pr = fromApi;
+    }
+    unified.push({
+      collection: "hackathonEventSignups",
+      docId: doc.id,
+      displayName: typeof profile?.displayName === "string" ? profile.displayName : null,
+      githubLogin,
+      mergedPrCount: pr,
+      signedUpAtMs: signedUpAtToMs(data.signedUpAt),
+      source: "website",
+      alreadyConfirmed: !!data.confirmedAt,
+    });
+  }
+
+  // ── Luma-only registrants ──
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+
+  const lumaGithubLogins: string[] = [];
+  const lumaEntries: { doc: FirebaseFirestore.QueryDocumentSnapshot; ghLogin: string | null }[] = [];
+
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (d.email as string || "").toLowerCase();
+    const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+    if (websiteEmails.has(email)) continue;
+    if (ghLogin && websiteGhSet.has(ghLogin.toLowerCase())) continue;
+    if (ghLogin) lumaGithubLogins.push(ghLogin);
+    lumaEntries.push({ doc, ghLogin });
+  }
+
+  let lumaPrCounts = new Map<string, number>();
+  if (lumaGithubLogins.length > 0) {
+    lumaPrCounts = await fetchMergedPrCountsForLogins(lumaGithubLogins);
+  }
+
+  for (const { doc, ghLogin } of lumaEntries) {
+    const d = doc.data();
+    const pr = ghLogin ? (lumaPrCounts.get(ghLogin.toLowerCase()) ?? 0) : 0;
+    unified.push({
+      collection: "hackathonLumaRegistrants",
+      docId: doc.id,
+      displayName: typeof d.name === "string" ? d.name : null,
+      githubLogin: ghLogin,
+      mergedPrCount: pr,
+      signedUpAtMs: typeof d.lumaCreatedAt === "string" ? new Date(d.lumaCreatedAt).getTime() : 0,
+      source: "luma_only",
+      alreadyConfirmed: !!d.confirmedAt,
+    });
+  }
+
+  console.log(`Found ${lumaEntries.length} Luma-only registrants.`);
+  console.log(`Total: ${unified.length} combined.`);
+
+  // Sort: PRs desc → website before luma → registration time asc
+  unified.sort((a, b) => {
+    if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
+    const aWeb = a.source === "website" ? 1 : 0;
+    const bWeb = b.source === "website" ? 1 : 0;
+    if (bWeb !== aWeb) return bWeb - aWeb;
+    return a.signedUpAtMs - b.signedUpAtMs;
+  });
+
+  const top = unified.slice(0, CURSOR_CREDIT_TOP_N);
+  const topDocKeys = new Set(top.map((r) => `${r.collection}:${r.docId}`));
+
+  // Find docs that need confirmedAt set or cleared
+  const toFreeze = top.filter((r) => !r.alreadyConfirmed);
+  const toClear = unified.filter(
+    (r) => r.alreadyConfirmed && !topDocKeys.has(`${r.collection}:${r.docId}`)
+  );
+
+  console.log(`\nTop ${CURSOR_CREDIT_TOP_N} (to be confirmed):`);
+  for (const [i, r] of top.entries()) {
+    const src = r.source === "website" ? "web" : "luma";
+    const tag = r.alreadyConfirmed ? " [already frozen]" : " ← will freeze";
+    console.log(
+      `  ${String(i + 1).padStart(3)}. ${(r.displayName || "?").padEnd(25)} @${(r.githubLogin || "?").padEnd(20)} PRs=${r.mergedPrCount} (${src})${tag}`
+    );
+  }
+
+  if (toClear.length > 0) {
+    console.log(`\nWill CLEAR confirmedAt from ${toClear.length} docs outside top ${CURSOR_CREDIT_TOP_N}:`);
+    for (const r of toClear) {
+      console.log(`  - ${r.displayName || "?"} @${r.githubLogin || "?"} (${r.collection}/${r.docId})`);
+    }
+  }
+
+  console.log(`\n${top.filter((r) => r.alreadyConfirmed).length} already frozen, ${toFreeze.length} to freeze, ${toClear.length} to clear.`);
+
+  if (dryRun) {
+    console.log("--dry-run: no writes. Use --write to apply.");
+    return;
+  }
+
+  if (toFreeze.length > 0) {
+    console.log("\nSetting confirmedAt…");
+    for (const r of toFreeze) {
+      await db.collection(r.collection).doc(r.docId).update({
+        confirmedAt: FieldValue.serverTimestamp(),
+      });
+      console.log(`  ✓ ${r.displayName} (${r.collection}/${r.docId})`);
+    }
+  }
+
+  if (toClear.length > 0) {
+    console.log("\nClearing confirmedAt…");
+    for (const r of toClear) {
+      await db.collection(r.collection).doc(r.docId).update({
+        confirmedAt: FieldValue.delete(),
+      });
+      console.log(`  ✗ ${r.displayName} (${r.collection}/${r.docId})`);
+    }
+  }
+
+  console.log(`\nDone. ${toFreeze.length} frozen, ${toClear.length} cleared.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Confirmed status now driven by `confirmedAt` Firestore field instead of dynamic rank
- Ranking: PRs desc → website signup → Luma registration order
- Top 50 frozen as confirmed; waitlist remains dynamic (people move up by merging PRs)
- Reads `confirmedAt` from both `hackathonEventSignups` and `hackathonLumaRegistrants`
- Includes `scripts/freeze-confirmed-top50.ts` used to stamp the current top 50

## Test plan
- [ ] Verified freeze script correctly stamps 50 users (31 web + 19 Luma)
- [ ] Confirmed list is static — new PR merges don't change it
- [ ] Waitlist still sorts dynamically by PRs desc → website → Luma time
- [ ] Website displays only "Confirmed" and "Waitlist" badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)