### PR TITLE
test(pair): API route tests for profile, request, respond

### DIFF
--- a/__tests__/app/api/pair/profile/route.test.ts
+++ b/__tests__/app/api/pair/profile/route.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/pair/profile/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getPairProfileServer,
+  createOrUpdatePairProfileServer,
+} from "@/lib/pair-programming/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pair-programming/data-server", () => ({
+  getPairProfileServer: jest.fn(),
+  createOrUpdatePairProfileServer: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetProfile = getPairProfileServer as jest.MockedFunction<typeof getPairProfileServer>;
+const mockCreateOrUpdate = createOrUpdatePairProfileServer as jest.MockedFunction<typeof createOrUpdatePairProfileServer>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/pair/profile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/pair/profile");
+}
+
+const validBody = {
+  skillsCanTeach: ["React"],
+  skillsWantToLearn: ["Rust"],
+  preferredLanguages: ["TypeScript"],
+  preferredFrameworks: ["Next.js"],
+  timezone: "America/New_York",
+  availability: ["weekends"],
+  sessionTypes: ["build-together"],
+  bio: "Hello world",
+  isActive: true,
+};
+
+describe("GET /api/pair/profile", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns profile when authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const profile = { userId: "u1", skillsCanTeach: ["React"] };
+    mockGetProfile.mockResolvedValue(profile as any);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.profile).toEqual(profile);
+  });
+
+  it("returns null profile when none exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetProfile.mockResolvedValue(null);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.profile).toBeNull();
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetProfile.mockRejectedValue(new Error("db down"));
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/pair/profile", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when skills arrays are missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, skillsCanTeach: "not-array" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Skills arrays");
+  });
+
+  it("returns 400 when timezone is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, timezone: "" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Timezone");
+  });
+
+  it("returns 400 when sessionTypes is empty", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, sessionTypes: [] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("session type");
+  });
+
+  it("returns 400 for invalid session type", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, sessionTypes: ["invalid-type"] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid session type");
+  });
+
+  it("returns 400 when array exceeds max length", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const longArray = Array.from({ length: 21 }, (_, i) => `skill-${i}`);
+    const res = await POST(makePostRequest({ ...validBody, skillsCanTeach: longArray }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("exceed");
+  });
+
+  it("returns 400 when array items are not valid strings", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, skillsCanTeach: [123] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid array items");
+  });
+
+  it("returns 400 when bio exceeds 1000 chars", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, bio: "x".repeat(1001) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Bio");
+  });
+
+  it("succeeds with valid body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateOrUpdate.mockResolvedValue(undefined);
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toContain("updated");
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith("u1", expect.objectContaining({
+      skillsCanTeach: ["React"],
+      timezone: "America/New_York",
+    }));
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateOrUpdate.mockRejectedValue(new Error("db down"));
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+
+  it("defaults isActive to true when not provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateOrUpdate.mockResolvedValue(undefined);
+    const { isActive, ...bodyWithout } = validBody;
+
+    const res = await POST(makePostRequest(bodyWithout));
+    expect(res.status).toBe(200);
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith("u1", expect.objectContaining({
+      isActive: true,
+    }));
+  });
+});

--- a/__tests__/app/api/pair/request/route.test.ts
+++ b/__tests__/app/api/pair/request/route.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/pair/request/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  createPairRequestServer,
+  getPairRequestsForUserServer,
+} from "@/lib/pair-programming/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pair-programming/data-server", () => ({
+  createPairRequestServer: jest.fn(),
+  getPairRequestsForUserServer: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCreateRequest = createPairRequestServer as jest.MockedFunction<typeof createPairRequestServer>;
+const mockGetRequests = getPairRequestsForUserServer as jest.MockedFunction<typeof getPairRequestsForUserServer>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/pair/request", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetRequest(type?: string) {
+  const url = type
+    ? `http://localhost/api/pair/request?type=${type}`
+    : "http://localhost/api/pair/request";
+  return new NextRequest(url);
+}
+
+const futureTime = new Date(Date.now() + 86400000).toISOString();
+
+const validBody = {
+  toUserId: "u2",
+  sessionType: "build-together",
+  message: "Let's pair!",
+  proposedTime: futureTime,
+};
+
+describe("GET /api/pair/request", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns received requests by default", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const requests = [{ id: "r1", fromUserId: "u2" }];
+    mockGetRequests.mockResolvedValue(requests as any);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.requests).toEqual(requests);
+    expect(mockGetRequests).toHaveBeenCalledWith("u1", "received");
+  });
+
+  it("returns sent requests when type=sent", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetRequests.mockResolvedValue([]);
+
+    const res = await GET(makeGetRequest("sent"));
+    expect(res.status).toBe(200);
+    expect(mockGetRequests).toHaveBeenCalledWith("u1", "sent");
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetRequests.mockRejectedValue(new Error("db down"));
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/pair/request", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when toUserId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, toUserId: "" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("toUserId");
+  });
+
+  it("returns 400 for invalid session type", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, sessionType: "invalid" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("session type");
+  });
+
+  it("returns 400 when message is empty", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, message: "   " }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Message");
+  });
+
+  it("returns 400 when message is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { message, ...noMessage } = validBody;
+    const res = await POST(makePostRequest(noMessage));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when message exceeds 1000 chars", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, message: "x".repeat(1001) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("1000");
+  });
+
+  it("returns 400 when sending request to yourself", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, toUserId: "u1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("yourself");
+  });
+
+  it("returns 400 for invalid proposed time format", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, proposedTime: "not-a-date" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid proposed time");
+  });
+
+  it("returns 400 when proposed time is in the past", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const pastTime = new Date(Date.now() - 86400000).toISOString();
+    const res = await POST(makePostRequest({ ...validBody, proposedTime: pastTime }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("future");
+  });
+
+  it("succeeds with valid body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateRequest.mockResolvedValue("req-123");
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.requestId).toBe("req-123");
+    expect(mockCreateRequest).toHaveBeenCalledWith(expect.objectContaining({
+      fromUserId: "u1",
+      toUserId: "u2",
+      sessionType: "build-together",
+      message: "Let's pair!",
+    }));
+  });
+
+  it("succeeds without proposedTime", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateRequest.mockResolvedValue("req-456");
+    const { proposedTime, ...bodyWithout } = validBody;
+
+    const res = await POST(makePostRequest(bodyWithout));
+    expect(res.status).toBe(200);
+    expect(mockCreateRequest).toHaveBeenCalledWith(expect.objectContaining({
+      proposedTime: undefined,
+    }));
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateRequest.mockRejectedValue(new Error("db down"));
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/pair/respond/route.test.ts
+++ b/__tests__/app/api/pair/respond/route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/pair/respond/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  respondToPairRequestServer,
+  PairRequestNotFoundError,
+  PairRequestUnauthorizedError,
+  PairRequestAlreadyRespondedError,
+} from "@/lib/pair-programming/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pair-programming/data-server", () => {
+  class PairRequestNotFoundError extends Error {
+    constructor() { super("Request not found"); this.name = "PairRequestNotFoundError"; }
+  }
+  class PairRequestUnauthorizedError extends Error {
+    constructor() { super("Unauthorized"); this.name = "PairRequestUnauthorizedError"; }
+  }
+  class PairRequestAlreadyRespondedError extends Error {
+    constructor() { super("Request has already been responded to"); this.name = "PairRequestAlreadyRespondedError"; }
+  }
+  return {
+    respondToPairRequestServer: jest.fn(),
+    PairRequestNotFoundError,
+    PairRequestUnauthorizedError,
+    PairRequestAlreadyRespondedError,
+  };
+});
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockRespond = respondToPairRequestServer as jest.MockedFunction<typeof respondToPairRequestServer>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/pair/respond", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/pair/respond", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when requestId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ action: "accept" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("requestId");
+  });
+
+  it("returns 400 when action is invalid", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ requestId: "r1", action: "maybe" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("accept");
+  });
+
+  it("returns success when accepting a request", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockRespond.mockResolvedValue({ status: "accepted", sessionId: "s1" });
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.sessionId).toBe("s1");
+    expect(body.message).toContain("accepted");
+    expect(mockRespond).toHaveBeenCalledWith("r1", "u1", "accept");
+  });
+
+  it("returns success when declining a request", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockRespond.mockResolvedValue({ status: "declined" });
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "decline" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toContain("declined");
+  });
+
+  it("returns 404 when request not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // Need to get the mocked error class from the mock module
+    const { PairRequestNotFoundError: MockNotFound } = jest.requireMock("@/lib/pair-programming/data-server");
+    mockRespond.mockRejectedValue(new MockNotFound());
+
+    const res = await POST(makePostRequest({ requestId: "bad", action: "accept" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when user is not the recipient", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { PairRequestUnauthorizedError: MockUnauth } = jest.requireMock("@/lib/pair-programming/data-server");
+    mockRespond.mockRejectedValue(new MockUnauth());
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("only respond");
+  });
+
+  it("returns 400 when request already responded to", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { PairRequestAlreadyRespondedError: MockAlready } = jest.requireMock("@/lib/pair-programming/data-server");
+    mockRespond.mockRejectedValue(new MockAlready());
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("already been responded");
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockRespond.mockRejectedValue(new Error("db down"));
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- Tests for `POST/GET /api/pair/profile` — auth, validation (skills arrays, timezone, session types, array length, string items, bio length), success path, error handling
- Tests for `POST/GET /api/pair/request` — auth, validation (toUserId, sessionType, message, self-request, proposedTime format/past), success with and without proposedTime, error handling
- Tests for `POST /api/pair/respond` — auth, validation (requestId, action), accept/decline success, domain errors (404 not found, 403 unauthorized, 400 already responded), error handling
- 40 test cases total across 3 test files

Partial progress on #232