### PR TITLE
Hack-a-Sprint 2026 submission: RogerRoger by MisterAwesome23

### DIFF
--- a/content/hackathons/hack-a-sprint-2026/submissions/MisterAwesome23.json
+++ b/content/hackathons/hack-a-sprint-2026/submissions/MisterAwesome23.json
@@ -1,0 +1,6 @@
+{
+  "projectRepoUrl": "https://github.com/MisterAwesome23/RogerRoger",
+  "title": "RogerRoger - Reddit Community Manager Agent",
+  "description": "A Chrome extension + AI agent that monitors your Reddit notifications and surfaces actionable insights. Since Reddit has no public API, the extension scrapes the /notifications page while the user is logged in, sends the data to a local Node.js server, and uses Claude AI to analyze and categorize activity. The agent identifies meeting opportunities, volunteer signals, and engagement patterns, then emails a rich summary directly to the user via InkBox (@community_manager identity). Stack: Chrome Extension (Manifest V3), Node.js/Express backend, Claude API (claude-sonnet) for analysis, InkBox for email delivery. Built at Hack-a-Sprint 2026 in Boston.",
+  "loomVideoUrl": "https://www.loom.com/share/placeholder-update-before-715pm"
+}


### PR DESCRIPTION
## RogerRoger — Reddit Community Manager Agent

**GitHub:** https://github.com/MisterAwesome23/RogerRoger

### What I built
A Chrome extension + AI agent that turns Reddit notifications into actionable intelligence. Since Reddit has no public API, the extension scrapes `/notifications` while the user is logged in, then an AI backend handles everything else automatically.

### How it works
1. **Chrome Extension** scrapes Reddit notifications DOM
2. **Node.js server** receives the data and auto-triggers analysis
3. **Claude AI** categorizes notifications, detects meeting opportunities, and suggests outreach contacts
4. **InkBox** (@community_manager) emails the full analysis to the user

### Stack
- Chrome Extension (Manifest V3) — content script, popup UI
- Node.js / Express — local backend server
- Claude API (claude-sonnet) — notification analysis
- InkBox SDK — email delivery via @community_manager identity

### Loom walkthrough
https://www.loom.com/share/placeholder-update-before-715pm

> ⚠️ Loom URL is a placeholder — will update before 7:15 PM ET scoring begins.