### PR TITLE
test: add AppShell and AnalyticsDashboard component tests

### DIFF
--- a/__tests__/components/AnalyticsDashboard.test.tsx
+++ b/__tests__/components/AnalyticsDashboard.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { AnalyticsSummary } from "@/app/api/analytics/summary/route";
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a {...props}>{children}</a>,
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/analytics",
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: null, auth: null }));
+jest.mock("firebase/auth", () => ({
+  getAuth: jest.fn(),
+  onAuthStateChanged: jest.fn(),
+}));
+jest.mock("firebase/firestore", () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  onSnapshot: jest.fn(),
+}));
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: null, loading: false }),
+}));
+
+jest.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+// Mock recharts — rendering real SVG charts in jsdom is unreliable
+jest.mock("recharts", () => {
+  const OriginalModule = jest.requireActual("recharts");
+  return {
+    ...OriginalModule,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: React.ReactNode;
+      width?: string | number;
+      height?: number;
+    }) => <div data-testid="responsive-container">{children}</div>,
+  };
+});
+
+import AnalyticsDashboard from "@/components/AnalyticsDashboard";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const MOCK_SUMMARY: AnalyticsSummary = {
+  totalMembers: 150,
+  totalEventRegistrations: 320,
+  totalShowcaseProjects: 45,
+  totalShowcaseInteractions: 890,
+  memberGrowth: [
+    { month: "2025-06", count: 10 },
+    { month: "2025-07", count: 15 },
+  ],
+  eventAttendance: [
+    { eventId: "e1", name: "AI Workshop", count: 40 },
+    { eventId: "e2", name: "Demo Night", count: 60 },
+  ],
+  skillDistribution: [
+    { skill: "React", count: 30 },
+    { skill: "Python", count: 25 },
+  ],
+  hackathonStats: {
+    teamsFormed: 12,
+    projectsSubmitted: 8,
+    teamsAsPercentOfMembers: 8,
+  },
+  communityActivity: [
+    { week: "2025-W20", posts: 5, replies: 12 },
+    { week: "2025-W21", posts: 8, replies: 15 },
+  ],
+  platformHealth: {
+    activeThisMonth: 42,
+    returningMembers: 28,
+  },
+  showcaseOverTime: [
+    { month: "2025-06", count: 5 },
+    { month: "2025-07", count: 10 },
+  ],
+  generatedAt: "2025-07-15T12:00:00.000Z",
+};
+
+function mockFetchSuccess(data: AnalyticsSummary) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchFailure() {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    json: () => Promise.resolve({}),
+  });
+}
+
+// Stub requestAnimationFrame for useCountUp hook
+const originalRAF = window.requestAnimationFrame;
+const originalCAF = window.cancelAnimationFrame;
+
+beforeAll(() => {
+  window.requestAnimationFrame = jest.fn((cb: FrameRequestCallback) => {
+    cb(performance.now() + 2000); // jump past animation duration
+    return 0;
+  });
+  window.cancelAnimationFrame = jest.fn();
+});
+
+afterAll(() => {
+  window.requestAnimationFrame = originalRAF;
+  window.cancelAnimationFrame = originalCAF;
+});
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("AnalyticsDashboard", () => {
+  it("shows loading skeleton initially", () => {
+    // Never-resolving fetch to keep it in loading state
+    global.fetch = jest.fn(
+      () => new Promise<Response>(() => {})
+    );
+
+    render(<AnalyticsDashboard />);
+    // Loading state renders multiple pulse skeletons
+    const pulseElements = document.querySelectorAll(".animate-pulse");
+    expect(pulseElements.length).toBeGreaterThan(0);
+  });
+
+  it("renders error message on fetch failure", async () => {
+    mockFetchFailure();
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Analytics are unavailable right now. Please try again later.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders stat cards with data after successful fetch", async () => {
+    mockFetchSuccess(MOCK_SUMMARY);
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Total Members")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Event Registrations")).toBeInTheDocument();
+    expect(screen.getByText("Showcase Projects")).toBeInTheDocument();
+    expect(screen.getByText("Showcase Interactions")).toBeInTheDocument();
+  });
+
+  it("renders platform health cards", async () => {
+    mockFetchSuccess(MOCK_SUMMARY);
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Active Members This Month")
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Returning Members")).toBeInTheDocument();
+  });
+
+  it("renders hackathon stats section", async () => {
+    mockFetchSuccess(MOCK_SUMMARY);
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Hackathon Stats")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Teams Formed")).toBeInTheDocument();
+    expect(screen.getByText("Projects Submitted")).toBeInTheDocument();
+    expect(screen.getByText("Teams as % of Members")).toBeInTheDocument();
+  });
+
+  it("renders chart titles", async () => {
+    mockFetchSuccess(MOCK_SUMMARY);
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Member Growth (Last 12 Months)")
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Top Events by Registrations")).toBeInTheDocument();
+    expect(screen.getByText("Top Skills in Community")).toBeInTheDocument();
+    expect(
+      screen.getByText("Community Feed Activity (Last 8 Weeks)")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Showcase Submissions Over Time")
+    ).toBeInTheDocument();
+  });
+
+  it("renders generatedAt timestamp", async () => {
+    mockFetchSuccess(MOCK_SUMMARY);
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Data cached hourly/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty chart messages when data arrays are empty", async () => {
+    const emptyData: AnalyticsSummary = {
+      ...MOCK_SUMMARY,
+      memberGrowth: [],
+      eventAttendance: [],
+      skillDistribution: [],
+      communityActivity: [],
+      showcaseOverTime: [],
+    };
+    mockFetchSuccess(emptyData);
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No member growth data available yet.")
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("No event registration data available yet.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No skill data yet. Skills are sourced from pair programming profiles."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No community feed activity data available yet.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No showcase submissions yet.")
+    ).toBeInTheDocument();
+  });
+
+  it("calls fetch with the correct API endpoint", async () => {
+    mockFetchSuccess(MOCK_SUMMARY);
+
+    render(<AnalyticsDashboard />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/analytics/summary",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+  });
+});

--- a/__tests__/components/AppShell.test.tsx
+++ b/__tests__/components/AppShell.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                              */
+/* ------------------------------------------------------------------ */
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a {...props}>{children}</a>,
+}));
+
+const mockPathname = jest.fn(() => "/");
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => mockPathname(),
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: null, auth: null }));
+jest.mock("firebase/auth", () => ({
+  getAuth: jest.fn(),
+  onAuthStateChanged: jest.fn(),
+}));
+jest.mock("firebase/firestore", () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  onSnapshot: jest.fn(),
+}));
+
+const mockUseAuth = jest.fn(() => ({ user: null, loading: false }));
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/components/Avatar", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="avatar" data-name={props.name} />
+  ),
+}));
+
+jest.mock("@/components/Footer", () => ({
+  __esModule: true,
+  default: () => <footer data-testid="footer" />,
+}));
+
+jest.mock("@/components/ThemeToggle", () => ({
+  ThemeToggle: () => <button data-testid="theme-toggle" />,
+}));
+
+import AppShell from "@/components/AppShell";
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  mockPathname.mockReturnValue("/");
+  mockUseAuth.mockReturnValue({ user: null, loading: false });
+  Storage.prototype.getItem = jest.fn(() => null);
+  Storage.prototype.setItem = jest.fn();
+});
+
+describe("AppShell", () => {
+  it("renders without crashing", () => {
+    render(<AppShell>Hello</AppShell>);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("renders the site navigation sidebar", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByLabelText("Site navigation")).toBeInTheDocument();
+  });
+
+  it("renders all nav group headers when sidebar is expanded", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByText("Community")).toBeInTheDocument();
+    expect(screen.getByText("Participate")).toBeInTheDocument();
+    expect(screen.getByText("Resources")).toBeInTheDocument();
+  });
+
+  it("renders expected navigation links", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByText("Events")).toBeInTheDocument();
+    expect(screen.getByText("Talks")).toBeInTheDocument();
+    expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getByText("Hackathons")).toBeInTheDocument();
+    expect(screen.getByText("Showcase")).toBeInTheDocument();
+    expect(screen.getByText("Analytics")).toBeInTheDocument();
+    expect(screen.getByText("About")).toBeInTheDocument();
+  });
+
+  it("renders the Cursor Boston home link", () => {
+    render(<AppShell>Content</AppShell>);
+    const homeLinks = screen.getAllByTitle("Cursor Boston home");
+    expect(homeLinks.length).toBeGreaterThan(0);
+  });
+
+  it("renders Sign In and Get Started when user is null", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByText("Sign In")).toBeInTheDocument();
+    expect(screen.getByText("Get Started")).toBeInTheDocument();
+  });
+
+  it("renders avatar when user is authenticated", () => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        photoURL: "https://example.com/photo.jpg",
+        displayName: "Test User",
+        email: "test@example.com",
+      },
+      loading: false,
+    });
+
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByTestId("avatar")).toBeInTheDocument();
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+  });
+
+  it("shows loading skeleton when auth is loading", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    render(<AppShell>Content</AppShell>);
+    // Loading state shows a pulsing div, no Sign In or avatar
+    expect(screen.queryByText("Sign In")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("avatar")).not.toBeInTheDocument();
+  });
+
+  it("renders the mobile header with open menu button", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByLabelText("Open menu")).toBeInTheDocument();
+  });
+
+  it("renders the footer", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+  });
+
+  it("renders the theme toggle", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
+  });
+
+  it("renders children inside main content area", () => {
+    render(
+      <AppShell>
+        <div data-testid="child">Child content</div>
+      </AppShell>
+    );
+    const main = screen.getByRole("main");
+    expect(main).toContainElement(screen.getByTestId("child"));
+  });
+
+  it("renders the collapse sidebar button", () => {
+    render(<AppShell>Content</AppShell>);
+    expect(screen.getByLabelText("Collapse navigation")).toBeInTheDocument();
+  });
+
+  it("toggles nav group sections on click", async () => {
+    const user = userEvent.setup();
+    render(<AppShell>Content</AppShell>);
+
+    // Community section should be open by default (multi-item group)
+    expect(screen.getByText("Events")).toBeInTheDocument();
+
+    // Click the Community group header to collapse it
+    const communityBtn = screen.getByText("Community");
+    await user.click(communityBtn);
+
+    // Events should no longer be visible
+    expect(screen.queryByText("Events")).not.toBeInTheDocument();
+
+    // Click again to expand
+    await user.click(communityBtn);
+    expect(screen.getByText("Events")).toBeInTheDocument();
+  });
+
+  it("highlights the active nav link based on pathname", () => {
+    mockPathname.mockReturnValue("/events");
+    render(<AppShell>Content</AppShell>);
+
+    const eventsLink = screen.getByText("Events").closest("a");
+    expect(eventsLink?.className).toContain("emerald");
+  });
+
+  it("reads collapsed state from localStorage", () => {
+    Storage.prototype.getItem = jest.fn(() => "1");
+    render(<AppShell>Content</AppShell>);
+
+    // When collapsed, the "Cursor Boston" text should not be visible
+    // and the expand navigation button should exist
+    expect(screen.getByLabelText("Expand navigation")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 16 tests for `AppShell` covering nav rendering, tab group toggle, auth states (loading/signed-out/signed-in), sidebar collapse via localStorage, active link highlighting, mobile header, and footer/theme-toggle presence
- Add 9 tests for `AnalyticsDashboard` covering loading skeleton, fetch error state, stat cards, platform health cards, hackathon stats, chart titles, empty data fallback messages, generatedAt timestamp, and API endpoint verification
- All 25 tests pass against jsdom with mocked Next.js, Firebase, and recharts dependencies

Partial progress on #232