### PR TITLE
Merge develop into main: 11 test coverage PRs

### DIFF
--- a/__tests__/app/api/agents/register.test.ts
+++ b/__tests__/app/api/agents/register.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/agents/register/route";
+
+const mockCreateAgent = jest.fn();
+const mockGetVerifiedAgent = jest.fn();
+
+jest.mock("@/lib/agents", () => ({
+  createAgent: (...args: unknown[]) => mockCreateAgent(...args),
+  getVerifiedAgent: (...args: unknown[]) => mockGetVerifiedAgent(...args),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/agents/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", host: "localhost:3000" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agents/register", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedAgent.mockResolvedValue(null);
+    mockCreateAgent.mockResolvedValue({
+      agent: { id: "agent-1", name: "TestBot", description: "", status: "unclaimed" },
+      apiKey: "cb_agent_xxx",
+      claimUrl: "/agents/claim/token123",
+    });
+  });
+
+  it("returns 409 if agent already registered", async () => {
+    mockGetVerifiedAgent.mockResolvedValue({ id: "existing", name: "Bot", status: "claimed" });
+    const res = await POST(makeRequest({ name: "Bot" }));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 400 for missing name", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for name too short", async () => {
+    const res = await POST(makeRequest({ name: "A" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for name too long", async () => {
+    const res = await POST(makeRequest({ name: "A".repeat(51) }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid name characters", async () => {
+    const res = await POST(makeRequest({ name: "Bot@Special!" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for description too long", async () => {
+    const res = await POST(makeRequest({ name: "TestBot", description: "A".repeat(501) }));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates agent and returns API key on success", async () => {
+    const res = await POST(makeRequest({ name: "TestBot", description: "A test bot" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.apiKey).toBe("cb_agent_xxx");
+    expect(body.agent.id).toBe("agent-1");
+    expect(body.claimUrl).toContain("/agents/claim/token123");
+    expect(mockCreateAgent).toHaveBeenCalledWith("TestBot", "A test bot");
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const req = new NextRequest("http://localhost/api/agents/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "bad",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/app/api/auth/remove-email.test.ts
+++ b/__tests__/app/api/auth/remove-email.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/remove-email/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockUpdate = jest.fn().mockResolvedValue(undefined);
+const mockDelete = jest.fn().mockResolvedValue(undefined);
+const mockUserGet = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: () =>
+        name === "users"
+          ? { get: mockUserGet, update: mockUpdate }
+          : { delete: mockDelete },
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/remove-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/remove-email", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for missing email", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when user doc not found", async () => {
+    mockUserGet.mockResolvedValue({ data: () => null });
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when email not in additionalEmails", async () => {
+    mockUserGet.mockResolvedValue({
+      data: () => ({ additionalEmails: [{ email: "other@example.com" }] }),
+    });
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("removes email and cleans up emailLookup on success", async () => {
+    mockUserGet.mockResolvedValue({
+      data: () => ({
+        additionalEmails: [{ email: "test@example.com" }],
+      }),
+    });
+    const res = await POST(makeRequest({ email: "Test@Example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockDelete).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/auth/resolve-email.test.ts
+++ b/__tests__/app/api/auth/resolve-email.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/resolve-email/route";
+
+const mockGetUserByEmail = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn() },
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({
+      doc: () => ({ get: mockGet }),
+    }),
+  })),
+  getAdminAuth: jest.fn(() => ({
+    getUserByEmail: mockGetUserByEmail,
+  })),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/resolve-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/resolve-email", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 400 for missing email", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-string email", async () => {
+    const res = await POST(makeRequest({ email: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns primary email when found in Firebase Auth", async () => {
+    mockGetUserByEmail.mockResolvedValue({ uid: "u1" });
+    const res = await POST(makeRequest({ email: "User@Example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBe("user@example.com");
+    expect(body.isAlias).toBe(false);
+  });
+
+  it("checks emailLookup when not a primary email", async () => {
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ uid: "u1" }),
+    });
+    // Second call for user doc
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ email: "primary@example.com" }),
+    });
+    const res = await POST(makeRequest({ email: "alias@example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBe("primary@example.com");
+    expect(body.isAlias).toBe(true);
+  });
+
+  it("returns null when email not found anywhere", async () => {
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockGet.mockResolvedValue({ exists: false });
+    const res = await POST(makeRequest({ email: "unknown@example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBeNull();
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const req = new NextRequest("http://localhost/api/auth/resolve-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "bad json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/app/api/community/delete.test.ts
+++ b/__tests__/app/api/community/delete.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/community/delete/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockDelete = jest.fn().mockResolvedValue(undefined);
+const mockGet = jest.fn();
+const mockDoc = jest.fn(() => ({
+  get: mockGet,
+  delete: mockDelete,
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({ doc: mockDoc }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/community/delete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/community/delete", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ messageId: "msg-1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid messageId format", async () => {
+    const res = await POST(makeRequest({ messageId: "invalid/path" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Invalid messageId/);
+  });
+
+  it("returns 400 for missing messageId", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when message does not exist", async () => {
+    mockGet.mockResolvedValue({ exists: false });
+    const res = await POST(makeRequest({ messageId: "msg-1" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when user is not the author", async () => {
+    mockGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ authorId: "other-user" }),
+    });
+    const res = await POST(makeRequest({ messageId: "msg-1" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("deletes the message when user is the author", async () => {
+    mockGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ authorId: "u1" }),
+    });
+    const res = await POST(makeRequest({ messageId: "msg-1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/community/post.test.ts
+++ b/__tests__/app/api/community/post.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/community/post/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  getDisplayName: (user: { name?: string }) => user.name || "Anonymous",
+}));
+
+const mockSet = jest.fn().mockResolvedValue(undefined);
+const mockDoc = jest.fn(() => ({ id: "msg-123", set: mockSet }));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({ doc: mockDoc }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const { checkRateLimit } = jest.requireMock("@/lib/rate-limit");
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/community/post", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validContent = "A".repeat(150);
+
+describe("POST /api/community/post", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    (checkRateLimit as jest.Mock).mockReturnValue({ success: true });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ content: validContent }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (checkRateLimit as jest.Mock).mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({ content: validContent }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.retryAfterSeconds).toBe(30);
+  });
+
+  it("returns 400 for content that is too short", async () => {
+    const res = await POST(makeRequest({ content: "too short" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/between 100 and 500/);
+  });
+
+  it("returns 400 for content that is too long", async () => {
+    const res = await POST(makeRequest({ content: "A".repeat(501) }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing content", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a message and returns messageId on success", async () => {
+    const res = await POST(makeRequest({ content: validContent }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.messageId).toBe("msg-123");
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: validContent,
+        authorId: "u1",
+        authorName: "Test User",
+        likeCount: 0,
+        dislikeCount: 0,
+        replyCount: 0,
+        repostCount: 0,
+      })
+    );
+  });
+
+  it("sanitizes HTML from content", async () => {
+    const htmlContent = "<b>" + "A".repeat(100) + "</b>" + "B".repeat(50);
+    const res = await POST(makeRequest({ content: htmlContent }));
+    expect(res.status).toBe(200);
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.not.stringContaining("<b>"),
+      })
+    );
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const req = new NextRequest("http://localhost/api/community/post", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/app/api/community/reaction.test.ts
+++ b/__tests__/app/api/community/reaction.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/community/reaction/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockTxGet = jest.fn();
+const mockTxSet = jest.fn();
+const mockTxUpdate = jest.fn();
+const mockTxDelete = jest.fn();
+const mockRunTransaction = jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+  return fn({
+    get: mockTxGet,
+    set: mockTxSet,
+    update: mockTxUpdate,
+    delete: mockTxDelete,
+  });
+});
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({
+      doc: () => ({}),
+    }),
+    runTransaction: mockRunTransaction,
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/community/reaction", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/community/reaction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ messageId: "msg-1", type: "like" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid messageId", async () => {
+    const res = await POST(makeRequest({ messageId: "bad/id", type: "like" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid type", async () => {
+    const res = await POST(makeRequest({ messageId: "msg-1", type: "love" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing fields", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when message does not exist", async () => {
+    mockTxGet.mockResolvedValueOnce({ exists: false }).mockResolvedValueOnce({ exists: false });
+    const res = await POST(makeRequest({ messageId: "msg-1", type: "like" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("adds a new reaction", async () => {
+    mockTxGet
+      .mockResolvedValueOnce({ exists: true, data: () => ({ likeCount: 0, dislikeCount: 0 }) })
+      .mockResolvedValueOnce({ exists: false });
+    const res = await POST(makeRequest({ messageId: "msg-1", type: "like" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.action).toBe("added");
+    expect(body.type).toBe("like");
+    expect(mockTxSet).toHaveBeenCalled();
+  });
+
+  it("removes reaction when toggling same type", async () => {
+    mockTxGet
+      .mockResolvedValueOnce({ exists: true, data: () => ({ likeCount: 1, dislikeCount: 0 }) })
+      .mockResolvedValueOnce({ exists: true, data: () => ({ type: "like" }) });
+    const res = await POST(makeRequest({ messageId: "msg-1", type: "like" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.action).toBe("removed");
+    expect(mockTxDelete).toHaveBeenCalled();
+  });
+
+  it("switches reaction when toggling different type", async () => {
+    mockTxGet
+      .mockResolvedValueOnce({ exists: true, data: () => ({ likeCount: 1, dislikeCount: 0 }) })
+      .mockResolvedValueOnce({ exists: true, data: () => ({ type: "like" }) });
+    const res = await POST(makeRequest({ messageId: "msg-1", type: "dislike" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.action).toBe("switched");
+    expect(body.type).toBe("dislike");
+    expect(body.previousType).toBe("like");
+    expect(mockTxUpdate).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/community/reply.test.ts
+++ b/__tests__/app/api/community/reply.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/community/reply/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  getDisplayName: (user: { name?: string }) => user.name || "Anonymous",
+}));
+
+const mockTxGet = jest.fn();
+const mockTxSet = jest.fn();
+const mockTxUpdate = jest.fn();
+const mockRunTransaction = jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+  return fn({ get: mockTxGet, set: mockTxSet, update: mockTxUpdate });
+});
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({ doc: jest.fn(() => ({ id: "reply-123" })) }),
+    runTransaction: mockRunTransaction,
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+const validContent = "A".repeat(150);
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/community/reply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/community/reply", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ parentId: "msg-1", content: validContent }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid parentId", async () => {
+    const res = await POST(makeRequest({ parentId: "bad/id", content: validContent }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for content too short", async () => {
+    const res = await POST(makeRequest({ parentId: "msg-1", content: "short" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when parent message not found", async () => {
+    mockTxGet.mockResolvedValue({ exists: false });
+    const res = await POST(makeRequest({ parentId: "msg-1", content: validContent }));
+    expect(res.status).toBe(404);
+  });
+
+  it("creates reply and increments parent replyCount", async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ replyCount: 2 }),
+    });
+    const res = await POST(makeRequest({ parentId: "msg-1", content: validContent }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.replyId).toBe("reply-123");
+    expect(mockTxSet).toHaveBeenCalled();
+    expect(mockTxUpdate).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/community/repost.test.ts
+++ b/__tests__/app/api/community/repost.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/community/repost/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  getDisplayName: (user: { name?: string }) => user.name || "Anonymous",
+}));
+
+const mockTxGet = jest.fn();
+const mockTxSet = jest.fn();
+const mockTxUpdate = jest.fn();
+const mockRunTransaction = jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+  return fn({ get: mockTxGet, set: mockTxSet, update: mockTxUpdate });
+});
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({ doc: jest.fn(() => ({ id: "repost-456" })) }),
+    runTransaction: mockRunTransaction,
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+const validContent = "A".repeat(150);
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/community/repost", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/community/repost", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ originalId: "msg-1", content: validContent }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid originalId", async () => {
+    const res = await POST(makeRequest({ originalId: "bad/id", content: validContent }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for content too short", async () => {
+    const res = await POST(makeRequest({ originalId: "msg-1", content: "short" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when original message not found", async () => {
+    mockTxGet.mockResolvedValue({ exists: false });
+    const res = await POST(makeRequest({ originalId: "msg-1", content: validContent }));
+    expect(res.status).toBe(404);
+  });
+
+  it("creates repost with original metadata and increments repostCount", async () => {
+    mockTxGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        authorId: "original-author",
+        authorName: "Original Author",
+        content: "Original content",
+        repostCount: 1,
+      }),
+    });
+    const res = await POST(makeRequest({ originalId: "msg-1", content: validContent }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.repostId).toBe("repost-456");
+    expect(mockTxSet).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        repostOf: expect.objectContaining({
+          originalId: "msg-1",
+          originalAuthorId: "original-author",
+        }),
+      })
+    );
+    expect(mockTxUpdate).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/notify-admin/cfp.test.ts
+++ b/__tests__/app/api/notify-admin/cfp.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/notify-admin/cfp/route";
+
+const mockSendEmail = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/notify-admin/cfp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  name: "Jane Doe",
+  email: "jane@example.com",
+  thesisTitle: "AI-Assisted Development Patterns",
+  school: "MIT",
+  department: "CS",
+};
+
+describe("POST /api/notify-admin/cfp", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 400 for missing required fields", async () => {
+    const res = await POST(makeRequest({ name: "Jane" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("sends email and returns 200 on success", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(mockSendEmail).toHaveBeenCalled();
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.stringContaining("AI-Assisted Development Patterns"),
+      })
+    );
+  });
+
+  it("returns 500 when email sending fails", async () => {
+    mockSendEmail.mockRejectedValueOnce(new Error("SMTP error"));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/notify-admin/event.test.ts
+++ b/__tests__/app/api/notify-admin/event.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/notify-admin/event/route";
+
+const mockSendEmail = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/notify-admin/event", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  name: "Jane Doe",
+  email: "jane@example.com",
+  title: "React Meetup",
+  organization: "Acme Corp",
+  eventType: "meetup",
+  description: "A fun event",
+};
+
+describe("POST /api/notify-admin/event", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 400 for missing required fields", async () => {
+    const res = await POST(makeRequest({ name: "Jane" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("sends email and returns 200 on success", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.stringContaining("React Meetup"),
+      })
+    );
+  });
+
+  it("returns 500 when email sending fails", async () => {
+    mockSendEmail.mockRejectedValueOnce(new Error("SMTP error"));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/notify-admin/talk.test.ts
+++ b/__tests__/app/api/notify-admin/talk.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/notify-admin/talk/route";
+
+const mockSendEmail = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/notify-admin/talk", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  name: "Jane Doe",
+  email: "jane@example.com",
+  title: "AI in Production",
+  description: "A talk about AI",
+  category: "tech",
+  duration: "30min",
+  experience: "intermediate",
+  bio: "Engineer",
+};
+
+describe("POST /api/notify-admin/talk", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 400 for missing required fields", async () => {
+    const res = await POST(makeRequest({ name: "Jane" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing name", async () => {
+    const res = await POST(makeRequest({ email: "j@e.com", title: "T" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("sends email and returns 200 on success", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.stringContaining("AI in Production"),
+      })
+    );
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const req = new NextRequest("http://localhost/api/notify-admin/talk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "bad",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when email sending fails", async () => {
+    mockSendEmail.mockRejectedValueOnce(new Error("SMTP error"));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/profile/visibility.test.ts
+++ b/__tests__/app/api/profile/visibility.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "@/app/api/profile/visibility/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockUpdate = jest.fn().mockResolvedValue(undefined);
+const mockGet = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({
+      doc: () => ({ get: mockGet, update: mockUpdate }),
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePatchRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/profile/visibility", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/profile/visibility");
+}
+
+describe("PATCH /api/profile/visibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await PATCH(makePatchRequest({ isPublic: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when no valid fields provided", async () => {
+    const res = await PATCH(makePatchRequest({ invalidField: true }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-boolean values", async () => {
+    const res = await PATCH(makePatchRequest({ isPublic: "yes" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates visibility fields and returns updated data", async () => {
+    mockGet.mockResolvedValue({
+      data: () => ({ visibility: { isPublic: true, showEmail: false } }),
+    });
+    const res = await PATCH(makePatchRequest({ isPublic: true, showEmail: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "visibility.isPublic": true,
+        "visibility.showEmail": false,
+      })
+    );
+  });
+});
+
+describe("GET /api/profile/visibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns default profile when user doc does not exist", async () => {
+    mockGet.mockResolvedValue({ exists: false });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profile.hasDisplayName).toBe(false);
+    expect(body.profile.hasGithub).toBe(false);
+  });
+
+  it("returns profile data when user doc exists", async () => {
+    mockGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        displayName: "Jane",
+        github: { login: "janedoe" },
+        discord: { username: "jane#1234" },
+        visibility: { isPublic: true },
+        photoURL: "https://example.com/photo.jpg",
+      }),
+    });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profile.hasDisplayName).toBe(true);
+    expect(body.profile.hasGithub).toBe(true);
+    expect(body.profile.githubUsername).toBe("janedoe");
+    expect(body.profile.visibility.isPublic).toBe(true);
+  });
+});

--- a/__tests__/lib/badges/definitions.test.ts
+++ b/__tests__/lib/badges/definitions.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  BADGE_DEFINITIONS,
+  BADGE_IDS,
+  BADGE_DEFINITIONS_BY_ID,
+} from "@/lib/badges/definitions";
+import type { BadgeId, BadgeCategory } from "@/lib/badges/types";
+
+const VALID_CATEGORIES: BadgeCategory[] = [
+  "onboarding",
+  "community",
+  "events",
+  "contributions",
+  "mentorship",
+];
+
+describe("BADGE_DEFINITIONS", () => {
+  it("contains at least one badge", () => {
+    expect(BADGE_DEFINITIONS.length).toBeGreaterThan(0);
+  });
+
+  it("every badge has required fields", () => {
+    for (const badge of BADGE_DEFINITIONS) {
+      expect(badge.id).toBeTruthy();
+      expect(badge.name).toBeTruthy();
+      expect(badge.description).toBeTruthy();
+      expect(badge.howToEarn).toBeTruthy();
+      expect(typeof badge.sortOrder).toBe("number");
+      expect(VALID_CATEGORIES).toContain(badge.category);
+    }
+  });
+
+  it("has unique badge IDs", () => {
+    const ids = BADGE_DEFINITIONS.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("has unique sort orders", () => {
+    const orders = BADGE_DEFINITIONS.map((b) => b.sortOrder);
+    expect(new Set(orders).size).toBe(orders.length);
+  });
+
+  it("sort orders are sequential starting from 1", () => {
+    const sorted = [...BADGE_DEFINITIONS].sort(
+      (a, b) => a.sortOrder - b.sortOrder
+    );
+    sorted.forEach((badge, i) => {
+      expect(badge.sortOrder).toBe(i + 1);
+    });
+  });
+});
+
+describe("BADGE_IDS", () => {
+  it("matches the IDs from BADGE_DEFINITIONS", () => {
+    const definitionIds = BADGE_DEFINITIONS.map((b) => b.id);
+    expect(BADGE_IDS).toEqual(definitionIds);
+  });
+
+  it("contains known badge IDs", () => {
+    const knownIds: BadgeId[] = [
+      "first-steps",
+      "connected",
+      "speaker",
+      "hacker",
+      "contributor",
+    ];
+    for (const id of knownIds) {
+      expect(BADGE_IDS).toContain(id);
+    }
+  });
+});
+
+describe("BADGE_DEFINITIONS_BY_ID", () => {
+  it("has an entry for every badge ID", () => {
+    for (const id of BADGE_IDS) {
+      expect(BADGE_DEFINITIONS_BY_ID[id]).toBeDefined();
+      expect(BADGE_DEFINITIONS_BY_ID[id].id).toBe(id);
+    }
+  });
+
+  it("lookup returns the correct badge", () => {
+    const badge = BADGE_DEFINITIONS_BY_ID["contributor"];
+    expect(badge.name).toBe("Contributor");
+    expect(badge.category).toBe("contributions");
+  });
+});

--- a/__tests__/lib/cookbook-labels.test.ts
+++ b/__tests__/lib/cookbook-labels.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { CATEGORY_LABELS } from "@/lib/cookbook-labels";
+import { COOKBOOK_CATEGORIES } from "@/types/cookbook";
+
+describe("CATEGORY_LABELS", () => {
+  it("has a label for every cookbook category", () => {
+    for (const category of COOKBOOK_CATEGORIES) {
+      expect(CATEGORY_LABELS[category]).toBeDefined();
+      expect(typeof CATEGORY_LABELS[category]).toBe("string");
+      expect(CATEGORY_LABELS[category].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("contains expected categories", () => {
+    expect(CATEGORY_LABELS.debugging).toBe("Debugging");
+    expect(CATEGORY_LABELS.refactoring).toBe("Refactoring");
+    expect(CATEGORY_LABELS["code-generation"]).toBe("Code Generation");
+    expect(CATEGORY_LABELS.other).toBe("Other");
+  });
+});

--- a/__tests__/lib/format-cookbook-date.test.ts
+++ b/__tests__/lib/format-cookbook-date.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { formatCookbookDate } from "@/lib/format-cookbook-date";
+
+describe("formatCookbookDate", () => {
+  it("returns empty string for falsy input", () => {
+    expect(formatCookbookDate("")).toBe("");
+  });
+
+  it("formats ISO date string to short locale format", () => {
+    const result = formatCookbookDate("2026-03-05T12:00:00Z");
+    expect(result).toMatch(/Mar\s+5,\s+2026/);
+  });
+
+  it("handles date-only ISO string", () => {
+    const result = formatCookbookDate("2026-12-25T00:00:00Z");
+    expect(result).toMatch(/Dec\s+2[45],\s+2026/);
+  });
+});

--- a/__tests__/lib/hackathons.test.ts
+++ b/__tests__/lib/hackathons.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  getCurrentVirtualHackathonId,
+  getVirtualHackathonIdForDate,
+  isVirtualHackathonId,
+  getMonthEndFromVirtualId,
+  getVirtualMonthStartEndUtc,
+  getCurrentVirtualMonthStart,
+  getCurrentVirtualMonthEnd,
+  getSubmissionCutoffForMonth,
+} from "@/lib/hackathons";
+
+describe("isVirtualHackathonId", () => {
+  it("returns true for valid virtual IDs", () => {
+    expect(isVirtualHackathonId("virtual-2025-01")).toBe(true);
+    expect(isVirtualHackathonId("virtual-2026-12")).toBe(true);
+  });
+
+  it("returns false for invalid formats", () => {
+    expect(isVirtualHackathonId("virtual-2025-1")).toBe(false);
+    expect(isVirtualHackathonId("hack-a-sprint-2026")).toBe(false);
+    expect(isVirtualHackathonId("virtual-25-01")).toBe(false);
+    expect(isVirtualHackathonId("")).toBe(false);
+  });
+});
+
+describe("getCurrentVirtualHackathonId", () => {
+  it("returns a valid virtual hackathon ID", () => {
+    const id = getCurrentVirtualHackathonId();
+    expect(isVirtualHackathonId(id)).toBe(true);
+  });
+
+  it("matches the virtual-YYYY-MM pattern", () => {
+    const id = getCurrentVirtualHackathonId();
+    expect(id).toMatch(/^virtual-\d{4}-\d{2}$/);
+  });
+});
+
+describe("getVirtualHackathonIdForDate", () => {
+  it("returns correct ID for a known date", () => {
+    const date = new Date("2026-03-15T12:00:00Z");
+    const id = getVirtualHackathonIdForDate(date);
+    expect(id).toBe("virtual-2026-03");
+  });
+
+  it("returns correct ID for January", () => {
+    const date = new Date("2025-01-01T12:00:00Z");
+    const id = getVirtualHackathonIdForDate(date);
+    expect(id).toBe("virtual-2025-01");
+  });
+});
+
+describe("getMonthEndFromVirtualId", () => {
+  it("returns last day of January", () => {
+    const end = getMonthEndFromVirtualId("virtual-2026-01");
+    expect(end.getDate()).toBe(31);
+    expect(end.getMonth()).toBe(0); // January
+    expect(end.getFullYear()).toBe(2026);
+  });
+
+  it("returns last day of February (non-leap year)", () => {
+    const end = getMonthEndFromVirtualId("virtual-2025-02");
+    expect(end.getDate()).toBe(28);
+  });
+
+  it("returns last day of February (leap year)", () => {
+    const end = getMonthEndFromVirtualId("virtual-2028-02");
+    expect(end.getDate()).toBe(29);
+  });
+
+  it("returns current date for invalid ID", () => {
+    const end = getMonthEndFromVirtualId("invalid");
+    expect(end).toBeInstanceOf(Date);
+  });
+});
+
+describe("getVirtualMonthStartEndUtc", () => {
+  it("returns null for invalid ID", () => {
+    expect(getVirtualMonthStartEndUtc("invalid")).toBeNull();
+  });
+
+  it("returns start and end dates for valid ID", () => {
+    const result = getVirtualMonthStartEndUtc("virtual-2026-03");
+    expect(result).not.toBeNull();
+    expect(result!.start).toBeInstanceOf(Date);
+    expect(result!.end).toBeInstanceOf(Date);
+    expect(result!.start.getTime()).toBeLessThan(result!.end.getTime());
+  });
+
+  it("start is on the 1st of the month", () => {
+    const result = getVirtualMonthStartEndUtc("virtual-2026-06");
+    expect(result).not.toBeNull();
+    expect(result!.start.getUTCDate()).toBe(1);
+  });
+});
+
+describe("getCurrentVirtualMonthStart", () => {
+  it("returns the 1st of the current month", () => {
+    const start = getCurrentVirtualMonthStart();
+    expect(start.getDate()).toBe(1);
+  });
+});
+
+describe("getCurrentVirtualMonthEnd", () => {
+  it("returns a date after getCurrentVirtualMonthStart", () => {
+    const start = getCurrentVirtualMonthStart();
+    const end = getCurrentVirtualMonthEnd();
+    expect(end.getTime()).toBeGreaterThan(start.getTime());
+  });
+
+  it("end time is 23:59:59", () => {
+    const end = getCurrentVirtualMonthEnd();
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+    expect(end.getSeconds()).toBe(59);
+  });
+});
+
+describe("getSubmissionCutoffForMonth", () => {
+  it("cutoff for January 2026 is start of February 2026 UTC", () => {
+    const cutoff = getSubmissionCutoffForMonth(2026, 1);
+    expect(cutoff.getUTCMonth()).toBe(1); // February
+    expect(cutoff.getUTCDate()).toBe(1);
+    expect(cutoff.getUTCFullYear()).toBe(2026);
+  });
+
+  it("cutoff for December wraps to January of next year", () => {
+    const cutoff = getSubmissionCutoffForMonth(2025, 12);
+    expect(cutoff.getUTCMonth()).toBe(0); // January
+    expect(cutoff.getUTCFullYear()).toBe(2026);
+  });
+
+  it("cutoff hour accounts for Boston timezone offset (4 or 5 UTC)", () => {
+    const cutoff = getSubmissionCutoffForMonth(2026, 6);
+    // Boston is EDT (UTC-4) in June, so cutoff should be 04:00 UTC
+    expect(cutoff.getUTCHours()).toBe(4);
+  });
+});

--- a/__tests__/lib/pair-programming/matching.test.ts
+++ b/__tests__/lib/pair-programming/matching.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { calculateMatchScore, getTopMatches } from "@/lib/pair-programming/matching";
+import type { PairProfile } from "@/lib/pair-programming/types";
+
+function makeProfile(overrides: Partial<PairProfile> = {}): PairProfile {
+  return {
+    userId: "user-1",
+    skillsCanTeach: [],
+    skillsWantToLearn: [],
+    preferredLanguages: [],
+    preferredFrameworks: [],
+    timezone: "America/New_York",
+    availability: [],
+    sessionTypes: [],
+    bio: "",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe("calculateMatchScore", () => {
+  it("returns low score for two empty profiles (only timezone bonus)", () => {
+    const p1 = makeProfile();
+    const p2 = makeProfile({ userId: "user-2" });
+    const result = calculateMatchScore(p1, p2);
+    expect(result.score).toBeLessThanOrEqual(10);
+    expect(result.userId).toBe("user-2");
+  });
+
+  it("scores skill complementarity (teach/learn match)", () => {
+    const p1 = makeProfile({
+      skillsCanTeach: ["React"],
+      skillsWantToLearn: ["Python"],
+    });
+    const p2 = makeProfile({
+      userId: "user-2",
+      skillsCanTeach: ["Python"],
+      skillsWantToLearn: ["React"],
+    });
+    const result = calculateMatchScore(p1, p2);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.reasons.some((r) => r.includes("React"))).toBe(true);
+    expect(result.reasons.some((r) => r.includes("Python"))).toBe(true);
+  });
+
+  it("skill matching is case-insensitive", () => {
+    const p1 = makeProfile({ skillsCanTeach: ["react"] });
+    const p2 = makeProfile({
+      userId: "user-2",
+      skillsWantToLearn: ["React"],
+    });
+    const result = calculateMatchScore(p1, p2);
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it("scores language/framework overlap", () => {
+    const p1 = makeProfile({ preferredLanguages: ["TypeScript", "Go"] });
+    const p2 = makeProfile({
+      userId: "user-2",
+      preferredLanguages: ["TypeScript"],
+    });
+    const result = calculateMatchScore(p1, p2);
+    expect(result.reasons.some((r) => r.includes("TypeScript"))).toBe(true);
+  });
+
+  it("scores session type overlap", () => {
+    const p1 = makeProfile({ sessionTypes: ["teach-me", "build-together"] });
+    const p2 = makeProfile({
+      userId: "user-2",
+      sessionTypes: ["build-together"],
+    });
+    const result = calculateMatchScore(p1, p2);
+    expect(result.reasons.some((r) => r.includes("build-together"))).toBe(true);
+  });
+
+  it("gives timezone bonus for same timezone", () => {
+    const p1 = makeProfile({ timezone: "America/New_York" });
+    const p2 = makeProfile({ userId: "user-2", timezone: "America/New_York" });
+    const withSameTz = calculateMatchScore(p1, p2);
+
+    const p3 = makeProfile({ userId: "user-3", timezone: "Asia/Tokyo" });
+    const withDiffTz = calculateMatchScore(p1, p3);
+
+    expect(withSameTz.score).toBeGreaterThanOrEqual(withDiffTz.score);
+  });
+
+  it("scores availability overlap", () => {
+    const avail = [{ dayOfWeek: 1, startTime: "09:00", endTime: "17:00" }];
+    const p1 = makeProfile({ availability: avail });
+    const p2 = makeProfile({ userId: "user-2", availability: avail });
+    const result = calculateMatchScore(p1, p2);
+    expect(result.reasons.some((r) => r.includes("availability"))).toBe(true);
+  });
+
+  it("penalizes empty skill profiles", () => {
+    const p1 = makeProfile({
+      skillsCanTeach: ["React"],
+      preferredLanguages: ["TypeScript"],
+    });
+    const p2Full = makeProfile({
+      userId: "user-2",
+      skillsWantToLearn: ["React"],
+      preferredLanguages: ["TypeScript"],
+    });
+    const p2Empty = makeProfile({
+      userId: "user-3",
+      skillsCanTeach: [],
+      skillsWantToLearn: [],
+      preferredLanguages: ["TypeScript"],
+    });
+    const fullScore = calculateMatchScore(p1, p2Full);
+    const emptyScore = calculateMatchScore(p1, p2Empty);
+    expect(fullScore.score).toBeGreaterThan(emptyScore.score);
+  });
+
+  it("caps score at 100", () => {
+    const skills = ["React", "Vue", "Angular", "Svelte", "Next.js", "Nuxt"];
+    const p1 = makeProfile({
+      skillsCanTeach: skills,
+      skillsWantToLearn: skills,
+      preferredLanguages: ["TypeScript", "JavaScript", "Python"],
+      preferredFrameworks: ["Express", "Fastify"],
+      sessionTypes: ["teach-me", "build-together", "code-review"],
+      availability: [
+        { dayOfWeek: 1, startTime: "09:00", endTime: "17:00" },
+        { dayOfWeek: 2, startTime: "09:00", endTime: "17:00" },
+      ],
+    });
+    const p2 = makeProfile({
+      userId: "user-2",
+      skillsCanTeach: skills,
+      skillsWantToLearn: skills,
+      preferredLanguages: ["TypeScript", "JavaScript", "Python"],
+      preferredFrameworks: ["Express", "Fastify"],
+      sessionTypes: ["teach-me", "build-together", "code-review"],
+      availability: [
+        { dayOfWeek: 1, startTime: "09:00", endTime: "17:00" },
+        { dayOfWeek: 2, startTime: "09:00", endTime: "17:00" },
+      ],
+    });
+    const result = calculateMatchScore(p1, p2);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("getTopMatches", () => {
+  it("excludes the user's own profile", async () => {
+    const me = makeProfile({ userId: "me" });
+    const profiles = [
+      me,
+      makeProfile({ userId: "other", skillsWantToLearn: ["React"] }),
+    ];
+    const matches = await getTopMatches(
+      makeProfile({ userId: "me", skillsCanTeach: ["React"] }),
+      profiles
+    );
+    expect(matches.every((m) => m.userId !== "me")).toBe(true);
+  });
+
+  it("excludes inactive profiles", async () => {
+    const me = makeProfile({ userId: "me", skillsCanTeach: ["React"] });
+    const inactive = makeProfile({
+      userId: "inactive",
+      isActive: false,
+      skillsWantToLearn: ["React"],
+    });
+    const matches = await getTopMatches(me, [inactive]);
+    expect(matches).toHaveLength(0);
+  });
+
+  it("returns matches sorted by score descending", async () => {
+    const me = makeProfile({
+      userId: "me",
+      skillsCanTeach: ["React", "TypeScript"],
+    });
+    const lowMatch = makeProfile({
+      userId: "low",
+      skillsWantToLearn: ["React"],
+    });
+    const highMatch = makeProfile({
+      userId: "high",
+      skillsWantToLearn: ["React", "TypeScript"],
+    });
+    const matches = await getTopMatches(me, [lowMatch, highMatch]);
+    expect(matches.length).toBe(2);
+    expect(matches[0].userId).toBe("high");
+  });
+
+  it("respects the limit parameter", async () => {
+    const me = makeProfile({ userId: "me", skillsCanTeach: ["React"] });
+    const profiles = Array.from({ length: 20 }, (_, i) =>
+      makeProfile({ userId: `user-${i}`, skillsWantToLearn: ["React"] })
+    );
+    const matches = await getTopMatches(me, profiles, 5);
+    expect(matches.length).toBe(5);
+  });
+
+  it("excludes zero-score matches", async () => {
+    const me = makeProfile({ userId: "me", timezone: "America/New_York" });
+    const other = makeProfile({ userId: "other", timezone: "Asia/Tokyo" });
+    // Different timezones + no skills = 0 score after empty profile penalty
+    const matches = await getTopMatches(me, [other]);
+    expect(matches).toHaveLength(0);
+  });
+});

--- a/__tests__/lib/unsubscribe-token.test.ts
+++ b/__tests__/lib/unsubscribe-token.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  generateUnsubscribeToken,
+  verifyUnsubscribeToken,
+  buildUnsubscribeUrl,
+} from "@/lib/unsubscribe-token";
+
+describe("generateUnsubscribeToken", () => {
+  it("returns a hex string", () => {
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(token).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("is deterministic for the same email", () => {
+    const t1 = generateUnsubscribeToken("user@example.com");
+    const t2 = generateUnsubscribeToken("user@example.com");
+    expect(t1).toBe(t2);
+  });
+
+  it("normalizes email to lowercase and trimmed", () => {
+    const t1 = generateUnsubscribeToken("User@Example.COM");
+    const t2 = generateUnsubscribeToken("  user@example.com  ");
+    expect(t1).toBe(t2);
+  });
+
+  it("produces different tokens for different emails", () => {
+    const t1 = generateUnsubscribeToken("a@example.com");
+    const t2 = generateUnsubscribeToken("b@example.com");
+    expect(t1).not.toBe(t2);
+  });
+});
+
+describe("verifyUnsubscribeToken", () => {
+  it("returns true for a valid token", () => {
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(verifyUnsubscribeToken("user@example.com", token)).toBe(true);
+  });
+
+  it("returns false for an invalid token", () => {
+    expect(verifyUnsubscribeToken("user@example.com", "badtoken")).toBe(false);
+  });
+
+  it("returns false for wrong email", () => {
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(verifyUnsubscribeToken("other@example.com", token)).toBe(false);
+  });
+});
+
+describe("buildUnsubscribeUrl", () => {
+  it("contains the email and token as query params", () => {
+    const url = buildUnsubscribeUrl("user@example.com");
+    expect(url).toContain("/api/notifications/unsubscribe");
+    expect(url).toContain("email=user%40example.com");
+    expect(url).toContain("token=");
+  });
+
+  it("uses the correct token for the email", () => {
+    const url = buildUnsubscribeUrl("user@example.com");
+    const token = generateUnsubscribeToken("user@example.com");
+    expect(url).toContain(`token=${token}`);
+  });
+});


### PR DESCRIPTION
## Summary

Merges 11 test-coverage PRs from `develop` into `main`:

- #385 — 7 tests for profile visibility GET/PATCH routes
- #384 — 10 tests for community reply and repost API routes
- #383 — 8 tests for agents register API route
- #382 — 11 tests for notify-admin talk, event, and cfp routes
- #381 — 11 tests for auth resolve-email and remove-email routes
- #380 — 8 tests for community reaction API route
- #379 — 14 tests for community post and delete API routes
- #376 — 14 tests for pair programming matching algorithm
- #374 — 9 tests for lib/badges/definitions.ts
- #372 — 19 tests for lib/hackathons.ts
- #371 — 14 tests for cookbook-labels, format-cookbook-date, unsubscribe-token

**Total: ~125 new tests.** All test-only changes — no production code modified.