### PR TITLE
fix(feed): show error state when real-time feed listener fails

### DIFF
--- a/components/feed/CommunityFeed.tsx
+++ b/components/feed/CommunityFeed.tsx
@@ -21,6 +21,8 @@ interface CommunityFeedProps {
 export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps) {
   const {
     loading,
+    error,
+    clearError,
     newMessage,
     setNewMessage,
     posting,
@@ -118,6 +120,19 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
           onSubmit={postMessage}
           posting={posting}
         />
+
+        {/* Error State */}
+        {error && (
+          <div className="flex items-center justify-between gap-4 p-4 mb-6 bg-red-500/10 border border-red-500/20 rounded-lg">
+            <p className="text-red-400 text-sm">{error}</p>
+            <button
+              onClick={clearError}
+              className="text-sm text-red-400 hover:text-red-300 underline shrink-0"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
 
         {/* Messages Feed */}
         {loading ? (

--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -51,6 +51,7 @@ export function useFeed(user: User | null, isActive: boolean) {
       setLoading(false);
     }, (error) => {
       console.error("Error listening to messages:", error);
+      setError("Failed to load feed. Please refresh.");
       setLoading(false);
     });
 


### PR DESCRIPTION
## Description
The `onSnapshot` error callback in `hooks/useFeed.ts` was logging errors but not setting any UI state, causing users to see stale data indefinitely with no indication the feed was broken. This PR sets the error state when the listener fails and displays a visible error banner in `CommunityFeed.tsx` with a dismiss button.

Fixes #246

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings