### PR TITLE
feat: add bundle size tracking with @next/bundle-analyzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,41 @@ jobs:
           NEXT_PUBLIC_FIREBASE_APP_ID: "1:123456789:web:abcdef"
           NEXT_PUBLIC_FIREBASE_DATABASE_URL: "https://test-project.firebaseio.com"
 
+      - name: Report bundle size
+        run: |
+          echo "## Bundle Size Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f .next/analyze/client.html ]; then
+            echo "Bundle analyzer reports generated. Download the artifact to inspect." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          # Parse Next.js build output for page sizes
+          if ls .next/server/app/**/*.html 1>/dev/null 2>&1; then
+            TOTAL_SIZE=$(du -sh .next/ | cut -f1)
+            CLIENT_SIZE=$(du -sh .next/static/ 2>/dev/null | cut -f1 || echo "N/A")
+            echo "| Metric | Size |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|--------|------|" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Total .next/ | $TOTAL_SIZE |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Client static | $CLIENT_SIZE |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Check JS bundle budget (500KB first-load warning)
+        run: |
+          # Find the largest first-load JS chunks and warn if any exceed 500KB
+          OVER_BUDGET=0
+          for f in .next/static/chunks/*.js; do
+            SIZE=$(wc -c < "$f")
+            if [ "$SIZE" -gt 512000 ]; then
+              KB=$((SIZE / 1024))
+              echo "::warning file=$f::Chunk $(basename $f) is ${KB}KB (budget: 500KB)"
+              OVER_BUDGET=1
+            fi
+          done
+          if [ "$OVER_BUDGET" -eq 1 ]; then
+            echo "::warning::One or more JS chunks exceed the 500KB budget. Consider code splitting."
+          else
+            echo "All JS chunks are within the 500KB budget."
+          fi
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,7 @@
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+})
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Standalone output is only for Docker builds (see docker/Dockerfile). Omit on Vercel.
@@ -80,4 +84,4 @@ const nextConfig = {
   },
 }
 
-module.exports = nextConfig
+module.exports = withBundleAnalyzer(nextConfig)

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@eslint/compat": "^2.0.4",
         "@eslint/eslintrc": "^3.3.5",
         "@firebase/rules-unit-testing": "^5.0.0",
+        "@next/bundle-analyzer": "^16.2.3",
         "@next/eslint-plugin-next": "^16.2.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.1.5",
@@ -1195,6 +1196,16 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@electric-sql/pglite": {
@@ -4861,6 +4872,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.3.tgz",
+      "integrity": "sha512-aDwW4f4SVqbQDWzSBHQJ1KI6H+lx8oX/vS3xGqzLajUu+KQb7uakK88AIMvRIf7TlIonce67g594rzpxvBuJIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
@@ -5248,6 +5269,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -9798,6 +9826,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -10146,6 +10181,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexify": {
       "version": "4.1.3",
@@ -13078,6 +13120,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -14220,6 +14278,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -18259,6 +18327,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -19051,6 +19129,16 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.2.1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -21474,6 +21562,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -22842,6 +22945,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -23722,6 +23835,44 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "generate-contributors": "bash scripts/generate-contributors.sh",
     "prebuild": "npm run validate-env",
     "prepare": "husky install",
-    "add:gpl-headers": "node scripts/add-gpl-headers.js"
+    "add:gpl-headers": "node scripts/add-gpl-headers.js",
+    "analyze": "ANALYZE=true next build"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.2",
@@ -87,6 +88,7 @@
     "@eslint/compat": "^2.0.4",
     "@eslint/eslintrc": "^3.3.5",
     "@firebase/rules-unit-testing": "^5.0.0",
+    "@next/bundle-analyzer": "^16.2.3",
     "@next/eslint-plugin-next": "^16.2.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.1.5",


### PR DESCRIPTION
## Summary

- Added `@next/bundle-analyzer` as a dev dependency, wired into `next.config.js` behind `ANALYZE=true`
- Added `npm run analyze` script for local bundle inspection (opens interactive treemap in browser)
- Added two CI steps to the build job:
  - **Bundle size report**: outputs total and client static sizes in the GitHub step summary
  - **JS chunk budget check**: warns (no failure) if any chunk exceeds 500KB

Warnings only — this won't block CI, just gives visibility into bundle size regressions on PRs.

Closes #237