### PR TITLE
test: add 14 tests for cookbook-labels, format-cookbook-date, unsubscribe-token

### DIFF
--- a/__tests__/lib/cookbook-labels.test.ts
+++ b/__tests__/lib/cookbook-labels.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { CATEGORY_LABELS } from "@/lib/cookbook-labels";
+import { COOKBOOK_CATEGORIES } from "@/types/cookbook";
+
+describe("CATEGORY_LABELS", () => {
+  it("has a label for every cookbook category", () => {
+    for (const category of COOKBOOK_CATEGORIES) {
+      expect(CATEGORY_LABELS[category]).toBeDefined();
+      expect(typeof CATEGORY_LABELS[category]).toBe("string");
+      expect(CATEGORY_LABELS[category].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("contains expected categories", () => {
+    expect(CATEGORY_LABELS.debugging).toBe("Debugging");
+    expect(CATEGORY_LABELS.refactoring).toBe("Refactoring");
+    expect(CATEGORY_LABELS["code-generation"]).toBe("Code Generation");
+    expect(CATEGORY_LABELS.other).toBe("Other");
+  });
+});

--- a/__tests__/lib/format-cookbook-date.test.ts
+++ b/__tests__/lib/format-cookbook-date.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { formatCookbookDate } from "@/lib/format-cookbook-date";
+
+describe("formatCookbookDate", () => {
+  it("returns empty string for falsy input", () => {
+    expect(formatCookbookDate("")).toBe("");
+  });
+
+  it("formats ISO date string to short locale format", () => {
+    const result = formatCookbookDate("2026-03-05T12:00:00Z");
+    expect(result).toMatch(/Mar\s+5,\s+2026/);
+  });
+
+  it("handles date-only ISO string", () => {
+    const result = formatCookbookDate("2026-12-25T00:00:00Z");
+    expect(result).toMatch(/Dec\s+2[45],\s+2026/);
+  });
+});

--- a/__tests__/lib/unsubscribe-token.test.ts
+++ b/__tests__/lib/unsubscribe-token.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  generateUnsubscribeToken,
+  verifyUnsubscribeToken,
+  buildUnsubscribeUrl,
+} from "@/lib/unsubscribe-token";
+
+describe("generateUnsubscribeToken", () => {
+  it("returns a hex string", () => {
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(token).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("is deterministic for the same email", () => {
+    const t1 = generateUnsubscribeToken("user@example.com");
+    const t2 = generateUnsubscribeToken("user@example.com");
+    expect(t1).toBe(t2);
+  });
+
+  it("normalizes email to lowercase and trimmed", () => {
+    const t1 = generateUnsubscribeToken("User@Example.COM");
+    const t2 = generateUnsubscribeToken("  user@example.com  ");
+    expect(t1).toBe(t2);
+  });
+
+  it("produces different tokens for different emails", () => {
+    const t1 = generateUnsubscribeToken("a@example.com");
+    const t2 = generateUnsubscribeToken("b@example.com");
+    expect(t1).not.toBe(t2);
+  });
+});
+
+describe("verifyUnsubscribeToken", () => {
+  it("returns true for a valid token", () => {
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(verifyUnsubscribeToken("user@example.com", token)).toBe(true);
+  });
+
+  it("returns false for an invalid token", () => {
+    expect(verifyUnsubscribeToken("user@example.com", "badtoken")).toBe(false);
+  });
+
+  it("returns false for wrong email", () => {
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(verifyUnsubscribeToken("other@example.com", token)).toBe(false);
+  });
+});
+
+describe("buildUnsubscribeUrl", () => {
+  it("contains the email and token as query params", () => {
+    const url = buildUnsubscribeUrl("user@example.com");
+    expect(url).toContain("/api/notifications/unsubscribe");
+    expect(url).toContain("email=user%40example.com");
+    expect(url).toContain("token=");
+  });
+
+  it("uses the correct token for the email", () => {
+    const url = buildUnsubscribeUrl("user@example.com");
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(url).toContain(`token=${token}`);
+  });
+});


### PR DESCRIPTION
## Summary

- Added tests for three previously untested pure utility modules
- `cookbook-labels`: verifies label completeness for all categories
- `format-cookbook-date`: ISO date formatting and edge cases
- `unsubscribe-token`: HMAC generation, verification, and URL building
- 14 new tests, all passing

Partial progress on #232