### PR TITLE
claude/add-linkedin-certificate-page-cskev

### DIFF
--- a/app/api/certificate/claim/route.ts
+++ b/app/api/certificate/claim/route.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getClientIdentifier } from "@/lib/rate-limit";
+import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
+import { reconcileMergedPrCreditForUser } from "@/lib/github-merged-pr-reconcile";
+import {
+  CERTIFICATES_COLLECTION,
+  CERTIFICATE_PR_THRESHOLD,
+  CERTIFICATE_NAME,
+  getCertificateDocId,
+  getCertVerifyUrl,
+  parseCertificateFromFirestore,
+  buildLinkedInAddToProfileUrl,
+} from "@/lib/certificate";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "certificate-claim",
+      windowMs: RATE_LIMIT.windowMs,
+      maxRequests: RATE_LIMIT.maxRequests,
+      identifier: `uid:${user.uid}|ip:${getClientIdentifier(request as unknown as Request)}`,
+      fallbackMode: "strict-memory",
+      fallbackMaxRequests: 5,
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(rateResult, RATE_LIMIT.maxRequests),
+        }
+      );
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    // Fetch user profile to get GitHub login
+    const userDoc = await db.collection("users").doc(user.uid).get();
+    const userData = userDoc.data();
+    const githubLogin =
+      userData?.github &&
+      typeof userData.github === "object" &&
+      typeof (userData.github as { login?: string }).login === "string"
+        ? (userData.github as { login: string }).login.trim()
+        : "";
+
+    if (!githubLogin) {
+      return NextResponse.json(
+        { error: "GitHub account must be connected to claim a certificate" },
+        { status: 400 }
+      );
+    }
+
+    // Check if certificate already exists (idempotent)
+    const certDocId = getCertificateDocId(user.uid);
+    const existingDoc = await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).get();
+    if (existingDoc.exists) {
+      const existing = parseCertificateFromFirestore(
+        certDocId,
+        existingDoc.data() as Record<string, unknown>
+      );
+      if (existing) {
+        return NextResponse.json({
+          certificate: existing,
+          linkedInAddToProfileUrl: buildLinkedInAddToProfileUrl(existing),
+        });
+      }
+    }
+
+    // Verify merged PR count via real-time GitHub reconciliation
+    const { mergedPrCount } = await reconcileMergedPrCreditForUser(user.uid, githubLogin);
+
+    if (mergedPrCount < CERTIFICATE_PR_THRESHOLD) {
+      return NextResponse.json(
+        {
+          error: "Not enough merged pull requests",
+          eligible: false,
+          pullRequestsCount: mergedPrCount,
+          required: CERTIFICATE_PR_THRESHOLD,
+        },
+        { status: 403 }
+      );
+    }
+
+    // Create certificate
+    const displayName = userData?.displayName || user.name || githubLogin;
+    const certUrl = getCertVerifyUrl(certDocId);
+
+    await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).set({
+      id: certDocId,
+      userId: user.uid,
+      displayName,
+      githubLogin,
+      pullRequestsCount: mergedPrCount,
+      issuedAt: FieldValue.serverTimestamp(),
+      certName: CERTIFICATE_NAME,
+      certUrl,
+    });
+
+    // Read back to get the server timestamp resolved
+    const createdDoc = await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).get();
+    const certificate = parseCertificateFromFirestore(
+      certDocId,
+      createdDoc.data() as Record<string, unknown>
+    );
+
+    if (!certificate) {
+      return NextResponse.json({ error: "Failed to create certificate" }, { status: 500 });
+    }
+
+    logger.info("Certificate claimed", {
+      userId: user.uid,
+      githubLogin,
+      mergedPrCount,
+      certDocId,
+    });
+
+    return NextResponse.json({
+      certificate,
+      linkedInAddToProfileUrl: buildLinkedInAddToProfileUrl(certificate),
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/certificate/claim",
+      method: "POST",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/certificate/_components/CertificateCard.tsx
+++ b/app/certificate/_components/CertificateCard.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Award, ExternalLink } from "lucide-react";
+import { LinkedInIcon } from "@/components/icons";
+import type { Certificate } from "@/types/certificate";
+
+interface CertificateCardProps {
+  certificate: Certificate;
+  linkedInAddToProfileUrl: string;
+}
+
+export function CertificateCard({ certificate, linkedInAddToProfileUrl }: CertificateCardProps) {
+  const issuedDate = new Date(certificate.issuedAt);
+  const formattedDate = issuedDate.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Certificate visual */}
+      <div className="rounded-2xl border-2 border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-8 text-center relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-emerald-50/50 to-transparent dark:from-emerald-950/20 dark:to-transparent" />
+        <div className="relative">
+          <div className="flex justify-center mb-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
+              <Award className="h-7 w-7 text-emerald-600 dark:text-emerald-400" />
+            </div>
+          </div>
+          <p className="text-xs uppercase tracking-widest text-neutral-500 dark:text-neutral-400 mb-2">
+            Certificate of Achievement
+          </p>
+          <h2 className="text-2xl font-bold text-foreground mb-1">
+            {certificate.certName}
+          </h2>
+          <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+            Awarded to
+          </p>
+          <p className="text-xl font-semibold text-foreground mb-1">
+            {certificate.displayName}
+          </p>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
+            @{certificate.githubLogin}
+          </p>
+          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
+            <span className="text-emerald-700 dark:text-emerald-300 font-medium">
+              {certificate.pullRequestsCount} merged PRs
+            </span>
+          </div>
+          <p className="mt-4 text-xs text-neutral-400 dark:text-neutral-500">
+            Issued {formattedDate}
+          </p>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <a
+          href={linkedInAddToProfileUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-1 inline-flex items-center justify-center gap-2 rounded-lg bg-[#0A66C2] px-4 py-3 text-sm font-medium text-white hover:bg-[#004182] transition-colors"
+        >
+          <LinkedInIcon size={16} />
+          Add to LinkedIn Profile
+        </a>
+        <a
+          href={certificate.certUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-1 inline-flex items-center justify-center gap-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-4 py-3 text-sm font-medium text-foreground hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
+        >
+          <ExternalLink className="h-4 w-4" />
+          View Verification Page
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/app/certificate/_components/CertificateProgress.tsx
+++ b/app/certificate/_components/CertificateProgress.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { CERTIFICATE_PR_THRESHOLD } from "@/lib/certificate";
+
+interface CertificateProgressProps {
+  pullRequestsCount: number;
+}
+
+export function CertificateProgress({ pullRequestsCount }: CertificateProgressProps) {
+  const remaining = CERTIFICATE_PR_THRESHOLD - pullRequestsCount;
+  const percentage = Math.min(
+    100,
+    Math.round((pullRequestsCount / CERTIFICATE_PR_THRESHOLD) * 100)
+  );
+
+  return (
+    <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800">
+          <span className="text-lg">🔒</span>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Certificate Locked</h2>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            Merge {remaining} more PR{remaining !== 1 ? "s" : ""} to unlock
+          </p>
+        </div>
+      </div>
+
+      <div className="mb-2">
+        <div className="flex justify-between text-sm mb-1">
+          <span className="text-neutral-600 dark:text-neutral-400">Progress</span>
+          <span className="font-medium text-foreground">
+            {pullRequestsCount} / {CERTIFICATE_PR_THRESHOLD} merged PRs
+          </span>
+        </div>
+        <div className="h-3 rounded-full bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm text-neutral-500 dark:text-neutral-400">
+        Contribute to the{" "}
+        <a
+          href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-emerald-600 dark:text-emerald-400 hover:underline"
+        >
+          Cursor Boston repository
+        </a>{" "}
+        and get your pull requests merged to earn your certificate.
+      </p>
+    </div>
+  );
+}

--- a/app/certificate/page.tsx
+++ b/app/certificate/page.tsx
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Award } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { CERTIFICATE_PR_THRESHOLD } from "@/lib/certificate";
+import type { ProfileDataApiResponse } from "@/lib/profile-data-types";
+import type { Certificate, CertificateClaimResponse } from "@/types/certificate";
+import { CertificateCard } from "./_components/CertificateCard";
+import { CertificateProgress } from "./_components/CertificateProgress";
+
+export default function CertificatePage() {
+  const { user, userProfile, loading } = useAuth();
+  const router = useRouter();
+  const [pullRequestsCount, setPullRequestsCount] = useState<number>(0);
+  const [loadingData, setLoadingData] = useState(true);
+  const [claiming, setClaiming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [certificate, setCertificate] = useState<Certificate | null>(null);
+  const [linkedInUrl, setLinkedInUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login?redirect=/certificate");
+    }
+  }, [loading, user, router]);
+
+  // Fetch PR count and check for existing certificate
+  useEffect(() => {
+    if (!user) return;
+
+    (async () => {
+      try {
+        const headers = { Authorization: `Bearer ${await user.getIdToken()}` };
+
+        // Fetch profile data (includes PR count)
+        const res = await fetch("/api/profile/data", { headers });
+        if (!res.ok) throw new Error(`Profile data failed: ${res.status}`);
+        const json = (await res.json()) as ProfileDataApiResponse;
+
+        let prCount = json.stats.pullRequestsCount ?? 0;
+
+        // If GitHub connected but 0 PRs, try reconciliation
+        const githubLogin =
+          userProfile?.github &&
+          typeof userProfile.github === "object" &&
+          "login" in userProfile.github &&
+          typeof (userProfile.github as { login?: string }).login === "string"
+            ? (userProfile.github as { login: string }).login.trim()
+            : "";
+
+        if (githubLogin && prCount === 0) {
+          const res2 = await fetch("/api/profile/data?reconcileGithub=1", {
+            headers: { Authorization: `Bearer ${await user.getIdToken()}` },
+          });
+          if (res2.ok) {
+            const json2 = (await res2.json()) as ProfileDataApiResponse;
+            prCount = json2.stats.pullRequestsCount ?? 0;
+          }
+        }
+
+        setPullRequestsCount(prCount);
+
+        // Try to claim to check if already claimed (idempotent endpoint)
+        if (prCount >= CERTIFICATE_PR_THRESHOLD) {
+          const claimRes = await fetch("/api/certificate/claim", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${await user.getIdToken()}`,
+            },
+          });
+          if (claimRes.ok) {
+            const claimData = (await claimRes.json()) as CertificateClaimResponse;
+            setCertificate(claimData.certificate);
+            setLinkedInUrl(claimData.linkedInAddToProfileUrl);
+          }
+        }
+      } catch (err) {
+        console.error("Error loading certificate data:", err);
+      } finally {
+        setLoadingData(false);
+      }
+    })();
+  }, [user, userProfile]);
+
+  const handleClaim = async () => {
+    if (!user) return;
+    setClaiming(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/certificate/claim", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${await user.getIdToken()}`,
+        },
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to claim certificate");
+        return;
+      }
+
+      const data = (await res.json()) as CertificateClaimResponse;
+      setCertificate(data.certificate);
+      setLinkedInUrl(data.linkedInAddToProfileUrl);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  if (loading || !user) {
+    return (
+      <div className="min-h-[80vh] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900 dark:border-white" />
+      </div>
+    );
+  }
+
+  const isEligible = pullRequestsCount >= CERTIFICATE_PR_THRESHOLD;
+
+  return (
+    <div className="min-h-[80vh] px-6 py-8 md:py-12">
+      <div className="max-w-2xl mx-auto">
+        <section className="mb-6">
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-2">
+            LinkedIn Certificate
+          </h1>
+          <p className="text-neutral-600 dark:text-neutral-400 max-w-2xl">
+            Earn your Cursor Boston Open Source Contributor certificate by merging{" "}
+            {CERTIFICATE_PR_THRESHOLD} pull requests, then add it to your LinkedIn profile.
+          </p>
+        </section>
+
+        {loadingData ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900 dark:border-white" />
+          </div>
+        ) : certificate && linkedInUrl ? (
+          <CertificateCard certificate={certificate} linkedInAddToProfileUrl={linkedInUrl} />
+        ) : isEligible ? (
+          <div className="rounded-2xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-6 text-center">
+            <div className="flex justify-center mb-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
+                <Award className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+              </div>
+            </div>
+            <h2 className="text-xl font-semibold text-foreground mb-2">
+              You&apos;re eligible!
+            </h2>
+            <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+              You have {pullRequestsCount} merged PRs. Claim your certificate to add it to
+              your LinkedIn profile.
+            </p>
+            {error && (
+              <p className="text-sm text-red-600 dark:text-red-400 mb-4">{error}</p>
+            )}
+            <button
+              onClick={handleClaim}
+              disabled={claiming}
+              className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {claiming ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-white" />
+                  Claiming...
+                </>
+              ) : (
+                <>
+                  <Award className="h-4 w-4" />
+                  Claim Your Certificate
+                </>
+              )}
+            </button>
+          </div>
+        ) : (
+          <CertificateProgress pullRequestsCount={pullRequestsCount} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/certificate/verify/[certId]/page.tsx
+++ b/app/certificate/verify/[certId]/page.tsx
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Award, CheckCircle } from "lucide-react";
+import { GitHubIcon } from "@/components/icons";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  CERTIFICATES_COLLECTION,
+  parseCertificateFromFirestore,
+} from "@/lib/certificate";
+
+interface Props {
+  params: Promise<{ certId: string }>;
+}
+
+async function getCertificate(certId: string) {
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const doc = await db.collection(CERTIFICATES_COLLECTION).doc(certId).get();
+  if (!doc.exists) return null;
+
+  return parseCertificateFromFirestore(certId, doc.data() as Record<string, unknown>);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { certId } = await params;
+  const cert = await getCertificate(certId);
+
+  if (!cert) {
+    return { title: "Certificate Not Found | Cursor Boston" };
+  }
+
+  return {
+    title: `${cert.displayName} - ${cert.certName} | Cursor Boston`,
+    description: `${cert.displayName} (@${cert.githubLogin}) earned the ${cert.certName} certificate with ${cert.pullRequestsCount} merged pull requests.`,
+    openGraph: {
+      title: `${cert.displayName} - ${cert.certName}`,
+      description: `Verified open source contributor with ${cert.pullRequestsCount} merged PRs to Cursor Boston.`,
+      type: "profile",
+    },
+  };
+}
+
+export default async function CertificateVerifyPage({ params }: Props) {
+  const { certId } = await params;
+  const cert = await getCertificate(certId);
+
+  if (!cert) {
+    notFound();
+  }
+
+  const issuedDate = new Date(cert.issuedAt);
+  const formattedDate = issuedDate.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="min-h-[80vh] px-6 py-8 md:py-12">
+      <div className="max-w-2xl mx-auto">
+        {/* Verified badge */}
+        <div className="flex items-center gap-2 mb-6">
+          <CheckCircle className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+          <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+            Verified Certificate
+          </span>
+        </div>
+
+        {/* Certificate display */}
+        <div className="rounded-2xl border-2 border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-8 text-center relative overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-br from-emerald-50/50 to-transparent dark:from-emerald-950/20 dark:to-transparent" />
+          <div className="relative">
+            <div className="flex justify-center mb-4">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
+                <Award className="h-7 w-7 text-emerald-600 dark:text-emerald-400" />
+              </div>
+            </div>
+            <p className="text-xs uppercase tracking-widest text-neutral-500 dark:text-neutral-400 mb-2">
+              Certificate of Achievement
+            </p>
+            <h1 className="text-2xl font-bold text-foreground mb-1">
+              {cert.certName}
+            </h1>
+            <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+              Awarded to
+            </p>
+            <p className="text-xl font-semibold text-foreground mb-1">
+              {cert.displayName}
+            </p>
+            <a
+              href={`https://github.com/${cert.githubLogin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-neutral-500 dark:text-neutral-400 hover:text-foreground transition-colors mb-4"
+            >
+              <GitHubIcon size={14} />
+              @{cert.githubLogin}
+            </a>
+            <div className="flex justify-center">
+              <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
+                <span className="text-emerald-700 dark:text-emerald-300 font-medium">
+                  {cert.pullRequestsCount} merged PRs
+                </span>
+              </div>
+            </div>
+            <p className="mt-4 text-xs text-neutral-400 dark:text-neutral-500">
+              Issued {formattedDate}
+            </p>
+          </div>
+        </div>
+
+        {/* Verification details */}
+        <div className="mt-6 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-4">
+          <h2 className="text-sm font-medium text-foreground mb-3">Verification Details</h2>
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Certificate ID</dt>
+              <dd className="font-mono text-foreground">{cert.id}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Issued By</dt>
+              <dd className="text-foreground">Cursor Boston</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Issue Date</dt>
+              <dd className="text-foreground">{formattedDate}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Merged PRs at Issuance</dt>
+              <dd className="text-foreground">{cert.pullRequestsCount}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-neutral-400 dark:text-neutral-500">
+          This certificate was issued by{" "}
+          <a
+            href="https://cursorboston.com"
+            className="hover:underline"
+          >
+            Cursor Boston
+          </a>{" "}
+          for open source contributions to the{" "}
+          <a
+            href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            cursor-boston
+          </a>{" "}
+          repository.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -18,6 +18,7 @@ import {
   type ReactNode,
 } from "react";
 import {
+  Award,
   BarChart2,
   BookOpen,
   Briefcase,
@@ -76,6 +77,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/showcase", label: "Showcase", icon: LayoutGrid },
       { href: "/cookbook", label: "Cookbook", icon: ChefHat },
       { href: "/opportunities", label: "Opportunities", icon: Briefcase },
+      { href: "/certificate", label: "Certificate", icon: Award },
     ],
   },
   {

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -113,6 +113,12 @@ service cloud.firestore {
       allow write: if false; // Only server-side writes via webhook
     }
 
+    // Certificates - public read for LinkedIn verification, server-side writes only
+    match /certificates/{certId} {
+      allow read: if true;
+      allow write: if false; // Only server-side writes via Admin SDK
+    }
+
     // API rate limiter buckets - server-side only
     match /apiRateLimits/{docId} {
       allow read, write: if false;

--- a/lib/certificate.ts
+++ b/lib/certificate.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Certificate } from "@/types/certificate";
+
+export const CERTIFICATES_COLLECTION = "certificates";
+export const CERTIFICATE_PR_THRESHOLD = 10;
+export const CERTIFICATE_NAME = "Cursor Boston Open Source Contributor";
+export const LINKEDIN_ORGANIZATION_ID = "112955918";
+
+function getSiteOrigin(): string {
+  return process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com";
+}
+
+export function getCertificateDocId(userId: string): string {
+  return `cert_${userId}`;
+}
+
+export function getCertVerifyUrl(certId: string): string {
+  return `${getSiteOrigin()}/certificate/verify/${certId}`;
+}
+
+export function buildLinkedInAddToProfileUrl(cert: Certificate): string {
+  const issuedDate = new Date(cert.issuedAt);
+  const params = new URLSearchParams({
+    startTask: "CERTIFICATION_NAME",
+    name: cert.certName,
+    organizationId: LINKEDIN_ORGANIZATION_ID,
+    issueYear: String(issuedDate.getFullYear()),
+    issueMonth: String(issuedDate.getMonth() + 1),
+    certUrl: cert.certUrl,
+    certId: cert.id,
+  });
+  return `https://www.linkedin.com/profile/add?${params.toString()}`;
+}
+
+export function parseCertificateFromFirestore(
+  docId: string,
+  data: Record<string, unknown>
+): Certificate | null {
+  const rawIssuedAt = data.issuedAt as
+    | string
+    | { toDate?: () => Date; seconds?: number }
+    | undefined;
+
+  let issuedAt: string | null = null;
+  if (typeof rawIssuedAt === "string") {
+    issuedAt = rawIssuedAt;
+  } else if (rawIssuedAt && typeof rawIssuedAt.toDate === "function") {
+    issuedAt = rawIssuedAt.toDate().toISOString();
+  } else if (rawIssuedAt && typeof rawIssuedAt.seconds === "number") {
+    issuedAt = new Date(rawIssuedAt.seconds * 1000).toISOString();
+  }
+
+  if (
+    !data.userId ||
+    !data.displayName ||
+    !data.githubLogin ||
+    !issuedAt ||
+    typeof data.pullRequestsCount !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    id: (data.id as string) || docId,
+    userId: data.userId as string,
+    displayName: data.displayName as string,
+    githubLogin: data.githubLogin as string,
+    pullRequestsCount: data.pullRequestsCount as number,
+    issuedAt,
+    certName: (data.certName as string) || CERTIFICATE_NAME,
+    certUrl: (data.certUrl as string) || getCertVerifyUrl(docId),
+  };
+}

--- a/types/certificate.ts
+++ b/types/certificate.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export interface Certificate {
+  id: string;
+  userId: string;
+  displayName: string;
+  githubLogin: string;
+  pullRequestsCount: number;
+  issuedAt: string;
+  certName: string;
+  certUrl: string;
+}
+
+export interface CertificateClaimResponse {
+  certificate: Certificate;
+  linkedInAddToProfileUrl: string;
+}
+
+export interface CertificateClaimErrorResponse {
+  error: string;
+  eligible?: false;
+  pullRequestsCount?: number;
+  required?: number;
+}


### PR DESCRIPTION
Users with 10+ merged PRs can claim a "Cursor Boston Open Source Contributor"
certificate and add it to their LinkedIn profile via LinkedIn's Add to Profile
URL. Includes a public verification page for LinkedIn to link back to.

- New types, library helpers, and API route for certificate claiming
- Certificate page with progress bar, claim flow, and LinkedIn button
- Public /certificate/verify/[certId] page with OpenGraph metadata
- Firestore rules for certificates collection (public read, server write)
- Navigation entry in AppShell sidebar under Participate

https://claude.ai/code/session_01W238fiMXGRDJK18MXsKRxP