### PR TITLE
feat(footer): add X and LinkedIn links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,13 @@ import LumaCheckoutTracker from "@/components/LumaCheckoutTracker";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ThemeProvider } from "@/components/ThemeProvider";
 
+const ORGANIZATION_SOCIAL_LINKS = [
+  "https://discord.gg/Wsncg8YYqc",
+  "https://lu.ma/cursor-boston",
+  "https://x.com/cursorboston",
+  "https://www.linkedin.com/company/cursor-boston/",
+];
+
 export const metadata: Metadata = {
   title: {
     default: "Cursor Boston",
@@ -62,10 +69,7 @@ const organizationJsonLd = {
     "Boston's community for AI-assisted development with Cursor IDE. Meetups, workshops, and hackathons for developers, founders, and students.",
   url: "https://cursorboston.com",
   logo: "https://cursorboston.com/cursor-boston-logo.png",
-  sameAs: [
-    "https://discord.gg/Wsncg8YYqc",
-    "https://lu.ma/cursor-boston",
-  ],
+  sameAs: ORGANIZATION_SOCIAL_LINKS,
   address: {
     "@type": "PostalAddress",
     addressLocality: "Boston",

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,20 @@
 import Link from "next/link";
 import Image from "next/image";
 import Logo from "@/components/Logo";
-import { DiscordIcon } from "@/components/icons";
+import { DiscordIcon, LinkedInIcon, XIcon } from "@/components/icons";
+
+const SOCIAL_LINKS = [
+  {
+    href: "https://x.com/cursorboston",
+    label: "Follow Cursor Boston on X",
+    Icon: XIcon,
+  },
+  {
+    href: "https://www.linkedin.com/company/cursor-boston/",
+    label: "Follow Cursor Boston on LinkedIn",
+    Icon: LinkedInIcon,
+  },
+] as const;
 
 export default function Footer() {
   return (
@@ -37,6 +50,21 @@ export default function Footer() {
               <DiscordIcon size={18} className="mr-2" />
               Join Discord
             </a>
+            <div className="flex items-center gap-3 mt-4">
+              {SOCIAL_LINKS.map(({ href, label, Icon }) => (
+                <a
+                  key={href}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`${label} (opens in new tab)`}
+                  title={label}
+                  className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg border border-neutral-300 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white hover:border-neutral-500 dark:hover:border-neutral-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                >
+                  <Icon size={18} />
+                </a>
+              ))}
+            </div>
           </div>
 
           {/* Links columns */}

--- a/components/icons/index.tsx
+++ b/components/icons/index.tsx
@@ -44,6 +44,36 @@ export function GitHubIcon({ size = 14, ...props }: IconProps) {
   );
 }
 
+export function LinkedInIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+export function XIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
 export function CalendarIcon({ size = 20, ...props }: IconProps) {
   return (
     <svg


### PR DESCRIPTION
## Summary
- add reusable X and LinkedIn icon components and show them in the site footer
- expose the new social URLs in the organization's structured metadata alongside Discord and Luma
- keep the change isolated to site chrome for an easy review

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm test -- --runInBand` was run and only the Firestore rules suite failed because no emulator host/port was available locally
- [x] `npm run test:rules` was attempted and was blocked because the local Firebase CLI requires JDK 21+

## Notes
- this PR assumes the official social URLs will be `https://x.com/cursorboston` and `https://www.linkedin.com/company/cursor-boston/`

Made with [Cursor](https://cursor.com)