### PR TITLE
fix: confirmed use frozen rank, waitlisted use live PRs

### DIFF
--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -144,6 +144,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       displayName: string | null;
       githubLogin: string | null;
       confirmedAt: number | null;
+      frozenRank: number | null;
+      frozenPrCount: number | null;
       checkedInAt: number | null;
       willBeLate: boolean;
       queuingForSpot: boolean;
@@ -187,6 +189,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
           typeof profile?.displayName === "string" ? profile.displayName : null,
         githubLogin,
         confirmedAt: data.confirmedAt ? signedUpAtToMs(data.confirmedAt) : null,
+        frozenRank: typeof data.frozenRank === "number" ? data.frozenRank : null,
+        frozenPrCount: typeof data.frozenPrCount === "number" ? data.frozenPrCount : null,
         checkedInAt: data.checkedInAt ? signedUpAtToMs(data.checkedInAt) : null,
         willBeLate: data.willBeLate === true,
         queuingForSpot: data.queuingForSpot === true,
@@ -217,6 +221,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       lumaCreatedAt: string;
       mergedPrCount: number;
       confirmedAt: number | null;
+      frozenRank: number | null;
+      frozenPrCount: number | null;
     };
     const lumaRows: LumaRow[] = [];
 
@@ -234,6 +240,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
         lumaCreatedAt: typeof d.lumaCreatedAt === "string" ? d.lumaCreatedAt : "",
         mergedPrCount: 0,
         confirmedAt: d.confirmedAt ? signedUpAtToMs(d.confirmedAt) : null,
+        frozenRank: typeof d.frozenRank === "number" ? d.frozenRank : null,
+        frozenPrCount: typeof d.frozenPrCount === "number" ? d.frozenPrCount : null,
       });
     }
 
@@ -248,8 +256,6 @@ export async function GET(request: NextRequest, context: RouteContext) {
       }
     }
 
-    // Merge everything into one unified list, sorted by PR count then signup time
-    type EntrySource = "website" | "luma_only";
     type UnifiedRow = {
       userId: string | null;
       displayName: string | null;
@@ -257,8 +263,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
       mergedPrCount: number;
       signedUpAtMs: number;
       signedUpAtIso: string;
-      source: EntrySource;
       confirmedAt: number | null;
+      frozenRank: number | null;
+      frozenPrCount: number | null;
       checkedInAt: number | null;
       willBeLate: boolean;
       queuingForSpot: boolean;
@@ -273,8 +280,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
         mergedPrCount: r.mergedPrCount,
         signedUpAtMs: r.signedUpAtMs,
         signedUpAtIso: new Date(r.signedUpAtMs).toISOString(),
-        source: "website",
         confirmedAt: r.confirmedAt,
+        frozenRank: r.frozenRank,
+        frozenPrCount: r.frozenPrCount,
         checkedInAt: r.checkedInAt,
         willBeLate: r.willBeLate,
         queuingForSpot: r.queuingForSpot,
@@ -288,35 +296,48 @@ export async function GET(request: NextRequest, context: RouteContext) {
         mergedPrCount: lr.mergedPrCount,
         signedUpAtMs: lr.lumaCreatedAt ? new Date(lr.lumaCreatedAt).getTime() : 0,
         signedUpAtIso: lr.lumaCreatedAt,
-        source: "luma_only",
         confirmedAt: lr.confirmedAt,
+        frozenRank: typeof lr.frozenRank === "number" ? lr.frozenRank : null,
+        frozenPrCount: typeof lr.frozenPrCount === "number" ? lr.frozenPrCount : null,
         checkedInAt: null,
         willBeLate: false,
         queuingForSpot: false,
       });
     }
 
-    // Confirmed first (frozen top 50), then waitlisted. Within each group: PRs desc → time asc.
-    unified.sort((a, b) => {
-      const aConf = a.confirmedAt != null ? 1 : 0;
-      const bConf = b.confirmedAt != null ? 1 : 0;
-      if (bConf !== aConf) return bConf - aConf;
+    // Split into confirmed (frozen rank) and waitlisted (live PRs)
+    const confirmed = unified.filter((u) => u.confirmedAt != null);
+    const waitlisted = unified.filter((u) => u.confirmedAt == null);
+
+    // Confirmed: sort by frozen rank (from ranking JSON), fallback to PRs desc → time asc
+    confirmed.sort((a, b) => {
+      if (a.frozenRank != null && b.frozenRank != null) return a.frozenRank - b.frozenRank;
+      if (a.frozenRank != null) return -1;
+      if (b.frozenRank != null) return 1;
       if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
       return a.signedUpAtMs - b.signedUpAtMs;
     });
 
-    // Build ranked entries — status driven by confirmedAt field
+    // Waitlisted: sort by all-time PRs desc (jockeying) → signup time asc
+    waitlisted.sort((a, b) => {
+      if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
+      return a.signedUpAtMs - b.signedUpAtMs;
+    });
+
+    const sorted = [...confirmed, ...waitlisted];
+
     type EntryStatus = "confirmed" | "waitlisted";
     const websiteCount = rows.length;
-    const entries = unified.map((u, i) => {
+    const entries = sorted.map((u, i) => {
       const rank = i + 1;
       const isConfirmed = u.confirmedAt != null;
+      const displayPrs = isConfirmed && u.frozenPrCount != null ? u.frozenPrCount : u.mergedPrCount;
       return {
         rank,
         userId: u.userId,
         displayName: u.displayName,
         githubLogin: u.githubLogin,
-        mergedPrCount: u.mergedPrCount,
+        mergedPrCount: displayPrs,
         signedUpAt: u.signedUpAtIso,
         creditEligible: isConfirmed,
         status: (isConfirmed ? "confirmed" : "waitlisted") as EntryStatus,

--- a/scripts/sync-ranking-to-firestore.ts
+++ b/scripts/sync-ranking-to-firestore.ts
@@ -27,6 +27,7 @@ type RankingEntry = {
   email: string;
   name: string;
   githubLogin: string | null;
+  prsThruApr9: number;
 };
 
 async function main() {
@@ -42,15 +43,16 @@ async function main() {
   ).ranking;
   console.log(`Loaded ${ranking.length} entries from ranking JSON.`);
 
-  const confirmedEmails = new Set(
-    ranking.filter((r) => r.status === "confirmed").map((r) => r.email)
-  );
-  const confirmedGithubs = new Set(
-    ranking
-      .filter((r) => r.status === "confirmed" && r.githubLogin)
-      .map((r) => r.githubLogin!.toLowerCase())
-  );
-  console.log(`Confirmed: ${confirmedEmails.size} emails, ${confirmedGithubs.size} GitHub logins.`);
+  type ConfirmedInfo = { rank: number; prsThruApr9: number };
+  const confirmedByEmail = new Map<string, ConfirmedInfo>();
+  const confirmedByGithub = new Map<string, ConfirmedInfo>();
+  for (const r of ranking) {
+    if (r.status !== "confirmed") continue;
+    const info = { rank: r.rank, prsThruApr9: r.prsThruApr9 };
+    confirmedByEmail.set(r.email, info);
+    if (r.githubLogin) confirmedByGithub.set(r.githubLogin.toLowerCase(), info);
+  }
+  console.log(`Confirmed: ${confirmedByEmail.size} emails, ${confirmedByGithub.size} GitHub logins.`);
 
   const db = getAdminDb();
   if (!db) {
@@ -96,23 +98,37 @@ async function main() {
     const user = userMap.get(uid);
     const isCurrentlyConfirmed = !!data.confirmedAt;
 
-    const shouldBeConfirmed =
-      (user?.email && confirmedEmails.has(user.email)) ||
-      (user?.githubLogin && confirmedGithubs.has(user.githubLogin));
+    const info =
+      (user?.email && confirmedByEmail.get(user.email)) ||
+      (user?.githubLogin && confirmedByGithub.get(user.githubLogin)) ||
+      null;
+    const shouldBeConfirmed = info != null;
 
-    if (shouldBeConfirmed && !isCurrentlyConfirmed) {
-      console.log(`  SET confirmedAt: ${user?.email || uid} (${user?.githubLogin || "?"})`);
-      if (write) {
-        await db.collection("hackathonEventSignups").doc(doc.id).update({
-          confirmedAt: FieldValue.serverTimestamp(),
-        });
+    if (shouldBeConfirmed) {
+      const needsUpdate =
+        !isCurrentlyConfirmed ||
+        data.frozenRank !== info.rank ||
+        data.frozenPrCount !== info.prsThruApr9;
+      if (needsUpdate) {
+        console.log(`  SET confirmed #${info.rank}: ${user?.email || uid} (${user?.githubLogin || "?"})`);
+        if (write) {
+          await db.collection("hackathonEventSignups").doc(doc.id).update({
+            confirmedAt: isCurrentlyConfirmed ? data.confirmedAt : FieldValue.serverTimestamp(),
+            frozenRank: info.rank,
+            frozenPrCount: info.prsThruApr9,
+          });
+        }
+        setCount++;
+      } else {
+        unchangedCount++;
       }
-      setCount++;
-    } else if (!shouldBeConfirmed && isCurrentlyConfirmed) {
-      console.log(`  CLEAR confirmedAt: ${user?.email || uid} (${user?.githubLogin || "?"})`);
+    } else if (isCurrentlyConfirmed || data.frozenRank != null) {
+      console.log(`  CLEAR confirmed: ${user?.email || uid} (${user?.githubLogin || "?"})`);
       if (write) {
         await db.collection("hackathonEventSignups").doc(doc.id).update({
           confirmedAt: FieldValue.delete(),
+          frozenRank: FieldValue.delete(),
+          frozenPrCount: FieldValue.delete(),
         });
       }
       clearCount++;
@@ -134,22 +150,35 @@ async function main() {
     const gh = typeof d.githubLogin === "string" ? d.githubLogin.toLowerCase() : null;
     const isCurrentlyConfirmed = !!d.confirmedAt;
 
-    const shouldBeConfirmed =
-      confirmedEmails.has(email) || (gh && confirmedGithubs.has(gh));
+    const info =
+      confirmedByEmail.get(email) || (gh && confirmedByGithub.get(gh)) || null;
+    const shouldBeConfirmed = info != null;
 
-    if (shouldBeConfirmed && !isCurrentlyConfirmed) {
-      console.log(`  SET confirmedAt: ${email} (${gh || "?"})`);
-      if (write) {
-        await db.collection("hackathonLumaRegistrants").doc(doc.id).update({
-          confirmedAt: FieldValue.serverTimestamp(),
-        });
+    if (shouldBeConfirmed) {
+      const needsUpdate =
+        !isCurrentlyConfirmed ||
+        d.frozenRank !== info.rank ||
+        d.frozenPrCount !== info.prsThruApr9;
+      if (needsUpdate) {
+        console.log(`  SET confirmed #${info.rank}: ${email} (${gh || "?"})`);
+        if (write) {
+          await db.collection("hackathonLumaRegistrants").doc(doc.id).update({
+            confirmedAt: isCurrentlyConfirmed ? d.confirmedAt : FieldValue.serverTimestamp(),
+            frozenRank: info.rank,
+            frozenPrCount: info.prsThruApr9,
+          });
+        }
+        setCount++;
+      } else {
+        unchangedCount++;
       }
-      setCount++;
-    } else if (!shouldBeConfirmed && isCurrentlyConfirmed) {
-      console.log(`  CLEAR confirmedAt: ${email} (${gh || "?"})`);
+    } else if (isCurrentlyConfirmed || d.frozenRank != null) {
+      console.log(`  CLEAR confirmed: ${email} (${gh || "?"})`);
       if (write) {
         await db.collection("hackathonLumaRegistrants").doc(doc.id).update({
           confirmedAt: FieldValue.delete(),
+          frozenRank: FieldValue.delete(),
+          frozenPrCount: FieldValue.delete(),
         });
       }
       clearCount++;


### PR DESCRIPTION
## Summary
- Confirmed people (#1-50) now sort by their frozen rank (PRs through April 9 + Luma signup date)
- Waitlisted people (#51+) sort by all-time PRs (jockeying enabled) + signup time
- PR counts shown: confirmed = frozen April 9 count, waitlisted = live all-time count
- Sync script writes frozenRank and frozenPrCount to Firestore docs

Made with [Cursor](https://cursor.com)