### PR TITLE
fix: safe JSON parsing for request.json() across 21 API routes

### DIFF
--- a/app/api/agents/me/route.ts
+++ b/app/api/agents/me/route.ts
@@ -11,6 +11,7 @@ import {
   toPublicProfile,
 } from "@/lib/agents";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { parseRequestBody } from "@/lib/api-response";
 
 // Rate limit config for agent API endpoints
 const AGENT_API_RATE_LIMIT = {
@@ -133,8 +134,9 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { name, description, avatarUrl, visibility } = body;
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { name, description, avatarUrl, visibility } = bodyOrError;
 
     // Build update object with only provided fields
     const updates: Record<string, unknown> = {};

--- a/app/api/agents/register/route.ts
+++ b/app/api/agents/register/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAgent, getVerifiedAgent } from "@/lib/agents";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { parseRequestBody } from "@/lib/api-response";
 
 export async function POST(request: NextRequest) {
   try {
@@ -48,8 +49,9 @@ export async function POST(request: NextRequest) {
     }
 
     // Parse request body
-    const body = await request.json();
-    const { name, description } = body;
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { name, description } = bodyOrError;
 
     // Validate name
     if (!name || typeof name !== "string") {

--- a/app/api/auth/change-primary-email/route.ts
+++ b/app/api/auth/change-primary-email/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
+import { parseRequestBody } from "@/lib/api-response";
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,7 +17,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { newPrimaryEmail } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { newPrimaryEmail } = bodyOrError;
     if (!newPrimaryEmail || typeof newPrimaryEmail !== "string") {
       return NextResponse.json({ error: "New primary email is required" }, { status: 400 });
     }

--- a/app/api/auth/remove-email/route.ts
+++ b/app/api/auth/remove-email/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
+import { parseRequestBody } from "@/lib/api-response";
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,7 +17,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { email } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { email } = bodyOrError;
     if (!email || typeof email !== "string") {
       return NextResponse.json({ error: "Email is required" }, { status: 400 });
     }

--- a/app/api/auth/resolve-email/route.ts
+++ b/app/api/auth/resolve-email/route.ts
@@ -6,10 +6,13 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
+import { parseRequestBody } from "@/lib/api-response";
 
 export async function POST(request: NextRequest) {
   try {
-    const { email } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { email } = bodyOrError;
     if (!email || typeof email !== "string") {
       return NextResponse.json({ error: "Email is required" }, { status: 400 });
     }

--- a/app/api/auth/send-email-verification/route.ts
+++ b/app/api/auth/send-email-verification/route.ts
@@ -10,6 +10,7 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
 import { logApiError } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 import { sendEmail } from "@/lib/mailgun";
 
 export async function POST(request: NextRequest) {
@@ -19,7 +20,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { email } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { email } = bodyOrError;
     if (!email || typeof email !== "string") {
       return NextResponse.json({ error: "Email is required" }, { status: 400 });
     }

--- a/app/api/cfp/send-edu-code/route.ts
+++ b/app/api/cfp/send-edu-code/route.ts
@@ -11,6 +11,7 @@ import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
 import { logApiError, logger } from "@/lib/logger";
 import { sendEmail } from "@/lib/mailgun";
+import { parseRequestBody } from "@/lib/api-response";
 
 const CODE_LENGTH = 6;
 const CODE_EXPIRY_MINUTES = 15;
@@ -46,7 +47,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { email } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { email } = bodyOrError;
     if (!email || typeof email !== "string") {
       logger.warn("CFP send-edu-code rejected: missing email payload", {
         uid: user.uid,

--- a/app/api/cfp/verify-edu-code/route.ts
+++ b/app/api/cfp/verify-edu-code/route.ts
@@ -9,6 +9,7 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
 import { logApiError } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 
 function isValidEduEmail(email: string): boolean {
   return email.toLowerCase().trim().endsWith(".edu");
@@ -21,7 +22,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { email, code } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { email, code } = bodyOrError;
     if (!email || typeof email !== "string" || !code || typeof code !== "string") {
       return NextResponse.json(
         { error: "Email and code are required" },

--- a/app/api/community/delete/route.ts
+++ b/app/api/community/delete/route.ts
@@ -9,6 +9,7 @@ import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { parseRequestBody } from "@/lib/api-response";
 import { sanitizeDocId } from "@/lib/sanitize";
 
 export const runtime = "nodejs";
@@ -38,7 +39,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { messageId } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { messageId } = bodyOrError;
 
     const sanitizedId = sanitizeDocId(messageId);
     if (!sanitizedId) {

--- a/app/api/community/post/route.ts
+++ b/app/api/community/post/route.ts
@@ -9,6 +9,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { sanitizeText } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
@@ -40,7 +41,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { content } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { content } = bodyOrError;
 
     const sanitizedContent = sanitizeText(typeof content === "string" ? content : "");
     if (sanitizedContent.length < 100 || sanitizedContent.length > 500) {

--- a/app/api/community/reaction/route.ts
+++ b/app/api/community/reaction/route.ts
@@ -9,6 +9,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { sanitizeDocId } from "@/lib/sanitize";
 
@@ -42,8 +43,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { messageId, type } = await request.json();
-    
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { messageId, type } = bodyOrError;
+
     // Validate and sanitize messageId
     const sanitizedMessageId = sanitizeDocId(messageId);
     if (!sanitizedMessageId || (type !== "like" && type !== "dislike")) {

--- a/app/api/community/reply/route.ts
+++ b/app/api/community/reply/route.ts
@@ -9,6 +9,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
@@ -41,8 +42,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { parentId, content } = await request.json();
-    
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { parentId, content } = bodyOrError;
+
     // Validate and sanitize parentId
     const sanitizedParentId = sanitizeDocId(parentId);
     if (!sanitizedParentId) {

--- a/app/api/community/repost/route.ts
+++ b/app/api/community/repost/route.ts
@@ -9,6 +9,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
@@ -41,8 +42,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { originalId, content } = await request.json();
-    
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { originalId, content } = bodyOrError;
+
     // Validate and sanitize originalId
     const sanitizedOriginalId = sanitizeDocId(originalId);
     if (!sanitizedOriginalId) {

--- a/app/api/cookbook/vote/route.ts
+++ b/app/api/cookbook/vote/route.ts
@@ -9,6 +9,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { sanitizeDocId } from "@/lib/sanitize";
 
@@ -66,7 +67,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const rawBody = await request.json();
+    const rawBody = await parseRequestBody(request);
+    if (rawBody instanceof NextResponse) return rawBody;
     if (!isNonNullObject(rawBody)) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }

--- a/app/api/notify-admin/cfp/route.ts
+++ b/app/api/notify-admin/cfp/route.ts
@@ -6,6 +6,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { sendEmail } from "@/lib/mailgun";
+import { parseRequestBody } from "@/lib/api-response";
 
 function escapeHtml(text: string | undefined): string {
   if (!text) return "";
@@ -21,8 +22,9 @@ const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "hello@cursorboston.com";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { name, email, school, department, advisor, thesisTitle, abstract, userId } = body;
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { name, email, school, department, advisor, thesisTitle, abstract, userId } = bodyOrError;
 
     if (!name || !email || !thesisTitle) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 });

--- a/app/api/notify-admin/event/route.ts
+++ b/app/api/notify-admin/event/route.ts
@@ -6,6 +6,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { sendEmail } from "@/lib/mailgun";
+import { parseRequestBody } from "@/lib/api-response";
 
 function escapeHtml(text: string | undefined): string {
   if (!text) return "";
@@ -21,8 +22,9 @@ const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "hello@cursorboston.com";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { name, email, organization, eventType, title, description, proposedDate, expectedAttendees, venue, additionalInfo, requestId } = body;
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { name, email, organization, eventType, title, description, proposedDate, expectedAttendees, venue, additionalInfo, requestId } = bodyOrError;
 
     if (!name || !email || !title) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 });

--- a/app/api/notify-admin/talk/route.ts
+++ b/app/api/notify-admin/talk/route.ts
@@ -6,6 +6,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { sendEmail } from "@/lib/mailgun";
+import { parseRequestBody } from "@/lib/api-response";
 
 function escapeHtml(text: string | undefined): string {
   if (!text) return "";
@@ -21,8 +22,9 @@ const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "hello@cursorboston.com";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { name, email, title, description, category, duration, experience, bio, linkedIn, twitter, previousTalks, submissionId } = body;
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { name, email, title, description, category, duration, experience, bio, linkedIn, twitter, previousTalks, submissionId } = bodyOrError;
 
     if (!name || !email || !title) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 });

--- a/app/api/pair/profile/route.ts
+++ b/app/api/pair/profile/route.ts
@@ -12,6 +12,8 @@ import {
 } from "@/lib/pair-programming/data-server";
 import type { PairProfile, SessionType } from "@/lib/pair-programming/types";
 
+import { parseRequestBody } from "@/lib/api-response";
+
 const VALID_SESSION_TYPES: SessionType[] = [
   "teach-me",
   "build-together",
@@ -64,7 +66,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
     const {
       skillsCanTeach,
       skillsWantToLearn,
@@ -75,7 +78,7 @@ export async function POST(request: NextRequest) {
       sessionTypes,
       bio,
       isActive,
-    } = body;
+    } = bodyOrError;
 
     // Validate arrays
     if (!Array.isArray(skillsCanTeach) || !Array.isArray(skillsWantToLearn)) {

--- a/app/api/pair/request/route.ts
+++ b/app/api/pair/request/route.ts
@@ -12,6 +12,8 @@ import {
 } from "@/lib/pair-programming/data-server";
 import type { SessionType } from "@/lib/pair-programming/types";
 
+import { parseRequestBody } from "@/lib/api-response";
+
 const VALID_SESSION_TYPES: SessionType[] = [
   "teach-me",
   "build-together",
@@ -67,8 +69,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { toUserId, sessionType, message, proposedTime } = body;
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { toUserId, sessionType, message, proposedTime } = bodyOrError;
 
     if (!toUserId || typeof toUserId !== "string") {
       return NextResponse.json(

--- a/app/api/pair/respond/route.ts
+++ b/app/api/pair/respond/route.ts
@@ -12,6 +12,7 @@ import {
   PairRequestUnauthorizedError,
   PairRequestAlreadyRespondedError,
 } from "@/lib/pair-programming/data-server";
+import { parseRequestBody } from "@/lib/api-response";
 
 /**
  * POST /api/pair/respond
@@ -27,8 +28,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
-    const { requestId, action } = body;
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { requestId, action } = bodyOrError;
 
     if (!requestId || typeof requestId !== "string") {
       return NextResponse.json(

--- a/app/api/showcase/vote/route.ts
+++ b/app/api/showcase/vote/route.ts
@@ -9,6 +9,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { sanitizeDocId } from "@/lib/sanitize";
 
@@ -41,7 +42,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const { projectId, type } = await request.json();
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { projectId, type } = bodyOrError;
 
     const sanitizedProjectId = sanitizeDocId(projectId);
     if (!sanitizedProjectId || (type !== "up" && type !== "down")) {

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -4,7 +4,7 @@
  * See LICENSE file for details.
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Standard error codes for API responses.
@@ -50,6 +50,23 @@ export function apiSuccess<T extends Record<string, unknown>>(
   status: number = 200
 ): NextResponse {
   return NextResponse.json({ success: true, ...data }, { status });
+}
+
+/**
+ * Safely parse JSON from a request body, returning a 400 response on failure.
+ * Use instanceof NextResponse to check for errors before accessing the data.
+ */
+export async function parseRequestBody<T = Record<string, any>>(
+  request: NextRequest | Request
+): Promise<T | NextResponse> {
+  try {
+    return (await request.json()) as T;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON in request body" },
+      { status: 400 }
+    );
+  }
 }
 
 function inferErrorCode(status: number): ErrorCodeType {


### PR DESCRIPTION
## Summary

- Added `parseRequestBody()` utility to `lib/api-response.ts` that wraps `request.json()` in a try/catch and returns a proper 400 response for malformed/empty JSON bodies
- Applied it to all 21 unguarded API routes across auth, community, pair programming, agents, cookbook, showcase, notify-admin, and CFP endpoints
- Previously, malformed request bodies would throw unhandled exceptions and return generic 500 errors instead of informative 400 responses

Closes #242