### PR TITLE
feat: add Weekly AI Dev Tips newsletter feature

### DIFF
--- a/.github/workflows/weekly-tips.yml
+++ b/.github/workflows/weekly-tips.yml
@@ -1,0 +1,36 @@
+name: Weekly Tips Newsletter
+
+on:
+  schedule:
+    # Every Monday at 10:00 AM ET (14:00 UTC, 15:00 UTC during DST)
+    - cron: "0 14 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  send-weekly-tip:
+    name: Send Weekly Tip Email
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger newsletter endpoint
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          APP_URL: ${{ vars.APP_URL || 'https://cursorboston.com' }}
+        run: |
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            -H "Content-Type: application/json" \
+            "$APP_URL/api/newsletter/tips")
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | head -n -1)
+
+          echo "Status: $http_code"
+          echo "Response: $body"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::Newsletter send failed with status $http_code"
+            exit 1
+          fi

--- a/__tests__/app/api/newsletter/tips/route.test.ts
+++ b/__tests__/app/api/newsletter/tips/route.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/newsletter/tips/route";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockGetLatestScheduledTip = jest.fn();
+const mockUpdateTipStatus = jest.fn();
+jest.mock("@/lib/tips", () => ({
+  getLatestScheduledTip: () => mockGetLatestScheduledTip(),
+  updateTipStatus: (...args: unknown[]) => mockUpdateTipStatus(...args),
+}));
+
+const mockGetActiveSubscribers = jest.fn();
+jest.mock("@/lib/tip-subscribers", () => ({
+  getActiveSubscribers: () => mockGetActiveSubscribers(),
+}));
+
+const mockSendEmail = jest.fn();
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+jest.mock("@/lib/unsubscribe-token", () => ({
+  buildUnsubscribeUrl: jest.fn((email: string) => `https://cursorboston.com/unsub?email=${email}`),
+}));
+
+const CRON_SECRET = "test-secret";
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/newsletter/tips", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${CRON_SECRET}` },
+  });
+}
+
+describe("POST /api/newsletter/tips", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CRON_SECRET = CRON_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 401 without valid secret", async () => {
+    const req = new NextRequest("http://localhost/api/newsletter/tips", {
+      method: "POST",
+      headers: { Authorization: "Bearer wrong-secret" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns success when no scheduled tip found", async () => {
+    mockGetLatestScheduledTip.mockResolvedValue(null);
+    const res = await POST(makeRequest());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.message).toContain("No scheduled tip");
+  });
+
+  it("returns success when no subscribers", async () => {
+    mockGetLatestScheduledTip.mockResolvedValue({
+      id: "tip-1",
+      title: "Test Tip",
+      content: "Content",
+      authorName: "Alice",
+    });
+    mockGetActiveSubscribers.mockResolvedValue([]);
+
+    const res = await POST(makeRequest());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.message).toContain("No active subscribers");
+  });
+
+  it("sends emails and updates tip status", async () => {
+    mockGetLatestScheduledTip.mockResolvedValue({
+      id: "tip-1",
+      title: "Test Tip",
+      content: "Content",
+      authorName: "Alice",
+    });
+    mockGetActiveSubscribers.mockResolvedValue([
+      { email: "bob@example.com" },
+      { email: "carol@example.com" },
+    ]);
+    mockSendEmail.mockResolvedValue(undefined);
+    mockUpdateTipStatus.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.sent).toBe(2);
+    expect(data.failed).toBe(0);
+    expect(data.tipId).toBe("tip-1");
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(mockUpdateTipStatus).toHaveBeenCalledWith(
+      "tip-1",
+      "published",
+      expect.objectContaining({ publishedAt: expect.any(String) })
+    );
+  });
+
+  it("counts failures without crashing", async () => {
+    mockGetLatestScheduledTip.mockResolvedValue({
+      id: "tip-2",
+      title: "Tip",
+      content: "Content",
+      authorName: "Bob",
+    });
+    mockGetActiveSubscribers.mockResolvedValue([
+      { email: "fail@example.com" },
+      { email: "ok@example.com" },
+    ]);
+    mockSendEmail
+      .mockRejectedValueOnce(new Error("Mailgun error"))
+      .mockResolvedValueOnce(undefined);
+    mockUpdateTipStatus.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest());
+    const data = await res.json();
+
+    expect(data.sent).toBe(1);
+    expect(data.failed).toBe(1);
+  });
+});

--- a/__tests__/app/api/tips/route.test.ts
+++ b/__tests__/app/api/tips/route.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from "@/app/api/tips/route";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockGetPublishedTips = jest.fn();
+jest.mock("@/lib/tips", () => ({
+  getPublishedTips: () => mockGetPublishedTips(),
+}));
+
+describe("GET /api/tips", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns published tips", async () => {
+    const tips = [
+      { id: "1", title: "Tip 1", content: "Content 1", status: "published" },
+      { id: "2", title: "Tip 2", content: "Content 2", status: "published" },
+    ];
+    mockGetPublishedTips.mockResolvedValue(tips);
+
+    const res = await GET();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.tips).toHaveLength(2);
+    expect(data.tips[0].title).toBe("Tip 1");
+  });
+
+  it("returns empty array when no tips exist", async () => {
+    mockGetPublishedTips.mockResolvedValue([]);
+    const res = await GET();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.tips).toHaveLength(0);
+  });
+
+  it("returns 500 on error", async () => {
+    mockGetPublishedTips.mockRejectedValue(new Error("DB error"));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/app/api/tips/submit/route.test.ts
+++ b/__tests__/app/api/tips/submit/route.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/tips/submit/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-client"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeText: jest.fn((s: string) => s),
+}));
+
+const mockCreateTip = jest.fn();
+jest.mock("@/lib/tips", () => ({
+  createTip: (...args: unknown[]) => mockCreateTip(...args),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/tips/submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/tips/submit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ title: "Test", content: "Content" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when title is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Alice" });
+    const res = await POST(makeRequest({ content: "Content" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when content is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Alice" });
+    const res = await POST(makeRequest({ title: "Title" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a tip with pending status for regular users", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Alice" });
+    mockCreateTip.mockResolvedValue("tip-123");
+
+    const res = await POST(
+      makeRequest({ title: "My Tip", content: "Use Cmd+K", category: "Keyboard Shortcuts" })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.id).toBe("tip-123");
+    expect(data.status).toBe("pending");
+    expect(mockCreateTip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "My Tip",
+        content: "Use Cmd+K",
+        category: "Keyboard Shortcuts",
+        status: "pending",
+        authorId: "u1",
+        authorName: "Alice",
+      })
+    );
+  });
+
+  it("creates a tip with published status for admins", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Admin", isAdmin: true });
+    mockCreateTip.mockResolvedValue("tip-456");
+
+    const res = await POST(makeRequest({ title: "Admin Tip", content: "Admin content" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.status).toBe("published");
+  });
+
+  it("defaults to General category when invalid category is provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", name: "Alice" });
+    mockCreateTip.mockResolvedValue("tip-789");
+
+    await POST(makeRequest({ title: "Tip", content: "Content", category: "invalid" }));
+
+    expect(mockCreateTip).toHaveBeenCalledWith(
+      expect.objectContaining({ category: "General" })
+    );
+  });
+});

--- a/__tests__/app/api/tips/subscribe/route.test.ts
+++ b/__tests__/app/api/tips/subscribe/route.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST, DELETE } from "@/app/api/tips/subscribe/route";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-client"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+const mockAddSubscriber = jest.fn();
+const mockRemoveSubscriber = jest.fn();
+jest.mock("@/lib/tip-subscribers", () => ({
+  addSubscriber: (...args: unknown[]) => mockAddSubscriber(...args),
+  removeSubscriber: (...args: unknown[]) => mockRemoveSubscriber(...args),
+}));
+
+jest.mock("@/lib/unsubscribe-token", () => ({
+  verifyUnsubscribeToken: jest.fn((email: string, token: string) => token === "valid-token"),
+}));
+
+describe("POST /api/tips/subscribe", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("subscribes with a valid email", async () => {
+    mockAddSubscriber.mockResolvedValue(undefined);
+    const req = new NextRequest("http://localhost/api/tips/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "alice@example.com" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    expect(mockAddSubscriber).toHaveBeenCalledWith("alice@example.com", undefined);
+  });
+
+  it("returns 400 for invalid email", async () => {
+    const req = new NextRequest("http://localhost/api/tips/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing email", async () => {
+    const req = new NextRequest("http://localhost/api/tips/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/tips/subscribe", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("unsubscribes with valid token", async () => {
+    mockRemoveSubscriber.mockResolvedValue(undefined);
+    const req = new NextRequest(
+      "http://localhost/api/tips/subscribe?email=alice@example.com&token=valid-token",
+      { method: "DELETE" }
+    );
+
+    const res = await DELETE(req);
+    expect(res.status).toBe(200);
+    expect(mockRemoveSubscriber).toHaveBeenCalledWith("alice@example.com");
+  });
+
+  it("returns 403 for invalid token", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/tips/subscribe?email=alice@example.com&token=bad-token",
+      { method: "DELETE" }
+    );
+
+    const res = await DELETE(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when email or token is missing", async () => {
+    const req = new NextRequest("http://localhost/api/tips/subscribe?email=alice@example.com", {
+      method: "DELETE",
+    });
+
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/components/tips/SubscribeForm.test.tsx
+++ b/__tests__/components/tips/SubscribeForm.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SubscribeForm } from "@/components/tips/SubscribeForm";
+
+describe("SubscribeForm", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  it("renders email input and subscribe button", () => {
+    render(<SubscribeForm />);
+    expect(screen.getByPlaceholderText("your@email.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /subscribe/i })).toBeInTheDocument();
+  });
+
+  it("shows success message after subscribing", async () => {
+    const user = userEvent.setup();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ message: "Subscribed" }),
+    });
+
+    render(<SubscribeForm />);
+    await user.type(screen.getByPlaceholderText("your@email.com"), "alice@example.com");
+    await user.click(screen.getByRole("button", { name: /subscribe/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/you're subscribed/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error on failure", async () => {
+    const user = userEvent.setup();
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: "Already subscribed" } }),
+    });
+
+    render(<SubscribeForm />);
+    await user.type(screen.getByPlaceholderText("your@email.com"), "alice@example.com");
+    await user.click(screen.getByRole("button", { name: /subscribe/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Already subscribed")).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/tips/TipCard.test.tsx
+++ b/__tests__/components/tips/TipCard.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { TipCard } from "@/components/tips/TipCard";
+import type { WeeklyTip } from "@/types/tips";
+
+function makeTip(overrides: Partial<WeeklyTip> = {}): WeeklyTip {
+  return {
+    id: "tip-1",
+    title: "Use Cmd+K for inline edits",
+    content: "Select any block of code and press Cmd+K to get AI-powered inline suggestions.",
+    authorId: "u1",
+    authorName: "Alice",
+    category: "Keyboard Shortcuts",
+    status: "published",
+    createdAt: "2026-04-01T00:00:00Z",
+    publishedAt: "2026-04-07T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("TipCard", () => {
+  it("renders tip title and content", () => {
+    render(<TipCard tip={makeTip()} />);
+    expect(screen.getByRole("heading", { name: /Cmd\+K/i })).toBeInTheDocument();
+    expect(screen.getByText(/inline suggestions/)).toBeInTheDocument();
+  });
+
+  it("renders author name", () => {
+    render(<TipCard tip={makeTip()} />);
+    expect(screen.getByText("by Alice")).toBeInTheDocument();
+  });
+
+  it("renders formatted publish date", () => {
+    render(<TipCard tip={makeTip()} />);
+    expect(screen.getByText(/Apr 7, 2026/)).toBeInTheDocument();
+  });
+
+  it("renders category badge for non-General categories", () => {
+    render(<TipCard tip={makeTip({ category: "Prompt Tricks" })} />);
+    expect(screen.getByText("Prompt Tricks")).toBeInTheDocument();
+  });
+
+  it("does not render category badge for General", () => {
+    render(<TipCard tip={makeTip({ category: "General" })} />);
+    expect(screen.queryByText("General")).not.toBeInTheDocument();
+  });
+
+  it("does not render date when publishedAt is absent", () => {
+    render(<TipCard tip={makeTip({ publishedAt: undefined })} />);
+    expect(screen.queryByRole("time")).not.toBeInTheDocument();
+  });
+});

--- a/app/api/newsletter/tips/route.ts
+++ b/app/api/newsletter/tips/route.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { getLatestScheduledTip, updateTipStatus } from "@/lib/tips";
+import { getActiveSubscribers } from "@/lib/tip-subscribers";
+import { sendEmail } from "@/lib/mailgun";
+import { buildUnsubscribeUrl } from "@/lib/unsubscribe-token";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SITE_ORIGIN = (
+  process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com"
+).replace(/\/$/, "");
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildTipEmailHtml(tip: { title: string; content: string; authorName: string }, unsubUrl: string): string {
+  return `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;margin:0 auto;">
+<h2 style="color:#10b981;margin-bottom:4px;">Tip of the Week</h2>
+<h3 style="margin-top:0;">${escapeHtml(tip.title)}</h3>
+<p>${escapeHtml(tip.content)}</p>
+<p style="font-size:14px;color:#666;">— ${escapeHtml(tip.authorName)}</p>
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:24px 0;" />
+<p style="font-size:14px;">
+  <a href="${SITE_ORIGIN}/tips" style="color:#10b981;font-weight:600;">Browse all tips</a> · 
+  <a href="${SITE_ORIGIN}/tips/submit" style="color:#10b981;font-weight:600;">Submit your own tip</a>
+</p>
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you subscribed to Cursor Boston weekly tips.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+}
+
+function buildTipEmailText(tip: { title: string; content: string; authorName: string }, unsubUrl: string): string {
+  return `TIP OF THE WEEK: ${tip.title}
+
+${tip.content}
+
+— ${tip.authorName}
+
+Browse all tips: ${SITE_ORIGIN}/tips
+Submit your own: ${SITE_ORIGIN}/tips/submit
+
+---
+Unsubscribe: ${unsubUrl}`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const cronSecret = process.env.CRON_SECRET;
+    const authHeader = request.headers.get("authorization") || "";
+
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+      return apiError("Unauthorized", 401);
+    }
+
+    const tip = await getLatestScheduledTip();
+    if (!tip) {
+      return apiSuccess({ message: "No scheduled tip found, nothing to send" });
+    }
+
+    const subscribers = await getActiveSubscribers();
+    if (subscribers.length === 0) {
+      return apiSuccess({ message: "No active subscribers" });
+    }
+
+    let sent = 0;
+    let failed = 0;
+
+    for (const sub of subscribers) {
+      try {
+        const unsubUrl = buildUnsubscribeUrl(sub.email);
+        await sendEmail({
+          to: sub.email,
+          subject: `Cursor Boston Tip: ${tip.title}`,
+          html: buildTipEmailHtml(tip, unsubUrl),
+          text: buildTipEmailText(tip, unsubUrl),
+        });
+        sent++;
+      } catch (err) {
+        failed++;
+        logger.logError(err, { subscriber: sub.email, tipId: tip.id });
+      }
+    }
+
+    await updateTipStatus(tip.id, "published", {
+      publishedAt: new Date().toISOString(),
+    });
+
+    return apiSuccess({ sent, failed, tipId: tip.id });
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/newsletter/tips POST" });
+    return apiError("Internal server error", 500);
+  }
+}

--- a/app/api/tips/route.ts
+++ b/app/api/tips/route.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { getPublishedTips } from "@/lib/tips";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const tips = await getPublishedTips();
+    return apiSuccess({ tips });
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/tips GET" });
+    return apiError("Internal server error", 500);
+  }
+}

--- a/app/api/tips/submit/route.ts
+++ b/app/api/tips/submit/route.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { createTip } from "@/lib/tips";
+import { sanitizeText } from "@/lib/sanitize";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { withRateLimit, rateLimitConfigs } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+import { TIP_CATEGORIES, type TipCategory } from "@/types/tips";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_TITLE_LENGTH = 120;
+const MAX_CONTENT_LENGTH = 500;
+
+async function handler(request: Request) {
+  try {
+    const user = await getVerifiedUser(request as NextRequest);
+    if (!user) return apiError("Unauthorized", 401);
+
+    const body = await request.json();
+    const { title, content, category } = body;
+
+    if (!title || !content) {
+      return apiError("Title and content are required", 400);
+    }
+
+    const sanitizedTitle = sanitizeText(title).slice(0, MAX_TITLE_LENGTH);
+    const sanitizedContent = sanitizeText(content).slice(0, MAX_CONTENT_LENGTH);
+
+    if (!sanitizedTitle || !sanitizedContent) {
+      return apiError("Title and content cannot be empty after sanitization", 400);
+    }
+
+    const validCategory: TipCategory =
+      category && TIP_CATEGORIES.includes(category) ? category : "General";
+
+    const status = user.isAdmin ? "published" : "pending";
+
+    const id = await createTip({
+      title: sanitizedTitle,
+      content: sanitizedContent,
+      category: validCategory,
+      authorId: user.uid,
+      authorName: user.name || "Anonymous",
+      status,
+    });
+
+    return apiSuccess({ id, status }, 201);
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/tips/submit POST" });
+    return apiError("Internal server error", 500);
+  }
+}
+
+export const POST = withRateLimit(rateLimitConfigs.standard, handler);

--- a/app/api/tips/subscribe/route.ts
+++ b/app/api/tips/subscribe/route.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { addSubscriber, removeSubscriber } from "@/lib/tip-subscribers";
+import { verifyUnsubscribeToken } from "@/lib/unsubscribe-token";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { withRateLimit, rateLimitConfigs } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+async function postHandler(request: Request) {
+  try {
+    const body = await request.json();
+    const { email, name } = body;
+
+    if (!email || typeof email !== "string" || !EMAIL_RE.test(email.trim())) {
+      return apiError("A valid email address is required", 400);
+    }
+
+    await addSubscriber(email.trim(), name?.trim?.());
+    return apiSuccess({ message: "Subscribed to weekly tips" }, 201);
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/tips/subscribe POST" });
+    return apiError("Internal server error", 500);
+  }
+}
+
+async function deleteHandler(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const email = searchParams.get("email");
+    const token = searchParams.get("token");
+
+    if (!email || !token) {
+      return apiError("Email and token are required", 400);
+    }
+
+    if (!verifyUnsubscribeToken(email, token)) {
+      return apiError("Invalid unsubscribe token", 403);
+    }
+
+    await removeSubscriber(email);
+    return apiSuccess({ message: "Unsubscribed from weekly tips" });
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/tips/subscribe DELETE" });
+    return apiError("Internal server error", 500);
+  }
+}
+
+export const POST = withRateLimit(rateLimitConfigs.standard, postHandler);
+export const DELETE = withRateLimit(rateLimitConfigs.standard, deleteHandler);

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -79,6 +79,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
+      url: `${baseUrl}/tips`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/cookbook`,
       lastModified: new Date(),
       changeFrequency: 'weekly',

--- a/app/tips/TipsArchive.tsx
+++ b/app/tips/TipsArchive.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { Search, Plus } from "lucide-react";
+import { TipCard } from "@/components/tips/TipCard";
+import { SubscribeForm } from "@/components/tips/SubscribeForm";
+import type { WeeklyTip } from "@/types/tips";
+
+interface Props {
+  initialTips: WeeklyTip[];
+}
+
+export default function TipsArchive({ initialTips }: Props) {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredTips = useMemo(() => {
+    if (!searchTerm) return initialTips;
+    const q = searchTerm.toLowerCase();
+    return initialTips.filter(
+      (t) =>
+        t.title.toLowerCase().includes(q) ||
+        t.content.toLowerCase().includes(q) ||
+        t.authorName.toLowerCase().includes(q)
+    );
+  }, [initialTips, searchTerm]);
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-12">
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-6 mb-8">
+        <div>
+          <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-4 tracking-tight">
+            Weekly Tips
+          </h1>
+          <p className="text-lg text-neutral-600 dark:text-neutral-400 max-w-2xl">
+            Community-sourced Cursor workflow hacks, keyboard shortcuts, and prompt tricks.
+          </p>
+        </div>
+        <Link
+          href="/tips/submit"
+          className="flex items-center gap-2 px-6 py-3 bg-emerald-500 text-white rounded-xl font-bold hover:bg-emerald-400 transition-all shadow-lg shadow-emerald-500/10 shrink-0"
+        >
+          <Plus className="w-5 h-5" />
+          Submit a Tip
+        </Link>
+      </div>
+
+      <div className="mb-10 p-6 bg-neutral-50 dark:bg-neutral-900/50 rounded-2xl border border-neutral-200 dark:border-neutral-800">
+        <h2 className="text-sm font-bold text-neutral-700 dark:text-neutral-300 uppercase tracking-tight mb-3">
+          Get tips in your inbox every Monday
+        </h2>
+        <SubscribeForm />
+      </div>
+
+      <div className="relative mb-8 group">
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-neutral-400 group-focus-within:text-emerald-500 transition-colors" />
+        <input
+          type="text"
+          placeholder="Search tips..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full pl-12 pr-4 py-4 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-2xl outline-none focus:ring-2 focus:ring-emerald-500 transition-all shadow-sm group-hover:shadow-md"
+        />
+      </div>
+
+      {filteredTips.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {filteredTips.map((tip) => (
+            <TipCard key={tip.id} tip={tip} />
+          ))}
+        </div>
+      ) : (
+        <div className="py-20 text-center bg-neutral-50 dark:bg-neutral-900/50 rounded-3xl border border-dashed border-neutral-200 dark:border-neutral-800">
+          <p className="text-neutral-500 dark:text-neutral-400 text-lg">
+            {initialTips.length === 0
+              ? "No tips yet — be the first to submit one!"
+              : "No tips found matching your search."}
+          </p>
+          {searchTerm && (
+            <button
+              onClick={() => setSearchTerm("")}
+              className="mt-4 text-emerald-500 font-bold hover:underline"
+            >
+              Clear search
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/tips/page.tsx
+++ b/app/tips/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import { getPublishedTips } from "@/lib/tips";
+import TipsArchive from "./TipsArchive";
+
+export const metadata: Metadata = {
+  title: "Weekly AI Dev Tips",
+  description:
+    "Community-sourced Cursor workflow hacks, keyboard shortcuts, and prompt tricks — delivered weekly.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function TipsPage() {
+  const tips = await getPublishedTips();
+
+  return (
+    <main id="main-content" className="min-h-screen bg-white dark:bg-neutral-950">
+      <TipsArchive initialTips={tips} />
+    </main>
+  );
+}

--- a/app/tips/submit/TipSubmitPage.tsx
+++ b/app/tips/submit/TipSubmitPage.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { TipSubmitForm } from "@/components/tips/TipSubmitForm";
+
+export default function TipSubmitPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-12">
+      <Link
+        href="/tips"
+        className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-foreground transition-colors mb-8"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Back to Tips
+      </Link>
+      <h1 className="text-4xl font-bold text-foreground mb-4 tracking-tight">
+        Submit a Tip
+      </h1>
+      <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-10">
+        Share a 2-3 sentence Cursor workflow hack, keyboard shortcut, or prompt trick.
+        Curated tips are sent to subscribers every Monday.
+      </p>
+      <TipSubmitForm />
+    </div>
+  );
+}

--- a/app/tips/submit/page.tsx
+++ b/app/tips/submit/page.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import TipSubmitPage from "./TipSubmitPage";
+
+export const metadata: Metadata = {
+  title: "Submit a Tip — Weekly AI Dev Tips",
+  description: "Share your favorite Cursor workflow hack with the community.",
+};
+
+export default function Page() {
+  return (
+    <main id="main-content" className="min-h-screen bg-white dark:bg-neutral-950">
+      <TipSubmitPage />
+    </main>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -29,6 +29,7 @@ import {
   Info,
   LayoutGrid,
   Library,
+  Lightbulb,
   LogIn,
   Map,
   Menu,
@@ -83,6 +84,7 @@ const NAV_GROUPS: NavGroup[] = [
     items: [
       { href: "/map", label: "Map", icon: Map },
       { href: "/glossary", label: "Glossary", icon: Library },
+      { href: "/tips", label: "Tips", icon: Lightbulb },
       { href: "/blog", label: "Blog", icon: BookOpen },
       { href: "/analytics", label: "Analytics", icon: BarChart2 },
     ],

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -66,6 +66,11 @@ export default function Footer() {
                       About
                     </Link>
                   </li>
+                  <li>
+                    <Link href="/tips" className="text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white text-sm transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
+                      Tips
+                    </Link>
+                  </li>
                 </ul>
               </div>
 

--- a/components/tips/SubscribeForm.tsx
+++ b/components/tips/SubscribeForm.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { Loader2, Mail, Check } from "lucide-react";
+
+export function SubscribeForm() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [subscribed, setSubscribed] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/tips/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error?.message || "Failed to subscribe");
+
+      setSubscribed(true);
+      setEmail("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (subscribed) {
+    return (
+      <div className="flex items-center gap-2 p-4 bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-800 rounded-xl text-emerald-700 dark:text-emerald-400 text-sm font-medium">
+        <Check className="w-5 h-5 shrink-0" />
+        You&apos;re subscribed! Check your inbox every Monday.
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3">
+      <div className="relative flex-1">
+        <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          placeholder="your@email.com"
+          className="w-full pl-10 pr-4 py-3 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-xl outline-none focus:ring-2 focus:ring-emerald-500 transition-all text-sm"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="px-6 py-3 bg-emerald-500 text-white rounded-xl font-bold text-sm hover:bg-emerald-400 disabled:opacity-50 transition-all shadow-lg shadow-emerald-500/20 shrink-0"
+      >
+        {loading ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Subscribe"}
+      </button>
+      {error && <p className="text-red-500 text-xs mt-1 sm:mt-0">{error}</p>}
+    </form>
+  );
+}

--- a/components/tips/TipCard.tsx
+++ b/components/tips/TipCard.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { WeeklyTip } from "@/types/tips";
+
+interface Props {
+  tip: WeeklyTip;
+}
+
+export function TipCard({ tip }: Props) {
+  const date = tip.publishedAt
+    ? new Date(tip.publishedAt).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : null;
+
+  return (
+    <article className="bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-2xl p-6 hover:border-emerald-500/30 dark:hover:border-emerald-500/30 hover:shadow-lg transition-all duration-200">
+      <div className="flex items-start justify-between gap-4 mb-3">
+        <h3 className="text-lg font-bold text-foreground">{tip.title}</h3>
+        {tip.category && tip.category !== "General" && (
+          <span className="shrink-0 px-2.5 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-medium rounded-full">
+            {tip.category}
+          </span>
+        )}
+      </div>
+      <p className="text-neutral-600 dark:text-neutral-400 text-sm leading-relaxed mb-4">
+        {tip.content}
+      </p>
+      <div className="flex items-center justify-between text-xs text-neutral-500">
+        <span>by {tip.authorName}</span>
+        {date && <time dateTime={tip.publishedAt}>{date}</time>}
+      </div>
+    </article>
+  );
+}

--- a/components/tips/TipSubmitForm.tsx
+++ b/components/tips/TipSubmitForm.tsx
@@ -1,0 +1,187 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Loader2, Plus } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { TIP_CATEGORIES } from "@/types/tips";
+
+const MAX_CONTENT_LENGTH = 500;
+
+export function TipSubmitForm({ onSuccess }: { onSuccess?: () => void }) {
+  const { user } = useAuth();
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [category, setCategory] = useState("General");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { getIdToken } = await import("firebase/auth");
+      const token = await getIdToken(user);
+
+      const res = await fetch("/api/tips/submit", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ title, content, category }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error?.message || "Failed to submit");
+      }
+
+      setSuccess(true);
+      setTitle("");
+      setContent("");
+      setCategory("General");
+      onSuccess?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="p-8 text-center bg-neutral-50 dark:bg-neutral-900 rounded-2xl border border-dashed border-neutral-300 dark:border-neutral-700">
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+          Sign in to share a Cursor workflow tip with the community.
+        </p>
+        <Link
+          href="/login?redirect=/tips/submit"
+          className="inline-flex items-center px-6 py-3 bg-emerald-500 text-white rounded-xl font-bold hover:bg-emerald-400 transition-all shadow-lg shadow-emerald-500/20"
+        >
+          Sign In
+        </Link>
+      </div>
+    );
+  }
+
+  if (success) {
+    return (
+      <div className="p-8 text-center bg-emerald-50 dark:bg-emerald-950/30 rounded-2xl border border-emerald-200 dark:border-emerald-800">
+        <p className="text-emerald-700 dark:text-emerald-400 font-semibold mb-2">
+          Tip submitted!
+        </p>
+        <p className="text-neutral-600 dark:text-neutral-400 text-sm">
+          Your tip will be reviewed and published soon.
+        </p>
+        <button
+          onClick={() => setSuccess(false)}
+          className="mt-4 text-emerald-500 font-bold hover:underline text-sm"
+        >
+          Submit another tip
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-2xl p-6 md:p-8 space-y-6 shadow-sm">
+        <div>
+          <label
+            htmlFor="tip-title"
+            className="block text-sm font-bold text-neutral-700 dark:text-neutral-300 mb-2 uppercase tracking-tight"
+          >
+            Tip Title
+          </label>
+          <input
+            id="tip-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+            maxLength={120}
+            className="w-full px-4 py-3 rounded-xl bg-neutral-50 dark:bg-neutral-950 border border-neutral-200 dark:border-neutral-800 focus:ring-2 focus:ring-emerald-500 outline-none transition-all"
+            placeholder='e.g. "Use Cmd+K to inline edit any selection"'
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="tip-category"
+            className="block text-sm font-bold text-neutral-700 dark:text-neutral-300 mb-2 uppercase tracking-tight"
+          >
+            Category
+          </label>
+          <select
+            id="tip-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="w-full px-4 py-3 rounded-xl bg-neutral-50 dark:bg-neutral-950 border border-neutral-200 dark:border-neutral-800 focus:ring-2 focus:ring-emerald-500 outline-none transition-all"
+          >
+            {TIP_CATEGORIES.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="tip-content"
+            className="block text-sm font-bold text-neutral-700 dark:text-neutral-300 mb-2 uppercase tracking-tight"
+          >
+            Tip Content
+          </label>
+          <textarea
+            id="tip-content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            required
+            maxLength={MAX_CONTENT_LENGTH}
+            rows={4}
+            className="w-full px-4 py-3 rounded-xl bg-neutral-50 dark:bg-neutral-950 border border-neutral-200 dark:border-neutral-800 focus:ring-2 focus:ring-emerald-500 outline-none transition-all resize-none"
+            placeholder="Share a 2-3 sentence workflow tip..."
+          />
+          <p className="mt-1 text-xs text-neutral-500 text-right">
+            {content.length}/{MAX_CONTENT_LENGTH}
+          </p>
+        </div>
+
+        {error && (
+          <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-600 dark:text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full flex items-center justify-center gap-2 py-4 bg-emerald-500 text-white rounded-xl font-bold hover:bg-emerald-400 disabled:opacity-50 transition-all shadow-lg shadow-emerald-500/20"
+        >
+          {loading ? (
+            <Loader2 className="w-5 h-5 animate-spin" />
+          ) : (
+            <>
+              <Plus className="w-5 h-5" />
+              Submit Tip
+            </>
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -283,5 +283,16 @@ service cloud.firestore {
     match /eventContacts/{docId} {
       allow read, write: if false;
     }
+
+    // Weekly tips — public read, Admin SDK writes only
+    match /weeklyTips/{tipId} {
+      allow read: if true;
+      allow write: if false;
+    }
+
+    // Tip newsletter subscribers — Admin SDK only
+    match /tipSubscribers/{docId} {
+      allow read, write: if false;
+    }
   }
 }

--- a/lib/tip-subscribers.ts
+++ b/lib/tip-subscribers.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { getAdminDb } from "./firebase-admin";
+import type { TipSubscriber } from "@/types/tips";
+
+const COLLECTION = "tipSubscribers";
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export async function addSubscriber(email: string, name?: string): Promise<void> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firestore not configured");
+
+  const normalized = normalizeEmail(email);
+  const docRef = db.collection(COLLECTION).doc(normalized);
+  const existing = await docRef.get();
+
+  if (existing.exists) {
+    const data = existing.data();
+    if (data?.unsubscribed) {
+      await docRef.update({
+        unsubscribed: false,
+        subscribedAt: new Date().toISOString(),
+        ...(name && { name }),
+      });
+    }
+    return;
+  }
+
+  await docRef.set({
+    email: normalized,
+    name: name || null,
+    subscribedAt: new Date().toISOString(),
+    unsubscribed: false,
+  });
+}
+
+export async function removeSubscriber(email: string): Promise<void> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firestore not configured");
+
+  const normalized = normalizeEmail(email);
+  const docRef = db.collection(COLLECTION).doc(normalized);
+  const existing = await docRef.get();
+
+  if (!existing.exists) return;
+
+  await docRef.update({
+    unsubscribed: true,
+    unsubscribedAt: new Date().toISOString(),
+  });
+}
+
+export async function getActiveSubscribers(): Promise<TipSubscriber[]> {
+  const db = getAdminDb();
+  if (!db) return [];
+
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("unsubscribed", "==", false)
+    .get();
+
+  return snapshot.docs.map((doc) => doc.data() as TipSubscriber);
+}

--- a/lib/tips.ts
+++ b/lib/tips.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { getAdminDb } from "./firebase-admin";
+import type { WeeklyTip, TipStatus } from "@/types/tips";
+
+const COLLECTION = "weeklyTips";
+
+export async function getPublishedTips(): Promise<WeeklyTip[]> {
+  const db = getAdminDb();
+  if (!db) return [];
+
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("status", "==", "published")
+    .orderBy("publishedAt", "desc")
+    .get();
+
+  return snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...(doc.data() as Omit<WeeklyTip, "id">),
+  }));
+}
+
+export async function getScheduledTipForWeek(weekOf: string): Promise<WeeklyTip | null> {
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("status", "in", ["scheduled", "published"])
+    .where("weekOf", "==", weekOf)
+    .limit(1)
+    .get();
+
+  if (snapshot.empty) return null;
+  const doc = snapshot.docs[0];
+  return { id: doc.id, ...(doc.data() as Omit<WeeklyTip, "id">) };
+}
+
+export async function getLatestScheduledTip(): Promise<WeeklyTip | null> {
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const snapshot = await db
+    .collection(COLLECTION)
+    .where("status", "==", "scheduled")
+    .orderBy("createdAt", "desc")
+    .limit(1)
+    .get();
+
+  if (snapshot.empty) return null;
+  const doc = snapshot.docs[0];
+  return { id: doc.id, ...(doc.data() as Omit<WeeklyTip, "id">) };
+}
+
+export async function createTip(data: {
+  title: string;
+  content: string;
+  category: string;
+  authorId: string;
+  authorName: string;
+  status: TipStatus;
+}): Promise<string> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firestore not configured");
+
+  const docRef = await db.collection(COLLECTION).add({
+    ...data,
+    createdAt: new Date().toISOString(),
+  });
+
+  return docRef.id;
+}
+
+export async function updateTipStatus(
+  tipId: string,
+  status: TipStatus,
+  extra: Record<string, unknown> = {}
+): Promise<void> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firestore not configured");
+
+  await db
+    .collection(COLLECTION)
+    .doc(tipId)
+    .update({ status, ...extra });
+}

--- a/types/tips.ts
+++ b/types/tips.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export const TIP_CATEGORIES = [
+  "Keyboard Shortcuts",
+  "Prompt Tricks",
+  "Workflow Hacks",
+  "Extensions & Tools",
+  "AI Concepts",
+  "General",
+] as const;
+
+export type TipCategory = (typeof TIP_CATEGORIES)[number];
+
+export type TipStatus = "pending" | "scheduled" | "published";
+
+export interface WeeklyTip {
+  id: string;
+  title: string;
+  content: string;
+  authorId: string;
+  authorName: string;
+  category: TipCategory;
+  status: TipStatus;
+  createdAt: string;
+  publishedAt?: string;
+  weekOf?: string;
+}
+
+export interface TipSubscriber {
+  email: string;
+  name?: string;
+  subscribedAt: string;
+  unsubscribed: boolean;
+  unsubscribedAt?: string;
+}


### PR DESCRIPTION
## Summary

- Add **Weekly AI Dev Tips** feature: community members submit 2-3 sentence Cursor workflow tips, curated by admins, auto-sent to subscribers every Monday via Mailgun
- Full stack: types, data layer, 4 API routes, 3 components, 2 pages, Firestore rules, sidebar/footer/sitemap integration, GitHub Actions cron workflow
- 29 tests across 6 suites covering all API routes and components

### What's included

| Area | Files |
|------|-------|
| **Types** | `types/tips.ts` |
| **Data layer** | `lib/tips.ts`, `lib/tip-subscribers.ts` |
| **API routes** | `/api/tips` (GET), `/api/tips/submit` (POST), `/api/tips/subscribe` (POST/DELETE), `/api/newsletter/tips` (POST) |
| **Pages** | `/tips` (archive + search + subscribe), `/tips/submit` (auth-gated form) |
| **Components** | `TipCard`, `TipSubmitForm`, `SubscribeForm` |
| **Firestore** | `weeklyTips` (public read, Admin SDK write), `tipSubscribers` (Admin SDK only) |
| **Automation** | `.github/workflows/weekly-tips.yml` — cron every Monday 10 AM ET |
| **Nav** | Added to AppShell sidebar, Footer, sitemap |

### New env var needed

- `CRON_SECRET` — shared secret for the GitHub Actions cron to authenticate against `/api/newsletter/tips`

Closes #259

## Test plan

- [x] 29 tests pass across 6 suites (API routes + components)
- [x] Full suite (1,152 tests) passes with no regressions
- [x] TypeScript compiles with zero errors
- [ ] CI passes (lint, typecheck, test, build)


Made with [Cursor](https://cursor.com)