### PR TITLE
Merge develop into main

### DIFF
--- a/scripts/data/hack-a-sprint-2026-ranking.json
+++ b/scripts/data/hack-a-sprint-2026-ranking.json
@@ -2,8 +2,8 @@
   "generatedAt": "2026-04-11T13:23:24.882Z",
   "prCutoffDate": "2026-04-09",
   "topN": 50,
-  "totalParticipants": 109,
-  "confirmedCount": 50,
+  "totalParticipants": 108,
+  "confirmedCount": 49,
   "waitlistedCount": 59,
   "githubLoginCorrections": {
     "mhoniseus": "smrifaki",
@@ -96,16 +96,6 @@
     {
       "rank": 9,
       "status": "confirmed",
-      "email": "leonardo@stepai.co.jp",
-      "name": "Ryuu Leonardo Sato",
-      "githubLogin": "rysat0",
-      "prsThruApr9": 2,
-      "prsAllTime": 2,
-      "lumaCreatedAt": "2026-04-09T20:38:21.511Z"
-    },
-    {
-      "rank": 10,
-      "status": "confirmed",
       "email": "abishek.bm@gmail.com",
       "name": "Abishek Bangalore Muralikrishna",
       "githubLogin": "Abi5678",
@@ -114,7 +104,7 @@
       "lumaCreatedAt": "2026-03-20T23:43:20.664Z"
     },
     {
-      "rank": 11,
+      "rank": 10,
       "status": "confirmed",
       "email": "nagaonkar.p@northeastern.edu",
       "name": "Payal Sanjay Nagaonkar",
@@ -124,7 +114,7 @@
       "lumaCreatedAt": "2026-03-21T02:07:07.231Z"
     },
     {
-      "rank": 12,
+      "rank": 11,
       "status": "confirmed",
       "email": "chloezzx@bu.edu",
       "name": "Zhixin Zhang",
@@ -135,7 +125,7 @@
       "lumaCreatedAt": "2026-03-21T23:44:20.273Z"
     },
     {
-      "rank": 13,
+      "rank": 12,
       "status": "confirmed",
       "email": "dungarani.j@northeastern.edu",
       "name": "Jaydip",
@@ -145,7 +135,7 @@
       "lumaCreatedAt": "2026-03-30T03:54:14.301Z"
     },
     {
-      "rank": 14,
+      "rank": 13,
       "status": "confirmed",
       "email": "scblouir@gmail.com",
       "name": "Sam Blouir",
@@ -155,7 +145,7 @@
       "lumaCreatedAt": "2026-04-03T15:43:47.330Z"
     },
     {
-      "rank": 15,
+      "rank": 14,
       "status": "confirmed",
       "email": "ayeshafatimazra@gmail.com",
       "name": "Ayesha Fatima",
@@ -165,7 +155,7 @@
       "lumaCreatedAt": "2026-03-20T17:09:37.992Z"
     },
     {
-      "rank": 16,
+      "rank": 15,
       "status": "confirmed",
       "email": "ananya@aicollective.com",
       "name": "Ananya Shah",
@@ -175,7 +165,7 @@
       "lumaCreatedAt": "2026-03-20T17:11:14.308Z"
     },
     {
-      "rank": 17,
+      "rank": 16,
       "status": "confirmed",
       "email": "michael@web-schulte.de",
       "name": "Michael Schulte",
@@ -185,7 +175,7 @@
       "lumaCreatedAt": "2026-03-20T17:22:43.447Z"
     },
     {
-      "rank": 18,
+      "rank": 17,
       "status": "confirmed",
       "email": "aaron.grace@comcast.net",
       "name": "Aaron Grace",
@@ -195,7 +185,7 @@
       "lumaCreatedAt": "2026-03-20T17:54:29.853Z"
     },
     {
-      "rank": 19,
+      "rank": 18,
       "status": "confirmed",
       "email": "john.obrien@gmail.com",
       "name": "John OBrien",
@@ -205,7 +195,7 @@
       "lumaCreatedAt": "2026-03-20T22:20:29.180Z"
     },
     {
-      "rank": 20,
+      "rank": 19,
       "status": "confirmed",
       "email": "chun.yimin@gmail.com",
       "name": "Yi Min",
@@ -215,7 +205,7 @@
       "lumaCreatedAt": "2026-03-20T22:36:12.748Z"
     },
     {
-      "rank": 21,
+      "rank": 20,
       "status": "confirmed",
       "email": "grosz.justin@bcg.com",
       "name": "Justin Grosz",
@@ -225,7 +215,7 @@
       "lumaCreatedAt": "2026-03-20T23:48:15.457Z"
     },
     {
-      "rank": 22,
+      "rank": 21,
       "status": "confirmed",
       "email": "hao.cai@gmail.com",
       "name": "Iain Cai",
@@ -235,7 +225,7 @@
       "lumaCreatedAt": "2026-03-21T01:18:31.958Z"
     },
     {
-      "rank": 23,
+      "rank": 22,
       "status": "confirmed",
       "email": "taralthota@gmail.com",
       "name": "Taral T",
@@ -245,7 +235,7 @@
       "lumaCreatedAt": "2026-03-21T01:18:35.666Z"
     },
     {
-      "rank": 24,
+      "rank": 23,
       "status": "confirmed",
       "email": "priyanka2bhutada@gmail.com",
       "name": "Priyanka Bhutada",
@@ -255,7 +245,7 @@
       "lumaCreatedAt": "2026-03-21T01:44:26.306Z"
     },
     {
-      "rank": 25,
+      "rank": 24,
       "status": "confirmed",
       "email": "malikzeeshan3.1417@gmail.com",
       "name": "Muhammad Zeeshan",
@@ -265,7 +255,7 @@
       "lumaCreatedAt": "2026-03-21T19:35:31.940Z"
     },
     {
-      "rank": 26,
+      "rank": 25,
       "status": "confirmed",
       "email": "bg2879@columbia.edu",
       "name": "Bharath Vishal",
@@ -275,7 +265,7 @@
       "lumaCreatedAt": "2026-03-21T23:14:18.416Z"
     },
     {
-      "rank": 27,
+      "rank": 26,
       "status": "confirmed",
       "email": "sahana359@gmail.com",
       "name": "Sahana Rajashekara",
@@ -285,7 +275,7 @@
       "lumaCreatedAt": "2026-03-21T23:15:29.004Z"
     },
     {
-      "rank": 28,
+      "rank": 27,
       "status": "confirmed",
       "email": "emilyjolam@gmail.com",
       "name": "Emily L",
@@ -295,7 +285,7 @@
       "lumaCreatedAt": "2026-03-21T23:22:24.260Z"
     },
     {
-      "rank": 29,
+      "rank": 28,
       "status": "confirmed",
       "email": "patil.jaye@northeastern.edu",
       "name": "Jayesh Patil",
@@ -305,7 +295,7 @@
       "lumaCreatedAt": "2026-03-21T23:25:20.733Z"
     },
     {
-      "rank": 30,
+      "rank": 29,
       "status": "confirmed",
       "email": "salve.a@northeastern.edu",
       "name": "Agnel Salve",
@@ -315,7 +305,7 @@
       "lumaCreatedAt": "2026-03-21T23:39:15.338Z"
     },
     {
-      "rank": 31,
+      "rank": 30,
       "status": "confirmed",
       "email": "eugenio.zuccarelli@gmail.com",
       "name": "Eugenio Zuccarelli",
@@ -325,7 +315,7 @@
       "lumaCreatedAt": "2026-03-21T23:53:12.856Z"
     },
     {
-      "rank": 32,
+      "rank": 31,
       "status": "confirmed",
       "email": "5kf2mfbv8v@privaterelay.appleid.com",
       "name": "Jack Digilov",
@@ -335,7 +325,7 @@
       "lumaCreatedAt": "2026-03-22T00:11:42.645Z"
     },
     {
-      "rank": 33,
+      "rank": 32,
       "status": "confirmed",
       "email": "mark2pm@gmail.com",
       "name": "Nithin Yash Menezes",
@@ -345,7 +335,7 @@
       "lumaCreatedAt": "2026-03-22T01:28:39.096Z"
     },
     {
-      "rank": 34,
+      "rank": 33,
       "status": "confirmed",
       "email": "sahu.man@northeastern.edu",
       "name": "Manisha Sahu",
@@ -355,7 +345,7 @@
       "lumaCreatedAt": "2026-03-22T01:30:22.108Z"
     },
     {
-      "rank": 35,
+      "rank": 34,
       "status": "confirmed",
       "email": "saikumarreddy221@gmail.com",
       "name": "Kumar Reddy P V Sai",
@@ -365,7 +355,7 @@
       "lumaCreatedAt": "2026-03-22T03:08:55.358Z"
     },
     {
-      "rank": 36,
+      "rank": 35,
       "status": "confirmed",
       "email": "kompella.sa@northeastern.edu",
       "name": "Satyasai Aditya Kompella",
@@ -375,7 +365,7 @@
       "lumaCreatedAt": "2026-03-22T06:30:36.776Z"
     },
     {
-      "rank": 37,
+      "rank": 36,
       "status": "confirmed",
       "email": "samirizvi25@gmail.com",
       "name": "Rizvi Syed Abdul Sami",
@@ -385,7 +375,7 @@
       "lumaCreatedAt": "2026-03-22T07:39:40.794Z"
     },
     {
-      "rank": 38,
+      "rank": 37,
       "status": "confirmed",
       "email": "mikeboensel@gmail.com",
       "name": "Mike Boensel",
@@ -395,7 +385,7 @@
       "lumaCreatedAt": "2026-03-22T13:01:07.378Z"
     },
     {
-      "rank": 39,
+      "rank": 38,
       "status": "confirmed",
       "email": "nicholas@mindsettech.ai",
       "name": "Nicholas Kozhemiakin",
@@ -405,7 +395,7 @@
       "lumaCreatedAt": "2026-03-22T14:51:54.218Z"
     },
     {
-      "rank": 40,
+      "rank": 39,
       "status": "confirmed",
       "email": "oftherose91@gmail.com",
       "name": "Argenis De La Rosa",
@@ -415,7 +405,7 @@
       "lumaCreatedAt": "2026-03-22T18:03:56.688Z"
     },
     {
-      "rank": 41,
+      "rank": 40,
       "status": "confirmed",
       "email": "alex@srge.co",
       "name": "Alex Zuffoletti",
@@ -425,7 +415,7 @@
       "lumaCreatedAt": "2026-03-23T01:04:55.731Z"
     },
     {
-      "rank": 42,
+      "rank": 41,
       "status": "confirmed",
       "email": "mekhalrajr@gmail.com",
       "name": "Mekhal Raj",
@@ -435,7 +425,7 @@
       "lumaCreatedAt": "2026-03-23T05:38:02.003Z"
     },
     {
-      "rank": 43,
+      "rank": 42,
       "status": "confirmed",
       "email": "kmondlane@gmail.com",
       "name": "Kris Mondlane",
@@ -445,7 +435,7 @@
       "lumaCreatedAt": "2026-03-23T14:47:24.393Z"
     },
     {
-      "rank": 44,
+      "rank": 43,
       "status": "confirmed",
       "email": "asceniccola@gmail.com",
       "name": "Andrew Ceniccola",
@@ -455,7 +445,7 @@
       "lumaCreatedAt": "2026-03-24T17:47:54.303Z"
     },
     {
-      "rank": 45,
+      "rank": 44,
       "status": "confirmed",
       "email": "samtem300@gmail.com",
       "name": "Samet T",
@@ -465,7 +455,7 @@
       "lumaCreatedAt": "2026-03-26T03:12:36.450Z"
     },
     {
-      "rank": 46,
+      "rank": 45,
       "status": "confirmed",
       "email": "vyahhi@gmail.com",
       "name": "Nikolay Vyahhi",
@@ -475,7 +465,7 @@
       "lumaCreatedAt": "2026-03-26T14:25:34.089Z"
     },
     {
-      "rank": 47,
+      "rank": 46,
       "status": "confirmed",
       "email": "matthewb10@outlook.com",
       "name": "Matthew Birov",
@@ -485,7 +475,7 @@
       "lumaCreatedAt": "2026-03-26T16:05:36.153Z"
     },
     {
-      "rank": 48,
+      "rank": 47,
       "status": "confirmed",
       "email": "krishnamurthy.p@northeastern.edu",
       "name": "Prarthana Krishnamurthy",
@@ -495,7 +485,7 @@
       "lumaCreatedAt": "2026-03-26T18:02:37.887Z"
     },
     {
-      "rank": 49,
+      "rank": 48,
       "status": "confirmed",
       "email": "satishparaddi@gmail.com",
       "name": "Satish Mallikarjun",
@@ -505,7 +495,7 @@
       "lumaCreatedAt": "2026-03-27T00:41:45.339Z"
     },
     {
-      "rank": 50,
+      "rank": 49,
       "status": "confirmed",
       "email": "adhithyan245@gmail.com",
       "name": "Adhithyan Aravind",
@@ -515,7 +505,7 @@
       "lumaCreatedAt": "2026-03-27T22:02:54.189Z"
     },
     {
-      "rank": 51,
+      "rank": 50,
       "status": "waitlisted",
       "email": "aakashmkj@gmail.com",
       "name": "Aakash Mukherjee",
@@ -526,7 +516,7 @@
       "lumaCreatedAt": "2026-04-06T15:42:47.323Z"
     },
     {
-      "rank": 52,
+      "rank": 51,
       "status": "waitlisted",
       "email": "singh.para@northeastern.edu",
       "name": "Paramjeet Singh",
@@ -536,17 +526,17 @@
       "lumaCreatedAt": "2026-04-08T23:37:22.271Z"
     },
     {
-      "rank": 53,
+      "rank": 52,
       "status": "waitlisted",
       "email": "sebastian@wallkoetter.net",
-      "name": "Sebastian Wallkötter",
+      "name": "Sebastian Wallk\u00f6tter",
       "githubLogin": "FirefoxMetzger",
       "prsThruApr9": 0,
       "prsAllTime": 1,
       "lumaCreatedAt": "2026-04-09T23:14:45.059Z"
     },
     {
-      "rank": 54,
+      "rank": 53,
       "status": "waitlisted",
       "email": "karthikeyan.k@northeastern.edu",
       "name": "Kannan Karthikeyan",
@@ -556,7 +546,7 @@
       "lumaCreatedAt": "2026-04-10T22:46:37.016Z"
     },
     {
-      "rank": 55,
+      "rank": 54,
       "status": "waitlisted",
       "email": "simba@forkoff.xyz",
       "name": "Simba",
@@ -566,7 +556,7 @@
       "lumaCreatedAt": "2026-03-28T09:25:47.622Z"
     },
     {
-      "rank": 56,
+      "rank": 55,
       "status": "waitlisted",
       "email": "phang.monica@bcg.com",
       "name": "Monica Phang",
@@ -576,7 +566,7 @@
       "lumaCreatedAt": "2026-03-28T17:38:48.808Z"
     },
     {
-      "rank": 57,
+      "rank": 56,
       "status": "waitlisted",
       "email": "torresr14@gmail.com",
       "name": "Randy Torres",
@@ -586,7 +576,7 @@
       "lumaCreatedAt": "2026-03-29T01:01:18.291Z"
     },
     {
-      "rank": 58,
+      "rank": 57,
       "status": "waitlisted",
       "email": "ashutoshiwale39@gmail.com",
       "name": "Ashutosh Iwale",
@@ -596,7 +586,7 @@
       "lumaCreatedAt": "2026-03-29T23:14:01.506Z"
     },
     {
-      "rank": 59,
+      "rank": 58,
       "status": "waitlisted",
       "email": "ashbhatia@gmail.com",
       "name": "Ashish Bhatia",
@@ -606,7 +596,7 @@
       "lumaCreatedAt": "2026-03-30T02:14:27.917Z"
     },
     {
-      "rank": 60,
+      "rank": 59,
       "status": "waitlisted",
       "email": "yuri.braga@carefuseai.com",
       "name": "Yuri Braga",
@@ -616,7 +606,7 @@
       "lumaCreatedAt": "2026-03-30T14:09:32.071Z"
     },
     {
-      "rank": 61,
+      "rank": 60,
       "status": "waitlisted",
       "email": "naik.san@northeastern.edu",
       "name": "Sanath Naik",
@@ -626,7 +616,7 @@
       "lumaCreatedAt": "2026-03-30T15:38:59.523Z"
     },
     {
-      "rank": 62,
+      "rank": 61,
       "status": "waitlisted",
       "email": "murali.na@northeastern.edu",
       "name": "Naveen Murali",
@@ -636,7 +626,7 @@
       "lumaCreatedAt": "2026-03-30T15:40:32.195Z"
     },
     {
-      "rank": 63,
+      "rank": 62,
       "status": "waitlisted",
       "email": "ahijith@gmail.com",
       "name": "Reghunaath Ajith Kumar Ahila",
@@ -646,7 +636,7 @@
       "lumaCreatedAt": "2026-03-30T21:32:45.766Z"
     },
     {
-      "rank": 64,
+      "rank": 63,
       "status": "waitlisted",
       "email": "nagapavithralagisetty@gmail.com",
       "name": "Pavithra Lagisetty",
@@ -656,7 +646,7 @@
       "lumaCreatedAt": "2026-03-30T21:47:21.123Z"
     },
     {
-      "rank": 65,
+      "rank": 64,
       "status": "waitlisted",
       "email": "bradegan@gmail.com",
       "name": "Brad Egan",
@@ -666,7 +656,7 @@
       "lumaCreatedAt": "2026-03-31T01:12:15.081Z"
     },
     {
-      "rank": 66,
+      "rank": 65,
       "status": "waitlisted",
       "email": "ankittejyadav@gmail.com",
       "name": "Ankit Yadav",
@@ -676,7 +666,7 @@
       "lumaCreatedAt": "2026-03-31T01:40:08.003Z"
     },
     {
-      "rank": 67,
+      "rank": 66,
       "status": "waitlisted",
       "email": "wakrson@gmail.com",
       "name": "Mark Robinson",
@@ -686,7 +676,7 @@
       "lumaCreatedAt": "2026-03-31T22:15:51.812Z"
     },
     {
-      "rank": 68,
+      "rank": 67,
       "status": "waitlisted",
       "email": "ajithkumarahila.r@northeastern.edu",
       "name": "Reghunaath A A",
@@ -696,7 +686,7 @@
       "lumaCreatedAt": "2026-03-31T22:29:29.590Z"
     },
     {
-      "rank": 69,
+      "rank": 68,
       "status": "waitlisted",
       "email": "oalshayeb1@babson.edu",
       "name": "Obyda Alshayeb",
@@ -706,7 +696,7 @@
       "lumaCreatedAt": "2026-04-01T04:28:42.898Z"
     },
     {
-      "rank": 70,
+      "rank": 69,
       "status": "waitlisted",
       "email": "monicaphang.mp@gmail.com",
       "name": "Monica Phang",
@@ -716,7 +706,7 @@
       "lumaCreatedAt": "2026-04-01T18:21:51.346Z"
     },
     {
-      "rank": 71,
+      "rank": 70,
       "status": "waitlisted",
       "email": "janna@aicollective.com",
       "name": "Janna Hong",
@@ -726,7 +716,7 @@
       "lumaCreatedAt": "2026-04-01T23:20:22.174Z"
     },
     {
-      "rank": 72,
+      "rank": 71,
       "status": "waitlisted",
       "email": "dagmawimilkias@gmail.com",
       "name": "Dagmawi Milkias",
@@ -736,7 +726,7 @@
       "lumaCreatedAt": "2026-04-02T05:34:26.909Z"
     },
     {
-      "rank": 73,
+      "rank": 72,
       "status": "waitlisted",
       "email": "himanshuchouhan@gmail.com",
       "name": "Himanshu Chouhan",
@@ -746,7 +736,7 @@
       "lumaCreatedAt": "2026-04-02T17:19:54.955Z"
     },
     {
-      "rank": 74,
+      "rank": 73,
       "status": "waitlisted",
       "email": "buse@bluesense.ai",
       "name": "Buse Demir",
@@ -756,7 +746,7 @@
       "lumaCreatedAt": "2026-04-02T19:39:57.497Z"
     },
     {
-      "rank": 75,
+      "rank": 74,
       "status": "waitlisted",
       "email": "thebarmaeffect@gmail.com",
       "name": "Karthik Barma",
@@ -766,7 +756,7 @@
       "lumaCreatedAt": "2026-04-02T22:44:54.423Z"
     },
     {
-      "rank": 76,
+      "rank": 75,
       "status": "waitlisted",
       "email": "jaisinganmol@gmail.com",
       "name": "Anmol Jaising",
@@ -776,7 +766,7 @@
       "lumaCreatedAt": "2026-04-03T01:05:40.449Z"
     },
     {
-      "rank": 77,
+      "rank": 76,
       "status": "waitlisted",
       "email": "mrcalebhung@gmail.com",
       "name": "Caleb Hung",
@@ -786,7 +776,7 @@
       "lumaCreatedAt": "2026-04-04T02:40:32.350Z"
     },
     {
-      "rank": 78,
+      "rank": 77,
       "status": "waitlisted",
       "email": "ceo@grepone.com",
       "name": "Joshua Elkington",
@@ -796,7 +786,7 @@
       "lumaCreatedAt": "2026-04-04T20:54:04.127Z"
     },
     {
-      "rank": 79,
+      "rank": 78,
       "status": "waitlisted",
       "email": "aatuusa@gmail.com",
       "name": "aatu usa",
@@ -806,7 +796,7 @@
       "lumaCreatedAt": "2026-04-04T23:25:55.649Z"
     },
     {
-      "rank": 80,
+      "rank": 79,
       "status": "waitlisted",
       "email": "jinalthakkar2022@gmail.com",
       "name": "Jinal Thakker",
@@ -816,7 +806,7 @@
       "lumaCreatedAt": "2026-04-05T00:03:33.168Z"
     },
     {
-      "rank": 81,
+      "rank": 80,
       "status": "waitlisted",
       "email": "muradhossainmgr@gmail.com",
       "name": "Morad Hossain",
@@ -826,7 +816,7 @@
       "lumaCreatedAt": "2026-04-05T02:46:25.236Z"
     },
     {
-      "rank": 82,
+      "rank": 81,
       "status": "waitlisted",
       "email": "orcino.raphael@gmail.com",
       "name": "Raphael Orcino",
@@ -836,7 +826,7 @@
       "lumaCreatedAt": "2026-04-05T05:13:53.533Z"
     },
     {
-      "rank": 83,
+      "rank": 82,
       "status": "waitlisted",
       "email": "hirvitakabariya@gmail.com",
       "name": "HK",
@@ -846,7 +836,7 @@
       "lumaCreatedAt": "2026-04-05T16:39:23.696Z"
     },
     {
-      "rank": 84,
+      "rank": 83,
       "status": "waitlisted",
       "email": "saks2730@gmail.com",
       "name": "Sakshi Chavan",
@@ -856,7 +846,7 @@
       "lumaCreatedAt": "2026-04-05T19:09:25.232Z"
     },
     {
-      "rank": 85,
+      "rank": 84,
       "status": "waitlisted",
       "email": "sneha.sonkusare15@gmail.com",
       "name": "Sneha Sonkusare",
@@ -866,7 +856,7 @@
       "lumaCreatedAt": "2026-04-05T19:11:07.630Z"
     },
     {
-      "rank": 86,
+      "rank": 85,
       "status": "waitlisted",
       "email": "hansome594@gmail.com",
       "name": "Clevelini Maris",
@@ -876,7 +866,7 @@
       "lumaCreatedAt": "2026-04-06T03:29:56.339Z"
     },
     {
-      "rank": 87,
+      "rank": 86,
       "status": "waitlisted",
       "email": "bhuvaneshwaran.r@northeastern.edu",
       "name": "Ramshankar B",
@@ -886,7 +876,7 @@
       "lumaCreatedAt": "2026-04-06T09:45:22.043Z"
     },
     {
-      "rank": 88,
+      "rank": 87,
       "status": "waitlisted",
       "email": "sai@thinkwithada.com",
       "name": "Sai Bolla",
@@ -896,7 +886,7 @@
       "lumaCreatedAt": "2026-04-06T14:23:20.718Z"
     },
     {
-      "rank": 89,
+      "rank": 88,
       "status": "waitlisted",
       "email": "ivormontenegro@gmail.com",
       "name": "Ivo Rosa Montenegro",
@@ -906,7 +896,7 @@
       "lumaCreatedAt": "2026-04-06T14:51:18.054Z"
     },
     {
-      "rank": 90,
+      "rank": 89,
       "status": "waitlisted",
       "email": "heronalps@gmail.com",
       "name": "Michael Zhang",
@@ -916,17 +906,17 @@
       "lumaCreatedAt": "2026-04-06T15:43:45.616Z"
     },
     {
-      "rank": 91,
+      "rank": 90,
       "status": "waitlisted",
       "email": "lucas196700@gmail.com",
-      "name": "俊安 金",
+      "name": "\u4fca\u5b89 \u91d1",
       "githubLogin": "lucasking0109",
       "prsThruApr9": 0,
       "prsAllTime": 0,
       "lumaCreatedAt": "2026-04-06T16:34:17.755Z"
     },
     {
-      "rank": 92,
+      "rank": 91,
       "status": "waitlisted",
       "email": "aarjav02@gmail.com",
       "name": "Aarjav Jain",
@@ -936,7 +926,7 @@
       "lumaCreatedAt": "2026-04-06T19:33:10.714Z"
     },
     {
-      "rank": 93,
+      "rank": 92,
       "status": "waitlisted",
       "email": "zhiyi_lu@brown.edu",
       "name": "Nikky Lu",
@@ -946,7 +936,7 @@
       "lumaCreatedAt": "2026-04-06T19:50:45.708Z"
     },
     {
-      "rank": 94,
+      "rank": 93,
       "status": "waitlisted",
       "email": "manthan@legitreach.com",
       "name": "Manthan Admane",
@@ -956,7 +946,7 @@
       "lumaCreatedAt": "2026-04-06T23:35:00.912Z"
     },
     {
-      "rank": 95,
+      "rank": 94,
       "status": "waitlisted",
       "email": "ridhambhagat@gmail.com",
       "name": "Ridham Bhagat",
@@ -966,7 +956,7 @@
       "lumaCreatedAt": "2026-04-07T03:32:22.292Z"
     },
     {
-      "rank": 96,
+      "rank": 95,
       "status": "waitlisted",
       "email": "teozhihao123@gmail.com",
       "name": "Zhi Hao Teo",
@@ -976,7 +966,7 @@
       "lumaCreatedAt": "2026-04-07T04:28:46.741Z"
     },
     {
-      "rank": 97,
+      "rank": 96,
       "status": "waitlisted",
       "email": "dannygarciacotes1@gmail.com",
       "name": "Danny Garcia Cortes",
@@ -987,7 +977,7 @@
       "lumaCreatedAt": "2026-04-07T14:42:50.780Z"
     },
     {
-      "rank": 98,
+      "rank": 97,
       "status": "waitlisted",
       "email": "patelheer2002@gmail.com",
       "name": "Heer",
@@ -997,7 +987,7 @@
       "lumaCreatedAt": "2026-04-07T19:05:17.390Z"
     },
     {
-      "rank": 99,
+      "rank": 98,
       "status": "waitlisted",
       "email": "siddhanth@huedmamas.com",
       "name": "Siddhanth Pai",
@@ -1007,7 +997,7 @@
       "lumaCreatedAt": "2026-04-07T20:49:40.697Z"
     },
     {
-      "rank": 100,
+      "rank": 99,
       "status": "waitlisted",
       "email": "kashettyshruthi@gmail.com",
       "name": "Shruthi",
@@ -1017,7 +1007,7 @@
       "lumaCreatedAt": "2026-04-08T13:43:05.669Z"
     },
     {
-      "rank": 101,
+      "rank": 100,
       "status": "waitlisted",
       "email": "omkarsheth30@gmail.com",
       "name": "Omkar Sheth",
@@ -1027,7 +1017,7 @@
       "lumaCreatedAt": "2026-04-09T02:09:11.132Z"
     },
     {
-      "rank": 102,
+      "rank": 101,
       "status": "waitlisted",
       "email": "ssiddula.dev@gmail.com",
       "name": "Sreekar Siddula",
@@ -1037,7 +1027,7 @@
       "lumaCreatedAt": "2026-04-09T03:16:54.952Z"
     },
     {
-      "rank": 103,
+      "rank": 102,
       "status": "waitlisted",
       "email": "zaraaurora82@gmail.com",
       "name": "Zara aura",
@@ -1047,7 +1037,7 @@
       "lumaCreatedAt": "2026-04-09T10:57:57.948Z"
     },
     {
-      "rank": 104,
+      "rank": 103,
       "status": "waitlisted",
       "email": "amitanveri@gmail.com",
       "name": "Amit Anveri",
@@ -1057,7 +1047,7 @@
       "lumaCreatedAt": "2026-04-10T00:49:52.209Z"
     },
     {
-      "rank": 105,
+      "rank": 104,
       "status": "waitlisted",
       "email": "vasilis@vasilistsolis.com",
       "name": "Vasilis Tsolis",
@@ -1067,7 +1057,7 @@
       "lumaCreatedAt": "2026-04-10T01:32:21.828Z"
     },
     {
-      "rank": 106,
+      "rank": 105,
       "status": "waitlisted",
       "email": "icey@starlaskincare.com",
       "name": "Icey Roongpiti",
@@ -1077,7 +1067,7 @@
       "lumaCreatedAt": "2026-04-10T04:35:09.289Z"
     },
     {
-      "rank": 107,
+      "rank": 106,
       "status": "waitlisted",
       "email": "andre@genesisfund.co",
       "name": "Andre Kirby",
@@ -1087,7 +1077,7 @@
       "lumaCreatedAt": "2026-04-10T23:39:17.129Z"
     },
     {
-      "rank": 108,
+      "rank": 107,
       "status": "waitlisted",
       "email": "d5222c@gmail.com",
       "name": "Yinzheng Guan",
@@ -1097,7 +1087,7 @@
       "lumaCreatedAt": "2026-04-11T01:34:58.477Z"
     },
     {
-      "rank": 109,
+      "rank": 108,
       "status": "waitlisted",
       "email": "miloschwartz@outlook.com",
       "name": "Milo Scharwarx",


### PR DESCRIPTION
## Summary

- **fix:** carry over confirmed status when Luma registrant signs up on website (Blake Mauri bug)
- **fix:** remove duplicate Ryuu Leonardo Sato entry from ranking JSON

Run `npx tsx scripts/sync-ranking-to-firestore.ts --write` after deploy to sync ranking data to Firestore.