### PR TITLE
test: add 11 tests for auth resolve-email and remove-email routes

### DIFF
--- a/__tests__/app/api/auth/remove-email.test.ts
+++ b/__tests__/app/api/auth/remove-email.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/remove-email/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockUpdate = jest.fn().mockResolvedValue(undefined);
+const mockDelete = jest.fn().mockResolvedValue(undefined);
+const mockUserGet = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: () =>
+        name === "users"
+          ? { get: mockUserGet, update: mockUpdate }
+          : { delete: mockDelete },
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/remove-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/remove-email", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for missing email", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when user doc not found", async () => {
+    mockUserGet.mockResolvedValue({ data: () => null });
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when email not in additionalEmails", async () => {
+    mockUserGet.mockResolvedValue({
+      data: () => ({ additionalEmails: [{ email: "other@example.com" }] }),
+    });
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("removes email and cleans up emailLookup on success", async () => {
+    mockUserGet.mockResolvedValue({
+      data: () => ({
+        additionalEmails: [{ email: "test@example.com" }],
+      }),
+    });
+    const res = await POST(makeRequest({ email: "Test@Example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockDelete).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/auth/resolve-email.test.ts
+++ b/__tests__/app/api/auth/resolve-email.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/resolve-email/route";
+
+const mockGetUserByEmail = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn() },
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({
+      doc: () => ({ get: mockGet }),
+    }),
+  })),
+  getAdminAuth: jest.fn(() => ({
+    getUserByEmail: mockGetUserByEmail,
+  })),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/resolve-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/resolve-email", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 400 for missing email", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-string email", async () => {
+    const res = await POST(makeRequest({ email: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns primary email when found in Firebase Auth", async () => {
+    mockGetUserByEmail.mockResolvedValue({ uid: "u1" });
+    const res = await POST(makeRequest({ email: "User@Example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBe("user@example.com");
+    expect(body.isAlias).toBe(false);
+  });
+
+  it("checks emailLookup when not a primary email", async () => {
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ uid: "u1" }),
+    });
+    // Second call for user doc
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ email: "primary@example.com" }),
+    });
+    const res = await POST(makeRequest({ email: "alias@example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBe("primary@example.com");
+    expect(body.isAlias).toBe(true);
+  });
+
+  it("returns null when email not found anywhere", async () => {
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockGet.mockResolvedValue({ exists: false });
+    const res = await POST(makeRequest({ email: "unknown@example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBeNull();
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const req = new NextRequest("http://localhost/api/auth/resolve-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "bad json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

- Tests for `POST /api/auth/resolve-email` (6 tests): primary email lookup, alias resolution via emailLookup collection, not-found handling
- Tests for `POST /api/auth/remove-email` (5 tests): authentication, validation, additionalEmails check, emailLookup cleanup
- First test coverage for any auth API routes

Partial progress on #232