### PR TITLE
test(members): add MemberCard and MemberDirectory component tests

### DIFF
--- a/__tests__/components/members/MemberCard.test.tsx
+++ b/__tests__/components/members/MemberCard.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen } from "@testing-library/react";
+import type { PublicMember } from "@/types/members";
+
+// Mock next/image
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img data-fill={fill ? "true" : undefined} {...rest} />;
+  },
+}));
+
+// Mock Firebase client
+jest.mock("@/lib/firebase", () => ({ db: null }));
+jest.mock("firebase/firestore", () => ({
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  getDocs: jest.fn(),
+  onSnapshot: jest.fn(),
+}));
+
+// Mock badge subsystem — keep tests focused on MemberCard rendering
+jest.mock("@/lib/badges/definitions", () => ({
+  BADGE_DEFINITIONS: [
+    { id: "first-steps", name: "First Steps", description: "d", category: "onboarding", howToEarn: "h", sortOrder: 1 },
+    { id: "connected", name: "Connected", description: "d", category: "community", howToEarn: "h", sortOrder: 2 },
+    { id: "contributor", name: "Contributor", description: "d", category: "contributions", howToEarn: "h", sortOrder: 3 },
+  ],
+}));
+
+jest.mock("@/lib/badges/eligibility", () => ({
+  evaluateBadgeEligibility: jest.fn(() => ({
+    "first-steps": { badgeId: "first-steps", isEligible: true },
+    connected: { badgeId: "connected", isEligible: false },
+    contributor: { badgeId: "contributor", isEligible: false },
+  })),
+}));
+
+jest.mock("@/lib/badges/utils", () => ({
+  getEarnedBadgeIds: jest.fn(() => ["first-steps"]),
+}));
+
+jest.mock("@/components/badges/BadgeGrid", () => ({
+  BadgeGrid: (props: Record<string, unknown>) => (
+    <div data-testid="badge-grid" data-compact={props.compact ? "true" : undefined} />
+  ),
+}));
+
+import { MemberCard } from "@/components/members/MemberCard";
+
+function buildMember(overrides: Partial<PublicMember> = {}): PublicMember {
+  return {
+    uid: "user-1",
+    displayName: "Jane Doe",
+    photoURL: null,
+    memberType: "human",
+    bio: "Full-stack developer",
+    location: "Boston, MA",
+    company: "Acme Corp",
+    jobTitle: "Senior Engineer",
+    discord: { username: "jane#1234" },
+    github: { login: "janedoe", html_url: "https://github.com/janedoe" },
+    eventsAttended: 3,
+    talksGiven: 1,
+    pullRequestsCount: 5,
+    socialLinks: {
+      website: "https://jane.dev",
+      linkedIn: "https://linkedin.com/in/janedoe",
+      twitter: "https://x.com/janedoe",
+      github: "https://github.com/janedoe",
+      substack: "https://janedoe.substack.com",
+    },
+    visibility: {
+      showEmail: false,
+      showBio: true,
+      showLocation: true,
+      showCompany: true,
+      showJobTitle: true,
+      showDiscord: true,
+      showGithubBadge: true,
+      showEventsAttended: true,
+      showTalksGiven: true,
+      showWebsite: true,
+      showLinkedIn: true,
+      showTwitter: true,
+      showGithub: true,
+      showSubstack: true,
+      showMemberSince: true,
+    },
+    createdAt: { toDate: () => new Date("2025-06-15") },
+    ...overrides,
+  };
+}
+
+describe("MemberCard", () => {
+  it("renders the member display name", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("shows 'Anonymous' when displayName is null", () => {
+    render(<MemberCard member={buildMember({ displayName: null })} />);
+    expect(screen.getByText("Anonymous")).toBeInTheDocument();
+  });
+
+  it("renders the member photo when photoURL is provided", () => {
+    render(<MemberCard member={buildMember({ photoURL: "https://example.com/photo.jpg" })} />);
+    const img = screen.getByAltText("Jane Doe");
+    expect(img).toHaveAttribute("src", "https://example.com/photo.jpg");
+  });
+
+  it("renders initials when no photoURL is provided", () => {
+    render(<MemberCard member={buildMember({ photoURL: null })} />);
+    expect(screen.getByText("JD")).toBeInTheDocument();
+  });
+
+  it("displays the 'Human' type tag for human members", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("Human")).toBeInTheDocument();
+  });
+
+  it("displays the 'Agent' type tag for agent members", () => {
+    render(<MemberCard member={buildMember({ memberType: "agent" })} />);
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("shows job title and company when visible", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("Senior Engineer")).toBeInTheDocument();
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+  });
+
+  it("hides job title when visibility is off", () => {
+    const member = buildMember({
+      visibility: { ...buildMember().visibility!, showJobTitle: false },
+    });
+    render(<MemberCard member={member} />);
+    expect(screen.queryByText("Senior Engineer")).not.toBeInTheDocument();
+  });
+
+  it("shows bio when visible", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("Full-stack developer")).toBeInTheDocument();
+  });
+
+  it("hides bio when showBio is false", () => {
+    const member = buildMember({
+      visibility: { ...buildMember().visibility!, showBio: false },
+    });
+    render(<MemberCard member={member} />);
+    expect(screen.queryByText("Full-stack developer")).not.toBeInTheDocument();
+  });
+
+  it("shows location when visible", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("Boston, MA")).toBeInTheDocument();
+  });
+
+  it("hides location when showLocation is false", () => {
+    const member = buildMember({
+      visibility: { ...buildMember().visibility!, showLocation: false },
+    });
+    render(<MemberCard member={member} />);
+    expect(screen.queryByText("Boston, MA")).not.toBeInTheDocument();
+  });
+
+  it("shows Discord badge when visible and connected", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("Discord")).toBeInTheDocument();
+  });
+
+  it("shows GitHub badge when visible and connected", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+  });
+
+  it("shows events attended count", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("3 events attended")).toBeInTheDocument();
+  });
+
+  it("shows singular 'event' for count of 1", () => {
+    render(<MemberCard member={buildMember({ eventsAttended: 1 })} />);
+    expect(screen.getByText("1 event attended")).toBeInTheDocument();
+  });
+
+  it("shows talks given count", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("1 talk given")).toBeInTheDocument();
+  });
+
+  it("shows pull requests count", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText("5 PRs")).toBeInTheDocument();
+  });
+
+  it("shows singular 'PR' for count of 1", () => {
+    render(<MemberCard member={buildMember({ pullRequestsCount: 1 })} />);
+    expect(screen.getByText("1 PR")).toBeInTheDocument();
+  });
+
+  it("shows Hack-a-Sprint badge when present", () => {
+    render(<MemberCard member={buildMember({ hackASprint2026ShowcaseBadge: true })} />);
+    expect(screen.getByText("Hack-a-Sprint '26")).toBeInTheDocument();
+  });
+
+  it("renders social links when visible", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByLabelText("Website (opens in new tab)")).toHaveAttribute("href", "https://jane.dev");
+    expect(screen.getByLabelText("LinkedIn (opens in new tab)")).toHaveAttribute("href", "https://linkedin.com/in/janedoe");
+    expect(screen.getByLabelText("X/Twitter (opens in new tab)")).toHaveAttribute("href", "https://x.com/janedoe");
+    expect(screen.getByLabelText("GitHub (opens in new tab)")).toHaveAttribute("href", "https://github.com/janedoe");
+    expect(screen.getByLabelText("Substack (opens in new tab)")).toHaveAttribute("href", "https://janedoe.substack.com");
+  });
+
+  it("shows 'Member since' date when visible", () => {
+    render(<MemberCard member={buildMember()} />);
+    expect(screen.getByText(/Member since/)).toBeInTheDocument();
+    expect(screen.getByText(/Jun 2025/)).toBeInTheDocument();
+  });
+
+  it("hides 'Member since' when showMemberSince is false", () => {
+    const member = buildMember({
+      visibility: { ...buildMember().visibility!, showMemberSince: false },
+    });
+    render(<MemberCard member={member} />);
+    expect(screen.queryByText(/Member since/)).not.toBeInTheDocument();
+  });
+
+  it("renders the badge grid with compact mode", () => {
+    render(<MemberCard member={buildMember()} />);
+    const grid = screen.getByTestId("badge-grid");
+    expect(grid).toBeInTheDocument();
+    expect(grid).toHaveAttribute("data-compact", "true");
+  });
+
+  describe("agent members", () => {
+    it("does not show job title or company for agents", () => {
+      render(
+        <MemberCard
+          member={buildMember({
+            memberType: "agent",
+            jobTitle: "Bot",
+            company: "BotCo",
+          })}
+        />
+      );
+      expect(screen.queryByText("Bot")).not.toBeInTheDocument();
+      expect(screen.queryByText("BotCo")).not.toBeInTheDocument();
+    });
+
+    it("shows owner name when visible", () => {
+      render(
+        <MemberCard
+          member={buildMember({
+            memberType: "agent",
+            owner: { displayName: "Alice" },
+            visibility: { ...buildMember().visibility!, showOwner: true },
+          })}
+        />
+      );
+      expect(screen.getByText("Owned by Alice")).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/members/MemberDirectory.test.tsx
+++ b/__tests__/components/members/MemberDirectory.test.tsx
@@ -1,0 +1,350 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PublicMember, MemberFilters, SortOption } from "@/types/members";
+
+// Mock next/image
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img data-fill={fill ? "true" : undefined} {...rest} />;
+  },
+}));
+
+// Mock next/link
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock Firebase client
+jest.mock("@/lib/firebase", () => ({ db: null }));
+jest.mock("firebase/firestore", () => ({
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  getDocs: jest.fn(),
+  onSnapshot: jest.fn(),
+}));
+
+// Mock MemberCard to keep tests focused on directory logic
+jest.mock("@/components/members/MemberCard", () => ({
+  MemberCard: ({ member }: { member: PublicMember }) => (
+    <div data-testid="member-card">{member.displayName}</div>
+  ),
+}));
+
+// Mock skeleton
+jest.mock("@/components/skeletons/MemberCardSkeleton", () => ({
+  MemberCardSkeleton: () => <div data-testid="member-skeleton" />,
+}));
+
+// --- useMembers mock state ---
+type SetFilters = (fn: (f: MemberFilters) => MemberFilters) => void;
+
+const defaultFilters: MemberFilters = {
+  hasDiscord: false,
+  hasLinkedIn: false,
+  hasTwitter: false,
+  hasGithub: false,
+  hasSubstack: false,
+  hasWebsite: false,
+  memberType: "all",
+};
+
+let mockHookReturn: {
+  members: PublicMember[];
+  loading: boolean;
+  searchQuery: string;
+  setSearchQuery: jest.Mock;
+  filters: MemberFilters;
+  setFilters: jest.Mock<void, [fn: (f: MemberFilters) => MemberFilters]>;
+  sortBy: SortOption;
+  setSortBy: jest.Mock;
+  filteredAndSortedMembers: PublicMember[];
+  activeFilterCount: number;
+  clearFilters: jest.Mock;
+};
+
+function buildMockHook(overrides: Partial<typeof mockHookReturn> = {}) {
+  mockHookReturn = {
+    members: [],
+    loading: false,
+    searchQuery: "",
+    setSearchQuery: jest.fn(),
+    filters: defaultFilters,
+    setFilters: jest.fn(),
+    sortBy: "newest" as SortOption,
+    setSortBy: jest.fn(),
+    filteredAndSortedMembers: [],
+    activeFilterCount: 0,
+    clearFilters: jest.fn(),
+    ...overrides,
+  };
+}
+
+jest.mock("@/hooks/useMembers", () => ({
+  useMembers: () => mockHookReturn,
+}));
+
+import { MemberDirectory } from "@/components/members/MemberDirectory";
+
+function buildMember(overrides: Partial<PublicMember> = {}): PublicMember {
+  return {
+    uid: "user-1",
+    displayName: "Jane Doe",
+    photoURL: null,
+    memberType: "human",
+    ...overrides,
+  };
+}
+
+describe("MemberDirectory", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("loading state", () => {
+    it("renders skeletons while loading", () => {
+      buildMockHook({ loading: true });
+      render(<MemberDirectory />);
+      const skeletons = screen.getAllByTestId("member-skeleton");
+      expect(skeletons).toHaveLength(6);
+    });
+
+    it("does not render search controls while loading", () => {
+      buildMockHook({ loading: true });
+      render(<MemberDirectory />);
+      expect(screen.queryByPlaceholderText(/Search by name/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty message when no members exist", () => {
+      buildMockHook({ members: [], loading: false });
+      render(<MemberDirectory />);
+      expect(screen.getByText("No public profiles yet.")).toBeInTheDocument();
+    });
+
+    it("links to profile page in empty state", () => {
+      buildMockHook({ members: [], loading: false });
+      render(<MemberDirectory />);
+      const link = screen.getByText("make your profile public");
+      expect(link).toHaveAttribute("href", "/profile");
+    });
+  });
+
+  describe("no results state", () => {
+    it("shows no-results message when filters yield zero", () => {
+      const member = buildMember();
+      buildMockHook({
+        members: [member],
+        filteredAndSortedMembers: [],
+        loading: false,
+      });
+      render(<MemberDirectory />);
+      expect(screen.getByText("No members match your search.")).toBeInTheDocument();
+    });
+
+    it("has a clear filters button in no-results state", async () => {
+      const member = buildMember();
+      buildMockHook({
+        members: [member],
+        filteredAndSortedMembers: [],
+        loading: false,
+      });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      const clearBtn = screen.getByText("Clear filters");
+      await user.click(clearBtn);
+      expect(mockHookReturn.clearFilters).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/members", { scroll: false });
+    });
+  });
+
+  describe("member list rendering", () => {
+    it("renders member cards for each filtered member", () => {
+      const members = [
+        buildMember({ uid: "u1", displayName: "Alice" }),
+        buildMember({ uid: "u2", displayName: "Bob" }),
+      ];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      render(<MemberDirectory />);
+      const cards = screen.getAllByTestId("member-card");
+      expect(cards).toHaveLength(2);
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+    });
+
+    it("displays total member count when not filtered", () => {
+      const members = [
+        buildMember({ uid: "u1" }),
+        buildMember({ uid: "u2" }),
+        buildMember({ uid: "u3" }),
+      ];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      render(<MemberDirectory />);
+      expect(screen.getByText("3 members")).toBeInTheDocument();
+    });
+
+    it("displays filtered count when search narrows results", () => {
+      const allMembers = [
+        buildMember({ uid: "u1" }),
+        buildMember({ uid: "u2" }),
+        buildMember({ uid: "u3" }),
+      ];
+      const filtered = [allMembers[0]];
+      buildMockHook({ members: allMembers, filteredAndSortedMembers: filtered, loading: false });
+      render(<MemberDirectory />);
+      expect(screen.getByText("1 of 3 members")).toBeInTheDocument();
+    });
+
+    it("uses singular 'member' for count of 1", () => {
+      const members = [buildMember({ uid: "u1" })];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      render(<MemberDirectory />);
+      expect(screen.getByText("1 member")).toBeInTheDocument();
+    });
+  });
+
+  describe("search", () => {
+    it("renders the search input", () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      render(<MemberDirectory />);
+      expect(screen.getByPlaceholderText("Search by name, location, job, bio...")).toBeInTheDocument();
+    });
+
+    it("calls setSearchQuery on input change", async () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      const input = screen.getByPlaceholderText("Search by name, location, job, bio...");
+      await user.type(input, "test");
+      expect(mockHookReturn.setSearchQuery).toHaveBeenCalled();
+    });
+  });
+
+  describe("sort dropdown", () => {
+    it("renders the sort dropdown with options", () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      render(<MemberDirectory />);
+      const select = screen.getByDisplayValue("Newest Members");
+      expect(select).toBeInTheDocument();
+    });
+
+    it("calls setSortBy when sort option changes", async () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      const select = screen.getByDisplayValue("Newest Members");
+      await user.selectOptions(select, "name");
+      expect(mockHookReturn.setSortBy).toHaveBeenCalledWith("name");
+    });
+  });
+
+  describe("filter panel", () => {
+    it("toggles filter panel on button click", async () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+
+      expect(screen.queryByText("Member type")).not.toBeInTheDocument();
+      await user.click(screen.getByText("Filters"));
+      expect(screen.getByText("Member type")).toBeInTheDocument();
+    });
+
+    it("shows active filter count badge", () => {
+      const members = [buildMember()];
+      buildMockHook({
+        members,
+        filteredAndSortedMembers: members,
+        loading: false,
+        activeFilterCount: 2,
+      });
+      render(<MemberDirectory />);
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+
+    it("renders member type filter buttons", async () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      await user.click(screen.getByText("Filters"));
+
+      expect(screen.getByText("All")).toBeInTheDocument();
+      expect(screen.getByText("Humans")).toBeInTheDocument();
+      expect(screen.getByText("Agents")).toBeInTheDocument();
+    });
+
+    it("calls setFilters when member type button is clicked", async () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      await user.click(screen.getByText("Filters"));
+      await user.click(screen.getByText("Agents"));
+      expect(mockHookReturn.setFilters).toHaveBeenCalled();
+    });
+
+    it("renders connected account filter checkboxes", async () => {
+      const members = [buildMember()];
+      buildMockHook({ members, filteredAndSortedMembers: members, loading: false });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      await user.click(screen.getByText("Filters"));
+
+      expect(screen.getByText("Discord")).toBeInTheDocument();
+      expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+      expect(screen.getByText("X")).toBeInTheDocument();
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Substack")).toBeInTheDocument();
+      expect(screen.getByText("Website")).toBeInTheDocument();
+    });
+
+    it("shows 'Clear all' button when filters are active", async () => {
+      const members = [buildMember()];
+      buildMockHook({
+        members,
+        filteredAndSortedMembers: members,
+        loading: false,
+        activeFilterCount: 1,
+      });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      await user.click(screen.getByText("Filters"));
+      expect(screen.getByText("Clear all")).toBeInTheDocument();
+    });
+
+    it("calls clearFilters and navigates when 'Clear all' is clicked", async () => {
+      const members = [buildMember()];
+      buildMockHook({
+        members,
+        filteredAndSortedMembers: members,
+        loading: false,
+        activeFilterCount: 1,
+      });
+      const user = userEvent.setup();
+      render(<MemberDirectory />);
+      await user.click(screen.getByText("Filters"));
+      await user.click(screen.getByText("Clear all"));
+      expect(mockHookReturn.clearFilters).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/members", { scroll: false });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 26 tests for `MemberCard` covering rendering, visibility toggles, social links, badge grid, agent vs human display, member-since date, and pluralization
- Add 21 tests for `MemberDirectory` covering loading skeletons, empty/no-results states, search input, sort dropdown, filter panel toggle, member type buttons, connected account checkboxes, and clear filters navigation
- All 47 tests pass with jsdom environment

Partial progress on #232