### PR TITLE
test(lib): add tests for cfp-submissions, github-merged-pr-count, github

### DIFF
--- a/__tests__/lib/cfp-submissions.test.ts
+++ b/__tests__/lib/cfp-submissions.test.ts
@@ -1,0 +1,290 @@
+/**
+ * @jest-environment node
+ */
+
+/* ------------------------------------------------------------------ */
+/*  Mocks – must be declared before any import that touches them      */
+/* ------------------------------------------------------------------ */
+
+const mockDoc = jest.fn();
+const mockSetDoc = jest.fn();
+const mockGetDoc = jest.fn();
+const mockServerTimestamp = jest.fn(() => "SERVER_TS");
+
+jest.mock("firebase/firestore", () => ({
+  doc: (...args: unknown[]) => mockDoc(...args),
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+  Timestamp: {},
+}));
+
+jest.mock("@/lib/firebase", () => ({
+  db: "MOCK_DB",
+}));
+
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeText: (s: string) => s.trim(),
+  sanitizeName: (s: string) => s.trim(),
+}));
+
+// Mock fetch for the admin notification call
+const mockFetch = jest.fn().mockResolvedValue({ ok: true });
+global.fetch = mockFetch;
+
+import {
+  countWords,
+  isValidEduEmail,
+  hasVerifiedEduEmail,
+  getVerifiedEduEmail,
+  validateCfpSubmission,
+  submitCfpProposal,
+  getCfpSubmission,
+  CfpSubmissionInput,
+} from "@/lib/cfp-submissions";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeValidInput(overrides: Partial<CfpSubmissionInput> = {}): CfpSubmissionInput {
+  // Generate abstract with enough words (1500+)
+  const words = Array.from({ length: 1600 }, (_, i) => `word${i}`).join(" ");
+  return {
+    abstract: words,
+    name: "Jane Doe",
+    email: "jane@mit.edu",
+    school: "MIT",
+    department: "CS",
+    advisor: "Dr. Smith",
+    thesisTitle: "On Testing",
+    ...overrides,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  countWords                                                         */
+/* ------------------------------------------------------------------ */
+
+describe("countWords", () => {
+  it("counts space-separated words", () => {
+    expect(countWords("hello world foo")).toBe(3);
+  });
+
+  it("returns 0 for empty or falsy input", () => {
+    expect(countWords("")).toBe(0);
+    expect(countWords(null as unknown as string)).toBe(0);
+    expect(countWords(undefined as unknown as string)).toBe(0);
+  });
+
+  it("handles extra whitespace", () => {
+    expect(countWords("  a   b   c  ")).toBe(3);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isValidEduEmail                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("isValidEduEmail", () => {
+  it("accepts .edu emails", () => {
+    expect(isValidEduEmail("student@harvard.edu")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isValidEduEmail("Student@MIT.EDU")).toBe(true);
+  });
+
+  it("rejects non-.edu emails", () => {
+    expect(isValidEduEmail("user@gmail.com")).toBe(false);
+  });
+
+  it("returns false for falsy values", () => {
+    expect(isValidEduEmail("")).toBe(false);
+    expect(isValidEduEmail(null as unknown as string)).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  hasVerifiedEduEmail                                                */
+/* ------------------------------------------------------------------ */
+
+describe("hasVerifiedEduEmail", () => {
+  it("returns true when primary email is .edu", () => {
+    expect(hasVerifiedEduEmail("u@mit.edu", null)).toBe(true);
+  });
+
+  it("returns true when an additional verified email is .edu", () => {
+    const profile = {
+      additionalEmails: [{ email: "u@harvard.edu", verified: true }],
+    };
+    expect(hasVerifiedEduEmail("u@gmail.com", profile)).toBe(true);
+  });
+
+  it("returns false when additional .edu is not verified", () => {
+    const profile = {
+      additionalEmails: [{ email: "u@harvard.edu", verified: false }],
+    };
+    expect(hasVerifiedEduEmail("u@gmail.com", profile)).toBe(false);
+  });
+
+  it("returns false when no .edu at all", () => {
+    expect(hasVerifiedEduEmail("u@gmail.com", null)).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  getVerifiedEduEmail                                                */
+/* ------------------------------------------------------------------ */
+
+describe("getVerifiedEduEmail", () => {
+  it("returns primary .edu email lowercased", () => {
+    expect(getVerifiedEduEmail("U@MIT.EDU", null)).toBe("u@mit.edu");
+  });
+
+  it("falls back to first verified additional .edu", () => {
+    const profile = {
+      additionalEmails: [
+        { email: "X@HARVARD.EDU", verified: true },
+        { email: "Y@YALE.EDU", verified: true },
+      ],
+    };
+    expect(getVerifiedEduEmail("u@gmail.com", profile)).toBe("x@harvard.edu");
+  });
+
+  it("returns null when none available", () => {
+    expect(getVerifiedEduEmail("u@gmail.com", null)).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  validateCfpSubmission                                              */
+/* ------------------------------------------------------------------ */
+
+describe("validateCfpSubmission", () => {
+  it("returns null for valid submission", () => {
+    expect(validateCfpSubmission(makeValidInput())).toBeNull();
+  });
+
+  it("rejects abstract with too few words", () => {
+    const result = validateCfpSubmission(makeValidInput({ abstract: "short" }));
+    expect(result).toContain("at least 1500");
+  });
+
+  it("rejects abstract with too many words", () => {
+    const long = Array.from({ length: 3000 }, (_, i) => `w${i}`).join(" ");
+    const result = validateCfpSubmission(makeValidInput({ abstract: long }));
+    expect(result).toContain("at most 2500");
+  });
+
+  it("rejects non-.edu email", () => {
+    const result = validateCfpSubmission(makeValidInput({ email: "user@gmail.com" }));
+    expect(result).toContain(".edu");
+  });
+
+  it("rejects missing name", () => {
+    const result = validateCfpSubmission(makeValidInput({ name: "" }));
+    expect(result).toContain("Name");
+  });
+
+  it("rejects missing school", () => {
+    const result = validateCfpSubmission(makeValidInput({ school: "  " }));
+    expect(result).toContain("School");
+  });
+
+  it("rejects missing department", () => {
+    const result = validateCfpSubmission(makeValidInput({ department: "" }));
+    expect(result).toContain("Department");
+  });
+
+  it("rejects missing advisor", () => {
+    const result = validateCfpSubmission(makeValidInput({ advisor: "" }));
+    expect(result).toContain("Advisor");
+  });
+
+  it("rejects missing thesis title", () => {
+    const result = validateCfpSubmission(makeValidInput({ thesisTitle: "" }));
+    expect(result).toContain("Thesis");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  submitCfpProposal                                                  */
+/* ------------------------------------------------------------------ */
+
+describe("submitCfpProposal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDoc.mockReturnValue("DOC_REF");
+    mockSetDoc.mockResolvedValue(undefined);
+    mockFetch.mockResolvedValue({ ok: true });
+  });
+
+  it("creates a new document with createdAt when doc does not exist", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false });
+
+    await submitCfpProposal(makeValidInput(), "user-1");
+
+    expect(mockDoc).toHaveBeenCalledWith("MOCK_DB", "cfpSubmissions", "user-1");
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      "DOC_REF",
+      expect.objectContaining({
+        userId: "user-1",
+        createdAt: "SERVER_TS",
+        updatedAt: "SERVER_TS",
+      }),
+      { merge: true }
+    );
+  });
+
+  it("omits createdAt when doc already exists", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => true });
+
+    await submitCfpProposal(makeValidInput(), "user-1");
+
+    const payload = mockSetDoc.mock.calls[0][1];
+    expect(payload.createdAt).toBeUndefined();
+    expect(payload.updatedAt).toBe("SERVER_TS");
+  });
+
+  it("throws on validation error", async () => {
+    await expect(
+      submitCfpProposal(makeValidInput({ abstract: "too short" }), "user-1")
+    ).rejects.toThrow("at least 1500");
+  });
+
+  it("still succeeds when admin notification fetch fails", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false });
+    mockFetch.mockRejectedValue(new Error("network"));
+
+    // Should not throw
+    await submitCfpProposal(makeValidInput(), "user-1");
+    expect(mockSetDoc).toHaveBeenCalled();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  getCfpSubmission                                                   */
+/* ------------------------------------------------------------------ */
+
+describe("getCfpSubmission", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDoc.mockReturnValue("DOC_REF");
+  });
+
+  it("returns data when document exists", async () => {
+    const fakeData = { abstract: "...", name: "Test" };
+    mockGetDoc.mockResolvedValue({ exists: () => true, data: () => fakeData });
+
+    const result = await getCfpSubmission("user-1");
+    expect(result).toEqual(fakeData);
+  });
+
+  it("returns null when document does not exist", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false });
+
+    const result = await getCfpSubmission("user-1");
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/lib/github-merged-pr-count.test.ts
+++ b/__tests__/lib/github-merged-pr-count.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: () => ({ owner: "test-owner", repo: "test-repo" }),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+import {
+  fetchMergedPrCountByAuthorForRepo,
+  fetchMergedPrCountsForLogins,
+} from "@/lib/github-merged-pr-count";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function okResponse(items: { user?: { login?: string } }[], total = items.length) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ total_count: total, items }),
+  };
+}
+
+function errorResponse(status: number, retryAfter?: string) {
+  return {
+    ok: false,
+    status,
+    headers: { get: (h: string) => (h === "retry-after" ? retryAfter ?? null : null) },
+    json: async () => ({}),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  fetchMergedPrCountByAuthorForRepo                                  */
+/* ------------------------------------------------------------------ */
+
+describe("fetchMergedPrCountByAuthorForRepo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.GITHUB_TOKEN;
+  });
+
+  it("aggregates counts by author across pages", async () => {
+    // Page 1: full page (100 items) triggers next page fetch
+    const page1Items = Array.from({ length: 100 }, (_, i) => ({
+      user: { login: i < 60 ? "Alice" : "Bob" },
+    }));
+    // Page 2: partial page (less than 100) stops pagination
+    const page2Items = [
+      { user: { login: "Alice" } },
+      { user: { login: "charlie" } },
+    ];
+
+    mockFetch
+      .mockResolvedValueOnce(okResponse(page1Items))
+      .mockResolvedValueOnce(okResponse(page2Items));
+
+    const result = await fetchMergedPrCountByAuthorForRepo();
+
+    expect(result).toBeInstanceOf(Map);
+    expect(result!.get("alice")).toBe(61);
+    expect(result!.get("bob")).toBe(40);
+    expect(result!.get("charlie")).toBe(1);
+  });
+
+  it("stops when items array is empty", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([]));
+
+    const result = await fetchMergedPrCountByAuthorForRepo();
+    expect(result).toBeInstanceOf(Map);
+    expect(result!.size).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when first page fails", async () => {
+    mockFetch.mockResolvedValueOnce(errorResponse(500));
+
+    const result = await fetchMergedPrCountByAuthorForRepo();
+    expect(result).toBeNull();
+  });
+
+  it("returns partial counts when a later page fails", async () => {
+    const page1Items = Array.from({ length: 100 }, () => ({
+      user: { login: "alice" },
+    }));
+    mockFetch
+      .mockResolvedValueOnce(okResponse(page1Items))
+      .mockResolvedValueOnce(errorResponse(500));
+
+    const result = await fetchMergedPrCountByAuthorForRepo();
+    expect(result).toBeInstanceOf(Map);
+    expect(result!.get("alice")).toBe(100);
+  });
+
+  it("retries on 429 rate-limit for first page", async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(429, "1"))
+      .mockResolvedValueOnce(okResponse([{ user: { login: "alice" } }]));
+
+    const result = await fetchMergedPrCountByAuthorForRepo();
+    expect(result!.get("alice")).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+
+    const result = await fetchMergedPrCountByAuthorForRepo();
+    expect(result).toBeNull();
+  });
+
+  it("skips items without a user login", async () => {
+    mockFetch.mockResolvedValueOnce(
+      okResponse([{ user: { login: "alice" } }, { user: null }, {}])
+    );
+
+    const result = await fetchMergedPrCountByAuthorForRepo();
+    expect(result!.size).toBe(1);
+    expect(result!.get("alice")).toBe(1);
+  });
+
+  it("includes Authorization header when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test123";
+    mockFetch.mockResolvedValueOnce(okResponse([]));
+
+    await fetchMergedPrCountByAuthorForRepo();
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe("Bearer ghp_test123");
+    delete process.env.GITHUB_TOKEN;
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  fetchMergedPrCountsForLogins                                       */
+/* ------------------------------------------------------------------ */
+
+describe("fetchMergedPrCountsForLogins", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns counts from preloaded bulk map", async () => {
+    const bulk = new Map([
+      ["alice", 5],
+      ["bob", 3],
+    ]);
+
+    const result = await fetchMergedPrCountsForLogins(["Alice", "Bob", "Charlie"], bulk);
+    expect(result.get("alice")).toBe(5);
+    expect(result.get("bob")).toBe(3);
+    expect(result.get("charlie")).toBe(0);
+  });
+
+  it("returns empty map for empty logins", async () => {
+    const result = await fetchMergedPrCountsForLogins([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty map when bulk is null", async () => {
+    const result = await fetchMergedPrCountsForLogins(["alice"], null);
+    expect(result.size).toBe(0);
+  });
+
+  it("deduplicates logins and trims whitespace", async () => {
+    const bulk = new Map([["alice", 10]]);
+    const result = await fetchMergedPrCountsForLogins(
+      ["Alice", " alice ", "ALICE"],
+      bulk
+    );
+    expect(result.size).toBe(1);
+    expect(result.get("alice")).toBe(10);
+  });
+
+  it("fetches bulk when preloadedBulk is not provided", async () => {
+    mockFetch.mockResolvedValueOnce(
+      okResponse([{ user: { login: "alice" } }])
+    );
+
+    const result = await fetchMergedPrCountsForLogins(["alice"]);
+    expect(result.get("alice")).toBe(1);
+    expect(mockFetch).toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/github.test.ts
+++ b/__tests__/lib/github.test.ts
@@ -1,0 +1,339 @@
+/**
+ * @jest-environment node
+ */
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+const mockUpdate = jest.fn();
+const mockCollection = jest.fn();
+const mockDocFn = jest.fn();
+const mockWhere = jest.fn();
+const mockLimit = jest.fn();
+
+const mockDb = {
+  collection: (...args: unknown[]) => {
+    mockCollection(...args);
+    return {
+      doc: (...dArgs: unknown[]) => {
+        mockDocFn(...dArgs);
+        return { get: mockGet, set: mockSet, update: mockUpdate };
+      },
+      where: (...wArgs: unknown[]) => {
+        mockWhere(...wArgs);
+        return {
+          limit: (...lArgs: unknown[]) => {
+            mockLimit(...lArgs);
+            return { get: mockGet };
+          },
+        };
+      },
+    };
+  },
+};
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: () => ({ owner: "test-owner", repo: "test-repo" }),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => "SERVER_TS",
+    increment: (n: number) => `INCREMENT(${n})`,
+  },
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+import {
+  verifyWebhookSignature,
+  findUserByGitHubLogin,
+  isTargetRepository,
+  fetchPullRequestChangedFilenames,
+  processPullRequest,
+} from "@/lib/github";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makePrData(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 42,
+    title: "Fix bug",
+    state: "closed",
+    merged: true,
+    user: { login: "alice" },
+    html_url: "https://github.com/test-owner/test-repo/pull/42",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    merged_at: "2026-01-02T00:00:00Z",
+    repository: { owner: { login: "test-owner" }, name: "test-repo" },
+    ...overrides,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  verifyWebhookSignature                                             */
+/* ------------------------------------------------------------------ */
+
+describe("verifyWebhookSignature", () => {
+  const origEnv = process.env.GITHUB_WEBHOOK_SECRET;
+
+  afterEach(() => {
+    if (origEnv !== undefined) {
+      process.env.GITHUB_WEBHOOK_SECRET = origEnv;
+    } else {
+      delete process.env.GITHUB_WEBHOOK_SECRET;
+    }
+  });
+
+  it("returns false when secret is not set", () => {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+    // Need to re-import to pick up the changed env. Since the module caches
+    // GITHUB_WEBHOOK_SECRET at import time, we test the null-signature branch.
+    expect(verifyWebhookSignature("payload", null)).toBe(false);
+  });
+
+  it("returns false when signature is null", () => {
+    expect(verifyWebhookSignature("payload", null)).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isTargetRepository                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("isTargetRepository", () => {
+  it("returns true for matching owner/repo", () => {
+    expect(isTargetRepository("test-owner", "test-repo")).toBe(true);
+  });
+
+  it("returns false for non-matching owner", () => {
+    expect(isTargetRepository("other", "test-repo")).toBe(false);
+  });
+
+  it("returns false for non-matching repo", () => {
+    expect(isTargetRepository("test-owner", "other")).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  findUserByGitHubLogin                                              */
+/* ------------------------------------------------------------------ */
+
+describe("findUserByGitHubLogin", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns userId when user found", async () => {
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "user-123" }],
+    });
+
+    const result = await findUserByGitHubLogin("alice");
+    expect(result).toBe("user-123");
+    expect(mockWhere).toHaveBeenCalledWith("github.login", "==", "alice");
+  });
+
+  it("returns null when no user found", async () => {
+    mockGet.mockResolvedValueOnce({ empty: true, docs: [] });
+
+    const result = await findUserByGitHubLogin("unknown");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on error", async () => {
+    mockGet.mockRejectedValueOnce(new Error("db error"));
+
+    const result = await findUserByGitHubLogin("alice");
+    expect(result).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  fetchPullRequestChangedFilenames                                   */
+/* ------------------------------------------------------------------ */
+
+describe("fetchPullRequestChangedFilenames", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns filenames on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ filename: "a.ts" }, { filename: "b.ts" }],
+    });
+
+    const result = await fetchPullRequestChangedFilenames("owner", "repo", 1);
+    expect(result).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("returns empty array on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const result = await fetchPullRequestChangedFilenames("owner", "repo", 1);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array on fetch error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network"));
+
+    const result = await fetchPullRequestChangedFilenames("owner", "repo", 1);
+    expect(result).toEqual([]);
+  });
+
+  it("filters out entries without filename", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ filename: "a.ts" }, {}, { filename: undefined }],
+    });
+
+    const result = await fetchPullRequestChangedFilenames("owner", "repo", 1);
+    expect(result).toEqual(["a.ts"]);
+  });
+
+  it("returns empty array when response is not an array", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ not: "an array" }),
+    });
+
+    const result = await fetchPullRequestChangedFilenames("owner", "repo", 1);
+    expect(result).toEqual([]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  processPullRequest                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("processPullRequest", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: user found, PR doc does not exist
+    mockGet.mockResolvedValue({ empty: false, docs: [{ id: "user-123" }] });
+    mockSet.mockResolvedValue(undefined);
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it("skips PRs from non-target repository", async () => {
+    const pr = makePrData({
+      repository: { owner: { login: "other-owner" }, name: "other-repo" },
+    });
+
+    await processPullRequest(pr as Parameters<typeof processPullRequest>[0]);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("skips PRs from users without GitHub account", async () => {
+    // First call: user lookup returns empty
+    mockGet.mockResolvedValueOnce({ empty: true, docs: [] });
+
+    await processPullRequest(makePrData() as Parameters<typeof processPullRequest>[0]);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("creates PR doc and increments count for newly merged PR", async () => {
+    // First call: user lookup
+    mockGet.mockResolvedValueOnce({ empty: false, docs: [{ id: "user-123" }] });
+    // Second call: existing PR check - does not exist
+    mockGet.mockResolvedValueOnce({ exists: false, data: () => null });
+
+    await processPullRequest(makePrData() as Parameters<typeof processPullRequest>[0]);
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prNumber: 42,
+        state: "merged",
+        authorLogin: "alice",
+        userId: "user-123",
+      }),
+      { merge: true }
+    );
+    expect(mockUpdate).toHaveBeenCalledWith({
+      pullRequestsCount: "INCREMENT(1)",
+    });
+  });
+
+  it("does not increment count when PR was already merged", async () => {
+    // User lookup
+    mockGet.mockResolvedValueOnce({ empty: false, docs: [{ id: "user-123" }] });
+    // PR already exists and was merged
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ state: "merged" }),
+    });
+
+    await processPullRequest(makePrData() as Parameters<typeof processPullRequest>[0]);
+
+    expect(mockSet).toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("sets state to open for non-merged, non-closed PRs", async () => {
+    mockGet.mockResolvedValueOnce({ empty: false, docs: [{ id: "user-123" }] });
+    mockGet.mockResolvedValueOnce({ exists: false, data: () => null });
+
+    const pr = makePrData({ state: "open", merged: false, merged_at: null });
+    await processPullRequest(pr as Parameters<typeof processPullRequest>[0]);
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "open" }),
+      { merge: true }
+    );
+  });
+
+  it("sets state to closed for closed non-merged PRs", async () => {
+    mockGet.mockResolvedValueOnce({ empty: false, docs: [{ id: "user-123" }] });
+    mockGet.mockResolvedValueOnce({ exists: false, data: () => null });
+
+    const pr = makePrData({ state: "closed", merged: false, merged_at: null });
+    await processPullRequest(pr as Parameters<typeof processPullRequest>[0]);
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "closed" }),
+      { merge: true }
+    );
+  });
+
+  it("decrements count when PR was merged but is no longer", async () => {
+    mockGet.mockResolvedValueOnce({ empty: false, docs: [{ id: "user-123" }] });
+    // PR was previously merged
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ state: "merged" }),
+    });
+    // User doc for count check
+    mockGet.mockResolvedValueOnce({
+      data: () => ({ pullRequestsCount: 5 }),
+    });
+
+    const pr = makePrData({ state: "closed", merged: false, merged_at: null });
+    await processPullRequest(pr as Parameters<typeof processPullRequest>[0]);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      pullRequestsCount: "INCREMENT(-1)",
+    });
+  });
+
+  it("throws when Firebase Admin is not configured", async () => {
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    (getAdminDb as jest.Mock).mockReturnValueOnce(null);
+
+    await expect(
+      processPullRequest(makePrData() as Parameters<typeof processPullRequest>[0])
+    ).rejects.toThrow("Firebase Admin is not configured");
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `lib/cfp-submissions.ts` (29 tests): countWords, isValidEduEmail, hasVerifiedEduEmail, getVerifiedEduEmail, validateCfpSubmission, submitCfpProposal, getCfpSubmission
- Add unit tests for `lib/github-merged-pr-count.ts` (13 tests): fetchMergedPrCountByAuthorForRepo pagination, rate-limiting, error handling; fetchMergedPrCountsForLogins with preloaded and fetched bulk maps
- Add unit tests for `lib/github.ts` (21 tests): verifyWebhookSignature, findUserByGitHubLogin, isTargetRepository, fetchPullRequestChangedFilenames, processPullRequest state transitions and PR count increment/decrement logic
- All external calls (Firebase, GitHub API fetch) are mocked

Partial progress on #232