### PR TITLE
feat(hack-a-sprint-2026): add FirefoxMetzger showcase submission

### DIFF
--- a/content/hackathons/hack-a-sprint-2026/submissions/firefoxmetzger.json
+++ b/content/hackathons/hack-a-sprint-2026/submissions/firefoxmetzger.json
@@ -1,0 +1,5 @@
+{
+    "projectRepoUrl": "https://github.com/FirefoxMetzger/com-knowledgebase",
+    "title": "Newsletter Knowledge Base",
+    "description": "A Karpathy wiki/KB that uses newsletters as a source for the knowledge base.",
+}


### PR DESCRIPTION
Adds a Hack-a-Sprint 2026 showcase submission JSON for **Newsletter Knowledge Base** (`FirefoxMetzger/com-knowledgebase`): a Karpathy-style wiki/knowledge base sourced from newsletters.

Targets `develop` per project contribution guidelines.

Made with [Cursor](https://cursor.com)