### PR TITLE
feat(seo): add metadata to pair requests page

### DIFF
--- a/app/pair/requests/layout.tsx
+++ b/app/pair/requests/layout.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+
+const title = "Pair Programming Requests | Cursor Boston";
+const description =
+  "Browse and manage your pair programming requests with the Boston Cursor community.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  openGraph: {
+    title,
+    description,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+  },
+  alternates: {
+    canonical: "https://cursorboston.com/pair/requests",
+  },
+};
+
+export default function PairRequestsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}


### PR DESCRIPTION
## Summary
- Adds `layout.tsx` with SEO metadata for the `pair/requests` page
- Includes OpenGraph and Twitter card tags for social sharing
- Adds canonical URL for search engine indexing

## Test plan
- [ ] Verify the pair/requests page still renders correctly
- [ ] Check page source for `<meta>` tags (title, description, og:*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)