### PR TITLE
test: add coverage for hackathon team profile and eligibility routes

### DIFF
--- a/__tests__/app/api/hackathons/eligibility/route.test.ts
+++ b/__tests__/app/api/hackathons/eligibility/route.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/hackathons/eligibility/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/hackathons", () => ({
+  getCurrentVirtualHackathonId: jest.fn(() => "2026-04"),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+function makeRequest(query?: string) {
+  const url = query
+    ? `http://localhost/api/hackathons/eligibility?${query}`
+    : "http://localhost/api/hackathons/eligibility";
+  return new NextRequest(url, { method: "GET" });
+}
+
+function mockDbWithProfile(profileData: Record<string, unknown> | null, leftTeamExists = false) {
+  mockGetAdminDb.mockReturnValue({
+    collection: jest.fn((name: string) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () =>
+              profileData
+                ? { exists: true, data: () => profileData }
+                : { exists: false, data: () => undefined }
+            ),
+          })),
+        };
+      }
+      if (name === "hackathonLeftTeam") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({ exists: leftTeamExists })),
+          })),
+        };
+      }
+      return { doc: jest.fn() };
+    }),
+  } as never);
+}
+
+const FULL_PROFILE = {
+  github: "user123",
+  discord: "user#1234",
+  visibility: { isPublic: true, showDiscord: true },
+};
+
+describe("GET /api/hackathons/eligibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true, retryAfter: 0 });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+    const data = await res.json();
+    expect(data.error).toMatch(/too many/i);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns eligible=false when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/not configured/i);
+  });
+
+  it("returns eligible=false when profile not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/profile not found/i);
+  });
+
+  it("returns eligible=false when profile is not public", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ github: "gh", discord: "dc", visibility: { isPublic: false, showDiscord: true } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/public/i);
+  });
+
+  it("returns eligible=false when GitHub is not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ discord: "dc", visibility: { isPublic: true, showDiscord: true } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/github/i);
+  });
+
+  it("returns eligible=false when Discord is not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ github: "gh", visibility: { isPublic: true, showDiscord: true } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/discord/i);
+  });
+
+  it("returns eligible=false when showDiscord is off", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ github: "gh", discord: "dc", visibility: { isPublic: true, showDiscord: false } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/show discord/i);
+  });
+
+  it("returns eligible=false when user left a team this month", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile(FULL_PROFILE, true);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/left a team/i);
+  });
+
+  it("returns eligible=true when all conditions are met", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile(FULL_PROFILE, false);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(true);
+  });
+
+  it("uses hackathonId from query parameter when provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    const docMock = jest.fn();
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name === "users") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn(async () => ({
+                exists: true,
+                data: () => FULL_PROFILE,
+              })),
+            })),
+          };
+        }
+        if (name === "hackathonLeftTeam") {
+          return {
+            doc: docMock.mockReturnValue({
+              get: jest.fn(async () => ({ exists: false })),
+            }),
+          };
+        }
+        return { doc: jest.fn() };
+      }),
+    } as never);
+
+    const res = await GET(makeRequest("hackathonId=custom-hack-2026"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(true);
+    expect(docMock).toHaveBeenCalledWith("u1_custom-hack-2026");
+  });
+});

--- a/__tests__/app/api/hackathons/team/profile/route.test.ts
+++ b/__tests__/app/api/hackathons/team/profile/route.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/hackathons/team/profile/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/hackathons/team/profile", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/hackathons/team/profile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true, retryAfter: 0 });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await PATCH(makeRequest({ teamId: "t1", name: "New" }));
+    expect(res.status).toBe(429);
+    const data = await res.json();
+    expect(data.error).toMatch(/too many/i);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ teamId: "t1", name: "New" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const res = await PATCH(makeRequest({ teamId: "t1", name: "New" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({} as never);
+    const req = new NextRequest("http://localhost/api/hackathons/team/profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when teamId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({ collection: jest.fn() } as never);
+    const res = await PATCH(makeRequest({ name: "New" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid teamId/i);
+  });
+
+  it("returns 404 when team does not exist", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({ exists: false })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "New" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when user is not a team member", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u2", "u3"], wins: 2 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "New" }));
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toMatch(/not a member/i);
+  });
+
+  it("returns 403 when team has zero wins", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 0 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "New" }));
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toMatch(/wins/i);
+  });
+
+  it("returns 400 when name exceeds 50 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+        })),
+      })),
+    } as never);
+    const longName = "A".repeat(51);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: longName }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/50 characters/i);
+  });
+
+  it("returns 400 when neither name nor logoUrl provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/provide name/i);
+  });
+
+  it("returns 200 and updates team name successfully", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+          update: updateMock,
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "Cool Team" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Cool Team" })
+    );
+  });
+
+  it("returns 200 and updates logoUrl successfully", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 3 }),
+          })),
+          update: updateMock,
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", logoUrl: "https://example.com/logo.png" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ logoUrl: "https://example.com/logo.png" })
+    );
+  });
+
+  it("returns 400 for invalid logoUrl format", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", logoUrl: "javascript:alert(1)" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid logoUrl/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 13 tests for `PATCH /api/hackathons/team/profile` covering auth (401), rate limiting (429), validation (400 for missing teamId, long name, invalid logoUrl, no fields), authorization (403 for non-member, zero wins), not found (404), and success paths for name and logoUrl updates
- Add 11 tests for `GET /api/hackathons/eligibility` covering auth (401), rate limiting (429), db not configured, profile not found, missing public profile/GitHub/Discord/showDiscord, left-team lockout, custom hackathonId query param, and full eligibility success path

Partial progress on #232