### PR TITLE
Merge develop into main: ratchet coverage thresholds (#398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,10 @@ jobs:
         run: |
           COVERAGE=$(cat coverage/coverage-summary.json | jq '.total.lines.pct')
           echo "Current coverage: $COVERAGE%"
-          # Aligned with jest.config.js coverageThreshold (lines: 12).
+          # Aligned with jest.config.js coverageThreshold (lines: 30).
           # Ratchet this up as tests are added.
-          if (( $(echo "$COVERAGE < 12" | bc -l) )); then
-            echo "::error::Coverage is below 12% threshold"
+          if (( $(echo "$COVERAGE < 30" | bc -l) )); then
+            echo "::error::Coverage is below 30% threshold"
             exit 1
           fi
 

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -35,13 +35,13 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/__tests__/config/firebase/firestore.rules.test.ts',
   ],
-  // Coverage thresholds - ratchet up as tests are added (current: ~13%)
+  // Coverage thresholds - ratchet up as tests are added (current: ~31%)
   coverageThreshold: {
     global: {
-      branches: 10,
-      functions: 12,
-      lines: 12,
-      statements: 12,
+      branches: 22,
+      functions: 20,
+      lines: 30,
+      statements: 29,
     },
   },
   // Generate JSON summary for CI coverage checks


### PR DESCRIPTION
## Summary

- Merges the coverage threshold ratcheting from PR #398 into main
- Jest and CI thresholds raised to match current ~31% coverage level (lines 30%, statements 29%, branches 22%, functions 20%)
- All CI checks passed on develop before merge