### PR TITLE
test(profile): add component tests for profile page

### DIFF
--- a/__tests__/app/profile/ActivitySection.test.tsx
+++ b/__tests__/app/profile/ActivitySection.test.tsx
@@ -1,0 +1,132 @@
+ 
+
+import { render, screen } from "@testing-library/react";
+import { ActivitySection } from "@/app/(auth)/profile/_components/ActivitySection";
+import type { ProfileContextValue } from "@/app/(auth)/profile/_contexts/ProfileContext";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+let mockContextValue: Partial<ProfileContextValue>;
+
+jest.mock("@/app/(auth)/profile/_contexts/ProfileContext", () => ({
+  useProfileContext: () => mockContextValue,
+}));
+
+const makeRegistration = (id: string, title: string, status: string, date?: string) => ({
+  id,
+  eventId: `event-${id}`,
+  eventTitle: title,
+  eventDate: date,
+  userId: "u1",
+  userEmail: "u@e.com",
+  registeredAt: { toDate: () => new Date("2026-01-01") },
+  source: "manual" as const,
+  status: status as "registered" | "attended" | "cancelled",
+});
+
+const makeTalk = (id: string, title: string, status: string) => ({
+  id,
+  title,
+  status,
+  submittedAt: { toDate: () => new Date("2026-02-01") },
+});
+
+describe("ActivitySection", () => {
+  beforeEach(() => {
+    mockContextValue = {
+      data: {
+        registrations: [],
+        talkSubmissions: [],
+        loadingData: false,
+      } as unknown as ProfileContextValue["data"],
+    };
+  });
+
+  it("shows loading spinner when data is loading", () => {
+    mockContextValue = {
+      data: { registrations: [], talkSubmissions: [], loadingData: true } as unknown as ProfileContextValue["data"],
+    };
+    render(<ActivitySection />);
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    // Spinner has animate-spin class
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("shows empty state with links when no activity", () => {
+    render(<ActivitySection />);
+    expect(screen.getByText("No activity yet")).toBeInTheDocument();
+    expect(screen.getByText("Browse Events")).toBeInTheDocument();
+    expect(screen.getByText("Submit a Talk")).toBeInTheDocument();
+  });
+
+  it("renders event registrations", () => {
+    mockContextValue = {
+      data: {
+        registrations: [makeRegistration("1", "React Meetup", "attended", "2026-03-15")],
+        talkSubmissions: [],
+        loadingData: false,
+      } as unknown as ProfileContextValue["data"],
+    };
+    render(<ActivitySection />);
+    expect(screen.getByText("React Meetup")).toBeInTheDocument();
+    expect(screen.getByText("2026-03-15")).toBeInTheDocument();
+    expect(screen.getByText("attended")).toBeInTheDocument();
+  });
+
+  it("renders talk submissions", () => {
+    mockContextValue = {
+      data: {
+        registrations: [],
+        talkSubmissions: [makeTalk("t1", "My Talk", "approved")],
+        loadingData: false,
+      } as unknown as ProfileContextValue["data"],
+    };
+    render(<ActivitySection />);
+    expect(screen.getByText("My Talk")).toBeInTheDocument();
+    expect(screen.getByText("approved")).toBeInTheDocument();
+  });
+
+  it("shows overflow message when more than 5 events", () => {
+    const regs = Array.from({ length: 7 }, (_, i) =>
+      makeRegistration(`r${i}`, `Event ${i}`, "registered")
+    );
+    mockContextValue = {
+      data: {
+        registrations: regs,
+        talkSubmissions: [],
+        loadingData: false,
+      } as unknown as ProfileContextValue["data"],
+    };
+    render(<ActivitySection />);
+    expect(screen.getByText("+2 more events")).toBeInTheDocument();
+  });
+
+  it("applies correct status colors", () => {
+    mockContextValue = {
+      data: {
+        registrations: [
+          makeRegistration("1", "Attended Event", "attended"),
+          makeRegistration("2", "Cancelled Event", "cancelled"),
+          makeRegistration("3", "Registered Event", "registered"),
+        ],
+        talkSubmissions: [],
+        loadingData: false,
+      } as unknown as ProfileContextValue["data"],
+    };
+    render(<ActivitySection />);
+    const attended = screen.getByText("attended");
+    expect(attended.className).toContain("text-emerald-400");
+    const cancelled = screen.getByText("cancelled");
+    expect(cancelled.className).toContain("text-red-400");
+    const registered = screen.getByText("registered");
+    expect(registered.className).toContain("text-blue-400");
+  });
+});

--- a/__tests__/app/profile/EarnedBadgesSection.test.tsx
+++ b/__tests__/app/profile/EarnedBadgesSection.test.tsx
@@ -1,0 +1,138 @@
+ 
+
+import { render, screen } from "@testing-library/react";
+import { EarnedBadgesSection } from "@/app/(auth)/profile/_components/EarnedBadgesSection";
+import type { ProfileContextValue } from "@/app/(auth)/profile/_contexts/ProfileContext";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+jest.mock("@/components/badges/BadgeGrid", () => ({
+  BadgeGrid: ({ definitions }: { definitions: unknown[] }) => (
+    <div data-testid="badge-grid">
+      {definitions.length} badge(s)
+    </div>
+  ),
+}));
+
+let mockContextValue: Partial<ProfileContextValue>;
+
+jest.mock("@/app/(auth)/profile/_contexts/ProfileContext", () => ({
+  useProfileContext: () => mockContextValue,
+}));
+
+const baseBadges = {
+  eligibilityMap: {},
+  userBadgeMap: {},
+  earnedIds: [] as string[],
+  earnedDefinitions: [] as unknown[],
+  loading: false,
+  dataStatus: { state: "complete" as const, isAuthoritative: true, failedSources: [], message: null },
+  persistenceStatus: { state: "complete" as const, message: null },
+  usingFallback: false,
+};
+
+describe("EarnedBadgesSection", () => {
+  beforeEach(() => {
+    mockContextValue = { badges: { ...baseBadges } as unknown as ProfileContextValue["badges"] };
+  });
+
+  it("renders section title and link", () => {
+    render(<EarnedBadgesSection />);
+    expect(screen.getByText("Earned Badges")).toBeInTheDocument();
+    const link = screen.getByText("View all badges");
+    expect(link.closest("a")).toHaveAttribute("href", "/badges");
+  });
+
+  it("shows empty state when no badges earned", () => {
+    render(<EarnedBadgesSection />);
+    expect(screen.getByText(/No badges earned yet/)).toBeInTheDocument();
+  });
+
+  it("shows loading indicator", () => {
+    mockContextValue = {
+      badges: { ...baseBadges, loading: true } as unknown as ProfileContextValue["badges"],
+    };
+    render(<EarnedBadgesSection />);
+    expect(screen.getByText("Updating...")).toBeInTheDocument();
+  });
+
+  it("renders BadgeGrid when badges are earned", () => {
+    mockContextValue = {
+      badges: {
+        ...baseBadges,
+        earnedDefinitions: [{ id: "b1", name: "First Badge" }],
+        earnedIds: ["b1"],
+      } as unknown as ProfileContextValue["badges"],
+    };
+    render(<EarnedBadgesSection />);
+    expect(screen.getByTestId("badge-grid")).toBeInTheDocument();
+    expect(screen.getByText("1 badge(s)")).toBeInTheDocument();
+  });
+
+  it("shows warning when data status is not complete", () => {
+    mockContextValue = {
+      badges: {
+        ...baseBadges,
+        dataStatus: {
+          state: "partial",
+          isAuthoritative: false,
+          failedSources: [],
+          message: "Some data unavailable",
+        },
+      } as unknown as ProfileContextValue["badges"],
+    };
+    render(<EarnedBadgesSection />);
+    expect(screen.getByText("Some data unavailable")).toBeInTheDocument();
+  });
+
+  it("shows error when persistence status failed", () => {
+    mockContextValue = {
+      badges: {
+        ...baseBadges,
+        persistenceStatus: {
+          state: "failed",
+          message: "Save failed",
+        },
+      } as unknown as ProfileContextValue["badges"],
+    };
+    render(<EarnedBadgesSection />);
+    expect(screen.getByText("Save failed")).toBeInTheDocument();
+  });
+
+  it("shows fallback notice when using fallback data", () => {
+    mockContextValue = {
+      badges: {
+        ...baseBadges,
+        usingFallback: true,
+      } as unknown as ProfileContextValue["badges"],
+    };
+    render(<EarnedBadgesSection />);
+    expect(screen.getByText(/fallback data/)).toBeInTheDocument();
+  });
+
+  it("shows failed sources in dev mode", () => {
+    const originalEnv = process.env.NODE_ENV;
+    Object.defineProperty(process.env, "NODE_ENV", { value: "development", writable: true });
+    mockContextValue = {
+      badges: {
+        ...baseBadges,
+        dataStatus: {
+          state: "partial",
+          isAuthoritative: false,
+          failedSources: ["github", "discord"],
+          message: "Partial data",
+        },
+      } as unknown as ProfileContextValue["badges"],
+    };
+    render(<EarnedBadgesSection />);
+    expect(screen.getByText(/github, discord/)).toBeInTheDocument();
+    Object.defineProperty(process.env, "NODE_ENV", { value: originalEnv, writable: true });
+  });
+});

--- a/__tests__/app/profile/EditProfileModal.test.tsx
+++ b/__tests__/app/profile/EditProfileModal.test.tsx
@@ -1,0 +1,116 @@
+/* eslint-disable @next/next/no-img-element */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EditProfileModal } from "@/app/(auth)/profile/_components/EditProfileModal";
+import type { User } from "firebase/auth";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    return <img alt="" data-fill={fill ? "true" : undefined} {...rest} />;
+  },
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+jest.mock("@/components/Avatar", () => ({
+  __esModule: true,
+  default: ({ name }: { name?: string | null }) => (
+    <div data-testid="avatar">{name}</div>
+  ),
+}));
+
+jest.mock("@/components/ui/FormField", () => ({
+  FormInput: (props: Record<string, unknown>) => (
+    <input
+      id={props.id as string}
+      value={props.value as string}
+      onChange={props.onChange as React.ChangeEventHandler<HTMLInputElement>}
+      placeholder={props.placeholder as string}
+      aria-label={props.label as string}
+    />
+  ),
+}));
+
+const mockUser = {
+  displayName: "Test User",
+  photoURL: "https://example.com/photo.jpg",
+  email: "test@example.com",
+} as unknown as User;
+
+describe("EditProfileModal", () => {
+  const onSave = jest.fn().mockResolvedValue(undefined);
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the modal with title and buttons", () => {
+    render(<EditProfileModal user={mockUser} onSave={onSave} onClose={onClose} />);
+    expect(screen.getByText("Edit Profile")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+    expect(screen.getByText("Save Changes")).toBeInTheDocument();
+    expect(screen.getByText("Choose Photo")).toBeInTheDocument();
+  });
+
+  it("pre-fills the name input with user displayName", () => {
+    render(<EditProfileModal user={mockUser} onSave={onSave} onClose={onClose} />);
+    const input = screen.getByDisplayValue("Test User");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(<EditProfileModal user={mockUser} onSave={onSave} onClose={onClose} />);
+    await user.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when close button (aria-label Close) is clicked", async () => {
+    const user = userEvent.setup();
+    render(<EditProfileModal user={mockUser} onSave={onSave} onClose={onClose} />);
+    await user.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onSave with trimmed name when Save is clicked", async () => {
+    const user = userEvent.setup();
+    render(<EditProfileModal user={mockUser} onSave={onSave} onClose={onClose} />);
+    await user.click(screen.getByText("Save Changes"));
+    expect(onSave).toHaveBeenCalledWith("Test User", undefined);
+  });
+
+  it("shows saving state while save is in progress", async () => {
+    let resolveSave: () => void;
+    const slowSave = jest.fn(
+      () => new Promise<void>((r) => { resolveSave = r; })
+    );
+    const user = userEvent.setup();
+    render(<EditProfileModal user={mockUser} onSave={slowSave} onClose={onClose} />);
+    await user.click(screen.getByText("Save Changes"));
+    expect(screen.getByText("Saving...")).toBeInTheDocument();
+    resolveSave!();
+  });
+
+  it("shows error message when save fails", async () => {
+    const failSave = jest.fn().mockRejectedValue(new Error("Network error"));
+    const user = userEvent.setup();
+    render(<EditProfileModal user={mockUser} onSave={failSave} onClose={onClose} />);
+    await user.click(screen.getByText("Save Changes"));
+    expect(await screen.findByText("Network error")).toBeInTheDocument();
+  });
+
+  it("has role=dialog and aria-modal", () => {
+    render(<EditProfileModal user={mockUser} onSave={onSave} onClose={onClose} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("renders avatar when no photo is selected", () => {
+    render(<EditProfileModal user={mockUser} onSave={onSave} onClose={onClose} />);
+    expect(screen.getByTestId("avatar")).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/profile/EventsTab.test.tsx
+++ b/__tests__/app/profile/EventsTab.test.tsx
@@ -1,0 +1,88 @@
+ 
+
+import { render, screen } from "@testing-library/react";
+import { EventsTab } from "@/app/(auth)/profile/_components/EventsTab";
+import type { EventRegistration } from "@/lib/registrations";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+const makeRegistration = (
+  id: string,
+  title: string,
+  status: "registered" | "attended" | "cancelled",
+  date?: string
+): EventRegistration => ({
+  id,
+  eventId: `event-${id}`,
+  eventTitle: title,
+  eventDate: date,
+  userId: "u1",
+  userEmail: "u@e.com",
+  registeredAt: { toDate: () => new Date("2026-01-01") } as unknown as EventRegistration["registeredAt"],
+  source: "manual",
+  status,
+});
+
+describe("EventsTab", () => {
+  it("renders section title and Browse Events link", () => {
+    render(<EventsTab registrations={[]} loadingData={false} />);
+    expect(screen.getByText("My Event Registrations")).toBeInTheDocument();
+    expect(screen.getAllByText("Browse Events").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows loading spinner when loading", () => {
+    render(<EventsTab registrations={[]} loadingData={true} />);
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("shows empty state when no registrations", () => {
+    render(<EventsTab registrations={[]} loadingData={false} />);
+    expect(screen.getByText(/haven.*registered for any events yet/)).toBeInTheDocument();
+  });
+
+  it("renders event registrations with details", () => {
+    const regs = [makeRegistration("1", "AI Workshop", "attended", "2026-04-10")];
+    render(<EventsTab registrations={regs} loadingData={false} />);
+    expect(screen.getByText("AI Workshop")).toBeInTheDocument();
+    expect(screen.getByText("2026-04-10")).toBeInTheDocument();
+    expect(screen.getByText("Attended")).toBeInTheDocument();
+  });
+
+  it("shows Date TBD when no event date", () => {
+    const regs = [makeRegistration("1", "Mystery Event", "registered")];
+    render(<EventsTab registrations={regs} loadingData={false} />);
+    expect(screen.getByText("Date TBD")).toBeInTheDocument();
+  });
+
+  it("displays correct status labels", () => {
+    const regs = [
+      makeRegistration("1", "Event A", "attended"),
+      makeRegistration("2", "Event B", "cancelled"),
+      makeRegistration("3", "Event C", "registered"),
+    ];
+    render(<EventsTab registrations={regs} loadingData={false} />);
+    expect(screen.getByText("Attended")).toBeInTheDocument();
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.getByText("Registered")).toBeInTheDocument();
+  });
+
+  it("applies correct color classes per status", () => {
+    const regs = [
+      makeRegistration("1", "Event A", "attended"),
+      makeRegistration("2", "Event B", "cancelled"),
+      makeRegistration("3", "Event C", "registered"),
+    ];
+    render(<EventsTab registrations={regs} loadingData={false} />);
+    expect(screen.getByText("Attended").className).toContain("text-emerald-400");
+    expect(screen.getByText("Cancelled").className).toContain("text-red-400");
+    expect(screen.getByText("Registered").className).toContain("text-blue-400");
+  });
+});

--- a/__tests__/app/profile/OnboardingChecklist.test.tsx
+++ b/__tests__/app/profile/OnboardingChecklist.test.tsx
@@ -1,0 +1,125 @@
+ 
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OnboardingChecklist } from "@/app/(auth)/profile/_components/OnboardingChecklist";
+import type { ProfileContextValue } from "@/app/(auth)/profile/_contexts/ProfileContext";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+const makeContext = (overrides: Partial<ProfileContextValue> = {}): ProfileContextValue => ({
+  user: { photoURL: null, displayName: "Test" } as ProfileContextValue["user"],
+  userProfile: { bio: "" } as ProfileContextValue["userProfile"],
+  refreshUserProfile: jest.fn(),
+  data: {
+    stats: { pullRequestsCount: 0 },
+    registrations: [],
+    talkSubmissions: [],
+    loadingData: false,
+    connectedAgents: [],
+    loadingAgents: false,
+  } as unknown as ProfileContextValue["data"],
+  badges: {} as ProfileContextValue["badges"],
+  discord: { discordInfo: null, connect: jest.fn() } as unknown as ProfileContextValue["discord"],
+  github: { githubInfo: null, connect: jest.fn() } as unknown as ProfileContextValue["github"],
+  google: {} as ProfileContextValue["google"],
+  mfa: {} as ProfileContextValue["mfa"],
+  email: {} as ProfileContextValue["email"],
+  profileSettings: {
+    settings: { visibility: { isPublic: false } },
+    togglePublic: jest.fn(),
+  } as unknown as ProfileContextValue["profileSettings"],
+  password: {} as ProfileContextValue["password"],
+  signOut: jest.fn(),
+  signOutError: null,
+  isSigningOut: false,
+  handleSignOut: jest.fn(),
+  ...overrides,
+});
+
+let mockContextValue: ProfileContextValue;
+
+jest.mock("@/app/(auth)/profile/_contexts/ProfileContext", () => ({
+  useProfileContext: () => mockContextValue,
+}));
+
+describe("OnboardingChecklist", () => {
+  beforeEach(() => {
+    mockContextValue = makeContext();
+  });
+
+  it("renders checklist with progress", () => {
+    render(<OnboardingChecklist />);
+    expect(screen.getByText("Get Started")).toBeInTheDocument();
+    // "Create your account" is always done
+    expect(screen.getByText("Create your account")).toBeInTheDocument();
+    expect(screen.getByText(/complete/)).toBeInTheDocument();
+  });
+
+  it("shows completed count correctly", () => {
+    render(<OnboardingChecklist />);
+    // Only "Create your account" is done by default
+    expect(screen.getByText("1/7 complete")).toBeInTheDocument();
+  });
+
+  it("returns null when all items are done", () => {
+    mockContextValue = makeContext({
+      user: { photoURL: "https://img.com/photo.jpg", displayName: "Test" } as ProfileContextValue["user"],
+      userProfile: { bio: "I build things" } as ProfileContextValue["userProfile"],
+      data: {
+        stats: { pullRequestsCount: 3 },
+        registrations: [],
+        talkSubmissions: [],
+        loadingData: false,
+        connectedAgents: [],
+        loadingAgents: false,
+      } as unknown as ProfileContextValue["data"],
+      discord: { discordInfo: { username: "user#1234" }, connect: jest.fn() } as unknown as ProfileContextValue["discord"],
+      github: { githubInfo: { login: "testuser" }, connect: jest.fn() } as unknown as ProfileContextValue["github"],
+      profileSettings: {
+        settings: { visibility: { isPublic: true } },
+        togglePublic: jest.fn(),
+      } as unknown as ProfileContextValue["profileSettings"],
+    });
+    const { container } = render(<OnboardingChecklist />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders connect buttons for incomplete social items", () => {
+    render(<OnboardingChecklist />);
+    expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Connect Discord")).toBeInTheDocument();
+  });
+
+  it("calls github.connect when Connect GitHub is clicked", async () => {
+    const user = userEvent.setup();
+    render(<OnboardingChecklist />);
+    // Find the button wrapping "Connect GitHub"
+    const ghButton = screen.getByText("Connect GitHub").closest("button");
+    expect(ghButton).toBeInTheDocument();
+    await user.click(ghButton!);
+    expect(mockContextValue.github.connect).toHaveBeenCalled();
+  });
+
+  it("shows connected status for GitHub when linked", () => {
+    mockContextValue = makeContext({
+      github: { githubInfo: { login: "octocat" }, connect: jest.fn() } as unknown as ProfileContextValue["github"],
+    });
+    render(<OnboardingChecklist />);
+    expect(screen.getByText("Connected as octocat")).toBeInTheDocument();
+  });
+
+  it("renders external link for Submit a pull request", () => {
+    render(<OnboardingChecklist />);
+    expect(screen.getByText("Submit a pull request")).toBeInTheDocument();
+    const link = screen.getByText("Submit a pull request").closest("a");
+    expect(link).toHaveAttribute("href", "https://github.com/rogerSuperBuilderAlpha/cursor-boston");
+  });
+});

--- a/__tests__/app/profile/OverviewTab.test.tsx
+++ b/__tests__/app/profile/OverviewTab.test.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable @next/next/no-img-element */
+
+import { render, screen } from "@testing-library/react";
+import { OverviewTab } from "@/app/(auth)/profile/_components/OverviewTab";
+import type { EventRegistration } from "@/lib/registrations";
+import type { TalkSubmission, ConnectedAgent } from "@/app/(auth)/profile/_types";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    return <img alt="" data-fill={fill ? "true" : undefined} {...rest} />;
+  },
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+const makeRegistration = (id: string, title: string): EventRegistration => ({
+  id,
+  eventId: `event-${id}`,
+  eventTitle: title,
+  eventDate: "2026-04-10",
+  userId: "u1",
+  userEmail: "u@e.com",
+  registeredAt: { toDate: () => new Date("2026-01-01") } as unknown as EventRegistration["registeredAt"],
+  source: "manual",
+  status: "registered",
+});
+
+const makeTalk = (id: string, title: string): TalkSubmission => ({
+  id,
+  title,
+  status: "pending",
+  submittedAt: { toDate: () => new Date("2026-02-01") },
+});
+
+const makeAgent = (id: string, name: string, opts?: Partial<ConnectedAgent>): ConnectedAgent => ({
+  id,
+  name,
+  ...opts,
+});
+
+const defaultProps = {
+  registrations: [] as EventRegistration[],
+  talkSubmissions: [] as TalkSubmission[],
+  connectedAgents: [] as ConnectedAgent[],
+  loadingData: false,
+  loadingAgents: false,
+};
+
+describe("OverviewTab", () => {
+  it("renders quick action links", () => {
+    render(<OverviewTab {...defaultProps} />);
+    expect(screen.getByText("Browse Events")).toBeInTheDocument();
+    expect(screen.getByText("Submit a Talk")).toBeInTheDocument();
+    expect(screen.getByText("Join Discord")).toBeInTheDocument();
+    expect(screen.getByText("Request an Event")).toBeInTheDocument();
+  });
+
+  it("shows empty activity state when no data", () => {
+    render(<OverviewTab {...defaultProps} />);
+    expect(screen.getByText("No activity yet")).toBeInTheDocument();
+    expect(screen.getByText(/Browse upcoming events/)).toBeInTheDocument();
+  });
+
+  it("shows loading spinner for recent activity", () => {
+    render(<OverviewTab {...defaultProps} loadingData={true} />);
+    const spinners = document.querySelectorAll(".animate-spin");
+    expect(spinners.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders recent registrations", () => {
+    const regs = [makeRegistration("1", "AI Workshop")];
+    render(<OverviewTab {...defaultProps} registrations={regs} />);
+    expect(screen.getByText("Registered for AI Workshop")).toBeInTheDocument();
+  });
+
+  it("renders recent talk submissions", () => {
+    const talks = [makeTalk("t1", "My Talk")];
+    render(<OverviewTab {...defaultProps} talkSubmissions={talks} />);
+    expect(screen.getByText("Submitted talk: My Talk")).toBeInTheDocument();
+    expect(screen.getByText("Status: pending")).toBeInTheDocument();
+  });
+
+  it("does not render AI Agents section when no agents", () => {
+    render(<OverviewTab {...defaultProps} />);
+    expect(screen.queryByText("Your AI Agents")).not.toBeInTheDocument();
+  });
+
+  it("renders AI Agents section with connected agents", () => {
+    const agents = [makeAgent("a1", "CodeBot", { description: "Helps with code" })];
+    render(<OverviewTab {...defaultProps} connectedAgents={agents} />);
+    expect(screen.getByText("Your AI Agents")).toBeInTheDocument();
+    expect(screen.getByText("CodeBot")).toBeInTheDocument();
+    expect(screen.getByText("Helps with code")).toBeInTheDocument();
+    expect(screen.getByText("1 connected")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("renders agent avatar when avatarUrl is provided", () => {
+    const agents = [makeAgent("a1", "AvatarBot", { avatarUrl: "https://img.com/bot.png" })];
+    render(<OverviewTab {...defaultProps} connectedAgents={agents} />);
+    const img = screen.getByAltText("AvatarBot");
+    expect(img).toHaveAttribute("src", "https://img.com/bot.png");
+  });
+
+  it("shows loading spinner for agents section", () => {
+    render(<OverviewTab {...defaultProps} connectedAgents={[makeAgent("a1", "Bot")]} loadingAgents={true} />);
+    expect(screen.getByText("Your AI Agents")).toBeInTheDocument();
+    const spinners = document.querySelectorAll(".animate-spin");
+    expect(spinners.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("limits recent activity to 3 items each", () => {
+    const regs = Array.from({ length: 5 }, (_, i) => makeRegistration(`r${i}`, `Event ${i}`));
+    const talks = Array.from({ length: 5 }, (_, i) => makeTalk(`t${i}`, `Talk ${i}`));
+    render(<OverviewTab {...defaultProps} registrations={regs} talkSubmissions={talks} />);
+    // Only 3 of each should render
+    const regItems = screen.getAllByText(/^Registered for Event/);
+    expect(regItems).toHaveLength(3);
+    const talkItems = screen.getAllByText(/^Submitted talk: Talk/);
+    expect(talkItems).toHaveLength(3);
+  });
+});

--- a/__tests__/app/profile/TalksTab.test.tsx
+++ b/__tests__/app/profile/TalksTab.test.tsx
@@ -1,0 +1,84 @@
+ 
+
+import { render, screen } from "@testing-library/react";
+import { TalksTab } from "@/app/(auth)/profile/_components/TalksTab";
+import type { TalkSubmission } from "@/app/(auth)/profile/_types";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+jest.mock("firebase/auth", () => ({ getAuth: jest.fn() }));
+
+const makeTalk = (
+  id: string,
+  title: string,
+  status: string,
+  date?: Date
+): TalkSubmission => ({
+  id,
+  title,
+  status,
+  submittedAt: date ? { toDate: () => date } : null,
+});
+
+describe("TalksTab", () => {
+  it("renders section title and Submit a Talk link", () => {
+    render(<TalksTab talkSubmissions={[]} loadingData={false} />);
+    expect(screen.getByText("My Talk Submissions")).toBeInTheDocument();
+    expect(screen.getAllByText("Submit a Talk").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows loading spinner when loading", () => {
+    render(<TalksTab talkSubmissions={[]} loadingData={true} />);
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("shows empty state when no talks submitted", () => {
+    render(<TalksTab talkSubmissions={[]} loadingData={false} />);
+    expect(screen.getByText(/haven.*submitted any talks yet/)).toBeInTheDocument();
+  });
+
+  it("renders talk submissions with details", () => {
+    const talks = [makeTalk("1", "Building AI Apps", "approved", new Date("2026-03-15"))];
+    render(<TalksTab talkSubmissions={talks} loadingData={false} />);
+    expect(screen.getByText("Building AI Apps")).toBeInTheDocument();
+    expect(screen.getByText("approved")).toBeInTheDocument();
+  });
+
+  it("shows 'Recently submitted' when no submittedAt", () => {
+    const talks = [makeTalk("1", "No Date Talk", "pending")];
+    render(<TalksTab talkSubmissions={talks} loadingData={false} />);
+    expect(screen.getByText("Recently submitted")).toBeInTheDocument();
+  });
+
+  it("displays correct status colors", () => {
+    const talks = [
+      makeTalk("1", "Talk A", "approved"),
+      makeTalk("2", "Talk B", "rejected"),
+      makeTalk("3", "Talk C", "completed"),
+      makeTalk("4", "Talk D", "pending"),
+    ];
+    render(<TalksTab talkSubmissions={talks} loadingData={false} />);
+    expect(screen.getByText("approved").className).toContain("text-emerald-400");
+    expect(screen.getByText("rejected").className).toContain("text-red-400");
+    expect(screen.getByText("completed").className).toContain("text-purple-400");
+    expect(screen.getByText("pending").className).toContain("text-yellow-400");
+  });
+
+  it("renders multiple submissions", () => {
+    const talks = [
+      makeTalk("1", "Talk One", "approved"),
+      makeTalk("2", "Talk Two", "pending"),
+      makeTalk("3", "Talk Three", "rejected"),
+    ];
+    render(<TalksTab talkSubmissions={talks} loadingData={false} />);
+    expect(screen.getByText("Talk One")).toBeInTheDocument();
+    expect(screen.getByText("Talk Two")).toBeInTheDocument();
+    expect(screen.getByText("Talk Three")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add React component tests for 7 profile page components: EditProfileModal, OnboardingChecklist, ActivitySection, EarnedBadgesSection, EventsTab, OverviewTab, TalksTab
- Tests cover rendering, conditional states (loading/empty/data), user interactions (clicks, save/cancel), status-based styling, and accessibility attributes
- 54 total test cases all passing

Partial progress on #232