### PR TITLE
test: add component tests for badges and UI components

### DIFF
--- a/__tests__/components/badges/BadgeCard.test.tsx
+++ b/__tests__/components/badges/BadgeCard.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BadgeCard } from "@/components/badges/BadgeCard";
+import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
+
+const baseDef: BadgeDefinition = {
+  id: "first-steps",
+  name: "First Steps",
+  description: "Complete your profile setup",
+  category: "onboarding",
+  howToEarn: "Fill out all profile fields",
+  sortOrder: 1,
+  iconKey: "sparkles",
+};
+
+describe("BadgeCard", () => {
+  it("renders the badge name and description", () => {
+    render(<BadgeCard definition={baseDef} />);
+    expect(screen.getByText("First Steps")).toBeInTheDocument();
+    expect(screen.getByText("Complete your profile setup")).toBeInTheDocument();
+  });
+
+  it("shows 'Locked' status when not earned", () => {
+    render(<BadgeCard definition={baseDef} earned={false} />);
+    expect(screen.getByText("Locked")).toBeInTheDocument();
+  });
+
+  it("shows 'Earned' status when earned is true", () => {
+    render(<BadgeCard definition={baseDef} earned={true} />);
+    expect(screen.getByText("Earned")).toBeInTheDocument();
+  });
+
+  it("derives earned state from eligibility when earned prop is undefined", () => {
+    const eligibility: BadgeEligibilityResult = {
+      badgeId: "first-steps",
+      isEligible: true,
+    };
+    render(<BadgeCard definition={baseDef} eligibility={eligibility} />);
+    expect(screen.getByText("Earned")).toBeInTheDocument();
+  });
+
+  it("displays the eligibility reason when not earned", () => {
+    const eligibility: BadgeEligibilityResult = {
+      badgeId: "first-steps",
+      isEligible: false,
+      reason: "Need to add a bio",
+    };
+    render(<BadgeCard definition={baseDef} eligibility={eligibility} earned={false} />);
+    expect(screen.getByText("Need to add a bio")).toBeInTheDocument();
+  });
+
+  it("shows progress bar when eligibility has progress", () => {
+    const eligibility: BadgeEligibilityResult = {
+      badgeId: "first-steps",
+      isEligible: false,
+      progress: { current: 3, target: 5, unit: "events" },
+    };
+    render(<BadgeCard definition={baseDef} eligibility={eligibility} earned={false} />);
+    expect(screen.getByText("Progress: 3/5 events")).toBeInTheDocument();
+  });
+
+  it("shows earned date when awardedAt is provided and earned", () => {
+    render(
+      <BadgeCard definition={baseDef} earned={true} awardedAt="2026-01-15T00:00:00Z" />
+    );
+    expect(screen.getByText("Earned Jan 2026")).toBeInTheDocument();
+  });
+
+  it("shows unverified data text when not authoritative and not earned", () => {
+    render(<BadgeCard definition={baseDef} earned={false} isAuthoritative={false} />);
+    expect(screen.getByText("Unverified data")).toBeInTheDocument();
+  });
+
+  it("opens popover on click", () => {
+    render(<BadgeCard definition={baseDef} />);
+    const article = screen.getByRole("button", { name: "First Steps" });
+    fireEvent.click(article);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("has correct aria attributes", () => {
+    render(<BadgeCard definition={baseDef} />);
+    const article = screen.getByRole("button", { name: "First Steps" });
+    expect(article).toHaveAttribute("aria-haspopup", "dialog");
+    expect(article).toHaveAttribute("tabindex", "0");
+  });
+
+  it("applies custom className", () => {
+    render(<BadgeCard definition={baseDef} className="custom-class" />);
+    const article = screen.getByRole("button", { name: "First Steps" });
+    expect(article.className).toContain("custom-class");
+  });
+
+  it("renders the fallback icon when iconKey is undefined", () => {
+    const defNoIcon = { ...baseDef, iconKey: undefined };
+    render(<BadgeCard definition={defNoIcon} />);
+    // Renders without crashing - fallback icon used
+    expect(screen.getByRole("button", { name: "First Steps" })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/badges/BadgeGrid.test.tsx
+++ b/__tests__/components/badges/BadgeGrid.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import type { BadgeDefinition, BadgeEligibilityMap } from "@/lib/badges/types";
+
+const definitions: BadgeDefinition[] = [
+  {
+    id: "first-steps",
+    name: "First Steps",
+    description: "Complete your profile",
+    category: "onboarding",
+    howToEarn: "Fill out profile",
+    sortOrder: 1,
+    iconKey: "sparkles",
+  },
+  {
+    id: "connected",
+    name: "Connected",
+    description: "Link your accounts",
+    category: "onboarding",
+    howToEarn: "Connect Discord and GitHub",
+    sortOrder: 2,
+    iconKey: "link",
+  },
+];
+
+describe("BadgeGrid", () => {
+  it("renders all badge definitions", () => {
+    render(<BadgeGrid definitions={definitions} />);
+    expect(screen.getByText("First Steps")).toBeInTheDocument();
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+  });
+
+  it("renders a section element", () => {
+    const { container } = render(<BadgeGrid definitions={definitions} />);
+    expect(container.querySelector("section")).toBeInTheDocument();
+  });
+
+  it("applies custom className to section", () => {
+    const { container } = render(
+      <BadgeGrid definitions={definitions} className="my-grid" />
+    );
+    expect(container.querySelector("section")?.className).toContain("my-grid");
+  });
+
+  it("renders grid layout by default", () => {
+    const { container } = render(<BadgeGrid definitions={definitions} />);
+    const grid = container.querySelector("section > div");
+    expect(grid?.className).toContain("grid");
+  });
+
+  it("renders horizontal layout when specified", () => {
+    const { container } = render(
+      <BadgeGrid definitions={definitions} layout="horizontal" />
+    );
+    const flex = container.querySelector("section > div");
+    expect(flex?.className).toContain("flex");
+  });
+
+  it("wraps cards in a min-width container for horizontal layout", () => {
+    const { container } = render(
+      <BadgeGrid definitions={definitions} layout="horizontal" />
+    );
+    const wrappers = container.querySelectorAll(".min-w-\\[260px\\]");
+    expect(wrappers.length).toBe(2);
+  });
+
+  it("passes earned state from earnedBadgeIds", () => {
+    render(
+      <BadgeGrid definitions={definitions} earnedBadgeIds={["first-steps"]} />
+    );
+    const earnedLabels = screen.getAllByText("Earned");
+    expect(earnedLabels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("passes eligibility from eligibilityMap", () => {
+    const eligibilityMap = {
+      "first-steps": {
+        badgeId: "first-steps" as const,
+        isEligible: false,
+        reason: "Need bio",
+        progress: { current: 2, target: 5 },
+      },
+    } as BadgeEligibilityMap;
+
+    render(
+      <BadgeGrid definitions={definitions} eligibilityMap={eligibilityMap} />
+    );
+    expect(screen.getByText("Progress: 2/5")).toBeInTheDocument();
+  });
+
+  it("renders empty grid when definitions is empty", () => {
+    const { container } = render(<BadgeGrid definitions={[]} />);
+    const grid = container.querySelector("section > div");
+    expect(grid?.children.length).toBe(0);
+  });
+});

--- a/__tests__/components/badges/BadgePopover.test.tsx
+++ b/__tests__/components/badges/BadgePopover.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BadgePopover } from "@/components/badges/BadgePopover";
+import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
+
+const baseDef: BadgeDefinition = {
+  id: "first-steps",
+  name: "First Steps",
+  description: "Complete your profile setup",
+  category: "onboarding",
+  howToEarn: "Fill out all profile fields",
+  sortOrder: 1,
+};
+
+const onClose = jest.fn();
+
+beforeEach(() => {
+  onClose.mockClear();
+});
+
+describe("BadgePopover", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <BadgePopover definition={baseDef} isOpen={false} onClose={onClose} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the dialog when isOpen is true", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("displays the badge name as heading", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    expect(screen.getByText("First Steps")).toBeInTheDocument();
+  });
+
+  it("displays description and howToEarn", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    expect(screen.getByText("Complete your profile setup")).toBeInTheDocument();
+    expect(screen.getByText("Fill out all profile fields")).toBeInTheDocument();
+  });
+
+  it("shows 'Locked' when not eligible", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    expect(screen.getByText("Locked")).toBeInTheDocument();
+  });
+
+  it("shows 'Earned' when eligible", () => {
+    const eligibility: BadgeEligibilityResult = {
+      badgeId: "first-steps",
+      isEligible: true,
+    };
+    render(
+      <BadgePopover
+        definition={baseDef}
+        eligibility={eligibility}
+        isOpen={true}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByText("Earned")).toBeInTheDocument();
+  });
+
+  it("displays progress bar when eligibility has progress", () => {
+    const eligibility: BadgeEligibilityResult = {
+      badgeId: "first-steps",
+      isEligible: false,
+      progress: { current: 2, target: 10, unit: "posts" },
+    };
+    render(
+      <BadgePopover
+        definition={baseDef}
+        eligibility={eligibility}
+        isOpen={true}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByText("2/10 posts")).toBeInTheDocument();
+  });
+
+  it("displays reason as 'Next step' when not earned", () => {
+    const eligibility: BadgeEligibilityResult = {
+      badgeId: "first-steps",
+      isEligible: false,
+      reason: "Add a bio to your profile",
+    };
+    render(
+      <BadgePopover
+        definition={baseDef}
+        eligibility={eligibility}
+        isOpen={true}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByText("Next step")).toBeInTheDocument();
+    expect(screen.getByText("Add a bio to your profile")).toBeInTheDocument();
+  });
+
+  it("does not show reason when earned", () => {
+    const eligibility: BadgeEligibilityResult = {
+      badgeId: "first-steps",
+      isEligible: true,
+      reason: "Completed",
+    };
+    render(
+      <BadgePopover
+        definition={baseDef}
+        eligibility={eligibility}
+        isOpen={true}
+        onClose={onClose}
+      />
+    );
+    expect(screen.queryByText("Next step")).not.toBeInTheDocument();
+  });
+
+  it("displays showcaseApprovalNote when provided", () => {
+    render(
+      <BadgePopover
+        definition={baseDef}
+        isOpen={true}
+        onClose={onClose}
+        showcaseApprovalNote="Must have approved submission"
+      />
+    );
+    expect(screen.getByText("Must have approved submission")).toBeInTheDocument();
+    expect(screen.getByText("Verification")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Close button is clicked", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    fireEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    const backdrop = screen.getAllByRole("button", { name: "Close" })[0];
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("displays anchorLabel when provided", () => {
+    render(
+      <BadgePopover
+        definition={baseDef}
+        isOpen={true}
+        onClose={onClose}
+        anchorLabel="Custom label"
+      />
+    );
+    expect(screen.getByText("Custom label")).toBeInTheDocument();
+  });
+
+  it("defaults to 'Achievement badge' when no anchorLabel", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    expect(screen.getByText("Achievement badge")).toBeInTheDocument();
+  });
+
+  it("has correct aria attributes on dialog", () => {
+    render(<BadgePopover definition={baseDef} isOpen={true} onClose={onClose} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute(
+      "aria-labelledby",
+      `badge-popover-title-${baseDef.id}`
+    );
+  });
+});

--- a/__tests__/components/ui/Avatar.test.tsx
+++ b/__tests__/components/ui/Avatar.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Avatar from "@/components/Avatar";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, priority, onError, ...rest } = props;
+    return (
+      // eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
+      <img
+        data-fill={fill ? "true" : undefined}
+        onClick={() => {
+          // simulate error for testing fallback
+          if (typeof onError === "function") (onError as () => void)();
+        }}
+        {...rest}
+      />
+    );
+  },
+}));
+
+describe("Avatar", () => {
+  it("renders image when src is provided", () => {
+    render(<Avatar src="/photo.jpg" name="Alice" />);
+    const img = screen.getByAltText("Alice");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "/photo.jpg");
+  });
+
+  it("renders initials when no src", () => {
+    render(<Avatar name="Alice Baker" />);
+    expect(screen.getByText("AB")).toBeInTheDocument();
+  });
+
+  it("renders single initial for single name", () => {
+    render(<Avatar name="Alice" />);
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("falls back to email initial when no name", () => {
+    render(<Avatar email="bob@test.com" />);
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("shows ? when no name and no email", () => {
+    render(<Avatar />);
+    expect(screen.getByText("?")).toBeInTheDocument();
+  });
+
+  it("falls back to initials on image error", () => {
+    render(<Avatar src="/broken.jpg" name="Charlie Delta" />);
+    const img = screen.getByAltText("Charlie Delta");
+    // Simulate the error by clicking (our mock triggers onError on click)
+    fireEvent.click(img);
+    expect(screen.getByText("CD")).toBeInTheDocument();
+  });
+
+  it("applies the correct size class for sm", () => {
+    const { container } = render(<Avatar name="X" size="sm" />);
+    const el = container.firstElementChild;
+    expect(el?.className).toContain("w-8");
+  });
+
+  it("applies the correct size class for lg", () => {
+    const { container } = render(<Avatar name="X" size="lg" />);
+    const el = container.firstElementChild;
+    expect(el?.className).toContain("w-16");
+  });
+
+  it("defaults to xl size", () => {
+    const { container } = render(<Avatar name="X" />);
+    const el = container.firstElementChild;
+    expect(el?.className).toContain("w-24");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<Avatar name="X" className="my-custom" />);
+    const el = container.firstElementChild;
+    expect(el?.className).toContain("my-custom");
+  });
+
+  it("sets aria-label on fallback avatar", () => {
+    render(<Avatar name="Alice" />);
+    expect(screen.getByRole("img", { name: "Alice" })).toBeInTheDocument();
+  });
+
+  it("uses email for aria-label when no name", () => {
+    render(<Avatar email="test@x.com" />);
+    expect(screen.getByRole("img", { name: "test@x.com" })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/ui/FilterCheckbox.test.tsx
+++ b/__tests__/components/ui/FilterCheckbox.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FilterCheckbox } from "@/components/members/FilterCheckbox";
+
+describe("FilterCheckbox", () => {
+  const defaultProps = {
+    checked: false,
+    onChange: jest.fn(),
+    label: "Active",
+    icon: <span data-testid="icon">icon</span>,
+  };
+
+  beforeEach(() => {
+    (defaultProps.onChange as jest.Mock).mockClear();
+  });
+
+  it("renders without crashing", () => {
+    render(<FilterCheckbox {...defaultProps} />);
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("renders the icon", () => {
+    render(<FilterCheckbox {...defaultProps} />);
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("renders a hidden checkbox input", () => {
+    render(<FilterCheckbox {...defaultProps} />);
+    const checkbox = screen.getByRole("checkbox", { hidden: true });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("reflects checked state", () => {
+    render(<FilterCheckbox {...defaultProps} checked={true} />);
+    const checkbox = screen.getByRole("checkbox", { hidden: true });
+    expect(checkbox).toBeChecked();
+  });
+
+  it("calls onChange when clicked", () => {
+    render(<FilterCheckbox {...defaultProps} />);
+    fireEvent.click(screen.getByText("Active"));
+    expect(defaultProps.onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onChange with false when unchecking", () => {
+    render(<FilterCheckbox {...defaultProps} checked={true} />);
+    fireEvent.click(screen.getByText("Active"));
+    expect(defaultProps.onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("applies checked styling", () => {
+    const { container } = render(<FilterCheckbox {...defaultProps} checked={true} />);
+    const label = container.querySelector("label");
+    expect(label?.className).toContain("bg-emerald-500/10");
+  });
+
+  it("applies unchecked styling", () => {
+    const { container } = render(<FilterCheckbox {...defaultProps} checked={false} />);
+    const label = container.querySelector("label");
+    expect(label?.className).toContain("bg-neutral-100");
+  });
+});

--- a/__tests__/components/ui/FormField.test.tsx
+++ b/__tests__/components/ui/FormField.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FormInput, FormTextarea, ToggleSwitch } from "@/components/ui/FormField";
+
+describe("FormInput", () => {
+  it("renders without crashing", () => {
+    render(<FormInput id="test" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("renders with a label", () => {
+    render(<FormInput id="name" label="Name" />);
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+  });
+
+  it("does not render a label when not provided", () => {
+    const { container } = render(<FormInput id="test" />);
+    expect(container.querySelector("label")).toBeNull();
+  });
+
+  it("displays error message", () => {
+    render(<FormInput id="email" error="Invalid email" />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Invalid email");
+  });
+
+  it("does not render error when null", () => {
+    render(<FormInput id="email" error={null} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("sets aria-describedby when error is present", () => {
+    render(<FormInput id="field" error="Required" />);
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("aria-describedby", "field-error");
+  });
+
+  it("passes through extra input props", () => {
+    render(<FormInput id="test" placeholder="Enter text" type="email" />);
+    const input = screen.getByPlaceholderText("Enter text");
+    expect(input).toHaveAttribute("type", "email");
+  });
+});
+
+describe("FormTextarea", () => {
+  it("renders without crashing", () => {
+    render(<FormTextarea id="bio" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("renders with a label", () => {
+    render(<FormTextarea id="bio" label="Bio" />);
+    expect(screen.getByLabelText("Bio")).toBeInTheDocument();
+  });
+
+  it("displays error message", () => {
+    render(<FormTextarea id="bio" error="Too short" />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Too short");
+  });
+
+  it("defaults to 3 rows", () => {
+    render(<FormTextarea id="bio" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("rows", "3");
+  });
+
+  it("accepts custom rows", () => {
+    render(<FormTextarea id="bio" rows={6} />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("rows", "6");
+  });
+
+  it("sets aria-describedby when error present", () => {
+    render(<FormTextarea id="desc" error="Error" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("aria-describedby", "desc-error");
+  });
+});
+
+describe("ToggleSwitch", () => {
+  it("renders without crashing", () => {
+    render(<ToggleSwitch checked={false} onChange={jest.fn()} />);
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("reflects checked state", () => {
+    render(<ToggleSwitch checked={true} onChange={jest.fn()} />);
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("calls onChange when toggled", () => {
+    const onChange = jest.fn();
+    render(<ToggleSwitch checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("applies label as aria-label", () => {
+    render(<ToggleSwitch checked={false} onChange={jest.fn()} label="Dark mode" />);
+    expect(screen.getByRole("checkbox")).toHaveAttribute("aria-label", "Dark mode");
+  });
+
+  it("defaults aria-label to Toggle", () => {
+    render(<ToggleSwitch checked={false} onChange={jest.fn()} />);
+    expect(screen.getByRole("checkbox")).toHaveAttribute("aria-label", "Toggle");
+  });
+
+  it("disables the input when disabled is true", () => {
+    render(<ToggleSwitch checked={false} onChange={jest.fn()} disabled />);
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+});

--- a/__tests__/components/ui/Logo.test.tsx
+++ b/__tests__/components/ui/Logo.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Logo from "@/components/Logo";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, priority, ...rest } = props;
+    return (
+      // eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
+      <img
+        data-fill={fill ? "true" : undefined}
+        data-priority={priority ? "true" : undefined}
+        {...rest}
+      />
+    );
+  },
+}));
+
+describe("Logo", () => {
+  it("renders without crashing", () => {
+    render(<Logo size="sm" />);
+    expect(screen.getByAltText("Cursor Boston")).toBeInTheDocument();
+  });
+
+  it("renders the correct image src", () => {
+    render(<Logo size="sm" />);
+    const img = screen.getByAltText("Cursor Boston");
+    expect(img).toHaveAttribute("src", "/cursor-boston-logo.png");
+  });
+
+  it("applies sm size class", () => {
+    const { container } = render(<Logo size="sm" />);
+    expect(container.firstElementChild?.className).toContain("w-8");
+    expect(container.firstElementChild?.className).toContain("h-8");
+  });
+
+  it("applies header size class", () => {
+    const { container } = render(<Logo size="header" />);
+    expect(container.firstElementChild?.className).toContain("w-12");
+    expect(container.firstElementChild?.className).toContain("h-12");
+  });
+
+  it("applies hero size class", () => {
+    const { container } = render(<Logo size="hero" />);
+    expect(container.firstElementChild?.className).toContain("w-28");
+    expect(container.firstElementChild?.className).toContain("h-28");
+  });
+
+  it("applies heroHome size class", () => {
+    const { container } = render(<Logo size="heroHome" />);
+    expect(container.firstElementChild?.className).toContain("w-40");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<Logo size="sm" className="extra" />);
+    expect(container.firstElementChild?.className).toContain("extra");
+  });
+
+  it("sets fill attribute on the image", () => {
+    render(<Logo size="sm" />);
+    const img = screen.getByAltText("Cursor Boston");
+    expect(img).toHaveAttribute("data-fill", "true");
+  });
+
+  it("forwards priority to the image when true", () => {
+    render(<Logo size="sm" priority />);
+    const img = screen.getByAltText("Cursor Boston");
+    expect(img).toHaveAttribute("data-priority", "true");
+  });
+
+  it("does not set priority when false", () => {
+    render(<Logo size="sm" />);
+    const img = screen.getByAltText("Cursor Boston");
+    expect(img).not.toHaveAttribute("data-priority");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 85 tests across 7 test suites for presentational components: BadgeCard, BadgeGrid, BadgePopover, Logo, Avatar, FormField (FormInput, FormTextarea, ToggleSwitch), and FilterCheckbox
- Tests cover rendering, prop handling, conditional display logic, accessibility attributes, and user interactions (click, toggle)
- All tests use jsdom environment with mocked next/image and next/link where needed

Partial progress on #232