### PR TITLE
test: add coverage for health, badge definitions, and unsubscribe routes

### DIFF
--- a/__tests__/app/api/badges/definitions/route.test.ts
+++ b/__tests__/app/api/badges/definitions/route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from "@/app/api/badges/definitions/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+describe("GET /api/badges/definitions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns local fallback when db is unavailable", async () => {
+    mockGetAdminDb.mockReturnValue(null as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("local-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+  });
+
+  it("seeds Firestore and returns definitions when collection is empty", async () => {
+    const batchSet = jest.fn();
+    const batchCommit = jest.fn(async () => undefined);
+
+    const collectionRef = {
+      get: jest.fn(async () => ({ empty: true, docs: [] })),
+      doc: jest.fn(() => ({})),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+      batch: jest.fn(() => ({ set: batchSet, commit: batchCommit })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("seeded-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+    expect(batchSet).toHaveBeenCalledTimes(BADGE_DEFINITIONS.length);
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns Firestore definitions when all badges are present", async () => {
+    const firestoreDefs = BADGE_DEFINITIONS.map((def) => ({
+      id: def.id,
+      data: () => ({ ...def }),
+    }));
+
+    const collectionRef = {
+      get: jest.fn(async () => ({ empty: false, docs: firestoreDefs })),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("firestore");
+    expect(body.definitions.length).toBe(BADGE_DEFINITIONS.length);
+  });
+
+  it("falls back to local when Firestore definitions are incomplete", async () => {
+    // Return only one badge definition
+    const partialDefs = [
+      {
+        id: BADGE_DEFINITIONS[0].id,
+        data: () => ({ ...BADGE_DEFINITIONS[0] }),
+      },
+    ];
+
+    const collectionRef = {
+      get: jest.fn(async () => ({ empty: false, docs: partialDefs })),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("local-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+  });
+
+  it("returns local fallback on Firestore error", async () => {
+    const collectionRef = {
+      get: jest.fn(async () => {
+        throw new Error("Firestore unavailable");
+      }),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("local-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+  });
+});

--- a/__tests__/app/api/health/route.test.ts
+++ b/__tests__/app/api/health/route.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from "@/app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("returns 200 with healthy status", async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("healthy");
+    expect(body.timestamp).toBeDefined();
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  it("includes a version field", async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.version).toBeDefined();
+    expect(typeof body.version).toBe("string");
+  });
+
+  it("returns a valid ISO timestamp", async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    const parsed = new Date(body.timestamp);
+    expect(parsed.toISOString()).toBe(body.timestamp);
+  });
+});

--- a/__tests__/app/api/notifications/unsubscribe/route.test.ts
+++ b/__tests__/app/api/notifications/unsubscribe/route.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/notifications/unsubscribe/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { verifyUnsubscribeToken } from "@/lib/unsubscribe-token";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/unsubscribe-token", () => ({
+  verifyUnsubscribeToken: jest.fn(),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: jest.fn(() => "test-ip"),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockVerifyToken = verifyUnsubscribeToken as jest.MockedFunction<typeof verifyUnsubscribeToken>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+const VALID_TOKEN = "a".repeat(64);
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/notifications/unsubscribe");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url.toString(), { method: "GET" });
+}
+
+describe("GET /api/notifications/unsubscribe", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true } as never);
+  });
+
+  it("redirects to rate-limited when rate limit exceeded", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false } as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("rate-limited");
+  });
+
+  it("redirects to invalid when email is missing", async () => {
+    const res = await GET(makeRequest({ token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to invalid when token is missing", async () => {
+    const res = await GET(makeRequest({ email: "test@example.com" }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to invalid when token format is wrong", async () => {
+    const res = await GET(makeRequest({ email: "test@example.com", token: "bad-token" }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to invalid when token verification fails", async () => {
+    mockVerifyToken.mockReturnValue(false);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to error when db is unavailable", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockGetAdminDb.mockReturnValue(null as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("error");
+  });
+
+  it("redirects to success when contact does not exist (no info leak)", async () => {
+    mockVerifyToken.mockReturnValue(true);
+
+    const docRef = {
+      get: jest.fn(async () => ({ exists: false })),
+    };
+
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => docRef),
+      })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("success");
+  });
+
+  it("unsubscribes existing contact and redirects to success", async () => {
+    mockVerifyToken.mockReturnValue(true);
+
+    const updateFn = jest.fn(async () => undefined);
+    const docRef = {
+      get: jest.fn(async () => ({ exists: true })),
+      update: updateFn,
+    };
+
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => docRef),
+      })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("success");
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({ unsubscribed: true })
+    );
+  });
+
+  it("redirects to error on Firestore exception", async () => {
+    mockVerifyToken.mockReturnValue(true);
+
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => {
+            throw new Error("Firestore down");
+          }),
+        })),
+      })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("error");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 3 tests for GET /api/health (status, version, timestamp validation)
- Add 5 tests for GET /api/badges/definitions (local fallback, Firestore seeding, complete/incomplete definitions, error handling)
- Add 9 tests for GET /api/notifications/unsubscribe (rate limiting, missing params, invalid token, token verification, db unavailable, contact not found, successful unsubscribe, Firestore errors)

Partial progress on #232