### PR TITLE
fix: exclude judges from participant list

### DIFF
--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/server-auth";
 import {
   CURSOR_CREDIT_TOP_N,
+  JUDGE_EMAILS,
   getHackathonEventSignupBlockReason,
   hackathonEventSignupDocId,
   isHackathonEventSignupId,
@@ -216,6 +217,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       const d = doc.data();
       const email = (d.email as string || "").toLowerCase();
       const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+      if (JUDGE_EMAILS.has(email)) continue;
       if (websiteEmails.has(email)) continue;
       if (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase())) continue;
       if (ghLogin) lumaGithubLogins.push(ghLogin);

--- a/lib/hackathon-event-signup.ts
+++ b/lib/hackathon-event-signup.ts
@@ -51,3 +51,9 @@ export function getHackathonEventSignupBlockReason(
 }
 
 export const CURSOR_CREDIT_TOP_N = 50;
+
+/** Judges / organizers — excluded from the participant list so they don't take a spot. */
+export const JUDGE_EMAILS = new Set([
+  "regorhunt02052@gmail.com",
+  "rayruizhiliao@gmail.com",
+]);

--- a/scripts/freeze-confirmed-top50.ts
+++ b/scripts/freeze-confirmed-top50.ts
@@ -21,7 +21,7 @@ loadEnvConfig(process.cwd());
 
 import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
-import { CURSOR_CREDIT_TOP_N } from "../lib/hackathon-event-signup";
+import { CURSOR_CREDIT_TOP_N, JUDGE_EMAILS } from "../lib/hackathon-event-signup";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "../lib/hackathon-showcase";
 import { fetchMergedPrCountsForLogins } from "../lib/github-merged-pr-count";
 import { getAdminDb } from "../lib/firebase-admin";
@@ -175,6 +175,7 @@ async function main() {
     const d = doc.data();
     const email = (d.email as string || "").toLowerCase();
     const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+    if (JUDGE_EMAILS.has(email)) continue;
     if (websiteEmails.has(email)) continue;
     if (ghLogin && websiteGhSet.has(ghLogin.toLowerCase())) continue;
     if (ghLogin) lumaGithubLogins.push(ghLogin);


### PR DESCRIPTION
## Summary
- Add `JUDGE_EMAILS` exclusion set (Roger Hunt, Ray Liao) to filter judges from the participant list
- Judges don't take up a spot in the top 50 confirmed list
- Cleared their `confirmedAt` in Firestore; 2 freed spots filled by next in line (Agnel Salve, Eugenio Zuccarelli)

## Test plan
- [ ] Roger Hunt and Ray Liao do not appear in the participant list
- [ ] Top 50 confirmed list has 50 participants (not 48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)