### PR TITLE
test: add route tests for showcase/vote GET, agents/user, agents/me

### DIFF
--- a/__tests__/app/api/agents/me/route.test.ts
+++ b/__tests__/app/api/agents/me/route.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "@/app/api/agents/me/route";
+import {
+  getVerifiedAgent,
+  updateAgentProfile,
+  toPublicProfile,
+} from "@/lib/agents";
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/agents", () => ({
+  getVerifiedAgent: jest.fn(),
+  updateAgentProfile: jest.fn(),
+  toPublicProfile: jest.fn((agent) => ({
+    id: agent.id,
+    name: agent.name,
+    description: agent.description,
+    status: agent.status,
+    avatarUrl: agent.avatarUrl,
+    createdAt: agent.createdAt,
+    lastActiveAt: agent.lastActiveAt,
+  })),
+}));
+
+jest.mock("@/lib/api-response", () => ({
+  parseRequestBody: jest.fn(async (req: Request) => {
+    try {
+      return await req.json();
+    } catch {
+      const { NextResponse } = require("next/server");
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+  }),
+}));
+
+const mockGetVerifiedAgent = getVerifiedAgent as jest.MockedFunction<
+  typeof getVerifiedAgent
+>;
+const mockUpdateAgentProfile = updateAgentProfile as jest.MockedFunction<
+  typeof updateAgentProfile
+>;
+const mockToPublicProfile = toPublicProfile as jest.MockedFunction<
+  typeof toPublicProfile
+>;
+
+const baseAgent = {
+  id: "agent1",
+  name: "TestBot",
+  description: "A test agent",
+  apiKeyHash: "hash",
+  apiKeyPrefix: "cb_agent_",
+  status: "claimed" as const,
+  ownerId: "u1",
+  ownerEmail: "test@example.com",
+  ownerDisplayName: "Tester",
+  claimedAt: { toDate: () => new Date() } as any,
+  createdAt: { toDate: () => new Date() } as any,
+  lastActiveAt: { toDate: () => new Date() } as any,
+  avatarUrl: "https://example.com/avatar.png",
+  visibility: { isPublic: true, showOwner: true },
+};
+
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/agents/me");
+}
+
+function makePatchRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/agents/me", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── GET /api/agents/me ─────────────────────────────────────────────────────
+
+describe("GET /api/agents/me", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when agent is not verified", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.hint).toContain("Authorization");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false, retryAfter: 45 });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.retryAfterSeconds).toBe(45);
+  });
+
+  it("returns full profile for claimed agent", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.agent.id).toBe("agent1");
+    expect(body.agent.name).toBe("TestBot");
+    expect(body.agent.owner.id).toBe("u1");
+    expect(body.agent.owner.email).toBe("test@example.com");
+    expect(body.agent.claimedAt).toBeDefined();
+  });
+
+  it("returns pending_claim fields when status is pending_claim", async () => {
+    const pendingAgent = {
+      ...baseAgent,
+      status: "pending_claim" as const,
+      claimExpiresAt: { toDate: () => new Date() } as any,
+    };
+    mockGetVerifiedAgent.mockResolvedValue(pendingAgent as any);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent.claimExpiresAt).toBeDefined();
+    expect(body.agent.owner).toBeUndefined();
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockGetVerifiedAgent.mockRejectedValue(new Error("boom"));
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to get profile");
+  });
+});
+
+// ─── PATCH /api/agents/me ───────────────────────────────────────────────────
+
+describe("PATCH /api/agents/me", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when agent is not verified", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(null);
+    const res = await PATCH(makePatchRequest({ name: "New" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false, retryAfter: 10 });
+
+    const res = await PATCH(makePatchRequest({ name: "New" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when no valid fields provided", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const res = await PATCH(makePatchRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("No valid fields");
+  });
+
+  it("validates name is a string", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const res = await PATCH(makePatchRequest({ name: 123 as any }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Name must be a string");
+  });
+
+  it("validates name length between 2 and 50", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const resShort = await PATCH(makePatchRequest({ name: "A" }));
+    expect(resShort.status).toBe(400);
+
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const resLong = await PATCH(makePatchRequest({ name: "A".repeat(51) }));
+    expect(resLong.status).toBe(400);
+  });
+
+  it("validates name characters", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const res = await PATCH(makePatchRequest({ name: "Bad<Name>" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("letters, numbers");
+  });
+
+  it("validates description length", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const res = await PATCH(
+      makePatchRequest({ description: "x".repeat(501) })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("500 characters");
+  });
+
+  it("validates avatarUrl is a valid URL", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const res = await PATCH(makePatchRequest({ avatarUrl: "not-a-url" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("valid URL");
+  });
+
+  it("validates visibility is an object", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    const res = await PATCH(makePatchRequest({ visibility: "bad" as any }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Visibility must be an object");
+  });
+
+  it("successfully updates name", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    mockUpdateAgentProfile.mockResolvedValue(undefined);
+
+    const res = await PATCH(makePatchRequest({ name: "NewBot" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockUpdateAgentProfile).toHaveBeenCalledWith("agent1", {
+      name: "NewBot",
+    });
+  });
+
+  it("successfully updates description to null", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    mockUpdateAgentProfile.mockResolvedValue(undefined);
+
+    const res = await PATCH(makePatchRequest({ description: null as any }));
+    expect(res.status).toBe(200);
+    expect(mockUpdateAgentProfile).toHaveBeenCalledWith("agent1", {
+      description: null,
+    });
+  });
+
+  it("successfully updates visibility", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    mockUpdateAgentProfile.mockResolvedValue(undefined);
+
+    const res = await PATCH(
+      makePatchRequest({ visibility: { isPublic: false } })
+    );
+    expect(res.status).toBe(200);
+    expect(mockUpdateAgentProfile).toHaveBeenCalledWith("agent1", {
+      visibility: { isPublic: false, showOwner: true },
+    });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockGetVerifiedAgent.mockResolvedValue(baseAgent as any);
+    mockUpdateAgentProfile.mockRejectedValue(new Error("db error"));
+
+    const res = await PATCH(makePatchRequest({ name: "NewBot" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to update profile");
+  });
+});

--- a/__tests__/app/api/agents/user/route.test.ts
+++ b/__tests__/app/api/agents/user/route.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/agents/user/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAgentsByOwner } from "@/lib/agents";
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/agents", () => ({
+  getAgentsByOwner: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+const mockGetAgentsByOwner = getAgentsByOwner as jest.MockedFunction<
+  typeof getAgentsByOwner
+>;
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/agents/user");
+}
+
+describe("GET /api/agents/user", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when getVerifiedUser throws", async () => {
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Authentication required");
+  });
+
+  it("returns 401 when getVerifiedUser returns null", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = require("@/lib/rate-limit");
+    checkRateLimit.mockReturnValueOnce({ success: false, retryAfter: 30 });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(body.retryAfterSeconds).toBe(30);
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("returns agents owned by authenticated user", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockGetAgentsByOwner.mockResolvedValue([
+      {
+        id: "agent1",
+        name: "Bot One",
+        description: "A test bot",
+        avatarUrl: "https://example.com/avatar.png",
+        status: "claimed",
+        claimedAt: { toDate: () => new Date() } as any,
+        lastActiveAt: { toDate: () => new Date() } as any,
+        visibility: { isPublic: true, showOwner: true },
+        apiKeyHash: "hash",
+        apiKeyPrefix: "cb_agent_",
+        createdAt: { toDate: () => new Date() } as any,
+        ownerId: "u1",
+      },
+    ]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0].id).toBe("agent1");
+    expect(body.agents[0].name).toBe("Bot One");
+    expect(body.agents[0].description).toBe("A test bot");
+    // Ensure sensitive fields are not leaked
+    expect(body.agents[0].apiKeyHash).toBeUndefined();
+    expect(body.agents[0].ownerId).toBeUndefined();
+  });
+
+  it("returns empty array when user has no agents", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u2", name: "Test2" });
+    mockGetAgentsByOwner.mockResolvedValue([]);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.agents).toEqual([]);
+  });
+
+  it("returns 500 when getAgentsByOwner throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Test" });
+    mockGetAgentsByOwner.mockRejectedValue(new Error("db error"));
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Failed to fetch agents");
+  });
+});

--- a/__tests__/app/api/showcase/vote/route.test.ts
+++ b/__tests__/app/api/showcase/vote/route.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/showcase/vote/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: () => ({ success: true }),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeDocId: (id: string) => (id && /^[a-zA-Z0-9_-]+$/.test(id) ? id : ""),
+}));
+
+const mockForEach = jest.fn();
+const mockQueryGet = jest.fn();
+const mockStartAfter = jest.fn();
+const mockDocGet = jest.fn();
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: (name: string) => {
+      if (name === "showcaseVotes") {
+        return {
+          where: jest.fn().mockReturnValue({
+            get: mockQueryGet,
+          }),
+        };
+      }
+      // showcaseProjects
+      return {
+        orderBy: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            startAfter: (...args: unknown[]) => {
+              mockStartAfter(...args);
+              return { get: () => Promise.resolve({ forEach: mockForEach }) };
+            },
+            get: () => Promise.resolve({ forEach: mockForEach }),
+          }),
+        }),
+        doc: (id: string) => ({
+          get: () => mockDocGet(id),
+        }),
+      };
+    },
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makeGetRequest(params?: Record<string, string>) {
+  const url = new URL("http://localhost/api/showcase/vote");
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  }
+  return new NextRequest(url);
+}
+
+describe("GET /api/showcase/vote", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns empty votes/userVotes when db is not configured", async () => {
+    // Override getAdminDb to return null for this test
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(null);
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ votes: {}, userVotes: {} });
+  });
+
+  it("returns vote counts from showcaseProjects", async () => {
+    mockForEach.mockImplementation(
+      (cb: (doc: { id: string; data: () => Record<string, number> }) => void) => {
+        cb({ id: "proj1", data: () => ({ upCount: 5, downCount: 2 }) });
+        cb({ id: "proj2", data: () => ({ upCount: 0, downCount: 3 }) });
+      }
+    );
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.votes).toEqual({
+      proj1: { upCount: 5, downCount: 2 },
+      proj2: { upCount: 0, downCount: 3 },
+    });
+    expect(body.userVotes).toEqual({});
+  });
+
+  it("returns user votes when authenticated", async () => {
+    mockForEach.mockImplementation(() => {});
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockQueryGet.mockResolvedValue({
+      forEach: (cb: (doc: { data: () => Record<string, string> }) => void) => {
+        cb({ data: () => ({ projectId: "proj1", type: "up" }) });
+        cb({ data: () => ({ projectId: "proj2", type: "down" }) });
+      },
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.userVotes).toEqual({ proj1: "up", proj2: "down" });
+  });
+
+  it("uses startAfter cursor when provided", async () => {
+    mockForEach.mockImplementation(() => {});
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+    mockDocGet.mockResolvedValue({ exists: true });
+
+    const res = await GET(makeGetRequest({ startAfter: "proj1" }));
+    expect(res.status).toBe(200);
+    expect(mockDocGet).toHaveBeenCalledWith("proj1");
+    expect(mockStartAfter).toHaveBeenCalled();
+  });
+
+  it("ignores invalid startAfter cursor", async () => {
+    mockForEach.mockImplementation(() => {});
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+
+    const res = await GET(makeGetRequest({ startAfter: "../../bad" }));
+    expect(res.status).toBe(200);
+    // sanitizeDocId returns "" for invalid input, so no cursor used
+    expect(mockDocGet).not.toHaveBeenCalled();
+    expect(mockStartAfter).not.toHaveBeenCalled();
+  });
+
+  it("skips startAfter when cursor doc does not exist", async () => {
+    mockForEach.mockImplementation(() => {});
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+    mockDocGet.mockResolvedValue({ exists: false });
+
+    const res = await GET(makeGetRequest({ startAfter: "nonexistent" }));
+    expect(res.status).toBe(200);
+    expect(mockStartAfter).not.toHaveBeenCalled();
+  });
+
+  it("respects limit parameter capped at 200", async () => {
+    mockForEach.mockImplementation(() => {});
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+
+    const res = await GET(makeGetRequest({ limit: "999" }));
+    expect(res.status).toBe(200);
+    // The route caps at 200, no direct assertion on internal call but ensures no error
+  });
+
+  it("defaults missing counts to 0", async () => {
+    mockForEach.mockImplementation(
+      (cb: (doc: { id: string; data: () => Record<string, unknown> }) => void) => {
+        cb({ id: "proj1", data: () => ({}) });
+      }
+    );
+    mockGetVerifiedUser.mockRejectedValue(new Error("unauth"));
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.votes).toEqual({ proj1: { upCount: 0, downCount: 0 } });
+  });
+
+  it("returns fallback on unexpected error", async () => {
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ votes: {}, userVotes: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 9 tests for `GET /api/showcase/vote`: pagination cursor (startAfter), vote counts, user votes when authenticated, fallback on db error, invalid cursor sanitization
- Add 6 tests for `GET /api/agents/user`: auth (throw + null), rate limiting, agent list mapping, empty results, error handling
- Add 18 tests for `GET/PATCH /api/agents/me`: auth, rate limiting, claimed vs pending_claim profiles, field validation (name length/chars, description length, avatarUrl format, visibility type), successful updates, error paths

Partial progress on #232