### PR TITLE
feat(a11y): add skip-to-content link for keyboard navigation

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -167,6 +167,13 @@ export default function AppShell({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex min-h-screen w-full bg-background text-foreground">
+      {/* Skip to main content link for keyboard users */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-lg focus:bg-emerald-500 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-emerald-300"
+      >
+        Skip to main content
+      </a>
       {/* Mobile drawer backdrop */}
       {mobileOpen ? (
         <button


### PR DESCRIPTION
## Summary
- Adds a skip-to-content link in `AppShell` that is visually hidden but appears on keyboard focus
- Links to the existing `#main-content` anchor on the `<main>` element
- Addresses the open-source roadmap item for skip-to-content links

## Test plan
- [ ] Press Tab on page load — the skip link should appear as the first focusable element
- [ ] Press Enter on the skip link — focus should jump to the main content area
- [ ] Verify the link is hidden during normal mouse browsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)