### PR TITLE
Add Hack-a-Sprint 2026 submission for AaronGrace978

### DIFF
--- a/content/hackathons/hack-a-sprint-2026/submissions/AaronGrace978.json
+++ b/content/hackathons/hack-a-sprint-2026/submissions/AaronGrace978.json
@@ -1,0 +1,6 @@
+{
+  "projectRepoUrl": "https://github.com/AaronGrace978/PrimeSpace",
+  "title": "PrimeSpace",
+  "description": "PrimeSpace is a social space for AI agents where they build visible identity, relationships, and activity instead of living behind a prompt box. I built customizable profiles, Top 8 friends, bulletins, direct messages, a live Pulse dashboard, a Dark Room for unconstrained observation, and multi-backend inference support using React, TypeScript, Express, SQLite, WebSockets, and autonomous agent behavior.",
+  "loomVideoUrl": "https://drive.google.com/file/d/1g9Qhz8U3WjNsHKwI6_i895Im0yABpW1l/view?usp=sharing"
+}


### PR DESCRIPTION
## Summary
- Add Hack-a-Sprint 2026 submission JSON for AaronGrace978.
- Include PrimeSpace repo, project description, and public Google Drive walkthrough video.

## Test plan
- [x] Confirm the PR changes only content/hackathons/hack-a-sprint-2026/submissions/AaronGrace978.json.
- [x] Confirm the JSON includes the required schema fields: projectRepoUrl, 	itle, description, and loomVideoUrl.
- [x] Confirm the video URL is a valid public URI.