### PR TITLE
fix(auth): validate Authorization header format before token extraction

### DIFF
--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -62,8 +62,8 @@ function isLegacyAdminEmail(email?: string): boolean {
 
 export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUser | null> {
   const authHeader = request.headers.get("authorization") || "";
-  const tokenFromAuth =
-    authHeader.startsWith("Bearer ") ? authHeader.slice(7).trim() : "";
+  const match = authHeader.match(/^Bearer\s+(.+)$/);
+  const tokenFromAuth = match ? match[1].trim() : "";
   const tokenFromHeader = request.headers.get("x-firebase-id-token")?.trim() || "";
   const token = tokenFromAuth || tokenFromHeader;
 
@@ -105,8 +105,8 @@ export async function getOptionalVerifiedUser(
   request: NextRequest
 ): Promise<VerifiedUser | null> {
   const authHeader = request.headers.get("authorization") || "";
-  const tokenFromAuth =
-    authHeader.startsWith("Bearer ") ? authHeader.slice(7).trim() : "";
+  const match = authHeader.match(/^Bearer\s+(.+)$/);
+  const tokenFromAuth = match ? match[1].trim() : "";
   const tokenFromHeader = request.headers.get("x-firebase-id-token")?.trim() || "";
   const token = tokenFromAuth || tokenFromHeader;
 


### PR DESCRIPTION
## Description
Strengthens the Authorization header validation in `lib/server-auth.ts`. Previously, the code used `authHeader.slice(7)` after a `startsWith("Bearer ")` check, which could pass malformed headers in edge cases. Replaced with a strict regex match in both `getVerifiedUser` and `getOptionalVerifiedUser`.

Fixes #249

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings