### PR TITLE
fix(a11y): add role="alert" to ErrorBoundary fallback

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -38,7 +38,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       }
 
       return (
-        <div className="min-h-[60vh] flex items-center justify-center p-8">
+        <div role="alert" className="min-h-[60vh] flex items-center justify-center p-8">
           <div className="text-center max-w-md">
             <h2 className="text-xl font-semibold text-foreground mb-2">
               Something went wrong


### PR DESCRIPTION
## Summary
- Adds `role="alert"` to the ErrorBoundary fallback container
- Ensures screen readers immediately announce the error state to assistive technology users

## Test plan
- [ ] Trigger an error boundary (e.g., throw in a child component) and verify the alert role is present in the DOM
- [ ] Test with VoiceOver/NVDA to confirm the error message is announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)