### PR TITLE
fix: resolve 8 npm audit vulnerabilities via http-proxy-agent override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5892,16 +5892,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -13422,7 +13412,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -22510,21 +22500,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/teeny-request/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/teeny-request/node_modules/https-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,8 @@
     "react-leaflet-cluster": {
       "react": "$react",
       "react-dom": "$react-dom"
-    }
+    },
+    "http-proxy-agent": "^7.0.0"
   },
   "lint-staged": {
     "**/*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

- Added npm override for `http-proxy-agent` to v7, which drops the vulnerable `@tootallnate/once` transitive dependency entirely
- Resolves all 8 low-severity vulnerabilities in the `firebase-admin` → `@google-cloud/storage` → `teeny-request` → `http-proxy-agent` → `@tootallnate/once` chain
- `npm audit` now returns 0 vulnerabilities
- No runtime changes — only package.json override and lockfile update

Closes #233