### PR TITLE
Merge develop into main: test coverage batch (#387-#396)

### DIFF
--- a/__tests__/app/api/auth/change-primary-email.test.ts
+++ b/__tests__/app/api/auth/change-primary-email.test.ts
@@ -1,0 +1,231 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/change-primary-email/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockUpdate = jest.fn();
+const mockGet = jest.fn();
+const mockDelete = jest.fn();
+const mockSet = jest.fn();
+const mockUpdateUser = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+  getAdminAuth: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockGetAdminAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/change-primary-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeMalformedRequest() {
+  return new NextRequest("http://localhost/api/auth/change-primary-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json{",
+  });
+}
+
+function setupFirebaseMocks(userData: Record<string, unknown> | null = null) {
+  const docMocks: Record<string, { get: jest.Mock; update: jest.Mock; delete: jest.Mock; set: jest.Mock }> = {};
+
+  const getDocMock = (collection: string, docId: string) => {
+    const key = `${collection}/${docId}`;
+    if (!docMocks[key]) {
+      docMocks[key] = { get: jest.fn(), update: jest.fn(), delete: jest.fn(), set: jest.fn() };
+    }
+    return docMocks[key];
+  };
+
+  const db = {
+    collection: jest.fn((collectionName: string) => ({
+      doc: jest.fn((docId: string) => getDocMock(collectionName, docId)),
+    })),
+  };
+
+  // Set up the user doc
+  const userDoc = getDocMock("users", "user-1");
+  userDoc.get.mockResolvedValue({ data: () => userData });
+  userDoc.update.mockImplementation(mockUpdate);
+
+  mockGetAdminDb.mockReturnValue(db as any);
+  mockGetAdminAuth.mockReturnValue({ updateUser: mockUpdateUser } as any);
+
+  return { db, getDocMock };
+}
+
+describe("POST /api/auth/change-primary-email", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdate.mockResolvedValue(undefined);
+    mockUpdateUser.mockResolvedValue(undefined);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ newPrimaryEmail: "new@example.com" }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const res = await POST(makeMalformedRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when newPrimaryEmail is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("New primary email is required");
+  });
+
+  it("returns 400 when newPrimaryEmail is not a string", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const res = await POST(makeRequest({ newPrimaryEmail: 123 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("New primary email is required");
+  });
+
+  it("returns 500 when admin services are not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    mockGetAdminDb.mockReturnValue(null as any);
+    mockGetAdminAuth.mockReturnValue(null as any);
+    const res = await POST(makeRequest({ newPrimaryEmail: "new@example.com" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Server not configured");
+  });
+
+  it("returns 404 when user document is not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks(null);
+    const res = await POST(makeRequest({ newPrimaryEmail: "new@example.com" }));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("User not found");
+  });
+
+  it("returns 400 when email is not a verified additional email", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [
+        { email: "unverified@example.com", verified: false },
+      ],
+    });
+    const res = await POST(makeRequest({ newPrimaryEmail: "new@example.com" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Email must be a verified additional email on your account");
+  });
+
+  it("returns 400 when email is additional but not verified", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [
+        { email: "new@example.com", verified: false },
+      ],
+    });
+    const res = await POST(makeRequest({ newPrimaryEmail: "new@example.com" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Email must be a verified additional email on your account");
+  });
+
+  it("successfully changes primary email", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [
+        { email: "new@example.com", verified: true },
+      ],
+    });
+
+    // emailLookup doc for old primary
+    const oldLookupDoc = getDocMock("emailLookup", "old@example.com");
+    oldLookupDoc.get.mockResolvedValue({ exists: true, data: () => ({ uid: "user-1" }) });
+    oldLookupDoc.delete.mockResolvedValue(undefined);
+    oldLookupDoc.set.mockResolvedValue(undefined);
+
+    // emailLookup doc for new primary
+    const newLookupDoc = getDocMock("emailLookup", "new@example.com");
+    newLookupDoc.delete.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest({ newPrimaryEmail: "new@example.com" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.message).toBe("Primary email changed successfully");
+
+    // Verify Firebase Auth was updated
+    expect(mockUpdateUser).toHaveBeenCalledWith("user-1", { email: "new@example.com" });
+  });
+
+  it("normalizes email to lowercase", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [
+        { email: "new@example.com", verified: true },
+      ],
+    });
+
+    const oldLookupDoc = getDocMock("emailLookup", "old@example.com");
+    oldLookupDoc.get.mockResolvedValue({ exists: true, data: () => ({ uid: "user-1" }) });
+    oldLookupDoc.delete.mockResolvedValue(undefined);
+    oldLookupDoc.set.mockResolvedValue(undefined);
+
+    const newLookupDoc = getDocMock("emailLookup", "new@example.com");
+    newLookupDoc.delete.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest({ newPrimaryEmail: "  NEW@Example.com  " }));
+    expect(res.status).toBe(200);
+    expect(mockUpdateUser).toHaveBeenCalledWith("user-1", { email: "new@example.com" });
+  });
+
+  it("rolls back Firebase Auth on Firestore failure", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [
+        { email: "new@example.com", verified: true },
+      ],
+    });
+
+    // Make the Firestore update fail
+    mockUpdate.mockRejectedValue(new Error("Firestore write failed"));
+
+    const res = await POST(makeRequest({ newPrimaryEmail: "new@example.com" }));
+    expect(res.status).toBe(500);
+
+    // Auth should have been called twice: once to set new, once to rollback
+    expect(mockUpdateUser).toHaveBeenCalledTimes(2);
+    expect(mockUpdateUser).toHaveBeenCalledWith("user-1", { email: "new@example.com" });
+    expect(mockUpdateUser).toHaveBeenCalledWith("user-1", { email: "old@example.com" });
+  });
+});

--- a/__tests__/app/api/auth/send-email-verification.test.ts
+++ b/__tests__/app/api/auth/send-email-verification.test.ts
@@ -1,0 +1,278 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/auth/send-email-verification/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
+import { sendEmail } from "@/lib/mailgun";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+  getAdminAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logApiError: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockGetAdminAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
+const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/send-email-verification", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeMalformedRequest() {
+  return new NextRequest("http://localhost/api/auth/send-email-verification", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json{",
+  });
+}
+
+function setupFirebaseMocks(userData: Record<string, unknown> | null = null) {
+  const mockDocSet = jest.fn().mockResolvedValue(undefined);
+  const mockDocGet = jest.fn();
+
+  const docMocks: Record<string, { get: jest.Mock; set: jest.Mock }> = {};
+
+  const getDocMock = (collection: string, docId: string) => {
+    const key = `${collection}/${docId}`;
+    if (!docMocks[key]) {
+      docMocks[key] = { get: jest.fn(), set: jest.fn().mockResolvedValue(undefined) };
+    }
+    return docMocks[key];
+  };
+
+  const db = {
+    collection: jest.fn((collectionName: string) => ({
+      doc: jest.fn((docId: string) => getDocMock(collectionName, docId)),
+    })),
+  };
+
+  // Set up user doc
+  const userDocMock = getDocMock("users", "user-1");
+  userDocMock.get.mockResolvedValue({ data: () => userData });
+
+  const getUserByEmail = jest.fn();
+
+  mockGetAdminDb.mockReturnValue(db as any);
+  mockGetAdminAuth.mockReturnValue({ getUserByEmail } as any);
+
+  return { db, getDocMock, getUserByEmail };
+}
+
+describe("POST /api/auth/send-email-verification", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendEmail.mockResolvedValue(undefined as any);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const res = await POST(makeMalformedRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Email is required");
+  });
+
+  it("returns 400 when email is not a string", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const res = await POST(makeRequest({ email: 42 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Email is required");
+  });
+
+  it("returns 400 when email is too long", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const longEmail = "a".repeat(250) + "@b.co";
+    const res = await POST(makeRequest({ email: longEmail }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Email is too long");
+  });
+
+  it("returns 400 for invalid email format", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    setupFirebaseMocks();
+    const res = await POST(makeRequest({ email: "not-an-email" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid email format");
+  });
+
+  it("returns 500 when admin services are not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    mockGetAdminDb.mockReturnValue(null as any);
+    mockGetAdminAuth.mockReturnValue(null as any);
+    const res = await POST(makeRequest({ email: "new@example.com" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Server not configured");
+  });
+
+  it("returns 400 when email is already used by another account in Firebase Auth", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getUserByEmail } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [],
+    });
+    getUserByEmail.mockResolvedValue({ uid: "other-user" });
+
+    const res = await POST(makeRequest({ email: "taken@example.com" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("This email is already associated with an account");
+  });
+
+  it("returns 400 when email exists in emailLookup collection", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getUserByEmail, getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [],
+    });
+    getUserByEmail.mockRejectedValue(new Error("not found"));
+
+    const lookupDoc = getDocMock("emailLookup", "taken@example.com");
+    lookupDoc.get.mockResolvedValue({ exists: true });
+
+    const res = await POST(makeRequest({ email: "taken@example.com" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("This email is already associated with an account");
+  });
+
+  it("returns 400 when email is already the primary email", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getUserByEmail, getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [],
+    });
+    getUserByEmail.mockRejectedValue(new Error("not found"));
+
+    const lookupDoc = getDocMock("emailLookup", "old@example.com");
+    lookupDoc.get.mockResolvedValue({ exists: false });
+
+    const res = await POST(makeRequest({ email: "old@example.com" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("This is already your primary email");
+  });
+
+  it("returns 400 when email is already an additional email", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getUserByEmail, getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [{ email: "extra@example.com", verified: true }],
+    });
+    getUserByEmail.mockRejectedValue(new Error("not found"));
+
+    const lookupDoc = getDocMock("emailLookup", "extra@example.com");
+    lookupDoc.get.mockResolvedValue({ exists: false });
+
+    const res = await POST(makeRequest({ email: "extra@example.com" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("This email is already added to your account");
+  });
+
+  it("successfully sends verification email", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getUserByEmail, getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      displayName: "Test User",
+      additionalEmails: [],
+    });
+    getUserByEmail.mockRejectedValue(new Error("not found"));
+
+    const lookupDoc = getDocMock("emailLookup", "new@example.com");
+    lookupDoc.get.mockResolvedValue({ exists: false });
+
+    const res = await POST(makeRequest({ email: "new@example.com" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.message).toBe("Verification email sent");
+
+    // Verify sendEmail was called with the right recipient
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "new@example.com",
+        subject: "Verify your email address",
+      })
+    );
+  });
+
+  it("normalizes email to lowercase and trims whitespace", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getUserByEmail, getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [],
+    });
+    getUserByEmail.mockRejectedValue(new Error("not found"));
+
+    const lookupDoc = getDocMock("emailLookup", "new@example.com");
+    lookupDoc.get.mockResolvedValue({ exists: false });
+
+    const res = await POST(makeRequest({ email: "  NEW@Example.com  " }));
+    expect(res.status).toBe(200);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "new@example.com" })
+    );
+  });
+
+  it("returns 500 when sendEmail throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    const { getUserByEmail, getDocMock } = setupFirebaseMocks({
+      email: "old@example.com",
+      additionalEmails: [],
+    });
+    getUserByEmail.mockRejectedValue(new Error("not found"));
+
+    const lookupDoc = getDocMock("emailLookup", "new@example.com");
+    lookupDoc.get.mockResolvedValue({ exists: false });
+
+    mockSendEmail.mockRejectedValue(new Error("Mailgun error"));
+
+    const res = await POST(makeRequest({ email: "new@example.com" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Failed to send verification email");
+  });
+});

--- a/__tests__/app/api/badges/definitions/route.test.ts
+++ b/__tests__/app/api/badges/definitions/route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from "@/app/api/badges/definitions/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+describe("GET /api/badges/definitions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns local fallback when db is unavailable", async () => {
+    mockGetAdminDb.mockReturnValue(null as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("local-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+  });
+
+  it("seeds Firestore and returns definitions when collection is empty", async () => {
+    const batchSet = jest.fn();
+    const batchCommit = jest.fn(async () => undefined);
+
+    const collectionRef = {
+      get: jest.fn(async () => ({ empty: true, docs: [] })),
+      doc: jest.fn(() => ({})),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+      batch: jest.fn(() => ({ set: batchSet, commit: batchCommit })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("seeded-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+    expect(batchSet).toHaveBeenCalledTimes(BADGE_DEFINITIONS.length);
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns Firestore definitions when all badges are present", async () => {
+    const firestoreDefs = BADGE_DEFINITIONS.map((def) => ({
+      id: def.id,
+      data: () => ({ ...def }),
+    }));
+
+    const collectionRef = {
+      get: jest.fn(async () => ({ empty: false, docs: firestoreDefs })),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("firestore");
+    expect(body.definitions.length).toBe(BADGE_DEFINITIONS.length);
+  });
+
+  it("falls back to local when Firestore definitions are incomplete", async () => {
+    // Return only one badge definition
+    const partialDefs = [
+      {
+        id: BADGE_DEFINITIONS[0].id,
+        data: () => ({ ...BADGE_DEFINITIONS[0] }),
+      },
+    ];
+
+    const collectionRef = {
+      get: jest.fn(async () => ({ empty: false, docs: partialDefs })),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("local-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+  });
+
+  it("returns local fallback on Firestore error", async () => {
+    const collectionRef = {
+      get: jest.fn(async () => {
+        throw new Error("Firestore unavailable");
+      }),
+    };
+
+    const db = {
+      collection: jest.fn(() => collectionRef),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe("local-fallback");
+    expect(body.definitions).toEqual(BADGE_DEFINITIONS);
+  });
+});

--- a/__tests__/app/api/cfp/send-edu-code.route.test.ts
+++ b/__tests__/app/api/cfp/send-edu-code.route.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/cfp/send-edu-code/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { sendEmail } from "@/lib/mailgun";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    logError: jest.fn(),
+  },
+  logApiError: jest.fn(),
+}));
+
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockSet = jest.fn().mockResolvedValue(undefined);
+const mockDocGet = jest.fn();
+const mockDocRef = { get: mockDocGet, set: mockSet };
+const mockGetUserByEmail = jest.fn();
+
+const mockDb = {
+  collection: jest.fn((name: string) => ({
+    doc: jest.fn(() => {
+      if (name === "eduVerificationCodes") return { set: mockSet };
+      if (name === "emailLookup") return { get: mockDocGet };
+      if (name === "users")
+        return { get: jest.fn().mockResolvedValue(mockUserDoc) };
+      return mockDocRef;
+    }),
+  })),
+};
+
+const mockAuth = {
+  getUserByEmail: mockGetUserByEmail,
+};
+
+let mockUserDoc = {
+  data: () => ({ email: "primary@gmail.com", additionalEmails: [] }),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+  getAdminAuth: jest.fn(() => mockAuth),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP") },
+}));
+
+jest.mock("crypto", () => ({
+  randomInt: jest.fn(() => 123456),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+
+const testUser: VerifiedUser = { uid: "user123", name: "Test User" };
+
+function makeRequest(
+  body: Record<string, unknown>,
+  options?: { omitAuth?: boolean }
+) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!options?.omitAuth) {
+    headers["authorization"] = "Bearer valid-token";
+  }
+  return new NextRequest("http://localhost/api/cfp/send-edu-code", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function makeRawRequest(body: string, hasAuth = true) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (hasAuth) headers["authorization"] = "Bearer valid-token";
+  return new NextRequest("http://localhost/api/cfp/send-edu-code", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("POST /api/cfp/send-edu-code", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockDocGet.mockResolvedValue({ exists: false });
+    mockUserDoc = {
+      data: () => ({ email: "primary@gmail.com", additionalEmails: [] }),
+    };
+  });
+
+  // --- Auth tests ---
+
+  it("returns 401 when no auth token is provided", async () => {
+    const req = new NextRequest("http://localhost/api/cfp/send-edu-code", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "student@mit.edu" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/sign in/i);
+  });
+
+  it("returns 401 when getVerifiedUser returns null", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/session/i);
+  });
+
+  // --- Validation tests ---
+
+  it("returns 400 when email is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/email/i);
+  });
+
+  it("returns 400 when email is not a .edu address", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "user@gmail.com" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/\.edu/i);
+  });
+
+  it("returns 400 when email is too long", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const longEmail = "a".repeat(250) + "@b.edu";
+    const res = await POST(makeRequest({ email: longEmail }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/too long/i);
+  });
+
+  it("returns 400 when email format is invalid", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "not-an-email.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid email|\.edu/i);
+  });
+
+  it("returns 400 for malformed JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRawRequest("{bad json}"));
+    expect(res.status).toBe(400);
+  });
+
+  // --- Duplicate email tests ---
+
+  it("returns 400 when email is already primary on another account", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetUserByEmail.mockResolvedValue({ uid: "other-user" });
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already associated/i);
+  });
+
+  it("returns 400 when email exists in emailLookup", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockDocGet.mockResolvedValue({ exists: true });
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already associated/i);
+  });
+
+  it("returns 400 when email is the user's primary email", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockUserDoc = {
+      data: () => ({
+        email: "student@mit.edu",
+        additionalEmails: [],
+      }),
+    };
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already your primary/i);
+  });
+
+  it("returns 400 when email is already an additional email", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockUserDoc = {
+      data: () => ({
+        email: "primary@gmail.com",
+        additionalEmails: [{ email: "student@mit.edu" }],
+      }),
+    };
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/already added/i);
+  });
+
+  // --- Success path ---
+
+  it("saves code and sends email on success", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.message).toMatch(/sent/i);
+    expect(mockSet).toHaveBeenCalled();
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "student@mit.edu",
+        subject: expect.stringContaining("verification"),
+      })
+    );
+  });
+
+  // --- Error handling ---
+
+  it("returns 401 for auth-related errors in catch block", async () => {
+    mockGetVerifiedUser.mockRejectedValue(
+      Object.assign(new Error("Error decoding token"), {
+        code: "auth/id-token-expired",
+      })
+    );
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 for unexpected errors", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("Something broke"));
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/failed/i);
+  });
+});

--- a/__tests__/app/api/cfp/verify-edu-code.route.test.ts
+++ b/__tests__/app/api/cfp/verify-edu-code.route.test.ts
@@ -1,0 +1,258 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/cfp/verify-edu-code/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    logError: jest.fn(),
+  },
+  logApiError: jest.fn(),
+}));
+
+const mockDelete = jest.fn().mockResolvedValue(undefined);
+const mockUpdate = jest.fn().mockResolvedValue(undefined);
+const mockCodeDocSet = jest.fn().mockResolvedValue(undefined);
+const mockEmailLookupSet = jest.fn().mockResolvedValue(undefined);
+let mockCodeDocData: Record<string, unknown> | undefined;
+let mockCodeDocExists = true;
+
+const mockDb = {
+  collection: jest.fn((name: string) => ({
+    doc: jest.fn(() => {
+      if (name === "eduVerificationCodes") {
+        return {
+          get: jest.fn().mockResolvedValue({
+            exists: mockCodeDocExists,
+            data: () => mockCodeDocData,
+          }),
+          set: mockCodeDocSet,
+          delete: mockDelete,
+        };
+      }
+      if (name === "users") {
+        return { update: mockUpdate };
+      }
+      if (name === "emailLookup") {
+        return { set: mockEmailLookupSet };
+      }
+      return {};
+    }),
+  })),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "MOCK_TIMESTAMP"),
+    arrayUnion: jest.fn((...args: unknown[]) => args),
+  },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "user123", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/cfp/verify-edu-code", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: "Bearer valid-token",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeRawRequest(body: string) {
+  return new NextRequest("http://localhost/api/cfp/verify-edu-code", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: "Bearer valid-token",
+    },
+    body,
+  });
+}
+
+describe("POST /api/cfp/verify-edu-code", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCodeDocExists = true;
+    mockCodeDocData = {
+      uid: testUser.uid,
+      email: "student@mit.edu",
+      code: "123456",
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000), // 10 min in future
+    };
+  });
+
+  // --- Auth tests ---
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/unauthorized/i);
+  });
+
+  // --- Validation tests ---
+
+  it("returns 400 when email is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ code: "123456" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/email.*code.*required/i);
+  });
+
+  it("returns 400 when code is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ email: "student@mit.edu" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/required/i);
+  });
+
+  it("returns 400 when email is not .edu", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makeRequest({ email: "user@gmail.com", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/\.edu/i);
+  });
+
+  it("returns 400 for malformed JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRawRequest("{not valid json"));
+    expect(res.status).toBe(400);
+  });
+
+  // --- Code verification tests ---
+
+  it("returns 400 when no verification code document exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocExists = false;
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid or expired/i);
+  });
+
+  it("returns 400 when code has expired", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocData = {
+      ...mockCodeDocData,
+      expiresAt: new Date(Date.now() - 60 * 1000), // 1 min ago
+    };
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/expired/i);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("returns 400 when code does not match", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "999999" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid code/i);
+  });
+
+  it("returns 400 when uid does not match", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocData = {
+      ...mockCodeDocData,
+      uid: "different-user",
+    };
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid/i);
+  });
+
+  it("returns 400 when email in doc does not match request", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCodeDocData = {
+      ...mockCodeDocData,
+      email: "other@harvard.edu",
+    };
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid/i);
+  });
+
+  // --- Success path ---
+
+  it("verifies code and updates user on success", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.email).toBe("student@mit.edu");
+
+    // Should update user doc with eduBadge and additionalEmails
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eduBadge: true,
+      })
+    );
+    // Should create emailLookup entry
+    expect(mockEmailLookupSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uid: testUser.uid,
+        isPrimary: false,
+      })
+    );
+    // Should delete the verification code doc
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  // --- Error handling ---
+
+  it("returns 500 for unexpected errors", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("Unexpected failure"));
+    const res = await POST(
+      makeRequest({ email: "student@mit.edu", code: "123456" })
+    );
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/failed to verify/i);
+  });
+});

--- a/__tests__/app/api/events/coworking/register/route.test.ts
+++ b/__tests__/app/api/events/coworking/register/route.test.ts
@@ -1,0 +1,257 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST, DELETE } from "@/app/api/events/[eventId]/coworking/register/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  checkCoworkingEligibility,
+  getUserProfileForRegistration,
+  registerForSession,
+  cancelRegistration,
+} from "@/lib/coworking";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/coworking", () => ({
+  checkCoworkingEligibility: jest.fn(),
+  getUserProfileForRegistration: jest.fn(),
+  registerForSession: jest.fn(),
+  cancelRegistration: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCheckEligibility = checkCoworkingEligibility as jest.MockedFunction<typeof checkCoworkingEligibility>;
+const mockGetProfile = getUserProfileForRegistration as jest.MockedFunction<typeof getUserProfileForRegistration>;
+const mockRegister = registerForSession as jest.MockedFunction<typeof registerForSession>;
+const mockCancelRegistration = cancelRegistration as jest.MockedFunction<typeof cancelRegistration>;
+
+const { checkRateLimit } = jest.requireMock("@/lib/rate-limit") as {
+  checkRateLimit: jest.Mock;
+};
+
+function makeContext(eventId: string) {
+  return { params: Promise.resolve({ eventId }) };
+}
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/events/test-event/coworking/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteRequest() {
+  return new NextRequest("http://localhost/api/events/test-event/coworking/register", {
+    method: "DELETE",
+  });
+}
+
+describe("POST /api/events/[eventId]/coworking/register", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    checkRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("test-event"));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("test-event"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for invalid event ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: true } as never);
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("../bad!"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid event ID");
+  });
+
+  it("returns 400 when user is not eligible", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: false, reason: "Not checked in" } as never);
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("test-event"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Not checked in");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: true } as never);
+
+    const req = new NextRequest("http://localhost/api/events/test-event/coworking/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+
+    const res = await POST(req, makeContext("test-event"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when sessionId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: true } as never);
+
+    const res = await POST(makePostRequest({}), makeContext("test-event"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Session ID is required");
+  });
+
+  it("returns 400 when sessionId is empty string", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: true } as never);
+
+    const res = await POST(makePostRequest({ sessionId: "" }), makeContext("test-event"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Session ID is required");
+  });
+
+  it("returns 400 when profile cannot be loaded", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: true } as never);
+    mockGetProfile.mockResolvedValue(null as never);
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("test-event"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Could not load your profile");
+  });
+
+  it("returns 400 when registration fails", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: true } as never);
+    const mockProfile = { name: "Test User", email: "test@example.com" };
+    mockGetProfile.mockResolvedValue(mockProfile as never);
+    mockRegister.mockResolvedValue({ success: false, error: "Session is full" } as never);
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("test-event"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Session is full");
+  });
+
+  it("returns 200 on successful registration", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCheckEligibility.mockResolvedValue({ eligible: true } as never);
+    const mockProfile = { name: "Test User", email: "test@example.com" };
+    mockGetProfile.mockResolvedValue(mockProfile as never);
+    const mockRegistration = { id: "reg1", sessionId: "s1", userId: "u1" };
+    mockRegister.mockResolvedValue({ success: true, registration: mockRegistration } as never);
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("test-event"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toBe("Successfully registered for coworking session!");
+    expect(body.registration).toEqual(mockRegistration);
+    expect(mockRegister).toHaveBeenCalledWith("test-event", "s1", "u1", mockProfile);
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("unexpected"));
+
+    const res = await POST(makePostRequest({ sessionId: "s1" }), makeContext("test-event"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to register");
+  });
+});
+
+describe("DELETE /api/events/[eventId]/coworking/register", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    checkRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+
+    const res = await DELETE(makeDeleteRequest(), makeContext("test-event"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+
+    const res = await DELETE(makeDeleteRequest(), makeContext("test-event"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid event ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+
+    const res = await DELETE(makeDeleteRequest(), makeContext("../bad!"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid event ID");
+  });
+
+  it("returns 400 when cancellation fails", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCancelRegistration.mockResolvedValue({ success: false, error: "No registration found" } as never);
+
+    const res = await DELETE(makeDeleteRequest(), makeContext("test-event"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("No registration found");
+  });
+
+  it("returns 200 on successful cancellation", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockCancelRegistration.mockResolvedValue({ success: true } as never);
+
+    const res = await DELETE(makeDeleteRequest(), makeContext("test-event"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toBe("Registration cancelled successfully");
+    expect(mockCancelRegistration).toHaveBeenCalledWith("test-event", "u1");
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("unexpected"));
+
+    const res = await DELETE(makeDeleteRequest(), makeContext("test-event"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to cancel registration");
+  });
+});

--- a/__tests__/app/api/events/coworking/slots/route.test.ts
+++ b/__tests__/app/api/events/coworking/slots/route.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/events/[eventId]/coworking/slots/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getSessionsWithStatus } from "@/lib/coworking";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/coworking", () => ({
+  getSessionsWithStatus: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const mockGetSessionsWithStatus = getSessionsWithStatus as jest.MockedFunction<
+  typeof getSessionsWithStatus
+>;
+
+const { checkRateLimit } = jest.requireMock("@/lib/rate-limit") as {
+  checkRateLimit: jest.Mock;
+};
+
+function makeContext(eventId: string) {
+  return { params: Promise.resolve({ eventId }) };
+}
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/events/test-event/coworking/slots");
+}
+
+describe("GET /api/events/[eventId]/coworking/slots", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    checkRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+
+    const res = await GET(makeRequest(), makeContext("test-event"));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(body.retryAfterSeconds).toBe(30);
+  });
+
+  it("returns 400 for invalid event ID", async () => {
+    const res = await GET(makeRequest(), makeContext("../invalid!@#"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid event ID");
+  });
+
+  it("returns 400 for empty event ID", async () => {
+    const res = await GET(makeRequest(), makeContext(""));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid event ID");
+  });
+
+  it("returns sessions for unauthenticated user", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+    const mockSessions = [
+      { id: "s1", title: "Morning Session", spotsLeft: 5 },
+      { id: "s2", title: "Afternoon Session", spotsLeft: 0 },
+    ];
+    mockGetSessionsWithStatus.mockResolvedValue(mockSessions as never);
+
+    const res = await GET(makeRequest(), makeContext("test-event"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.eventId).toBe("test-event");
+    expect(body.sessions).toEqual(mockSessions);
+    expect(mockGetSessionsWithStatus).toHaveBeenCalledWith("test-event", undefined);
+  });
+
+  it("returns sessions with user status for authenticated user", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    const mockSessions = [
+      { id: "s1", title: "Morning", registered: true },
+    ];
+    mockGetSessionsWithStatus.mockResolvedValue(mockSessions as never);
+
+    const res = await GET(makeRequest(), makeContext("test-event"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.sessions).toEqual(mockSessions);
+    expect(mockGetSessionsWithStatus).toHaveBeenCalledWith("test-event", "u1");
+  });
+
+  it("returns 500 when getSessionsWithStatus throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    mockGetSessionsWithStatus.mockRejectedValue(new Error("DB error"));
+
+    const res = await GET(makeRequest(), makeContext("test-event"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to get coworking slots");
+  });
+});

--- a/__tests__/app/api/hackathons/eligibility/route.test.ts
+++ b/__tests__/app/api/hackathons/eligibility/route.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/hackathons/eligibility/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/hackathons", () => ({
+  getCurrentVirtualHackathonId: jest.fn(() => "2026-04"),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+function makeRequest(query?: string) {
+  const url = query
+    ? `http://localhost/api/hackathons/eligibility?${query}`
+    : "http://localhost/api/hackathons/eligibility";
+  return new NextRequest(url, { method: "GET" });
+}
+
+function mockDbWithProfile(profileData: Record<string, unknown> | null, leftTeamExists = false) {
+  mockGetAdminDb.mockReturnValue({
+    collection: jest.fn((name: string) => {
+      if (name === "users") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () =>
+              profileData
+                ? { exists: true, data: () => profileData }
+                : { exists: false, data: () => undefined }
+            ),
+          })),
+        };
+      }
+      if (name === "hackathonLeftTeam") {
+        return {
+          doc: jest.fn(() => ({
+            get: jest.fn(async () => ({ exists: leftTeamExists })),
+          })),
+        };
+      }
+      return { doc: jest.fn() };
+    }),
+  } as never);
+}
+
+const FULL_PROFILE = {
+  github: "user123",
+  discord: "user#1234",
+  visibility: { isPublic: true, showDiscord: true },
+};
+
+describe("GET /api/hackathons/eligibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true, retryAfter: 0 });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+    const data = await res.json();
+    expect(data.error).toMatch(/too many/i);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns eligible=false when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/not configured/i);
+  });
+
+  it("returns eligible=false when profile not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/profile not found/i);
+  });
+
+  it("returns eligible=false when profile is not public", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ github: "gh", discord: "dc", visibility: { isPublic: false, showDiscord: true } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/public/i);
+  });
+
+  it("returns eligible=false when GitHub is not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ discord: "dc", visibility: { isPublic: true, showDiscord: true } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/github/i);
+  });
+
+  it("returns eligible=false when Discord is not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ github: "gh", visibility: { isPublic: true, showDiscord: true } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/discord/i);
+  });
+
+  it("returns eligible=false when showDiscord is off", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile({ github: "gh", discord: "dc", visibility: { isPublic: true, showDiscord: false } });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/show discord/i);
+  });
+
+  it("returns eligible=false when user left a team this month", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile(FULL_PROFILE, true);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toMatch(/left a team/i);
+  });
+
+  it("returns eligible=true when all conditions are met", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockDbWithProfile(FULL_PROFILE, false);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(true);
+  });
+
+  it("uses hackathonId from query parameter when provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    const docMock = jest.fn();
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name === "users") {
+          return {
+            doc: jest.fn(() => ({
+              get: jest.fn(async () => ({
+                exists: true,
+                data: () => FULL_PROFILE,
+              })),
+            })),
+          };
+        }
+        if (name === "hackathonLeftTeam") {
+          return {
+            doc: docMock.mockReturnValue({
+              get: jest.fn(async () => ({ exists: false })),
+            }),
+          };
+        }
+        return { doc: jest.fn() };
+      }),
+    } as never);
+
+    const res = await GET(makeRequest("hackathonId=custom-hack-2026"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.eligible).toBe(true);
+    expect(docMock).toHaveBeenCalledWith("u1_custom-hack-2026");
+  });
+});

--- a/__tests__/app/api/hackathons/events/checkin.route.test.ts
+++ b/__tests__/app/api/hackathons/events/checkin.route.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/events/[eventId]/checkin/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+const VALID_EVENT_ID = "hack-a-sprint-2026";
+
+function makeContext(eventId: string) {
+  return { params: Promise.resolve({ eventId }) };
+}
+
+function makeRequest(body?: unknown) {
+  const opts: RequestInit = { method: "POST" };
+  if (body) {
+    opts.headers = { "Content-Type": "application/json" };
+    opts.body = JSON.stringify(body);
+  }
+  return new NextRequest("http://localhost/api/hackathons/events/test/checkin", opts);
+}
+
+function makeMockDoc(data: Record<string, unknown> | null) {
+  return {
+    exists: data !== null,
+    id: "doc-id",
+    data: () => data,
+  };
+}
+
+describe("POST /api/hackathons/events/[eventId]/checkin", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 403 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const req = makeRequest({ userId: "u1", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when user is not admin", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", isAdmin: false });
+    const req = makeRequest({ userId: "u1", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 for unknown event ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+    const req = makeRequest({ userId: "u1", checkedIn: true });
+    const res = await POST(req, makeContext("bad-event"));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("Unknown event");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+    const req = new NextRequest("http://localhost/api/hackathons/events/test/checkin", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid JSON");
+  });
+
+  it("returns 400 when userId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+    mockGetAdminDb.mockReturnValue({} as never);
+    const req = makeRequest({ checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("userId required");
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const req = makeRequest({ userId: "u1", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("checks in an existing signup", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => makeMockDoc({ eventId: VALID_EVENT_ID, userId: "u1" })),
+          update: updateMock,
+        })),
+      })),
+    } as never);
+
+    const req = makeRequest({ userId: "u1", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.checkedIn).toBe(true);
+    expect(updateMock).toHaveBeenCalled();
+  });
+
+  it("unchecks in an existing signup when checkedIn is false", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => makeMockDoc({ eventId: VALID_EVENT_ID, userId: "u1" })),
+          update: updateMock,
+        })),
+      })),
+    } as never);
+
+    const req = makeRequest({ userId: "u1", checkedIn: false });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.checkedIn).toBe(false);
+    expect(updateMock).toHaveBeenCalled();
+  });
+
+  it("returns 404 when signup does not exist and checkedIn is false", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => makeMockDoc(null)),
+        })),
+      })),
+    } as never);
+
+    const req = makeRequest({ userId: "u1", checkedIn: false });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("User is not signed up for this event");
+  });
+
+  it("creates signup doc for walk-in when user exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+
+    const setMock = jest.fn().mockResolvedValue(undefined);
+    const userDoc = makeMockDoc({ displayName: "Walk In User" });
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => ({
+        doc: jest.fn(() => {
+          if (name === "users") return { get: jest.fn(async () => userDoc) };
+          return {
+            get: jest.fn(async () => makeMockDoc(null)),
+            set: setMock,
+          };
+        }),
+      })),
+    } as never);
+
+    const req = makeRequest({ userId: "walk-in-user", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.checkedIn).toBe(true);
+    expect(json.created).toBe(true);
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: VALID_EVENT_ID,
+        userId: "walk-in-user",
+      })
+    );
+  });
+
+  it("returns 404 when walk-in user does not have an account", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", email: "a@test.com", isAdmin: true });
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => ({
+        doc: jest.fn(() => {
+          if (name === "users") return { get: jest.fn(async () => makeMockDoc(null)) };
+          return { get: jest.fn(async () => makeMockDoc(null)) };
+        }),
+      })),
+    } as never);
+
+    const req = makeRequest({ userId: "no-account", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toContain("cursorboston.com account");
+  });
+});

--- a/__tests__/app/api/hackathons/events/signup.route.test.ts
+++ b/__tests__/app/api/hackathons/events/signup.route.test.ts
@@ -1,0 +1,346 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST, DELETE } from "@/app/api/hackathons/events/[eventId]/signup/route";
+import { getVerifiedUser, getOptionalVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  getOptionalVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/github-merged-pr-count", () => ({
+  fetchMergedPrCountsForLogins: jest.fn(async () => new Map()),
+}));
+
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: jest.fn(() => ({ owner: "test", repo: "repo" })),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetOptionalVerifiedUser = getOptionalVerifiedUser as jest.MockedFunction<typeof getOptionalVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+const VALID_EVENT_ID = "hack-a-sprint-2026";
+
+function makeContext(eventId: string) {
+  return { params: Promise.resolve({ eventId }) };
+}
+
+function makeRequest(method: string, body?: unknown) {
+  const opts: RequestInit = { method };
+  if (body) {
+    opts.headers = { "Content-Type": "application/json" };
+    opts.body = JSON.stringify(body);
+  }
+  return new NextRequest("http://localhost/api/hackathons/events/test/signup", opts);
+}
+
+/* ---------- Firestore mock helpers ---------- */
+
+function makeMockDoc(data: Record<string, unknown> | null) {
+  return {
+    exists: data !== null,
+    id: "doc-id",
+    data: () => data,
+  };
+}
+
+function makeMockCollection(docs: Array<{ id: string; data: () => Record<string, unknown> }> = []) {
+  return {
+    where: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => ({ docs })),
+  };
+}
+
+describe("GET /api/hackathons/events/[eventId]/signup", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 404 for unknown event ID", async () => {
+    mockGetOptionalVerifiedUser.mockResolvedValue(null);
+    const req = makeRequest("GET");
+    const res = await GET(req, makeContext("invalid-event"));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("Unknown event");
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetOptionalVerifiedUser.mockResolvedValue(null);
+    mockGetAdminDb.mockReturnValue(null as never);
+    const req = makeRequest("GET");
+    const res = await GET(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns entries with empty signups", async () => {
+    mockGetOptionalVerifiedUser.mockResolvedValue(null);
+    const signupsCol = makeMockCollection([]);
+    const lumaCol = makeMockCollection([]);
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name === "hackathonEventSignups") return signupsCol;
+        if (name === "hackathonLumaRegistrants") return lumaCol;
+        return makeMockCollection();
+      }),
+      getAll: jest.fn(async () => []),
+    } as never);
+
+    const req = makeRequest("GET");
+    const res = await GET(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.eventId).toBe(VALID_EVENT_ID);
+    expect(json.entries).toEqual([]);
+    expect(json.totalCount).toBe(0);
+    expect(json.me).toBeNull();
+  });
+
+  it("returns me object when user is authenticated and signed up", async () => {
+    const userId = "user-1";
+    mockGetOptionalVerifiedUser.mockResolvedValue({ uid: userId, email: "u@test.com" });
+
+    const signupDoc = {
+      id: `${VALID_EVENT_ID}__${userId}`,
+      data: () => ({
+        userId,
+        eventId: VALID_EVENT_ID,
+        signedUpAt: new Date("2026-01-01"),
+      }),
+    };
+
+    const userDoc = {
+      exists: true,
+      id: userId,
+      data: () => ({
+        displayName: "Test User",
+        github: { login: "testuser" },
+        email: "u@test.com",
+      }),
+    };
+
+    const signupsCol = makeMockCollection([signupDoc]);
+    const lumaCol = makeMockCollection([]);
+    const prCol = makeMockCollection([]);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name === "hackathonEventSignups") return signupsCol;
+        if (name === "hackathonLumaRegistrants") return lumaCol;
+        if (name === "pullRequests") return prCol;
+        if (name === "users") return { doc: jest.fn(() => userDoc) };
+        return makeMockCollection();
+      }),
+      getAll: jest.fn(async () => [userDoc]),
+    } as never);
+
+    const req = makeRequest("GET");
+    const res = await GET(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.me).toBeDefined();
+    expect(json.me.signedUp).toBe(true);
+    expect(json.me.rank).toBe(1);
+  });
+
+  it("returns me.signedUp false when user is authenticated but not signed up", async () => {
+    mockGetOptionalVerifiedUser.mockResolvedValue({ uid: "other-user", email: "o@test.com" });
+
+    const signupsCol = makeMockCollection([]);
+    const lumaCol = makeMockCollection([]);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => {
+        if (name === "hackathonEventSignups") return signupsCol;
+        if (name === "hackathonLumaRegistrants") return lumaCol;
+        return makeMockCollection();
+      }),
+      getAll: jest.fn(async () => []),
+    } as never);
+
+    const req = makeRequest("GET");
+    const res = await GET(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.me.signedUp).toBe(false);
+    expect(json.me.rank).toBeNull();
+  });
+});
+
+describe("POST /api/hackathons/events/[eventId]/signup", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const req = makeRequest("POST");
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for unknown event ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+    const req = makeRequest("POST");
+    const res = await POST(req, makeContext("bad-event"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const req = makeRequest("POST");
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 when user profile blocks signup", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+
+    const userDoc = makeMockDoc({ visibility: { isPublic: false } });
+    const signupDoc = makeMockDoc(null);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => ({
+        doc: jest.fn(() => {
+          if (name === "users") return { get: jest.fn(async () => userDoc) };
+          return { get: jest.fn(async () => signupDoc) };
+        }),
+      })),
+    } as never);
+
+    const req = makeRequest("POST");
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("public");
+  });
+
+  it("returns already signed up when doc exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+
+    const userDoc = makeMockDoc({
+      visibility: { isPublic: true, showDiscord: true },
+      github: { login: "test" },
+      discord: { id: "123" },
+    });
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => ({
+        doc: jest.fn(() => {
+          if (name === "users") return { get: jest.fn(async () => userDoc) };
+          return { get: jest.fn(async () => makeMockDoc({ eventId: VALID_EVENT_ID, userId: "u1" })) };
+        }),
+      })),
+    } as never);
+
+    const req = makeRequest("POST");
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.alreadySignedUp).toBe(true);
+  });
+
+  it("creates signup and returns 200 on success", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+
+    const userDoc = makeMockDoc({
+      visibility: { isPublic: true, showDiscord: true },
+      github: { login: "test" },
+      discord: { id: "123" },
+    });
+
+    const setMock = jest.fn().mockResolvedValue(undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn((name: string) => ({
+        doc: jest.fn(() => {
+          if (name === "users") return { get: jest.fn(async () => userDoc) };
+          return {
+            get: jest.fn(async () => makeMockDoc(null)),
+            set: setMock,
+          };
+        }),
+      })),
+    } as never);
+
+    const req = makeRequest("POST");
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.signedUp).toBe(true);
+    expect(json.alreadySignedUp).toBeUndefined();
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: VALID_EVENT_ID,
+        userId: "u1",
+      })
+    );
+  });
+});
+
+describe("DELETE /api/hackathons/events/[eventId]/signup", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for unknown event ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, makeContext("bad-event"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("deletes signup doc and returns left: true", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com" });
+
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          delete: deleteMock,
+        })),
+      })),
+    } as never);
+
+    const req = makeRequest("DELETE");
+    const res = await DELETE(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.left).toBe(true);
+    expect(deleteMock).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/hackathons/invites/accept/route.test.ts
+++ b/__tests__/app/api/hackathons/invites/accept/route.test.ts
@@ -1,0 +1,368 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/invites/accept/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockCheckRateLimit = jest.fn().mockReturnValue({ success: true });
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonAction: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeDocId: (input: string) => {
+    if (!input || typeof input !== "string" || !input.trim()) return null;
+    if (!/^[a-zA-Z0-9_-]+$/.test(input.trim())) return null;
+    return input.trim();
+  },
+}));
+
+const mockGet = jest.fn();
+const mockUpdate = jest.fn();
+const mockRunTransaction = jest.fn();
+const mockWhere = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        get: () => mockGet(name, id),
+        update: (data: unknown) => mockUpdate(name, id, data),
+      }),
+      where: (...args: unknown[]) => {
+        mockWhere(...args);
+        return {
+          where: (...args2: unknown[]) => {
+            mockWhere(...args2);
+            return {
+              limit: () => ({
+                get: () => mockGet("query", "existingTeam"),
+              }),
+            };
+          },
+        };
+      },
+    }),
+    runTransaction: (fn: (tx: unknown) => Promise<unknown>) =>
+      mockRunTransaction(fn),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+function makeRequest(body?: Record<string, unknown> | string) {
+  return new NextRequest("http://localhost/api/hackathons/invites/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body ?? {}),
+  });
+}
+
+describe("POST /api/hackathons/invites/accept", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest(
+      "http://localhost/api/hackathons/invites/accept",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "bad-json",
+      }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when inviteId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid inviteId format");
+  });
+
+  it("returns 400 when inviteId has invalid characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ inviteId: "inv/../bad" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid inviteId format");
+  });
+
+  it("returns 404 when invite not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Invite not found");
+  });
+
+  it("returns 403 when invite belongs to another user", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "other-user",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Not your invite");
+  });
+
+  it("returns 400 when invite already handled", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "accepted",
+            teamId: "t1",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invite already handled");
+  });
+
+  it("returns 404 when team not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Team not found");
+  });
+
+  it("returns 400 when team is full", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["a", "b", "c"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Team is full");
+  });
+
+  it("returns 200 and marks accepted when user already on team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1", "b"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "hackathonInvites",
+      "inv1",
+      { status: "accepted" }
+    );
+  });
+
+  it("returns 200 on successful accept via transaction", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["owner1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      // query for existing team
+      if (collection === "query") return { empty: true };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          get: jest.fn().mockResolvedValue({
+            data: () => ({ memberIds: ["owner1"], hackathonId: "2026-04" }),
+          }),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      }
+    );
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+  });
+
+  it("returns 400 when user already on another team (ALREADY_ON_TEAM)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["owner1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query") return { empty: true };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(async () => {
+      throw new Error("ALREADY_ON_TEAM");
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("You are already on a team for this hackathon");
+  });
+
+  it("returns 400 when team fills up during transaction (TEAM_FULL)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonInvites")
+        return {
+          exists: true,
+          data: () => ({
+            toUserId: "u1",
+            status: "pending",
+            teamId: "t1",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["owner1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query") return { empty: true };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(async () => {
+      throw new Error("TEAM_FULL");
+    });
+    const res = await POST(makeRequest({ inviteId: "inv1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Team is full");
+  });
+});

--- a/__tests__/app/api/hackathons/pool/join/route.test.ts
+++ b/__tests__/app/api/hackathons/pool/join/route.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/pool/join/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockCheckRateLimit = jest.fn().mockReturnValue({ success: true });
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonAction: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/hackathons", () => ({
+  getCurrentVirtualHackathonId: () => "2026-04",
+}));
+
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: (id: string) => {
+        mockDocTracker(name, id);
+        return { get: () => mockGet(name, id), set: mockSet };
+      },
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+/** Tracks which collection/doc combos are accessed */
+let docTracker: Array<{ collection: string; id: string }> = [];
+function mockDocTracker(collection: string, id: string) {
+  docTracker.push({ collection, id });
+}
+
+function makeRequest(body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/hackathons/pool/join", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : "invalid-json",
+  });
+}
+
+describe("POST /api/hackathons/pool/join", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    docTracker = [];
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(body.retryAfterSeconds).toBe(30);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest("http://localhost/api/hackathons/pool/join", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{{{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when user profile not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users") return { exists: false };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Profile not found");
+  });
+
+  it("returns 400 when profile is not public", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: false },
+            github: "user",
+            discord: "user#1234",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Make your profile public");
+  });
+
+  it("returns 400 when GitHub not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: true, showDiscord: true },
+            discord: "user#1234",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Connect GitHub");
+  });
+
+  it("returns 400 when Discord not connected", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: true, showDiscord: true },
+            github: "user",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Connect Discord");
+  });
+
+  it("returns 400 when showDiscord is not enabled", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return {
+          exists: true,
+          data: () => ({
+            visibility: { isPublic: true, showDiscord: false },
+            github: "user",
+            discord: "user#1234",
+          }),
+        };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Show Discord");
+  });
+
+  it("returns 400 when user left a team with a registered repo", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: true };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("left a team");
+  });
+
+  it("returns 200 when already in pool", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: false };
+      if (collection === "hackathonPool") return { exists: true };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.joined).toBe(true);
+  });
+
+  it("creates pool entry and returns 200 on success", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: false };
+      if (collection === "hackathonPool") return { exists: false };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.joined).toBe(true);
+    expect(body.hackathonId).toBe("2026-04");
+    expect(mockSet).toHaveBeenCalled();
+  });
+
+  it("uses provided hackathonId from body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const validProfile = {
+      visibility: { isPublic: true, showDiscord: true },
+      github: "user",
+      discord: "user#1234",
+    };
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "users")
+        return { exists: true, data: () => validProfile };
+      if (collection === "hackathonLeftTeam") return { exists: false };
+      if (collection === "hackathonPool") return { exists: false };
+      return { exists: false };
+    });
+    const res = await POST(makeRequest({ hackathonId: "2026-03" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hackathonId).toBe("2026-03");
+  });
+});

--- a/__tests__/app/api/hackathons/requests/accept/route.test.ts
+++ b/__tests__/app/api/hackathons/requests/accept/route.test.ts
@@ -1,0 +1,370 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/requests/accept/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockCheckRateLimit = jest.fn().mockReturnValue({ success: true });
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonAction: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeDocId: (input: string) => {
+    if (!input || typeof input !== "string" || !input.trim()) return null;
+    if (!/^[a-zA-Z0-9_-]+$/.test(input.trim())) return null;
+    return input.trim();
+  },
+}));
+
+const mockGet = jest.fn();
+const mockUpdate = jest.fn();
+const mockRunTransaction = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockWhere = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => ({
+      doc: (id: string) => {
+        const ref = {
+          get: () => mockGet(name, id),
+          update: (data: unknown) => mockUpdate(name, id, data),
+          ref: `${name}/${id}`,
+        };
+        return ref;
+      },
+      where: (...args: unknown[]) => {
+        mockWhere(...args);
+        return {
+          where: (...args2: unknown[]) => {
+            mockWhere(...args2);
+            return {
+              limit: () => ({
+                get: () => mockGet("query-existing-team", "check"),
+              }),
+              get: () => mockGet("query-pending-requests", "check"),
+            };
+          },
+        };
+      },
+    }),
+    runTransaction: (fn: (tx: unknown) => Promise<unknown>) =>
+      mockRunTransaction(fn),
+    batch: () => ({
+      update: mockBatchUpdate,
+      commit: mockBatchCommit,
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+function makeRequest(body?: Record<string, unknown> | string) {
+  return new NextRequest("http://localhost/api/hackathons/requests/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body ?? {}),
+  });
+}
+
+describe("POST /api/hackathons/requests/accept", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest(
+      "http://localhost/api/hackathons/requests/accept",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "bad-json",
+      }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when requestId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid requestId format");
+  });
+
+  it("returns 400 when requestId has invalid characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ requestId: "req/../evil" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when request not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Request not found");
+  });
+
+  it("returns 400 when request already handled", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "accepted",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Request already handled");
+  });
+
+  it("returns 404 when team not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return { exists: false, data: () => null };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Team not found");
+  });
+
+  it("returns 403 when current user is not a team member", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["other-user"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("You are not a member of this team");
+  });
+
+  it("returns 400 when team is full", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1", "b", "c"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Team is full");
+  });
+
+  it("returns 200 and marks accepted when requester already on team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1", "requester1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "hackathonJoinRequests",
+      "req1",
+      { status: "accepted" }
+    );
+  });
+
+  it("returns 400 when requester is already on another team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query-existing-team")
+        return { empty: false };
+      return { exists: false, data: () => null };
+    });
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe(
+      "That user is already on a team for this hackathon"
+    );
+  });
+
+  it("returns 200 on successful accept with transaction and batch cleanup", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockImplementation((collection: string) => {
+      if (collection === "hackathonJoinRequests")
+        return {
+          exists: true,
+          data: () => ({
+            fromUserId: "requester1",
+            teamId: "t1",
+            status: "pending",
+          }),
+        };
+      if (collection === "hackathonTeams")
+        return {
+          exists: true,
+          data: () => ({
+            memberIds: ["u1"],
+            hackathonId: "2026-04",
+          }),
+        };
+      if (collection === "query-existing-team") return { empty: true };
+      if (collection === "query-pending-requests")
+        return {
+          empty: false,
+          docs: [
+            {
+              id: "req1",
+              ref: "hackathonJoinRequests/req1",
+            },
+            {
+              id: "req2",
+              ref: "hackathonJoinRequests/req2",
+            },
+          ],
+        };
+      return { exists: false, data: () => null };
+    });
+    mockRunTransaction.mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = { update: jest.fn() };
+        return fn(tx);
+      }
+    );
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest({ requestId: "req1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(mockRunTransaction).toHaveBeenCalled();
+    // Should withdraw other pending requests (req2, not req1)
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      "hackathonJoinRequests/req2",
+      { status: "withdrawn" }
+    );
+    expect(mockBatchCommit).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/api/hackathons/submissions/register.route.test.ts
+++ b/__tests__/app/api/hackathons/submissions/register.route.test.ts
@@ -1,0 +1,369 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/submissions/register/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonMutation: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+const mockUpdate = jest.fn();
+const mockWhere = jest.fn();
+const mockLimit = jest.fn();
+const mockDocRef = { get: mockGet, set: mockSet, update: mockUpdate };
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    where: (...args: unknown[]) => {
+      mockWhere(...args);
+      return {
+        where: (...args2: unknown[]) => {
+          mockWhere(...args2);
+          return {
+            limit: (n: number) => {
+              mockLimit(n);
+              return { get: mockGet };
+            },
+          };
+        },
+      };
+    },
+    doc: jest.fn(() => mockDocRef),
+  })),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("@/lib/hackathons", () => ({
+  getCurrentVirtualHackathonId: () => "virtual-2026-04",
+  isVirtualHackathonId: (id: string) => /^virtual-\d{4}-\d{2}$/.test(id),
+  getVirtualMonthStartEndUtc: (id: string) => {
+    const match = id.match(/^virtual-(\d{4})-(\d{2})$/);
+    if (!match) return null;
+    const year = parseInt(match[1], 10);
+    const month0 = parseInt(match[2], 10) - 1;
+    return {
+      start: new Date(Date.UTC(year, month0, 1, 0, 0, 0, 0)),
+      end: new Date(Date.UTC(year, month0 + 1, 0, 23, 59, 59, 999)),
+    };
+  },
+}));
+
+// Mock global fetch for GitHub API calls
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+const testUser: VerifiedUser = { uid: "user-1", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/hackathons/submissions/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("POST /api/hackathons/submissions/register", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest("http://localhost/api/hackathons/submissions/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when repoUrl is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("repoUrl required");
+  });
+
+  it("returns 400 when repoUrl is empty string", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ repoUrl: "   " }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("repoUrl required");
+  });
+
+  it("returns 400 for non-GitHub URLs", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ repoUrl: "https://gitlab.com/a/b" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Invalid GitHub repo URL/);
+  });
+
+  it("returns 400 for malformed URLs", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ repoUrl: "not-a-url" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Invalid GitHub repo URL/);
+  });
+
+  it("returns 400 for GitHub URL without owner/repo", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when hackathonId is not a virtual ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b", hackathonId: "in-person-2026" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/virtual/i);
+  });
+
+  it("returns 403 when user is not on a team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({ empty: true, docs: [] });
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/not on a team/i);
+  });
+
+  it("returns 400 when GitHub repo is not found (404)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({ status: 404, ok: false });
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found or it is private/i);
+  });
+
+  it("returns 502 when GitHub API returns a non-OK, non-404 status", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({ status: 500, ok: false });
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/Could not verify repo/i);
+  });
+
+  it("returns 400 when repo is private", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ private: true, created_at: "2026-04-10T00:00:00Z" }),
+    });
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Repo must be public");
+  });
+
+  it("returns 400 when repo was created before the hackathon month", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ private: false, created_at: "2025-01-01T00:00:00Z" }),
+    });
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/created during the hackathon month/);
+  });
+
+  it("returns 400 when repo was created after the hackathon month", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ private: false, created_at: "2026-05-15T00:00:00Z" }),
+    });
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/created during the hackathon month/);
+  });
+
+  it("creates a new submission when none exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // Team query
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    // GitHub API
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ private: false, created_at: "2026-04-10T00:00:00Z" }),
+    });
+    // Existing submission check
+    mockGet.mockResolvedValueOnce({ exists: false });
+    mockSet.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/owner/repo" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.registered).toBe(true);
+    expect(body.submissionId).toBe("virtual-2026-04_team-1");
+    expect(body.repoUrl).toBe("https://github.com/owner/repo");
+    expect(mockSet).toHaveBeenCalled();
+  });
+
+  it("updates an existing submission", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ private: false, created_at: "2026-04-10T00:00:00Z" }),
+    });
+    // Existing submission exists
+    mockGet.mockResolvedValueOnce({ exists: true });
+    mockUpdate.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/owner/repo" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.registered).toBe(true);
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it("strips .git suffix from repo URL", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ private: false, created_at: "2026-04-10T00:00:00Z" }),
+    });
+    mockGet.mockResolvedValueOnce({ exists: false });
+    mockSet.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/owner/repo.git" }));
+    expect(res.status).toBe(200);
+    // The fetch call should use the parsed owner/repo (without .git)
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/owner/repo",
+      expect.any(Object)
+    );
+  });
+
+  it("defaults to current virtual hackathon when no hackathonId is provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ private: false, created_at: "2026-04-10T00:00:00Z" }),
+    });
+    mockGet.mockResolvedValueOnce({ exists: false });
+    mockSet.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.submissionId).toContain("virtual-2026-04");
+  });
+
+  it("returns 500 when an unexpected error occurs", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("boom"));
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to register repo");
+  });
+});

--- a/__tests__/app/api/hackathons/submissions/submit.route.test.ts
+++ b/__tests__/app/api/hackathons/submissions/submit.route.test.ts
@@ -1,0 +1,251 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/submissions/submit/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+  rateLimitConfigs: { hackathonMutation: { windowMs: 60000, maxRequests: 10 } },
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockGet = jest.fn();
+const mockUpdate = jest.fn();
+const mockWhere = jest.fn();
+const mockLimit = jest.fn();
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    where: (...args: unknown[]) => {
+      mockWhere(...args);
+      return {
+        where: (...args2: unknown[]) => {
+          mockWhere(...args2);
+          return {
+            limit: (n: number) => {
+              mockLimit(n);
+              return { get: mockGet };
+            },
+          };
+        },
+      };
+    },
+    doc: jest.fn(() => ({
+      get: mockGet,
+      update: mockUpdate,
+    })),
+  })),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+// Mock hackathons helpers to produce predictable values
+jest.mock("@/lib/hackathons", () => ({
+  getCurrentVirtualHackathonId: () => "virtual-2026-04",
+  isVirtualHackathonId: (id: string) => /^virtual-\d{4}-\d{2}$/.test(id),
+  getSubmissionCutoffForMonth: () => new Date("2099-05-01T04:00:00Z"), // far future = not expired
+}));
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+const testUser: VerifiedUser = { uid: "user-1", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/hackathons/submissions/submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("POST /api/hackathons/submissions/submit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const req = new NextRequest("http://localhost/api/hackathons/submissions/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when hackathonId is not a virtual ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ hackathonId: "in-person-2026" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/virtual/i);
+  });
+
+  it("returns 400 when submission period has ended", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    // Override cutoff to a past date for this test
+    const hackathons = jest.requireMock("@/lib/hackathons");
+    hackathons.getSubmissionCutoffForMonth = () => new Date("2020-01-01T00:00:00Z");
+
+    const res = await POST(makeRequest({ hackathonId: "virtual-2026-04" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/ended/i);
+
+    // Restore
+    hackathons.getSubmissionCutoffForMonth = () => new Date("2099-05-01T04:00:00Z");
+  });
+
+  it("returns 403 when user is not on a team", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({ empty: true, docs: [] });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/not on a team/i);
+  });
+
+  it("returns 400 when no submission doc exists (no repo registered)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // Team query
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    // Submission doc
+    mockGet.mockResolvedValueOnce({ exists: false, data: () => undefined });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/register a repo/i);
+  });
+
+  it("returns 400 when submission doc exists but data() returns undefined", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockGet.mockResolvedValueOnce({ exists: true, data: () => undefined });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/register a repo/i);
+  });
+
+  it("returns 409 when already submitted", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ submittedAt: "2026-04-10T00:00:00Z", repoUrl: "https://github.com/a/b" }),
+    });
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("Already submitted");
+    expect(body.submittedAt).toBeDefined();
+  });
+
+  it("returns success on valid first-time submission", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ repoUrl: "https://github.com/a/b" }),
+    });
+    mockUpdate.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.submitted).toBe(true);
+    expect(body.submissionId).toBe("virtual-2026-04_team-1");
+    expect(body.cutoffAt).toBeDefined();
+  });
+
+  it("defaults to current virtual hackathon when no hackathonId is provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ repoUrl: "https://github.com/a/b" }),
+    });
+    mockUpdate.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.submissionId).toContain("virtual-2026-04");
+  });
+
+  it("returns 500 when an unexpected error occurs", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("boom"));
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to submit");
+  });
+});

--- a/__tests__/app/api/hackathons/team/profile/route.test.ts
+++ b/__tests__/app/api/hackathons/team/profile/route.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/hackathons/team/profile/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/hackathons/team/profile", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/hackathons/team/profile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true, retryAfter: 0 });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await PATCH(makeRequest({ teamId: "t1", name: "New" }));
+    expect(res.status).toBe(429);
+    const data = await res.json();
+    expect(data.error).toMatch(/too many/i);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ teamId: "t1", name: "New" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const res = await PATCH(makeRequest({ teamId: "t1", name: "New" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({} as never);
+    const req = new NextRequest("http://localhost/api/hackathons/team/profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when teamId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({ collection: jest.fn() } as never);
+    const res = await PATCH(makeRequest({ name: "New" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid teamId/i);
+  });
+
+  it("returns 404 when team does not exist", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({ exists: false })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "New" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when user is not a team member", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u2", "u3"], wins: 2 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "New" }));
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toMatch(/not a member/i);
+  });
+
+  it("returns 403 when team has zero wins", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 0 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "New" }));
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toMatch(/wins/i);
+  });
+
+  it("returns 400 when name exceeds 50 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+        })),
+      })),
+    } as never);
+    const longName = "A".repeat(51);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: longName }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/50 characters/i);
+  });
+
+  it("returns 400 when neither name nor logoUrl provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/provide name/i);
+  });
+
+  it("returns 200 and updates team name successfully", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+          update: updateMock,
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", name: "Cool Team" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Cool Team" })
+    );
+  });
+
+  it("returns 200 and updates logoUrl successfully", async () => {
+    const updateMock = jest.fn().mockResolvedValue(undefined);
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 3 }),
+          })),
+          update: updateMock,
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", logoUrl: "https://example.com/logo.png" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ logoUrl: "https://example.com/logo.png" })
+    );
+  });
+
+  it("returns 400 for invalid logoUrl format", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u1@test.com" });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => ({
+            exists: true,
+            data: () => ({ memberIds: ["u1"], wins: 1 }),
+          })),
+        })),
+      })),
+    } as never);
+    const res = await PATCH(makeRequest({ teamId: "team123", logoUrl: "javascript:alert(1)" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid logoUrl/i);
+  });
+});

--- a/__tests__/app/api/health/route.test.ts
+++ b/__tests__/app/api/health/route.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from "@/app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("returns 200 with healthy status", async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("healthy");
+    expect(body.timestamp).toBeDefined();
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  it("includes a version field", async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.version).toBeDefined();
+    expect(typeof body.version).toBe("string");
+  });
+
+  it("returns a valid ISO timestamp", async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    const parsed = new Date(body.timestamp);
+    expect(parsed.toISOString()).toBe(body.timestamp);
+  });
+});

--- a/__tests__/app/api/notifications/unsubscribe/route.test.ts
+++ b/__tests__/app/api/notifications/unsubscribe/route.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/notifications/unsubscribe/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { verifyUnsubscribeToken } from "@/lib/unsubscribe-token";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/unsubscribe-token", () => ({
+  verifyUnsubscribeToken: jest.fn(),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: jest.fn(() => "test-ip"),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockVerifyToken = verifyUnsubscribeToken as jest.MockedFunction<typeof verifyUnsubscribeToken>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+const VALID_TOKEN = "a".repeat(64);
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/notifications/unsubscribe");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url.toString(), { method: "GET" });
+}
+
+describe("GET /api/notifications/unsubscribe", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue({ success: true } as never);
+  });
+
+  it("redirects to rate-limited when rate limit exceeded", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false } as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("rate-limited");
+  });
+
+  it("redirects to invalid when email is missing", async () => {
+    const res = await GET(makeRequest({ token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to invalid when token is missing", async () => {
+    const res = await GET(makeRequest({ email: "test@example.com" }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to invalid when token format is wrong", async () => {
+    const res = await GET(makeRequest({ email: "test@example.com", token: "bad-token" }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to invalid when token verification fails", async () => {
+    mockVerifyToken.mockReturnValue(false);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("invalid");
+  });
+
+  it("redirects to error when db is unavailable", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockGetAdminDb.mockReturnValue(null as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("error");
+  });
+
+  it("redirects to success when contact does not exist (no info leak)", async () => {
+    mockVerifyToken.mockReturnValue(true);
+
+    const docRef = {
+      get: jest.fn(async () => ({ exists: false })),
+    };
+
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => docRef),
+      })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("success");
+  });
+
+  it("unsubscribes existing contact and redirects to success", async () => {
+    mockVerifyToken.mockReturnValue(true);
+
+    const updateFn = jest.fn(async () => undefined);
+    const docRef = {
+      get: jest.fn(async () => ({ exists: true })),
+      update: updateFn,
+    };
+
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => docRef),
+      })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("success");
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({ unsubscribed: true })
+    );
+  });
+
+  it("redirects to error on Firestore exception", async () => {
+    mockVerifyToken.mockReturnValue(true);
+
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => {
+            throw new Error("Firestore down");
+          }),
+        })),
+      })),
+    };
+
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest({ email: "test@example.com", token: VALID_TOKEN }));
+
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).searchParams.get("status")).toBe("error");
+  });
+});

--- a/__tests__/app/api/pair/profile/route.test.ts
+++ b/__tests__/app/api/pair/profile/route.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/pair/profile/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getPairProfileServer,
+  createOrUpdatePairProfileServer,
+} from "@/lib/pair-programming/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pair-programming/data-server", () => ({
+  getPairProfileServer: jest.fn(),
+  createOrUpdatePairProfileServer: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetProfile = getPairProfileServer as jest.MockedFunction<typeof getPairProfileServer>;
+const mockCreateOrUpdate = createOrUpdatePairProfileServer as jest.MockedFunction<typeof createOrUpdatePairProfileServer>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/pair/profile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/pair/profile");
+}
+
+const validBody = {
+  skillsCanTeach: ["React"],
+  skillsWantToLearn: ["Rust"],
+  preferredLanguages: ["TypeScript"],
+  preferredFrameworks: ["Next.js"],
+  timezone: "America/New_York",
+  availability: ["weekends"],
+  sessionTypes: ["build-together"],
+  bio: "Hello world",
+  isActive: true,
+};
+
+describe("GET /api/pair/profile", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns profile when authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const profile = { userId: "u1", skillsCanTeach: ["React"] };
+    mockGetProfile.mockResolvedValue(profile as any);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.profile).toEqual(profile);
+  });
+
+  it("returns null profile when none exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetProfile.mockResolvedValue(null);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.profile).toBeNull();
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetProfile.mockRejectedValue(new Error("db down"));
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/pair/profile", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when skills arrays are missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, skillsCanTeach: "not-array" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Skills arrays");
+  });
+
+  it("returns 400 when timezone is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, timezone: "" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Timezone");
+  });
+
+  it("returns 400 when sessionTypes is empty", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, sessionTypes: [] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("session type");
+  });
+
+  it("returns 400 for invalid session type", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, sessionTypes: ["invalid-type"] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid session type");
+  });
+
+  it("returns 400 when array exceeds max length", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const longArray = Array.from({ length: 21 }, (_, i) => `skill-${i}`);
+    const res = await POST(makePostRequest({ ...validBody, skillsCanTeach: longArray }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("exceed");
+  });
+
+  it("returns 400 when array items are not valid strings", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, skillsCanTeach: [123] }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid array items");
+  });
+
+  it("returns 400 when bio exceeds 1000 chars", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, bio: "x".repeat(1001) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Bio");
+  });
+
+  it("succeeds with valid body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateOrUpdate.mockResolvedValue(undefined);
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toContain("updated");
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith("u1", expect.objectContaining({
+      skillsCanTeach: ["React"],
+      timezone: "America/New_York",
+    }));
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateOrUpdate.mockRejectedValue(new Error("db down"));
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+
+  it("defaults isActive to true when not provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateOrUpdate.mockResolvedValue(undefined);
+    const { isActive, ...bodyWithout } = validBody;
+
+    const res = await POST(makePostRequest(bodyWithout));
+    expect(res.status).toBe(200);
+    expect(mockCreateOrUpdate).toHaveBeenCalledWith("u1", expect.objectContaining({
+      isActive: true,
+    }));
+  });
+});

--- a/__tests__/app/api/pair/request/route.test.ts
+++ b/__tests__/app/api/pair/request/route.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/pair/request/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  createPairRequestServer,
+  getPairRequestsForUserServer,
+} from "@/lib/pair-programming/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pair-programming/data-server", () => ({
+  createPairRequestServer: jest.fn(),
+  getPairRequestsForUserServer: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCreateRequest = createPairRequestServer as jest.MockedFunction<typeof createPairRequestServer>;
+const mockGetRequests = getPairRequestsForUserServer as jest.MockedFunction<typeof getPairRequestsForUserServer>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/pair/request", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetRequest(type?: string) {
+  const url = type
+    ? `http://localhost/api/pair/request?type=${type}`
+    : "http://localhost/api/pair/request";
+  return new NextRequest(url);
+}
+
+const futureTime = new Date(Date.now() + 86400000).toISOString();
+
+const validBody = {
+  toUserId: "u2",
+  sessionType: "build-together",
+  message: "Let's pair!",
+  proposedTime: futureTime,
+};
+
+describe("GET /api/pair/request", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns received requests by default", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const requests = [{ id: "r1", fromUserId: "u2" }];
+    mockGetRequests.mockResolvedValue(requests as any);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.requests).toEqual(requests);
+    expect(mockGetRequests).toHaveBeenCalledWith("u1", "received");
+  });
+
+  it("returns sent requests when type=sent", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetRequests.mockResolvedValue([]);
+
+    const res = await GET(makeGetRequest("sent"));
+    expect(res.status).toBe(200);
+    expect(mockGetRequests).toHaveBeenCalledWith("u1", "sent");
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGetRequests.mockRejectedValue(new Error("db down"));
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/pair/request", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when toUserId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, toUserId: "" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("toUserId");
+  });
+
+  it("returns 400 for invalid session type", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, sessionType: "invalid" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("session type");
+  });
+
+  it("returns 400 when message is empty", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, message: "   " }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Message");
+  });
+
+  it("returns 400 when message is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { message, ...noMessage } = validBody;
+    const res = await POST(makePostRequest(noMessage));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when message exceeds 1000 chars", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, message: "x".repeat(1001) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("1000");
+  });
+
+  it("returns 400 when sending request to yourself", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, toUserId: "u1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("yourself");
+  });
+
+  it("returns 400 for invalid proposed time format", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ ...validBody, proposedTime: "not-a-date" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid proposed time");
+  });
+
+  it("returns 400 when proposed time is in the past", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const pastTime = new Date(Date.now() - 86400000).toISOString();
+    const res = await POST(makePostRequest({ ...validBody, proposedTime: pastTime }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("future");
+  });
+
+  it("succeeds with valid body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateRequest.mockResolvedValue("req-123");
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.requestId).toBe("req-123");
+    expect(mockCreateRequest).toHaveBeenCalledWith(expect.objectContaining({
+      fromUserId: "u1",
+      toUserId: "u2",
+      sessionType: "build-together",
+      message: "Let's pair!",
+    }));
+  });
+
+  it("succeeds without proposedTime", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateRequest.mockResolvedValue("req-456");
+    const { proposedTime, ...bodyWithout } = validBody;
+
+    const res = await POST(makePostRequest(bodyWithout));
+    expect(res.status).toBe(200);
+    expect(mockCreateRequest).toHaveBeenCalledWith(expect.objectContaining({
+      proposedTime: undefined,
+    }));
+  });
+
+  it("returns 500 on internal error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCreateRequest.mockRejectedValue(new Error("db down"));
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/pair/respond/route.test.ts
+++ b/__tests__/app/api/pair/respond/route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/pair/respond/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  respondToPairRequestServer,
+  PairRequestNotFoundError,
+  PairRequestUnauthorizedError,
+  PairRequestAlreadyRespondedError,
+} from "@/lib/pair-programming/data-server";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pair-programming/data-server", () => {
+  class PairRequestNotFoundError extends Error {
+    constructor() { super("Request not found"); this.name = "PairRequestNotFoundError"; }
+  }
+  class PairRequestUnauthorizedError extends Error {
+    constructor() { super("Unauthorized"); this.name = "PairRequestUnauthorizedError"; }
+  }
+  class PairRequestAlreadyRespondedError extends Error {
+    constructor() { super("Request has already been responded to"); this.name = "PairRequestAlreadyRespondedError"; }
+  }
+  return {
+    respondToPairRequestServer: jest.fn(),
+    PairRequestNotFoundError,
+    PairRequestUnauthorizedError,
+    PairRequestAlreadyRespondedError,
+  };
+});
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockRespond = respondToPairRequestServer as jest.MockedFunction<typeof respondToPairRequestServer>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/pair/respond", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/pair/respond", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when requestId is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ action: "accept" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("requestId");
+  });
+
+  it("returns 400 when action is invalid", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makePostRequest({ requestId: "r1", action: "maybe" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("accept");
+  });
+
+  it("returns success when accepting a request", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockRespond.mockResolvedValue({ status: "accepted", sessionId: "s1" });
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.sessionId).toBe("s1");
+    expect(body.message).toContain("accepted");
+    expect(mockRespond).toHaveBeenCalledWith("r1", "u1", "accept");
+  });
+
+  it("returns success when declining a request", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockRespond.mockResolvedValue({ status: "declined" });
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "decline" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toContain("declined");
+  });
+
+  it("returns 404 when request not found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // Need to get the mocked error class from the mock module
+    const { PairRequestNotFoundError: MockNotFound } = jest.requireMock("@/lib/pair-programming/data-server");
+    mockRespond.mockRejectedValue(new MockNotFound());
+
+    const res = await POST(makePostRequest({ requestId: "bad", action: "accept" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when user is not the recipient", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { PairRequestUnauthorizedError: MockUnauth } = jest.requireMock("@/lib/pair-programming/data-server");
+    mockRespond.mockRejectedValue(new MockUnauth());
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("only respond");
+  });
+
+  it("returns 400 when request already responded to", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { PairRequestAlreadyRespondedError: MockAlready } = jest.requireMock("@/lib/pair-programming/data-server");
+    mockRespond.mockRejectedValue(new MockAlready());
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("already been responded");
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockRespond.mockRejectedValue(new Error("db down"));
+
+    const res = await POST(makePostRequest({ requestId: "r1", action: "accept" }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/profile/subscription/route.test.ts
+++ b/__tests__/app/api/profile/subscription/route.test.ts
@@ -1,0 +1,309 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "@/app/api/profile/subscription/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockContactGet = jest.fn();
+const mockContactUpdate = jest.fn();
+const mockUserGet = jest.fn();
+
+const mockDb = {
+  collection: jest.fn((name: string) => {
+    if (name === "eventContacts") {
+      return {
+        doc: jest.fn(() => ({
+          get: mockContactGet,
+          update: mockContactUpdate,
+        })),
+      };
+    }
+    if (name === "users") {
+      return {
+        doc: jest.fn(() => ({
+          get: mockUserGet,
+        })),
+      };
+    }
+    return { doc: jest.fn(() => ({ get: jest.fn() })) };
+  }),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP"),
+    delete: jest.fn(() => "FIELD_DELETE"),
+  },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+
+const testUser: VerifiedUser & { email: string } = {
+  uid: "user-123",
+  name: "Test User",
+  email: "test@example.com",
+};
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/profile/subscription", {
+    method: "GET",
+  });
+}
+
+function makePatchRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/profile/subscription", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeMalformedPatchRequest() {
+  return new NextRequest("http://localhost/api/profile/subscription", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json{{{",
+  });
+}
+
+// ---------- GET ----------
+
+describe("GET /api/profile/subscription", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns onList=false when no contact doc exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({ exists: false });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ additionalEmails: [] }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(false);
+    expect(body.subscribed).toBe(false);
+  });
+
+  it("returns subscribed=true when contact exists and not unsubscribed", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: false }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(true);
+    expect(body.subscribed).toBe(true);
+  });
+
+  it("returns subscribed=false when contact is unsubscribed", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: true }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(true);
+    expect(body.subscribed).toBe(false);
+  });
+
+  it("finds contact via additional verified email", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // Primary email not found
+    mockContactGet
+      .mockResolvedValueOnce({ exists: false })
+      // Additional email found
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ unsubscribed: false }),
+      });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        additionalEmails: [{ email: "alt@example.com", verified: true }],
+      }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(true);
+    expect(body.subscribed).toBe(true);
+  });
+
+  it("skips unverified additional emails", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({ exists: false });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        additionalEmails: [{ email: "unverified@example.com", verified: false }],
+      }),
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.onList).toBe(false);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    getAdminDb.mockReturnValueOnce(null);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Server not configured");
+  });
+});
+
+// ---------- PATCH ----------
+
+describe("PATCH /api/profile/subscription", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeMalformedPatchRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON");
+  });
+
+  it("returns 400 when subscribed is not a boolean", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makePatchRequest({ subscribed: "yes" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("subscribed must be a boolean");
+  });
+
+  it("returns 400 when subscribed is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makePatchRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("subscribed must be a boolean");
+  });
+
+  it("returns 404 when no contact doc is found", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({ exists: false });
+    mockUserGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ additionalEmails: [] }),
+    });
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No event contact record found for your email");
+  });
+
+  it("resubscribes when subscribed=true", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: true }),
+    });
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscribed).toBe(true);
+    expect(mockContactUpdate).toHaveBeenCalledWith({
+      unsubscribed: false,
+      unsubscribedAt: "FIELD_DELETE",
+      resubscribedAt: "SERVER_TIMESTAMP",
+    });
+  });
+
+  it("unsubscribes when subscribed=false", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockContactGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ unsubscribed: false }),
+    });
+
+    const res = await PATCH(makePatchRequest({ subscribed: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscribed).toBe(false);
+    expect(mockContactUpdate).toHaveBeenCalledWith({
+      unsubscribed: true,
+      unsubscribedAt: "SERVER_TIMESTAMP",
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false });
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    getAdminDb.mockReturnValueOnce(null);
+
+    const res = await PATCH(makePatchRequest({ subscribed: true }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/profile/update/route.test.ts
+++ b/__tests__/app/api/profile/update/route.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/profile/update/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { error: jest.fn(), logError: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+const mockUpdate = jest.fn();
+const mockGet = jest.fn();
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn(() => ({
+      update: mockUpdate,
+      get: mockGet,
+    })),
+  })),
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP"),
+  },
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+
+const testUser: VerifiedUser = { uid: "user-123", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/profile/update", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeMalformedRequest() {
+  return new NextRequest("http://localhost/api/profile/update", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json{{{",
+  });
+}
+
+describe("PATCH /api/profile/update", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        displayName: "Updated Name",
+        bio: "A bio",
+        location: "Boston",
+        company: "Acme",
+        jobTitle: "Dev",
+        socialLinks: { github: "https://github.com/test" },
+      }),
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ displayName: "Valid Name" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeMalformedRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+  });
+
+  it("returns 400 when no valid fields are provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ unknownField: "value" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("No valid fields to update");
+  });
+
+  it("returns 400 when displayName is too short", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ displayName: "A" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Display name must be at least 2 characters");
+  });
+
+  it("returns 400 when displayName is too long", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ displayName: "A".repeat(51) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Display name must be 50 characters or less");
+  });
+
+  it("returns 400 when bio exceeds 500 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ bio: "B".repeat(501) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Bio must be 500 characters or less");
+  });
+
+  it("returns 400 when location exceeds 100 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ location: "L".repeat(101) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Location must be 100 characters or less");
+  });
+
+  it("returns 400 when company exceeds 100 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ company: "C".repeat(101) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Company must be 100 characters or less");
+  });
+
+  it("returns 400 when jobTitle exceeds 100 characters", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ jobTitle: "J".repeat(101) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Job title must be 100 characters or less");
+  });
+
+  it("successfully updates displayName", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ displayName: "New Name" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.profile.displayName).toBe("Updated Name");
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: "New Name", updatedAt: "SERVER_TIMESTAMP" })
+    );
+  });
+
+  it("successfully updates multiple fields", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(
+      makeRequest({
+        displayName: "New Name",
+        bio: "A short bio",
+        location: "Boston",
+        company: "Acme Inc",
+        jobTitle: "Engineer",
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: "New Name",
+        bio: "A short bio",
+        location: "Boston",
+        company: "Acme Inc",
+        jobTitle: "Engineer",
+        updatedAt: "SERVER_TIMESTAMP",
+      })
+    );
+  });
+
+  it("sets empty strings to null for optional fields", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const res = await PATCH(makeRequest({ bio: "", location: "" }));
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ bio: null, location: null })
+    );
+  });
+
+  it("merges socialLinks with existing data", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    // First get() call is for reading existing socialLinks, second is for the final profile read
+    mockGet
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ socialLinks: { twitter: "https://twitter.com/old" } }),
+      })
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          displayName: "Test",
+          bio: null,
+          location: null,
+          company: null,
+          jobTitle: null,
+          socialLinks: {
+            twitter: "https://twitter.com/old",
+            github: "https://github.com/new",
+          },
+        }),
+      });
+
+    const res = await PATCH(
+      makeRequest({ socialLinks: { github: "https://github.com/new" } })
+    );
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socialLinks: {
+          twitter: "https://twitter.com/old",
+          github: "https://github.com/new",
+        },
+      })
+    );
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false, retryAfter: 30 });
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const res = await PATCH(makeRequest({ displayName: "Test" }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    getAdminDb.mockReturnValueOnce(null);
+
+    const res = await PATCH(makeRequest({ displayName: "Test" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Server not configured");
+  });
+
+  it("returns 500 when update throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockUpdate.mockRejectedValueOnce(new Error("Firestore error"));
+
+    const res = await PATCH(makeRequest({ displayName: "Valid Name" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to update profile");
+  });
+});


### PR DESCRIPTION
## Summary
- Merges 10 test coverage PRs (#387–#396) from `develop` into `main`
- Adds ~285 new unit tests across 21 test files covering: cfp, pair programming, auth, profile, hackathon team/eligibility, coworking, health/badges/unsubscribe, hackathon submissions, hackathon events, and hackathon pool/invites/requests
- All CI checks passed on every PR before merge to `develop`
- Partial progress on #232