### PR TITLE
Add Architecture Decision Records for key technical decisions #239

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,10 +51,19 @@ A read-only clone of upstream is fine for browsing or local experimentation, but
 - **`main`** tracks **production**. Changes reach `main` only through a **release PR** from `develop` after maintainers batch and review what should ship. That keeps production history and deployments controlled.
 - After a release merge, maintainers sync **`develop`** with **`main`** so both stay aligned.
 
+## Architecture Decision Records
+
+We document significant architectural choices in short, numbered records so future contributors understand *why* the project is built the way it is. ADRs live in [`docs/adr/`](../docs/adr/README.md).
+
+**When to write an ADR:** If your PR introduces a new technology, changes the deployment model, replaces a core library, or makes a decision that future contributors will wonder about — write an ADR. Copy the template from the ADR index, give it the next number, and include it in your PR.
+
+**When to update an existing ADR:** If your PR supersedes a previous decision, update the old ADR's status to `Superseded` and link to the new one.
+
 ## Table of Contents
 
 - [Contribution policy (fork and pull request only)](#contribution-policy-fork-and-pull-request-only)
 - [Branching model (develop and main)](#branching-model-develop-and-main)
+- [Architecture Decision Records](#architecture-decision-records)
 - [Code of Conduct](#code-of-conduct)
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
 - [Getting Started](#getting-started)

--- a/docs/adr/0004-webpack-bundler.md
+++ b/docs/adr/0004-webpack-bundler.md
@@ -1,0 +1,34 @@
+# ADR-0004: Webpack over Turbopack
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Authors:** @rogerSuperBuilderAlpha
+
+## Context
+
+Next.js 16 ships Turbopack as the default bundler for both `dev` and `build`. However, this project relies on the `@next/bundle-analyzer` webpack plugin to visualize production bundle composition (`ANALYZE=true next build`). Turbopack does not yet support the full webpack plugin API, which means plugins like `@next/bundle-analyzer` that wrap the webpack config cannot run under Turbopack.
+
+Alternatives considered:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Turbopack (default)** | Faster cold starts, incremental compilation | No `@next/bundle-analyzer` support, incomplete plugin ecosystem |
+| **Webpack (explicit `--webpack` flag)** | Full plugin compatibility, mature ecosystem, bundle analysis works | Slower cold starts than Turbopack |
+
+## Decision
+
+Explicitly opt into Webpack by passing the `--webpack` flag on both the `dev` and `build` scripts in `package.json`:
+
+```json
+"dev": "NODE_OPTIONS='--no-deprecation' next dev --webpack",
+"build": "npm run validate-env && next build --webpack"
+```
+
+Continue using `@next/bundle-analyzer` to wrap `next.config.js` for on-demand bundle analysis. Re-evaluate when Turbopack reaches full webpack plugin compatibility.
+
+## Consequences
+
+- **Bundle analysis available:** `ANALYZE=true npm run build` produces an interactive treemap of the production bundle, helping contributors catch size regressions.
+- **Slower dev cold starts:** Webpack is measurably slower than Turbopack on initial compilation. For a project of this size the difference is a few seconds, which is acceptable.
+- **Full plugin ecosystem:** Any webpack loader or plugin can be added without compatibility concerns.
+- **Easy to reverse:** Switching to Turbopack is a single-commit change — remove the `--webpack` flags and update `next.config.js` to drop the `withBundleAnalyzer` wrapper (or replace it with Turbopack-native analysis when available).

--- a/docs/adr/0005-in-memory-rate-limiting.md
+++ b/docs/adr/0005-in-memory-rate-limiting.md
@@ -1,0 +1,39 @@
+# ADR-0005: In-memory rate limiting with Firestore fallback
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Authors:** @rogerSuperBuilderAlpha
+
+## Context
+
+The platform exposes 50+ API routes that need rate limiting to prevent abuse. The project is deployed on Vercel serverless functions, where each invocation may run in a different isolate, making pure in-memory state unreliable for distributed enforcement. However, the project is a community platform with moderate traffic, not a high-scale SaaS — the threat model is casual abuse, not coordinated attacks.
+
+Alternatives considered:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Redis (e.g., Upstash)** | True distributed state, battle-tested | Monthly cost, extra service to configure, contributors need Redis locally |
+| **Firestore-only** | Distributed, already in stack | Transaction latency on every request, read/write cost at scale |
+| **In-memory only** | Zero cost, zero setup, fast | Per-isolate on Vercel — limits are not shared across instances |
+| **Two-tier (in-memory + Firestore)** | Zero extra infra, distributed when Admin DB is available, graceful fallback | Slightly more complex implementation |
+
+## Decision
+
+Use a **two-tier rate limiting architecture** with no external dependencies beyond Firebase:
+
+1. **Primary layer** (`lib/rate-limit.ts`): An in-memory limiter using a plain JavaScript object. It provides predefined configs (`rateLimitConfigs`) for different endpoint types (OAuth callbacks: 10 req/15 min, standard API: 60/min, webhooks: 30/min, hackathon mutations: 10–40/min, etc.). Automatic cleanup runs every 60 seconds with a 10,000-entry ceiling.
+
+2. **Secondary layer** (`lib/rate-limit-server.ts`): A Firestore-backed distributed limiter that uses transactions on the `apiRateLimits` collection for cross-instance consistency. When the Admin DB is unavailable, it falls back to the in-memory limiter with configurable modes:
+   - `strict-memory` (default): tighter in-memory limits as a safety net.
+   - `memory`: same limits as the distributed tier.
+   - `deny`: fail closed with 503 when the distributed limiter is unavailable.
+
+Both layers return standard `X-RateLimit-*` headers (Limit, Remaining, Reset) and `Retry-After` on denial.
+
+## Consequences
+
+- **Zero infrastructure cost:** No Redis or Upstash bill. The Firestore reads/writes for rate limiting fall within the free tier for moderate traffic.
+- **Contributor-friendly:** Local development requires no extra services — the in-memory limiter works standalone.
+- **Per-isolate caveat:** On Vercel, in-memory limits are scoped to each serverless isolate. A determined attacker hitting different isolates could exceed intended limits. This is acceptable for the project's threat model; the Firestore tier provides distributed protection for sensitive endpoints.
+- **Upgrade path:** If the project scales significantly, replacing the in-memory layer with Upstash Redis would be a targeted change to `lib/rate-limit.ts` without altering the `withRateLimit` / `rateLimitConfigs` API that API routes consume.
+- **Observability:** Both layers emit structured `rate_limit_observation` log events with source, scope, and fallback metadata for operational monitoring.

--- a/docs/adr/0006-develop-main-branching.md
+++ b/docs/adr/0006-develop-main-branching.md
@@ -1,0 +1,35 @@
+# ADR-0006: develop/main branching over trunk-based development
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Authors:** @rogerSuperBuilderAlpha
+
+## Context
+
+The project needs a branching strategy that balances contributor accessibility with deployment safety. [ADR-0003](0003-fork-only-workflow.md) establishes that contributions come through forks, but does not address how changes flow from integration to production.
+
+Trunk-based development (everyone merges to `main`, deploy continuously) is common in teams with strong CI, feature flags, and immediate rollback capability. This project has a small maintainer team, many first-time contributors, and no feature-flag infrastructure. Vercel is configured to deploy only when `main` is updated.
+
+Alternatives considered:
+
+| Model | Pros | Cons |
+|-------|------|------|
+| **Trunk-based** (single `main` branch) | Simpler model, faster path to production | Every merge deploys immediately, no batch verification, requires feature flags for incomplete work |
+| **develop/main** (two long-lived branches) | Maintainers control release cadence, PRs can be batched and verified together, `develop` can break without affecting production | Extra promotion step adds latency, contributors must target the correct branch |
+
+## Decision
+
+Use a **two-branch model**:
+
+- **`develop`** is the default branch on GitHub and the target for all contributor pull requests. CI (lint, type-check, tests) runs on every PR against `develop`.
+- **`main`** is the production branch. It is updated only via **release PRs** from `develop` after maintainers batch and verify what should ship.
+- Vercel deploys only on `main` merges — configured via `vercel.json` (`git.deploymentEnabled`) and `scripts/vercel-ignore-build.sh`, which rejects non-production builds.
+- After a release merge, maintainers sync `develop` with `main` so both branches stay aligned.
+
+## Consequences
+
+- **Controlled releases:** Maintainers batch multiple PRs into a single release PR, test them together, and ship when ready. This is safer for a project where many contributors are making their first open source PR.
+- **Safe integration branch:** `develop` can temporarily break (a contributor's PR introduces a regression that is caught in review) without affecting the live site.
+- **Deploy latency:** Changes merged to `develop` reach production hours to days later, not minutes. This is acceptable for a community platform that is not latency-sensitive.
+- **Branch targeting:** Contributors must open PRs against `develop`, not `main`. This is documented in [CONTRIBUTING.md](../../.github/CONTRIBUTING.md) and reinforced by GitHub's default branch setting.
+- **See also:** [ADR-0003](0003-fork-only-workflow.md) covers why contributions come through forks; this ADR covers where they land and how they reach production.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,9 @@ What becomes easier or more difficult because of this decision?
 | [0001](0001-gpl3-license.md) | GPL-3.0 license | Accepted | 2026-01-27 |
 | [0002](0002-firebase-backend.md) | Firebase as backend platform | Accepted | 2026-01-27 |
 | [0003](0003-fork-only-workflow.md) | Fork-only contribution workflow | Accepted | 2026-02-16 |
+| [0004](0004-webpack-bundler.md) | Webpack over Turbopack | Accepted | 2026-04-13 |
+| [0005](0005-in-memory-rate-limiting.md) | In-memory rate limiting with Firestore fallback | Accepted | 2026-04-13 |
+| [0006](0006-develop-main-branching.md) | develop/main branching strategy | Accepted | 2026-04-13 |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
## Description
  Adds 3 new Architecture Decision Records documenting key technical decisions that
  were previously undocumented, and updates the contributing guide to reference the   
  ADR process. New contributors can now understand *why* certain choices were made:
                                                                                      
  - **ADR-0004**: Webpack over Turbopack (bundle analyzer plugin compatibility)       
  - **ADR-0005**: In-memory rate limiting with Firestore fallback over Redis (zero
  infra cost, two-tier design)                                                        
  - **ADR-0006**: develop/main branching over trunk-based development (controlled
  releases, safe integration branch)                                                  
   
  The project already had 3 ADRs (GPL-3.0, Firebase, fork-only workflow), bringing the
   total to 6.                                              
                                                                                      
  **Base branch:** `develop`                                                          
   
  Fixes #239                                                                          
                                                            
  ## Type of Change

  - [x] Documentation update

  ## How Has This Been Tested?

  - [x] Tested locally                                                                
  - Verified all markdown files render correctly
  - Verified ADR index table links resolve to the correct files                       
  - Verified CONTRIBUTING.md ToC anchor links work                                    
                                                                                      
  ## Checklist                                                                        
  - [x] My code follows the code style of this project                                
  - [x] I have performed a self-review of my own code       
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
                                                                                      
  ## Additional Notes
  - Used the existing `docs/adr/` directory and template format rather than creating a
   new `docs/decisions/` directory, to avoid fragmenting the existing ADR structure.  
  - Each new ADR includes an alternatives comparison table, matching the style of
  ADR-0002 (Firebase).                                                                
  - ADR-0006 cross-references ADR-0003 since the branching strategy and fork-only
  workflow are related but distinct decisions. 