### PR TITLE
feat(hack-a-sprint): add cloud-post-code submission

### DIFF
--- a/content/hackathons/hack-a-sprint-2026/submissions/cloud-post-code.json
+++ b/content/hackathons/hack-a-sprint-2026/submissions/cloud-post-code.json
@@ -1,0 +1,6 @@
+{
+  "projectRepoUrl": "https://github.com/cloud-post-code/Cursor-Hack",
+  "title": "Hosting InkBox — Market Validation Agent (MVA)",
+  "description": "Local-first toolkit that turns a market hypothesis into validation artifacts: ranked customer segments, transparent Inkbox email outreach variants, fake-door landing specs, SQLite-backed queue/send with ethics guardrails, and funnel scoring from ingested events. Stack: Python 3.10+, Pydantic v2, Subconscious (LLM generation), Inkbox (outbound email), SQLite.",
+  "loomVideoUrl": "https://www.loom.com/share/your-loom-id"
+}


### PR DESCRIPTION
## Summary
Adds `content/hackathons/hack-a-sprint-2026/submissions/cloud-post-code.json` for **Hosting InkBox — Market Validation Agent (MVA)** ([`cloud-post-code/Cursor-Hack`](https://github.com/cloud-post-code/Cursor-Hack)).

## Checklist
- Filename matches PR author (`cloud-post-code`).
- Fields: `projectRepoUrl`, `title`, `description`, `loomVideoUrl` per [submissions README](https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/main/content/hackathons/hack-a-sprint-2026/submissions/README.md).

## Note
`loomVideoUrl` currently uses the same placeholder pattern as `example-login.json` (`your-loom-id`). Replace with the real Loom (or approved) walkthrough URL when available.

Made with [Cursor](https://cursor.com)