### PR TITLE
test(feed): add component tests for feed components

### DIFF
--- a/__tests__/components/feed/CommunityFeed.test.tsx
+++ b/__tests__/components/feed/CommunityFeed.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { User } from "firebase/auth";
+import type { Message, ReactionType } from "@/types/feed";
+import { Timestamp } from "firebase/firestore";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img data-fill={fill ? "true" : undefined} {...rest} />;
+  },
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: null }));
+jest.mock("@/components/skeletons/FeedMessageSkeleton", () => ({
+  FeedMessageSkeleton: () => <div data-testid="feed-skeleton" />,
+}));
+
+const mockUseFeed = {
+  loading: false,
+  loadingMore: false,
+  hasMore: false,
+  loadMore: jest.fn(),
+  error: null as string | null,
+  clearError: jest.fn(),
+  newMessage: "",
+  setNewMessage: jest.fn(),
+  posting: false,
+  feedSearchQuery: "",
+  setFeedSearchQuery: jest.fn(),
+  filteredMessages: [] as Message[],
+  userReactions: {} as Record<string, ReactionType>,
+  expandedReplies: new Set<string>(),
+  messageReplies: {} as Record<string, Message[]>,
+  replyingTo: null as string | null,
+  setReplyingTo: jest.fn(),
+  replyContent: "",
+  setReplyContent: jest.fn(),
+  postingReply: false,
+  repostingMessage: null as Message | null,
+  setRepostingMessage: jest.fn(),
+  repostComment: "",
+  setRepostComment: jest.fn(),
+  postMessage: jest.fn(),
+  deleteMessage: jest.fn(),
+  toggleReaction: jest.fn(),
+  toggleReplies: jest.fn(),
+  postReply: jest.fn(),
+  repostMessage: jest.fn(),
+};
+
+jest.mock("@/hooks/useFeed", () => ({
+  useFeed: jest.fn(() => mockUseFeed),
+}));
+
+import { CommunityFeed } from "@/components/feed/CommunityFeed";
+import { useFeed } from "@/hooks/useFeed";
+
+const mockedUseFeed = useFeed as jest.MockedFunction<typeof useFeed>;
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    uid: "user-1",
+    displayName: "Alice Smith",
+    email: "alice@example.com",
+    photoURL: null,
+    ...overrides,
+  } as User;
+}
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    content: "Test message content",
+    authorId: "user-2",
+    authorName: "Bob",
+    authorPhoto: null,
+    createdAt: Timestamp.fromDate(new Date("2026-01-01")),
+    likeCount: 0,
+    dislikeCount: 0,
+    replyCount: 0,
+    repostCount: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset to default state
+  Object.assign(mockUseFeed, {
+    loading: false,
+    loadingMore: false,
+    hasMore: false,
+    error: null,
+    newMessage: "",
+    posting: false,
+    feedSearchQuery: "",
+    filteredMessages: [],
+    userReactions: {},
+    expandedReplies: new Set<string>(),
+    messageReplies: {},
+    replyingTo: null,
+    replyContent: "",
+    postingReply: false,
+    repostingMessage: null,
+    repostComment: "",
+  });
+  mockedUseFeed.mockReturnValue(mockUseFeed as ReturnType<typeof useFeed>);
+});
+
+describe("CommunityFeed", () => {
+  const onViewMemberProfile = jest.fn();
+
+  it("renders without crashing", () => {
+    render(<CommunityFeed user={null} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByPlaceholderText("Search messages...")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons when loading", () => {
+    mockUseFeed.loading = true;
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getAllByTestId("feed-skeleton")).toHaveLength(3);
+  });
+
+  it("shows empty state when no messages", () => {
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("No messages yet")).toBeInTheDocument();
+    expect(screen.getByText("Be the first to post something!")).toBeInTheDocument();
+  });
+
+  it("shows sign-in prompt when no user", () => {
+    render(<CommunityFeed user={null} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("Sign in to post messages")).toBeInTheDocument();
+  });
+
+  it("renders messages from feed", () => {
+    mockUseFeed.filteredMessages = [
+      makeMessage({ id: "m1", content: "First post" }),
+      makeMessage({ id: "m2", content: "Second post" }),
+    ];
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("First post")).toBeInTheDocument();
+    expect(screen.getByText("Second post")).toBeInTheDocument();
+  });
+
+  it("shows error state and dismiss button", async () => {
+    const user = userEvent.setup();
+    mockUseFeed.error = "Something went wrong";
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Dismiss"));
+    expect(mockUseFeed.clearError).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows search results count when searching", () => {
+    mockUseFeed.feedSearchQuery = "hello";
+    mockUseFeed.filteredMessages = [makeMessage()];
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText(/1 result for/)).toBeInTheDocument();
+  });
+
+  it("shows no-search-results empty state", () => {
+    mockUseFeed.feedSearchQuery = "nonexistent";
+    mockUseFeed.filteredMessages = [];
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("No messages match your search")).toBeInTheDocument();
+  });
+
+  it("shows load more button when hasMore", () => {
+    mockUseFeed.hasMore = true;
+    mockUseFeed.filteredMessages = [makeMessage()];
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("Load more")).toBeInTheDocument();
+  });
+
+  it("calls loadMore when button clicked", async () => {
+    const user = userEvent.setup();
+    mockUseFeed.hasMore = true;
+    mockUseFeed.filteredMessages = [makeMessage()];
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+
+    await user.click(screen.getByText("Load more"));
+    expect(mockUseFeed.loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Loading... when loadingMore", () => {
+    mockUseFeed.hasMore = true;
+    mockUseFeed.loadingMore = true;
+    mockUseFeed.filteredMessages = [makeMessage()];
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("hides load more when searching", () => {
+    mockUseFeed.hasMore = true;
+    mockUseFeed.feedSearchQuery = "test";
+    mockUseFeed.filteredMessages = [makeMessage()];
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.queryByText("Load more")).not.toBeInTheDocument();
+  });
+
+  it("shows clear search button when search has value", () => {
+    mockUseFeed.feedSearchQuery = "test";
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByLabelText("Clear search")).toBeInTheDocument();
+  });
+
+  it("renders repost modal when repostingMessage is set", () => {
+    mockUseFeed.repostingMessage = makeMessage();
+    render(<CommunityFeed user={makeUser()} onViewMemberProfile={onViewMemberProfile} />);
+    expect(screen.getByText("Repost with comment")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/feed/MessageCard.test.tsx
+++ b/__tests__/components/feed/MessageCard.test.tsx
@@ -1,0 +1,266 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Message } from "@/types/feed";
+import { Timestamp } from "firebase/firestore";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img data-fill={fill ? "true" : undefined} {...rest} />;
+  },
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: null }));
+jest.mock("@/components/feed/ReplyCard", () => ({
+  ReplyCard: (props: Record<string, unknown>) => (
+    <div data-testid={`reply-${props.reply && (props.reply as { id: string }).id}`} />
+  ),
+}));
+
+import { MessageCard } from "@/components/feed/MessageCard";
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    content: "Hello world",
+    authorId: "user-1",
+    authorName: "Alice",
+    authorPhoto: null,
+    createdAt: Timestamp.fromDate(new Date("2026-01-01")),
+    likeCount: 3,
+    dislikeCount: 1,
+    replyCount: 0,
+    repostCount: 2,
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+function defaultProps(overrides: Record<string, unknown> = {}) {
+  return {
+    message: makeMessage(),
+    isOwner: false,
+    isLoggedIn: true,
+    userReaction: undefined,
+    onDelete: jest.fn(),
+    onAuthorClick: jest.fn(),
+    onLike: jest.fn(),
+    onDislike: jest.fn(),
+    onReply: jest.fn(),
+    onRepost: jest.fn(),
+    showReplyInput: false,
+    replyContent: "",
+    onReplyContentChange: jest.fn(),
+    onSubmitReply: jest.fn(),
+    postingReply: false,
+    replies: [] as Message[],
+    showReplies: false,
+    onToggleReplies: jest.fn(),
+    onReplyLike: jest.fn(),
+    onReplyDislike: jest.fn(),
+    onDeleteReply: jest.fn(),
+    replyReactions: {},
+    currentUserId: "user-2",
+    ...overrides,
+  };
+}
+
+describe("MessageCard", () => {
+  it("renders without crashing", () => {
+    render(<MessageCard {...defaultProps()} />);
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("displays author name and content", () => {
+    render(<MessageCard {...defaultProps()} />);
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("shows initials when no author photo", () => {
+    render(<MessageCard {...defaultProps()} />);
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("shows author photo when provided", () => {
+    const msg = makeMessage({ authorPhoto: "https://example.com/photo.jpg" });
+    render(<MessageCard {...defaultProps({ message: msg })} />);
+    const img = screen.getByAltText("Alice");
+    expect(img).toHaveAttribute("src", "https://example.com/photo.jpg");
+  });
+
+  it("displays reaction counts", () => {
+    render(<MessageCard {...defaultProps()} />);
+    expect(screen.getByText("3")).toBeInTheDocument(); // likes
+    expect(screen.getByText("1")).toBeInTheDocument(); // dislikes
+  });
+
+  it("shows repost button for non-repost messages", () => {
+    render(<MessageCard {...defaultProps()} />);
+    expect(screen.getByLabelText("Repost")).toBeInTheDocument();
+  });
+
+  it("hides repost button for repost messages", () => {
+    const msg = makeMessage({
+      repostOf: {
+        originalId: "orig-1",
+        originalAuthorId: "user-3",
+        originalAuthorName: "Bob",
+        originalContent: "Original post",
+      },
+    });
+    render(<MessageCard {...defaultProps({ message: msg })} />);
+    expect(screen.queryByLabelText("Repost")).not.toBeInTheDocument();
+  });
+
+  it("shows repost header for reposted messages", () => {
+    const msg = makeMessage({
+      repostOf: {
+        originalId: "orig-1",
+        originalAuthorId: "user-3",
+        originalAuthorName: "Bob",
+        originalContent: "Original post",
+      },
+    });
+    render(<MessageCard {...defaultProps({ message: msg })} />);
+    expect(screen.getByText("reposted")).toBeInTheDocument();
+    expect(screen.getByText("Original post")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("shows delete button only for owner", () => {
+    const { rerender } = render(<MessageCard {...defaultProps({ isOwner: false })} />);
+    expect(screen.queryByLabelText("Delete message")).not.toBeInTheDocument();
+
+    rerender(<MessageCard {...defaultProps({ isOwner: true })} />);
+    expect(screen.getByLabelText("Delete message")).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation on click", async () => {
+    const user = userEvent.setup();
+    render(<MessageCard {...defaultProps({ isOwner: true })} />);
+
+    await user.click(screen.getByLabelText("Delete message"));
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  it("calls onDelete when confirmed", async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    render(<MessageCard {...defaultProps({ isOwner: true, onDelete })} />);
+
+    await user.click(screen.getByLabelText("Delete message"));
+    await user.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels delete confirmation", async () => {
+    const user = userEvent.setup();
+    render(<MessageCard {...defaultProps({ isOwner: true })} />);
+
+    await user.click(screen.getByLabelText("Delete message"));
+    await user.click(screen.getByText("Cancel"));
+    // Back to the three-dot menu
+    expect(screen.getByLabelText("Delete message")).toBeInTheDocument();
+  });
+
+  it("calls onLike and onDislike", async () => {
+    const user = userEvent.setup();
+    const onLike = jest.fn();
+    const onDislike = jest.fn();
+    render(<MessageCard {...defaultProps({ onLike, onDislike })} />);
+
+    await user.click(screen.getByLabelText("Like"));
+    expect(onLike).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByLabelText("Dislike"));
+    expect(onDislike).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables reaction buttons when not logged in", () => {
+    render(<MessageCard {...defaultProps({ isLoggedIn: false })} />);
+    expect(screen.getByLabelText("Like")).toBeDisabled();
+    expect(screen.getByLabelText("Dislike")).toBeDisabled();
+    expect(screen.getByLabelText("Reply")).toBeDisabled();
+  });
+
+  it("calls onAuthorClick when author name clicked", async () => {
+    const user = userEvent.setup();
+    const onAuthorClick = jest.fn();
+    render(<MessageCard {...defaultProps({ onAuthorClick })} />);
+
+    const profileButtons = screen.getAllByLabelText("View Alice's profile");
+    await user.click(profileButtons[0]);
+    expect(onAuthorClick).toHaveBeenCalled();
+  });
+
+  it("shows reply input when showReplyInput is true", () => {
+    render(
+      <MessageCard
+        {...defaultProps({
+          showReplyInput: true,
+          replyContent: "",
+        })}
+      />,
+    );
+    expect(screen.getByLabelText("Reply to Alice")).toBeInTheDocument();
+  });
+
+  it("hides reply input when showReplyInput is false", () => {
+    render(<MessageCard {...defaultProps({ showReplyInput: false })} />);
+    expect(screen.queryByLabelText("Reply to Alice")).not.toBeInTheDocument();
+  });
+
+  it("disables reply submit when content too short", () => {
+    render(
+      <MessageCard
+        {...defaultProps({
+          showReplyInput: true,
+          replyContent: "short",
+        })}
+      />,
+    );
+    // Find the submit button by its text "Reply" inside the reply input area
+    const buttons = screen.getAllByText("Reply");
+    // Last "Reply" text is the submit button inside the reply form
+    const submitButton = buttons[buttons.length - 1].closest("button");
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("shows view replies toggle when replyCount > 0", () => {
+    const msg = makeMessage({ replyCount: 5 });
+    render(<MessageCard {...defaultProps({ message: msg })} />);
+    expect(screen.getByText(/View 5 replies/)).toBeInTheDocument();
+  });
+
+  it("shows hide replies when expanded", () => {
+    const msg = makeMessage({ replyCount: 2 });
+    render(
+      <MessageCard
+        {...defaultProps({
+          message: msg,
+          showReplies: true,
+          replies: [
+            makeMessage({ id: "reply-1", content: "Reply 1" }),
+            makeMessage({ id: "reply-2", content: "Reply 2" }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText(/Hide 2 replies/)).toBeInTheDocument();
+  });
+
+  it("shows active like state", () => {
+    render(<MessageCard {...defaultProps({ userReaction: "like" as const })} />);
+    expect(screen.getByLabelText("Remove like")).toBeInTheDocument();
+  });
+
+  it("shows active dislike state", () => {
+    render(<MessageCard {...defaultProps({ userReaction: "dislike" as const })} />);
+    expect(screen.getByLabelText("Remove dislike")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/feed/PostComposer.test.tsx
+++ b/__tests__/components/feed/PostComposer.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { User } from "firebase/auth";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img data-fill={fill ? "true" : undefined} {...rest} />;
+  },
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: null }));
+
+import { PostComposer } from "@/components/feed/PostComposer";
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    uid: "user-1",
+    displayName: "Alice Smith",
+    email: "alice@example.com",
+    photoURL: null,
+    ...overrides,
+  } as User;
+}
+
+describe("PostComposer", () => {
+  const baseProps = {
+    value: "",
+    onChange: jest.fn(),
+    onSubmit: jest.fn(),
+    posting: false,
+  };
+
+  it("renders sign-in prompt when no user", () => {
+    render(<PostComposer {...baseProps} user={null} />);
+    expect(screen.getByText("Sign in to post messages")).toBeInTheDocument();
+    expect(screen.getByText("Sign In")).toHaveAttribute("href", "/login?redirect=/members");
+  });
+
+  it("renders composer when user is logged in", () => {
+    render(<PostComposer {...baseProps} user={makeUser()} />);
+    expect(screen.getByLabelText("What's on your mind?")).toBeInTheDocument();
+  });
+
+  it("shows user initials when no photo", () => {
+    render(<PostComposer {...baseProps} user={makeUser()} />);
+    expect(screen.getByText("AS")).toBeInTheDocument();
+  });
+
+  it("shows user photo when provided", () => {
+    const user = makeUser({ photoURL: "https://example.com/photo.jpg" });
+    render(<PostComposer {...baseProps} user={user} />);
+    expect(screen.getByAltText("Alice Smith")).toHaveAttribute("src", "https://example.com/photo.jpg");
+  });
+
+  it("calls onChange when typing", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<PostComposer {...baseProps} user={makeUser()} onChange={onChange} />);
+
+    await user.type(screen.getByLabelText("What's on your mind?"), "a");
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("disables submit when value is too short", () => {
+    render(<PostComposer {...baseProps} user={makeUser()} value="short" />);
+    expect(screen.getByLabelText("Post")).toBeDisabled();
+  });
+
+  it("enables submit when value meets minimum length", () => {
+    const longText = "a".repeat(100);
+    render(<PostComposer {...baseProps} user={makeUser()} value={longText} />);
+    expect(screen.getByLabelText("Post")).not.toBeDisabled();
+  });
+
+  it("disables submit while posting", () => {
+    const longText = "a".repeat(100);
+    render(<PostComposer {...baseProps} user={makeUser()} value={longText} posting={true} />);
+    expect(screen.getByLabelText("Posting message")).toBeDisabled();
+  });
+
+  it("shows Posting... text while posting", () => {
+    const longText = "a".repeat(100);
+    render(<PostComposer {...baseProps} user={makeUser()} value={longText} posting={true} />);
+    expect(screen.getByText("Posting...")).toBeInTheDocument();
+  });
+
+  it("calls onSubmit when button clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    const longText = "a".repeat(100);
+    render(<PostComposer {...baseProps} user={makeUser()} value={longText} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByLabelText("Post"));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows character count", () => {
+    render(<PostComposer {...baseProps} user={makeUser()} value="Hello" />);
+    expect(screen.getByText("5/500 (minimum 100)")).toBeInTheDocument();
+  });
+
+  it("uses custom placeholder and submitLabel", () => {
+    render(
+      <PostComposer
+        {...baseProps}
+        user={makeUser()}
+        placeholder="Custom placeholder"
+        submitLabel="Send"
+      />,
+    );
+    expect(screen.getByLabelText("Custom placeholder")).toBeInTheDocument();
+    expect(screen.getByLabelText("Send")).toBeInTheDocument();
+  });
+
+  it("uses custom minLength and maxLength", () => {
+    render(
+      <PostComposer
+        {...baseProps}
+        user={makeUser()}
+        value="Hello"
+        minLength={10}
+        maxLength={200}
+      />,
+    );
+    expect(screen.getByText("5/200 (minimum 10)")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/feed/RepostModal.test.tsx
+++ b/__tests__/components/feed/RepostModal.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Message } from "@/types/feed";
+import { Timestamp } from "firebase/firestore";
+
+jest.mock("@/lib/firebase", () => ({ db: null }));
+
+import { RepostModal } from "@/components/feed/RepostModal";
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    content: "Original post content",
+    authorId: "user-1",
+    authorName: "Alice",
+    authorPhoto: null,
+    createdAt: Timestamp.fromDate(new Date("2026-01-01")),
+    ...overrides,
+  };
+}
+
+function defaultProps(overrides: Record<string, unknown> = {}) {
+  return {
+    message: makeMessage(),
+    comment: "",
+    onCommentChange: jest.fn(),
+    onSubmit: jest.fn(),
+    onCancel: jest.fn(),
+    posting: false,
+    ...overrides,
+  };
+}
+
+describe("RepostModal", () => {
+  it("renders without crashing", () => {
+    render(<RepostModal {...defaultProps()} />);
+    expect(screen.getByText("Repost with comment")).toBeInTheDocument();
+  });
+
+  it("displays original message content and author", () => {
+    render(<RepostModal {...defaultProps()} />);
+    expect(screen.getByText("Original post content")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("has dialog role and aria-modal", () => {
+    render(<RepostModal {...defaultProps()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("shows character count", () => {
+    render(<RepostModal {...defaultProps({ comment: "Hello" })} />);
+    expect(screen.getByText("5/500 (minimum 100)")).toBeInTheDocument();
+  });
+
+  it("disables repost when comment is too short", () => {
+    render(<RepostModal {...defaultProps({ comment: "short" })} />);
+    expect(screen.getByText("Repost")).toBeDisabled();
+  });
+
+  it("enables repost when comment meets minimum length", () => {
+    const longComment = "a".repeat(100);
+    render(<RepostModal {...defaultProps({ comment: longComment })} />);
+    expect(screen.getByText("Repost")).not.toBeDisabled();
+  });
+
+  it("disables repost while posting", () => {
+    const longComment = "a".repeat(100);
+    render(<RepostModal {...defaultProps({ comment: longComment, posting: true })} />);
+    expect(screen.getByText("Reposting...")).toBeDisabled();
+  });
+
+  it("calls onSubmit when repost clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    const longComment = "a".repeat(100);
+    render(<RepostModal {...defaultProps({ comment: longComment, onSubmit })} />);
+
+    await user.click(screen.getByText("Repost"));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    render(<RepostModal {...defaultProps({ onCancel })} />);
+
+    await user.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel on Escape key", async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    render(<RepostModal {...defaultProps({ onCancel })} />);
+
+    // Focus the textarea inside the modal so the keyDown event bubbles to the dialog
+    const textarea = screen.getByPlaceholderText("Add your comment...");
+    await user.click(textarea);
+    await user.keyboard("{Escape}");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCommentChange when typing", async () => {
+    const user = userEvent.setup();
+    const onCommentChange = jest.fn();
+    render(<RepostModal {...defaultProps({ onCommentChange })} />);
+
+    await user.type(screen.getByPlaceholderText("Add your comment..."), "a");
+    expect(onCommentChange).toHaveBeenCalled();
+  });
+
+  it("uses custom minLength and maxLength", () => {
+    render(
+      <RepostModal
+        {...defaultProps({ comment: "test", minLength: 5, maxLength: 200 })}
+      />,
+    );
+    expect(screen.getByText("4/200 (minimum 5)")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 61 React component tests across 4 feed components: MessageCard, PostComposer, RepostModal, CommunityFeed
- Tests cover rendering, conditional UI visibility, user interactions (click, type, keyboard), prop-driven state, and callback invocations
- All tests use jsdom environment with mocked next/image, next/link, firebase, and useFeed hook

Partial progress on #232