### PR TITLE
release: develop → main 2026-04-14

### DIFF
--- a/.cursor/rules/maintainer-application-merge-policy.mdc
+++ b/.cursor/rules/maintainer-application-merge-policy.mdc
@@ -1,0 +1,18 @@
+---
+description: Never merge maintainer-application PRs without explicit repo owner approval
+alwaysApply: true
+---
+
+# Maintainer application branch — merge gate
+
+**Do not merge** any pull request whose **base branch** is `maintainer-application` (maintainer onboarding / application JSON, etc.) **unless the user has explicitly approved that merge in this chat session.**
+
+This includes:
+
+- `gh pr merge` targeting `maintainer-application`
+- Merging via the GitHub UI into `maintainer-application`
+- Landing application files (e.g. `*.json` under maintainer application paths) by any side channel
+
+**Allowed without a maintainer-application merge:** Triage, review, comments, requesting changes, or merging **normal feature PRs** into `develop` per the existing PR policies.
+
+**If the user asks to process maintainer applications:** Confirm whether they want **review-only** or an **actual merge** before using any merge command.


### PR DESCRIPTION
Sync `main` with `develop` (batched release PR per repo policy).

**Included changes**
- `chore(cursor)`: require explicit approval before merging PRs into `maintainer-application` (Cursor rule).

**Pre-merge**
- Confirmed `develop` is one commit ahead of `main` (this PR).

Made with [Cursor](https://cursor.com)