### PR TITLE
fix(a11y): add role and aria attrs to check-in toggle

### DIFF
--- a/app/hackathons/hack-a-sprint-2026/admin/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/admin/page.tsx
@@ -620,6 +620,9 @@ function CheckInRow({
           <button
             disabled={busy}
             onClick={() => onToggle(e.userId!, e.checkedIn)}
+            role="switch"
+            aria-checked={e.checkedIn}
+            aria-label={e.checkedIn ? "Undo check-in" : "Check in"}
             className={`relative inline-flex h-7 w-12 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 ${
               e.checkedIn
                 ? "bg-emerald-500"


### PR DESCRIPTION
## Summary
- Adds `role="switch"` and `aria-checked` to the hackathon admin check-in toggle button
- Adds `aria-label` so screen readers announce the toggle purpose and state
- Improves WCAG compliance for the admin dashboard

## Test plan
- [ ] Verify toggle still works visually in the admin panel
- [ ] Test with a screen reader (VoiceOver/NVDA) to confirm it announces as a switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)