### PR TITLE
feat: add cursor-based pagination to community feed

### DIFF
--- a/components/feed/CommunityFeed.tsx
+++ b/components/feed/CommunityFeed.tsx
@@ -21,6 +21,9 @@ interface CommunityFeedProps {
 export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps) {
   const {
     loading,
+    loadingMore,
+    hasMore,
+    loadMore,
     error,
     clearError,
     newMessage,
@@ -189,6 +192,17 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
                 currentUserId={user?.uid}
               />
             ))}
+            {hasMore && !feedSearchQuery && (
+              <div className="flex justify-center pt-4 pb-2">
+                <button
+                  onClick={loadMore}
+                  disabled={loadingMore}
+                  className="px-6 py-2.5 text-sm font-medium text-neutral-300 bg-neutral-800 border border-neutral-700 rounded-lg hover:bg-neutral-700 hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {loadingMore ? "Loading..." : "Load more"}
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -6,11 +6,13 @@
 
 "use client";
 
-import { useEffect, useState, useCallback, useMemo } from "react";
-import { collection, query, where, getDocs, orderBy, limit, Timestamp, onSnapshot } from "firebase/firestore";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { collection, query, where, getDocs, orderBy, limit, startAfter, Timestamp, onSnapshot, QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { User } from "firebase/auth";
 import type { Message, ReactionType } from "@/types/feed";
+
+const PAGE_SIZE = 20;
 
 export function useFeed(user: User | null, isActive: boolean) {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -29,16 +31,20 @@ export function useFeed(user: User | null, isActive: boolean) {
   const [repostingMessage, setRepostingMessage] = useState<Message | null>(null);
   const [repostComment, setRepostComment] = useState("");
 
+  const [hasMore, setHasMore] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const lastDocRef = useRef<QueryDocumentSnapshot<DocumentData> | null>(null);
+
   const [error, setError] = useState<string | null>(null);
   const clearError = useCallback(() => setError(null), []);
 
-  // Subscribe to real-time messages when feed tab is active
+  // Subscribe to real-time messages when feed tab is active (first page only)
   useEffect(() => {
     if (!isActive || !db) return;
 
     setLoading(true);
     const messagesRef = collection(db, "communityMessages");
-    const q = query(messagesRef, orderBy("createdAt", "desc"), limit(50));
+    const q = query(messagesRef, orderBy("createdAt", "desc"), limit(PAGE_SIZE));
 
     const unsubscribe = onSnapshot(q, (snapshot) => {
       const fetchedMessages = snapshot.docs
@@ -48,6 +54,8 @@ export function useFeed(user: User | null, isActive: boolean) {
         } as Message))
         .filter((msg) => !msg.parentId);
       setMessages(fetchedMessages);
+      setHasMore(snapshot.docs.length === PAGE_SIZE);
+      lastDocRef.current = snapshot.docs[snapshot.docs.length - 1] ?? null;
       setLoading(false);
     }, (error) => {
       console.error("Error listening to messages:", error);
@@ -57,6 +65,42 @@ export function useFeed(user: User | null, isActive: boolean) {
 
     return () => unsubscribe();
   }, [isActive]);
+
+  // Load more messages using cursor-based pagination
+  const loadMore = useCallback(async () => {
+    if (!db || !lastDocRef.current || loadingMore || !hasMore) return;
+
+    setLoadingMore(true);
+    try {
+      const messagesRef = collection(db, "communityMessages");
+      const q = query(
+        messagesRef,
+        orderBy("createdAt", "desc"),
+        startAfter(lastDocRef.current),
+        limit(PAGE_SIZE)
+      );
+      const snapshot = await getDocs(q);
+      const olderMessages = snapshot.docs
+        .map((d) => ({
+          id: d.id,
+          ...d.data(),
+        } as Message))
+        .filter((msg) => !msg.parentId);
+
+      setMessages((prev) => {
+        const existingIds = new Set(prev.map((m) => m.id));
+        const deduped = olderMessages.filter((m) => !existingIds.has(m.id));
+        return [...prev, ...deduped];
+      });
+      setHasMore(snapshot.docs.length === PAGE_SIZE);
+      lastDocRef.current = snapshot.docs[snapshot.docs.length - 1] ?? null;
+    } catch (error) {
+      console.error("Error loading more messages:", error);
+      setError("Failed to load more messages.");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, hasMore]);
 
   // Fetch user's reactions when logged in (one-time, updated optimistically)
   useEffect(() => {
@@ -396,6 +440,9 @@ export function useFeed(user: User | null, isActive: boolean) {
   return {
     messages,
     loading,
+    loadingMore,
+    hasMore,
+    loadMore,
     error,
     clearError,
     newMessage,


### PR DESCRIPTION
## Summary

- Community feed previously loaded a hardcoded 50 messages with no way to see older posts
- Now loads 20 at a time with cursor-based pagination using Firestore `startAfter()`
- Added "Load more" button at the bottom of the feed (hidden during search since filtering is client-side)
- Deduplicates messages to avoid conflicts between the real-time `onSnapshot` listener and paginated fetches
- Reduces initial Firestore reads from 50 to 20

2 files changed: `hooks/useFeed.ts`, `components/feed/CommunityFeed.tsx`

Partial progress on #241