### PR TITLE
fix(hackathons): move submission read inside transaction to prevent r…

### DIFF
--- a/app/api/hackathons/team/leave/route.ts
+++ b/app/api/hackathons/team/leave/route.ts
@@ -74,17 +74,19 @@ export async function POST(request: NextRequest) {
 
     const hackathonId = team.hackathonId;
 
-    const submissionSnap = await db
+    const submissionQuery = db
       .collection("hackathonSubmissions")
       .where("teamId", "==", sanitizedTeamId)
       .where("hackathonId", "==", hackathonId)
-      .limit(1)
-      .get();
+      .limit(1);
 
-    const hadSubmission = !submissionSnap.empty;
-    const submissionRef = submissionSnap.docs[0]?.ref;
+      let hadSubmission = false;
 
-    await db.runTransaction(async (tx) => {
+      await db.runTransaction(async (tx) => {
+        const submissionSnap = await tx.get(submissionQuery);
+        hadSubmission = !submissionSnap.empty;
+      const submissionRef = submissionSnap.docs[0]?.ref;
+
       const newMemberIds = memberIds.filter((id) => id !== user.uid);
       if (newMemberIds.length <= 1) {
         tx.delete(teamRef);


### PR DESCRIPTION
## Description
In `app/api/hackathons/team/leave/route.ts`, the Firestore submission query was executed outside the transaction. This created a race condition where a concurrent delete between the query and transaction execution could cause a silent failure on `tx.update(submissionRef)`. The fix moves the submission read inside the transaction using `tx.get()` so all reads and writes are atomic.

Fixes #244

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings