### PR TITLE
test(cfp): add route tests for send-edu-code and verify-edu-code

### DIFF
--- a/__tests__/app/api/cfp/send-edu-code.route.test.ts
+++ b/__tests__/app/api/cfp/send-edu-code.route.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/cfp/send-edu-code/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { sendEmail } from "@/lib/mailgun";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    logError: jest.fn(),
+  },
+  logApiError: jest.fn(),
+}));
+
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockSet = jest.fn().mockResolvedValue(undefined);
+const mockDocGet = jest.fn();
+const mockDocRef = { get: mockDocGet, set: mockSet };
+const mockGetUserByEmail = jest.fn();
+
+const mockDb = {
+  collection: jest.fn((name: string) => ({
+    doc: jest.fn(() => {
+      if (name === "eduVerificationCodes") return { set: mockSet };
+      if (name === "emailLookup") return { get: mockDocGet };
+      if (name === "users")
+        return { get: jest.fn().mockResolvedValue(mockUserDoc) };
+      return mockDocRef;
+    }),
+  })),
+};
+
+const mockAuth = {
+  getUserByEmail: mockGetUserByEmail,
+};
+
+let mockUserDoc = {
+  data: () => ({ email: "primary@gmail.com", additionalEmails: [] }),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+  getAdminAuth: jest.fn(() => mockAuth),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP") },
+}));
+
+jest.mock("crypto", () => ({
+  randomInt: jest.fn(() => 123456),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+
+const testUser: VerifiedUser = { uid: "user123", name: "Test User" };
+
+function makeRequest(
+  body: Record<string, unknown>,
+  options?: { omitAuth?: boolean }
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!options?.omitAuth) {
+    headers["authorization"] = "Bearer valid-token";
+  }
+  return new NextRequest("http://localhost/api/cfp/send-edu-code", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function makeRawRequest(body: string, hasAuth = true) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (hasAuth) headers["authorization"] = "Bearer valid-token";
+  return new NextRequest("http://localhost/api/cfp/send-edu-code", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("POST /api/cfp/send-edu-code", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockDocGet.mockResolvedValue({ exists: false });
+    mockUserDoc = {
+      data: () => ({ email: "primary@gmail.com", additionalEmails: [] }),
+    };
+  });
+
+  // --- Auth tests ---
+
+  it("returns 401 when no auth token is provided", async () => {
+    const req = new NextRequest("http://localhost/api/cfp/send-edu-code", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "student@mit.edu" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/sign in/i);
+  });
+
+  it("returns 401 when getVerifiedUser returns null", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/session/i);
+  });
+
+  // --- Validation tests ---
+
+  it("returns 400 when email is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/email/i);
+  });
+
+  it("returns 400 when email is not a .edu address", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "user@gmail.com" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/\.edu/i);
+  });
+
+  it("returns 400 when email is too long", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const longEmail = "a".repeat(250) + "@b.edu";
+    const res = await POST(makeRequest({ email: longEmail }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/too long/i);
+  });
+
+  it("returns 400 when email format is invalid", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "not-an-email.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid email|\.edu/i);
+  });
+
+  it("returns 400 for malformed JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRawRequest("{bad json}"));
+    expect(res.status).toBe(400);
+  });
+
+  // --- Duplicate email tests ---
+
+  it("returns 400 when email is already primary on another account", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetUserByEmail.mockResolvedValue({ uid: "other-user" });
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already associated/i);
+  });
+
+  it("returns 400 when email exists in emailLookup", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockDocGet.mockResolvedValue({ exists: true });
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already associated/i);
+  });
+
+  it("returns 400 when email is the user's primary email", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockUserDoc = {
+      data: () => ({
+        email: "student@mit.edu",
+        additionalEmails: [],
+      }),
+    };
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already your primary/i);
+  });
+
+  it("returns 400 when email is already an additional email", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockUserDoc = {
+      data: () => ({
+        email: "primary@gmail.com",
+        additionalEmails: [{ email: "student@mit.edu" }],
+      }),
+    };
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already added/i);
+  });
+
+  // --- Success path ---
+
+  it("saves code and sends email on success", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.message).toMatch(/sent/i);
+    expect(mockSet).toHaveBeenCalled();
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "student@mit.edu",
+        subject: expect.stringContaining("verification"),
+      })
+    );
+  });
+
+  // --- Error handling ---
+
+  it("returns 401 for auth-related errors in catch block", async () => {
+    mockGetVerifiedUser.mockRejectedValue(
+      Object.assign(new Error("Error decoding token"), {
+        code: "auth/id-token-expired",
+      })
+    );
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 for unexpected errors", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("Something broke"));
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/failed/i);
+  });
+});

--- a/__tests__/app/api/cfp/verify-edu-code.route.test.ts
+++ b/__tests__/app/api/cfp/verify-edu-code.route.test.ts
@@ -1,0 +1,258 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/cfp/verify-edu-code/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    logError: jest.fn(),
+  },
+  logApiError: jest.fn(),
+}));
+
+const mockDelete = jest.fn().mockResolvedValue(undefined);
+const mockUpdate = jest.fn().mockResolvedValue(undefined);
+const mockCodeDocSet = jest.fn().mockResolvedValue(undefined);
+const mockEmailLookupSet = jest.fn().mockResolvedValue(undefined);
+let mockCodeDocData: Record<string, unknown> | undefined;
+let mockCodeDocExists = true;
+
+const mockDb = {
+  collection: jest.fn((name: string) => ({
+    doc: jest.fn(() => {
+      if (name === "eduVerificationCodes") {
+        return {
+          get: jest.fn().mockResolvedValue({
+            exists: mockCodeDocExists,
+            data: () => mockCodeDocData,
+          }),
+          set: mockCodeDocSet,
+          delete: mockDelete,
+        };
+      }
+      if (name === "users") {
+        return { update: mockUpdate };
+      }
+      if (name === "emailLookup") {
+        return { set: mockEmailLookupSet };
+      }
+      return {};
+    }),
+  })),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+    arrayUnion: jest.fn((...args: unknown[]) => args),
+  },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "user123", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/cfp/verify-edu-code", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: "Bearer valid-token",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeRawRequest(body: string) {
+  return new NextRequest("http://localhost/api/cfp/verify-edu-code", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: "Bearer valid-token",
+    },
+    body,
+  });
+}
+
+describe("POST /api/cfp/verify-edu-code", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCodeDocExists = true;
+    mockCodeDocData = {
+      uid: testUser.uid,
+      email: "student@mit.edu",
+      code: "123456",
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000), // 10 min in future
+    };
+  });
+
+  // --- Auth tests ---
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/unauthorized/i);
+  });
+
+  // --- Validation tests ---
+
+  it("returns 400 when email is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ code: "123456" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/email.*code.*required/i);
+  });
+
+  it("returns 400 when code is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/required/i);
+  });
+
+  it("returns 400 when email is not .edu", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makeRequest({ email: "user@gmail.com", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/\.edu/i);
+  });
+
+  it("returns 400 for malformed JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRawRequest("{not valid json"));
+    expect(res.status).toBe(400);
+  });
+
+  // --- Code verification tests ---
+
+  it("returns 400 when no verification code document exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocExists = false;
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid or expired/i);
+  });
+
+  it("returns 400 when code has expired", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocData = {
+      ...mockCodeDocData,
+      expiresAt: new Date(Date.now() - 60 * 1000), // 1 min ago
+    };
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/expired/i);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("returns 400 when code does not match", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "999999" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid code/i);
+  });
+
+  it("returns 400 when uid does not match", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocData = {
+      ...mockCodeDocData,
+      uid: "different-user",
+    };
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid/i);
+  });
+
+  it("returns 400 when email in doc does not match request", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocData = {
+      ...mockCodeDocData,
+      email: "other@harvard.edu",
+    };
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid/i);
+  });
+
+  // --- Success path ---
+
+  it("verifies code and updates user on success", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.email).toBe("student@mit.edu");
+
+    // Should update user doc with eduBadge and additionalEmails
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eduBadge: true,
+      })
+    );
+    // Should create emailLookup entry
+    expect(mockEmailLookupSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uid: testUser.uid,
+        isPrimary: false,
+      })
+    );
+    // Should delete the verification code doc
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  // --- Error handling ---
+
+  it("returns 500 for unexpected errors", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("Unexpected failure"));
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/failed to verify/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 14 tests for `POST /api/cfp/send-edu-code`: auth (missing token, invalid session), validation (missing email, non-.edu, too long, invalid format, malformed JSON), duplicate-email checks (primary on other account, emailLookup, own primary, additional email), success path (saves code + sends email), and error handling (auth errors -> 401, unexpected -> 500)
- Add 12 tests for `POST /api/cfp/verify-edu-code`: auth (401), validation (missing email/code, non-.edu, malformed JSON), code verification (no doc, expired code deletes doc, wrong code, uid mismatch, email mismatch), success path (updates user with eduBadge, creates emailLookup, deletes code doc), and error handling (500)

Partial progress on #232