### PR TITLE
test(profile): add coverage for update and subscription routes

### DIFF
--- a/__tests__/app/api/profile/subscription/route.test.ts
+++ b/__tests__/app/api/profile/subscription/route.test.ts
@@ -1,0 +1,309 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "@/app/api/profile/subscription/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockContactGet = jest.fn();
+const mockContactUpdate = jest.fn();
+const mockUserGet = jest.fn();
+
+const mockDb = {
+  collection: jest.fn((name: string) => {
+    if (name === "eventContacts") {
+      return {
+        doc: jest.fn(() => ({
+          get: mockContactGet,
+          update: mockContactUpdate,
+        })),
+      };
+    }
+    if (name === "users") {
+      return {
+        doc: jest.fn(() => ({
+          get: mockUserGet,
+        })),
+      };
+    }
+    return { doc: jest.fn(() => ({ get: jest.fn() })) };
+  }),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP"),
+    delete: jest.fn(() => "FIELD_DELETE"),
+  },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+
+const testUser: VerifiedUser & { email: string } = {
+  uid: "user-123",
+  name: "Test User",
+  email: "test@example.com",
+};
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/profile/subscription", {
+    method: "GET",
+  });
+}
+
+function makePatchRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/profile/subscription", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeMalformedPatchRequest() {
+  return new NextRequest("http://localhost/api/profile/subscription", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json{{{",
+  });
+}
+
+// ---------- GET ----------
+
+describe("GET /api/profile/subscription", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns onList=false when no contact doc exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({ exists: false });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ additionalEmails: [] }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(false);
+    expect(body.subscribed).toBe(false);
+  });
+
+  it("returns subscribed=true when contact exists and not unsubscribed", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: false }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(true);
+    expect(body.subscribed).toBe(true);
+  });
+
+  it("returns subscribed=false when contact is unsubscribed", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: true }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(true);
+    expect(body.subscribed).toBe(false);
+  });
+
+  it("finds contact via additional verified email", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // Primary email not found
+    mockContactGet
+      .mockResolvedValueOnce({ exists: false })
+      // Additional email found
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ unsubscribed: false }),
+      });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        additionalEmails: [{ email: "alt@example.com", verified: true }],
+      }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(true);
+    expect(body.subscribed).toBe(true);
+  });
+
+  it("skips unverified additional emails", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({ exists: false });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        additionalEmails: [{ email: "unverified@example.com", verified: false }],
+      }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(false);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    getAdminDb.mockReturnValueOnce(null);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Server not configured");
+  });
+});
+
+// ---------- PATCH ----------
+
+describe("PATCH /api/profile/subscription", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeMalformedPatchRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON");
+  });
+
+  it("returns 400 when subscribed is not a boolean", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makePatchRequest({ subscribed: "yes" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("subscribed must be a boolean");
+  });
+
+  it("returns 400 when subscribed is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makePatchRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("subscribed must be a boolean");
+  });
+
+  it("returns 404 when no contact doc is found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({ exists: false });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ additionalEmails: [] }),
+    });
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No event contact record found for your email");
+  });
+
+  it("resubscribes when subscribed=true", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: true }),
+    });
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscribed).toBe(true);
+    expect(mockContactUpdate).toHaveBeenCalledWith({
+      unsubscribed: false,
+      unsubscribedAt: "FIELD_DELETE",
+      resubscribedAt: "SERVER_TIMESTAMP",
+    });
+  });
+
+  it("unsubscribes when subscribed=false", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: false }),
+    });
+
+    const res = await PATCH(makePatchRequest({ subscribed: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscribed).toBe(false);
+    expect(mockContactUpdate).toHaveBeenCalledWith({
+      unsubscribed: true,
+      unsubscribedAt: "SERVER_TIMESTAMP",
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false });
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    getAdminDb.mockReturnValueOnce(null);
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/profile/update/route.test.ts
+++ b/__tests__/app/api/profile/update/route.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/profile/update/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockUpdate = jest.fn();
+const mockGet = jest.fn();
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn(() => ({
+      update: mockUpdate,
+      get: mockGet,
+    })),
+  })),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP"),
+  },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+
+const testUser: VerifiedUser = { uid: "user-123", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/profile/update", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeMalformedRequest() {
+  return new NextRequest("http://localhost/api/profile/update", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json{{{",
+  });
+}
+
+describe("PATCH /api/profile/update", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        displayName: "Updated Name",
+        bio: "A bio",
+        location: "Boston",
+        company: "Acme",
+        jobTitle: "Dev",
+        socialLinks: { github: "https://github.com/test" },
+      }),
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ displayName: "Valid Name" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeMalformedRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when no valid fields are provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ unknownField: "value" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("No valid fields to update");
+  });
+
+  it("returns 400 when displayName is too short", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ displayName: "A" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Display name must be at least 2 characters");
+  });
+
+  it("returns 400 when displayName is too long", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ displayName: "A".repeat(51) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Display name must be 50 characters or less");
+  });
+
+  it("returns 400 when bio exceeds 500 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ bio: "B".repeat(501) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Bio must be 500 characters or less");
+  });
+
+  it("returns 400 when location exceeds 100 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ location: "L".repeat(101) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Location must be 100 characters or less");
+  });
+
+  it("returns 400 when company exceeds 100 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ company: "C".repeat(101) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Company must be 100 characters or less");
+  });
+
+  it("returns 400 when jobTitle exceeds 100 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ jobTitle: "J".repeat(101) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Job title must be 100 characters or less");
+  });
+
+  it("successfully updates displayName", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ displayName: "New Name" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.profile.displayName).toBe("Updated Name");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: "New Name", updatedAt: "SERVER_TIMESTAMP" })
+    );
+  });
+
+  it("successfully updates multiple fields", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(
+      makeRequest({
+        displayName: "New Name",
+        bio: "A short bio",
+        location: "Boston",
+        company: "Acme Inc",
+        jobTitle: "Engineer",
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: "New Name",
+        bio: "A short bio",
+        location: "Boston",
+        company: "Acme Inc",
+        jobTitle: "Engineer",
+        updatedAt: "SERVER_TIMESTAMP",
+      })
+    );
+  });
+
+  it("sets empty strings to null for optional fields", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ bio: "", location: "" }));
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ bio: null, location: null })
+    );
+  });
+
+  it("merges socialLinks with existing data", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // First get() call is for reading existing socialLinks, second is for the final profile read
+    mockGet
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ socialLinks: { twitter: "https://twitter.com/old" } }),
+      })
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          displayName: "Test",
+          bio: null,
+          location: null,
+          company: null,
+          jobTitle: null,
+          socialLinks: {
+            twitter: "https://twitter.com/old",
+            github: "https://github.com/new",
+          },
+        }),
+      });
+
+    const res = await PATCH(
+      makeRequest({ socialLinks: { github: "https://github.com/new" } })
+    );
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialLinks: {
+          twitter: "https://twitter.com/old",
+          github: "https://github.com/new",
+        },
+      })
+    );
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false, retryAfter: 30 });
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const res = await PATCH(makeRequest({ displayName: "Test" }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    getAdminDb.mockReturnValueOnce(null);
+
+    const res = await PATCH(makeRequest({ displayName: "Test" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Server not configured");
+  });
+
+  it("returns 500 when update throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockUpdate.mockRejectedValueOnce(new Error("Firestore error"));
+
+    const res = await PATCH(makeRequest({ displayName: "Valid Name" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to update profile");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 16 tests for `PATCH /api/profile/update` covering auth, validation (field length limits for displayName, bio, location, company, jobTitle), socialLinks merging, rate limiting, malformed JSON, and error paths
- Add 17 tests for `GET/PATCH /api/profile/subscription` covering auth, contact lookup via primary and additional verified emails, subscribe/unsubscribe flows, rate limiting, and error paths

Partial progress on #232