### PR TITLE
fix: ratchet coverage thresholds to 30% to prevent regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,10 @@ jobs:
         run: |
           COVERAGE=$(cat coverage/coverage-summary.json | jq '.total.lines.pct')
           echo "Current coverage: $COVERAGE%"
-          # Aligned with jest.config.js coverageThreshold (lines: 12).
+          # Aligned with jest.config.js coverageThreshold (lines: 30).
           # Ratchet this up as tests are added.
-          if (( $(echo "$COVERAGE < 12" | bc -l) )); then
-            echo "::error::Coverage is below 12% threshold"
+          if (( $(echo "$COVERAGE < 30" | bc -l) )); then
+            echo "::error::Coverage is below 30% threshold"
             exit 1
           fi
 

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -35,13 +35,13 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/__tests__/config/firebase/firestore.rules.test.ts',
   ],
-  // Coverage thresholds - ratchet up as tests are added (current: ~13%)
+  // Coverage thresholds - ratchet up as tests are added (current: ~31%)
   coverageThreshold: {
     global: {
-      branches: 10,
-      functions: 12,
-      lines: 12,
-      statements: 12,
+      branches: 22,
+      functions: 20,
+      lines: 30,
+      statements: 29,
     },
   },
   // Generate JSON summary for CI coverage checks


### PR DESCRIPTION
## Summary

- Coverage has been raised from ~14% to ~31% across recent PRs (171 → 613 tests)
- Ratcheted jest.config.js thresholds: lines 12→30, statements 12→29, branches 10→22, functions 12→20
- Aligned CI workflow threshold to 30% lines
- Prevents coverage from regressing below current levels