### PR TITLE
fix: remove debug console.log from LumaCheckoutTracker

### DIFF
--- a/components/LumaCheckoutTracker.tsx
+++ b/components/LumaCheckoutTracker.tsx
@@ -75,7 +75,7 @@ export default function LumaCheckoutTracker() {
               guestId
             );
 
-            console.log("Registration tracked for event:", eventId);
+            /* registration tracked successfully */
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- Removes a `console.log("Registration tracked for event:", eventId)` statement left in production code
- Keeps the `console.error` for actual error handling intact

## Test plan
- [ ] Verify Luma checkout tracking still works
- [ ] Confirm no debug logs appear in browser console on registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)