### PR TITLE
feat: Hack-a-Sprint 2026 events, gallery, Firestore read reductions

### DIFF
--- a/__tests__/app/api/analytics/summary/route.test.ts
+++ b/__tests__/app/api/analytics/summary/route.test.ts
@@ -28,6 +28,7 @@ jest.mock("@/content/showcase.json", () => ({
 jest.mock("@/content/events.json", () => ({
   upcoming: [{ id: "evt1", title: "Event One" }],
   past: [],
+  oldEvents: [],
 }));
 
 import { GET } from "@/app/api/analytics/summary/route";

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/submissions.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/submissions.route.test.ts
@@ -4,22 +4,16 @@
 
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/submissions/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getOptionalVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
-import {
-  userIsCheckedInForHackASprint2026,
-  userHasHackASprint2026Signup,
-  userHackASprint2026PeerVoteComplete,
-  getParticipantScoresForUser,
-  getAllHackASprint2026ParticipantScoreDocs,
-} from "@/lib/hackathon-asprint-2026-state";
-import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
+import { getAllHackASprint2026ParticipantScoreDocs } from "@/lib/hackathon-asprint-2026-state";
+import { userIsHackASprint2026JudgeFromUserData } from "@/lib/hackathon-showcase-admin";
 import { profileMatchesHackathonJudgeCheckinException } from "@/lib/hackathon-event-signup";
 import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
 import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getOptionalVerifiedUser: jest.fn(),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -37,15 +31,11 @@ jest.mock("@/lib/hackathon-asprint-2026-schedule", () => ({
 
 jest.mock("@/lib/hackathon-asprint-2026-state", () => ({
   ...jest.requireActual("@/lib/hackathon-asprint-2026-state"),
-  userIsCheckedInForHackASprint2026: jest.fn(),
-  userHasHackASprint2026Signup: jest.fn(),
-  userHackASprint2026PeerVoteComplete: jest.fn(),
-  getParticipantScoresForUser: jest.fn(),
   getAllHackASprint2026ParticipantScoreDocs: jest.fn(),
 }));
 
 jest.mock("@/lib/hackathon-showcase-admin", () => ({
-  userIsHackASprint2026Judge: jest.fn(),
+  userIsHackASprint2026JudgeFromUserData: jest.fn(),
 }));
 
 jest.mock("@/lib/hackathon-event-signup", () => ({
@@ -53,8 +43,8 @@ jest.mock("@/lib/hackathon-event-signup", () => ({
   profileMatchesHackathonJudgeCheckinException: jest.fn(),
 }));
 
-const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
-  typeof getVerifiedUser
+const mockGetOptionalUser = getOptionalVerifiedUser as jest.MockedFunction<
+  typeof getOptionalVerifiedUser
 >;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockFetchSubmissions =
@@ -64,24 +54,12 @@ const mockFetchSubmissions =
 const mockPhase = getHackASprint2026Phase as jest.MockedFunction<
   typeof getHackASprint2026Phase
 >;
-const mockCheckedIn = userIsCheckedInForHackASprint2026 as jest.MockedFunction<
-  typeof userIsCheckedInForHackASprint2026
->;
-const mockSignedUp = userHasHackASprint2026Signup as jest.MockedFunction<
-  typeof userHasHackASprint2026Signup
->;
-const mockPeerComplete = userHackASprint2026PeerVoteComplete as jest.MockedFunction<
-  typeof userHackASprint2026PeerVoteComplete
->;
-const mockGetParticipantScores = getParticipantScoresForUser as jest.MockedFunction<
-  typeof getParticipantScoresForUser
->;
 const mockAllParticipantDocs =
   getAllHackASprint2026ParticipantScoreDocs as jest.MockedFunction<
     typeof getAllHackASprint2026ParticipantScoreDocs
   >;
-const mockIsJudge = userIsHackASprint2026Judge as jest.MockedFunction<
-  typeof userIsHackASprint2026Judge
+const mockJudgeFromProfile = userIsHackASprint2026JudgeFromUserData as jest.MockedFunction<
+  typeof userIsHackASprint2026JudgeFromUserData
 >;
 const mockJudgeCheckinBypass =
   profileMatchesHackathonJudgeCheckinException as jest.MockedFunction<
@@ -111,38 +89,57 @@ const FIXTURE_SUBMISSIONS = [
   },
 ];
 
-function makeScoreSnap(data: Record<string, unknown>) {
-  return { exists: true, data: () => data };
+function makeSnap(exists: boolean, data?: Record<string, unknown>) {
+  return {
+    exists,
+    data: () => data ?? {},
+  };
 }
 
+/** Participant scores doc: incomplete ballot = only own key; complete = includes bob-proj. */
+let participantScoresPayload: Record<string, number> = {};
+
 function buildMockDb() {
-  const getAll = jest.fn().mockResolvedValue([
-    makeScoreSnap({ aiScore: 9, aiReasoning: "Strong", peerVoteCount: 2 }),
-    makeScoreSnap({ aiScore: 6, aiReasoning: "Fine", peerVoteCount: 1 }),
-  ]);
+  let getAllCall = 0;
+  const getAll = jest.fn().mockImplementation(() => {
+    getAllCall += 1;
+    if (getAllCall === 1) {
+      return Promise.resolve([
+        makeSnap(true, { checkedInAt: new Date() }),
+        makeSnap(true, { github: { login: "alice" } }),
+      ]);
+    }
+    return Promise.resolve([
+      makeScoreSnap({ aiScore: 9, aiReasoning: "Strong", peerVoteCount: 2 }),
+      makeScoreSnap({ aiScore: 6, aiReasoning: "Fine", peerVoteCount: 1 }),
+    ]);
+  });
+
+  const participantGet = jest.fn().mockImplementation(() =>
+    Promise.resolve(
+      makeSnap(true, {
+        scores: participantScoresPayload,
+      })
+    )
+  );
 
   const db = {
-    collection: jest.fn(() => ({
-      doc: jest.fn(() => ({})),
+    collection: jest.fn((name: string) => ({
+      doc: jest.fn((id: string) => {
+        if (name === "hackathonASprint2026ParticipantScores") {
+          return { get: participantGet };
+        }
+        return {};
+      }),
     })),
     getAll,
   };
 
-  const userGet = jest.fn().mockResolvedValue({
-    exists: true,
-    data: () => ({ github: { login: "viewergh" } }),
-  });
+  return { db, getAll, participantGet };
+}
 
-  (db.collection as jest.Mock).mockImplementation((name: string) => ({
-    doc: jest.fn((id: string) => {
-      if (name === "users" && id === "u1") {
-        return { get: userGet };
-      }
-      return { get: jest.fn().mockResolvedValue({ exists: false, data: () => undefined }) };
-    }),
-  }));
-
-  return { db, getAll, userGet };
+function makeScoreSnap(data: Record<string, unknown>) {
+  return { exists: true, data: () => data };
 }
 
 function makeGetRequest() {
@@ -153,18 +150,15 @@ function makeGetRequest() {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockGetVerifiedUser.mockResolvedValue({
+  participantScoresPayload = {};
+  mockGetOptionalUser.mockResolvedValue({
     uid: "u1",
     email: "viewer@example.com",
-  } as Awaited<ReturnType<typeof getVerifiedUser>>);
+  } as Awaited<ReturnType<typeof getOptionalVerifiedUser>>);
   mockPhase.mockReturnValue("peerVotingOpen");
   mockFetchSubmissions.mockResolvedValue(FIXTURE_SUBMISSIONS);
-  mockCheckedIn.mockResolvedValue(true);
-  mockSignedUp.mockResolvedValue(true);
-  mockIsJudge.mockResolvedValue(false);
+  mockJudgeFromProfile.mockReturnValue(false);
   mockJudgeCheckinBypass.mockReturnValue(false);
-  mockPeerComplete.mockResolvedValue(false);
-  mockGetParticipantScores.mockResolvedValue({ "alice-proj": 8 });
   mockAllParticipantDocs.mockResolvedValue([]);
 
   const { db } = buildMockDb();
@@ -172,14 +166,17 @@ beforeEach(() => {
 });
 
 describe("GET /api/hackathons/showcase/hack-a-sprint-2026/submissions", () => {
-  it("returns 401 when unauthenticated", async () => {
-    mockGetVerifiedUser.mockResolvedValueOnce(null);
+  it("returns 200 for unauthenticated public gallery", async () => {
+    mockGetOptionalUser.mockResolvedValueOnce(null);
     const res = await GET(makeGetRequest());
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { viewer: { checkedIn: boolean }; submissions: unknown[] };
+    expect(body.viewer.checkedIn).toBe(false);
+    expect(Array.isArray(body.submissions)).toBe(true);
   });
 
-  it("strips AI and peer fields for a participant who has not finished peer voting", async () => {
-    mockPeerComplete.mockResolvedValue(false);
+  it("strips AI and peer fields for a submitter who has not finished peer voting", async () => {
+    participantScoresPayload = { "alice-proj": 8 };
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -219,7 +216,7 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/submissions", () => {
   });
 
   it("includes AI and peer fields after peer voting is complete", async () => {
-    mockPeerComplete.mockResolvedValue(true);
+    participantScoresPayload = { "bob-proj": 9 };
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -239,8 +236,8 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/submissions", () => {
   });
 
   it("reveals scores for judges even when peer voting is incomplete", async () => {
-    mockPeerComplete.mockResolvedValue(false);
-    mockIsJudge.mockResolvedValue(true);
+    participantScoresPayload = { "alice-proj": 8 };
+    mockJudgeFromProfile.mockReturnValue(true);
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -255,7 +252,7 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/submissions", () => {
   });
 
   it("reveals scores when organizer check-in bypass applies", async () => {
-    mockPeerComplete.mockResolvedValue(false);
+    participantScoresPayload = { "alice-proj": 8 };
     mockJudgeCheckinBypass.mockReturnValue(true);
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);

--- a/__tests__/components/members/MemberCard.test.tsx
+++ b/__tests__/components/members/MemberCard.test.tsx
@@ -207,6 +207,18 @@ describe("MemberCard", () => {
     expect(screen.getByText("Hack-a-Sprint '26")).toBeInTheDocument();
   });
 
+  it("shows Hack-a-Sprint showcase winner ribbons when present", () => {
+    render(
+      <MemberCard
+        member={buildMember({
+          hackASprint2026ShowcaseAwards: ["judgesWinner", "peerReviewWinner"],
+        })}
+      />
+    );
+    expect(screen.getByText("Judges winner")).toBeInTheDocument();
+    expect(screen.getByText("Peer review winner")).toBeInTheDocument();
+  });
+
   it("renders social links when visible", () => {
     render(<MemberCard member={buildMember()} />);
     expect(screen.getByLabelText("Website (opens in new tab)")).toHaveAttribute("href", "https://jane.dev");

--- a/__tests__/config/firebase/firestore.rules.test.ts
+++ b/__tests__/config/firebase/firestore.rules.test.ts
@@ -165,6 +165,12 @@ describe("Firestore rules: badge trust boundaries", () => {
       })
     );
 
+    await assertFails(
+      updateDoc(userRef, {
+        hackASprint2026ShowcaseAwards: ["judgesWinner"],
+      })
+    );
+
     const userWithCounterRef = doc(
       testEnv.authenticatedContext("user-contributor-2").firestore(),
       "users",

--- a/__tests__/lib/hackathon-asprint-2026-awards.test.ts
+++ b/__tests__/lib/hackathon-asprint-2026-awards.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  computeShowcaseAwards,
+  hackASprint2026ZonedWallTimeToUtcMs,
+  isHackASprint2026PeerAwardsRevealed,
+  type ShowcaseAwardInput,
+} from "@/lib/hackathon-asprint-2026-awards";
+import { HACK_A_SPRINT_2026_TIMEZONE } from "@/lib/hackathon-asprint-2026-schedule";
+
+describe("hackASprint2026ZonedWallTimeToUtcMs", () => {
+  it("maps April 17, 2026 12:00 NY wall time to the correct UTC instant (EDT)", () => {
+    const ms = hackASprint2026ZonedWallTimeToUtcMs(
+      HACK_A_SPRINT_2026_TIMEZONE,
+      2026,
+      4,
+      17,
+      12,
+      0
+    );
+    const fmt = new Intl.DateTimeFormat("en-CA", {
+      timeZone: HACK_A_SPRINT_2026_TIMEZONE,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    const parts = fmt.formatToParts(new Date(ms));
+    const get = (t: Intl.DateTimeFormatPartTypes) =>
+      Number(parts.find((p) => p.type === t)?.value ?? "0");
+    expect(get("year")).toBe(2026);
+    expect(get("month")).toBe(4);
+    expect(get("day")).toBe(17);
+    expect(get("hour")).toBe(12);
+    expect(get("minute")).toBe(0);
+  });
+});
+
+describe("computeShowcaseAwards", () => {
+  const base: ShowcaseAwardInput[] = [
+    {
+      submissionId: "michaelrschulte",
+      githubLogin: "michaelrschulte",
+      aiRank: 1,
+      aiScore: 10,
+      peerAverage: 9,
+    },
+    {
+      submissionId: "zombiedays",
+      githubLogin: "Zombiedays",
+      aiRank: 10,
+      aiScore: 4,
+      peerAverage: 5,
+    },
+    {
+      submissionId: "alice",
+      githubLogin: "alice",
+      aiRank: 2,
+      aiScore: 9,
+      peerAverage: 8.5,
+    },
+    {
+      submissionId: "bob",
+      githubLogin: "bob",
+      aiRank: 3,
+      aiScore: 8,
+      peerAverage: 9.5,
+    },
+    {
+      submissionId: "carol",
+      githubLogin: "carol",
+      aiRank: 4,
+      aiScore: 7,
+      peerAverage: 7,
+    },
+    {
+      submissionId: "dave",
+      githubLogin: "dave",
+      aiRank: 5,
+      aiScore: 6,
+      peerAverage: 8.2,
+    },
+  ];
+
+  it("assigns two judges winners and next two AI ranks, excluding judges from AI slots", () => {
+    const beforePeer = new Date("2026-04-17T11:00:00-04:00");
+    const m = computeShowcaseAwards(base, beforePeer);
+    expect(m.get("michaelrschulte")).toEqual(["judgesWinner"]);
+    expect(m.get("zombiedays")).toEqual(["judgesWinner"]);
+    expect(m.get("alice")).toEqual(["aiJudgedWinner"]);
+    expect(m.get("bob")).toEqual(["aiJudgedWinner"]);
+    expect(m.get("carol")).toBeUndefined();
+  });
+
+  it("after peer reveal, assigns two peer winners by average excluding prior winners", () => {
+    const afterPeer = new Date("2026-04-17T13:00:00-04:00");
+    const m = computeShowcaseAwards(base, afterPeer);
+    expect(m.get("michaelrschulte")).toEqual(["judgesWinner"]);
+    expect(m.get("zombiedays")).toEqual(["judgesWinner"]);
+    expect(m.get("alice")).toEqual(["aiJudgedWinner"]);
+    expect(m.get("bob")).toEqual(["aiJudgedWinner"]);
+    expect(m.get("dave")).toEqual(["peerReviewWinner"]);
+    expect(m.get("carol")).toEqual(["peerReviewWinner"]);
+  });
+
+  it("isHackASprint2026PeerAwardsRevealed respects time", () => {
+    expect(isHackASprint2026PeerAwardsRevealed(new Date("2026-04-17T11:59:00-04:00"))).toBe(
+      false
+    );
+    expect(isHackASprint2026PeerAwardsRevealed(new Date("2026-04-17T12:01:00-04:00"))).toBe(
+      true
+    );
+  });
+});

--- a/app/(auth)/profile/_components/ConnectionsSection.tsx
+++ b/app/(auth)/profile/_components/ConnectionsSection.tsx
@@ -11,6 +11,7 @@ import {
   GitHubIcon,
   UserCardIcon,
 } from "@/components/icons";
+import { SHOWCASE_AWARD_LABEL } from "@/lib/hackathon-asprint-2026-awards";
 import { useProfileContext } from "../_contexts/ProfileContext";
 
 export function ConnectionsSection() {
@@ -103,7 +104,8 @@ export function ConnectionsSection() {
       {(connectedAgents.length > 0 ||
         userProfile?.eduBadge ||
         userProfile?.additionalEmails?.some((e) => e.verified && e.email.toLowerCase().endsWith(".edu")) ||
-        userProfile?.hackASprint2026ShowcaseBadge) && (
+        userProfile?.hackASprint2026ShowcaseBadge ||
+        (userProfile?.hackASprint2026ShowcaseAwards?.length ?? 0) > 0) && (
         <div className="flex flex-wrap gap-2 mt-3">
           {connectedAgents.length > 0 && (
             <span className="px-3 py-1 bg-purple-500/10 text-purple-400 text-xs rounded-full inline-flex items-center gap-1">
@@ -118,6 +120,14 @@ export function ConnectionsSection() {
           {userProfile?.hackASprint2026ShowcaseBadge && (
             <span className="px-3 py-1 bg-cyan-500/10 text-cyan-400 text-xs rounded-full">Hack-a-Sprint &apos;26</span>
           )}
+          {userProfile?.hackASprint2026ShowcaseAwards?.map((kind) => (
+            <span
+              key={kind}
+              className="px-3 py-1 bg-amber-500/10 text-amber-400 text-xs rounded-full"
+            >
+              {SHOWCASE_AWARD_LABEL[kind]}
+            </span>
+          ))}
         </div>
       )}
 

--- a/app/api/analytics/summary/route.ts
+++ b/app/api/analytics/summary/route.ts
@@ -10,16 +10,19 @@ import { logger } from "@/lib/logger";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import showcaseData from "@/content/showcase.json";
 import eventsData from "@/content/events.json";
+import type { EventsData } from "@/types/events";
 
 const RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 60 };
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours — full scans are read-heavy; refresh less often
 
 // Build a lookup map from eventId → event title using the static events JSON
+const typedEvents = eventsData as unknown as EventsData;
 const eventNameMap: Record<string, string> = {};
 [
-  ...(eventsData.upcoming ?? []),
-  ...(eventsData.past ?? []),
-].forEach((event: { id?: string; title?: string }) => {
+  ...typedEvents.upcoming,
+  ...typedEvents.past,
+  ...(typedEvents.oldEvents ?? []),
+].forEach((event) => {
   if (event.id && event.title) {
     eventNameMap[event.id] = event.title;
   }
@@ -61,6 +64,10 @@ const EMPTY_SUMMARY: AnalyticsSummary = {
   generatedAt: new Date().toISOString(),
 };
 
+const cacheHeaders = {
+  "Cache-Control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+};
+
 export async function GET(request: NextRequest) {
   const clientId = getClientIdentifier(request as unknown as Request);
   const rateResult = checkRateLimit(`analytics-summary:${clientId}`, RATE_LIMIT);
@@ -76,15 +83,21 @@ export async function GET(request: NextRequest) {
     db = getAdminDb();
   } catch (initError) {
     logger.logError(initError, { endpoint: "/api/analytics/summary", phase: "init" });
-    return NextResponse.json({ ...EMPTY_SUMMARY, generatedAt: new Date().toISOString() });
+    return NextResponse.json(
+      { ...EMPTY_SUMMARY, generatedAt: new Date().toISOString() },
+      { headers: cacheHeaders }
+    );
   }
 
   if (!db) {
-    return NextResponse.json({ ...EMPTY_SUMMARY, generatedAt: new Date().toISOString() });
+    return NextResponse.json(
+      { ...EMPTY_SUMMARY, generatedAt: new Date().toISOString() },
+      { headers: cacheHeaders }
+    );
   }
 
   try {
-    // --- Check analytics_snapshots cache (1-hour TTL) ---
+    // --- Check analytics_snapshots cache (see CACHE_TTL_MS) ---
     const cacheRef = db.collection("analytics_snapshots").doc("latest");
     try {
       const cacheDoc = await cacheRef.get();
@@ -92,7 +105,9 @@ export async function GET(request: NextRequest) {
         const cached = cacheDoc.data();
         const expiresAt = cached?.expiresAt?.toDate ? (cached.expiresAt.toDate() as Date) : null;
         if (expiresAt && expiresAt > new Date()) {
-          return NextResponse.json(cached?.summary as AnalyticsSummary);
+          return NextResponse.json(cached?.summary as AnalyticsSummary, {
+            headers: cacheHeaders,
+          });
         }
       }
     } catch {
@@ -285,10 +300,13 @@ export async function GET(request: NextRequest) {
       // Cache write failure is non-fatal
     }
 
-    return NextResponse.json(summary);
+    return NextResponse.json(summary, { headers: cacheHeaders });
   } catch (error) {
     logger.logError(error, { endpoint: "/api/analytics/summary" });
     // Return empty data rather than a 500 so the page still renders gracefully
-    return NextResponse.json({ ...EMPTY_SUMMARY, generatedAt: new Date().toISOString() });
+    return NextResponse.json(
+      { ...EMPTY_SUMMARY, generatedAt: new Date().toISOString() },
+      { headers: cacheHeaders }
+    );
   }
 }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
@@ -19,6 +19,7 @@ import { computePeerAverages } from "@/lib/hackathon-asprint-2026-participant-sc
 import {
   getAllHackASprint2026ParticipantScoreDocs,
   hackASprint2026ScoreDocId,
+  resolveVoterGithubByUid,
 } from "@/lib/hackathon-asprint-2026-state";
 import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
@@ -69,16 +70,7 @@ export async function GET(request: NextRequest) {
       githubLogin: s.githubLogin,
     }));
     const voterDocs = await getAllHackASprint2026ParticipantScoreDocs(db);
-    const voterUids = [...new Set(voterDocs.map((d) => d.userId))];
-    const voterRefs = voterUids.map((uid) => db.collection("users").doc(uid));
-    const voterSnaps = voterRefs.length > 0 ? await db.getAll(...voterRefs) : [];
-    const voterGithubByUid = new Map<string, string>();
-    for (const snap of voterSnaps) {
-      const login = snap.data()?.github?.login;
-      if (typeof login === "string" && login.trim()) {
-        voterGithubByUid.set(snap.id, login.trim().toLowerCase());
-      }
-    }
+    const voterGithubByUid = await resolveVoterGithubByUid(db, voterDocs);
     const peerAvgBySid = computePeerAverages(
       identities,
       voterDocs,

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/me/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/me/route.ts
@@ -8,19 +8,23 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {
+  HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
   getJudgeUidSet,
   githubUserHasMergedLabeledShowcasePr,
 } from "@/lib/hackathon-showcase";
-import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
+import { userIsHackASprint2026JudgeFromUserData } from "@/lib/hackathon-showcase-admin";
 import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
-import { participantPrizeEligibility } from "@/lib/hackathon-asprint-2026-participant-scoring";
 import {
-  getParticipantScoresForUser,
-  userHasHackASprint2026Signup,
-  userIsCheckedInForHackASprint2026,
-  userHackASprint2026PeerVoteComplete,
-} from "@/lib/hackathon-asprint-2026-state";
+  hackASprint2026ParticipantScoresDocId,
+  normalizeParticipantScores,
+  participantBallotComplete,
+  participantPrizeEligibility,
+} from "@/lib/hackathon-asprint-2026-participant-scoring";
+import {
+  hackathonEventSignupDocId,
+  profileMatchesHackathonJudgeCheckinException,
+} from "@/lib/hackathon-event-signup";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -55,21 +59,31 @@ export async function GET(request: NextRequest) {
     let highScoreCount = 0;
     let requiredHighScores = 0;
 
-    const judgeEligible = db
-      ? await userIsHackASprint2026Judge(db, user.uid, user.email)
-      : getJudgeUidSet().has(user.uid);
-
     const phase = getHackASprint2026Phase();
 
+    let judgeEligible = getJudgeUidSet().has(user.uid);
+
     if (db) {
-      const userSnap = await db.collection("users").doc(user.uid).get();
-      const ud = userSnap.data();
-      const login = ud?.github?.login;
-      if (typeof login === "string" && login.trim()) {
-        githubLogin = login.trim();
+      const signupRef = db
+        .collection("hackathonEventSignups")
+        .doc(hackathonEventSignupDocId(HACK_A_SPRINT_2026_EVENT_ID, user.uid));
+      const userRef = db.collection("users").doc(user.uid);
+      const [signupSnap, userSnap] = await db.getAll(signupRef, userRef);
+      const profile = userSnap.data() as Record<string, unknown> | undefined;
+      judgeEligible = userIsHackASprint2026JudgeFromUserData(
+        user.uid,
+        user.email,
+        profile
+      );
+      signedUp = signupSnap.exists;
+      checkedIn =
+        Boolean(signupSnap.exists && signupSnap.data()?.checkedInAt != null) ||
+        profileMatchesHackathonJudgeCheckinException(user.email, profile);
+      const gh = profile?.github as { login?: unknown } | undefined;
+      const login = typeof gh?.login === "string" ? gh.login : "";
+      if (login.trim()) {
+        githubLogin = login.trim().toLowerCase();
       }
-      checkedIn = await userIsCheckedInForHackASprint2026(db, user.uid, user.email);
-      signedUp = await userHasHackASprint2026Signup(db, user.uid);
 
       if (githubLogin && checkedIn && signedUp) {
         let submissions = await fetchShowcaseSubmissionsFromGitHub();
@@ -78,13 +92,20 @@ export async function GET(request: NextRequest) {
           submissionId: s.submissionId,
           githubLogin: s.githubLogin,
         }));
-        hasCompletedPeerVoting = await userHackASprint2026PeerVoteComplete(
-          db,
-          user.uid,
-          identities,
-          githubLogin
+        const psRef = db
+          .collection("hackathonASprint2026ParticipantScores")
+          .doc(hackASprint2026ParticipantScoresDocId(user.uid));
+        const psSnap = await psRef.get();
+        const scores = psSnap.exists
+          ? normalizeParticipantScores(
+              psSnap.data()?.scores as Record<string, unknown> | undefined
+            )
+          : {};
+        hasCompletedPeerVoting = participantBallotComplete(
+          scores,
+          githubLogin,
+          identities
         );
-        const scores = await getParticipantScoresForUser(db, user.uid);
         const pe = participantPrizeEligibility(scores, githubLogin, identities);
         prizeEligible = pe.eligible;
         highScoreCount = pe.highScoreCount;

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/participant-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/participant-score/route.ts
@@ -16,10 +16,8 @@ import {
   hackASprint2026ParticipantScoresDocId,
   normalizeParticipantScores,
 } from "@/lib/hackathon-asprint-2026-participant-scoring";
-import {
-  userHasHackASprint2026Signup,
-  userIsCheckedInForHackASprint2026,
-} from "@/lib/hackathon-asprint-2026-state";
+import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
+import { hackathonEventSignupDocId, profileMatchesHackathonJudgeCheckinException } from "@/lib/hackathon-event-signup";
 import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
@@ -48,15 +46,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const checkedIn = await userIsCheckedInForHackASprint2026(db, user.uid, user.email);
-    if (!checkedIn) {
-      return NextResponse.json({ error: "You must be checked in." }, { status: 403 });
-    }
-
-    const signedUp = await userHasHackASprint2026Signup(db, user.uid);
-    if (!signedUp) {
-      return NextResponse.json({ error: "Website event signup required." }, { status: 403 });
-    }
+    const phase = getHackASprint2026Phase();
 
     let body: { submissionId?: string; score?: number };
     try {
@@ -95,8 +85,37 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Connect GitHub on your profile." }, { status: 403 });
     }
 
+    const submitterSet = new Set(
+      submissions.map((s) => s.githubLogin.trim().toLowerCase())
+    );
+    if (!submitterSet.has(gh)) {
+      return NextResponse.json(
+        { error: "Peer scoring is only available if you have a merged showcase submission." },
+        { status: 403 }
+      );
+    }
+
     if (target.githubLogin.trim().toLowerCase() === gh) {
       return NextResponse.json({ error: "You cannot score your own submission." }, { status: 400 });
+    }
+
+    const relaxSignupCheckin =
+      phase === "resultsOpen" || phase === "peerVotingOpen";
+
+    if (!relaxSignupCheckin) {
+      const signupSnap = await db
+        .collection("hackathonEventSignups")
+        .doc(hackathonEventSignupDocId(HACK_A_SPRINT_2026_EVENT_ID, user.uid))
+        .get();
+      const checkedIn =
+        Boolean(signupSnap.exists && signupSnap.data()?.checkedInAt != null) ||
+        profileMatchesHackathonJudgeCheckinException(user.email, ud as Record<string, unknown> | undefined);
+      if (!checkedIn) {
+        return NextResponse.json({ error: "You must be checked in." }, { status: 403 });
+      }
+      if (!signupSnap.exists) {
+        return NextResponse.json({ error: "Website event signup required." }, { status: 403 });
+      }
     }
 
     const uidRate = checkRateLimit(
@@ -122,6 +141,7 @@ export async function POST(request: NextRequest) {
       {
         eventId: HACK_A_SPRINT_2026_EVENT_ID,
         userId: user.uid,
+        githubLogin: gh,
         scores: nextScores,
         updatedAt: FieldValue.serverTimestamp(),
       },

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/submissions/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/submissions/route.ts
@@ -7,8 +7,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { DocumentData } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getOptionalVerifiedUser } from "@/lib/server-auth";
 import {
+  HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
   type ShowcaseSubmission,
 } from "@/lib/hackathon-showcase";
@@ -17,17 +18,22 @@ import {
   computeAiRanksBySubmissionId,
   computeHackASprint2026RawScore,
 } from "@/lib/hackathon-asprint-2026-scores";
-import { computePeerAverages } from "@/lib/hackathon-asprint-2026-participant-scoring";
+import {
+  computePeerAverages,
+  hackASprint2026ParticipantScoresDocId,
+  normalizeParticipantScores,
+  participantBallotComplete,
+} from "@/lib/hackathon-asprint-2026-participant-scoring";
 import {
   getAllHackASprint2026ParticipantScoreDocs,
-  getParticipantScoresForUser,
   hackASprint2026ScoreDocId,
-  userHasHackASprint2026Signup,
-  userIsCheckedInForHackASprint2026,
-  userHackASprint2026PeerVoteComplete,
+  resolveVoterGithubByUid,
 } from "@/lib/hackathon-asprint-2026-state";
-import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
-import { profileMatchesHackathonJudgeCheckinException } from "@/lib/hackathon-event-signup";
+import { userIsHackASprint2026JudgeFromUserData } from "@/lib/hackathon-showcase-admin";
+import {
+  hackathonEventSignupDocId,
+  profileMatchesHackathonJudgeCheckinException,
+} from "@/lib/hackathon-event-signup";
 import { getJudgeUidSet } from "@/lib/hackathon-showcase";
 
 export const runtime = "nodejs";
@@ -46,10 +52,7 @@ function averageJudgeScores(
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+    const user = await getOptionalVerifiedUser(request);
 
     const phase = getHackASprint2026Phase();
     const db = getAdminDb();
@@ -62,60 +65,74 @@ export async function GET(request: NextRequest) {
     let judgeCheckinBypass = false;
     let viewerGithub: string | null = null;
 
-    if (db) {
-      checkedIn = await userIsCheckedInForHackASprint2026(db, user.uid, user.email);
-      signedUp = await userHasHackASprint2026Signup(db, user.uid);
-      judgeEligible = await userIsHackASprint2026Judge(
-        db,
-        user.uid,
-        user.email
-      );
-      const uSnap = await db.collection("users").doc(user.uid).get();
-      const profile = uSnap.data() as Record<string, unknown> | undefined;
+    if (user && db) {
+      const signupRef = db
+        .collection("hackathonEventSignups")
+        .doc(hackathonEventSignupDocId(HACK_A_SPRINT_2026_EVENT_ID, user.uid));
+      const userRef = db.collection("users").doc(user.uid);
+      const [signupSnap, userSnap] = await db.getAll(signupRef, userRef);
+      const profile = userSnap.data() as Record<string, unknown> | undefined;
+      signedUp = signupSnap.exists;
+      checkedIn =
+        Boolean(signupSnap.exists && signupSnap.data()?.checkedInAt != null) ||
+        profileMatchesHackathonJudgeCheckinException(user.email, profile);
       judgeCheckinBypass = profileMatchesHackathonJudgeCheckinException(
+        user.email,
+        profile
+      );
+      judgeEligible = userIsHackASprint2026JudgeFromUserData(
+        user.uid,
         user.email,
         profile
       );
       const gh = profile?.github as { login?: unknown } | undefined;
       const lg = typeof gh?.login === "string" ? gh.login : "";
       viewerGithub = lg.trim() ? lg.trim().toLowerCase() : null;
-    } else {
+    } else if (user && !db) {
       judgeEligible = getJudgeUidSet().has(user.uid);
     }
 
-    // Judges/organizers may match check-in bypass without a hackathonEventSignups doc;
-    // they still need the same checked-in gate as /me.
-    const showSubmissionList =
-      checkedIn && (signedUp || judgeEligible || judgeCheckinBypass);
-
+    /** Public gallery: submissions are always listed (no check-in gate on GET). */
     let submissions: ShowcaseSubmission[] = [];
-    if (showSubmissionList) {
-      submissions = await fetchShowcaseSubmissionsFromGitHub();
+    submissions = await fetchShowcaseSubmissionsFromGitHub();
 
-      const allowedRaw = process.env.HACK_A_SPRINT_2026_ALLOWED_SUBMISSIONS || "";
-      if (allowedRaw.trim()) {
-        const allowed = new Set(
-          allowedRaw
-            .split(",")
-            .map((s) => s.trim().toLowerCase())
-            .filter(Boolean)
-        );
-        submissions = submissions.filter((s) => allowed.has(s.submissionId));
-      }
+    const allowedRaw = process.env.HACK_A_SPRINT_2026_ALLOWED_SUBMISSIONS || "";
+    if (allowedRaw.trim()) {
+      const allowed = new Set(
+        allowedRaw
+          .split(",")
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean)
+      );
+      submissions = submissions.filter((s) => allowed.has(s.submissionId));
     }
 
-    if (db && viewerGithub && submissions.length > 0) {
+    const submissionGithubSet = new Set(
+      submissions.map((s) => s.githubLogin.trim().toLowerCase())
+    );
+    const isSubmitter = Boolean(
+      viewerGithub && submissionGithubSet.has(viewerGithub)
+    );
+
+    if (user && db && viewerGithub && submissions.length > 0) {
       const identities = submissions.map((s) => ({
         submissionId: s.submissionId,
         githubLogin: s.githubLogin,
       }));
-      hasCompletedPeerVoting = await userHackASprint2026PeerVoteComplete(
-        db,
-        user.uid,
-        identities,
-        viewerGithub
+      const psRef = db
+        .collection("hackathonASprint2026ParticipantScores")
+        .doc(hackASprint2026ParticipantScoresDocId(user.uid));
+      const psSnap = await psRef.get();
+      myParticipantScores = psSnap.exists
+        ? normalizeParticipantScores(
+            psSnap.data()?.scores as Record<string, unknown> | undefined
+          )
+        : {};
+      hasCompletedPeerVoting = participantBallotComplete(
+        myParticipantScores,
+        viewerGithub,
+        identities
       );
-      myParticipantScores = await getParticipantScoresForUser(db, user.uid);
     }
 
     const revealJudgesAndPeers = phase === "resultsOpen";
@@ -141,17 +158,7 @@ export async function GET(request: NextRequest) {
       }));
 
       const voterDocs = await getAllHackASprint2026ParticipantScoreDocs(db);
-      const voterUids = [...new Set(voterDocs.map((d) => d.userId))];
-      const voterRefs = voterUids.map((uid) => db.collection("users").doc(uid));
-      const voterSnaps =
-        voterRefs.length > 0 ? await db.getAll(...voterRefs) : [];
-      const voterGithubByUid = new Map<string, string>();
-      for (const snap of voterSnaps) {
-        const login = snap.data()?.github?.login;
-        if (typeof login === "string" && login.trim()) {
-          voterGithubByUid.set(snap.id, login.trim().toLowerCase());
-        }
-      }
+      const voterGithubByUid = await resolveVoterGithubByUid(db, voterDocs);
 
       const peerAvgBySid = computePeerAverages(
         identities,
@@ -206,7 +213,7 @@ export async function GET(request: NextRequest) {
         const rawScore = computeHackASprint2026RawScore(aiScore, judgeScores);
 
         const myJudge =
-          judgeEligible && judgeScores
+          user && judgeEligible && judgeScores
             ? judgeScores[user.uid] ?? null
             : null;
         const myJudgeScore =
@@ -247,7 +254,19 @@ export async function GET(request: NextRequest) {
 
     const isJudgeView = judgeEligible || judgeCheckinBypass;
     const revealScoresToViewer =
-      isJudgeView || hasCompletedPeerVoting;
+      isJudgeView ||
+      !user ||
+      !isSubmitter ||
+      hasCompletedPeerVoting ||
+      phase === "resultsOpen";
+
+    const canPeerVote = Boolean(
+      user &&
+        isSubmitter &&
+        !judgeEligible &&
+        !judgeCheckinBypass &&
+        (phase === "peerVotingOpen" || phase === "resultsOpen")
+    );
 
     const submissionsOut = revealScoresToViewer
       ? rows
@@ -272,6 +291,8 @@ export async function GET(request: NextRequest) {
         isJudge: isJudgeView,
         peerScoresRevealed: revealScoresToViewer,
         myParticipantScores,
+        canPeerVote,
+        isSubmitter,
       },
       submissions: submissionsOut,
     });

--- a/app/api/members/public/route.ts
+++ b/app/api/members/public/route.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import { getAdminDb } from "@/lib/firebase-admin";
+import type { PublicMember, MemberType } from "@/types/members";
+
+export const runtime = "nodejs";
+
+const CACHE_TAG = "public-members-directory-v1";
+const REVALIDATE_SECONDS = 300;
+
+function toPlainJson(value: unknown): unknown {
+  if (value === undefined || value === null) return value;
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { toDate?: () => Date }).toDate === "function"
+  ) {
+    const d = (value as { toDate: () => Date }).toDate();
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  if (Array.isArray(value)) return value.map(toPlainJson);
+  if (typeof value === "object" && value !== null) {
+    const o = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(o)) {
+      out[k] = toPlainJson(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+async function loadPublicMembersFromFirestore(): Promise<PublicMember[]> {
+  const db = getAdminDb();
+  if (!db) return [];
+
+  const [usersSnap, agentsSnap] = await Promise.all([
+    db
+      .collection("users")
+      .where("visibility.isPublic", "==", true)
+      .orderBy("createdAt", "desc")
+      .get(),
+    db
+      .collection("agents")
+      .where("visibility.isPublic", "==", true)
+      .where("status", "==", "claimed")
+      .orderBy("createdAt", "desc")
+      .get(),
+  ]);
+
+  const humanMembers = usersSnap.docs.map((doc) => {
+    const merged = {
+      uid: doc.id,
+      memberType: "human" as MemberType,
+      ...(doc.data() as Record<string, unknown>),
+    };
+    return toPlainJson(merged) as PublicMember;
+  });
+
+  const agentMembers = agentsSnap.docs.map((doc) => {
+    const data = doc.data();
+    const merged = {
+      uid: doc.id,
+      memberType: "agent" as MemberType,
+      displayName: data.name,
+      photoURL: data.avatarUrl || null,
+      bio: data.description,
+      visibility: {
+        ...data.visibility,
+        showBio: true,
+        showMemberSince: true,
+      },
+      createdAt: data.createdAt,
+      owner: data.visibility?.showOwner
+        ? {
+            displayName: data.ownerDisplayName,
+            email: data.ownerEmail,
+          }
+        : undefined,
+    };
+    return toPlainJson(merged) as PublicMember;
+  });
+
+  return [...humanMembers, ...agentMembers].sort((a, b) => {
+    const ta =
+      typeof a.createdAt === "string"
+        ? new Date(a.createdAt).getTime()
+        : a.createdAt?.toDate?.()?.getTime() || 0;
+    const tb =
+      typeof b.createdAt === "string"
+        ? new Date(b.createdAt).getTime()
+        : b.createdAt?.toDate?.()?.getTime() || 0;
+    return tb - ta;
+  });
+}
+
+const getCachedPublicMembers = unstable_cache(
+  () => loadPublicMembersFromFirestore(),
+  [CACHE_TAG],
+  { revalidate: REVALIDATE_SECONDS }
+);
+
+export async function GET() {
+  try {
+    const members = await getCachedPublicMembers();
+    return NextResponse.json(
+      { members },
+      {
+        headers: {
+          "Cache-Control": `public, max-age=60, s-maxage=${REVALIDATE_SECONDS}, stale-while-revalidate=${REVALIDATE_SECONDS * 2}`,
+        },
+      }
+    );
+  } catch (e) {
+    console.error("[api/members/public]", e);
+    return NextResponse.json(
+      { error: "Failed to load members" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import eventsData from "@/content/events.json";
+import type { EventsData } from "@/types/events";
 import CoworkingSlots from "@/components/events/CoworkingSlots";
 import {
   getLumaCheckoutEventId,
@@ -87,11 +88,14 @@ interface Event {
   coworkingInfo?: CoworkingInfo;
 }
 
-// Get all events (upcoming + past) for static generation
+const typedEvents = eventsData as unknown as EventsData;
+
+// Get all events (upcoming + past + archived) for static generation
 function getAllEvents(): Event[] {
   return [
-    ...(eventsData.upcoming as Event[]),
-    ...(eventsData.past as Event[]),
+    ...(typedEvents.upcoming as Event[]),
+    ...(typedEvents.past as Event[]),
+    ...((typedEvents.oldEvents ?? []) as Event[]),
   ];
 }
 

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -5,16 +5,21 @@
  */
 
 import { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
 import eventsData from "@/content/events.json";
-import {
-  getLumaCheckoutEventId,
-  getLumaCheckoutHref,
-} from "@/lib/luma-event";
+import { EventsBrowse } from "@/components/events/EventsBrowse";
+import { todayYmdInListingTz } from "@/lib/events-calendar-buckets";
 import { EventsData } from "@/types/events";
 
+export const dynamic = "force-dynamic";
+
 const typedEventsData = eventsData as unknown as EventsData;
+
+const allListingEvents = [
+  ...typedEventsData.upcoming,
+  ...typedEventsData.past,
+  ...(typedEventsData.oldEvents ?? []),
+];
 
 export const metadata: Metadata = {
   title: "Events",
@@ -147,6 +152,7 @@ const eventTypes = [
 ];
 
 export default function EventsPage() {
+  const listingTodayYmd = todayYmdInListingTz(new Date());
   const eventsJsonLd = generateEventsJsonLd();
 
   return (
@@ -240,210 +246,9 @@ export default function EventsPage() {
         </div>
       </section>
 
-      {/* Upcoming Events */}
-      <section className="py-16 px-6">
-        <div className="max-w-6xl mx-auto">
-          <div className="flex items-center justify-between mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold text-foreground">
-              Upcoming Events
-            </h2>
-          </div>
-
-          {typedEventsData.upcoming.length > 0 ? (
-            <div className="grid gap-8">
-              {typedEventsData.upcoming.map((event) => (
-                <div
-                  key={event.id}
-                  className="bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800"
-                >
-                  <div className="grid md:grid-cols-2 gap-0">
-                    {/* Event Image */}
-                    <div className="relative aspect-9/16 md:aspect-auto md:min-h-[400px] bg-neutral-100 dark:bg-neutral-800">
-                      <Image
-                        src={event.image}
-                        alt={event.title}
-                        fill
-                        className="object-contain"
-                      />
-                      {/* QR Code Overlay */}
-                      <div className="absolute bottom-[2%] right-[3%] w-[15%] aspect-square bg-white p-1 rounded">
-                        <Image
-                          src="/luma-qr.png"
-                          alt="Scan to register"
-                          fill
-                          className="object-contain"
-                        />
-                      </div>
-                    </div>
-
-                    {/* Event Details */}
-                    <div className="p-8 flex flex-col justify-center">
-                      <span className="inline-block px-3 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-sm font-medium rounded-full mb-4 w-fit capitalize">
-                        {event.type}
-                      </span>
-                      <h3 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
-                        {event.title}
-                      </h3>
-                      <p className="text-neutral-600 dark:text-neutral-400 mb-6 leading-relaxed">
-                        {event.description}
-                      </p>
-
-                      {event.topics && (
-                        <div className="mb-6">
-                          <h4 className="text-sm font-semibold text-neutral-500 uppercase tracking-wider mb-3">
-                            Topics Covered
-                          </h4>
-                          <div className="flex flex-wrap gap-2">
-                            {event.topics.map((topic) => (
-                              <span
-                                key={topic}
-                                className="px-3 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-sm rounded-full"
-                              >
-                                {topic}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      <div className="space-y-3 mb-6">
-                        <div className="flex items-center gap-3 text-neutral-700 dark:text-neutral-300">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="20"
-                            height="20"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            aria-hidden="true"
-                          >
-                            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-                            <circle cx="12" cy="10" r="3" />
-                          </svg>
-                          <span>{event.location}</span>
-                        </div>
-                      </div>
-
-                      <div className="flex flex-col sm:flex-row gap-3">
-                        <Link
-                          href={`/events/${event.slug}`}
-                          className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-neutral-900 text-white dark:bg-white dark:text-black rounded-lg text-base font-semibold hover:bg-neutral-700 dark:hover:bg-neutral-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
-                        >
-                          View Details
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="18"
-                            height="18"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            aria-hidden="true"
-                          >
-                            <path d="M5 12h14M12 5l7 7-7 7" />
-                          </svg>
-                        </Link>
-                        <a
-                          href={getLumaCheckoutHref(event)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={`Register for ${event.title} (opens in new tab)`}
-                          className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 border border-neutral-300 dark:border-neutral-700 text-foreground rounded-lg text-base font-semibold hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto luma-checkout--button"
-                          data-luma-action="checkout"
-                          data-luma-event-id={getLumaCheckoutEventId(event)}
-                        >
-                          Register on Luma
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="18"
-                            height="18"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            aria-hidden="true"
-                          >
-                            <path d="M7 17l9.2-9.2M17 17V7H7" />
-                          </svg>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="bg-white dark:bg-neutral-900 rounded-2xl p-12 text-center border border-neutral-200 dark:border-neutral-800">
-              <p className="text-neutral-600 dark:text-neutral-400 mb-4">
-                No upcoming events scheduled yet.
-              </p>
-              <a
-                href="https://lu.ma/cursor-boston"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-foreground hover:underline focus-visible:outline-none focus-visible:underline"
-              >
-                Subscribe on Luma to get notified &rarr;
-              </a>
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Past Events */}
+      {/* Today / future / past (tabbed) */}
       <section className="py-16 px-6 bg-neutral-50 dark:bg-neutral-950">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-8">
-            Past Events
-          </h2>
-
-          {typedEventsData.past.length > 0 ? (
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {typedEventsData.past.map((event) => (
-                <Link
-                  key={event.id}
-                  href={`/events/${event.slug}`}
-                  className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors group"
-                >
-                  <span className="inline-block px-2.5 py-0.5 bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-medium rounded-full mb-3 capitalize">
-                    {event.type}
-                  </span>
-                  <h3 className="text-lg font-semibold text-foreground mb-2 group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors">
-                    {event.title}
-                  </h3>
-                  <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-1">
-                    {event.date === "TBD"
-                      ? "Date TBD"
-                      : new Date(event.date).toLocaleDateString("en-US", {
-                          month: "long",
-                          day: "numeric",
-                          year: "numeric",
-                        })}
-                  </p>
-                  <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
-                    {event.location}
-                  </p>
-                  <p className="text-sm text-neutral-600 dark:text-neutral-400 line-clamp-2">
-                    {event.description}
-                  </p>
-                </Link>
-              ))}
-            </div>
-          ) : (
-            <div className="bg-white dark:bg-neutral-900 rounded-2xl p-12 text-center border border-neutral-200 dark:border-neutral-800">
-              <p className="text-neutral-600 dark:text-neutral-400">
-                Past events will appear here after our first event.
-              </p>
-            </div>
-          )}
-        </div>
+        <EventsBrowse events={allListingEvents} listingTodayYmd={listingTodayYmd} />
       </section>
 
       {/* Submit Event CTA */}

--- a/app/hackathons/hack-a-sprint-2026/admin/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/admin/page.tsx
@@ -750,8 +750,9 @@ function DashboardTab({ data }: { data: DashboardData | null }) {
                 Peer review gallery ({data.submissions.length})
               </h2>
               <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400 max-w-2xl">
-                Expand each row to open repo, demo, and Loom. Cast your six peer
-                picks on the live hub (checked-in attendees only).
+                Expand each row to open repo, demo, and Loom. Peer scores (1–10 on
+                every other submission) are entered on the public submissions page by
+                merged submitters when voting is open.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-2">

--- a/app/hackathons/hack-a-sprint-2026/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/page.tsx
@@ -8,15 +8,17 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
-import { getGithubRepoWebBaseUrl } from "@/lib/github-recent-merged-prs";
-import {
-  HACK_A_SPRINT_2026_LABEL,
-  HACK_A_SPRINT_2026_SUBMISSIONS_PATH,
-} from "@/lib/hackathon-showcase";
 import type { ShowcaseSubmission } from "@/lib/hackathon-showcase";
 import type { HackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
+import {
+  computeShowcaseAwards,
+  HACK_A_SPRINT_2026_JUDGES_PICK_GITHUB_LOGINS,
+  HACK_A_SPRINT_2026_PEER_REVIEW_WINNER_COUNT,
+  isHackASprint2026PeerAwardsRevealed,
+  showcaseAwardLabelsForRow,
+  type ShowcaseAwardKind,
+} from "@/lib/hackathon-asprint-2026-awards";
 
 type MeResponse = {
   phase: HackASprint2026Phase;
@@ -53,6 +55,8 @@ type SubmissionsResponse = {
     isJudge: boolean;
     peerScoresRevealed: boolean;
     myParticipantScores: Record<string, number>;
+    canPeerVote: boolean;
+    isSubmitter: boolean;
   };
   submissions: SubmissionRow[];
 };
@@ -87,13 +91,6 @@ function compareSubmissionRows(
   return dir * (na < nb ? -1 : 1);
 }
 
-const JSON_TEMPLATE = `{
-  "projectRepoUrl": "https://github.com/your-username/your-hack-project",
-  "title": "Short title for your build",
-  "description": "What you built, stack, and learnings.",
-  "loomVideoUrl": "https://www.loom.com/share/your-recording"
-}`;
-
 const PHASE_LABEL: Record<HackASprint2026Phase, string> = {
   preEvent: "Before event (opens 5:00 PM ET)",
   submissionOpen: "Build & submit",
@@ -101,11 +98,7 @@ const PHASE_LABEL: Record<HackASprint2026Phase, string> = {
   resultsOpen: "Final results",
 };
 
-const PEER_VOTING_REDIRECT_KEY = "hackASprint2026_redirect_peer_voting";
-
 export default function HackASprint2026ShowcasePage() {
-  const router = useRouter();
-  const pathname = usePathname();
   const { user, loading: authLoading } = useAuth();
   const [me, setMe] = useState<MeResponse | null>(null);
   const [data, setData] = useState<SubmissionsResponse | null>(null);
@@ -122,37 +115,50 @@ export default function HackASprint2026ShowcasePage() {
   const [gallerySearch, setGallerySearch] = useState("");
   const [gallerySortKey, setGallerySortKey] = useState<GallerySortKey>("title");
   const [gallerySortAsc, setGallerySortAsc] = useState(true);
-
-  const repoBase = getGithubRepoWebBaseUrl();
-  const submissionsPath = HACK_A_SPRINT_2026_SUBMISSIONS_PATH;
+  const [awardClock, setAwardClock] = useState(0);
+  /** Advances when awardClock ticks so time-based award rules recompute. */
+  const awardsAsOf = useMemo(() => {
+    void awardClock;
+    return new Date();
+  }, [awardClock]);
 
   const loadAll = useCallback(async () => {
-    if (!user) return;
     setLoadError(null);
     try {
-      const token = await user.getIdToken();
-      const headers = { Authorization: `Bearer ${token}` };
-      const [meRes, subRes, creditRes] = await Promise.all([
-        fetch("/api/hackathons/showcase/hack-a-sprint-2026/me", { headers }),
-        fetch("/api/hackathons/showcase/hack-a-sprint-2026/submissions", {
-          headers,
-        }),
-        fetch("/api/hackathons/showcase/hack-a-sprint-2026/credit-code", {
-          headers,
-        }),
-      ]);
-      if (!meRes.ok) {
-        throw new Error("Could not load eligibility");
-      }
+      const token = user ? await user.getIdToken() : null;
+      const authHeaders: HeadersInit = token
+        ? { Authorization: `Bearer ${token}` }
+        : {};
+      const subRes = await fetch(
+        "/api/hackathons/showcase/hack-a-sprint-2026/submissions",
+        { headers: authHeaders }
+      );
       if (!subRes.ok) {
         throw new Error("Could not load submissions");
       }
-      const meJson = (await meRes.json()) as MeResponse;
       const subJson = (await subRes.json()) as SubmissionsResponse;
-      setMe(meJson);
       setData(subJson);
-      if (creditRes.ok) {
-        setCreditCode(await creditRes.json());
+      if (user) {
+        const [meRes, creditRes] = await Promise.all([
+          fetch("/api/hackathons/showcase/hack-a-sprint-2026/me", {
+            headers: authHeaders,
+          }),
+          fetch("/api/hackathons/showcase/hack-a-sprint-2026/credit-code", {
+            headers: authHeaders,
+          }),
+        ]);
+        if (!meRes.ok) {
+          throw new Error("Could not load eligibility");
+        }
+        setMe((await meRes.json()) as MeResponse);
+        if (creditRes.ok) {
+          setCreditCode(await creditRes.json());
+        } else {
+          setCreditCode(null);
+        }
+      } else {
+        setMe(null);
+        setCreditCode(null);
       }
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : "Failed to load");
@@ -170,27 +176,46 @@ export default function HackASprint2026ShowcasePage() {
   );
 
   useEffect(() => {
-    if (user) {
-      void loadAll();
-    } else {
-      setMe(null);
-      setData(null);
-    }
-  }, [user, loadAll]);
+    void loadAll();
+  }, [loadAll]);
 
   useEffect(() => {
-    if (!user || !me) return;
-    const t = window.setInterval(() => void loadAll(), 45_000);
-    return () => window.clearInterval(t);
-  }, [user, me, loadAll]);
+    const POLL_MS = 120_000;
+    let intervalId: number | undefined;
+    const start = () => {
+      if (intervalId != null) return;
+      intervalId = window.setInterval(() => {
+        if (document.visibilityState === "hidden") return;
+        void loadAll();
+      }, POLL_MS);
+    };
+    const stop = () => {
+      if (intervalId != null) {
+        window.clearInterval(intervalId);
+        intervalId = undefined;
+      }
+    };
+    const onVis = () => {
+      if (document.visibilityState === "visible") {
+        void loadAll();
+        start();
+      } else {
+        stop();
+      }
+    };
+    if (document.visibilityState === "visible") start();
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      document.removeEventListener("visibilitychange", onVis);
+      stop();
+    };
+  }, [loadAll]);
 
   useEffect(() => {
-    if (!me?.participantEligible || !me?.checkedIn) return;
     if (typeof window === "undefined") return;
-    if (sessionStorage.getItem(PEER_VOTING_REDIRECT_KEY)) return;
-    sessionStorage.setItem(PEER_VOTING_REDIRECT_KEY, "1");
-    router.replace(`${pathname}#peer-voting`);
-  }, [me?.participantEligible, me?.checkedIn, pathname, router]);
+    const id = window.setInterval(() => setAwardClock((c) => c + 1), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
 
   const submitParticipantScore = async (submissionId: string, score: number) => {
     if (!user) return;
@@ -302,31 +327,49 @@ export default function HackASprint2026ShowcasePage() {
     return { totalOthers: others.length, scored };
   }, [data?.submissions, data?.viewer?.myParticipantScores, me?.githubLogin]);
 
+  const phase = me?.phase ?? data?.phase;
   const isJudgeView = data?.viewer.isJudge ?? false;
   const peerScoresRevealed = data?.viewer.peerScoresRevealed ?? false;
   const participantQueueMode = Boolean(
     data &&
       me &&
+      phase !== "resultsOpen" &&
       !isJudgeView &&
-      !data.viewer.hasCompletedPeerVoting
+      !data.viewer.hasCompletedPeerVoting &&
+      data.viewer.canPeerVote
   );
 
   const { queueUnscored, queueScored, queueOwn, galleryList } = useMemo(() => {
-    if (!data?.submissions?.length || !me?.githubLogin) {
+    if (!data?.submissions?.length) {
       return {
         queueUnscored: [] as SubmissionRow[],
         queueScored: [] as SubmissionRow[],
         queueOwn: null as SubmissionRow | null,
-        galleryList: data?.submissions ?? [],
+        galleryList: [] as SubmissionRow[],
       };
     }
-    const ownGh = me.githubLogin.trim().toLowerCase();
     const q = gallerySearch.trim().toLowerCase();
     const matches = (s: SubmissionRow) =>
       !q ||
       s.payload.title.toLowerCase().includes(q) ||
       s.githubLogin.toLowerCase().includes(q);
 
+    const galleryListSorted = [...data.submissions]
+      .filter(matches)
+      .sort((a, b) =>
+        compareSubmissionRows(a, b, gallerySortKey, gallerySortAsc)
+      );
+
+    if (!me?.githubLogin) {
+      return {
+        queueUnscored: [],
+        queueScored: [],
+        queueOwn: null,
+        galleryList: galleryListSorted,
+      };
+    }
+
+    const ownGh = me.githubLogin.trim().toLowerCase();
     const others = data.submissions.filter(
       (s) => s.githubLogin.trim().toLowerCase() !== ownGh
     );
@@ -358,12 +401,6 @@ export default function HackASprint2026ShowcasePage() {
         })
       );
 
-    const galleryListSorted = [...data.submissions]
-      .filter(matches)
-      .sort((a, b) =>
-        compareSubmissionRows(a, b, gallerySortKey, gallerySortAsc)
-      );
-
     return {
       queueUnscored: unscored,
       queueScored: scored,
@@ -378,6 +415,26 @@ export default function HackASprint2026ShowcasePage() {
     gallerySortAsc,
   ]);
 
+  const showcaseAwardsBySid = useMemo(() => {
+    const ph = me?.phase ?? data?.phase;
+    const reveal = data?.viewer.peerScoresRevealed ?? false;
+    if (ph !== "resultsOpen" || !reveal || !data?.submissions?.length) {
+      return new Map<string, ShowcaseAwardKind[]>();
+    }
+    return computeShowcaseAwards(data.submissions, awardsAsOf);
+  }, [
+    me?.phase,
+    data?.phase,
+    data?.submissions,
+    data?.viewer.peerScoresRevealed,
+    awardsAsOf,
+  ]);
+
+  const peerWinnerBadgesLive = useMemo(
+    () => isHackASprint2026PeerAwardsRevealed(awardsAsOf),
+    [awardsAsOf]
+  );
+
   if (authLoading) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[40vh] px-6">
@@ -387,59 +444,7 @@ export default function HackASprint2026ShowcasePage() {
     );
   }
 
-  if (!user) {
-    return (
-      <div className="flex flex-col">
-        <section className="py-16 md:py-20 px-6 border-b border-neutral-200 dark:border-neutral-800">
-          <div className="max-w-2xl mx-auto text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-              Hack-a-Sprint 2026
-            </h1>
-            <p className="text-neutral-600 dark:text-neutral-400 mb-8">
-              Sign in for the live schedule, submission instructions, peer scoring,
-              and results — all on this page during the event on April 13, 2026.
-            </p>
-            <Link
-              href="/login?redirect=/hackathons/hack-a-sprint-2026"
-              className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            >
-              Sign in to continue
-            </Link>
-            <p className="mt-6 text-sm text-neutral-500 space-x-3">
-              <Link
-                href="/hackathons/hack-a-sprint-2026/signup"
-                className="text-emerald-600 dark:text-emerald-400 hover:underline"
-              >
-                Website signup &amp; ranking
-              </Link>
-              <span aria-hidden="true">·</span>
-              <Link
-                href="/hackathons/hack-a-sprint-2026/instructions"
-                className="text-emerald-600 dark:text-emerald-400 hover:underline"
-              >
-                Pre-event instructions
-              </Link>
-              <span aria-hidden="true">·</span>
-              <Link
-                href="/hackathons"
-                className="text-emerald-600 dark:text-emerald-400 hover:underline"
-              >
-                ← Hackathons
-              </Link>
-            </p>
-          </div>
-        </section>
-      </div>
-    );
-  }
-
-  const phase = me?.phase ?? data?.phase;
-  const checkedIn = me?.checkedIn ?? data?.viewer.checkedIn;
-
-  const viewer = data?.viewer;
-  const judgeEligible = me?.judgeEligible ?? viewer?.judgeEligible;
-
-  if (!me && !data) {
+  if (!data && !loadError) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[40vh] px-6">
         <div className="h-10 w-10 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
@@ -448,50 +453,35 @@ export default function HackASprint2026ShowcasePage() {
     );
   }
 
-  if (!checkedIn) {
+  if (!data) {
     return (
-      <div className="flex flex-col">
-        <section className="py-16 md:py-24 px-6">
-          <div className="max-w-2xl mx-auto text-center">
-            <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-              Hack-a-Sprint 2026
-            </h1>
-            <div className="rounded-2xl border-2 border-rose-400 dark:border-rose-600 bg-rose-50 dark:bg-rose-950/30 p-8 mb-6">
-              <p className="text-xl font-bold text-rose-700 dark:text-rose-400 mb-2">
-                BLOCKED
-              </p>
-              <p className="text-sm text-rose-600 dark:text-rose-400">
-                You have not been checked in for the hackathon. Ask an organizer
-                at the door to check you in.
-              </p>
-            </div>
-            <p className="text-sm text-neutral-500 space-x-3">
-              <Link
-                href="/hackathons/hack-a-sprint-2026/instructions"
-                className="text-emerald-600 dark:text-emerald-400 hover:underline"
-              >
-                Pre-event instructions
-              </Link>
-              <span aria-hidden="true">·</span>
-              <Link
-                href="/hackathons"
-                className="text-emerald-600 dark:text-emerald-400 hover:underline"
-              >
-                ← Hackathons
-              </Link>
-            </p>
-          </div>
-        </section>
+      <div className="flex flex-col items-center justify-center min-h-[40vh] px-6">
+        <p className="text-rose-600 dark:text-rose-400 text-sm" role="alert">
+          {loadError ?? "Could not load submissions."}
+        </p>
+        <Link
+          href="/hackathons"
+          className="mt-4 text-sm font-semibold text-emerald-600 dark:text-emerald-400 hover:underline"
+        >
+          ← Hackathons
+        </Link>
       </div>
     );
   }
 
+  const viewer = data.viewer;
+  const judgeEligible = me?.judgeEligible ?? viewer.judgeEligible;
+  const allowPeerScores = Boolean(user && viewer.canPeerVote);
+  const showSubmitterPeerHelp = Boolean(user && viewer.isSubmitter);
+
   function SubmissionCard({
     s,
     ownQueueNote,
+    showPeerScoreInput,
   }: {
     s: SubmissionRow;
     ownQueueNote?: string;
+    showPeerScoreInput: boolean;
   }) {
     const own = isOwnSubmission(s);
     const showCommunityBlock =
@@ -500,6 +490,7 @@ export default function HackASprint2026ShowcasePage() {
       (s.peerAverage != null ||
         (phase === "resultsOpen" && s.judgeAverage != null) ||
         (phase === "resultsOpen" && s.rawScore != null));
+    const awardLabels = showcaseAwardLabelsForRow(showcaseAwardsBySid, s.submissionId);
 
     return (
       <li className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-6 shadow-sm bg-white dark:bg-neutral-900">
@@ -516,6 +507,18 @@ export default function HackASprint2026ShowcasePage() {
             <h3 className="text-lg font-semibold text-foreground mb-2">
               {s.payload.title}
             </h3>
+            {awardLabels.length > 0 ? (
+              <div className="flex flex-wrap gap-2 mb-2" aria-label="Awards">
+                {awardLabels.map((label) => (
+                  <span
+                    key={`${s.submissionId}-${label}`}
+                    className="inline-flex items-center rounded-full border border-amber-500/45 bg-amber-500/12 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-900 dark:text-amber-100"
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            ) : null}
             {ownQueueNote ? (
               <p className="text-sm text-amber-700 dark:text-amber-400 mb-2">
                 {ownQueueNote}
@@ -588,7 +591,7 @@ export default function HackASprint2026ShowcasePage() {
               </div>
             )}
           </div>
-          {!own && (
+          {!own && showPeerScoreInput && (
             <div className="shrink-0 flex flex-col gap-1">
               <label className="text-xs font-semibold text-neutral-500 uppercase">
                 Your peer score (1–10)
@@ -624,7 +627,7 @@ export default function HackASprint2026ShowcasePage() {
           )}
         </div>
 
-        {judgeEligible && phase === "peerVotingOpen" && (
+        {user && judgeEligible && phase === "peerVotingOpen" && (
           <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-neutral-200 dark:border-neutral-700 pt-4">
             <label className="text-xs font-semibold text-neutral-500 uppercase">
               Judge score (1–10)
@@ -709,25 +712,35 @@ export default function HackASprint2026ShowcasePage() {
             April 13, 2026 · Back Bay, Boston
           </p>
           <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Hack-a-Sprint 2026 — Live hub
+            Hack-a-Sprint 2026 — Submissions
           </h1>
           {phase && (
             <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400 mb-4">
               Current phase: {PHASE_LABEL[phase]}
             </p>
           )}
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4 max-w-2xl">
+            Public gallery of merged projects. If you submitted via GitHub (same
+            account linked on your{" "}
+            <Link href="/profile" className="text-emerald-600 dark:text-emerald-400 hover:underline font-medium">
+              profile
+            </Link>
+            ), you can enter peer scores when voting is open.
+          </p>
           <div className="flex flex-wrap gap-3">
+            {!user ? (
+              <Link
+                href="/login?redirect=/hackathons/hack-a-sprint-2026"
+                className="text-sm font-semibold text-emerald-600 dark:text-emerald-400 hover:underline"
+              >
+                Sign in for peer scoring
+              </Link>
+            ) : null}
             <Link
               href="/hackathons/hack-a-sprint-2026/instructions"
               className="text-sm font-semibold text-emerald-600 dark:text-emerald-400 hover:underline"
             >
               Instructions &amp; challenge details
-            </Link>
-            <Link
-              href="/hackathons/hack-a-sprint-2026/signup"
-              className="text-sm font-semibold text-emerald-600 dark:text-emerald-400 hover:underline"
-            >
-              Signup &amp; ranking
             </Link>
             <Link
               href="/hackathons"
@@ -738,73 +751,6 @@ export default function HackASprint2026ShowcasePage() {
           </div>
         </div>
       </section>
-
-      {(phase === "submissionOpen" ||
-        phase === "peerVotingOpen" ||
-        phase === "resultsOpen") && (
-        <section className="py-10 px-6 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950/50">
-          <div className="max-w-4xl mx-auto space-y-6">
-            <h2 className="text-xl font-bold text-foreground">
-              How to submit (GitHub PR)
-            </h2>
-            <p className="text-sm text-neutral-600 dark:text-neutral-400">
-              Your submission is one JSON file merged into this repo. It must
-              include a public{" "}
-              <strong className="text-foreground">GitHub repo</strong> for your
-              project, a <strong className="text-foreground">title</strong>,{" "}
-              <strong className="text-foreground">description</strong>, and a{" "}
-              <strong className="text-foreground">Loom video</strong> (or similar)
-              walkthrough. A live <strong className="text-foreground">deployedUrl</strong>{" "}
-              is optional if you add one.
-            </p>
-            <ol className="list-decimal list-inside space-y-3 text-neutral-600 dark:text-neutral-400 text-sm md:text-base">
-              <li>
-                <a
-                  href={`${repoBase}/fork`}
-                  className="text-emerald-600 dark:text-emerald-400 hover:underline font-medium"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Fork
-                </a>{" "}
-                <code className="text-xs bg-neutral-200 dark:bg-neutral-800 px-1 rounded">
-                  {repoBase}
-                </code>
-                .
-              </li>
-              <li>Create a branch (e.g. hack-a-sprint-submission).</li>
-              <li>
-                Add one file:{" "}
-                <code className="text-xs bg-neutral-200 dark:bg-neutral-800 px-1 rounded break-all">
-                  {submissionsPath}/&lt;your-github-login&gt;.json
-                </code>{" "}
-                (filename must match the PR author).
-              </li>
-              <li>
-                Use the template below; add <code>loomVideoUrl</code> when you can — the gallery still lists your entry if some fields are missing.
-              </li>
-              <li>
-                Open a PR that only changes that JSON file. CI validates the
-                schema.
-              </li>
-              <li>
-                Maintainers add label{" "}
-                <code className="text-xs bg-neutral-200 dark:bg-neutral-800 px-1 rounded">
-                  {HACK_A_SPRINT_2026_LABEL}
-                </code>{" "}
-                when merging. Connect GitHub on your{" "}
-                <Link href="/profile" className="text-emerald-600 dark:text-emerald-400 hover:underline">
-                  profile
-                </Link>
-                .
-              </li>
-            </ol>
-            <pre className="text-xs md:text-sm bg-neutral-900 text-neutral-100 p-4 rounded-lg overflow-x-auto border border-neutral-700">
-              {JSON_TEMPLATE}
-            </pre>
-          </div>
-        </section>
-      )}
 
       {creditCode?.eligible && creditCode.creditUrl && (
         <section className="py-6 px-6">
@@ -845,37 +791,43 @@ export default function HackASprint2026ShowcasePage() {
       <section id="peer-voting" className="py-10 px-6 scroll-mt-20">
         <div className="max-w-5xl mx-auto">
           <h2 className="text-xl font-bold text-foreground mb-2">
-            Submissions &amp; peer scoring
+            Submissions
           </h2>
-          <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4 max-w-3xl">
-            <strong className="text-foreground">Peer scores</strong> are a community ballot
-            (1–10 on every <em>other</em> project).{" "}
-            <strong className="text-foreground">Automated AI scores</strong> and{" "}
-            <strong className="text-foreground">community averages</strong> stay hidden until
-            you have submitted a peer score for every other project. Judges and organizers see
-            full scores immediately.
-          </p>
+          {showSubmitterPeerHelp ? (
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4 max-w-3xl">
+              <strong className="text-foreground">Peer scores</strong> are a community ballot
+              (1–10 on every <em>other</em> project).{" "}
+              <strong className="text-foreground">Automated AI scores</strong> and{" "}
+              <strong className="text-foreground">community averages</strong> stay hidden until
+              you have submitted a peer score for every other project. Judges and organizers
+              see full scores immediately.
+            </p>
+          ) : (
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4 max-w-3xl">
+              Merged projects from the event. Sign in with a profile that has the same GitHub
+              account as your submission to add or change peer scores when voting is open.
+            </p>
+          )}
           {loadError && (
             <p className="text-sm text-rose-600 dark:text-rose-400 mb-4" role="alert">
               {loadError}
             </p>
           )}
-          {!data || !me ? (
-            <p className="text-neutral-500">Loading…</p>
-          ) : data.submissions.length === 0 ? (
+          {data.submissions.length === 0 ? (
             <p className="text-neutral-600 dark:text-neutral-400">
               No merged submissions yet.
             </p>
           ) : (
             <>
-              <div className="mb-6 rounded-xl border border-neutral-200 dark:border-neutral-700 p-4 bg-white dark:bg-neutral-900/50 space-y-3">
+              {showSubmitterPeerHelp && me ? (
+                <div className="mb-6 rounded-xl border border-neutral-200 dark:border-neutral-700 p-4 bg-white dark:bg-neutral-900/50 space-y-3">
                   <p className="text-sm text-neutral-600 dark:text-neutral-400">
                     {participantQueueMode ? (
                       <>
-                        Below you only see <strong className="text-foreground">projects you
-                        have not scored yet</strong>. Use{" "}
-                        <strong className="text-foreground">Change a score</strong> if you need
-                        to fix a rating. Your own project is listed separately — you cannot
+                        Below you only see{" "}
+                        <strong className="text-foreground">projects you have not scored yet</strong>
+                        . Use <strong className="text-foreground">Change a score</strong> if you
+                        need to fix a rating. Your own project is listed separately — you cannot
                         score it.
                       </>
                     ) : (
@@ -900,18 +852,16 @@ export default function HackASprint2026ShowcasePage() {
                         : "text-amber-700 dark:text-amber-400"
                     }`}
                   >
-                    Prize eligibility: give a score <strong>above 8</strong> (9 or 10) to
-                    at least{" "}
-                    <strong>
-                      {me.requiredHighScores}
-                    </strong>{" "}
-                    other project{me.requiredHighScores === 1 ? "" : "s"}. You have{" "}
-                    <strong>{me.highScoreCount}</strong> so far.
+                    Prize eligibility: score <strong>every other</strong> project from 1–10, and
+                    among those, give <strong>above 8</strong> (9 or 10) to at least{" "}
+                    <strong>{me.requiredHighScores}</strong> (six if there are at least six
+                    other projects; otherwise everyone else). You have{" "}
+                    <strong>{me.highScoreCount}</strong> such scores so far.
                     {me.prizeEligible
                       ? " You meet this bar."
                       : " Keep scoring to qualify to win."}
                   </p>
-                  {viewer?.hasCompletedPeerVoting && (
+                  {viewer.hasCompletedPeerVoting && (
                     <p className="text-sm text-emerald-600 dark:text-emerald-400 font-medium">
                       Peer ballot complete — AI scores, your scores, and community averages are
                       shown on each card (judge/raw row when results are open).
@@ -924,6 +874,7 @@ export default function HackASprint2026ShowcasePage() {
                     </p>
                   )}
                 </div>
+              ) : null}
               <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
                 <label className="flex flex-col gap-1 text-sm min-w-[12rem] flex-1">
                   <span className="font-medium text-neutral-600 dark:text-neutral-400">
@@ -974,6 +925,37 @@ export default function HackASprint2026ShowcasePage() {
                   is not derived from peer voting.
                 </p>
               )}
+              {phase === "resultsOpen" &&
+                peerScoresRevealed &&
+                !participantQueueMode && (
+                  <div className="mb-6 space-y-3">
+                    <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                      <strong className="text-foreground">Judges winners</strong> (
+                      {HACK_A_SPRINT_2026_JUDGES_PICK_GITHUB_LOGINS.map((l) => `@${l}`).join(
+                        ", "
+                      )}
+                      ) and the{" "}
+                      <strong className="text-foreground">next two AI-ranked</strong>{" "}
+                      submissions are marked on each card. The same GitHub account cannot win
+                      more than one category. Judges picks only appear on cards for merged
+                      submissions.
+                    </p>
+                    {!peerWinnerBadgesLive ? (
+                      <p className="text-sm text-amber-900 dark:text-amber-100 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3">
+                        <strong className="text-foreground">Peer review winners</strong>{" "}
+                        (highest community averages) appear on cards starting{" "}
+                        <strong>Friday, April 17, 2026 at 12:00 PM Eastern Time</strong>.
+                      </p>
+                    ) : (
+                      <p className="text-sm text-emerald-800 dark:text-emerald-200 rounded-lg border border-emerald-500/35 bg-emerald-500/10 px-4 py-3">
+                        <strong className="text-foreground">Peer review winners</strong> are
+                        highlighted from peer averages (top{" "}
+                        {HACK_A_SPRINT_2026_PEER_REVIEW_WINNER_COUNT}, excluding anyone who
+                        already has a Judges or AI judged badge).
+                      </p>
+                    )}
+                  </div>
+                )}
               {peerScoresRevealed &&
                 data.submissions.some((s) => s.aiRank != null) && (
                 <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
@@ -993,6 +975,7 @@ export default function HackASprint2026ShowcasePage() {
                           key={queueOwn.submissionId}
                           s={queueOwn}
                           ownQueueNote="Automated AI score and community peer average for your project unlock after you finish scoring everyone else."
+                          showPeerScoreInput={false}
                         />
                       </ul>
                     </div>
@@ -1007,7 +990,11 @@ export default function HackASprint2026ShowcasePage() {
                   ) : null}
                   <ul className="space-y-8 mb-8">
                     {queueUnscored.map((s) => (
-                      <SubmissionCard key={s.submissionId} s={s} />
+                      <SubmissionCard
+                        key={s.submissionId}
+                        s={s}
+                        showPeerScoreInput={allowPeerScores}
+                      />
                     ))}
                   </ul>
                   {queueScored.length > 0 ? (
@@ -1017,7 +1004,11 @@ export default function HackASprint2026ShowcasePage() {
                       </summary>
                       <ul className="space-y-8 mt-4">
                         {queueScored.map((s) => (
-                          <SubmissionCard key={s.submissionId} s={s} />
+                          <SubmissionCard
+                            key={s.submissionId}
+                            s={s}
+                            showPeerScoreInput={allowPeerScores}
+                          />
                         ))}
                       </ul>
                     </details>
@@ -1026,7 +1017,11 @@ export default function HackASprint2026ShowcasePage() {
               ) : (
                 <ul className="space-y-8">
                   {galleryList.map((s) => (
-                    <SubmissionCard key={s.submissionId} s={s} />
+                    <SubmissionCard
+                      key={s.submissionId}
+                      s={s}
+                      showPeerScoreInput={allowPeerScores}
+                    />
                   ))}
                 </ul>
               )}

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -25,6 +25,10 @@ export default function MapPage() {
   const allEvents = [
     ...typedEventsData.upcoming.map((e) => ({ ...e, _upcoming: true })),
     ...typedEventsData.past.map((e) => ({ ...e, _upcoming: false })),
+    ...(typedEventsData.oldEvents ?? []).map((e) => ({
+      ...e,
+      _upcoming: false,
+    })),
   ] as (Event & { _upcoming: boolean })[];
 
   // Only include events with venue coordinates

--- a/components/events/EventsBrowse.module.css
+++ b/components/events/EventsBrowse.module.css
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/* Native radio tabs — labels toggle radios; CSS shows the matching panel (no React onClick). */
+.srOnlyRadio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  pointer-events: none;
+}
+
+.panels {
+  display: block;
+}
+
+.tabBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid rgb(229 229 229);
+  position: relative;
+  z-index: 20;
+}
+
+:global(.dark) .tabBar {
+  border-bottom-color: rgb(38 38 38);
+}
+
+.tabLabel {
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  border-radius: 0.375rem 0.375rem 0 0;
+  color: rgb(115 115 115);
+}
+
+:global(.dark) .tabLabel {
+  color: rgb(163 163 163);
+}
+
+.tabLabel:hover {
+  color: var(--foreground, #000);
+}
+
+:global(.dark) .tabLabel:hover {
+  color: #fff;
+}
+
+.radioToday:checked ~ .tabBar .tabLabel:nth-of-type(1),
+.radioFuture:checked ~ .tabBar .tabLabel:nth-of-type(2),
+.radioPast:checked ~ .tabBar .tabLabel:nth-of-type(3) {
+  border-bottom-color: rgb(16 185 129);
+  color: rgb(4 120 87);
+}
+
+:global(.dark) .radioToday:checked ~ .tabBar .tabLabel:nth-of-type(1),
+:global(.dark) .radioFuture:checked ~ .tabBar .tabLabel:nth-of-type(2),
+:global(.dark) .radioPast:checked ~ .tabBar .tabLabel:nth-of-type(3) {
+  color: rgb(52 211 153);
+}
+
+.panel {
+  display: none;
+}
+
+.radioToday:checked ~ .panels > .panel:nth-child(1),
+.radioFuture:checked ~ .panels > .panel:nth-child(2),
+.radioPast:checked ~ .panels > .panel:nth-child(3) {
+  display: block;
+}

--- a/components/events/EventsBrowse.tsx
+++ b/components/events/EventsBrowse.tsx
@@ -1,0 +1,321 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useId, useMemo } from "react";
+import type { Event } from "@/types/events";
+import { partitionEventsForBrowse } from "@/lib/events-calendar-buckets";
+import { getLumaCheckoutHref } from "@/lib/luma-event";
+import styles from "./EventsBrowse.module.css";
+
+type Props = {
+  events: Event[];
+  /** Boston calendar day `YYYY-MM-DD` from the server; must match SSR for hydration. */
+  listingTodayYmd: string;
+};
+
+function PastStyleEventCard({ event }: { event: Event }) {
+  return (
+    <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors flex flex-col">
+      <span className="inline-block px-2.5 py-0.5 bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-medium rounded-full mb-3 capitalize">
+        {event.type}
+      </span>
+      <h3 className="text-lg font-semibold text-foreground mb-2">{event.title}</h3>
+      <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-1">
+        {event.date === "TBD"
+          ? "Date TBD"
+          : new Date(event.date).toLocaleDateString("en-US", {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })}
+      </p>
+      <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
+        {event.location}
+      </p>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400 line-clamp-2 mb-4 flex-1">
+        {event.description}
+      </p>
+      <div className="flex flex-col gap-2 mt-auto">
+        {event.primaryCtaHref ? (
+          <Link
+            href={event.primaryCtaHref}
+            className="inline-flex items-center justify-center gap-2 px-4 py-2.5 bg-neutral-900 text-white dark:bg-white dark:text-black rounded-lg text-sm font-semibold hover:bg-neutral-700 dark:hover:bg-neutral-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white"
+          >
+            {event.primaryCtaLabel ?? "Open"}
+          </Link>
+        ) : null}
+        <Link
+          href={`/events/${event.slug}`}
+          className={`inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold border border-neutral-300 dark:border-neutral-700 text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors ${
+            event.primaryCtaHref
+              ? ""
+              : "bg-neutral-900 text-white dark:bg-white dark:text-black border-transparent hover:bg-neutral-700 dark:hover:bg-neutral-200"
+          }`}
+        >
+          {event.primaryCtaHref ? "Event recap" : "View details"}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export function EventsBrowse({ events, listingTodayYmd }: Props) {
+  const { today, future, past } = useMemo(
+    () => partitionEventsForBrowse(events, listingTodayYmd),
+    [events, listingTodayYmd]
+  );
+
+  const reactId = useId().replace(/:/g, "");
+  const groupName = `events-browse-tab-${reactId}`;
+  const idToday = `${groupName}-today`;
+  const idFuture = `${groupName}-future`;
+  const idPast = `${groupName}-past`;
+
+  const defaultTab: "today" | "future" | "past" =
+    today.length > 0 ? "today" : future.length > 0 ? "future" : "past";
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      {/*
+        Three radios first, then tab labels, then panels — CSS ~ siblings show the active panel.
+        Native labels toggle radios without React state (works even if client hydration is flaky).
+      */}
+      <input
+        type="radio"
+        name={groupName}
+        id={idToday}
+        className={`${styles.srOnlyRadio} ${styles.radioToday}`}
+        defaultChecked={defaultTab === "today"}
+      />
+      <input
+        type="radio"
+        name={groupName}
+        id={idFuture}
+        className={`${styles.srOnlyRadio} ${styles.radioFuture}`}
+        defaultChecked={defaultTab === "future"}
+      />
+      <input
+        type="radio"
+        name={groupName}
+        id={idPast}
+        className={`${styles.srOnlyRadio} ${styles.radioPast}`}
+        defaultChecked={defaultTab === "past"}
+      />
+
+      <div className={styles.tabBar} role="tablist" aria-label="Event listings">
+        <label htmlFor={idToday} className={styles.tabLabel} role="tab">
+          TODAY
+        </label>
+        <label htmlFor={idFuture} className={styles.tabLabel} role="tab">
+          FUTURE
+        </label>
+        <label htmlFor={idPast} className={styles.tabLabel} role="tab">
+          PAST
+        </label>
+      </div>
+
+      <div className={styles.panels}>
+        <div
+          className={styles.panel}
+          role="tabpanel"
+          id={`${groupName}-panel-today`}
+          aria-labelledby={idToday}
+        >
+          {today.length > 0 ? (
+            <div className="grid gap-8">
+              {today.map((event) => (
+                <FeaturedEventCard key={event.id} event={event} />
+              ))}
+            </div>
+          ) : (
+            <div className="bg-white dark:bg-neutral-900 rounded-2xl p-12 text-center border border-neutral-200 dark:border-neutral-800">
+              <p className="text-neutral-600 dark:text-neutral-400">
+                No events scheduled for today.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div
+          className={styles.panel}
+          role="tabpanel"
+          id={`${groupName}-panel-future`}
+          aria-labelledby={idFuture}
+        >
+          {future.length > 0 ? (
+            <div className="grid gap-8">
+              {future.map((event) => (
+                <FeaturedEventCard key={event.id} event={event} />
+              ))}
+            </div>
+          ) : (
+            <div className="bg-white dark:bg-neutral-900 rounded-2xl p-12 text-center border border-neutral-200 dark:border-neutral-800">
+              <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+                No upcoming events scheduled yet.
+              </p>
+              <a
+                href="https://lu.ma/cursor-boston"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-foreground hover:underline focus-visible:outline-none focus-visible:underline"
+              >
+                Subscribe on Luma to get notified &rarr;
+              </a>
+            </div>
+          )}
+        </div>
+
+        <div
+          className={styles.panel}
+          role="tabpanel"
+          id={`${groupName}-panel-past`}
+          aria-labelledby={idPast}
+        >
+          {past.length > 0 ? (
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {past.map((event) => (
+                <PastStyleEventCard key={event.id} event={event} />
+              ))}
+            </div>
+          ) : (
+            <div className="bg-white dark:bg-neutral-900 rounded-2xl p-12 text-center border border-neutral-200 dark:border-neutral-800">
+              <p className="text-neutral-600 dark:text-neutral-400">
+                Past events will appear here after our first event.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Large hero-style card; register uses a normal Luma link (no checkout embed) so clicks always navigate. */
+function FeaturedEventCard({ event }: { event: Event }) {
+  const registerHref =
+    event.lumaUrl?.trim() || getLumaCheckoutHref(event);
+
+  return (
+    <div className="bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800">
+      <div className="grid md:grid-cols-2 gap-0">
+        <div className="relative aspect-9/16 md:aspect-auto md:min-h-[400px] bg-neutral-100 dark:bg-neutral-800 isolate">
+          <Image
+            src={event.image}
+            alt={event.title}
+            fill
+            className="object-contain pointer-events-none"
+            sizes="(max-width: 768px) 100vw, 50vw"
+          />
+          <div className="absolute bottom-[2%] right-[3%] z-20 w-[15%] aspect-square bg-white p-1 rounded pointer-events-none">
+            <Image
+              src="/luma-qr.png"
+              alt="Scan to register"
+              fill
+              className="object-contain"
+            />
+          </div>
+        </div>
+        <div className="p-8 flex flex-col justify-center relative z-10">
+          <span className="inline-block px-3 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-sm font-medium rounded-full mb-4 w-fit capitalize">
+            {event.type}
+          </span>
+          <h3 className="text-2xl md:text-3xl font-bold text-foreground mb-4">
+            {event.title}
+          </h3>
+          <p className="text-neutral-600 dark:text-neutral-400 mb-6 leading-relaxed">
+            {event.description}
+          </p>
+          {event.topics && event.topics.length > 0 ? (
+            <div className="mb-6">
+              <h4 className="text-sm font-semibold text-neutral-500 uppercase tracking-wider mb-3">
+                Topics Covered
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {event.topics.map((topic) => (
+                  <span
+                    key={topic}
+                    className="px-3 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-sm rounded-full"
+                  >
+                    {topic}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          <div className="space-y-3 mb-6">
+            <div className="flex items-center gap-3 text-neutral-700 dark:text-neutral-300">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+                <circle cx="12" cy="10" r="3" />
+              </svg>
+              <span>{event.location}</span>
+            </div>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-3 relative z-10">
+            <Link
+              href={`/events/${event.slug}`}
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-neutral-900 text-white dark:bg-white dark:text-black rounded-lg text-base font-semibold hover:bg-neutral-700 dark:hover:bg-neutral-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
+            >
+              View Details
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14M12 5l7 7-7 7" />
+              </svg>
+            </Link>
+            <a
+              href={registerHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Register for ${event.title} (opens in new tab)`}
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 border border-neutral-300 dark:border-neutral-700 text-foreground rounded-lg text-base font-semibold hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
+            >
+              Register on Luma
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M7 17l9.2-9.2M17 17V7H7" />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -14,6 +14,7 @@ import type { BadgeEligibilityInput, BadgeId } from "@/lib/badges/types";
 import { getBaseBadgeEligibilityInput } from "@/lib/badges/getBadgeEligibilityInput";
 import { getEarnedBadgeIds } from "@/lib/badges/utils";
 import { BadgeGrid } from "@/components/badges/BadgeGrid";
+import { SHOWCASE_AWARD_LABEL } from "@/lib/hackathon-asprint-2026-awards";
 
 interface MemberCardProps {
   member: PublicMember;
@@ -177,6 +178,14 @@ export function MemberCard({ member }: MemberCardProps) {
             Hack-a-Sprint &apos;26
           </span>
         )}
+        {member.hackASprint2026ShowcaseAwards?.map((kind) => (
+          <span
+            key={kind}
+            className="px-2 py-1 bg-amber-500/15 text-amber-800 dark:text-amber-300 text-xs rounded-full"
+          >
+            {SHOWCASE_AWARD_LABEL[kind]}
+          </span>
+        ))}
       </div>
 
       <div className="mb-4">

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -44,11 +44,11 @@ service cloud.firestore {
                   || (request.auth != null && request.auth.uid == userId);
       allow create: if request.auth != null
                     && request.auth.uid == userId
-                    && !request.resource.data.keys().hasAny(['earnedBadgeIds', 'pullRequestsCount', 'hackASprint2026ShowcaseBadge', 'hackASprint2026Unlocked', 'hackASprint2026UnlockedAt', 'hackASprint2026CreditEmailSentAt']);
+                    && !request.resource.data.keys().hasAny(['earnedBadgeIds', 'pullRequestsCount', 'hackASprint2026ShowcaseBadge', 'hackASprint2026ShowcaseAwards', 'hackASprint2026Unlocked', 'hackASprint2026UnlockedAt', 'hackASprint2026CreditEmailSentAt']);
       allow update: if request.auth != null 
                     && request.auth.uid == userId
                     && !request.resource.data.diff(resource.data).affectedKeys()
-                        .hasAny(['uid', 'createdAt', 'role', 'email', 'earnedBadgeIds', 'pullRequestsCount', 'hackASprint2026ShowcaseBadge', 'hackASprint2026Unlocked', 'hackASprint2026UnlockedAt', 'hackASprint2026CreditEmailSentAt']);
+                        .hasAny(['uid', 'createdAt', 'role', 'email', 'earnedBadgeIds', 'pullRequestsCount', 'hackASprint2026ShowcaseBadge', 'hackASprint2026ShowcaseAwards', 'hackASprint2026Unlocked', 'hackASprint2026UnlockedAt', 'hackASprint2026CreditEmailSentAt']);
       allow delete: if false; // Users cannot delete their own accounts via client
     }
     

--- a/content/events.json
+++ b/content/events.json
@@ -1,91 +1,12 @@
 {
   "upcoming": [
     {
-      "id": "cursor-boston-hack-a-sprint-2026",
-      "slug": "cursor-boston-hack-a-sprint-2026",
-      "title": "Cursor Boston Hack-a-Sprint",
-      "subtitle": "Inaugural in-person sprint — 50 builders, solo competition, co-hosted with inkbox.ai & Genesis Fund",
-      "date": "2026-04-13",
-      "time": "4:00 PM – 8:00 PM ET",
-      "location": "Back Bay, Boston, MA",
-      "venue": {
-        "name": "Back Bay (exact address after approval)",
-        "address": "Register on Luma to see the venue address after you're approved.",
-        "mapUrl": null
-      },
-      "type": "hackathon",
-      "description": "First-ever Cursor Boston Hack-a-Sprint: 50 developers, fast solo competition, fully fed and watered. $50 in Cursor Credits for every selected participant, $1,200 prize pool (six $200 spots). Monday April 13 in Back Bay — register on Luma; approval required.",
-      "longDescription": "We're thrilled to announce our inaugural Hack-a-Sprint, co-hosted with inkbox.ai and genesisfund.co. We're bringing together 50 developers for a fast-paced, solo competition.\n\nWhether you're building something brand new or pushing the limits of your current project, this is your chance to code, compete, and connect with the Boston Cursor community. You will be fully fed and watered.\n\nThe Perks & Prizes\n\nGuaranteed bounty: Every selected participant receives $50 in Cursor Credits.\nPrize pool: $1,200 total, split across six $200 Cursor Credit winning spots.\n\nWhen & Where\n\nDate: Monday, April 13, 2026\nLocation: Back Bay, Boston — exact address is shown on Luma after your registration is approved.\n\nThe Schedule\n\n4:00 PM — Meet, greet, and get set up.\n4:30 PM – 7:00 PM — The Hack-a-Sprint.\n7:00 PM – 8:00 PM — Scoring and judging. Results use participants, judges, and AI; a detailed rubric will be shared soon.\n\nHow to Secure Your Spot\n\nWe have exactly 50 spots; everyone competes individually. Selection happens about one week before the event. Priority order:\n\n1. Open source: Most merged PRs to github.com/rogerSuperBuilderAlpha/cursor-boston — get to work!\n2. Community profile: Completed profile on cursorboston.com.\n3. Discord: Member of the Cursor Boston Discord server.\n4. Sign-up order: Early birds get the worm.\n\nRegistration is subject to host approval. Luma may ask you to verify token ownership with your wallet as part of checkout.\n\nWe qualify participants rigorously. If selected people don't meet criteria or drop out, we pull aggressively from the waitlist.\n\nGet Involved\n\nDidn't make the top 50? Join the waitlist — drop-outs happen. Want to judge instead? Contact the hosts on Luma.\n\nMore info is coming soon; don't wait to request your spot.",
-      "lumaCheckoutEventId": "evt-Wkfyzu00afkUQaX",
-      "lumaEmbedSrc": "https://luma.com/embed/event/evt-Wkfyzu00afkUQaX/simple",
-      "image": "/cursor-boston-logo.png",
-      "lumaUrl": "https://luma.com/uixo8hl6",
-      "lumaEventId": "uixo8hl6",
-      "registrationRequired": true,
-      "capacity": 50,
-      "perks": [
-        "$50 Cursor credits (guaranteed for every participant)",
-        "$1,200 prize pool (six $200 winning spots)",
-        "Food and drinks"
-      ],
-      "topics": [
-        "Solo competition",
-        "Cursor Credits",
-        "Judging (participants + judges + AI)"
-      ],
-      "agenda": [
-        {
-          "time": "4:00 PM",
-          "title": "Meet, greet, and get set up",
-          "description": "Arrive, connect with fellow developers, and get ready to build"
-        },
-        {
-          "time": "4:30 PM – 7:00 PM",
-          "title": "Hack-a-Sprint",
-          "description": "The main build period—code, compete, and ship"
-        },
-        {
-          "time": "7:00 PM – 8:00 PM",
-          "title": "Scoring and Judging",
-          "description": "Results calculated by participants, judges, and AI"
-        }
-      ],
-      "faq": [
-        {
-          "question": "Who should apply?",
-          "answer": "Developers and builders who want to compete individually in a fast-paced hackathon. You must have a completed profile on cursorboston.com and be in the Cursor Boston Discord server."
-        },
-        {
-          "question": "Is this a team or solo competition?",
-          "answer": "Solo! Everyone competes individually. We have exactly 50 spots."
-        },
-        {
-          "question": "Will food be provided?",
-          "answer": "Yes. You will be fully fed and watered."
-        },
-        {
-          "question": "Is the date and venue final?",
-          "answer": "Date: Monday, April 13, 2026 in Back Bay, Boston. The exact address appears on Luma after your registration is approved."
-        },
-        {
-          "question": "What if I don't make the top 50?",
-          "answer": "Join the waitlist! Drop-outs happen, and you could be next in line. You can also contact us to become a judge."
-        }
-      ],
-      "whatToBring": [
-        "Laptop and charger",
-        "A project idea or problem you want to explore",
-        "A willingness to build with new tools"
-      ],
-      "featured": true
-    },
-    {
       "id": "cursor-boston-aic-open-source-workshop-2026",
       "slug": "cursor-boston-aic-open-source-workshop-2026",
       "title": "Cursor Boston/AIC BTW Open Source Workshop",
-      "subtitle": "Hands-on open source contributions with Cursor as your AI co-pilot — co-hosted with AIC",
+      "subtitle": "Hands-on open source contributions with Cursor as your AI co-pilot \u2014 co-hosted with AIC",
       "date": "2026-05-30",
-      "time": "12:00 PM – 5:00 PM ET",
+      "time": "12:00 PM \u2013 5:00 PM ET",
       "location": "Boston, MA",
       "venue": {
         "name": "TBD (exact address after approval)",
@@ -93,8 +14,8 @@
         "mapUrl": null
       },
       "type": "workshop",
-      "description": "Open Source Drop-In Workshop co-hosted by Cursor Boston and AIC. A hands-on half-day session with two tracks: contribute to the Cursor Boston repo (beginner-friendly) or tackle curated impactful open source projects using Cursor as your AI co-pilot. Walk away with merged PRs, Cursor credits, and practical open source skills. Saturday May 30 in Boston — register on Luma; approval required.",
-      "longDescription": "We're thrilled to announce the Open Source Drop-In Workshop, co-hosted by Cursor Boston and AIC (AI Community).\n\nThis is a hands-on half-day session designed to teach you how to contribute to real open source projects using Cursor as your AI co-pilot. Whether you've never opened a pull request or you're a seasoned contributor looking for high-impact projects, there's a track for you.\n\nTwo Tracks\n\nTrack A — Cursor Boston Repo (Beginner-Friendly): Learn the fundamentals of open source contribution by working directly on the Cursor Boston community repository. Mentors will guide you through forking, branching, making changes, and opening your first PR.\n\nTrack B — Curated Impactful Projects: For more experienced developers, we've hand-picked a set of impactful open source projects with beginner-friendly issues. Use Cursor's AI capabilities to understand unfamiliar codebases quickly and ship meaningful contributions.\n\nWhat You'll Walk Away With\n\nMerged pull requests on real open source projects, Cursor credits, and practical skills you can use immediately. This isn't a lecture — it's a working session where you'll ship real code.\n\nHosted by Roger Hunt, Ananya Shah, Janna, Kanal Patel, and Jason Morris.",
+      "description": "Open Source Drop-In Workshop co-hosted by Cursor Boston and AIC. A hands-on half-day session with two tracks: contribute to the Cursor Boston repo (beginner-friendly) or tackle curated impactful open source projects using Cursor as your AI co-pilot. Walk away with merged PRs, Cursor credits, and practical open source skills. Saturday May 30 in Boston \u2014 register on Luma; approval required.",
+      "longDescription": "We're thrilled to announce the Open Source Drop-In Workshop, co-hosted by Cursor Boston and AIC (AI Community).\n\nThis is a hands-on half-day session designed to teach you how to contribute to real open source projects using Cursor as your AI co-pilot. Whether you've never opened a pull request or you're a seasoned contributor looking for high-impact projects, there's a track for you.\n\nTwo Tracks\n\nTrack A \u2014 Cursor Boston Repo (Beginner-Friendly): Learn the fundamentals of open source contribution by working directly on the Cursor Boston community repository. Mentors will guide you through forking, branching, making changes, and opening your first PR.\n\nTrack B \u2014 Curated Impactful Projects: For more experienced developers, we've hand-picked a set of impactful open source projects with beginner-friendly issues. Use Cursor's AI capabilities to understand unfamiliar codebases quickly and ship meaningful contributions.\n\nWhat You'll Walk Away With\n\nMerged pull requests on real open source projects, Cursor credits, and practical skills you can use immediately. This isn't a lecture \u2014 it's a working session where you'll ship real code.\n\nHosted by Roger Hunt, Ananya Shah, Janna, Kanal Patel, and Jason Morris.",
       "lumaCheckoutEventId": "evt-2erXQCohWrtPWp9",
       "lumaEmbedSrc": "https://luma.com/embed/event/evt-2erXQCohWrtPWp9/simple",
       "image": "/cursor-boston-logo.png",
@@ -125,17 +46,17 @@
           "description": "Introduction to open source contribution, overview of Track A (Cursor Boston repo) and Track B (curated projects), and how to pick your track"
         },
         {
-          "time": "1:00 PM – 4:00 PM",
+          "time": "1:00 PM \u2013 4:00 PM",
           "title": "Hands-On Contribution Session",
           "description": "Work on your chosen track with mentor support. Fork repos, pick issues, write code with Cursor as your AI co-pilot, and open pull requests"
         },
         {
-          "time": "4:00 PM – 4:30 PM",
+          "time": "4:00 PM \u2013 4:30 PM",
           "title": "PR Review & Merging",
           "description": "Get your pull requests reviewed and merged. Celebrate your contributions with the group"
         },
         {
-          "time": "4:30 PM – 5:00 PM",
+          "time": "4:30 PM \u2013 5:00 PM",
           "title": "Wrap-Up & Networking",
           "description": "Share what you built, exchange contacts, and connect with the Cursor Boston and AIC communities"
         }
@@ -147,7 +68,7 @@
         },
         {
           "question": "What are the two tracks?",
-          "answer": "Track A focuses on contributing to the Cursor Boston community repository — perfect for beginners. Track B is for more experienced developers who want to contribute to curated, impactful open source projects. You can choose your track when you arrive."
+          "answer": "Track A focuses on contributing to the Cursor Boston community repository \u2014 perfect for beginners. Track B is for more experienced developers who want to contribute to curated, impactful open source projects. You can choose your track when you arrive."
         },
         {
           "question": "What do I get for participating?",
@@ -188,11 +109,14 @@
         "name": "Caffe Nero",
         "address": "100 Cambridgeside Pl, Cambridge, MA 02141",
         "mapUrl": null,
-        "coordinates": { "lat": 42.3677, "lng": -71.0764 }
+        "coordinates": {
+          "lat": 42.3677,
+          "lng": -71.0764
+        }
       },
       "type": "meetup",
       "description": "Join us for the first Cursor community event in Boston. Featuring co-working, Cursor workshops for entrepreneurs, engineers, and non-technical folks. Meet the community, learn something new, and grab some coffee.",
-      "longDescription": "Cafe Cursor Boston is an intimate gathering designed to bring together developers, entrepreneurs, and curious minds who want to explore the future of AI-powered development.\n\nWhether you're a seasoned engineer looking to supercharge your workflow, an entrepreneur wanting to build faster, or someone who's never written a line of code but is curious about what's possible — this event is for you.\n\nWe'll have hands-on workshops, open co-working time, and plenty of opportunities to connect with fellow community members over great coffee.",
+      "longDescription": "Cafe Cursor Boston is an intimate gathering designed to bring together developers, entrepreneurs, and curious minds who want to explore the future of AI-powered development.\n\nWhether you're a seasoned engineer looking to supercharge your workflow, an entrepreneur wanting to build faster, or someone who's never written a line of code but is curious about what's possible \u2014 this event is for you.\n\nWe'll have hands-on workshops, open co-working time, and plenty of opportunities to connect with fellow community members over great coffee.",
       "image": "/Gemini_Generated_Image_lc032wlc032wlc03.png",
       "lumaUrl": "https://luma.com/u43ar9pi",
       "lumaEventId": "u43ar9pi",
@@ -272,6 +196,89 @@
         "startTime": "9:00 AM",
         "endTime": "3:00 PM"
       }
+    }
+  ],
+  "oldEvents": [
+    {
+      "id": "cursor-boston-hack-a-sprint-2026",
+      "slug": "cursor-boston-hack-a-sprint-2026",
+      "title": "Cursor Boston Hack-a-Sprint",
+      "subtitle": "Inaugural in-person sprint \u2014 50 builders, solo competition, co-hosted with inkbox.ai & Genesis Fund",
+      "date": "2026-04-13",
+      "time": "4:00 PM \u2013 8:00 PM ET",
+      "location": "Back Bay, Boston, MA",
+      "venue": {
+        "name": "Back Bay (exact address after approval)",
+        "address": "Register on Luma to see the venue address after you're approved.",
+        "mapUrl": null
+      },
+      "type": "hackathon",
+      "description": "First-ever Cursor Boston Hack-a-Sprint: 50 developers, fast solo competition, fully fed and watered. $50 in Cursor Credits for every selected participant, $1,200 prize pool (six $200 spots). Monday April 13 in Back Bay \u2014 register on Luma; approval required.",
+      "longDescription": "We're thrilled to announce our inaugural Hack-a-Sprint, co-hosted with inkbox.ai and genesisfund.co. We're bringing together 50 developers for a fast-paced, solo competition.\n\nWhether you're building something brand new or pushing the limits of your current project, this is your chance to code, compete, and connect with the Boston Cursor community. You will be fully fed and watered.\n\nThe Perks & Prizes\n\nGuaranteed bounty: Every selected participant receives $50 in Cursor Credits.\nPrize pool: $1,200 total, split across six $200 Cursor Credit winning spots.\n\nWhen & Where\n\nDate: Monday, April 13, 2026\nLocation: Back Bay, Boston \u2014 exact address is shown on Luma after your registration is approved.\n\nThe Schedule\n\n4:00 PM \u2014 Meet, greet, and get set up.\n4:30 PM \u2013 7:00 PM \u2014 The Hack-a-Sprint.\n7:00 PM \u2013 8:00 PM \u2014 Scoring and judging. Results use participants, judges, and AI; a detailed rubric will be shared soon.\n\nHow to Secure Your Spot\n\nWe have exactly 50 spots; everyone competes individually. Selection happens about one week before the event. Priority order:\n\n1. Open source: Most merged PRs to github.com/rogerSuperBuilderAlpha/cursor-boston \u2014 get to work!\n2. Community profile: Completed profile on cursorboston.com.\n3. Discord: Member of the Cursor Boston Discord server.\n4. Sign-up order: Early birds get the worm.\n\nRegistration is subject to host approval. Luma may ask you to verify token ownership with your wallet as part of checkout.\n\nWe qualify participants rigorously. If selected people don't meet criteria or drop out, we pull aggressively from the waitlist.\n\nGet Involved\n\nDidn't make the top 50? Join the waitlist \u2014 drop-outs happen. Want to judge instead? Contact the hosts on Luma.\n\nMore info is coming soon; don't wait to request your spot.",
+      "lumaCheckoutEventId": "evt-Wkfyzu00afkUQaX",
+      "lumaEmbedSrc": "https://luma.com/embed/event/evt-Wkfyzu00afkUQaX/simple",
+      "image": "/cursor-boston-logo.png",
+      "lumaUrl": "https://luma.com/uixo8hl6",
+      "lumaEventId": "uixo8hl6",
+      "registrationRequired": true,
+      "capacity": 50,
+      "perks": [
+        "$50 Cursor credits (guaranteed for every participant)",
+        "$1,200 prize pool (six $200 winning spots)",
+        "Food and drinks"
+      ],
+      "topics": [
+        "Solo competition",
+        "Cursor Credits",
+        "Judging (participants + judges + AI)"
+      ],
+      "agenda": [
+        {
+          "time": "4:00 PM",
+          "title": "Meet, greet, and get set up",
+          "description": "Arrive, connect with fellow developers, and get ready to build"
+        },
+        {
+          "time": "4:30 PM \u2013 7:00 PM",
+          "title": "Hack-a-Sprint",
+          "description": "The main build period\u2014code, compete, and ship"
+        },
+        {
+          "time": "7:00 PM \u2013 8:00 PM",
+          "title": "Scoring and Judging",
+          "description": "Results calculated by participants, judges, and AI"
+        }
+      ],
+      "faq": [
+        {
+          "question": "Who should apply?",
+          "answer": "Developers and builders who want to compete individually in a fast-paced hackathon. You must have a completed profile on cursorboston.com and be in the Cursor Boston Discord server."
+        },
+        {
+          "question": "Is this a team or solo competition?",
+          "answer": "Solo! Everyone competes individually. We have exactly 50 spots."
+        },
+        {
+          "question": "Will food be provided?",
+          "answer": "Yes. You will be fully fed and watered."
+        },
+        {
+          "question": "Is the date and venue final?",
+          "answer": "Date: Monday, April 13, 2026 in Back Bay, Boston. The exact address appears on Luma after your registration is approved."
+        },
+        {
+          "question": "What if I don't make the top 50?",
+          "answer": "Join the waitlist! Drop-outs happen, and you could be next in line. You can also contact us to become a judge."
+        }
+      ],
+      "whatToBring": [
+        "Laptop and charger",
+        "A project idea or problem you want to explore",
+        "A willingness to build with new tools"
+      ],
+      "featured": false,
+      "primaryCtaHref": "/hackathons/hack-a-sprint-2026",
+      "primaryCtaLabel": "View submissions"
     }
   ]
 }

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ import {
   useState,
   ReactNode,
 } from "react";
+import type { ShowcaseAwardKind } from "@/lib/hackathon-asprint-2026-awards";
 import {
   User,
   onAuthStateChanged,
@@ -90,6 +91,8 @@ interface UserProfile {
   eduBadge?: boolean;
   /** Server-set when a merged PR adds the user's Hack-a-Sprint 2026 showcase submission. */
   hackASprint2026ShowcaseBadge?: boolean;
+  /** Server-set winner ribbons for Hack-a-Sprint 2026 showcase (judges / AI / peer). */
+  hackASprint2026ShowcaseAwards?: ShowcaseAwardKind[];
   /** @deprecated Passcode unlock removed; check-in at the door is now the gate. */
   hackASprint2026Unlocked?: boolean;
   hackASprint2026UnlockedAt?: Date;

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   ReactNode,
 } from "react";
@@ -127,6 +128,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const profileFetchGen = useRef(0);
 
   // Create or update user profile in Firestore
   const createUserProfile = async (user: User, provider: string) => {
@@ -189,22 +191,36 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
-      setUser(user);
-      if (user && db) {
-        // Fetch user profile from Firestore
-        const userRef = doc(db, "users", user.uid);
-        const userSnap = await getDoc(userRef);
-        if (userSnap.exists()) {
-          setUserProfile(userSnap.data() as UserProfile);
-        }
-      } else {
+    const unsubscribe = onAuthStateChanged(auth, (nextUser) => {
+      const gen = ++profileFetchGen.current;
+      setUser(nextUser);
+      if (!nextUser || !db) {
         setUserProfile(null);
+        setLoading(false);
+        return;
       }
+      // Do not block initial render (or pages like hackathon showcase) on Firestore.
       setLoading(false);
+      void (async () => {
+        try {
+          const userRef = doc(db, "users", nextUser.uid);
+          const userSnap = await getDoc(userRef);
+          if (gen !== profileFetchGen.current) return;
+          if (userSnap.exists()) {
+            setUserProfile(userSnap.data() as UserProfile);
+          } else {
+            setUserProfile(null);
+          }
+        } catch {
+          if (gen !== profileFetchGen.current) return;
+        }
+      })();
     });
 
-    return () => unsubscribe();
+    return () => {
+      profileFetchGen.current += 1;
+      unsubscribe();
+    };
   }, []);
 
   const signIn = async (email: string, password: string) => {

--- a/hooks/useMembers.ts
+++ b/hooks/useMembers.ts
@@ -7,9 +7,18 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import { collection, query, where, getDocs, orderBy } from "firebase/firestore";
-import { db } from "@/lib/firebase";
-import type { PublicMember, MemberFilters, SortOption, MemberType } from "@/types/members";
+import type { PublicMember, MemberFilters, SortOption } from "@/types/members";
+
+function revivePublicMember(raw: PublicMember): PublicMember {
+  const c = raw.createdAt as unknown;
+  if (typeof c === "string") {
+    return {
+      ...raw,
+      createdAt: { toDate: () => new Date(c) },
+    };
+  }
+  return raw;
+}
 
 const defaultFilters: MemberFilters = {
   hasDiscord: false,
@@ -28,67 +37,17 @@ export function useMembers(initialSearch: string = "") {
   const [filters, setFilters] = useState<MemberFilters>(defaultFilters);
   const [sortBy, setSortBy] = useState<SortOption>("newest");
 
-  // Fetch members on mount
+  // Load via cached API (avoids N client Firestore reads per visitor).
   useEffect(() => {
     async function fetchPublicMembers() {
-      if (!db) {
-        setLoading(false);
-        return;
-      }
-
       try {
-        // Fetch human members
-        const usersRef = collection(db, "users");
-        const usersQuery = query(
-          usersRef,
-          where("visibility.isPublic", "==", true),
-          orderBy("createdAt", "desc")
-        );
-        const usersSnapshot = await getDocs(usersQuery);
-        const humanMembers = usersSnapshot.docs.map((doc) => ({
-          uid: doc.id,
-          memberType: "human" as MemberType,
-          ...doc.data(),
-        })) as PublicMember[];
-
-        // Fetch agent members
-        const agentsRef = collection(db, "agents");
-        const agentsQuery = query(
-          agentsRef,
-          where("visibility.isPublic", "==", true),
-          where("status", "==", "claimed"),
-          orderBy("createdAt", "desc")
-        );
-        const agentsSnapshot = await getDocs(agentsQuery);
-        const agentMembers = agentsSnapshot.docs.map((doc) => {
-          const data = doc.data();
-          return {
-            uid: doc.id,
-            memberType: "agent" as MemberType,
-            displayName: data.name,
-            photoURL: data.avatarUrl || null,
-            bio: data.description,
-            visibility: {
-              ...data.visibility,
-              showBio: true,
-              showMemberSince: true,
-            },
-            createdAt: data.createdAt,
-            owner: data.visibility?.showOwner ? {
-              displayName: data.ownerDisplayName,
-              email: data.ownerEmail,
-            } : undefined,
-          } as PublicMember;
-        });
-
-        // Combine and sort by creation date
-        const allMembers = [...humanMembers, ...agentMembers].sort((a, b) => {
-          const dateA = a.createdAt?.toDate?.()?.getTime() || 0;
-          const dateB = b.createdAt?.toDate?.()?.getTime() || 0;
-          return dateB - dateA;
-        });
-
-        setMembers(allMembers);
+        const res = await fetch("/api/members/public");
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const body = (await res.json()) as { members?: PublicMember[] };
+        const list = Array.isArray(body.members) ? body.members : [];
+        setMembers(list.map(revivePublicMember));
       } catch (error) {
         console.error("Error fetching members:", error);
       } finally {
@@ -96,7 +55,7 @@ export function useMembers(initialSearch: string = "") {
       }
     }
 
-    fetchPublicMembers();
+    void fetchPublicMembers();
   }, []);
 
   // Filter and sort members

--- a/lib/events-calendar-buckets.ts
+++ b/lib/events-calendar-buckets.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Event } from "@/types/events";
+
+/** Calendar day boundary for Boston-area listings. */
+export const EVENTS_LISTING_TIMEZONE = "America/New_York";
+
+export function todayYmdInListingTz(
+  now: Date = new Date(),
+  timeZone: string = EVENTS_LISTING_TIMEZONE
+): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+/**
+ * Split events into today / future / past by calendar date in `EVENTS_LISTING_TIMEZONE`.
+ * Pass `listingTodayYmd` from the server (e.g. `todayYmdInListingTz(new Date())`) so SSR and
+ * the client hydrate identically — using `new Date()` only on the client breaks tab interactivity.
+ * `TBD` dates are treated as future. De-duplicates by `event.id` (first wins).
+ */
+export function partitionEventsForBrowse(
+  events: Event[],
+  listingTodayYmd: string
+): { today: Event[]; future: Event[]; past: Event[] } {
+  const todayYmd = listingTodayYmd;
+  const today: Event[] = [];
+  const future: Event[] = [];
+  const past: Event[] = [];
+  const seen = new Set<string>();
+
+  for (const event of events) {
+    if (seen.has(event.id)) continue;
+    seen.add(event.id);
+
+    if (event.date === "TBD") {
+      future.push(event);
+      continue;
+    }
+    const ymd = event.date.slice(0, 10);
+    if (ymd === todayYmd) today.push(event);
+    else if (ymd > todayYmd) future.push(event);
+    else past.push(event);
+  }
+
+  const futureSort = (a: Event, b: Event) => {
+    if (a.date === "TBD" && b.date !== "TBD") return 1;
+    if (b.date === "TBD" && a.date !== "TBD") return -1;
+    if (a.date !== b.date) return a.date.localeCompare(b.date);
+    return a.title.localeCompare(b.title, "en", { sensitivity: "base" });
+  };
+
+  const pastSort = (a: Event, b: Event) => {
+    if (a.date !== b.date) return b.date.localeCompare(a.date);
+    return a.title.localeCompare(b.title, "en", { sensitivity: "base" });
+  };
+
+  today.sort(futureSort);
+  future.sort(futureSort);
+  past.sort(pastSort);
+
+  return { today, future, past };
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -47,18 +47,22 @@ export async function findUserByGitHubLogin(
   logger.info("Looking up user by GitHub login", { githubLogin });
 
   try {
-    const snapshot = await db
-      .collection("users")
-      .where("github.login", "==", githubLogin)
-      .limit(1)
-      .get();
+    const trimmed = githubLogin.trim();
+    const variants = [...new Set([trimmed, trimmed.toLowerCase()])];
+    for (const v of variants) {
+      const snapshot = await db
+        .collection("users")
+        .where("github.login", "==", v)
+        .limit(1)
+        .get();
 
-    if (!snapshot.empty) {
-      const userId = snapshot.docs[0].id;
-      logger.info("Found user by GitHub login", { githubLogin, userId });
-      return userId;
+      if (!snapshot.empty) {
+        const userId = snapshot.docs[0].id;
+        logger.info("Found user by GitHub login", { githubLogin, userId });
+        return userId;
+      }
     }
-    
+
     logger.warn("No user found with GitHub login", { githubLogin });
     return null;
   } catch (error) {

--- a/lib/hackathon-asprint-2026-award-profile-sync.ts
+++ b/lib/hackathon-asprint-2026-award-profile-sync.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { FieldValue } from "firebase-admin/firestore";
+import type { Firestore } from "firebase-admin/firestore";
+import {
+  computeShowcaseAwards,
+  type ShowcaseAwardInput,
+} from "@/lib/hackathon-asprint-2026-awards";
+import { computeAiRanksBySubmissionId } from "@/lib/hackathon-asprint-2026-scores";
+import { computePeerAverages } from "@/lib/hackathon-asprint-2026-participant-scoring";
+import {
+  getAllHackASprint2026ParticipantScoreDocs,
+  hackASprint2026ScoreDocId,
+  resolveVoterGithubByUid,
+} from "@/lib/hackathon-asprint-2026-state";
+import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
+import { findUserByGitHubLogin } from "@/lib/github";
+
+/**
+ * Same inputs as the public gallery awards (AI rank/score, peer averages).
+ */
+export async function loadHackASprint2026ShowcaseAwardInputs(
+  db: Firestore
+): Promise<ShowcaseAwardInput[]> {
+  const submissions = await fetchShowcaseSubmissionsFromGitHub();
+  if (submissions.length === 0) return [];
+
+  const identities = submissions.map((s) => ({
+    submissionId: s.submissionId,
+    githubLogin: s.githubLogin,
+  }));
+
+  const voterDocs = await getAllHackASprint2026ParticipantScoreDocs(db);
+  const voterGithubByUid = await resolveVoterGithubByUid(db, voterDocs);
+  const peerAvgBySid = computePeerAverages(identities, voterDocs, voterGithubByUid);
+
+  const refs = submissions.map((s) =>
+    db.collection("hackathonShowcaseScores").doc(hackASprint2026ScoreDocId(s.submissionId))
+  );
+  const snaps = await db.getAll(...refs);
+
+  const aiScoreBySubmissionId = new Map<string, number | null>();
+  submissions.forEach((s, i) => {
+    const snap = snaps[i];
+    const data = snap?.exists ? snap.data() : undefined;
+    const ai =
+      typeof data?.aiScore === "number" && data.aiScore >= 1 && data.aiScore <= 10
+        ? data.aiScore
+        : null;
+    aiScoreBySubmissionId.set(s.submissionId, ai);
+  });
+
+  const aiRankBySubmissionId = computeAiRanksBySubmissionId(
+    submissions.map((s) => s.submissionId),
+    aiScoreBySubmissionId
+  );
+
+  return submissions.map((s) => ({
+    submissionId: s.submissionId,
+    githubLogin: s.githubLogin,
+    aiRank: aiRankBySubmissionId.get(s.submissionId) ?? null,
+    aiScore: aiScoreBySubmissionId.get(s.submissionId) ?? null,
+    peerAverage: peerAvgBySid.get(s.submissionId.toLowerCase()) ?? null,
+  }));
+}
+
+/**
+ * Writes `hackASprint2026ShowcaseAwards` on each linked user (merge).
+ * Uses `new Date()` for peer-reveal gating, matching the gallery.
+ */
+export async function syncHackASprint2026ShowcaseAwardsToUserProfiles(
+  db: Firestore,
+  options: { dryRun: boolean; now?: Date }
+): Promise<{
+  written: number;
+  missingUser: number;
+  lines: string[];
+}> {
+  const inputs = await loadHackASprint2026ShowcaseAwardInputs(db);
+  const awardsBySid = computeShowcaseAwards(inputs, options.now ?? new Date());
+
+  const lines: string[] = [];
+  let written = 0;
+  let missingUser = 0;
+
+  for (const row of inputs) {
+    const sid = row.submissionId.trim().toLowerCase();
+    const kinds = awardsBySid.get(sid) ?? [];
+    const gh = row.githubLogin.trim();
+    const uid = await findUserByGitHubLogin(gh);
+    if (!uid) {
+      missingUser += 1;
+      lines.push(`skip (no linked user) github=${gh} submission=${sid} would=${JSON.stringify(kinds)}`);
+      continue;
+    }
+    lines.push(`user ${uid} github=${gh} submission=${sid} awards=${JSON.stringify(kinds)}`);
+    if (!options.dryRun) {
+      await db
+        .collection("users")
+        .doc(uid)
+        .set(
+          {
+            hackASprint2026ShowcaseAwards: kinds,
+            updatedAt: FieldValue.serverTimestamp(),
+          },
+          { merge: true }
+        );
+    }
+    written += 1;
+  }
+
+  return { written, missingUser, lines };
+}

--- a/lib/hackathon-asprint-2026-awards.ts
+++ b/lib/hackathon-asprint-2026-awards.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { HACK_A_SPRINT_2026_TIMEZONE } from "@/lib/hackathon-asprint-2026-schedule";
+
+/**
+ * GitHub logins (lowercase) for human judges' top picks — one badge each if they appear in the gallery.
+ * (If someone has not merged a submission JSON, they will not show a card or badge.)
+ */
+export const HACK_A_SPRINT_2026_JUDGES_PICK_GITHUB_LOGINS = [
+  "michaelrschulte",
+  "zombiedays",
+] as const;
+
+/** How many additional submissions win strictly from AI rank (excluding judges' pick). */
+export const HACK_A_SPRINT_2026_AI_JUDGED_WINNER_COUNT = 2;
+
+/**
+ * How many peer-review winners after the reveal instant (by mean peer score, highest first).
+ * Excludes anyone who already has a judges' pick or an AI-judged slot.
+ */
+export const HACK_A_SPRINT_2026_PEER_REVIEW_WINNER_COUNT = 2;
+
+/** Wall time in America/New_York when peer-review winner badges appear (event week Friday, 12:00). */
+export const HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_NY = {
+  year: 2026,
+  month: 4,
+  day: 17,
+  hour: 12,
+  minute: 0,
+} as const;
+
+export type ShowcaseAwardKind =
+  | "judgesWinner"
+  | "aiJudgedWinner"
+  | "peerReviewWinner";
+
+export const SHOWCASE_AWARD_LABEL: Record<ShowcaseAwardKind, string> = {
+  judgesWinner: "Judges winner",
+  aiJudgedWinner: "AI judged winner",
+  peerReviewWinner: "Peer review winner",
+};
+
+export type ShowcaseAwardInput = {
+  submissionId: string;
+  githubLogin: string;
+  aiRank: number | null;
+  aiScore: number | null;
+  peerAverage: number | null;
+};
+
+/**
+ * UTC instant for a fixed calendar date + clock time interpreted in `America/New_York`
+ * (handles EST/EDT). Used for the peer-review winner reveal.
+ */
+export function hackASprint2026ZonedWallTimeToUtcMs(
+  timeZone: string,
+  y: number,
+  m: number,
+  d: number,
+  hour: number,
+  minute: number
+): number {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const low = Date.UTC(y, m - 1, d - 1);
+  const high = Date.UTC(y, m - 1, d + 2);
+  for (let t = low; t < high; t += 60_000) {
+    const parts = formatter.formatToParts(new Date(t));
+    const get = (ty: Intl.DateTimeFormatPartTypes) =>
+      Number(parts.find((p) => p.type === ty)?.value ?? "0");
+    if (
+      get("year") === y &&
+      get("month") === m &&
+      get("day") === d &&
+      get("hour") === hour &&
+      get("minute") === minute
+    ) {
+      return t;
+    }
+  }
+  return Date.UTC(y, m - 1, d, 16, minute, 0);
+}
+
+function normGh(login: string): string {
+  return login.trim().toLowerCase();
+}
+
+function normSid(id: string): string {
+  return id.trim().toLowerCase();
+}
+
+function peerRevealUtcMs(): number {
+  const raw =
+    process.env.NEXT_PUBLIC_HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT?.trim() ||
+    process.env.HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT?.trim();
+  if (raw) {
+    const ms = Date.parse(raw);
+    if (!Number.isNaN(ms)) return ms;
+  }
+  const z = HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_NY;
+  return hackASprint2026ZonedWallTimeToUtcMs(
+    HACK_A_SPRINT_2026_TIMEZONE,
+    z.year,
+    z.month,
+    z.day,
+    z.hour,
+    z.minute
+  );
+}
+
+export function isHackASprint2026PeerAwardsRevealed(now: Date = new Date()): boolean {
+  return now.getTime() >= peerRevealUtcMs();
+}
+
+/**
+ * Deterministic awards for the public gallery. One GitHub login cannot receive more than one award.
+ * Order: judges' picks → AI-judged (by AI rank) → peer review (by peer average) after reveal time.
+ */
+export function computeShowcaseAwards(
+  rows: ShowcaseAwardInput[],
+  now: Date = new Date()
+): Map<string, ShowcaseAwardKind[]> {
+  const out = new Map<string, ShowcaseAwardKind[]>();
+  const excluded = new Set<string>();
+
+  const byLogin = new Map<string, ShowcaseAwardInput>();
+  for (const r of rows) {
+    byLogin.set(normGh(r.githubLogin), r);
+  }
+
+  for (const pick of HACK_A_SPRINT_2026_JUDGES_PICK_GITHUB_LOGINS) {
+    const judgesGh = normGh(pick);
+    const judgesRow = byLogin.get(judgesGh);
+    if (judgesRow) {
+      const sid = normSid(judgesRow.submissionId);
+      out.set(sid, ["judgesWinner"]);
+      excluded.add(judgesGh);
+    }
+  }
+
+  const aiOrdered = [...rows].sort((a, b) => {
+    const ra = a.aiRank ?? Number.POSITIVE_INFINITY;
+    const rb = b.aiRank ?? Number.POSITIVE_INFINITY;
+    if (ra !== rb) return ra - rb;
+    const sa = a.aiScore ?? -1;
+    const sb = b.aiScore ?? -1;
+    if (sb !== sa) return sb - sa;
+    return normSid(a.submissionId).localeCompare(normSid(b.submissionId));
+  });
+
+  let aiSlots = 0;
+  for (const r of aiOrdered) {
+    if (aiSlots >= HACK_A_SPRINT_2026_AI_JUDGED_WINNER_COUNT) break;
+    const gh = normGh(r.githubLogin);
+    if (excluded.has(gh)) continue;
+    if (r.aiRank == null && r.aiScore == null) continue;
+    const sid = normSid(r.submissionId);
+    const prev = out.get(sid) ?? [];
+    out.set(sid, [...prev, "aiJudgedWinner"]);
+    excluded.add(gh);
+    aiSlots++;
+  }
+
+  if (!isHackASprint2026PeerAwardsRevealed(now)) {
+    return out;
+  }
+
+  const peerOrdered = [...rows].sort((a, b) => {
+    const pa = a.peerAverage;
+    const pb = b.peerAverage;
+    if (pa == null && pb == null) return normSid(a.submissionId).localeCompare(normSid(b.submissionId));
+    if (pa == null) return 1;
+    if (pb == null) return -1;
+    if (pb !== pa) return pb - pa;
+    return normSid(a.submissionId).localeCompare(normSid(b.submissionId));
+  });
+
+  let peerSlots = 0;
+  for (const r of peerOrdered) {
+    if (peerSlots >= HACK_A_SPRINT_2026_PEER_REVIEW_WINNER_COUNT) break;
+    const gh = normGh(r.githubLogin);
+    if (excluded.has(gh)) continue;
+    if (r.peerAverage == null) continue;
+    const sid = normSid(r.submissionId);
+    const prev = out.get(sid) ?? [];
+    out.set(sid, [...prev, "peerReviewWinner"]);
+    excluded.add(gh);
+    peerSlots++;
+  }
+
+  return out;
+}
+
+export function showcaseAwardLabelsForRow(
+  awards: Map<string, ShowcaseAwardKind[]>,
+  submissionId: string
+): string[] {
+  const kinds = awards.get(normSid(submissionId)) ?? [];
+  return kinds.map((k) => SHOWCASE_AWARD_LABEL[k]);
+}

--- a/lib/hackathon-asprint-2026-participant-scoring.ts
+++ b/lib/hackathon-asprint-2026-participant-scoring.ts
@@ -50,7 +50,8 @@ export function participantBallotComplete(
 }
 
 /**
- * Prize eligibility: at least `min(6, #other submissions)` scores strictly above 8 on others.
+ * Prize eligibility: (1) valid 1–10 on every other submission (full ballot), and
+ * (2) at least `min(6, #others)` of those scores strictly above 8 (9 or 10).
  */
 export function participantPrizeEligibility(
   scores: Record<string, number> | undefined,
@@ -66,12 +67,17 @@ export function participantPrizeEligibility(
     (s) => s.githubLogin.trim().toLowerCase() !== own
   );
   const requiredHighScores = Math.min(6, others.length);
-  if (requiredHighScores === 0) {
+  if (others.length === 0) {
     return { eligible: true, highScoreCount: 0, requiredHighScores: 0 };
   }
   if (!scores) {
     return { eligible: false, highScoreCount: 0, requiredHighScores };
   }
+  const ballotComplete = participantBallotComplete(
+    scores,
+    ownGithubLogin,
+    allSubmissions
+  );
   let highScoreCount = 0;
   for (const s of others) {
     const sid = s.submissionId.trim().toLowerCase();
@@ -79,7 +85,8 @@ export function participantPrizeEligibility(
     if (typeof v === "number" && v > 8) highScoreCount++;
   }
   return {
-    eligible: highScoreCount >= requiredHighScores,
+    eligible:
+      ballotComplete && highScoreCount >= requiredHighScores,
     highScoreCount,
     requiredHighScores,
   };

--- a/lib/hackathon-asprint-2026-state.ts
+++ b/lib/hackathon-asprint-2026-state.ts
@@ -83,9 +83,16 @@ export async function getParticipantScoresForUser(
   );
 }
 
+export type HackASprintParticipantScoreDocRow = {
+  userId: string;
+  scores: Record<string, number>;
+  /** Lowercased GitHub login, denormalized on participant-score writes. */
+  githubLogin?: string | null;
+};
+
 export async function getAllHackASprint2026ParticipantScoreDocs(
   db: Firestore
-): Promise<Array<{ userId: string; scores: Record<string, number> }>> {
+): Promise<HackASprintParticipantScoreDocRow[]> {
   const snap = await db
     .collection("hackathonASprint2026ParticipantScores")
     .where("eventId", "==", HACK_A_SPRINT_2026_EVENT_ID)
@@ -98,12 +105,47 @@ export async function getAllHackASprint2026ParticipantScoreDocs(
         const parts = d.id.split("__");
         userId = parts.length >= 2 ? parts.slice(1).join("__") : "";
       }
+      const ghRaw = data.githubLogin;
+      const githubLogin =
+        typeof ghRaw === "string" && ghRaw.trim()
+          ? ghRaw.trim().toLowerCase()
+          : undefined;
       return {
         userId,
+        githubLogin,
         scores: normalizeParticipantScores(
           data.scores as Record<string, unknown> | undefined
         ),
       };
     })
     .filter((x) => Boolean(x.userId));
+}
+
+/**
+ * Map voter uid → GitHub login for peer averaging. Uses denormalized `githubLogin`
+ * on participant score docs when present; otherwise loads `users/{uid}` (batched getAll).
+ */
+export async function resolveVoterGithubByUid(
+  db: Firestore,
+  voterDocs: HackASprintParticipantScoreDocRow[]
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const missing: string[] = [];
+  for (const d of voterDocs) {
+    const g =
+      typeof d.githubLogin === "string" ? d.githubLogin.trim().toLowerCase() : "";
+    if (g) map.set(d.userId, g);
+    else missing.push(d.userId);
+  }
+  const uniqueMissing = [...new Set(missing)];
+  if (uniqueMissing.length === 0) return map;
+  const refs = uniqueMissing.map((uid) => db.collection("users").doc(uid));
+  const snaps = await db.getAll(...refs);
+  for (const snap of snaps) {
+    const login = snap.data()?.github?.login;
+    if (typeof login === "string" && login.trim()) {
+      map.set(snap.id, login.trim().toLowerCase());
+    }
+  }
+  return map;
 }

--- a/lib/hackathon-showcase-admin.ts
+++ b/lib/hackathon-showcase-admin.ts
@@ -48,11 +48,12 @@ export async function awardHackASprint2026ShowcaseBadge(
   });
 }
 
-export async function userIsHackASprint2026Judge(
-  db: Firestore,
+/** Judge eligibility from an already-loaded `users/{uid}` document (avoids extra reads). */
+export function userIsHackASprint2026JudgeFromUserData(
   uid: string,
-  tokenEmail?: string | null
-): Promise<boolean> {
+  tokenEmail: string | null | undefined,
+  userData: Record<string, unknown> | undefined
+): boolean {
   if (getJudgeUidSet().has(uid)) return true;
   const allowed = getJudgeEmailSet();
   if (allowed.size === 0) return false;
@@ -61,16 +62,14 @@ export async function userIsHackASprint2026Judge(
   if (tokenEmail) {
     candidates.add(tokenEmail.trim().toLowerCase());
   }
-  const snap = await db.collection("users").doc(uid).get();
-  const d = snap.data();
-  if (typeof d?.email === "string") {
-    candidates.add(d.email.trim().toLowerCase());
+  if (typeof userData?.email === "string") {
+    candidates.add(userData.email.trim().toLowerCase());
   }
-  for (const entry of d?.additionalEmails ?? []) {
-    if (
-      entry?.verified &&
-      typeof entry?.email === "string"
-    ) {
+  for (const entry of (userData?.additionalEmails ?? []) as Array<{
+    verified?: boolean;
+    email?: string;
+  }>) {
+    if (entry?.verified && typeof entry?.email === "string") {
       candidates.add(entry.email.trim().toLowerCase());
     }
   }
@@ -78,4 +77,17 @@ export async function userIsHackASprint2026Judge(
     if (allowed.has(c)) return true;
   }
   return false;
+}
+
+export async function userIsHackASprint2026Judge(
+  db: Firestore,
+  uid: string,
+  tokenEmail?: string | null
+): Promise<boolean> {
+  const snap = await db.collection("users").doc(uid).get();
+  return userIsHackASprint2026JudgeFromUserData(
+    uid,
+    tokenEmail ?? null,
+    snap.data() as Record<string, unknown> | undefined
+  );
 }

--- a/scripts/backfill-asprint-2026-participant-github-login.ts
+++ b/scripts/backfill-asprint-2026-participant-github-login.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Backfill `githubLogin` (lowercase) on `hackathonASprint2026ParticipantScores`
+ * for Hack-a-Sprint 2026 so peer-average reads skip per-voter `users/{uid}` lookups.
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-asprint-2026-participant-github-login.ts
+ *   npx tsx scripts/backfill-asprint-2026-participant-github-login.ts --apply
+ */
+
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import type { DocumentReference } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "../lib/hackathon-showcase";
+
+function userIdFromParticipantDoc(
+  docId: string,
+  data: Record<string, unknown>
+): string {
+  const fromField = data.userId;
+  if (typeof fromField === "string" && fromField.trim()) return fromField.trim();
+  const parts = docId.split("__");
+  return parts.length >= 2 ? parts.slice(1).join("__") : "";
+}
+
+function docNeedsGithubLogin(data: Record<string, unknown> | undefined): boolean {
+  const g = data?.githubLogin;
+  return typeof g !== "string" || !g.trim();
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "No admin DB. Set FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS."
+    );
+    process.exit(1);
+  }
+
+  const snap = await db
+    .collection("hackathonASprint2026ParticipantScores")
+    .where("eventId", "==", HACK_A_SPRINT_2026_EVENT_ID)
+    .get();
+
+  const refsByUid = new Map<string, DocumentReference[]>();
+  for (const d of snap.docs) {
+    const raw = d.data() as Record<string, unknown>;
+    if (!docNeedsGithubLogin(raw)) continue;
+    const uid = userIdFromParticipantDoc(d.id, raw);
+    if (!uid) {
+      console.warn("[skip] no userId:", d.id);
+      continue;
+    }
+    const list = refsByUid.get(uid) ?? [];
+    list.push(d.ref);
+    refsByUid.set(uid, list);
+  }
+
+  const missingDocs = [...refsByUid.values()].reduce((n, a) => n + a.length, 0);
+  console.log(
+    `Event ${HACK_A_SPRINT_2026_EVENT_ID}: ${snap.size} docs, ${missingDocs} missing githubLogin (${refsByUid.size} unique uids).`
+  );
+  if (refsByUid.size === 0) {
+    console.log("Nothing to backfill.");
+    return;
+  }
+
+  let updated = 0;
+  let noGithub = 0;
+  let batch = db.batch();
+  let batchOps = 0;
+  let dryRunLogged = 0;
+
+  const flushBatch = async () => {
+    if (batchOps === 0) return;
+    if (apply) await batch.commit();
+    batch = db.batch();
+    batchOps = 0;
+  };
+
+  for (const [uid, refs] of refsByUid) {
+    const userSnap = await db.collection("users").doc(uid).get();
+    const loginRaw = userSnap.data()?.github?.login;
+    const gh =
+      typeof loginRaw === "string" && loginRaw.trim()
+        ? loginRaw.trim().toLowerCase()
+        : "";
+    if (!gh) {
+      noGithub += refs.length;
+      console.warn(
+        `[no github.login] uid=${uid} docs=${refs.length} (user exists: ${userSnap.exists})`
+      );
+      continue;
+    }
+
+    for (const ref of refs) {
+      if (apply) {
+        batch.set(ref, { githubLogin: gh }, { merge: true });
+        batchOps += 1;
+        if (batchOps >= 400) await flushBatch();
+      }
+      updated += 1;
+      if (!apply && dryRunLogged < 15) {
+        console.log(`[dry-run] ${ref.path} <- githubLogin=${gh}`);
+        dryRunLogged += 1;
+      }
+    }
+  }
+  await flushBatch();
+
+  if (apply) {
+    console.log(`Applied: ${updated} documents updated, ${noGithub} skipped (no GitHub on profile).`);
+  } else {
+    if (updated > dryRunLogged) {
+      console.log(`[dry-run] … and ${updated - dryRunLogged} more (same pattern).`);
+    }
+    console.log(
+      `Dry run: would update ${updated} documents; ${noGithub} skipped. Re-run with --apply to write.`
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/distribute-cursor-credits.ts
+++ b/scripts/distribute-cursor-credits.ts
@@ -29,6 +29,7 @@ import { computePeerAverages } from "../lib/hackathon-asprint-2026-participant-s
 import {
   getAllHackASprint2026ParticipantScoreDocs,
   hackASprint2026ScoreDocId,
+  resolveVoterGithubByUid,
 } from "../lib/hackathon-asprint-2026-state";
 import { CURSOR_CREDIT_TOP_N } from "../lib/hackathon-event-signup";
 import { sendEmail } from "../lib/mailgun";
@@ -146,16 +147,7 @@ async function main() {
     githubLogin: s.githubLogin,
   }));
   const voterDocs = await getAllHackASprint2026ParticipantScoreDocs(db);
-  const voterUids = [...new Set(voterDocs.map((d) => d.userId))];
-  const voterRefs = voterUids.map((uid) => db.collection("users").doc(uid));
-  const voterSnaps = voterRefs.length > 0 ? await db.getAll(...voterRefs) : [];
-  const voterGithubByUid = new Map<string, string>();
-  for (const snap of voterSnaps) {
-    const login = snap.data()?.github?.login;
-    if (typeof login === "string" && login.trim()) {
-      voterGithubByUid.set(snap.id, login.trim().toLowerCase());
-    }
-  }
+  const voterGithubByUid = await resolveVoterGithubByUid(db, voterDocs);
   const peerAvgBySid = computePeerAverages(
     identities,
     voterDocs,

--- a/scripts/sync-hack-a-sprint-showcase-awards-to-profiles.ts
+++ b/scripts/sync-hack-a-sprint-showcase-awards-to-profiles.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Sync Hack-a-Sprint 2026 showcase winner ribbons to Firebase user profiles
+ * (`hackASprint2026ShowcaseAwards`), using the same rules as the public gallery.
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS,
+ * plus GitHub/API env used by fetchShowcaseSubmissionsFromGitHub.
+ *
+ * Usage:
+ *   npx tsx scripts/sync-hack-a-sprint-showcase-awards-to-profiles.ts
+ *   npx tsx scripts/sync-hack-a-sprint-showcase-awards-to-profiles.ts --apply
+ */
+
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { syncHackASprint2026ShowcaseAwardsToUserProfiles } from "../lib/hackathon-asprint-2026-award-profile-sync";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "No admin DB. Set FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS."
+    );
+    process.exit(1);
+  }
+
+  const { written, missingUser, lines } =
+    await syncHackASprint2026ShowcaseAwardsToUserProfiles(db, { dryRun: !apply });
+
+  for (const line of lines) {
+    console.log(line);
+  }
+  console.log(
+    apply
+      ? `Applied: ${written} profiles updated, ${missingUser} submissions with no linked user.`
+      : `Dry run: would touch ${written} profiles; ${missingUser} unlinked. Re-run with --apply.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/types/events.ts
+++ b/types/events.ts
@@ -101,11 +101,17 @@ export interface Event {
   isCancelled?: boolean;
   isPostponed?: boolean;
   postponedTo?: string;
+
+  /** Past events: primary button target (e.g. submissions gallery) instead of only /events/[slug]. */
+  primaryCtaHref?: string;
+  primaryCtaLabel?: string;
 }
 
 export interface EventsData {
   upcoming: Event[];
   past: Event[];
+  /** Archived listings (e.g. hackathons whose gallery lives elsewhere). */
+  oldEvents: Event[];
 }
 
 /**

--- a/types/members.ts
+++ b/types/members.ts
@@ -4,6 +4,8 @@
  * See LICENSE file for details.
  */
 
+import type { ShowcaseAwardKind } from "@/lib/hackathon-asprint-2026-awards";
+
 export type MemberType = "human" | "agent";
 
 export interface PublicMember {
@@ -49,6 +51,8 @@ export interface PublicMember {
   talksGiven?: number;
   pullRequestsCount?: number;
   hackASprint2026ShowcaseBadge?: boolean;
+  /** Server-synced showcase winner ribbons (see scripts/sync-hack-a-sprint-showcase-awards-to-profiles.ts). */
+  hackASprint2026ShowcaseAwards?: ShowcaseAwardKind[];
   earnedBadgeIds?: string[];
   github?: {
     login: string;


### PR DESCRIPTION
Integrates Hack-a-Sprint 2026 events and showcase updates with Firestore read optimizations.

- Events browse (today/future/past), archived Hack-a-Sprint listing, related map/event pages.
- Showcase gallery, peer scoring rules, awards helpers; consolidated hackathon signup/user/participant reads.
- Denormalized `githubLogin` on participant scores, voter resolution helper, optional backfill script.
- Public members directory via cached `/api/members/public`; analytics snapshot TTL and HTTP caching.

All commits are signed off for DCO.

Made with [Cursor](https://cursor.com)