### PR TITLE
fix: ratchet coverage thresholds to 42% to lock in gains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,10 @@ jobs:
         run: |
           COVERAGE=$(cat coverage/coverage-summary.json | jq '.total.lines.pct')
           echo "Current coverage: $COVERAGE%"
-          # Aligned with jest.config.js coverageThreshold (lines: 30).
+          # Aligned with jest.config.js coverageThreshold (lines: 42).
           # Ratchet this up as tests are added.
-          if (( $(echo "$COVERAGE < 30" | bc -l) )); then
-            echo "::error::Coverage is below 30% threshold"
+          if (( $(echo "$COVERAGE < 42" | bc -l) )); then
+            echo "::error::Coverage is below 42% threshold"
             exit 1
           fi
 

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -35,13 +35,13 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/__tests__/config/firebase/firestore.rules.test.ts',
   ],
-  // Coverage thresholds - ratchet up as tests are added (current: ~31%)
+  // Coverage thresholds - ratchet up as tests are added (current: ~43%)
   coverageThreshold: {
     global: {
-      branches: 22,
-      functions: 20,
-      lines: 30,
-      statements: 29,
+      branches: 35,
+      functions: 32,
+      lines: 42,
+      statements: 40,
     },
   },
   // Generate JSON summary for CI coverage checks


### PR DESCRIPTION
## Summary

- Coverage now at ~43% lines (up from 14%), with 1,123 tests across 108 suites
- Ratcheted jest.config.js: lines 30→42, statements 29→40, branches 22→35, functions 20→32
- Aligned CI workflow threshold to 42%
- Prevents coverage from regressing below current levels