### PR TITLE
fix: exclude declined registrants from participant list

### DIFF
--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/server-auth";
 import {
   CURSOR_CREDIT_TOP_N,
+  DECLINED_EMAILS,
   JUDGE_EMAILS,
   getHackathonEventSignupBlockReason,
   hackathonEventSignupDocId,
@@ -217,7 +218,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       const d = doc.data();
       const email = (d.email as string || "").toLowerCase();
       const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
-      if (JUDGE_EMAILS.has(email)) continue;
+      if (JUDGE_EMAILS.has(email) || DECLINED_EMAILS.has(email)) continue;
       if (websiteEmails.has(email)) continue;
       if (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase())) continue;
       if (ghLogin) lumaGithubLogins.push(ghLogin);

--- a/lib/hackathon-event-signup.ts
+++ b/lib/hackathon-event-signup.ts
@@ -57,3 +57,14 @@ export const JUDGE_EMAILS = new Set([
   "regorhunt02052@gmail.com",
   "rayruizhiliao@gmail.com",
 ]);
+
+/** Luma registrants who declined — excluded from the participant list. */
+export const DECLINED_EMAILS = new Set([
+  "nasit.v@northeastern.edu",
+  "renganathan.b@northeastern.edu",
+  "revoftc@gmail.com",
+  "sakhare.c@northeastern.edu",
+  "lnu.ava@northeastern.edu",
+  "harrychow8888@gmail.com",
+  "brucejia@bu.edu",
+]);

--- a/scripts/freeze-confirmed-top50.ts
+++ b/scripts/freeze-confirmed-top50.ts
@@ -21,7 +21,7 @@ loadEnvConfig(process.cwd());
 
 import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
-import { CURSOR_CREDIT_TOP_N, JUDGE_EMAILS } from "../lib/hackathon-event-signup";
+import { CURSOR_CREDIT_TOP_N, DECLINED_EMAILS, JUDGE_EMAILS } from "../lib/hackathon-event-signup";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "../lib/hackathon-showcase";
 import { fetchMergedPrCountsForLogins } from "../lib/github-merged-pr-count";
 import { getAdminDb } from "../lib/firebase-admin";
@@ -175,7 +175,7 @@ async function main() {
     const d = doc.data();
     const email = (d.email as string || "").toLowerCase();
     const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
-    if (JUDGE_EMAILS.has(email)) continue;
+    if (JUDGE_EMAILS.has(email) || DECLINED_EMAILS.has(email)) continue;
     if (websiteEmails.has(email)) continue;
     if (ghLogin && websiteGhSet.has(ghLogin.toLowerCase())) continue;
     if (ghLogin) lumaGithubLogins.push(ghLogin);
@@ -214,14 +214,13 @@ async function main() {
     return a.signedUpAtMs - b.signedUpAtMs;
   });
 
-  const top = unified.slice(0, CURSOR_CREDIT_TOP_N);
-  const topDocKeys = new Set(top.map((r) => `${r.collection}:${r.docId}`));
-
-  // Find docs that need confirmedAt set or cleared
-  const toFreeze = top.filter((r) => !r.alreadyConfirmed);
-  const toClear = unified.filter(
-    (r) => r.alreadyConfirmed && !topDocKeys.has(`${r.collection}:${r.docId}`)
-  );
+  // Already-frozen users stay frozen (confirmedAt is permanent).
+  // Only fill remaining spots up to CURSOR_CREDIT_TOP_N with unfrozen users.
+  const alreadyFrozen = unified.filter((r) => r.alreadyConfirmed);
+  const unfrozen = unified.filter((r) => !r.alreadyConfirmed);
+  const spotsLeft = Math.max(0, CURSOR_CREDIT_TOP_N - alreadyFrozen.length);
+  const top = [...alreadyFrozen, ...unfrozen.slice(0, spotsLeft)];
+  const toFreeze = unfrozen.slice(0, spotsLeft);
 
   console.log(`\nTop ${CURSOR_CREDIT_TOP_N} (to be confirmed):`);
   for (const [i, r] of top.entries()) {
@@ -232,14 +231,7 @@ async function main() {
     );
   }
 
-  if (toClear.length > 0) {
-    console.log(`\nWill CLEAR confirmedAt from ${toClear.length} docs outside top ${CURSOR_CREDIT_TOP_N}:`);
-    for (const r of toClear) {
-      console.log(`  - ${r.displayName || "?"} @${r.githubLogin || "?"} (${r.collection}/${r.docId})`);
-    }
-  }
-
-  console.log(`\n${top.filter((r) => r.alreadyConfirmed).length} already frozen, ${toFreeze.length} to freeze, ${toClear.length} to clear.`);
+  console.log(`\n${alreadyFrozen.length} already frozen, ${toFreeze.length} to freeze.`);
 
   if (dryRun) {
     console.log("--dry-run: no writes. Use --write to apply.");
@@ -256,17 +248,7 @@ async function main() {
     }
   }
 
-  if (toClear.length > 0) {
-    console.log("\nClearing confirmedAt…");
-    for (const r of toClear) {
-      await db.collection(r.collection).doc(r.docId).update({
-        confirmedAt: FieldValue.delete(),
-      });
-      console.log(`  ✗ ${r.displayName} (${r.collection}/${r.docId})`);
-    }
-  }
-
-  console.log(`\nDone. ${toFreeze.length} frozen, ${toClear.length} cleared.`);
+  console.log(`\nDone. ${toFreeze.length} frozen.`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Exclude 7 Luma registrants who declined (including Shuyue JIA who was in top 50)
- Fix freeze script to never clear `confirmedAt` from already-frozen users — prevents GitHub API flakes from erroneously unfreezing people
- Freed spot filled by Nithin Yash Menezes

## Test plan
- [ ] Declined registrants don't appear in participant list
- [ ] Re-running freeze script with flaky GitHub API doesn't unfreeze anyone
- [ ] Top 50 confirmed list still has exactly 50 people

🤖 Generated with [Claude Code](https://claude.com/claude-code)