### PR TITLE
feat(pair): add availability scheduling UI to profile form

### DIFF
--- a/app/pair/page.tsx
+++ b/app/pair/page.tsx
@@ -14,6 +14,7 @@ import type {
   MatchScore,
   PairRequest,
   SessionType,
+  AvailabilityWindow,
 } from "@/lib/pair-programming/types";
 import Image from "next/image";
 import { getPairProfile, getAllActiveProfiles } from "@/lib/pair-programming/data";
@@ -408,6 +409,12 @@ function ProfileForm({
     existingProfile?.preferredFrameworks || []
   );
   const [timezone, setTimezone] = useState(existingProfile?.timezone || "America/New_York");
+  const [availability, setAvailability] = useState<AvailabilityWindow[]>(
+    existingProfile?.availability || []
+  );
+  const [newDay, setNewDay] = useState<number>(1);
+  const [newStart, setNewStart] = useState("09:00");
+  const [newEnd, setNewEnd] = useState("17:00");
   const [sessionTypes, setSessionTypes] = useState<SessionType[]>(
     existingProfile?.sessionTypes || []
   );
@@ -442,7 +449,7 @@ function ProfileForm({
           preferredLanguages,
           preferredFrameworks,
           timezone,
-          availability: existingProfile?.availability || [],
+          availability,
           sessionTypes,
           bio,
           isActive,
@@ -640,6 +647,67 @@ function ProfileForm({
           <option value="America/Los_Angeles">Pacific Time (PT)</option>
           <option value="UTC">UTC</option>
         </select>
+      </div>
+
+      {/* Availability */}
+      <div>
+        <label className="block text-sm font-medium mb-2">Availability</label>
+        <div className="flex flex-wrap gap-2 mb-3">
+          <select
+            value={newDay}
+            onChange={(e) => setNewDay(Number(e.target.value))}
+            className="px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+          >
+            {["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"].map((d, i) => (
+              <option key={d} value={i}>{d}</option>
+            ))}
+          </select>
+          <input
+            type="time"
+            value={newStart}
+            onChange={(e) => setNewStart(e.target.value)}
+            className="px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+          />
+          <span className="self-center text-sm text-neutral-500">to</span>
+          <input
+            type="time"
+            value={newEnd}
+            onChange={(e) => setNewEnd(e.target.value)}
+            className="px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              if (newStart >= newEnd) {
+                alert("End time must be after start time");
+                return;
+              }
+              setAvailability([...availability, { dayOfWeek: newDay, startTime: newStart, endTime: newEnd }]);
+            }}
+            className="px-4 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+          >
+            Add
+          </button>
+        </div>
+        <div className="space-y-2">
+          {availability.map((w, idx) => (
+            <div key={idx} className="flex items-center justify-between px-3 py-2 bg-neutral-50 dark:bg-neutral-800 rounded-lg text-sm">
+              <span>
+                {["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][w.dayOfWeek]} &nbsp;{w.startTime}–{w.endTime}
+              </span>
+              <button
+                type="button"
+                onClick={() => setAvailability(availability.filter((_, i) => i !== idx))}
+                className="text-neutral-400 hover:text-red-500 transition-colors"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          {availability.length === 0 && (
+            <p className="text-sm text-neutral-400">No availability windows added yet.</p>
+          )}
+        </div>
       </div>
 
       {/* Session Types */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "cross-env": "^10.1.0",
         "eslint": "^10.2.0",
         "eslint-config-next": "^16.2.3",
         "eslint-plugin-import": "^2.32.0",
@@ -1257,6 +1258,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -9549,22 +9557,21 @@
       "license": "MIT"
     },
     "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.1"
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
       },
       "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -10740,16 +10747,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.2.tgz",
-      "integrity": "sha512-IOPbWzDQ+76AtjZioaCjpIY72xNSDMnarZ2GMQ4wjNLvnJEJHqxQwGFhgnIWLV9klb4g/+amg88Tk5OXVpyLTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "3.3.1"
       }
     },
     "node_modules/eslint-config-next/node_modules/eslint-import-resolver-typescript": {
@@ -12032,6 +12029,25 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/firebase-tools/node_modules/gcp-metadata": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "firestore"
   ],
   "scripts": {
-    "dev": "NODE_OPTIONS='--no-deprecation' next dev --webpack -H localhost",
+    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --webpack -H localhost",
     "build": "next build --webpack",
-    "start": "NODE_OPTIONS='--no-deprecation' next start",
+    "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "test": "jest --config config/jest.config.js",
@@ -100,6 +100,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "cross-env": "^10.1.0",
     "eslint": "^10.2.0",
     "eslint-config-next": "^16.2.3",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
Closes #80 (partial)

## What
Adds an availability scheduling section to the pair programming profile form.
Users can now pick a day of the week, start time, and end time to build up
their weekly availability windows.

Previously the profile form was hardcoded to submit `availability: []`,
so the matching algorithm's availability overlap scoring (up to 15 pts)
was never used.

Also fixes `npm run dev` on Windows by replacing Unix-only `NODE_OPTIONS='...'`
syntax with `cross-env`.

## Changes
- `app/pair/page.tsx` — availability UI (day picker + time inputs + saved windows list)
- `package.json` / `package-lock.json` — add `cross-env`, fix dev/start scripts