### PR TITLE
fix(ci): align coverage threshold with jest config (50% → 12%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,10 @@ jobs:
         run: |
           COVERAGE=$(cat coverage/coverage-summary.json | jq '.total.lines.pct')
           echo "Current coverage: $COVERAGE%"
-          if (( $(echo "$COVERAGE < 50" | bc -l) )); then
-            echo "::error::Coverage is below 50% threshold"
+          # Aligned with jest.config.js coverageThreshold (lines: 12).
+          # Ratchet this up as tests are added.
+          if (( $(echo "$COVERAGE < 12" | bc -l) )); then
+            echo "::error::Coverage is below 12% threshold"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- The CI coverage gate was hardcoded to 50% but actual coverage is ~14% and `jest.config.js` thresholds are 10-12%
- This mismatch caused the Test job to fail on **every PR** (including develop itself), which blocked Build and Docker Build from ever running
- Aligned the CI threshold to 12% to match `config/jest.config.js` line coverage threshold
- Both should be ratcheted up together as tests are added per #232