### PR TITLE
test: hackathon pool/join, invites/accept, requests/accept coverage

### DIFF
--- a/__tests__/app/api/hackathons/invites/accept/route.test.ts
+++ b/__tests__/app/api/hackathons/invites/accept/route.test.ts
@@ -1,0 +1,368 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/invites/accept/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockCheckRateLimit = jest.fn().mockReturnValue({ success: true });
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonAction: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeDocId: (input: string) => {
+    if (!input || typeof input !== "string" || !input.trim()) return null;
+    if (!/^[a-zA-Z0-9_-]+$/.test(input.trim())) return null;
+    return input.trim();
+  },
+}));
+
+const mockGet = jest.fn();
+const mockUpdate = jest.fn();
+const mockRunTransaction = jest.fn();
+const mockWhere = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        get: () => mockGet(name, id),
+        update: (data: unknown) => mockUpdate(name, id, data),
+      }),
+      where: (...args: unknown[]) => {
+        mockWhere(...args);
+        return {
+          where: (...args2: unknown[]) => {
+            mockWhere(...args2);
+            return {
+              limit: () => ({
+                get: () => mockGet("query", "existingTeam"),
+              }),
+            };
+          },
+        };
+      },
+    }),
+    runTransaction: (fn: (tx: unknown) => Promise<unknown>) =>
+      mockRunTransaction(fn),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+function makeRequest(body?: Record<string, unknown> | string) {
+  return new NextRequest("http://localhost/api/hackathons/invites/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body ?? {}),
+  });
+}
+
+describe("POST /api/hackathons/invites/accept", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest(
+      "http://localhost/api/hackathons/invites/accept",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "bad-json",
+      }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when inviteId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid inviteId format");
+  });
+
+  it("returns 400 when inviteId has invalid characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ inviteId: "inv/../bad" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid inviteId format");
+  });
+
+  it("returns 404 when invite not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Invite not found");
+  });
+
+  it("returns 403 when invite belongs to another user", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "other-user",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Not your invite");
+  });
+
+  it("returns 400 when invite already handled", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "accepted",
+            teamId: "t1",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invite already handled");
+  });
+
+  it("returns 404 when team not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Team not found");
+  });
+
+  it("returns 400 when team is full", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["a", "b", "c"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Team is full");
+  });
+
+  it("returns 200 and marks accepted when user already on team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1", "b"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "hackathonInvites",
+      "inv1",
+      { status: "accepted" }
+    );
+  });
+
+  it("returns 200 on successful accept via transaction", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["owner1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      // query for existing team
+      if (collection === "query") return { empty: true };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          get: jest.fn().mockResolvedValue({
+            data: () => ({ memberIds: ["owner1"], hackathonId: "2026-04" }),
+          }),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      }
+    );
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+  });
+
+  it("returns 400 when user already on another team (ALREADY_ON_TEAM)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["owner1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query") return { empty: true };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(async () => {
+      throw new Error("ALREADY_ON_TEAM");
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("You are already on a team for this hackathon");
+  });
+
+  it("returns 400 when team fills up during transaction (TEAM_FULL)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["owner1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query") return { empty: true };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(async () => {
+      throw new Error("TEAM_FULL");
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Team is full");
+  });
+});

--- a/__tests__/app/api/hackathons/pool/join/route.test.ts
+++ b/__tests__/app/api/hackathons/pool/join/route.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/pool/join/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockCheckRateLimit = jest.fn().mockReturnValue({ success: true });
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonAction: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/hackathons", () => ({
+  getCurrentVirtualHackathonId: () => "2026-04",
+}));
+
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: (id: string) => {
+        mockDocTracker(name, id);
+        return { get: () => mockGet(name, id), set: mockSet };
+      },
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+/** Tracks which collection/doc combos are accessed */
+let docTracker: Array<{ collection: string; id: string }> = [];
+function mockDocTracker(collection: string, id: string) {
+  docTracker.push({ collection, id });
+}
+
+function makeRequest(body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/hackathons/pool/join", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : "invalid-json",
+  });
+}
+
+describe("POST /api/hackathons/pool/join", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    docTracker = [];
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(body.retryAfterSeconds).toBe(30);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest("http://localhost/api/hackathons/pool/join", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{{{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when user profile not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users") return { exists: false };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Profile not found");
+  });
+
+  it("returns 400 when profile is not public", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: false },
+            github: "user",
+            discord: "user#1234",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Make your profile public");
+  });
+
+  it("returns 400 when GitHub not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: true, showDiscord: true },
+            discord: "user#1234",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Connect GitHub");
+  });
+
+  it("returns 400 when Discord not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: true, showDiscord: true },
+            github: "user",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Connect Discord");
+  });
+
+  it("returns 400 when showDiscord is not enabled", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: true, showDiscord: false },
+            github: "user",
+            discord: "user#1234",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Show Discord");
+  });
+
+  it("returns 400 when user left a team with a registered repo", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: true };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("left a team");
+  });
+
+  it("returns 200 when already in pool", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: false };
+      if (collection === "hackathonPool") return { exists: true };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.joined).toBe(true);
+  });
+
+  it("creates pool entry and returns 200 on success", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: false };
+      if (collection === "hackathonPool") return { exists: false };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.joined).toBe(true);
+    expect(body.hackathonId).toBe("2026-04");
+    expect(mockSet).toHaveBeenCalled();
+  });
+
+  it("uses provided hackathonId from body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: false };
+      if (collection === "hackathonPool") return { exists: false };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({ hackathonId: "2026-03" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hackathonId).toBe("2026-03");
+  });
+});

--- a/__tests__/app/api/hackathons/requests/accept/route.test.ts
+++ b/__tests__/app/api/hackathons/requests/accept/route.test.ts
@@ -1,0 +1,370 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/requests/accept/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockCheckRateLimit = jest.fn().mockReturnValue({ success: true });
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonAction: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeDocId: (input: string) => {
+    if (!input || typeof input !== "string" || !input.trim()) return null;
+    if (!/^[a-zA-Z0-9_-]+$/.test(input.trim())) return null;
+    return input.trim();
+  },
+}));
+
+const mockGet = jest.fn();
+const mockUpdate = jest.fn();
+const mockRunTransaction = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockWhere = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: (id: string) => {
+        const ref = {
+          get: () => mockGet(name, id),
+          update: (data: unknown) => mockUpdate(name, id, data),
+          ref: `${name}/${id}`,
+        };
+        return ref;
+      },
+      where: (...args: unknown[]) => {
+        mockWhere(...args);
+        return {
+          where: (...args2: unknown[]) => {
+            mockWhere(...args2);
+            return {
+              limit: () => ({
+                get: () => mockGet("query-existing-team", "check"),
+              }),
+              get: () => mockGet("query-pending-requests", "check"),
+            };
+          },
+        };
+      },
+    }),
+    runTransaction: (fn: (tx: unknown) => Promise<unknown>) =>
+      mockRunTransaction(fn),
+    batch: () => ({
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+function makeRequest(body?: Record<string, unknown> | string) {
+  return new NextRequest("http://localhost/api/hackathons/requests/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body ?? {}),
+  });
+}
+
+describe("POST /api/hackathons/requests/accept", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest(
+      "http://localhost/api/hackathons/requests/accept",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "bad-json",
+      }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when requestId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid requestId format");
+  });
+
+  it("returns 400 when requestId has invalid characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ requestId: "req/../evil" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when request not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Request not found");
+  });
+
+  it("returns 400 when request already handled", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "accepted",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Request already handled");
+  });
+
+  it("returns 404 when team not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Team not found");
+  });
+
+  it("returns 403 when current user is not a team member", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["other-user"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("You are not a member of this team");
+  });
+
+  it("returns 400 when team is full", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1", "b", "c"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Team is full");
+  });
+
+  it("returns 200 and marks accepted when requester already on team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1", "requester1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "hackathonJoinRequests",
+      "req1",
+      { status: "accepted" }
+    );
+  });
+
+  it("returns 400 when requester is already on another team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query-existing-team")
+        return { empty: false };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe(
+      "That user is already on a team for this hackathon"
+    );
+  });
+
+  it("returns 200 on successful accept with transaction and batch cleanup", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query-existing-team") return { empty: true };
+      if (collection === "query-pending-requests")
+        return {
+          empty: false,
+          docs: [
+            {
+              id: "req1",
+              ref: "hackathonJoinRequests/req1",
+            },
+            {
+              id: "req2",
+              ref: "hackathonJoinRequests/req2",
+            },
+          ],
+        };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = { update: jest.fn() };
+        return fn(tx);
+      }
+    );
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(mockRunTransaction).toHaveBeenCalled();
+    // Should withdraw other pending requests (req2, not req1)
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      "hackathonJoinRequests/req2",
+      { status: "withdrawn" }
+    );
+    expect(mockBatchCommit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12 tests for `POST /api/hackathons/pool/join` covering auth, rate limiting, profile eligibility checks (public profile, GitHub, Discord, showDiscord), left-team guard, already-in-pool idempotency, and successful pool entry creation
- Add 14 tests for `POST /api/hackathons/invites/accept` covering auth, rate limiting, input sanitization, invite ownership (403), already-handled invites, team-full checks, already-on-team idempotency, transaction success, and ALREADY_ON_TEAM/TEAM_FULL race-condition errors
- Add 13 tests for `POST /api/hackathons/requests/accept` covering auth, rate limiting, input sanitization, team membership authorization (403), team-full, requester-already-on-team idempotency, requester-on-another-team guard, transaction success, and batch withdrawal of other pending requests

Partial progress on #232