### PR TITLE
fix(security): sanitize cursor params used as Firestore doc IDs

### DIFF
--- a/app/api/cookbook/entries/route.ts
+++ b/app/api/cookbook/entries/route.ts
@@ -17,7 +17,7 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { matchesCookbookSearchTerms } from "@/lib/cookbook-search";
-import { sanitizeText } from "@/lib/sanitize";
+import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import {
   COOKBOOK_CATEGORIES,
   WORKS_WITH_LANGUAGES,
@@ -149,7 +149,8 @@ export async function GET(request: NextRequest) {
       Number(searchParams.get("limit")) || PAGE_SIZE,
       MAX_PAGE_SIZE
     );
-    const cursor = searchParams.get("cursor")?.trim() || null;
+    const rawCursor = searchParams.get("cursor")?.trim() || null;
+    const cursor = rawCursor ? sanitizeDocId(rawCursor) : null;
     const sortParam = parseSort(searchParams.get("sort"));
     const hasSearch = searchRaw.length > 0;
     const sort: CookbookSort = hasSearch ? "newest" : sortParam;

--- a/app/api/showcase/vote/route.ts
+++ b/app/api/showcase/vote/route.ts
@@ -181,8 +181,9 @@ export async function GET(request: NextRequest) {
       .orderBy("lastVoteAt", "desc")
       .limit(limitParam);
 
-    if (startAfterParam) {
-      const cursorDoc = await db.collection("showcaseProjects").doc(startAfterParam).get();
+    const sanitizedCursor = startAfterParam ? sanitizeDocId(startAfterParam) : null;
+    if (sanitizedCursor) {
+      const cursorDoc = await db.collection("showcaseProjects").doc(sanitizedCursor).get();
       if (cursorDoc.exists) {
         projectsQuery = projectsQuery.startAfter(cursorDoc);
       }


### PR DESCRIPTION
## Summary

- Showcase vote GET and cookbook entries GET both accept user-supplied cursor/startAfter query params and pass them directly to Firestore `.doc()` without `sanitizeDocId()`
- Unsanitized doc IDs can contain path separators (`/`) that traverse into subcollections
- Applied `sanitizeDocId()` to both endpoints, consistent with how all other user-supplied doc IDs are handled in the codebase

2 files changed, +6/-4