### PR TITLE
release: develop → main 2026-04-11

### DIFF
--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -425,9 +425,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
 /**
  * PATCH RSVP flags on the user's own signup doc.
- * Body: { willBeLate?: boolean, queuingForSpot?: boolean }
+ * Body: { willBeLate?: boolean, queuingForSpot?: boolean, giveUpSpot?: true }
  * - willBeLate: only when confirmed (confirmedAt set)
  * - queuingForSpot: only when waitlisted (no confirmedAt)
+ * - giveUpSpot: confirmed attendee releases their spot (clears confirmedAt)
  */
 export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
@@ -472,6 +473,21 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
     const data = snap.data() ?? {};
     const isConfirmed = Boolean(data.confirmedAt);
+
+    if (body.giveUpSpot === true) {
+      if (!isConfirmed) {
+        return NextResponse.json(
+          { error: "Only confirmed attendees can give up their spot" },
+          { status: 400 }
+        );
+      }
+      await ref.update({
+        confirmedAt: FieldValue.delete(),
+        gaveUpSpotAt: FieldValue.serverTimestamp(),
+        willBeLate: FieldValue.delete(),
+      });
+      return NextResponse.json({ ok: true, gaveUpSpot: true }, { status: 200 });
+    }
 
     const patch: Record<string, unknown> = {};
     if (Object.prototype.hasOwnProperty.call(body, "willBeLate")) {

--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -13,6 +13,7 @@ import {
   getOptionalVerifiedUser,
 } from "@/lib/server-auth";
 import {
+  compareUnifiedHackathonRanking,
   CURSOR_CREDIT_TOP_N,
   DECLINED_EMAILS,
   JUDGE_EMAILS,
@@ -296,17 +297,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
       });
     }
 
-    // Frozen confirmed first; within each group: PRs desc → website before luma → registration time asc
-    unified.sort((a, b) => {
-      const ac = a.confirmedAt != null ? 1 : 0;
-      const bc = b.confirmedAt != null ? 1 : 0;
-      if (bc !== ac) return bc - ac;
-      if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
-      const aWeb = a.source === "website" ? 1 : 0;
-      const bWeb = b.source === "website" ? 1 : 0;
-      if (bWeb !== aWeb) return bWeb - aWeb;
-      return a.signedUpAtMs - b.signedUpAtMs;
-    });
+    // Competition order (same as freeze top-N): PRs desc → website before Luma → time asc.
+    // Confirmed vs waitlisted still come from confirmedAt, not from rank alone.
+    unified.sort(compareUnifiedHackathonRanking);
 
     // Build ranked entries — status driven by confirmedAt field
     type EntryStatus = "confirmed" | "waitlisted";

--- a/app/hackathons/hack-a-sprint-2026/signup/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/signup/page.tsx
@@ -174,6 +174,38 @@ export default function HackASprint2026SignupPage() {
     }
   };
 
+  const handleGiveUpSpot = async () => {
+    if (!user) return;
+    if (
+      !window.confirm(
+        "Are you sure you want to give up your confirmed spot? This will move you to the waitlist and your spot will go to the next person in line."
+      )
+    )
+      return;
+    setRsvpBusy(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(apiUrl, {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ giveUpSpot: true }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(json.error || "Could not give up spot");
+      }
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not give up spot");
+    } finally {
+      setRsvpBusy(false);
+    }
+  };
+
   const patchRsvp = async (body: { willBeLate?: boolean; queuingForSpot?: boolean }) => {
     if (!user) return;
     setRsvpBusy(true);
@@ -435,6 +467,19 @@ export default function HackASprint2026SignupPage() {
                           Clear — I&apos;ll arrive by 4:00 PM
                         </button>
                       ) : null}
+                    </div>
+                    <div className="mt-4 border-t border-neutral-200 pt-4 dark:border-neutral-700">
+                      <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-2">
+                        Can&apos;t make it? Release your spot so the next person on the waitlist can attend.
+                      </p>
+                      <button
+                        type="button"
+                        disabled={rsvpBusy}
+                        onClick={() => void handleGiveUpSpot()}
+                        className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20"
+                      >
+                        Give up my confirmed spot
+                      </button>
                     </div>
                   </div>
                 ) : (

--- a/lib/hackathon-event-signup.ts
+++ b/lib/hackathon-event-signup.ts
@@ -52,6 +52,29 @@ export function getHackathonEventSignupBlockReason(
 
 export const CURSOR_CREDIT_TOP_N = 50;
 
+/**
+ * Sort key for the combined website + Luma leaderboard (and freeze top-N).
+ * PR count desc → website signup before Luma-only → earlier registration first.
+ */
+export type UnifiedHackathonRankSortFields = {
+  mergedPrCount: number;
+  source: "website" | "luma_only";
+  signedUpAtMs: number;
+};
+
+export function compareUnifiedHackathonRanking(
+  a: UnifiedHackathonRankSortFields,
+  b: UnifiedHackathonRankSortFields
+): number {
+  if (b.mergedPrCount !== a.mergedPrCount) {
+    return b.mergedPrCount - a.mergedPrCount;
+  }
+  const aWeb = a.source === "website" ? 1 : 0;
+  const bWeb = b.source === "website" ? 1 : 0;
+  if (bWeb !== aWeb) return bWeb - aWeb;
+  return a.signedUpAtMs - b.signedUpAtMs;
+}
+
 /** Judges / organizers — excluded from the participant list so they don't take a spot. */
 export const JUDGE_EMAILS = new Set([
   "regorhunt02052@gmail.com",

--- a/scripts/build-hack-a-sprint-ranking.ts
+++ b/scripts/build-hack-a-sprint-ranking.ts
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * Build and store the definitive Hack-a-Sprint 2026 ranking.
+ *
+ * Ranking criteria:
+ *   1. Merged PRs to the community repo through April 9, 2026 (descending)
+ *   2. Luma signup date (ascending — earlier = higher)
+ *
+ * Top 50 = confirmed (frozen), rest = waitlisted.
+ * Waitlisted participants can jockey based on PRs merged after April 9.
+ *
+ * Usage:
+ *   npx tsx scripts/build-hack-a-sprint-ranking.ts [--csv path/to/luma.csv]
+ *
+ * Outputs: scripts/data/hack-a-sprint-2026-ranking.json
+ */
+import { readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join, resolve } from "path";
+
+const REPO_OWNER = "rogerSuperBuilderAlpha";
+const REPO_NAME = "cursor-boston";
+const PR_CUTOFF = "2026-04-09T23:59:59Z";
+const TOP_N = 50;
+
+const JUDGE_LOGINS = new Set(["rogersuperbuilderalpha", "rayruizhiliao"]);
+const BOT_SUFFIXES = ["[bot]"];
+const JUDGE_EMAILS = new Set(["regorhunt02052@gmail.com", "rayruizhiliao@gmail.com"]);
+const DECLINED_EMAILS = new Set([
+  "nasit.v@northeastern.edu",
+  "renganathan.b@northeastern.edu",
+  "revoftc@gmail.com",
+  "sakhare.c@northeastern.edu",
+  "lnu.ava@northeastern.edu",
+  "harrychow8888@gmail.com",
+  "brucejia@bu.edu",
+]);
+
+/**
+ * Known GitHub login corrections: Luma free-text → actual GitHub OAuth login.
+ * Populated from cross-referencing Luma CSV usernames with the repo's merged PR authors.
+ */
+const GITHUB_LOGIN_CORRECTIONS: Record<string, string> = {
+  mhoniseus: "smrifaki",
+  chloezzxzzc: "chloezhangzzc",
+  aakashmkj: "aakashm1712",
+  dannygarciadev: "DannyGarciaDEV",
+};
+
+const INVALID_LOGIN_TOKENS = new Set([
+  "", "n", "no", "none", "na", "n/a", "-", ".", "unknown",
+]);
+
+type CsvRow = Record<string, string>;
+
+function parseCsv(content: string): CsvRow[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') { field += '"'; i++; }
+        else inQuotes = false;
+      } else field += c;
+    } else if (c === '"') inQuotes = true;
+    else if (c === ",") { row.push(field); field = ""; }
+    else if (c === "\r") { /* skip */ }
+    else if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; }
+    else field += c;
+  }
+  row.push(field);
+  if (row.some((cell) => cell.length > 0)) rows.push(row);
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  return rows.slice(1).map((line) => {
+    const obj: CsvRow = {};
+    for (let j = 0; j < header.length; j++) obj[header[j]!] = (line[j] ?? "").trim();
+    return obj;
+  });
+}
+
+function parseGithubLogin(raw: string): string | null {
+  if (!raw) return null;
+  let s = raw.trim();
+  const lower = s.toLowerCase();
+  if (lower.startsWith("http://") || lower.startsWith("https://")) {
+    try {
+      const u = new URL(s);
+      if (!u.hostname.includes("github.com")) return null;
+      const parts = u.pathname.split("/").filter(Boolean);
+      if (parts.length === 0) return null;
+      s = parts[0]!;
+    } catch { return null; }
+  } else if (lower.includes("github.com")) {
+    const idx = lower.indexOf("github.com");
+    const rest = s.slice(idx + "github.com".length).replace(/^[/:]+/, "");
+    const parts = rest.split("/").filter(Boolean);
+    if (parts.length === 0) return null;
+    s = parts[0]!;
+  }
+  s = s.replace(/^@+/, "");
+  if (INVALID_LOGIN_TOKENS.has(s.toLowerCase()) || s.length < 2) return null;
+  return s;
+}
+
+function resolveGithubLogin(lumaLogin: string): string {
+  const corrected = GITHUB_LOGIN_CORRECTIONS[lumaLogin.toLowerCase()];
+  return corrected ?? lumaLogin;
+}
+
+async function fetchAllMergedPrs(): Promise<
+  Array<{ login: string; merged_at: string }>
+> {
+  const prs: Array<{ login: string; merged_at: string }> = [];
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  for (let page = 1; page <= 30; page++) {
+    const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=closed&per_page=100&page=${page}&sort=created&direction=asc`;
+    const res = await fetch(url, { headers, cache: "no-store" });
+    if (!res.ok) { console.error(`GitHub API error: ${res.status} page ${page}`); break; }
+    const items = (await res.json()) as Array<{
+      merged_at?: string | null;
+      user?: { login?: string } | null;
+    }>;
+    if (items.length === 0) break;
+    for (const pr of items) {
+      if (!pr.merged_at || !pr.user?.login) continue;
+      prs.push({ login: pr.user.login.toLowerCase(), merged_at: pr.merged_at });
+    }
+    if (items.length < 100) break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return prs;
+}
+
+function countPrs(
+  prs: Array<{ login: string; merged_at: string }>,
+  cutoffMs?: number
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const pr of prs) {
+    if (JUDGE_LOGINS.has(pr.login)) continue;
+    if (BOT_SUFFIXES.some((s) => pr.login.endsWith(s))) continue;
+    if (cutoffMs !== undefined && new Date(pr.merged_at).getTime() > cutoffMs) continue;
+    counts.set(pr.login, (counts.get(pr.login) ?? 0) + 1);
+  }
+  return counts;
+}
+
+const GITHUB_COL = "What is your GitHub username?";
+
+type RankedEntry = {
+  rank: number;
+  status: "confirmed" | "waitlisted";
+  email: string;
+  name: string;
+  githubLogin: string | null;
+  resolvedGithubLogin: string | null;
+  prsThruApr9: number;
+  prsAllTime: number;
+  lumaCreatedAt: string;
+  lumaSignupMs: number;
+};
+
+async function main() {
+  const csvIdx = process.argv.indexOf("--csv");
+  const csvPath =
+    csvIdx >= 0 && process.argv[csvIdx + 1]
+      ? process.argv[csvIdx + 1]!
+      : join(homedir(), "Downloads", "Cursor Boston Hack-a-Sprint - Guests - 2026-04-11-12-28-29.csv");
+
+  const raw = readFileSync(csvPath, "utf8");
+  const csvRows = parseCsv(raw);
+  console.log(`Loaded ${csvRows.length} rows from ${csvPath}`);
+
+  console.log("Fetching all merged PRs from GitHub…");
+  const allPrs = await fetchAllMergedPrs();
+  console.log(`Fetched ${allPrs.length} merged PRs total.`);
+
+  const cutoffMs = new Date(PR_CUTOFF).getTime();
+  const prsThruApr9 = countPrs(allPrs, cutoffMs);
+  const prsAllTime = countPrs(allPrs);
+
+  console.log("\nPR counts through April 9:");
+  const sortedApr9 = [...prsThruApr9.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [login, count] of sortedApr9) console.log(`  ${login}: ${count}`);
+
+  console.log("\nPost-April 9 changes:");
+  for (const [login, total] of prsAllTime) {
+    const before = prsThruApr9.get(login) ?? 0;
+    if (total > before) console.log(`  ${login}: ${before} → ${total} (+${total - before})`);
+  }
+
+  const seen = new Set<string>();
+  const entries: Omit<RankedEntry, "rank" | "status">[] = [];
+
+  for (const row of csvRows) {
+    const email = (row.email ?? "").trim().toLowerCase();
+    if (!email || seen.has(email)) continue;
+    if (JUDGE_EMAILS.has(email) || DECLINED_EMAILS.has(email)) continue;
+    if ((row.approval_status || "").toLowerCase() === "declined") continue;
+    seen.add(email);
+
+    const rawGh = parseGithubLogin(row[GITHUB_COL] ?? "");
+    const resolved = rawGh ? resolveGithubLogin(rawGh) : null;
+    const resolvedLower = resolved?.toLowerCase() ?? null;
+
+    const fn = row.first_name?.trim();
+    const ln = row.last_name?.trim();
+    const name = [fn, ln].filter(Boolean).join(" ") || row.name?.trim() || "there";
+    const lumaCreatedAt = row.created_at ?? "";
+
+    entries.push({
+      email,
+      name,
+      githubLogin: rawGh,
+      resolvedGithubLogin: resolved,
+      prsThruApr9: resolvedLower ? (prsThruApr9.get(resolvedLower) ?? 0) : 0,
+      prsAllTime: resolvedLower ? (prsAllTime.get(resolvedLower) ?? 0) : 0,
+      lumaCreatedAt,
+      lumaSignupMs: lumaCreatedAt ? new Date(lumaCreatedAt).getTime() : Infinity,
+    });
+  }
+
+  // Sort: PRs through Apr 9 desc, then Luma signup asc
+  entries.sort((a, b) => {
+    if (b.prsThruApr9 !== a.prsThruApr9) return b.prsThruApr9 - a.prsThruApr9;
+    return a.lumaSignupMs - b.lumaSignupMs;
+  });
+
+  const ranked: RankedEntry[] = entries.map((e, i) => ({
+    ...e,
+    rank: i + 1,
+    status: i < TOP_N ? ("confirmed" as const) : ("waitlisted" as const),
+  }));
+
+  // For waitlisted people, re-rank by all-time PRs + Luma date
+  const confirmed = ranked.filter((r) => r.status === "confirmed");
+  const waitlisted = ranked.filter((r) => r.status === "waitlisted");
+  waitlisted.sort((a, b) => {
+    if (b.prsAllTime !== a.prsAllTime) return b.prsAllTime - a.prsAllTime;
+    return a.lumaSignupMs - b.lumaSignupMs;
+  });
+  for (let i = 0; i < waitlisted.length; i++) {
+    waitlisted[i]!.rank = TOP_N + 1 + i;
+  }
+
+  const final = [...confirmed, ...waitlisted];
+
+  console.log("\n=== DEFINITIVE RANKING ===");
+  const pad = (s: string, n: number) => s.slice(0, n).padEnd(n);
+  for (const r of final) {
+    const prInfo =
+      r.prsAllTime > r.prsThruApr9
+        ? `apr9=${r.prsThruApr9} now=${r.prsAllTime}`
+        : `pr=${r.prsThruApr9}`;
+    console.log(
+      [
+        pad(`#${r.rank}`, 5),
+        pad(r.status.toUpperCase(), 12),
+        pad(r.email, 42),
+        pad(prInfo, 20),
+        r.resolvedGithubLogin ? `@${r.resolvedGithubLogin}` : "—",
+        r.githubLogin !== r.resolvedGithubLogin ? `(luma: @${r.githubLogin})` : "",
+      ]
+        .filter(Boolean)
+        .join("  ")
+    );
+  }
+
+  const outPath = resolve(__dirname, "data/hack-a-sprint-2026-ranking.json");
+  const output = {
+    generatedAt: new Date().toISOString(),
+    prCutoffDate: "2026-04-09",
+    topN: TOP_N,
+    totalParticipants: final.length,
+    confirmedCount: confirmed.length,
+    waitlistedCount: waitlisted.length,
+    githubLoginCorrections: GITHUB_LOGIN_CORRECTIONS,
+    ranking: final.map((r) => ({
+      rank: r.rank,
+      status: r.status,
+      email: r.email,
+      name: r.name,
+      githubLogin: r.resolvedGithubLogin,
+      lumaGithubLogin: r.githubLogin !== r.resolvedGithubLogin ? r.githubLogin : undefined,
+      prsThruApr9: r.prsThruApr9,
+      prsAllTime: r.prsAllTime,
+      lumaCreatedAt: r.lumaCreatedAt,
+    })),
+  };
+
+  writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n");
+  console.log(`\nStored ranking to ${outPath}`);
+  console.log(`Confirmed: ${confirmed.length}, Waitlisted: ${waitlisted.length}, Total: ${final.length}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/data/hack-a-sprint-2026-ranking.json
+++ b/scripts/data/hack-a-sprint-2026-ranking.json
@@ -1,0 +1,1110 @@
+{
+  "generatedAt": "2026-04-11T13:23:24.882Z",
+  "prCutoffDate": "2026-04-09",
+  "topN": 50,
+  "totalParticipants": 109,
+  "confirmedCount": 50,
+  "waitlistedCount": 59,
+  "githubLoginCorrections": {
+    "mhoniseus": "smrifaki",
+    "chloezzxzzc": "chloezhangzzc",
+    "aakashmkj": "aakashm1712",
+    "dannygarciadev": "DannyGarciaDEV"
+  },
+  "ranking": [
+    {
+      "rank": 1,
+      "status": "confirmed",
+      "email": "rishierish@plmbr.app",
+      "name": "Rishab Nandi",
+      "githubLogin": "RshieRish",
+      "prsThruApr9": 15,
+      "prsAllTime": 15,
+      "lumaCreatedAt": "2026-04-06T23:50:06.772Z"
+    },
+    {
+      "rank": 2,
+      "status": "confirmed",
+      "email": "sonwaneshreyas@gmail.com",
+      "name": "Shreyas Sonwane",
+      "githubLogin": "Shreyas0786",
+      "prsThruApr9": 8,
+      "prsAllTime": 11,
+      "lumaCreatedAt": "2026-03-23T06:40:34.971Z"
+    },
+    {
+      "rank": 3,
+      "status": "confirmed",
+      "email": "sikeswillmcrae@gmail.com",
+      "name": "Sikes Mcrae",
+      "githubLogin": "Sikes1112",
+      "prsThruApr9": 7,
+      "prsAllTime": 7,
+      "lumaCreatedAt": "2026-03-22T12:57:32.706Z"
+    },
+    {
+      "rank": 4,
+      "status": "confirmed",
+      "email": "nebullii3@gmail.com",
+      "name": "Neha Chaudhari",
+      "githubLogin": "nebullii",
+      "prsThruApr9": 7,
+      "prsAllTime": 7,
+      "lumaCreatedAt": "2026-03-23T16:25:59.788Z"
+    },
+    {
+      "rank": 5,
+      "status": "confirmed",
+      "email": "mouhssine.rifaki@nyu.edu",
+      "name": "Mouhssine Rifaki",
+      "githubLogin": "smrifaki",
+      "lumaGithubLogin": "mhoniseus",
+      "prsThruApr9": 7,
+      "prsAllTime": 7,
+      "lumaCreatedAt": "2026-03-30T17:50:17.403Z"
+    },
+    {
+      "rank": 6,
+      "status": "confirmed",
+      "email": "jack@stepwise.ai",
+      "name": "Jack Schultz",
+      "githubLogin": "Stepwise-ai-dev",
+      "prsThruApr9": 4,
+      "prsAllTime": 4,
+      "lumaCreatedAt": "2026-03-28T18:06:50.852Z"
+    },
+    {
+      "rank": 7,
+      "status": "confirmed",
+      "email": "blakemauri2@gmail.com",
+      "name": "Blake Mauri",
+      "githubLogin": "Cloud-post-code",
+      "prsThruApr9": 2,
+      "prsAllTime": 2,
+      "lumaCreatedAt": "2026-03-25T18:06:50.910Z"
+    },
+    {
+      "rank": 8,
+      "status": "confirmed",
+      "email": "leonarudoryuu0629@gmail.com",
+      "name": "Ryuu Leonardo Sato",
+      "githubLogin": "rysat0",
+      "prsThruApr9": 2,
+      "prsAllTime": 2,
+      "lumaCreatedAt": "2026-04-09T20:21:04.565Z"
+    },
+    {
+      "rank": 9,
+      "status": "confirmed",
+      "email": "leonardo@stepai.co.jp",
+      "name": "Ryuu Leonardo Sato",
+      "githubLogin": "rysat0",
+      "prsThruApr9": 2,
+      "prsAllTime": 2,
+      "lumaCreatedAt": "2026-04-09T20:38:21.511Z"
+    },
+    {
+      "rank": 10,
+      "status": "confirmed",
+      "email": "abishek.bm@gmail.com",
+      "name": "Abishek Bangalore Muralikrishna",
+      "githubLogin": "Abi5678",
+      "prsThruApr9": 1,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-03-20T23:43:20.664Z"
+    },
+    {
+      "rank": 11,
+      "status": "confirmed",
+      "email": "nagaonkar.p@northeastern.edu",
+      "name": "Payal Sanjay Nagaonkar",
+      "githubLogin": "Payal2000",
+      "prsThruApr9": 1,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-03-21T02:07:07.231Z"
+    },
+    {
+      "rank": 12,
+      "status": "confirmed",
+      "email": "chloezzx@bu.edu",
+      "name": "Zhixin Zhang",
+      "githubLogin": "chloezhangzzc",
+      "lumaGithubLogin": "chloezzxzzc",
+      "prsThruApr9": 1,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-03-21T23:44:20.273Z"
+    },
+    {
+      "rank": 13,
+      "status": "confirmed",
+      "email": "dungarani.j@northeastern.edu",
+      "name": "Jaydip",
+      "githubLogin": "17-jd",
+      "prsThruApr9": 1,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-03-30T03:54:14.301Z"
+    },
+    {
+      "rank": 14,
+      "status": "confirmed",
+      "email": "scblouir@gmail.com",
+      "name": "Sam Blouir",
+      "githubLogin": "SamBlouir",
+      "prsThruApr9": 1,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-04-03T15:43:47.330Z"
+    },
+    {
+      "rank": 15,
+      "status": "confirmed",
+      "email": "ayeshafatimazra@gmail.com",
+      "name": "Ayesha Fatima",
+      "githubLogin": null,
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-20T17:09:37.992Z"
+    },
+    {
+      "rank": 16,
+      "status": "confirmed",
+      "email": "ananya@aicollective.com",
+      "name": "Ananya Shah",
+      "githubLogin": null,
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-20T17:11:14.308Z"
+    },
+    {
+      "rank": 17,
+      "status": "confirmed",
+      "email": "michael@web-schulte.de",
+      "name": "Michael Schulte",
+      "githubLogin": null,
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-20T17:22:43.447Z"
+    },
+    {
+      "rank": 18,
+      "status": "confirmed",
+      "email": "aaron.grace@comcast.net",
+      "name": "Aaron Grace",
+      "githubLogin": null,
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-20T17:54:29.853Z"
+    },
+    {
+      "rank": 19,
+      "status": "confirmed",
+      "email": "john.obrien@gmail.com",
+      "name": "John OBrien",
+      "githubLogin": "Johnobrien",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-20T22:20:29.180Z"
+    },
+    {
+      "rank": 20,
+      "status": "confirmed",
+      "email": "chun.yimin@gmail.com",
+      "name": "Yi Min",
+      "githubLogin": "yiminchun",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-20T22:36:12.748Z"
+    },
+    {
+      "rank": 21,
+      "status": "confirmed",
+      "email": "grosz.justin@bcg.com",
+      "name": "Justin Grosz",
+      "githubLogin": "grosz99",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-20T23:48:15.457Z"
+    },
+    {
+      "rank": 22,
+      "status": "confirmed",
+      "email": "hao.cai@gmail.com",
+      "name": "Iain Cai",
+      "githubLogin": "open2claw",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T01:18:31.958Z"
+    },
+    {
+      "rank": 23,
+      "status": "confirmed",
+      "email": "taralthota@gmail.com",
+      "name": "Taral T",
+      "githubLogin": "tvtt2k",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T01:18:35.666Z"
+    },
+    {
+      "rank": 24,
+      "status": "confirmed",
+      "email": "priyanka2bhutada@gmail.com",
+      "name": "Priyanka Bhutada",
+      "githubLogin": "priyanka-0207",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T01:44:26.306Z"
+    },
+    {
+      "rank": 25,
+      "status": "confirmed",
+      "email": "malikzeeshan3.1417@gmail.com",
+      "name": "Muhammad Zeeshan",
+      "githubLogin": "MalikZeeshan1122",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T19:35:31.940Z"
+    },
+    {
+      "rank": 26,
+      "status": "confirmed",
+      "email": "bg2879@columbia.edu",
+      "name": "Bharath Vishal",
+      "githubLogin": "bharath-knight",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T23:14:18.416Z"
+    },
+    {
+      "rank": 27,
+      "status": "confirmed",
+      "email": "sahana359@gmail.com",
+      "name": "Sahana Rajashekara",
+      "githubLogin": "sahana359",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T23:15:29.004Z"
+    },
+    {
+      "rank": 28,
+      "status": "confirmed",
+      "email": "emilyjolam@gmail.com",
+      "name": "Emily L",
+      "githubLogin": "littlepuppi",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T23:22:24.260Z"
+    },
+    {
+      "rank": 29,
+      "status": "confirmed",
+      "email": "patil.jaye@northeastern.edu",
+      "name": "Jayesh Patil",
+      "githubLogin": "JayDataWorld08",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T23:25:20.733Z"
+    },
+    {
+      "rank": 30,
+      "status": "confirmed",
+      "email": "salve.a@northeastern.edu",
+      "name": "Agnel Salve",
+      "githubLogin": "agnelsalve",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T23:39:15.338Z"
+    },
+    {
+      "rank": 31,
+      "status": "confirmed",
+      "email": "eugenio.zuccarelli@gmail.com",
+      "name": "Eugenio Zuccarelli",
+      "githubLogin": "jayzuccarelli",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-21T23:53:12.856Z"
+    },
+    {
+      "rank": 32,
+      "status": "confirmed",
+      "email": "5kf2mfbv8v@privaterelay.appleid.com",
+      "name": "Jack Digilov",
+      "githubLogin": "jackfruitsandwich",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T00:11:42.645Z"
+    },
+    {
+      "rank": 33,
+      "status": "confirmed",
+      "email": "mark2pm@gmail.com",
+      "name": "Nithin Yash Menezes",
+      "githubLogin": "Nithin123q",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T01:28:39.096Z"
+    },
+    {
+      "rank": 34,
+      "status": "confirmed",
+      "email": "sahu.man@northeastern.edu",
+      "name": "Manisha Sahu",
+      "githubLogin": "manishasahu271",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T01:30:22.108Z"
+    },
+    {
+      "rank": 35,
+      "status": "confirmed",
+      "email": "saikumarreddy221@gmail.com",
+      "name": "Kumar Reddy P V Sai",
+      "githubLogin": "saikumar221",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T03:08:55.358Z"
+    },
+    {
+      "rank": 36,
+      "status": "confirmed",
+      "email": "kompella.sa@northeastern.edu",
+      "name": "Satyasai Aditya Kompella",
+      "githubLogin": "sakompella",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T06:30:36.776Z"
+    },
+    {
+      "rank": 37,
+      "status": "confirmed",
+      "email": "samirizvi25@gmail.com",
+      "name": "Rizvi Syed Abdul Sami",
+      "githubLogin": "abdulsami123",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T07:39:40.794Z"
+    },
+    {
+      "rank": 38,
+      "status": "confirmed",
+      "email": "mikeboensel@gmail.com",
+      "name": "Mike Boensel",
+      "githubLogin": "mikeboensel",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T13:01:07.378Z"
+    },
+    {
+      "rank": 39,
+      "status": "confirmed",
+      "email": "nicholas@mindsettech.ai",
+      "name": "Nicholas Kozhemiakin",
+      "githubLogin": "nickkozh",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T14:51:54.218Z"
+    },
+    {
+      "rank": 40,
+      "status": "confirmed",
+      "email": "oftherose91@gmail.com",
+      "name": "Argenis De La Rosa",
+      "githubLogin": "theonlyhennygod",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-22T18:03:56.688Z"
+    },
+    {
+      "rank": 41,
+      "status": "confirmed",
+      "email": "alex@srge.co",
+      "name": "Alex Zuffoletti",
+      "githubLogin": "alexcbzuff",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-23T01:04:55.731Z"
+    },
+    {
+      "rank": 42,
+      "status": "confirmed",
+      "email": "mekhalrajr@gmail.com",
+      "name": "Mekhal Raj",
+      "githubLogin": "mekhalraj",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-23T05:38:02.003Z"
+    },
+    {
+      "rank": 43,
+      "status": "confirmed",
+      "email": "kmondlane@gmail.com",
+      "name": "Kris Mondlane",
+      "githubLogin": "pappacorleone",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-23T14:47:24.393Z"
+    },
+    {
+      "rank": 44,
+      "status": "confirmed",
+      "email": "asceniccola@gmail.com",
+      "name": "Andrew Ceniccola",
+      "githubLogin": "aceniccola",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-24T17:47:54.303Z"
+    },
+    {
+      "rank": 45,
+      "status": "confirmed",
+      "email": "samtem300@gmail.com",
+      "name": "Samet T",
+      "githubLogin": "samettemurcin",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-26T03:12:36.450Z"
+    },
+    {
+      "rank": 46,
+      "status": "confirmed",
+      "email": "vyahhi@gmail.com",
+      "name": "Nikolay Vyahhi",
+      "githubLogin": "vyahhi",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-26T14:25:34.089Z"
+    },
+    {
+      "rank": 47,
+      "status": "confirmed",
+      "email": "matthewb10@outlook.com",
+      "name": "Matthew Birov",
+      "githubLogin": "matthewb100",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-26T16:05:36.153Z"
+    },
+    {
+      "rank": 48,
+      "status": "confirmed",
+      "email": "krishnamurthy.p@northeastern.edu",
+      "name": "Prarthana Krishnamurthy",
+      "githubLogin": "pkrishna1801",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-26T18:02:37.887Z"
+    },
+    {
+      "rank": 49,
+      "status": "confirmed",
+      "email": "satishparaddi@gmail.com",
+      "name": "Satish Mallikarjun",
+      "githubLogin": "satishparaddi",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-27T00:41:45.339Z"
+    },
+    {
+      "rank": 50,
+      "status": "confirmed",
+      "email": "adhithyan245@gmail.com",
+      "name": "Adhithyan Aravind",
+      "githubLogin": "Adhithyan245",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-27T22:02:54.189Z"
+    },
+    {
+      "rank": 51,
+      "status": "waitlisted",
+      "email": "aakashmkj@gmail.com",
+      "name": "Aakash Mukherjee",
+      "githubLogin": "aakashm1712",
+      "lumaGithubLogin": "aakashmkj",
+      "prsThruApr9": 0,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-04-06T15:42:47.323Z"
+    },
+    {
+      "rank": 52,
+      "status": "waitlisted",
+      "email": "singh.para@northeastern.edu",
+      "name": "Paramjeet Singh",
+      "githubLogin": "Paramjeet-singh-neu",
+      "prsThruApr9": 0,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-04-08T23:37:22.271Z"
+    },
+    {
+      "rank": 53,
+      "status": "waitlisted",
+      "email": "sebastian@wallkoetter.net",
+      "name": "Sebastian Wallkötter",
+      "githubLogin": "FirefoxMetzger",
+      "prsThruApr9": 0,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-04-09T23:14:45.059Z"
+    },
+    {
+      "rank": 54,
+      "status": "waitlisted",
+      "email": "karthikeyan.k@northeastern.edu",
+      "name": "Kannan Karthikeyan",
+      "githubLogin": "notkannan",
+      "prsThruApr9": 0,
+      "prsAllTime": 1,
+      "lumaCreatedAt": "2026-04-10T22:46:37.016Z"
+    },
+    {
+      "rank": 55,
+      "status": "waitlisted",
+      "email": "simba@forkoff.xyz",
+      "name": "Simba",
+      "githubLogin": "0x0Simba",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-28T09:25:47.622Z"
+    },
+    {
+      "rank": 56,
+      "status": "waitlisted",
+      "email": "phang.monica@bcg.com",
+      "name": "Monica Phang",
+      "githubLogin": "NobyDa",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-28T17:38:48.808Z"
+    },
+    {
+      "rank": 57,
+      "status": "waitlisted",
+      "email": "torresr14@gmail.com",
+      "name": "Randy Torres",
+      "githubLogin": "randytorres",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-29T01:01:18.291Z"
+    },
+    {
+      "rank": 58,
+      "status": "waitlisted",
+      "email": "ashutoshiwale39@gmail.com",
+      "name": "Ashutosh Iwale",
+      "githubLogin": "AshutoshRavindraIwale",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-29T23:14:01.506Z"
+    },
+    {
+      "rank": 59,
+      "status": "waitlisted",
+      "email": "ashbhatia@gmail.com",
+      "name": "Ashish Bhatia",
+      "githubLogin": "ashbhati",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-30T02:14:27.917Z"
+    },
+    {
+      "rank": 60,
+      "status": "waitlisted",
+      "email": "yuri.braga@carefuseai.com",
+      "name": "Yuri Braga",
+      "githubLogin": "yuribraga26",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-30T14:09:32.071Z"
+    },
+    {
+      "rank": 61,
+      "status": "waitlisted",
+      "email": "naik.san@northeastern.edu",
+      "name": "Sanath Naik",
+      "githubLogin": "sanath11598",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-30T15:38:59.523Z"
+    },
+    {
+      "rank": 62,
+      "status": "waitlisted",
+      "email": "murali.na@northeastern.edu",
+      "name": "Naveen Murali",
+      "githubLogin": "Naveennnm13",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-30T15:40:32.195Z"
+    },
+    {
+      "rank": 63,
+      "status": "waitlisted",
+      "email": "ahijith@gmail.com",
+      "name": "Reghunaath Ajith Kumar Ahila",
+      "githubLogin": "Reghunaath",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-30T21:32:45.766Z"
+    },
+    {
+      "rank": 64,
+      "status": "waitlisted",
+      "email": "nagapavithralagisetty@gmail.com",
+      "name": "Pavithra Lagisetty",
+      "githubLogin": "pavithralagisetty",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-30T21:47:21.123Z"
+    },
+    {
+      "rank": 65,
+      "status": "waitlisted",
+      "email": "bradegan@gmail.com",
+      "name": "Brad Egan",
+      "githubLogin": "bradAGI",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-31T01:12:15.081Z"
+    },
+    {
+      "rank": 66,
+      "status": "waitlisted",
+      "email": "ankittejyadav@gmail.com",
+      "name": "Ankit Yadav",
+      "githubLogin": "ankittejyadav",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-31T01:40:08.003Z"
+    },
+    {
+      "rank": 67,
+      "status": "waitlisted",
+      "email": "wakrson@gmail.com",
+      "name": "Mark Robinson",
+      "githubLogin": "wakrson",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-31T22:15:51.812Z"
+    },
+    {
+      "rank": 68,
+      "status": "waitlisted",
+      "email": "ajithkumarahila.r@northeastern.edu",
+      "name": "Reghunaath A A",
+      "githubLogin": "Reghunaath",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-03-31T22:29:29.590Z"
+    },
+    {
+      "rank": 69,
+      "status": "waitlisted",
+      "email": "oalshayeb1@babson.edu",
+      "name": "Obyda Alshayeb",
+      "githubLogin": null,
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-01T04:28:42.898Z"
+    },
+    {
+      "rank": 70,
+      "status": "waitlisted",
+      "email": "monicaphang.mp@gmail.com",
+      "name": "Monica Phang",
+      "githubLogin": "Zombiedays",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-01T18:21:51.346Z"
+    },
+    {
+      "rank": 71,
+      "status": "waitlisted",
+      "email": "janna@aicollective.com",
+      "name": "Janna Hong",
+      "githubLogin": "jannareverie",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-01T23:20:22.174Z"
+    },
+    {
+      "rank": 72,
+      "status": "waitlisted",
+      "email": "dagmawimilkias@gmail.com",
+      "name": "Dagmawi Milkias",
+      "githubLogin": "Dagi2004",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-02T05:34:26.909Z"
+    },
+    {
+      "rank": 73,
+      "status": "waitlisted",
+      "email": "himanshuchouhan@gmail.com",
+      "name": "Himanshu Chouhan",
+      "githubLogin": "himanshuchouhan",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-02T17:19:54.955Z"
+    },
+    {
+      "rank": 74,
+      "status": "waitlisted",
+      "email": "buse@bluesense.ai",
+      "name": "Buse Demir",
+      "githubLogin": "busedemir",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-02T19:39:57.497Z"
+    },
+    {
+      "rank": 75,
+      "status": "waitlisted",
+      "email": "thebarmaeffect@gmail.com",
+      "name": "Karthik Barma",
+      "githubLogin": "thebarmaeffect",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-02T22:44:54.423Z"
+    },
+    {
+      "rank": 76,
+      "status": "waitlisted",
+      "email": "jaisinganmol@gmail.com",
+      "name": "Anmol Jaising",
+      "githubLogin": "jaisinganmol",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-03T01:05:40.449Z"
+    },
+    {
+      "rank": 77,
+      "status": "waitlisted",
+      "email": "mrcalebhung@gmail.com",
+      "name": "Caleb Hung",
+      "githubLogin": "calebhung",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-04T02:40:32.350Z"
+    },
+    {
+      "rank": 78,
+      "status": "waitlisted",
+      "email": "ceo@grepone.com",
+      "name": "Joshua Elkington",
+      "githubLogin": "axialxyz",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-04T20:54:04.127Z"
+    },
+    {
+      "rank": 79,
+      "status": "waitlisted",
+      "email": "aatuusa@gmail.com",
+      "name": "aatu usa",
+      "githubLogin": "aatmaj28",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-04T23:25:55.649Z"
+    },
+    {
+      "rank": 80,
+      "status": "waitlisted",
+      "email": "jinalthakkar2022@gmail.com",
+      "name": "Jinal Thakker",
+      "githubLogin": "jinalthakkar7",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-05T00:03:33.168Z"
+    },
+    {
+      "rank": 81,
+      "status": "waitlisted",
+      "email": "muradhossainmgr@gmail.com",
+      "name": "Morad Hossain",
+      "githubLogin": "MGR",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-05T02:46:25.236Z"
+    },
+    {
+      "rank": 82,
+      "status": "waitlisted",
+      "email": "orcino.raphael@gmail.com",
+      "name": "Raphael Orcino",
+      "githubLogin": "RaphaelOrcino",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-05T05:13:53.533Z"
+    },
+    {
+      "rank": 83,
+      "status": "waitlisted",
+      "email": "hirvitakabariya@gmail.com",
+      "name": "HK",
+      "githubLogin": "hirvita-kabariya",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-05T16:39:23.696Z"
+    },
+    {
+      "rank": 84,
+      "status": "waitlisted",
+      "email": "saks2730@gmail.com",
+      "name": "Sakshi Chavan",
+      "githubLogin": "Sakshi3027",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-05T19:09:25.232Z"
+    },
+    {
+      "rank": 85,
+      "status": "waitlisted",
+      "email": "sneha.sonkusare15@gmail.com",
+      "name": "Sneha Sonkusare",
+      "githubLogin": "snehasonkusare-tech",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-05T19:11:07.630Z"
+    },
+    {
+      "rank": 86,
+      "status": "waitlisted",
+      "email": "hansome594@gmail.com",
+      "name": "Clevelini Maris",
+      "githubLogin": "yogesh",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T03:29:56.339Z"
+    },
+    {
+      "rank": 87,
+      "status": "waitlisted",
+      "email": "bhuvaneshwaran.r@northeastern.edu",
+      "name": "Ramshankar B",
+      "githubLogin": "Ramshankar07",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T09:45:22.043Z"
+    },
+    {
+      "rank": 88,
+      "status": "waitlisted",
+      "email": "sai@thinkwithada.com",
+      "name": "Sai Bolla",
+      "githubLogin": "saikrishnabolla",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T14:23:20.718Z"
+    },
+    {
+      "rank": 89,
+      "status": "waitlisted",
+      "email": "ivormontenegro@gmail.com",
+      "name": "Ivo Rosa Montenegro",
+      "githubLogin": "ivormontenegro",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T14:51:18.054Z"
+    },
+    {
+      "rank": 90,
+      "status": "waitlisted",
+      "email": "heronalps@gmail.com",
+      "name": "Michael Zhang",
+      "githubLogin": "heronalps",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T15:43:45.616Z"
+    },
+    {
+      "rank": 91,
+      "status": "waitlisted",
+      "email": "lucas196700@gmail.com",
+      "name": "俊安 金",
+      "githubLogin": "lucasking0109",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T16:34:17.755Z"
+    },
+    {
+      "rank": 92,
+      "status": "waitlisted",
+      "email": "aarjav02@gmail.com",
+      "name": "Aarjav Jain",
+      "githubLogin": "aarjav0210",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T19:33:10.714Z"
+    },
+    {
+      "rank": 93,
+      "status": "waitlisted",
+      "email": "zhiyi_lu@brown.edu",
+      "name": "Nikky Lu",
+      "githubLogin": "nikkylu",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T19:50:45.708Z"
+    },
+    {
+      "rank": 94,
+      "status": "waitlisted",
+      "email": "manthan@legitreach.com",
+      "name": "Manthan Admane",
+      "githubLogin": "MisterAwesome23",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-06T23:35:00.912Z"
+    },
+    {
+      "rank": 95,
+      "status": "waitlisted",
+      "email": "ridhambhagat@gmail.com",
+      "name": "Ridham Bhagat",
+      "githubLogin": "RasenRhino",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-07T03:32:22.292Z"
+    },
+    {
+      "rank": 96,
+      "status": "waitlisted",
+      "email": "teozhihao123@gmail.com",
+      "name": "Zhi Hao Teo",
+      "githubLogin": "zzzh1hao01",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-07T04:28:46.741Z"
+    },
+    {
+      "rank": 97,
+      "status": "waitlisted",
+      "email": "dannygarciacotes1@gmail.com",
+      "name": "Danny Garcia Cortes",
+      "githubLogin": "DannyGarciaDEV",
+      "lumaGithubLogin": "dannygarciadev",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-07T14:42:50.780Z"
+    },
+    {
+      "rank": 98,
+      "status": "waitlisted",
+      "email": "patelheer2002@gmail.com",
+      "name": "Heer",
+      "githubLogin": "patelheer2910",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-07T19:05:17.390Z"
+    },
+    {
+      "rank": 99,
+      "status": "waitlisted",
+      "email": "siddhanth@huedmamas.com",
+      "name": "Siddhanth Pai",
+      "githubLogin": "Siddhanth99-tech",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-07T20:49:40.697Z"
+    },
+    {
+      "rank": 100,
+      "status": "waitlisted",
+      "email": "kashettyshruthi@gmail.com",
+      "name": "Shruthi",
+      "githubLogin": "Shruthik99",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-08T13:43:05.669Z"
+    },
+    {
+      "rank": 101,
+      "status": "waitlisted",
+      "email": "omkarsheth30@gmail.com",
+      "name": "Omkar Sheth",
+      "githubLogin": "OmkarSheth8",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-09T02:09:11.132Z"
+    },
+    {
+      "rank": 102,
+      "status": "waitlisted",
+      "email": "ssiddula.dev@gmail.com",
+      "name": "Sreekar Siddula",
+      "githubLogin": "sreekar-ss",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-09T03:16:54.952Z"
+    },
+    {
+      "rank": 103,
+      "status": "waitlisted",
+      "email": "zaraaurora82@gmail.com",
+      "name": "Zara aura",
+      "githubLogin": "fghgfdhg",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-09T10:57:57.948Z"
+    },
+    {
+      "rank": 104,
+      "status": "waitlisted",
+      "email": "amitanveri@gmail.com",
+      "name": "Amit Anveri",
+      "githubLogin": "AmitAnveri",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-10T00:49:52.209Z"
+    },
+    {
+      "rank": 105,
+      "status": "waitlisted",
+      "email": "vasilis@vasilistsolis.com",
+      "name": "Vasilis Tsolis",
+      "githubLogin": "okc0mputex",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-10T01:32:21.828Z"
+    },
+    {
+      "rank": 106,
+      "status": "waitlisted",
+      "email": "icey@starlaskincare.com",
+      "name": "Icey Roongpiti",
+      "githubLogin": "iceystarla",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-10T04:35:09.289Z"
+    },
+    {
+      "rank": 107,
+      "status": "waitlisted",
+      "email": "andre@genesisfund.co",
+      "name": "Andre Kirby",
+      "githubLogin": "AndreFKirby",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-10T23:39:17.129Z"
+    },
+    {
+      "rank": 108,
+      "status": "waitlisted",
+      "email": "d5222c@gmail.com",
+      "name": "Yinzheng Guan",
+      "githubLogin": "yguan001",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-11T01:34:58.477Z"
+    },
+    {
+      "rank": 109,
+      "status": "waitlisted",
+      "email": "miloschwartz@outlook.com",
+      "name": "Milo Scharwarx",
+      "githubLogin": "milo",
+      "prsThruApr9": 0,
+      "prsAllTime": 0,
+      "lumaCreatedAt": "2026-04-11T06:49:29.843Z"
+    }
+  ]
+}

--- a/scripts/freeze-confirmed-top50.ts
+++ b/scripts/freeze-confirmed-top50.ts
@@ -23,7 +23,12 @@ loadEnvConfig(process.cwd());
 
 import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
-import { CURSOR_CREDIT_TOP_N, DECLINED_EMAILS, JUDGE_EMAILS } from "../lib/hackathon-event-signup";
+import {
+  compareUnifiedHackathonRanking,
+  CURSOR_CREDIT_TOP_N,
+  DECLINED_EMAILS,
+  JUDGE_EMAILS,
+} from "../lib/hackathon-event-signup";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "../lib/hackathon-showcase";
 import { fetchMergedPrCountsForLogins } from "../lib/github-merged-pr-count";
 import { getGithubRepoPair } from "../lib/github-recent-merged-prs";
@@ -107,14 +112,6 @@ type UnifiedEntry = {
   source: "website" | "luma_only";
   alreadyConfirmed: boolean;
 };
-
-function competitionSort(a: UnifiedEntry, b: UnifiedEntry): number {
-  if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
-  const aWeb = a.source === "website" ? 1 : 0;
-  const bWeb = b.source === "website" ? 1 : 0;
-  if (bWeb !== aWeb) return bWeb - aWeb;
-  return a.signedUpAtMs - b.signedUpAtMs;
-}
 
 async function main() {
   const dryRun = process.argv.includes("--dry-run");
@@ -233,7 +230,7 @@ async function main() {
   console.log(`Total: ${unified.length} combined.`);
 
   if (recalculate) {
-    const ranked = [...unified].sort(competitionSort);
+    const ranked = [...unified].sort(compareUnifiedHackathonRanking);
     const top = ranked.slice(0, CURSOR_CREDIT_TOP_N);
     const topSet = new Set(top.map((r) => `${r.collection}\0${r.docId}`));
 
@@ -270,7 +267,7 @@ async function main() {
   }
 
   // Sort: PRs desc → website before luma → registration time asc
-  unified.sort(competitionSort);
+  unified.sort(compareUnifiedHackathonRanking);
 
   // Already-frozen users stay frozen (confirmedAt is permanent).
   // Only fill remaining spots up to CURSOR_CREDIT_TOP_N with unfrozen users.

--- a/scripts/send-hack-a-sprint-emails.ts
+++ b/scripts/send-hack-a-sprint-emails.ts
@@ -10,6 +10,7 @@
  *   npx tsx scripts/send-hack-a-sprint-emails.ts --send [--csv path/to/export.csv]
  *   npx tsx scripts/send-hack-a-sprint-emails.ts --send --announce-list [--csv path/to/export.csv]
  *   npx tsx scripts/send-hack-a-sprint-emails.ts --dry-run --reminder [--csv path/to/export.csv]
+ *   npx tsx scripts/send-hack-a-sprint-emails.ts --dry-run --correction [--csv path/to/export.csv]
  *
  * --announce-list: sends a simpler email linking to the participant list page
  *   (accepted & waitlisted) instead of the full tier-specific emails.
@@ -882,11 +883,142 @@ ${block}
   return { subject, html, text: textParts.join("\n") };
 }
 
+const RANKING_JSON_PATH = join(__dirname, "data/hack-a-sprint-2026-ranking.json");
+
+type CorrectionRow = {
+  email: string;
+  name: string;
+  githubLogin: string | null;
+  mergedPrCount: number;
+  rank: number;
+  tier: "CONFIRMED" | "WAITLISTED";
+};
+
+function loadCorrectionRanking(): CorrectionRow[] {
+  const data = JSON.parse(readFileSync(RANKING_JSON_PATH, "utf8")) as {
+    ranking: Array<{
+      rank: number;
+      status: "confirmed" | "waitlisted";
+      email: string;
+      name: string;
+      githubLogin: string | null;
+      prsThruApr9: number;
+      prsAllTime: number;
+    }>;
+    totalParticipants: number;
+  };
+
+  return data.ranking.map((r) => ({
+    email: r.email,
+    name: r.name,
+    githubLogin: r.githubLogin,
+    mergedPrCount: r.status === "confirmed" ? r.prsThruApr9 : r.prsAllTime,
+    rank: r.rank,
+    tier: r.status === "confirmed" ? "CONFIRMED" as const : "WAITLISTED" as const,
+  }));
+}
+
+function buildCorrectionEmail(args: {
+  tier: Exclude<RegistrantTier, "DECLINED">;
+  name: string;
+  rank: number | null;
+  totalOnLeaderboard: number;
+  mergedPrCount: number;
+  profileBlockReason: string | null;
+}): { subject: string; html: string; text: string } {
+  const { tier, name, rank, totalOnLeaderboard, mergedPrCount, profileBlockReason } = args;
+  const first = escapeHtml(name);
+  const signupUrl = `${SITE_ORIGIN.replace(/\/$/, "")}${SIGNUP_PATH}`;
+  const repoUrl = getGithubRepoWebBaseUrl();
+
+  let subject: string;
+  let lead: string;
+
+  if (tier === "CONFIRMED") {
+    subject = "Correction: Your spot IS confirmed for Hack-a-Sprint April 13";
+    lead = `<p>Hi ${first},</p>
+<p><strong>We owe you an apology.</strong> Our previous email contained an error — some confirmed participants were incorrectly told they were waitlisted. We're sorry for the confusion.</p>
+<p><strong>Your correct status: CONFIRMED.</strong> You are <strong>#${rank}</strong> out of <strong>${totalOnLeaderboard}</strong> with <strong>${mergedPrCount}</strong> merged PR${mergedPrCount === 1 ? "" : "s"}.</p>
+<p><strong>What "confirmed" means:</strong></p>
+<ul>
+<li>You have a <strong>reserved seat</strong> at Hack-a-Sprint on April 13.</li>
+<li>You will receive <strong>$50 in Cursor credits</strong> when you check in.</li>
+<li>You are eligible for the <strong>$1,200 prize pool</strong> (six $200 spots).</li>
+</ul>
+<p><strong>What you need to do:</strong></p>
+<ol>
+<li><strong>Arrive by 4:00 PM ET on April 13.</strong> Unclaimed spots at 4:00 PM go to the waitlist.</li>
+<li>If you'll be late, contact roger@cursorboston.com <strong>before</strong> the event or use the Day-of RSVP on the website so we hold your spot.</li>
+<li>Bring your laptop, charger, and something you want to build. Sprint starts at 4:30 PM.</li>
+</ol>
+<p>If you can no longer attend, <strong>please remove yourself from <a href="${escapeHtml(LUMA_URL)}">Luma</a></strong> so we can give your spot to someone on the waitlist.</p>
+<p>See the full participant list: <a href="${escapeHtml(signupUrl)}">${escapeHtml(signupUrl)}</a></p>`;
+  } else if (tier === "WAITLISTED") {
+    subject = "Correction: Your Hack-a-Sprint status — waitlist for April 13";
+    lead = `<p>Hi ${first},</p>
+<p><strong>We owe you an apology.</strong> Our previous email contained an error — some participants received the wrong status. We're sorry for the confusion.</p>
+<p><strong>Your correct status: WAITLISTED.</strong> You are <strong>#${rank}</strong> out of <strong>${totalOnLeaderboard}</strong> with <strong>${mergedPrCount}</strong> merged PR${mergedPrCount === 1 ? "" : "s"}. The top <strong>${CURSOR_CREDIT_TOP_N}</strong> have confirmed spots — you are currently on the <strong>waitlist</strong>.</p>
+<p><strong>You can still move up.</strong> Merged PRs are the #1 way to climb the leaderboard. Open a PR to <a href="${escapeHtml(repoUrl)}">${escapeHtml(repoUrl)}</a> — documentation, bug fixes, and small features all count. As confirmed participants drop out or don't show up, waitlisted builders move in <strong>by rank order</strong>.</p>
+<p><strong>How day-of works:</strong> At 4:00 PM ET on April 13, unclaimed confirmed spots go to the waitlist in rank order. If you'd like a chance at a spot, be nearby and watch your email or Discord around 4:00 PM.</p>
+<p>If you know you won't be coming, please remove yourself from <a href="${escapeHtml(LUMA_URL)}">Luma</a> so others can move up.</p>
+<p>See the full participant list: <a href="${escapeHtml(signupUrl)}">${escapeHtml(signupUrl)}</a></p>`;
+  } else if (tier === "SIGNED_UP_NO_SPOT") {
+    subject = "Correction: Hack-a-Sprint status update — complete your signup";
+    const block =
+      profileBlockReason ?
+        `<p><strong>Before you can claim your spot:</strong> ${escapeHtml(profileBlockReason)}</p>`
+      : "";
+    lead = `<p>Hi ${first},</p>
+<p><strong>We owe you an apology.</strong> Our previous email contained an error for some participants. We're correcting everyone's status now.</p>
+<p>We found your <strong>cursorboston.com</strong> account, but you haven't joined the website signup list yet — so you're not currently ranked.</p>
+${block}
+<p>If you still want to attend, go to <a href="${escapeHtml(signupUrl)}">${escapeHtml(signupUrl)}</a> and claim your spot. You'll be ranked based on your merged PR count (<strong>${mergedPrCount}</strong>). The top <strong>${CURSOR_CREDIT_TOP_N}</strong> are confirmed; everyone else is waitlisted.</p>
+<p>If you can no longer attend, please remove yourself from <a href="${escapeHtml(LUMA_URL)}">Luma</a>.</p>`;
+  } else {
+    subject = "Correction: Hack-a-Sprint status update — complete your registration";
+    lead = `<p>Hi ${first},</p>
+<p><strong>We owe you an apology.</strong> Our previous email contained an error for some participants. We're correcting everyone's status now.</p>
+<p>You registered on <strong>Luma</strong>, but we don't see a matching <strong>cursorboston.com</strong> account — so you're not currently ranked on the leaderboard.</p>
+<p><strong>To get on the list:</strong></p>
+<ol>
+<li>Create an account at <a href="${escapeHtml(SITE_ORIGIN)}">cursorboston.com</a> (use this same email if possible).</li>
+<li>Connect <strong>GitHub</strong> and <strong>Discord</strong> on your profile.</li>
+<li>Set your profile to <strong>public</strong> with Discord visible.</li>
+<li>Go to <a href="${escapeHtml(signupUrl)}">${escapeHtml(signupUrl)}</a> and <strong>claim your spot</strong>.</li>
+</ol>
+<p>The top <strong>${CURSOR_CREDIT_TOP_N}</strong> are confirmed; everyone else is waitlisted. Merge PRs to <a href="${escapeHtml(repoUrl)}">${escapeHtml(repoUrl)}</a> to move up.</p>
+<p>If you can no longer attend, please remove yourself from <a href="${escapeHtml(LUMA_URL)}">Luma</a>.</p>`;
+  }
+
+  const html = emailShell(`${lead}${commonEventBlockHtml()}`);
+
+  const textParts = [
+    `Hi ${name},`,
+    "",
+    "CORRECTION: Our previous email contained an error — some participants received the wrong status. We apologize for the confusion.",
+    "",
+    tier === "CONFIRMED" ?
+      `Your correct status: CONFIRMED. You're #${rank} with a reserved seat for April 13. Arrive by 4:00 PM ET. $50 Cursor credits at check-in. If you can't come, remove yourself from Luma.`
+    : tier === "WAITLISTED" ?
+      `Your correct status: WAITLISTED. You're #${rank}. Top ${CURSOR_CREDIT_TOP_N} are confirmed. Merge PRs to ${repoUrl} to move up. At 4:00 PM ET on April 13, unclaimed spots go to waitlist in rank order.`
+    : tier === "SIGNED_UP_NO_SPOT" ?
+      `You have an account but aren't on the signup list yet. Claim your spot: ${signupUrl}` +
+        (profileBlockReason ? ` First fix: ${profileBlockReason}` : "")
+    : `Create a cursorboston.com account and claim your spot: ${signupUrl}`,
+    "",
+    `Full list: ${signupUrl}`,
+    `Event: April 13, 2026 4–8 PM ET, Back Bay Boston. Luma: ${LUMA_URL}`,
+  ];
+
+  return { subject, html, text: textParts.join("\n") };
+}
+
 function parseArgs(argv: string[]) {
   const dryRun = argv.includes("--dry-run");
   const send = argv.includes("--send");
   const announceList = argv.includes("--announce-list");
   const reminder = argv.includes("--reminder");
+  const correction = argv.includes("--correction");
   const csvIdx = argv.indexOf("--csv");
   const csvPath =
     csvIdx >= 0 && argv[csvIdx + 1] ?
@@ -901,11 +1033,12 @@ function parseArgs(argv: string[]) {
     console.error("Specify exactly one of: --dry-run | --send");
     process.exit(1);
   }
-  if (announceList && reminder) {
-    console.error("Use only one of: --announce-list | --reminder");
+  const modeCount = [announceList, reminder, correction].filter(Boolean).length;
+  if (modeCount > 1) {
+    console.error("Use only one of: --announce-list | --reminder | --correction");
     process.exit(1);
   }
-  return { dryRun, send, announceList, reminder, csvPath };
+  return { dryRun, send, announceList, reminder, correction, csvPath };
 }
 
 async function sleep(ms: number) {
@@ -913,7 +1046,7 @@ async function sleep(ms: number) {
 }
 
 async function main() {
-  const { dryRun, send, announceList, reminder, csvPath } = parseArgs(process.argv.slice(2));
+  const { dryRun, send, announceList, reminder, correction, csvPath } = parseArgs(process.argv.slice(2));
 
   let raw: string;
   try {
@@ -930,6 +1063,79 @@ async function main() {
     }
   }
 
+  const csvRows = parseCsv(raw);
+  if (csvRows.length === 0) {
+    console.error("No data rows in CSV.");
+    process.exit(1);
+  }
+
+  console.log(`Loaded ${csvRows.length} rows from ${csvPath}`);
+
+  if (correction) {
+    console.log(`Loading ranking from ${RANKING_JSON_PATH}…`);
+    const ranked = loadCorrectionRanking();
+    const confirmedCount = ranked.filter((r) => r.tier === "CONFIRMED").length;
+    const waitlistedCount = ranked.filter((r) => r.tier === "WAITLISTED").length;
+    console.log(`\nCorrection ranking: ${ranked.length} participants (${confirmedCount} confirmed, ${waitlistedCount} waitlisted)`);
+
+    const pad = (s: string, n: number) => s.slice(0, n).padEnd(n);
+    for (const r of ranked) {
+      console.log(
+        [
+          pad(`#${r.rank}`, 5),
+          pad(r.tier, 12),
+          pad(r.email, 42),
+          `pr=${r.mergedPrCount}`,
+          r.githubLogin ? `@${r.githubLogin}` : "—",
+        ].join("  ")
+      );
+    }
+
+    if (dryRun) {
+      console.log("\n--dry-run --correction: no emails sent. Preview:");
+      const sampleConfirmed = ranked.find((r) => r.tier === "CONFIRMED");
+      const sampleWaitlisted = ranked.find((r) => r.tier === "WAITLISTED");
+      for (const sample of [sampleConfirmed, sampleWaitlisted]) {
+        if (!sample) continue;
+        const { subject, html } = buildCorrectionEmail({
+          tier: sample.tier,
+          name: sample.name,
+          rank: sample.rank,
+          totalOnLeaderboard: ranked.length,
+          mergedPrCount: sample.mergedPrCount,
+          profileBlockReason: null,
+        });
+        console.log(`\n[${sample.tier}] Subject: ${subject}`);
+        console.log("HTML preview:\n---\n" + html.slice(0, 700) + "…\n---");
+      }
+      return;
+    }
+
+    let sent = 0;
+    let failed = 0;
+    for (const r of ranked) {
+      const { subject, html, text } = buildCorrectionEmail({
+        tier: r.tier,
+        name: r.name,
+        rank: r.rank,
+        totalOnLeaderboard: ranked.length,
+        mergedPrCount: r.mergedPrCount,
+        profileBlockReason: null,
+      });
+      try {
+        await sendEmail({ to: r.email, subject, html, text });
+        sent++;
+        console.log(`Sent: ${r.email} (${r.tier} #${r.rank})`);
+      } catch (e) {
+        failed++;
+        console.error(`Failed: ${r.email}`, e);
+      }
+      await sleep(450);
+    }
+    console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+    return;
+  }
+
   const db = getAdminDb();
   if (!db) {
     console.error("Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS).");
@@ -938,17 +1144,10 @@ async function main() {
 
   if (!process.env.GITHUB_TOKEN?.trim()) {
     console.warn(
-      "[warn] GITHUB_TOKEN is not set — GitHub Search may return 403; merged PR counts use Firestore where possible. Copy the token from your production/host env into .env.local for parity with the website."
+      "[warn] GITHUB_TOKEN is not set — GitHub Search may return 403; merged PR counts use Firestore where possible."
     );
   }
 
-  const csvRows = parseCsv(raw);
-  if (csvRows.length === 0) {
-    console.error("No data rows in CSV.");
-    process.exit(1);
-  }
-
-  console.log(`Loaded ${csvRows.length} rows from ${csvPath}`);
   console.log("Fetching merged PR counts from GitHub (one bulk search)…");
   const githubBulk = await fetchMergedPrCountByAuthorForRepo();
   if (githubBulk) {
@@ -1107,9 +1306,10 @@ async function main() {
     console.log("\n--dry-run: no emails sent. Review the table above.");
     if (announceList) console.log("(--announce-list mode: simplified participant-list email)");
     if (reminder) console.log("(--reminder mode: day-before blast)");
+    if (correction) console.log("(--correction mode: status correction email)");
     const pickSample = (t: RegistrantTier) => results.find((x) => x.tier === t && x.tier !== "DECLINED");
 
-    if (reminder) {
+    if (reminder || correction) {
       const previewTiers: RegistrantTier[] = [
         "CONFIRMED",
         "WAITLISTED",
@@ -1120,7 +1320,7 @@ async function main() {
         const sample = pickSample(tier);
         if (!sample) continue;
         const t = sample.tier as Exclude<RegistrantTier, "DECLINED">;
-        const { subject, html } = buildReminderEmail({
+        const emailArgs = {
           tier: t,
           name: sample.name,
           rank: sample.rank,
@@ -1128,7 +1328,10 @@ async function main() {
           mergedPrCount: sample.mergedPrCount,
           profileBlockReason: sample.profileBlock,
           csvSelfReportedPr: sample.csvSelfReportedPr,
-        });
+        };
+        const { subject, html } = correction
+          ? buildCorrectionEmail(emailArgs)
+          : buildReminderEmail(emailArgs);
         console.log(`\n[${tier}] Sample subject: ${subject}`);
         console.log("Sample HTML preview:\n---\n" + html.slice(0, 700) + "…\n---");
       }
@@ -1166,33 +1369,28 @@ async function main() {
   for (const r of results) {
     if (r.tier === "DECLINED") continue;
     const tier = r.tier as Exclude<RegistrantTier, "DECLINED">;
-    const { subject, html, text } = reminder
-      ? buildReminderEmail({
-          tier,
-          name: r.name,
-          rank: r.rank,
-          totalOnLeaderboard: totalOnPublicList,
-          mergedPrCount: r.mergedPrCount,
-          profileBlockReason: r.profileBlock,
-          csvSelfReportedPr: r.csvSelfReportedPr ?? "",
-        })
-      : announceList
-        ? buildListAnnouncementEmail({
-            tier,
-            name: r.name,
-            rank: r.rank,
-            totalOnLeaderboard: totalOnPublicList,
-            mergedPrCount: r.mergedPrCount,
-          })
-        : buildEmails({
-            tier,
-            name: r.name,
-            rank: r.rank,
-            totalOnLeaderboard: totalOnPublicList,
-            mergedPrCount: r.mergedPrCount,
-            profileBlockReason: r.profileBlock,
-            csvSelfReportedPr: r.csvSelfReportedPr ?? "",
-          });
+    const emailArgs = {
+      tier,
+      name: r.name,
+      rank: r.rank,
+      totalOnLeaderboard: totalOnPublicList,
+      mergedPrCount: r.mergedPrCount,
+      profileBlockReason: r.profileBlock,
+      csvSelfReportedPr: r.csvSelfReportedPr ?? "",
+    };
+    const { subject, html, text } = correction
+      ? buildCorrectionEmail(emailArgs)
+      : reminder
+        ? buildReminderEmail(emailArgs)
+        : announceList
+          ? buildListAnnouncementEmail({
+              tier,
+              name: r.name,
+              rank: r.rank,
+              totalOnLeaderboard: totalOnPublicList,
+              mergedPrCount: r.mergedPrCount,
+            })
+          : buildEmails(emailArgs);
     try {
       await sendEmail({ to: r.email, subject, html, text });
       sent++;

--- a/scripts/send-hack-a-sprint-emails.ts
+++ b/scripts/send-hack-a-sprint-emails.ts
@@ -31,6 +31,7 @@ loadEnvConfig(process.cwd());
 
 import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import {
+  compareUnifiedHackathonRanking,
   CURSOR_CREDIT_TOP_N,
   DECLINED_EMAILS,
   JUDGE_EMAILS,
@@ -482,16 +483,7 @@ async function buildUnifiedDisplayRankMaps(
     });
   }
 
-  unified.sort((a, b) => {
-    const ac = a.confirmedAt != null ? 1 : 0;
-    const bc = b.confirmedAt != null ? 1 : 0;
-    if (bc !== ac) return bc - ac;
-    if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
-    const aWeb = a.source === "website" ? 1 : 0;
-    const bWeb = b.source === "website" ? 1 : 0;
-    if (bWeb !== aWeb) return bWeb - aWeb;
-    return a.signedUpAtMs - b.signedUpAtMs;
-  });
+  unified.sort(compareUnifiedHackathonRanking);
 
   const rankByUserId = new Map<string, number>();
   const rankByEmail = new Map<string, number>();

--- a/scripts/sync-ranking-to-firestore.ts
+++ b/scripts/sync-ranking-to-firestore.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Sync Firestore confirmedAt from the stored ranking JSON.
+ *
+ * Sets confirmedAt on confirmed entries, clears it on everyone else.
+ * Matches ranking entries to Firestore docs by email → GitHub login.
+ *
+ * Usage:
+ *   npx tsx scripts/sync-ranking-to-firestore.ts --dry-run
+ *   npx tsx scripts/sync-ranking-to-firestore.ts --write
+ */
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "../lib/hackathon-showcase";
+
+const RANKING_PATH = resolve(__dirname, "data/hack-a-sprint-2026-ranking.json");
+const EVENT_ID = HACK_A_SPRINT_2026_EVENT_ID;
+
+type RankingEntry = {
+  rank: number;
+  status: "confirmed" | "waitlisted";
+  email: string;
+  name: string;
+  githubLogin: string | null;
+};
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const write = process.argv.includes("--write");
+  if (!dryRun && !write) {
+    console.error("Specify --dry-run or --write");
+    process.exit(1);
+  }
+
+  const ranking: RankingEntry[] = JSON.parse(
+    readFileSync(RANKING_PATH, "utf8")
+  ).ranking;
+  console.log(`Loaded ${ranking.length} entries from ranking JSON.`);
+
+  const confirmedEmails = new Set(
+    ranking.filter((r) => r.status === "confirmed").map((r) => r.email)
+  );
+  const confirmedGithubs = new Set(
+    ranking
+      .filter((r) => r.status === "confirmed" && r.githubLogin)
+      .map((r) => r.githubLogin!.toLowerCase())
+  );
+  console.log(`Confirmed: ${confirmedEmails.size} emails, ${confirmedGithubs.size} GitHub logins.`);
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase not configured.");
+    process.exit(1);
+  }
+
+  // --- Website signups (hackathonEventSignups) ---
+  const signupSnap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  console.log(`\nWebsite signups: ${signupSnap.docs.length}`);
+
+  const userIds = signupSnap.docs.map((d) => d.data().userId as string).filter(Boolean);
+  const userMap = new Map<string, { email?: string; githubLogin?: string }>();
+  const unique = [...new Set(userIds)];
+  for (let i = 0; i < unique.length; i += 10) {
+    const chunk = unique.slice(i, i + 10);
+    const refs = chunk.map((id) => db.collection("users").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) {
+      if (!s.exists) continue;
+      const d = s.data()!;
+      const gh =
+        d.github && typeof d.github === "object"
+          ? (d.github as { login?: string }).login
+          : undefined;
+      userMap.set(s.id, {
+        email: typeof d.email === "string" ? d.email.toLowerCase() : undefined,
+        githubLogin: typeof gh === "string" ? gh.toLowerCase() : undefined,
+      });
+    }
+  }
+
+  let setCount = 0;
+  let clearCount = 0;
+  let unchangedCount = 0;
+
+  for (const doc of signupSnap.docs) {
+    const data = doc.data();
+    const uid = data.userId as string;
+    const user = userMap.get(uid);
+    const isCurrentlyConfirmed = !!data.confirmedAt;
+
+    const shouldBeConfirmed =
+      (user?.email && confirmedEmails.has(user.email)) ||
+      (user?.githubLogin && confirmedGithubs.has(user.githubLogin));
+
+    if (shouldBeConfirmed && !isCurrentlyConfirmed) {
+      console.log(`  SET confirmedAt: ${user?.email || uid} (${user?.githubLogin || "?"})`);
+      if (write) {
+        await db.collection("hackathonEventSignups").doc(doc.id).update({
+          confirmedAt: FieldValue.serverTimestamp(),
+        });
+      }
+      setCount++;
+    } else if (!shouldBeConfirmed && isCurrentlyConfirmed) {
+      console.log(`  CLEAR confirmedAt: ${user?.email || uid} (${user?.githubLogin || "?"})`);
+      if (write) {
+        await db.collection("hackathonEventSignups").doc(doc.id).update({
+          confirmedAt: FieldValue.delete(),
+        });
+      }
+      clearCount++;
+    } else {
+      unchangedCount++;
+    }
+  }
+
+  // --- Luma registrants (hackathonLumaRegistrants) ---
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  console.log(`\nLuma registrants: ${lumaSnap.docs.length}`);
+
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (d.email as string || "").toLowerCase();
+    const gh = typeof d.githubLogin === "string" ? d.githubLogin.toLowerCase() : null;
+    const isCurrentlyConfirmed = !!d.confirmedAt;
+
+    const shouldBeConfirmed =
+      confirmedEmails.has(email) || (gh && confirmedGithubs.has(gh));
+
+    if (shouldBeConfirmed && !isCurrentlyConfirmed) {
+      console.log(`  SET confirmedAt: ${email} (${gh || "?"})`);
+      if (write) {
+        await db.collection("hackathonLumaRegistrants").doc(doc.id).update({
+          confirmedAt: FieldValue.serverTimestamp(),
+        });
+      }
+      setCount++;
+    } else if (!shouldBeConfirmed && isCurrentlyConfirmed) {
+      console.log(`  CLEAR confirmedAt: ${email} (${gh || "?"})`);
+      if (write) {
+        await db.collection("hackathonLumaRegistrants").doc(doc.id).update({
+          confirmedAt: FieldValue.delete(),
+        });
+      }
+      clearCount++;
+    } else {
+      unchangedCount++;
+    }
+  }
+
+  console.log(`\nSummary: ${setCount} set, ${clearCount} cleared, ${unchangedCount} unchanged.`);
+  if (dryRun) console.log("--dry-run: no writes. Use --write to apply.");
+  else console.log("Done. Firestore updated.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Correction emails sent to all 109 Hack-a-Sprint participants with correct confirmed/waitlisted status
- Stored definitive ranking JSON (PRs through Apr 9 + Luma signup date) as source of truth
- Synced Firestore confirmedAt flags from ranking JSON
- Added "Give up my confirmed spot" button for confirmed attendees to release their seat

## Changes
- `scripts/send-hack-a-sprint-emails.ts` — added `--correction` mode loading from ranking JSON
- `scripts/build-hack-a-sprint-ranking.ts` — new script to compute ranking from GitHub + Luma CSV
- `scripts/sync-ranking-to-firestore.ts` — new script to sync Firestore from ranking JSON
- `scripts/data/hack-a-sprint-2026-ranking.json` — stored ranking source of truth
- API PATCH `{ giveUpSpot: true }` on signup route
- Signup page "Give up my confirmed spot" button with confirmation dialog

Made with [Cursor](https://cursor.com)