### PR TITLE
feat: add Community Knowledge Q&A (#253)

### DIFF
--- a/__tests__/app/api/questions/accept/route.test.ts
+++ b/__tests__/app/api/questions/accept/route.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/questions/accept/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+
+const mockAcceptAnswer = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: () => ({ success: true }),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/questions/service", () => {
+  class QNF extends Error { constructor() { super("Question not found"); this.name = "QuestionNotFoundError"; } }
+  class ANF extends Error { constructor() { super("Answer not found"); this.name = "AnswerNotFoundError"; } }
+  class UA extends Error { constructor(m = "Unauthorized") { super(m); this.name = "UnauthorizedError"; } }
+  return {
+    getQuestionsService: () => ({
+      acceptAnswer: mockAcceptAnswer,
+    }),
+    QuestionNotFoundError: QNF,
+    AnswerNotFoundError: ANF,
+    UnauthorizedError: UA,
+  };
+});
+
+const { getVerifiedUser } = jest.requireMock("@/lib/server-auth") as {
+  getVerifiedUser: jest.MockedFunction<() => Promise<VerifiedUser | null>>;
+};
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/questions/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/questions/accept", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    getVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ questionId: "q1", answerId: "a1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when IDs are invalid", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ questionId: "", answerId: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when user is not the question author", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const { UnauthorizedError } = jest.requireMock("@/lib/questions/service");
+    mockAcceptAnswer.mockRejectedValue(new UnauthorizedError("Only the question author can accept an answer"));
+
+    const res = await POST(makeRequest({ questionId: "q1", answerId: "a1" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts an answer successfully", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockAcceptAnswer.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest({ questionId: "q1", answerId: "a1" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+  });
+});

--- a/__tests__/app/api/questions/answer/route.test.ts
+++ b/__tests__/app/api/questions/answer/route.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/questions/answer/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+
+const mockCreateAnswer = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: () => ({ success: true }),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/questions/service", () => ({
+  getQuestionsService: () => ({
+    createAnswer: mockCreateAnswer,
+  }),
+  QuestionNotFoundError: class extends Error {
+    constructor() { super("Question not found"); this.name = "QuestionNotFoundError"; }
+  },
+}));
+
+const { getVerifiedUser } = jest.requireMock("@/lib/server-auth") as {
+  getVerifiedUser: jest.MockedFunction<() => Promise<VerifiedUser | null>>;
+};
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/questions/answer", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/questions/answer", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    getVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ questionId: "q1", body: "An answer" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when questionId is invalid", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ questionId: "", body: "A long enough answer body here." }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when answer body is too short", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ questionId: "q1", body: "Short" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/answer/i);
+  });
+
+  it("creates an answer on valid input", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockCreateAnswer.mockResolvedValue("a1");
+
+    const res = await POST(
+      makeRequest({
+        questionId: "q1",
+        body: "Here is a detailed answer to your question about Cursor rules.",
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.answerId).toBe("a1");
+  });
+});

--- a/__tests__/app/api/questions/post/route.test.ts
+++ b/__tests__/app/api/questions/post/route.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/questions/post/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+
+const mockCreateQuestion = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: () => ({ success: true }),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/questions/service", () => ({
+  getQuestionsService: () => ({
+    createQuestion: mockCreateQuestion,
+  }),
+}));
+
+const { getVerifiedUser } = jest.requireMock("@/lib/server-auth") as {
+  getVerifiedUser: jest.MockedFunction<() => Promise<VerifiedUser | null>>;
+};
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test User" };
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/questions/post", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/questions/post", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    getVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest({ title: "Test", body: "Body here", tags: [] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when title is too short", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ title: "Short", body: "This body is long enough for validation.", tags: [] }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/title/i);
+  });
+
+  it("returns 400 when body is too short", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(makeRequest({ title: "A valid question title here", body: "Short", tags: [] }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/body/i);
+  });
+
+  it("creates a question on valid input", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockCreateQuestion.mockResolvedValue("new-q-id");
+
+    const res = await POST(
+      makeRequest({
+        title: "How do I configure Cursor rules?",
+        body: "I need help setting up rules for my project. Can someone explain?",
+        tags: ["cursor-rules", "workflows"],
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.questionId).toBe("new-q-id");
+    expect(mockCreateQuestion).toHaveBeenCalledWith(
+      "u1",
+      "Test User",
+      null,
+      expect.objectContaining({
+        tags: ["cursor-rules", "workflows"],
+      })
+    );
+  });
+
+  it("filters out invalid tags", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockCreateQuestion.mockResolvedValue("q-id");
+
+    await POST(
+      makeRequest({
+        title: "A valid question title here",
+        body: "This body is long enough to pass validation requirements.",
+        tags: ["debugging", "not-a-real-tag"],
+      })
+    );
+
+    expect(mockCreateQuestion).toHaveBeenCalledWith(
+      "u1",
+      "Test User",
+      null,
+      expect.objectContaining({
+        tags: ["debugging"],
+      })
+    );
+  });
+});

--- a/__tests__/app/api/questions/route.test.ts
+++ b/__tests__/app/api/questions/route.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/questions/route";
+
+const mockListQuestions = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: () => ({ success: true }),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/questions/service", () => ({
+  getQuestionsService: () => ({
+    listQuestions: mockListQuestions,
+  }),
+}));
+
+describe("GET /api/questions", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns questions list", async () => {
+    mockListQuestions.mockResolvedValue({
+      questions: [{ id: "q1", title: "Test" }],
+      nextCursor: null,
+    });
+
+    const req = new NextRequest("http://localhost/api/questions?sort=newest&limit=10");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.questions).toHaveLength(1);
+    expect(mockListQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "newest", limit: 10 })
+    );
+  });
+
+  it("passes search and tag params", async () => {
+    mockListQuestions.mockResolvedValue({ questions: [], nextCursor: null });
+
+    const req = new NextRequest("http://localhost/api/questions?search=debug&tag=debugging");
+    await GET(req);
+
+    expect(mockListQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "debug", tag: "debugging" })
+    );
+  });
+
+  it("clamps limit to 50", async () => {
+    mockListQuestions.mockResolvedValue({ questions: [], nextCursor: null });
+
+    const req = new NextRequest("http://localhost/api/questions?limit=999");
+    await GET(req);
+
+    expect(mockListQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 })
+    );
+  });
+});

--- a/__tests__/app/api/questions/vote/route.test.ts
+++ b/__tests__/app/api/questions/vote/route.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST, GET } from "@/app/api/questions/vote/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+
+const mockVote = jest.fn();
+const mockGetUserVotes = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: () => ({ success: true }),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/questions/service", () => ({
+  getQuestionsService: () => ({
+    vote: mockVote,
+    getUserVotes: mockGetUserVotes,
+  }),
+  QuestionNotFoundError: class extends Error {
+    constructor() { super("Question not found"); this.name = "QuestionNotFoundError"; }
+  },
+  AnswerNotFoundError: class extends Error {
+    constructor() { super("Answer not found"); this.name = "AnswerNotFoundError"; }
+  },
+}));
+
+const { getVerifiedUser } = jest.requireMock("@/lib/server-auth") as {
+  getVerifiedUser: jest.MockedFunction<() => Promise<VerifiedUser | null>>;
+};
+
+const testUser: VerifiedUser = { uid: "u1", name: "Test" };
+
+function makePostRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/questions/vote", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/questions/vote", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 401 when not authenticated", async () => {
+    getVerifiedUser.mockResolvedValue(null);
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "q1", type: "up" })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid targetType", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makePostRequest({ targetType: "invalid", targetId: "q1", type: "up" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid type", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "q1", type: "invalid" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when answer vote lacks questionId", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const res = await POST(
+      makePostRequest({ targetType: "answer", targetId: "a1", type: "up" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("votes on a question successfully", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockVote.mockResolvedValue({
+      action: "added", type: "up", upCount: 1, downCount: 0, netScore: 1,
+    });
+
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "q1", type: "up" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.action).toBe("added");
+  });
+});
+
+describe("GET /api/questions/vote", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns empty votes when not authenticated", async () => {
+    getVerifiedUser.mockResolvedValue(null);
+    const req = new NextRequest("http://localhost/api/questions/vote");
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data.userVotes).toEqual({});
+  });
+
+  it("returns user votes when authenticated", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockGetUserVotes.mockResolvedValue({ q1: "up", a1: "down" });
+
+    const req = new NextRequest("http://localhost/api/questions/vote");
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data.userVotes).toEqual({ q1: "up", a1: "down" });
+  });
+});

--- a/__tests__/components/questions/AnswerCard.test.tsx
+++ b/__tests__/components/questions/AnswerCard.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AnswerCard } from "@/components/questions/AnswerCard";
+import type { Answer } from "@/types/questions";
+
+const baseAnswer: Answer = {
+  id: "a1",
+  questionId: "q1",
+  body: "You can create a .cursorrules file in your project root to define custom rules.",
+  authorId: "u2",
+  authorName: "Bob",
+  authorPhoto: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  upCount: 3,
+  downCount: 0,
+  netScore: 3,
+  isAccepted: false,
+};
+
+describe("AnswerCard", () => {
+  const onVote = jest.fn();
+  const onAccept = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the answer body", () => {
+    render(
+      <AnswerCard
+        answer={baseAnswer}
+        isLoggedIn
+        isVoting={false}
+        isQuestionAuthor={false}
+        onVote={onVote}
+        onAccept={onAccept}
+      />
+    );
+    expect(screen.getByText(/\.cursorrules file/)).toBeInTheDocument();
+  });
+
+  it("shows net score", () => {
+    render(
+      <AnswerCard
+        answer={baseAnswer}
+        isLoggedIn
+        isVoting={false}
+        isQuestionAuthor={false}
+        onVote={onVote}
+        onAccept={onAccept}
+      />
+    );
+    expect(screen.getByText("+3")).toBeInTheDocument();
+  });
+
+  it("shows author name", () => {
+    render(
+      <AnswerCard
+        answer={baseAnswer}
+        isLoggedIn
+        isVoting={false}
+        isQuestionAuthor={false}
+        onVote={onVote}
+        onAccept={onAccept}
+      />
+    );
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("shows accept button only for question author", () => {
+    const { rerender } = render(
+      <AnswerCard
+        answer={baseAnswer}
+        isLoggedIn
+        isVoting={false}
+        isQuestionAuthor={false}
+        onVote={onVote}
+        onAccept={onAccept}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /accept/i })).not.toBeInTheDocument();
+
+    rerender(
+      <AnswerCard
+        answer={baseAnswer}
+        isLoggedIn
+        isVoting={false}
+        isQuestionAuthor
+        onVote={onVote}
+        onAccept={onAccept}
+      />
+    );
+    expect(screen.getByRole("button", { name: /accept/i })).toBeInTheDocument();
+  });
+
+  it("shows accepted badge when isAccepted is true", () => {
+    render(
+      <AnswerCard
+        answer={{ ...baseAnswer, isAccepted: true }}
+        isLoggedIn
+        isVoting={false}
+        isQuestionAuthor={false}
+        onVote={onVote}
+        onAccept={onAccept}
+      />
+    );
+    expect(screen.getByText("Accepted Answer")).toBeInTheDocument();
+  });
+
+  it("calls onAccept when accept button is clicked", () => {
+    render(
+      <AnswerCard
+        answer={baseAnswer}
+        isLoggedIn
+        isVoting={false}
+        isQuestionAuthor
+        onVote={onVote}
+        onAccept={onAccept}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+    expect(onAccept).toHaveBeenCalledWith("a1");
+  });
+});

--- a/__tests__/components/questions/QuestionCard.test.tsx
+++ b/__tests__/components/questions/QuestionCard.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuestionCard } from "@/components/questions/QuestionCard";
+import type { Question } from "@/types/questions";
+
+const baseQuestion: Question = {
+  id: "q1",
+  title: "How do I configure Cursor rules?",
+  body: "I want to set up custom rules for my project but can't find the right config.",
+  tags: ["cursor-rules", "workflows"],
+  authorId: "u1",
+  authorName: "Alice",
+  authorPhoto: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  upCount: 5,
+  downCount: 1,
+  netScore: 4,
+  answerCount: 3,
+};
+
+describe("QuestionCard", () => {
+  const onVote = jest.fn();
+  const onTagClick = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders title and body preview", () => {
+    render(
+      <QuestionCard
+        question={baseQuestion}
+        isLoggedIn
+        isVoting={false}
+        onVote={onVote}
+        onTagClick={onTagClick}
+      />
+    );
+    expect(screen.getByText("How do I configure Cursor rules?")).toBeInTheDocument();
+    expect(screen.getByText(/custom rules/)).toBeInTheDocument();
+  });
+
+  it("shows net score with correct sign", () => {
+    render(
+      <QuestionCard
+        question={baseQuestion}
+        isLoggedIn
+        isVoting={false}
+        onVote={onVote}
+      />
+    );
+    expect(screen.getByText("+4")).toBeInTheDocument();
+  });
+
+  it("renders tags as clickable buttons", () => {
+    render(
+      <QuestionCard
+        question={baseQuestion}
+        isLoggedIn
+        isVoting={false}
+        onVote={onVote}
+        onTagClick={onTagClick}
+      />
+    );
+    const tagBtn = screen.getByText("cursor-rules");
+    fireEvent.click(tagBtn);
+    expect(onTagClick).toHaveBeenCalledWith("cursor-rules");
+  });
+
+  it("displays answer count", () => {
+    render(
+      <QuestionCard
+        question={baseQuestion}
+        isLoggedIn
+        isVoting={false}
+        onVote={onVote}
+      />
+    );
+    expect(screen.getByText("3 answers")).toBeInTheDocument();
+  });
+
+  it("displays author name", () => {
+    render(
+      <QuestionCard
+        question={baseQuestion}
+        isLoggedIn
+        isVoting={false}
+        onVote={onVote}
+      />
+    );
+    expect(screen.getByText(/Alice/)).toBeInTheDocument();
+  });
+
+  it("disables vote buttons when not logged in", () => {
+    render(
+      <QuestionCard
+        question={baseQuestion}
+        isLoggedIn={false}
+        isVoting={false}
+        onVote={onVote}
+      />
+    );
+    const upBtn = screen.getByRole("button", { name: /upvote/i });
+    expect(upBtn).toBeDisabled();
+  });
+
+  it("calls onVote when upvote is clicked", () => {
+    render(
+      <QuestionCard
+        question={baseQuestion}
+        isLoggedIn
+        isVoting={false}
+        onVote={onVote}
+      />
+    );
+    const upBtn = screen.getByRole("button", { name: /upvote/i });
+    fireEvent.click(upBtn);
+    expect(onVote).toHaveBeenCalledWith("q1", "up");
+  });
+});

--- a/__tests__/lib/questions/search.test.ts
+++ b/__tests__/lib/questions/search.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+
+import { matchesQuestionSearchTerms } from "@/lib/questions/search";
+
+describe("matchesQuestionSearchTerms", () => {
+  it("returns true when no search terms provided", () => {
+    expect(matchesQuestionSearchTerms("Title", "Body", ["tag"], [])).toBe(true);
+  });
+
+  it("matches against title", () => {
+    expect(
+      matchesQuestionSearchTerms("How to debug Cursor rules", "Some body", ["other"], ["debug"])
+    ).toBe(true);
+  });
+
+  it("matches against body", () => {
+    expect(
+      matchesQuestionSearchTerms("Title", "Use prompting patterns for refactoring", ["other"], ["prompting"])
+    ).toBe(true);
+  });
+
+  it("matches against tags", () => {
+    expect(
+      matchesQuestionSearchTerms("Title", "Body", ["mcp", "agents"], ["agents"])
+    ).toBe(true);
+  });
+
+  it("is case insensitive", () => {
+    expect(
+      matchesQuestionSearchTerms("CURSOR RULES", "Body", [], ["cursor"])
+    ).toBe(true);
+  });
+
+  it("returns true if any term matches (OR logic)", () => {
+    expect(
+      matchesQuestionSearchTerms("Debugging tips", "Body", [], ["nonexistent", "debug"])
+    ).toBe(true);
+  });
+
+  it("returns false when no terms match", () => {
+    expect(
+      matchesQuestionSearchTerms("Title", "Body", ["testing"], ["zzzzz"])
+    ).toBe(false);
+  });
+});

--- a/__tests__/lib/questions/service.test.ts
+++ b/__tests__/lib/questions/service.test.ts
@@ -1,0 +1,293 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  QuestionsService,
+  QuestionNotFoundError,
+  AnswerNotFoundError,
+  UnauthorizedError,
+} from "@/lib/questions/service";
+
+const mockAdd = jest.fn();
+const mockDocGet = jest.fn();
+const mockDocUpdate = jest.fn();
+const mockDocSet = jest.fn();
+const mockDocDelete = jest.fn();
+const mockQueryGet = jest.fn();
+const mockRunTransaction = jest.fn();
+const mockWhere = jest.fn();
+const mockOrderBy = jest.fn();
+const mockLimit = jest.fn();
+const mockStartAfter = jest.fn();
+
+function createMockQuery() {
+  const q: Record<string, jest.Mock> = {};
+  q.where = jest.fn().mockReturnValue(q);
+  q.orderBy = jest.fn().mockReturnValue(q);
+  q.limit = jest.fn().mockReturnValue(q);
+  q.startAfter = jest.fn().mockReturnValue(q);
+  q.get = mockQueryGet;
+  return q;
+}
+
+const mockSubCollection = jest.fn();
+
+function createMockDocRef() {
+  return {
+    get: mockDocGet,
+    set: mockDocSet,
+    update: mockDocUpdate,
+    delete: mockDocDelete,
+    collection: mockSubCollection,
+    id: "mock-doc-id",
+  };
+}
+
+const mockQuery = createMockQuery();
+
+const mockDb = {
+  collection: jest.fn().mockReturnValue({
+    add: mockAdd,
+    doc: jest.fn().mockReturnValue(createMockDocRef()),
+    where: mockQuery.where,
+    orderBy: mockQuery.orderBy,
+    limit: mockQuery.limit,
+    startAfter: mockQuery.startAfter,
+    get: mockQueryGet,
+  }),
+  runTransaction: mockRunTransaction,
+} as unknown as FirebaseFirestore.Firestore;
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => mockDb),
+}));
+
+describe("QuestionsService", () => {
+  let service: QuestionsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new QuestionsService(mockDb);
+  });
+
+  describe("createQuestion", () => {
+    it("creates a question and returns the doc id", async () => {
+      mockAdd.mockResolvedValue({ id: "q1" });
+
+      const id = await service.createQuestion("u1", "User One", null, {
+        title: "How to debug?",
+        body: "I need help debugging.",
+        tags: ["debugging"],
+      });
+
+      expect(id).toBe("q1");
+      expect(mockAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "How to debug?",
+          body: "I need help debugging.",
+          tags: ["debugging"],
+          authorId: "u1",
+          authorName: "User One",
+          upCount: 0,
+          downCount: 0,
+          netScore: 0,
+          answerCount: 0,
+        })
+      );
+    });
+
+    it("filters invalid tags", async () => {
+      mockAdd.mockResolvedValue({ id: "q2" });
+
+      await service.createQuestion("u1", "User", null, {
+        title: "Question",
+        body: "Body",
+        tags: ["debugging", "invalid-tag" as never],
+      });
+
+      const callArgs = mockAdd.mock.calls[0][0];
+      expect(callArgs.tags).toEqual(["debugging"]);
+    });
+  });
+
+  describe("getQuestion", () => {
+    it("returns null when question does not exist", async () => {
+      mockDocGet.mockResolvedValue({ exists: false });
+      const result = await service.getQuestion("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("returns a question when it exists", async () => {
+      const createdAt = { toDate: () => new Date("2026-01-01") };
+      mockDocGet.mockResolvedValue({
+        exists: true,
+        id: "q1",
+        data: () => ({
+          title: "Test Q",
+          body: "Test body",
+          tags: ["debugging"],
+          authorId: "u1",
+          authorName: "User",
+          authorPhoto: null,
+          createdAt,
+          updatedAt: createdAt,
+          upCount: 5,
+          downCount: 1,
+          netScore: 4,
+          answerCount: 2,
+        }),
+      });
+
+      const result = await service.getQuestion("q1");
+      expect(result).not.toBeNull();
+      expect(result?.title).toBe("Test Q");
+      expect(result?.netScore).toBe(4);
+    });
+  });
+
+  describe("listQuestions", () => {
+    it("returns paginated questions", async () => {
+      const createdAt = { toDate: () => new Date("2026-01-01") };
+      mockQueryGet.mockResolvedValue({
+        docs: [
+          {
+            id: "q1",
+            data: () => ({
+              title: "Q1", body: "B1", tags: [], authorId: "u1", authorName: "U1",
+              authorPhoto: null, createdAt, updatedAt: createdAt,
+              upCount: 0, downCount: 0, netScore: 0, answerCount: 0,
+            }),
+          },
+        ],
+        empty: false,
+      });
+
+      const result = await service.listQuestions({ sort: "newest", limit: 20 });
+      expect(result.questions).toHaveLength(1);
+      expect(result.questions[0].title).toBe("Q1");
+      expect(result.nextCursor).toBeNull();
+    });
+  });
+
+  describe("vote", () => {
+    it("adds a new vote via transaction", async () => {
+      mockRunTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          get: jest.fn()
+            .mockResolvedValueOnce({
+              exists: true,
+              data: () => ({ upCount: 0, downCount: 0 }),
+            })
+            .mockResolvedValueOnce({ exists: false }),
+          set: jest.fn(),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+
+      const result = await service.vote("question", "q1", "u1", "up");
+      expect(result.action).toBe("added");
+      expect(result.type).toBe("up");
+      expect(result.upCount).toBe(1);
+      expect(result.downCount).toBe(0);
+    });
+
+    it("removes a vote when toggling same type", async () => {
+      mockRunTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          get: jest.fn()
+            .mockResolvedValueOnce({
+              exists: true,
+              data: () => ({ upCount: 1, downCount: 0 }),
+            })
+            .mockResolvedValueOnce({
+              exists: true,
+              data: () => ({ type: "up" }),
+            }),
+          delete: jest.fn(),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+
+      const result = await service.vote("question", "q1", "u1", "up");
+      expect(result.action).toBe("removed");
+      expect(result.upCount).toBe(0);
+    });
+
+    it("switches a vote", async () => {
+      mockRunTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          get: jest.fn()
+            .mockResolvedValueOnce({
+              exists: true,
+              data: () => ({ upCount: 1, downCount: 0 }),
+            })
+            .mockResolvedValueOnce({
+              exists: true,
+              data: () => ({ type: "up" }),
+            }),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+
+      const result = await service.vote("question", "q1", "u1", "down");
+      expect(result.action).toBe("switched");
+      expect(result.type).toBe("down");
+      expect(result.previousType).toBe("up");
+      expect(result.upCount).toBe(0);
+      expect(result.downCount).toBe(1);
+    });
+
+    it("throws QuestionNotFoundError when target does not exist", async () => {
+      mockRunTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          get: jest.fn()
+            .mockResolvedValueOnce({ exists: false })
+            .mockResolvedValueOnce({ exists: false }),
+        };
+        return fn(tx);
+      });
+
+      await expect(service.vote("question", "missing", "u1", "up")).rejects.toThrow(
+        QuestionNotFoundError
+      );
+    });
+  });
+
+  describe("getUserVotes", () => {
+    it("returns combined question and answer votes", async () => {
+      mockQueryGet
+        .mockResolvedValueOnce({
+          docs: [{ data: () => ({ targetId: "q1", type: "up" }) }],
+        })
+        .mockResolvedValueOnce({
+          docs: [{ data: () => ({ targetId: "a1", type: "down" }) }],
+        });
+
+      const votes = await service.getUserVotes("u1");
+      expect(votes).toEqual({ q1: "up", a1: "down" });
+    });
+  });
+
+  describe("error classes", () => {
+    it("QuestionNotFoundError has correct name", () => {
+      const err = new QuestionNotFoundError();
+      expect(err.name).toBe("QuestionNotFoundError");
+      expect(err.message).toBe("Question not found");
+    });
+
+    it("AnswerNotFoundError has correct name", () => {
+      const err = new AnswerNotFoundError();
+      expect(err.name).toBe("AnswerNotFoundError");
+    });
+
+    it("UnauthorizedError has correct name", () => {
+      const err = new UnauthorizedError("Custom msg");
+      expect(err.name).toBe("UnauthorizedError");
+      expect(err.message).toBe("Custom msg");
+    });
+  });
+});

--- a/app/api/questions/[questionId]/route.ts
+++ b/app/api/questions/[questionId]/route.ts
@@ -36,17 +36,16 @@ export async function GET(
     }
 
     const service = getQuestionsService();
-    const [question, answers, relatedCookbook] = await Promise.all([
+    const [question, answers] = await Promise.all([
       service.getQuestion(questionId),
       service.getAnswersForQuestion(questionId, "top"),
-      service.getQuestion(questionId).then((q) =>
-        q ? service.getRelatedCookbookEntries(q.tags) : []
-      ),
     ]);
 
     if (!question) {
       return NextResponse.json({ error: "Question not found" }, { status: 404 });
     }
+
+    const relatedCookbook = await service.getRelatedCookbookEntries(question.tags);
 
     return NextResponse.json({ question, answers, relatedCookbook });
   } catch (error) {

--- a/app/api/questions/[questionId]/route.ts
+++ b/app/api/questions/[questionId]/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getQuestionsService } from "@/lib/questions/service";
+import { logger } from "@/lib/logger";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { sanitizeDocId } from "@/lib/sanitize";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60_000, maxRequests: 100 };
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ questionId: string }> }
+) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`question-detail:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const { questionId: rawId } = await params;
+    const questionId = sanitizeDocId(rawId);
+    if (!questionId) {
+      return NextResponse.json({ error: "Invalid question ID" }, { status: 400 });
+    }
+
+    const service = getQuestionsService();
+    const [question, answers, relatedCookbook] = await Promise.all([
+      service.getQuestion(questionId),
+      service.getAnswersForQuestion(questionId, "top"),
+      service.getQuestion(questionId).then((q) =>
+        q ? service.getRelatedCookbookEntries(q.tags) : []
+      ),
+    ]);
+
+    if (!question) {
+      return NextResponse.json({ error: "Question not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ question, answers, relatedCookbook });
+  } catch (error) {
+    logger.logError(error, { endpoint: "GET /api/questions/[questionId]" });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/questions/accept/route.ts
+++ b/app/api/questions/accept/route.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getQuestionsService,
+  QuestionNotFoundError,
+  AnswerNotFoundError,
+  UnauthorizedError,
+} from "@/lib/questions/service";
+import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { sanitizeDocId } from "@/lib/sanitize";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60_000, maxRequests: 20 };
+
+export async function POST(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`questions-accept:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const { questionId: rawQId, answerId: rawAId } = bodyOrError as {
+      questionId?: string;
+      answerId?: string;
+    };
+
+    const questionId = sanitizeDocId(rawQId ?? "");
+    const answerId = sanitizeDocId(rawAId ?? "");
+    if (!questionId || !answerId) {
+      return NextResponse.json({ error: "Invalid question or answer ID" }, { status: 400 });
+    }
+
+    const service = getQuestionsService();
+    await service.acceptAnswer(questionId, answerId, user.uid);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof QuestionNotFoundError) {
+      return NextResponse.json({ error: "Question not found" }, { status: 404 });
+    }
+    if (error instanceof AnswerNotFoundError) {
+      return NextResponse.json({ error: "Answer not found" }, { status: 404 });
+    }
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    logger.logError(error, { endpoint: "POST /api/questions/accept" });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/questions/answer/route.ts
+++ b/app/api/questions/answer/route.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getQuestionsService,
+  QuestionNotFoundError,
+} from "@/lib/questions/service";
+import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
+import { getDisplayName } from "@/lib/utils";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60_000, maxRequests: 20 };
+
+export async function POST(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`questions-answer:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const { questionId: rawQId, body } = bodyOrError as {
+      questionId?: string;
+      body?: string;
+    };
+
+    const questionId = sanitizeDocId(rawQId ?? "");
+    if (!questionId) {
+      return NextResponse.json({ error: "Invalid question ID" }, { status: 400 });
+    }
+
+    const sanitizedBody = sanitizeText(body ?? "");
+    if (sanitizedBody.length < 20 || sanitizedBody.length > 5000) {
+      return NextResponse.json(
+        { error: "Answer must be between 20 and 5000 characters" },
+        { status: 400 }
+      );
+    }
+
+    const service = getQuestionsService();
+    const answerId = await service.createAnswer(
+      questionId,
+      user.uid,
+      getDisplayName(user),
+      user.picture ?? null,
+      sanitizedBody
+    );
+
+    return NextResponse.json({ answerId }, { status: 201 });
+  } catch (error) {
+    if (error instanceof QuestionNotFoundError) {
+      return NextResponse.json({ error: "Question not found" }, { status: 404 });
+    }
+    logger.logError(error, { endpoint: "POST /api/questions/answer" });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/questions/post/route.ts
+++ b/app/api/questions/post/route.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getQuestionsService } from "@/lib/questions/service";
+import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { sanitizeText } from "@/lib/sanitize";
+import { getDisplayName } from "@/lib/utils";
+import { QUESTION_TAGS, type QuestionTag } from "@/types/questions";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60_000, maxRequests: 10 };
+
+export async function POST(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`questions-post:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const { title, body, tags } = bodyOrError as {
+      title?: string;
+      body?: string;
+      tags?: string[];
+    };
+
+    const sanitizedTitle = sanitizeText(title ?? "");
+    const sanitizedBody = sanitizeText(body ?? "");
+
+    if (sanitizedTitle.length < 10 || sanitizedTitle.length > 200) {
+      return NextResponse.json(
+        { error: "Title must be between 10 and 200 characters" },
+        { status: 400 }
+      );
+    }
+
+    if (sanitizedBody.length < 20 || sanitizedBody.length > 5000) {
+      return NextResponse.json(
+        { error: "Body must be between 20 and 5000 characters" },
+        { status: 400 }
+      );
+    }
+
+    const validTags = (tags ?? [])
+      .filter((t): t is QuestionTag => (QUESTION_TAGS as readonly string[]).includes(t))
+      .slice(0, 10);
+
+    const service = getQuestionsService();
+    const questionId = await service.createQuestion(
+      user.uid,
+      getDisplayName(user),
+      user.picture ?? null,
+      { title: sanitizedTitle, body: sanitizedBody, tags: validTags }
+    );
+
+    return NextResponse.json({ questionId }, { status: 201 });
+  } catch (error) {
+    logger.logError(error, { endpoint: "POST /api/questions/post" });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getQuestionsService } from "@/lib/questions/service";
+import { logger } from "@/lib/logger";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import type { QuestionSort } from "@/types/questions";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60_000, maxRequests: 100 };
+
+export async function GET(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`questions-list:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const sort = (searchParams.get("sort") || "newest") as QuestionSort;
+    const tag = searchParams.get("tag") || undefined;
+    const search = searchParams.get("search") || undefined;
+    const limit = Math.min(Number(searchParams.get("limit")) || 20, 50);
+    const cursor = searchParams.get("cursor") || undefined;
+
+    let service;
+    try {
+      service = getQuestionsService();
+    } catch {
+      return NextResponse.json({ questions: [], nextCursor: null });
+    }
+    const result = await service.listQuestions({ sort, tag, search, limit, cursor });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.logError(error, { endpoint: "GET /api/questions" });
+    return NextResponse.json({ questions: [], nextCursor: null });
+  }
+}

--- a/app/api/questions/vote/route.ts
+++ b/app/api/questions/vote/route.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getQuestionsService,
+  QuestionNotFoundError,
+  AnswerNotFoundError,
+} from "@/lib/questions/service";
+import { logger } from "@/lib/logger";
+import { parseRequestBody } from "@/lib/api-response";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { sanitizeDocId } from "@/lib/sanitize";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60_000, maxRequests: 60 };
+
+export async function POST(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`questions-vote:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const { targetType, targetId: rawTargetId, questionId: rawQId, type } = bodyOrError as {
+      targetType?: string;
+      targetId?: string;
+      questionId?: string;
+      type?: string;
+    };
+
+    if (targetType !== "question" && targetType !== "answer") {
+      return NextResponse.json({ error: "targetType must be 'question' or 'answer'" }, { status: 400 });
+    }
+
+    const targetId = sanitizeDocId(rawTargetId ?? "");
+    if (!targetId) {
+      return NextResponse.json({ error: "Invalid target ID" }, { status: 400 });
+    }
+
+    if (type !== "up" && type !== "down") {
+      return NextResponse.json({ error: "type must be 'up' or 'down'" }, { status: 400 });
+    }
+
+    let questionId: string | undefined;
+    if (targetType === "answer") {
+      questionId = sanitizeDocId(rawQId ?? "") ?? undefined;
+      if (!questionId) {
+        return NextResponse.json({ error: "questionId required for answer votes" }, { status: 400 });
+      }
+    }
+
+    const service = getQuestionsService();
+    const result = await service.vote(targetType, targetId, user.uid, type, questionId);
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof QuestionNotFoundError || error instanceof AnswerNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    logger.logError(error, { endpoint: "POST /api/questions/vote" });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ userVotes: {} });
+    }
+
+    const service = getQuestionsService();
+    const userVotes = await service.getUserVotes(user.uid);
+
+    return NextResponse.json({ userVotes });
+  } catch (error) {
+    logger.logError(error, { endpoint: "GET /api/questions/vote" });
+    return NextResponse.json({ userVotes: {} });
+  }
+}

--- a/app/questions/[questionId]/page.tsx
+++ b/app/questions/[questionId]/page.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getQuestionsService } from "@/lib/questions/service";
+import { QuestionDetail } from "@/components/questions/QuestionDetail";
+
+interface PageProps {
+  params: Promise<{ questionId: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  try {
+    const { questionId } = await params;
+    const service = getQuestionsService();
+    const question = await service.getQuestion(questionId);
+    if (!question) return { title: "Question Not Found | Cursor Boston" };
+    return {
+      title: `${question.title} | Community Q&A | Cursor Boston`,
+      description: question.body.slice(0, 160),
+    };
+  } catch {
+    return { title: "Community Q&A | Cursor Boston" };
+  }
+}
+
+export default async function QuestionDetailPage({ params }: PageProps) {
+  let question, answers, relatedCookbook;
+
+  try {
+    const { questionId } = await params;
+    const service = getQuestionsService();
+    question = await service.getQuestion(questionId);
+    if (!question) notFound();
+
+    [answers, relatedCookbook] = await Promise.all([
+      service.getAnswersForQuestion(questionId, "top"),
+      service.getRelatedCookbookEntries(question.tags),
+    ]);
+  } catch {
+    notFound();
+  }
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
+      <QuestionDetail
+        questionId={question.id}
+        initialQuestion={question}
+        initialAnswers={answers}
+        initialRelatedCookbook={relatedCookbook}
+      />
+    </main>
+  );
+}

--- a/app/questions/ask/AskQuestionForm.tsx
+++ b/app/questions/ask/AskQuestionForm.tsx
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { QUESTION_TAGS, type QuestionTag } from "@/types/questions";
+
+const TAG_LABELS: Record<QuestionTag, string> = {
+  "cursor-rules": "Cursor Rules",
+  prompting: "Prompting",
+  debugging: "Debugging",
+  refactoring: "Refactoring",
+  testing: "Testing",
+  architecture: "Architecture",
+  performance: "Performance",
+  workflows: "Workflows",
+  mcp: "MCP",
+  agents: "Agents",
+  other: "Other",
+};
+
+export function AskQuestionForm() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [selectedTags, setSelectedTags] = useState<QuestionTag[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleTag = (tag: QuestionTag) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag].slice(0, 5)
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user || submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const { getIdToken } = await import("firebase/auth");
+      const token = await getIdToken(user);
+
+      const res = await fetch("/api/questions/post", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ title, body, tags: selectedTags }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to post question");
+      }
+
+      const { questionId } = await res.json();
+      router.push(`/questions/${questionId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to post question");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="text-center py-12">
+        <h1 className="text-2xl font-bold text-foreground mb-2">Ask a Question</h1>
+        <p className="text-neutral-500">Sign in to ask a question</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Link
+        href="/questions"
+        className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-foreground transition-colors mb-6"
+      >
+        <ArrowLeft size={16} />
+        Back to Q&A
+      </Link>
+
+      <h1 className="text-2xl font-bold text-foreground mb-6">Ask a Question</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label htmlFor="q-title" className="block text-sm font-medium text-foreground mb-1">
+            Title
+          </label>
+          <input
+            id="q-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What's your question? (10-200 characters)"
+            maxLength={200}
+            className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-background text-sm text-foreground placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          />
+          <span className="text-xs text-neutral-500 mt-1 block">{title.length}/200</span>
+        </div>
+
+        <div>
+          <label htmlFor="q-body" className="block text-sm font-medium text-foreground mb-1">
+            Details
+          </label>
+          <textarea
+            id="q-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Provide more context... (20-5000 characters)"
+            rows={8}
+            maxLength={5000}
+            className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-background text-sm text-foreground placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-y"
+          />
+          <span className="text-xs text-neutral-500 mt-1 block">{body.length}/5000</span>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-2">
+            Tags (up to 5)
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {QUESTION_TAGS.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                className={[
+                  "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+                  selectedTags.includes(tag)
+                    ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400"
+                    : "bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700",
+                ].join(" ")}
+              >
+                {TAG_LABELS[tag]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={submitting || title.trim().length < 10 || body.trim().length < 20}
+          className="w-full px-4 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+        >
+          {submitting ? "Posting..." : "Post Question"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/questions/ask/page.tsx
+++ b/app/questions/ask/page.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import { AskQuestionForm } from "./AskQuestionForm";
+
+export const metadata: Metadata = {
+  title: "Ask a Question | Community Q&A | Cursor Boston",
+  description: "Ask the Cursor Boston community a question about AI-assisted development.",
+};
+
+export default function AskQuestionPage() {
+  return (
+    <main className="max-w-2xl mx-auto px-4 sm:px-6 py-8">
+      <AskQuestionForm />
+    </main>
+  );
+}

--- a/app/questions/page.tsx
+++ b/app/questions/page.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import { QuestionsListing } from "@/components/questions/QuestionsListing";
+
+export const metadata: Metadata = {
+  title: "Community Q&A | Cursor Boston",
+  description:
+    "Ask and answer questions about Cursor workflows, prompting patterns, and AI-assisted development.",
+};
+
+export default function QuestionsPage() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
+      <QuestionsListing />
+    </main>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -132,6 +132,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.6,
     },
+    {
+      url: `${baseUrl}/questions`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.7,
+    },
     // Legal pages
     {
       url: `${baseUrl}/terms`,

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -27,6 +27,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  HelpCircle,
   Info,
   LayoutGrid,
   Library,
@@ -87,6 +88,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/glossary", label: "Glossary", icon: Library },
       { href: "/blog", label: "Blog", icon: BookOpen },
       { href: "/analytics", label: "Analytics", icon: BarChart2 },
+      { href: "/questions", label: "Q&A", icon: HelpCircle },
     ],
   },
   {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -90,6 +90,11 @@ export default function Footer() {
                     </Link>
                   </li>
                   <li>
+                    <Link href="/questions" className="text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white text-sm transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
+                      Q&A
+                    </Link>
+                  </li>
+                  <li>
                     <Link href="/about" className="text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white text-sm transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
                       About
                     </Link>

--- a/components/questions/AnswerCard.tsx
+++ b/components/questions/AnswerCard.tsx
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { ThumbsUp, ThumbsDown, CheckCircle2 } from "lucide-react";
+import type { Answer, VoteType } from "@/types/questions";
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+export function AnswerCard({
+  answer,
+  userVote,
+  isLoggedIn,
+  isVoting,
+  isQuestionAuthor,
+  onVote,
+  onAccept,
+}: {
+  answer: Answer;
+  userVote?: VoteType;
+  isLoggedIn: boolean;
+  isVoting: boolean;
+  isQuestionAuthor: boolean;
+  onVote: (answerId: string, type: VoteType) => void;
+  onAccept: (answerId: string) => void;
+}) {
+  const netScore = answer.upCount - answer.downCount;
+
+  return (
+    <div
+      className={[
+        "border rounded-xl p-4 sm:p-5 transition-colors",
+        answer.isAccepted
+          ? "border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-950/20"
+          : "border-neutral-200 dark:border-neutral-800",
+      ].join(" ")}
+    >
+      <div className="flex gap-4">
+        {/* Vote column */}
+        <div className="flex flex-col items-center gap-1 min-w-[40px]">
+          <button
+            type="button"
+            onClick={() => onVote(answer.id, "up")}
+            disabled={!isLoggedIn || isVoting}
+            aria-label={`Upvote answer by ${answer.authorName}`}
+            className={[
+              "p-1 rounded transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+              userVote === "up"
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
+              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
+            ].join(" ")}
+          >
+            <ThumbsUp size={16} />
+          </button>
+          <span
+            className={[
+              "text-sm font-semibold",
+              netScore > 0
+                ? "text-emerald-600 dark:text-emerald-400"
+                : netScore < 0
+                  ? "text-red-500"
+                  : "text-neutral-500",
+            ].join(" ")}
+          >
+            {netScore > 0 ? `+${netScore}` : netScore}
+          </span>
+          <button
+            type="button"
+            onClick={() => onVote(answer.id, "down")}
+            disabled={!isLoggedIn || isVoting}
+            aria-label={`Downvote answer by ${answer.authorName}`}
+            className={[
+              "p-1 rounded transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+              userVote === "down"
+                ? "text-red-500"
+                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
+              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
+            ].join(" ")}
+          >
+            <ThumbsDown size={16} />
+          </button>
+
+          {/* Accept button */}
+          {isQuestionAuthor && (
+            <button
+              type="button"
+              onClick={() => onAccept(answer.id)}
+              aria-label={answer.isAccepted ? "Unaccept this answer" : "Accept this answer"}
+              className={[
+                "p-1 rounded transition-colors mt-1",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+                answer.isAccepted
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-neutral-400 hover:text-emerald-600 dark:hover:text-emerald-400",
+              ].join(" ")}
+            >
+              <CheckCircle2 size={18} />
+            </button>
+          )}
+          {!isQuestionAuthor && answer.isAccepted && (
+            <span className="text-emerald-600 dark:text-emerald-400 mt-1" title="Accepted answer">
+              <CheckCircle2 size={18} />
+            </span>
+          )}
+        </div>
+
+        {/* Content column */}
+        <div className="flex-1 min-w-0">
+          {answer.isAccepted && (
+            <span className="inline-block text-xs font-medium text-emerald-700 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-900/50 px-2 py-0.5 rounded mb-2">
+              Accepted Answer
+            </span>
+          )}
+          <p className="text-sm text-foreground whitespace-pre-wrap">{answer.body}</p>
+          <div className="flex items-center gap-2 mt-3 text-xs text-neutral-500">
+            <span>{answer.authorName}</span>
+            <span>&middot;</span>
+            <span>{timeAgo(answer.createdAt)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/questions/AnswerComposer.tsx
+++ b/components/questions/AnswerComposer.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+
+export function AnswerComposer({
+  isLoggedIn,
+  onSubmit,
+}: {
+  isLoggedIn: boolean;
+  onSubmit: (body: string) => Promise<void>;
+}) {
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!body.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(body.trim());
+      setBody("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to post answer");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isLoggedIn) {
+    return (
+      <div className="border border-neutral-200 dark:border-neutral-800 rounded-xl p-5 text-center">
+        <p className="text-sm text-neutral-500">Sign in to post an answer</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded-xl p-5">
+      <h3 className="text-sm font-semibold text-foreground mb-3">Your Answer</h3>
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Share your knowledge... (min 20 characters)"
+        rows={5}
+        className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-background px-3 py-2 text-sm text-foreground placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-y"
+      />
+      {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
+      <div className="flex justify-between items-center mt-3">
+        <span className="text-xs text-neutral-500">{body.length}/5000</span>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={submitting || body.trim().length < 20}
+          className="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+        >
+          {submitting ? "Posting..." : "Post Answer"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/questions/QuestionCard.tsx
+++ b/components/questions/QuestionCard.tsx
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { ThumbsUp, ThumbsDown, MessageSquare } from "lucide-react";
+import type { Question, VoteType } from "@/types/questions";
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+export function QuestionCard({
+  question,
+  userVote,
+  isLoggedIn,
+  isVoting,
+  onVote,
+  onTagClick,
+}: {
+  question: Question;
+  userVote?: VoteType;
+  isLoggedIn: boolean;
+  isVoting: boolean;
+  onVote: (questionId: string, type: VoteType) => void;
+  onTagClick?: (tag: string) => void;
+}) {
+  const netScore = question.upCount - question.downCount;
+
+  return (
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded-xl p-4 sm:p-5 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors">
+      <div className="flex gap-4">
+        {/* Vote column */}
+        <div className="flex flex-col items-center gap-1 min-w-[40px]">
+          <button
+            type="button"
+            onClick={() => onVote(question.id, "up")}
+            disabled={!isLoggedIn || isVoting}
+            aria-label={`Upvote question: ${question.title}`}
+            className={[
+              "p-1 rounded transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+              userVote === "up"
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
+              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
+            ].join(" ")}
+          >
+            <ThumbsUp size={16} />
+          </button>
+          <span
+            className={[
+              "text-sm font-semibold",
+              netScore > 0
+                ? "text-emerald-600 dark:text-emerald-400"
+                : netScore < 0
+                  ? "text-red-500"
+                  : "text-neutral-500",
+            ].join(" ")}
+          >
+            {netScore > 0 ? `+${netScore}` : netScore}
+          </span>
+          <button
+            type="button"
+            onClick={() => onVote(question.id, "down")}
+            disabled={!isLoggedIn || isVoting}
+            aria-label={`Downvote question: ${question.title}`}
+            className={[
+              "p-1 rounded transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+              userVote === "down"
+                ? "text-red-500"
+                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
+              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
+            ].join(" ")}
+          >
+            <ThumbsDown size={16} />
+          </button>
+        </div>
+
+        {/* Content column */}
+        <div className="flex-1 min-w-0">
+          <Link
+            href={`/questions/${question.id}`}
+            className="text-base font-semibold text-foreground hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors line-clamp-2 focus-visible:outline-none focus-visible:underline"
+          >
+            {question.title}
+          </Link>
+
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-1 line-clamp-2">
+            {question.body}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-2 mt-3">
+            {question.tags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => onTagClick?.(tag)}
+                className="px-2 py-0.5 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 rounded text-xs hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+              >
+                {tag}
+              </button>
+            ))}
+
+            <span className="flex items-center gap-1 text-xs text-neutral-500 ml-auto">
+              <MessageSquare size={14} />
+              {question.answerCount} {question.answerCount === 1 ? "answer" : "answers"}
+            </span>
+
+            <span className="text-xs text-neutral-500">
+              {question.authorName} &middot; {timeAgo(question.createdAt)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/questions/QuestionDetail.tsx
+++ b/components/questions/QuestionDetail.tsx
@@ -1,0 +1,317 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { ArrowLeft, ThumbsUp, ThumbsDown } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { Question, Answer, VoteType } from "@/types/questions";
+import type { CookbookEntry } from "@/types/cookbook";
+import { AnswerCard } from "./AnswerCard";
+import { AnswerComposer } from "./AnswerComposer";
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+async function fetchIdToken(firebaseUser: import("firebase/auth").User) {
+  const { getIdToken } = await import("firebase/auth");
+  return getIdToken(firebaseUser);
+}
+
+export function QuestionDetail({
+  questionId,
+  initialQuestion,
+  initialAnswers,
+  initialRelatedCookbook,
+}: {
+  questionId: string;
+  initialQuestion: Question;
+  initialAnswers: Answer[];
+  initialRelatedCookbook: CookbookEntry[];
+}) {
+  const { user } = useAuth();
+  const [question, setQuestion] = useState(initialQuestion);
+  const [answers, setAnswers] = useState(initialAnswers);
+  const [userVotes, setUserVotes] = useState<Record<string, VoteType>>({});
+  const [votingId, setVotingId] = useState<string | null>(null);
+
+  const isLoggedIn = !!user;
+  const isQuestionAuthor = user?.uid === question.authorId;
+
+  const fetchVotes = useCallback(async () => {
+    if (!user) return;
+    try {
+      const token = await fetchIdToken(user);
+      const res = await fetch("/api/questions/vote", {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setUserVotes(data.userVotes || {});
+      }
+    } catch {
+      // Non-critical — UI still works without user vote state
+    }
+  }, [user]);
+
+  useEffect(() => {
+    fetchVotes();
+  }, [fetchVotes]);
+
+  const handleVote = useCallback(
+    async (targetType: "question" | "answer", targetId: string, voteType: VoteType) => {
+      if (!user || votingId) return;
+      setVotingId(targetId);
+      try {
+        const token = await fetchIdToken(user);
+        const res = await fetch("/api/questions/vote", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            targetType,
+            targetId,
+            type: voteType,
+            ...(targetType === "answer" ? { questionId } : {}),
+          }),
+        });
+        if (res.ok) {
+          const result = await res.json();
+          if (targetType === "question") {
+            setQuestion((prev) => ({
+              ...prev,
+              upCount: result.upCount,
+              downCount: result.downCount,
+              netScore: result.netScore,
+            }));
+          } else {
+            setAnswers((prev) =>
+              prev.map((a) =>
+                a.id === targetId
+                  ? { ...a, upCount: result.upCount, downCount: result.downCount, netScore: result.netScore }
+                  : a
+              )
+            );
+          }
+          setUserVotes((prev) => {
+            const next = { ...prev };
+            if (result.action === "removed") {
+              delete next[targetId];
+            } else {
+              next[targetId] = result.type;
+            }
+            return next;
+          });
+        }
+      } finally {
+        setVotingId(null);
+      }
+    },
+    [user, votingId, questionId]
+  );
+
+  const handleAccept = useCallback(
+    async (answerId: string) => {
+      if (!user) return;
+      try {
+        const token = await fetchIdToken(user);
+        const res = await fetch("/api/questions/accept", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ questionId, answerId }),
+        });
+        if (res.ok) {
+          setAnswers((prev) =>
+            prev.map((a) => ({
+              ...a,
+              isAccepted: a.id === answerId ? !a.isAccepted : false,
+            }))
+          );
+        }
+      } catch {
+        // Non-critical
+      }
+    },
+    [user, questionId]
+  );
+
+  const handleSubmitAnswer = useCallback(
+    async (body: string) => {
+      if (!user) throw new Error("Sign in to answer");
+      const token = await fetchIdToken(user);
+      const res = await fetch("/api/questions/answer", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ questionId, body }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to post answer");
+      }
+      // Refetch answers
+      const detailRes = await fetch(`/api/questions/${questionId}`);
+      if (detailRes.ok) {
+        const detail = await detailRes.json();
+        setAnswers(detail.answers);
+        setQuestion((prev) => ({ ...prev, answerCount: detail.question.answerCount }));
+      }
+    },
+    [user, questionId]
+  );
+
+  const netScore = question.upCount - question.downCount;
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      {/* Back link */}
+      <Link
+        href="/questions"
+        className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-foreground transition-colors mb-6"
+      >
+        <ArrowLeft size={16} />
+        Back to Q&A
+      </Link>
+
+      {/* Question */}
+      <div className="flex gap-4">
+        <div className="flex flex-col items-center gap-1 min-w-[48px]">
+          <button
+            type="button"
+            onClick={() => handleVote("question", question.id, "up")}
+            disabled={!isLoggedIn || !!votingId}
+            aria-label="Upvote question"
+            className={[
+              "p-1.5 rounded transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+              userVotes[question.id] === "up"
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
+              (!isLoggedIn || !!votingId) ? "opacity-50 cursor-not-allowed" : "",
+            ].join(" ")}
+          >
+            <ThumbsUp size={20} />
+          </button>
+          <span
+            className={[
+              "text-lg font-bold",
+              netScore > 0
+                ? "text-emerald-600 dark:text-emerald-400"
+                : netScore < 0
+                  ? "text-red-500"
+                  : "text-neutral-500",
+            ].join(" ")}
+          >
+            {netScore > 0 ? `+${netScore}` : netScore}
+          </span>
+          <button
+            type="button"
+            onClick={() => handleVote("question", question.id, "down")}
+            disabled={!isLoggedIn || !!votingId}
+            aria-label="Downvote question"
+            className={[
+              "p-1.5 rounded transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+              userVotes[question.id] === "down"
+                ? "text-red-500"
+                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
+              (!isLoggedIn || !!votingId) ? "opacity-50 cursor-not-allowed" : "",
+            ].join(" ")}
+          >
+            <ThumbsDown size={20} />
+          </button>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h1 className="text-2xl font-bold text-foreground">{question.title}</h1>
+          <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-neutral-500">
+            <span>Asked by {question.authorName}</span>
+            <span>&middot;</span>
+            <span>{timeAgo(question.createdAt)}</span>
+          </div>
+          <div className="flex flex-wrap gap-2 mt-3">
+            {question.tags.map((tag) => (
+              <Link
+                key={tag}
+                href={`/questions?tag=${tag}`}
+                className="px-2 py-0.5 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 rounded text-xs hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+              >
+                {tag}
+              </Link>
+            ))}
+          </div>
+          <div className="mt-4 text-sm text-foreground whitespace-pre-wrap leading-relaxed">
+            {question.body}
+          </div>
+        </div>
+      </div>
+
+      {/* Answers section */}
+      <div className="mt-10">
+        <h2 className="text-lg font-semibold text-foreground mb-4">
+          {answers.length} {answers.length === 1 ? "Answer" : "Answers"}
+        </h2>
+        <div className="space-y-4">
+          {answers.map((answer) => (
+            <AnswerCard
+              key={answer.id}
+              answer={answer}
+              userVote={userVotes[answer.id]}
+              isLoggedIn={isLoggedIn}
+              isVoting={votingId === answer.id}
+              isQuestionAuthor={isQuestionAuthor}
+              onVote={(answerId, type) => handleVote("answer", answerId, type)}
+              onAccept={handleAccept}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Answer composer */}
+      <div className="mt-8">
+        <AnswerComposer isLoggedIn={isLoggedIn} onSubmit={handleSubmitAnswer} />
+      </div>
+
+      {/* Related cookbook entries */}
+      {initialRelatedCookbook.length > 0 && (
+        <div className="mt-10 border border-neutral-200 dark:border-neutral-800 rounded-xl p-5">
+          <h3 className="text-sm font-semibold text-foreground mb-3">Related Cookbook Entries</h3>
+          <ul className="space-y-2">
+            {initialRelatedCookbook.map((entry) => (
+              <li key={entry.id}>
+                <Link
+                  href="/cookbook"
+                  className="text-sm text-emerald-600 dark:text-emerald-400 hover:underline"
+                >
+                  {entry.title}
+                </Link>
+                <p className="text-xs text-neutral-500 line-clamp-1">{entry.description}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/questions/QuestionDetail.tsx
+++ b/components/questions/QuestionDetail.tsx
@@ -301,7 +301,7 @@ export function QuestionDetail({
             {initialRelatedCookbook.map((entry) => (
               <li key={entry.id}>
                 <Link
-                  href="/cookbook"
+                  href={`/cookbook/${entry.id}`}
                   className="text-sm text-emerald-600 dark:text-emerald-400 hover:underline"
                 >
                   {entry.title}

--- a/components/questions/QuestionsListing.tsx
+++ b/components/questions/QuestionsListing.tsx
@@ -1,0 +1,254 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import Link from "next/link";
+import { Search, Plus, Loader2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { Question, QuestionSort, VoteType } from "@/types/questions";
+import { QuestionCard } from "./QuestionCard";
+import { TagFilter } from "./TagFilter";
+
+async function fetchIdToken(firebaseUser: import("firebase/auth").User) {
+  const { getIdToken } = await import("firebase/auth");
+  return getIdToken(firebaseUser);
+}
+
+export function QuestionsListing() {
+  const { user } = useAuth();
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+
+  const [sort, setSort] = useState<QuestionSort>("newest");
+  const [tag, setTag] = useState("");
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+
+  const [userVotes, setUserVotes] = useState<Record<string, VoteType>>({});
+  const [votingId, setVotingId] = useState<string | null>(null);
+
+  // Debounce search
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput.trim()), 350);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const fetchQuestions = useCallback(
+    async (cursor?: string): Promise<{ questions: Question[]; nextCursor: string | null }> => {
+      try {
+        const params = new URLSearchParams();
+        params.set("sort", sort);
+        params.set("limit", "20");
+        if (tag) params.set("tag", tag);
+        if (search) params.set("search", search);
+        if (cursor) params.set("cursor", cursor);
+
+        const res = await fetch(`/api/questions?${params}`);
+        if (!res.ok) return { questions: [], nextCursor: null };
+        return await res.json();
+      } catch {
+        return { questions: [], nextCursor: null };
+      }
+    },
+    [sort, tag, search]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchQuestions()
+      .then((data) => {
+        if (cancelled) return;
+        setQuestions(data.questions);
+        setNextCursor(data.nextCursor);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setQuestions([]);
+        setNextCursor(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [fetchQuestions]);
+
+  // Fetch user votes
+  useEffect(() => {
+    if (!user) { setUserVotes({}); return; }
+    (async () => {
+      try {
+        const token = await fetchIdToken(user);
+        const res = await fetch("/api/questions/vote", {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setUserVotes(data.userVotes || {});
+        }
+      } catch {
+        // Non-critical
+      }
+    })();
+  }, [user]);
+
+  const handleLoadMore = async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    const data = await fetchQuestions(nextCursor);
+    setQuestions((prev) => [...prev, ...data.questions]);
+    setNextCursor(data.nextCursor);
+    setLoadingMore(false);
+  };
+
+  const handleVote = useCallback(
+    async (questionId: string, type: VoteType) => {
+      if (!user || votingId) return;
+      setVotingId(questionId);
+      try {
+        const token = await fetchIdToken(user);
+        const res = await fetch("/api/questions/vote", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ targetType: "question", targetId: questionId, type }),
+        });
+        if (res.ok) {
+          const result = await res.json();
+          setQuestions((prev) =>
+            prev.map((q) =>
+              q.id === questionId
+                ? { ...q, upCount: result.upCount, downCount: result.downCount, netScore: result.netScore }
+                : q
+            )
+          );
+          setUserVotes((prev) => {
+            const next = { ...prev };
+            if (result.action === "removed") {
+              delete next[questionId];
+            } else {
+              next[questionId] = result.type;
+            }
+            return next;
+          });
+        }
+      } finally {
+        setVotingId(null);
+      }
+    },
+    [user, votingId]
+  );
+
+  const effectiveSort = useMemo(() => (search ? "newest" : sort), [search, sort]);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Community Q&A</h1>
+          <p className="text-sm text-neutral-500 mt-1">
+            Ask questions about Cursor workflows, prompting patterns, and AI-assisted development
+          </p>
+        </div>
+        {user && (
+          <Link
+            href="/questions/ask"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 shrink-0"
+          >
+            <Plus size={16} />
+            Ask Question
+          </Link>
+        )}
+      </div>
+
+      {/* Search + Sort */}
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <div className="relative flex-1">
+          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" />
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search questions..."
+            className="w-full pl-9 pr-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-background text-sm text-foreground placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          />
+        </div>
+        <select
+          value={effectiveSort}
+          onChange={(e) => setSort(e.target.value as QuestionSort)}
+          disabled={!!search}
+          className="px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-background text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50"
+        >
+          <option value="newest">Newest</option>
+          <option value="top">Top Voted</option>
+          <option value="unanswered">Unanswered</option>
+        </select>
+      </div>
+
+      {/* Tag filter */}
+      <div className="mb-6">
+        <TagFilter activeTag={tag} onTagChange={setTag} />
+      </div>
+
+      {/* Question list */}
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 size={24} className="animate-spin text-neutral-400" />
+        </div>
+      ) : questions.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-neutral-500">No questions found</p>
+          {user && (
+            <Link
+              href="/questions/ask"
+              className="text-sm text-emerald-600 dark:text-emerald-400 hover:underline mt-2 inline-block"
+            >
+              Be the first to ask a question
+            </Link>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {questions.map((q) => (
+            <QuestionCard
+              key={q.id}
+              question={q}
+              userVote={userVotes[q.id]}
+              isLoggedIn={!!user}
+              isVoting={votingId === q.id}
+              onVote={handleVote}
+              onTagClick={(t) => setTag(t)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Load more */}
+      {nextCursor && (
+        <div className="flex justify-center mt-8">
+          <button
+            type="button"
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className="px-6 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg text-sm text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+          >
+            {loadingMore ? (
+              <Loader2 size={16} className="animate-spin inline mr-2" />
+            ) : null}
+            Load More
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/questions/TagFilter.tsx
+++ b/components/questions/TagFilter.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { QUESTION_TAGS, type QuestionTag } from "@/types/questions";
+
+const TAG_LABELS: Record<QuestionTag, string> = {
+  "cursor-rules": "Cursor Rules",
+  prompting: "Prompting",
+  debugging: "Debugging",
+  refactoring: "Refactoring",
+  testing: "Testing",
+  architecture: "Architecture",
+  performance: "Performance",
+  workflows: "Workflows",
+  mcp: "MCP",
+  agents: "Agents",
+  other: "Other",
+};
+
+export function TagFilter({
+  activeTag,
+  onTagChange,
+}: {
+  activeTag: string;
+  onTagChange: (tag: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => onTagChange("")}
+        className={[
+          "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+          !activeTag
+            ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400"
+            : "bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700",
+        ].join(" ")}
+      >
+        All
+      </button>
+      {QUESTION_TAGS.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => onTagChange(tag === activeTag ? "" : tag)}
+          className={[
+            "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+            tag === activeTag
+              ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400"
+              : "bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700",
+          ].join(" ")}
+        >
+          {TAG_LABELS[tag]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -329,5 +329,26 @@ service cloud.firestore {
     match /treasureHuntRuntime/{docId} {
       allow read, write: if false;
     }
+
+    // Community Q&A — questions: public read, Admin SDK writes only
+    match /questions/{questionId} {
+      allow read: if true;
+      allow create, update, delete: if false;
+      match /answers/{answerId} {
+        allow read: if true;
+        allow create, update, delete: if false;
+      }
+    }
+
+    // Community Q&A — vote index collections: authenticated read, Admin SDK writes
+    match /question_votes/{voteId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
+
+    match /answer_votes/{voteId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
   }
 }

--- a/lib/questions/search.ts
+++ b/lib/questions/search.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/** Returns true if any search term matches the question's title, body, or tags (case-insensitive). */
+export function matchesQuestionSearchTerms(
+  title: string,
+  body: string,
+  tags: string[],
+  terms: string[]
+): boolean {
+  if (terms.length === 0) return true;
+  const titleL = title.toLowerCase();
+  const bodyL = body.toLowerCase();
+  const tagStr = tags.join(" ").toLowerCase();
+  return terms.some(
+    (term) =>
+      titleL.includes(term) ||
+      bodyL.includes(term) ||
+      tagStr.includes(term)
+  );
+}

--- a/lib/questions/service.ts
+++ b/lib/questions/service.ts
@@ -1,0 +1,475 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { FieldValue, Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { matchesQuestionSearchTerms } from "./search";
+import type {
+  Question,
+  Answer,
+  QuestionTag,
+  QuestionSort,
+  VoteType,
+  VoteResult,
+} from "@/types/questions";
+import { QUESTION_TAGS } from "@/types/questions";
+import type { CookbookEntry } from "@/types/cookbook";
+
+const COLLECTIONS = {
+  QUESTIONS: "questions",
+  QUESTION_VOTES: "question_votes",
+  ANSWER_VOTES: "answer_votes",
+  COOKBOOK_ENTRIES: "cookbook_entries",
+} as const;
+
+const ANSWERS_SUBCOLLECTION = "answers";
+
+const SEARCH_SCAN_BATCH = 40;
+const MAX_SEARCH_SCAN = 30;
+const DEFAULT_LIMIT = 20;
+
+export class QuestionNotFoundError extends Error {
+  constructor() { super("Question not found"); this.name = "QuestionNotFoundError"; }
+}
+export class AnswerNotFoundError extends Error {
+  constructor() { super("Answer not found"); this.name = "AnswerNotFoundError"; }
+}
+export class UnauthorizedError extends Error {
+  constructor(msg = "Unauthorized") { super(msg); this.name = "UnauthorizedError"; }
+}
+
+function questionVoteDocId(targetId: string, userId: string) {
+  return `${targetId}_${userId}`;
+}
+
+function toQuestion(id: string, data: FirebaseFirestore.DocumentData): Question {
+  return {
+    id,
+    title: data.title ?? "",
+    body: data.body ?? "",
+    tags: data.tags ?? [],
+    authorId: data.authorId ?? "",
+    authorName: data.authorName ?? "",
+    authorPhoto: data.authorPhoto ?? null,
+    createdAt: data.createdAt?.toDate?.().toISOString() ?? new Date().toISOString(),
+    updatedAt: data.updatedAt?.toDate?.().toISOString() ?? new Date().toISOString(),
+    upCount: Number(data.upCount ?? 0),
+    downCount: Number(data.downCount ?? 0),
+    netScore: Number(data.netScore ?? 0),
+    answerCount: Number(data.answerCount ?? 0),
+  };
+}
+
+function toAnswer(id: string, questionId: string, data: FirebaseFirestore.DocumentData): Answer {
+  return {
+    id,
+    questionId,
+    body: data.body ?? "",
+    authorId: data.authorId ?? "",
+    authorName: data.authorName ?? "",
+    authorPhoto: data.authorPhoto ?? null,
+    createdAt: data.createdAt?.toDate?.().toISOString() ?? new Date().toISOString(),
+    updatedAt: data.updatedAt?.toDate?.().toISOString() ?? new Date().toISOString(),
+    upCount: Number(data.upCount ?? 0),
+    downCount: Number(data.downCount ?? 0),
+    netScore: Number(data.netScore ?? 0),
+    isAccepted: Boolean(data.isAccepted),
+  };
+}
+
+export class QuestionsService {
+  private db: Firestore;
+
+  constructor(db?: Firestore) {
+    if (db) {
+      this.db = db;
+    } else {
+      const adminDb = getAdminDb();
+      if (!adminDb) throw new Error("Firebase Admin not initialized");
+      this.db = adminDb;
+    }
+  }
+
+  // ─── Questions CRUD ──────────────────────────────────────────────────────────
+
+  async createQuestion(
+    userId: string,
+    userName: string,
+    userPhoto: string | null,
+    data: { title: string; body: string; tags: QuestionTag[] }
+  ): Promise<string> {
+    const validTags = data.tags.filter(
+      (t): t is QuestionTag => (QUESTION_TAGS as readonly string[]).includes(t)
+    ).slice(0, 10);
+
+    const docRef = await this.db.collection(COLLECTIONS.QUESTIONS).add({
+      title: data.title,
+      body: data.body,
+      tags: validTags,
+      authorId: userId,
+      authorName: userName,
+      authorPhoto: userPhoto,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+      upCount: 0,
+      downCount: 0,
+      netScore: 0,
+      answerCount: 0,
+    });
+    return docRef.id;
+  }
+
+  async getQuestion(questionId: string): Promise<Question | null> {
+    const snap = await this.db.collection(COLLECTIONS.QUESTIONS).doc(questionId).get();
+    if (!snap.exists) return null;
+    return toQuestion(snap.id, snap.data()!);
+  }
+
+  async listQuestions(opts: {
+    sort?: QuestionSort;
+    tag?: string;
+    search?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ questions: Question[]; nextCursor: string | null }> {
+    const sort = opts.sort ?? "newest";
+    const limit = opts.limit ?? DEFAULT_LIMIT;
+    const searchRaw = opts.search?.trim().toLowerCase() ?? "";
+    const hasSearch = searchRaw.length > 0;
+    const searchTerms = hasSearch ? searchRaw.split(/\s+/).filter(Boolean) : [];
+
+    if (hasSearch) {
+      return this.searchQuestions(searchTerms, opts.tag, limit, opts.cursor);
+    }
+
+    let query: FirebaseFirestore.Query = this.db.collection(COLLECTIONS.QUESTIONS);
+
+    if (opts.tag && (QUESTION_TAGS as readonly string[]).includes(opts.tag)) {
+      query = query.where("tags", "array-contains", opts.tag);
+    }
+
+    if (sort === "top") {
+      query = query.orderBy("netScore", "desc").orderBy("createdAt", "desc");
+    } else if (sort === "unanswered") {
+      query = query.where("answerCount", "==", 0).orderBy("createdAt", "desc");
+    } else {
+      query = query.orderBy("createdAt", "desc");
+    }
+
+    if (opts.cursor) {
+      const cursorSnap = await this.db.collection(COLLECTIONS.QUESTIONS).doc(opts.cursor).get();
+      if (cursorSnap.exists) {
+        query = query.startAfter(cursorSnap);
+      }
+    }
+
+    query = query.limit(limit + 1);
+    const snapshot = await query.get();
+    const docs = snapshot.docs;
+    const hasMore = docs.length > limit;
+    const resultDocs = hasMore ? docs.slice(0, limit) : docs;
+
+    return {
+      questions: resultDocs.map((d) => toQuestion(d.id, d.data())),
+      nextCursor: hasMore ? resultDocs[resultDocs.length - 1].id : null,
+    };
+  }
+
+  private async searchQuestions(
+    searchTerms: string[],
+    tag: string | undefined,
+    limit: number,
+    cursor: string | undefined
+  ): Promise<{ questions: Question[]; nextCursor: string | null }> {
+    let baseQuery: FirebaseFirestore.Query = this.db.collection(COLLECTIONS.QUESTIONS);
+
+    if (tag && (QUESTION_TAGS as readonly string[]).includes(tag)) {
+      baseQuery = baseQuery.where("tags", "array-contains", tag);
+    }
+
+    baseQuery = baseQuery.orderBy("createdAt", "desc");
+
+    if (cursor) {
+      const cursorSnap = await this.db.collection(COLLECTIONS.QUESTIONS).doc(cursor).get();
+      if (cursorSnap.exists) {
+        baseQuery = baseQuery.startAfter(cursorSnap);
+      }
+    }
+
+    const results: Question[] = [];
+    let lastDoc: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+    let scans = 0;
+
+    while (results.length < limit && scans < MAX_SEARCH_SCAN) {
+      scans++;
+      let scanQuery = baseQuery.limit(SEARCH_SCAN_BATCH);
+      if (lastDoc) {
+        scanQuery = scanQuery.startAfter(lastDoc);
+      }
+      const batch = await scanQuery.get();
+      if (batch.empty) break;
+
+      for (const doc of batch.docs) {
+        const d = doc.data();
+        if (matchesQuestionSearchTerms(d.title ?? "", d.body ?? "", d.tags ?? [], searchTerms)) {
+          results.push(toQuestion(doc.id, d));
+          if (results.length >= limit + 1) break;
+        }
+      }
+      lastDoc = batch.docs[batch.docs.length - 1];
+      if (batch.docs.length < SEARCH_SCAN_BATCH) break;
+    }
+
+    const hasMore = results.length > limit;
+    const trimmed = hasMore ? results.slice(0, limit) : results;
+
+    return {
+      questions: trimmed,
+      nextCursor: hasMore ? trimmed[trimmed.length - 1].id : null,
+    };
+  }
+
+  // ─── Answers CRUD ─────────────────────────────────────────────────────────────
+
+  async createAnswer(
+    questionId: string,
+    userId: string,
+    userName: string,
+    userPhoto: string | null,
+    body: string
+  ): Promise<string> {
+    const questionRef = this.db.collection(COLLECTIONS.QUESTIONS).doc(questionId);
+
+    const answerId = await this.db.runTransaction(async (tx) => {
+      const qSnap = await tx.get(questionRef);
+      if (!qSnap.exists) throw new QuestionNotFoundError();
+
+      const answerRef = questionRef.collection(ANSWERS_SUBCOLLECTION).doc();
+      tx.set(answerRef, {
+        body,
+        authorId: userId,
+        authorName: userName,
+        authorPhoto: userPhoto,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        upCount: 0,
+        downCount: 0,
+        netScore: 0,
+        isAccepted: false,
+      });
+
+      tx.update(questionRef, {
+        answerCount: (Number(qSnap.data()?.answerCount) || 0) + 1,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+
+      return answerRef.id;
+    });
+
+    return answerId;
+  }
+
+  async getAnswersForQuestion(
+    questionId: string,
+    sort: "top" | "newest" = "top"
+  ): Promise<Answer[]> {
+    let query: FirebaseFirestore.Query = this.db
+      .collection(COLLECTIONS.QUESTIONS)
+      .doc(questionId)
+      .collection(ANSWERS_SUBCOLLECTION);
+
+    if (sort === "top") {
+      query = query.orderBy("netScore", "desc").orderBy("createdAt", "desc");
+    } else {
+      query = query.orderBy("createdAt", "desc");
+    }
+
+    const snapshot = await query.get();
+    const answers = snapshot.docs.map((d) => toAnswer(d.id, questionId, d.data()));
+
+    // Pin accepted answer to top
+    const accepted = answers.filter((a) => a.isAccepted);
+    const rest = answers.filter((a) => !a.isAccepted);
+    return [...accepted, ...rest];
+  }
+
+  async acceptAnswer(questionId: string, answerId: string, userId: string): Promise<void> {
+    const questionRef = this.db.collection(COLLECTIONS.QUESTIONS).doc(questionId);
+
+    await this.db.runTransaction(async (tx) => {
+      const qSnap = await tx.get(questionRef);
+      if (!qSnap.exists) throw new QuestionNotFoundError();
+      if (qSnap.data()?.authorId !== userId) {
+        throw new UnauthorizedError("Only the question author can accept an answer");
+      }
+
+      const answerRef = questionRef.collection(ANSWERS_SUBCOLLECTION).doc(answerId);
+      const aSnap = await tx.get(answerRef);
+      if (!aSnap.exists) throw new AnswerNotFoundError();
+
+      // Unaccept any previously accepted answer
+      const prevAccepted = await questionRef
+        .collection(ANSWERS_SUBCOLLECTION)
+        .where("isAccepted", "==", true)
+        .get();
+
+      for (const doc of prevAccepted.docs) {
+        if (doc.id !== answerId) {
+          tx.update(doc.ref, { isAccepted: false });
+        }
+      }
+
+      const isAlreadyAccepted = aSnap.data()?.isAccepted === true;
+      tx.update(answerRef, { isAccepted: !isAlreadyAccepted });
+    });
+  }
+
+  // ─── Voting ───────────────────────────────────────────────────────────────────
+
+  async vote(
+    targetType: "question" | "answer",
+    targetId: string,
+    userId: string,
+    voteType: VoteType,
+    questionId?: string
+  ): Promise<VoteResult> {
+    const voteCollection =
+      targetType === "question" ? COLLECTIONS.QUESTION_VOTES : COLLECTIONS.ANSWER_VOTES;
+
+    const targetRef =
+      targetType === "question"
+        ? this.db.collection(COLLECTIONS.QUESTIONS).doc(targetId)
+        : this.db
+            .collection(COLLECTIONS.QUESTIONS)
+            .doc(questionId!)
+            .collection(ANSWERS_SUBCOLLECTION)
+            .doc(targetId);
+
+    const voteRef = this.db
+      .collection(voteCollection)
+      .doc(questionVoteDocId(targetId, userId));
+
+    return this.db.runTransaction(async (tx) => {
+      const [targetSnap, voteSnap] = await Promise.all([
+        tx.get(targetRef),
+        tx.get(voteRef),
+      ]);
+
+      if (!targetSnap.exists) {
+        throw targetType === "question"
+          ? new QuestionNotFoundError()
+          : new AnswerNotFoundError();
+      }
+
+      const targetData = targetSnap.data()!;
+      const upCount = Number(targetData.upCount ?? 0);
+      const downCount = Number(targetData.downCount ?? 0);
+
+      if (voteSnap.exists) {
+        const existingType = voteSnap.data()?.type as VoteType | undefined;
+
+        if (existingType === voteType) {
+          // Toggle off
+          tx.delete(voteRef);
+          const nextUp = voteType === "up" ? Math.max(0, upCount - 1) : upCount;
+          const nextDown = voteType === "down" ? Math.max(0, downCount - 1) : downCount;
+          tx.update(targetRef, {
+            upCount: nextUp,
+            downCount: nextDown,
+            netScore: nextUp - nextDown,
+          });
+          return { action: "removed" as const, type: voteType, upCount: nextUp, downCount: nextDown, netScore: nextUp - nextDown };
+        }
+
+        // Switch
+        tx.update(voteRef, { type: voteType, updatedAt: FieldValue.serverTimestamp() });
+        const nextUp = (existingType === "up" ? Math.max(0, upCount - 1) : upCount) + (voteType === "up" ? 1 : 0);
+        const nextDown = (existingType === "down" ? Math.max(0, downCount - 1) : downCount) + (voteType === "down" ? 1 : 0);
+        tx.update(targetRef, {
+          upCount: nextUp,
+          downCount: nextDown,
+          netScore: nextUp - nextDown,
+        });
+        return { action: "switched" as const, type: voteType, previousType: existingType, upCount: nextUp, downCount: nextDown, netScore: nextUp - nextDown };
+      }
+
+      // New vote
+      tx.set(voteRef, {
+        targetId,
+        userId,
+        type: voteType,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+      const nextUp = voteType === "up" ? upCount + 1 : upCount;
+      const nextDown = voteType === "down" ? downCount + 1 : downCount;
+      tx.update(targetRef, {
+        upCount: nextUp,
+        downCount: nextDown,
+        netScore: nextUp - nextDown,
+      });
+      return { action: "added" as const, type: voteType, upCount: nextUp, downCount: nextDown, netScore: nextUp - nextDown };
+    });
+  }
+
+  async getUserVotes(userId: string): Promise<Record<string, VoteType>> {
+    const [qVotes, aVotes] = await Promise.all([
+      this.db.collection(COLLECTIONS.QUESTION_VOTES).where("userId", "==", userId).get(),
+      this.db.collection(COLLECTIONS.ANSWER_VOTES).where("userId", "==", userId).get(),
+    ]);
+
+    const result: Record<string, VoteType> = {};
+    for (const doc of qVotes.docs) {
+      const data = doc.data();
+      result[data.targetId] = data.type;
+    }
+    for (const doc of aVotes.docs) {
+      const data = doc.data();
+      result[data.targetId] = data.type;
+    }
+    return result;
+  }
+
+  // ─── Tag-based cookbook linking ────────────────────────────────────────────────
+
+  async getRelatedCookbookEntries(tags: string[], limit = 5): Promise<CookbookEntry[]> {
+    if (tags.length === 0) return [];
+
+    const queryTags = tags.slice(0, 10);
+    const snapshot = await this.db
+      .collection(COLLECTIONS.COOKBOOK_ENTRIES)
+      .where("tags", "array-contains-any", queryTags)
+      .orderBy("netScore", "desc")
+      .limit(limit)
+      .get();
+
+    return snapshot.docs.map((d) => {
+      const data = d.data();
+      return {
+        id: d.id,
+        title: data.title ?? "",
+        description: data.description ?? "",
+        promptContent: data.promptContent ?? "",
+        category: data.category ?? "other",
+        tags: data.tags ?? [],
+        worksWith: data.worksWith ?? [],
+        authorId: data.authorId ?? "",
+        authorDisplayName: data.authorDisplayName ?? "",
+        createdAt: data.createdAt?.toDate?.().toISOString() ?? new Date().toISOString(),
+        upCount: Number(data.upCount ?? 0),
+        downCount: Number(data.downCount ?? 0),
+      } as CookbookEntry;
+    });
+  }
+}
+
+let _instance: QuestionsService | null = null;
+
+export function getQuestionsService(): QuestionsService {
+  if (!_instance) {
+    _instance = new QuestionsService();
+  }
+  return _instance;
+}

--- a/lib/questions/service.ts
+++ b/lib/questions/service.ts
@@ -310,11 +310,12 @@ export class QuestionsService {
       const aSnap = await tx.get(answerRef);
       if (!aSnap.exists) throw new AnswerNotFoundError();
 
-      // Unaccept any previously accepted answer
-      const prevAccepted = await questionRef
-        .collection(ANSWERS_SUBCOLLECTION)
-        .where("isAccepted", "==", true)
-        .get();
+      // Unaccept any previously accepted answer (must read through tx)
+      const prevAccepted = await tx.get(
+        questionRef
+          .collection(ANSWERS_SUBCOLLECTION)
+          .where("isAccepted", "==", true)
+      );
 
       for (const doc of prevAccepted.docs) {
         if (doc.id !== answerId) {

--- a/types/questions.ts
+++ b/types/questions.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export const QUESTION_TAGS = [
+  "cursor-rules",
+  "prompting",
+  "debugging",
+  "refactoring",
+  "testing",
+  "architecture",
+  "performance",
+  "workflows",
+  "mcp",
+  "agents",
+  "other",
+] as const;
+
+export type QuestionTag = (typeof QUESTION_TAGS)[number];
+
+export type VoteType = "up" | "down";
+
+export type QuestionSort = "newest" | "top" | "unanswered";
+
+export interface Question {
+  id: string;
+  title: string;
+  body: string;
+  tags: QuestionTag[];
+  authorId: string;
+  authorName: string;
+  authorPhoto: string | null;
+  createdAt: string;
+  updatedAt: string;
+  upCount: number;
+  downCount: number;
+  netScore: number;
+  answerCount: number;
+}
+
+export interface Answer {
+  id: string;
+  questionId: string;
+  body: string;
+  authorId: string;
+  authorName: string;
+  authorPhoto: string | null;
+  createdAt: string;
+  updatedAt: string;
+  upCount: number;
+  downCount: number;
+  netScore: number;
+  isAccepted: boolean;
+}
+
+export interface VoteResult {
+  action: "added" | "removed" | "switched";
+  type: VoteType;
+  previousType?: VoteType;
+  upCount: number;
+  downCount: number;
+  netScore: number;
+}


### PR DESCRIPTION
## Summary

Implements the Community Knowledge Q&A system (closes #253). Members can post questions about Cursor workflows, prompting patterns, and AI-assisted dev challenges. The community votes on answers. Questions are indexed by tag and automatically linked to relevant cookbook entries.

- **QuestionsService class** centralizes all Firestore CRUD, voting, search, and tag-based cookbook linking in a single service layer (`lib/questions/service.ts`)
- **Up/down voting** on both questions and answers (Stack Overflow style) using transactional denormalized counters
- **Tag-based search** with batched scan pattern (matches existing cookbook search)
- **Tag-based cookbook linking** via `array-contains-any` to surface related cookbook entries on question detail pages
- **6 API routes**: list, detail, post question, post answer, vote, accept answer
- **6 UI components**: TagFilter, QuestionCard, AnswerCard, AnswerComposer, QuestionDetail, QuestionsListing
- **3 pages**: `/questions` (browse/search), `/questions/[id]` (detail), `/questions/ask` (compose)
- **Firestore security rules** for questions, answers subcollection, question_votes, answer_votes
- **Navigation**: Q&A added to AppShell sidebar (Resources group), Footer, and sitemap
- **9 test suites, 56 tests** — full suite passes (1,180 tests, 0 regressions)

## Test plan

- [ ] Verify `/questions` page loads and shows "No questions found" when empty
- [ ] Sign in and verify "Ask Question" button appears
- [ ] Submit a question via `/questions/ask` and verify it appears in the list
- [ ] Click into a question detail page and verify answers/voting work
- [ ] Vote on questions and answers, verify counts update
- [ ] Accept an answer as the question author
- [ ] Search questions by keyword and filter by tag
- [ ] Verify related cookbook entries show on question detail
- [ ] Confirm all 1,180 tests pass (`npm test`)

Made with [Cursor](https://cursor.com)