### PR TITLE
release: develop → main — treasure hunt + LinkedIn certificates

### DIFF
--- a/app/api/certificate/claim/route.ts
+++ b/app/api/certificate/claim/route.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getClientIdentifier } from "@/lib/rate-limit";
+import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
+import { reconcileMergedPrCreditForUser } from "@/lib/github-merged-pr-reconcile";
+import {
+  CERTIFICATES_COLLECTION,
+  CERTIFICATE_PR_THRESHOLD,
+  CERTIFICATE_NAME,
+  getCertificateDocId,
+  getCertVerifyUrl,
+  parseCertificateFromFirestore,
+  buildLinkedInAddToProfileUrl,
+} from "@/lib/certificate";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateResult = await checkServerRateLimit(request as unknown as Request, {
+      scope: "certificate-claim",
+      windowMs: RATE_LIMIT.windowMs,
+      maxRequests: RATE_LIMIT.maxRequests,
+      identifier: `uid:${user.uid}|ip:${getClientIdentifier(request as unknown as Request)}`,
+      fallbackMode: "strict-memory",
+      fallbackMaxRequests: 5,
+    });
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        {
+          status: rateResult.statusCode ?? 429,
+          headers: buildRateLimitHeaders(rateResult, RATE_LIMIT.maxRequests),
+        }
+      );
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    // Fetch user profile to get GitHub login
+    const userDoc = await db.collection("users").doc(user.uid).get();
+    const userData = userDoc.data();
+    const githubLogin =
+      userData?.github &&
+      typeof userData.github === "object" &&
+      typeof (userData.github as { login?: string }).login === "string"
+        ? (userData.github as { login: string }).login.trim()
+        : "";
+
+    if (!githubLogin) {
+      return NextResponse.json(
+        { error: "GitHub account must be connected to claim a certificate" },
+        { status: 400 }
+      );
+    }
+
+    // Check if certificate already exists (idempotent)
+    const certDocId = getCertificateDocId(user.uid);
+    const existingDoc = await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).get();
+    if (existingDoc.exists) {
+      const existing = parseCertificateFromFirestore(
+        certDocId,
+        existingDoc.data() as Record<string, unknown>
+      );
+      if (existing) {
+        return NextResponse.json({
+          certificate: existing,
+          linkedInAddToProfileUrl: buildLinkedInAddToProfileUrl(existing),
+        });
+      }
+    }
+
+    // Verify merged PR count via real-time GitHub reconciliation
+    const { mergedPrCount } = await reconcileMergedPrCreditForUser(user.uid, githubLogin);
+
+    if (mergedPrCount < CERTIFICATE_PR_THRESHOLD) {
+      return NextResponse.json(
+        {
+          error: "Not enough merged pull requests",
+          eligible: false,
+          pullRequestsCount: mergedPrCount,
+          required: CERTIFICATE_PR_THRESHOLD,
+        },
+        { status: 403 }
+      );
+    }
+
+    // Create certificate
+    const displayName = userData?.displayName || user.name || githubLogin;
+    const certUrl = getCertVerifyUrl(certDocId);
+
+    await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).set({
+      id: certDocId,
+      userId: user.uid,
+      displayName,
+      githubLogin,
+      pullRequestsCount: mergedPrCount,
+      issuedAt: FieldValue.serverTimestamp(),
+      certName: CERTIFICATE_NAME,
+      certUrl,
+    });
+
+    // Read back to get the server timestamp resolved
+    const createdDoc = await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).get();
+    const certificate = parseCertificateFromFirestore(
+      certDocId,
+      createdDoc.data() as Record<string, unknown>
+    );
+
+    if (!certificate) {
+      return NextResponse.json({ error: "Failed to create certificate" }, { status: 500 });
+    }
+
+    logger.info("Certificate claimed", {
+      userId: user.uid,
+      githubLogin,
+      mergedPrCount,
+      certDocId,
+    });
+
+    return NextResponse.json({
+      certificate,
+      linkedInAddToProfileUrl: buildLinkedInAddToProfileUrl(certificate),
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/certificate/claim",
+      method: "POST",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/hunt/oracle/konami/route.ts
+++ b/app/api/hunt/oracle/konami/route.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextResponse } from "next/server";
+import { getKonamiToken } from "@/lib/treasure-hunt-paths";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Returns the rotating daily Konami token. Only reveals it when the client
+ * presents proof they know the sequence (X-Konami-Sequence header). This
+ * stops a casual GET /api/hunt/oracle/konami from leaking the answer.
+ */
+export async function GET(request: Request) {
+  const sequence = request.headers.get("x-konami-sequence") || "";
+  if (sequence !== "UUDDLRLRBA") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ token: getKonamiToken() });
+}

--- a/app/api/hunt/oracle/route.ts
+++ b/app/api/hunt/oracle/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextResponse } from "next/server";
+import { createHash } from "crypto";
+import { getOracleAnswer } from "@/lib/treasure-hunt-paths";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Riddle: "I am what sha256 will become when fed today's salt and the UTC
+ * calendar date in YYYY-MM-DD. Submit my 64 hex characters."
+ *
+ * The client can compute this locally if they reverse-engineer the riddle,
+ * or they can just lift the value off this endpoint — both are valid moves.
+ * We still require them to submit it, so a passive reader doesn't win.
+ */
+export async function GET() {
+  const answerHash = createHash("sha256")
+    .update(getOracleAnswer())
+    .digest("hex")
+    .slice(0, 16);
+  return NextResponse.json({
+    riddle:
+      "I am the sha256 of today's UTC YYYY-MM-DD, salted with a phrase " +
+      "only this server knows. Submit my 64 hex characters at " +
+      "/api/hunt/paths/oracle/submit.",
+    dateUtc: new Date().toISOString().slice(0, 10),
+    answerFingerprint: answerHash,
+  });
+}

--- a/app/api/hunt/paths/[pathId]/submit/route.ts
+++ b/app/api/hunt/paths/[pathId]/submit/route.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { checkTreasureHuntEligibility } from "@/lib/treasure-hunt-eligibility";
+import { claimTreasureHuntPrize } from "@/lib/treasure-hunt-claim";
+import { getPath } from "@/lib/treasure-hunt-paths";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_WRONG_PER_HOUR = 5;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ pathId: string }> }
+) {
+  try {
+    const { pathId } = await params;
+    const path = getPath(pathId);
+    if (!path) {
+      return NextResponse.json({ error: "Unknown path" }, { status: 404 });
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const eligibility = await checkTreasureHuntEligibility(db, user.uid);
+    if (!eligibility.ok) {
+      return NextResponse.json(
+        { ok: false, reason: eligibility.reason },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const answer = typeof body?.answer === "string" ? body.answer : "";
+    if (!answer) {
+      return NextResponse.json({ error: "Missing answer" }, { status: 400 });
+    }
+
+    const rateKey = `${user.uid}__${pathId}`;
+    const rateRef = db.collection("treasureHuntRateLimit").doc(rateKey);
+    const rateSnap = await rateRef.get();
+    const now = Date.now();
+    const windowStart = now - 3600_000;
+    const wrongAttempts = ((rateSnap.data()?.wrongAt as number[]) || []).filter(
+      (t) => t >= windowStart
+    );
+    if (wrongAttempts.length >= MAX_WRONG_PER_HOUR) {
+      return NextResponse.json(
+        { ok: false, reason: "rate_limited" },
+        { status: 429 }
+      );
+    }
+
+    const ok = await path.verify(answer, {
+      uid: user.uid,
+      email: user.email || "",
+    });
+    if (!ok) {
+      await rateRef.set(
+        {
+          wrongAt: [...wrongAttempts, now],
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+      return NextResponse.json({ ok: false, reason: "wrong_answer" });
+    }
+
+    const claim = await claimTreasureHuntPrize(db, {
+      uid: user.uid,
+      email: user.email || "",
+      displayName: user.name || "",
+      pathId,
+    });
+    if (!claim.ok) {
+      return NextResponse.json(
+        { ok: false, reason: claim.reason },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      pathId,
+      message: "You cracked it. Check your email for the credit link.",
+    });
+  } catch (e) {
+    console.error("[hunt/paths/submit]", e);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/app/api/hunt/status/route.ts
+++ b/app/api/hunt/status/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  checkTreasureHuntEligibility,
+  treasureHuntEnabled,
+} from "@/lib/treasure-hunt-eligibility";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  if (!treasureHuntEnabled()) {
+    return NextResponse.json({ enabled: false });
+  }
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ enabled: true, eligible: false, reason: "not_signed_in" });
+    }
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const eligibility = await checkTreasureHuntEligibility(db, user.uid);
+
+    const [poolSnap, pathWinnersSnap] = await Promise.all([
+      db.collection("treasureHuntPrizes").where("status", "==", "available").count().get(),
+      db.collection("treasureHuntPathWinners").count().get(),
+    ]);
+
+    return NextResponse.json({
+      enabled: true,
+      eligible: eligibility.ok,
+      reason: eligibility.ok ? null : eligibility.reason,
+      prizesRemaining: poolSnap.data().count,
+      pathsClaimed: pathWinnersSnap.data().count,
+    });
+  } catch (e) {
+    console.error("[hunt/status]", e);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/app/api/internal/hunt/email-retry/route.ts
+++ b/app/api/internal/hunt/email-retry/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * Retries delivery of treasure-hunt prize emails where the claim transaction
+ * committed but Mailgun failed. Scans treasureHuntProgress docs with a prize
+ * assigned but no emailSentAt, re-sends, and marks them delivered.
+ *
+ * Invoke via Vercel cron (schedule in vercel.json) with CRON_SECRET header.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { sendEmail } from "@/lib/mailgun";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+function getCronSecret(request: NextRequest): string | null {
+  return (
+    request.headers.get("x-cron-secret") ||
+    request.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ||
+    null
+  );
+}
+
+async function handle(request: NextRequest) {
+  if (!CRON_SECRET) {
+    return NextResponse.json({ error: "CRON_SECRET missing" }, { status: 500 });
+  }
+  const provided = getCronSecret(request);
+  if (provided !== CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const db = getAdminDb();
+  if (!db) return NextResponse.json({ error: "No DB" }, { status: 500 });
+
+  const stuckSnap = await db
+    .collection("treasureHuntProgress")
+    .where("prizeEmailSentAt", "==", null)
+    .limit(25)
+    .get();
+
+  let sent = 0;
+  let failed = 0;
+  for (const doc of stuckSnap.docs) {
+    const d = doc.data();
+    const to = typeof d.winnerEmail === "string" ? d.winnerEmail : "";
+    const url = typeof d.prizeCreditUrl === "string" ? d.prizeCreditUrl : "";
+    if (!to || !url) continue;
+    try {
+      await sendEmail({
+        to,
+        subject: "🗺️ Your Cursor credit (retry)",
+        text: `Here is your Cursor credit link:\n\n${url}\n\n— Cursor Boston`,
+        html: `<p>Here is your Cursor credit link:</p><p><a href="${url}">${url}</a></p><p>— Cursor Boston</p>`,
+      });
+      await doc.ref.set(
+        { prizeEmailSentAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      sent += 1;
+    } catch (e) {
+      logger.warn("[hunt/email-retry] send failed", { uid: doc.id, error: String(e) });
+      failed += 1;
+    }
+  }
+
+  return NextResponse.json({ scanned: stuckSnap.size, sent, failed });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/certificate/_components/CertificateCard.tsx
+++ b/app/certificate/_components/CertificateCard.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Award, ExternalLink } from "lucide-react";
+import { LinkedInIcon } from "@/components/icons";
+import type { Certificate } from "@/types/certificate";
+
+interface CertificateCardProps {
+  certificate: Certificate;
+  linkedInAddToProfileUrl: string;
+}
+
+export function CertificateCard({ certificate, linkedInAddToProfileUrl }: CertificateCardProps) {
+  const issuedDate = new Date(certificate.issuedAt);
+  const formattedDate = issuedDate.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Certificate visual */}
+      <div className="rounded-2xl border-2 border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-8 text-center relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-emerald-50/50 to-transparent dark:from-emerald-950/20 dark:to-transparent" />
+        <div className="relative">
+          <div className="flex justify-center mb-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
+              <Award className="h-7 w-7 text-emerald-600 dark:text-emerald-400" />
+            </div>
+          </div>
+          <p className="text-xs uppercase tracking-widest text-neutral-500 dark:text-neutral-400 mb-2">
+            Certificate of Achievement
+          </p>
+          <h2 className="text-2xl font-bold text-foreground mb-1">
+            {certificate.certName}
+          </h2>
+          <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+            Awarded to
+          </p>
+          <p className="text-xl font-semibold text-foreground mb-1">
+            {certificate.displayName}
+          </p>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
+            @{certificate.githubLogin}
+          </p>
+          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
+            <span className="text-emerald-700 dark:text-emerald-300 font-medium">
+              {certificate.pullRequestsCount} merged PRs
+            </span>
+          </div>
+          <p className="mt-4 text-xs text-neutral-400 dark:text-neutral-500">
+            Issued {formattedDate}
+          </p>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <a
+          href={linkedInAddToProfileUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-1 inline-flex items-center justify-center gap-2 rounded-lg bg-[#0A66C2] px-4 py-3 text-sm font-medium text-white hover:bg-[#004182] transition-colors"
+        >
+          <LinkedInIcon size={16} />
+          Add to LinkedIn Profile
+        </a>
+        <a
+          href={certificate.certUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-1 inline-flex items-center justify-center gap-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-4 py-3 text-sm font-medium text-foreground hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
+        >
+          <ExternalLink className="h-4 w-4" />
+          View Verification Page
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/app/certificate/_components/CertificateProgress.tsx
+++ b/app/certificate/_components/CertificateProgress.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { CERTIFICATE_PR_THRESHOLD } from "@/lib/certificate";
+
+interface CertificateProgressProps {
+  pullRequestsCount: number;
+}
+
+export function CertificateProgress({ pullRequestsCount }: CertificateProgressProps) {
+  const remaining = CERTIFICATE_PR_THRESHOLD - pullRequestsCount;
+  const percentage = Math.min(
+    100,
+    Math.round((pullRequestsCount / CERTIFICATE_PR_THRESHOLD) * 100)
+  );
+
+  return (
+    <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800">
+          <span className="text-lg">🔒</span>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Certificate Locked</h2>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            Merge {remaining} more PR{remaining !== 1 ? "s" : ""} to unlock
+          </p>
+        </div>
+      </div>
+
+      <div className="mb-2">
+        <div className="flex justify-between text-sm mb-1">
+          <span className="text-neutral-600 dark:text-neutral-400">Progress</span>
+          <span className="font-medium text-foreground">
+            {pullRequestsCount} / {CERTIFICATE_PR_THRESHOLD} merged PRs
+          </span>
+        </div>
+        <div className="h-3 rounded-full bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm text-neutral-500 dark:text-neutral-400">
+        Contribute to the{" "}
+        <a
+          href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-emerald-600 dark:text-emerald-400 hover:underline"
+        >
+          Cursor Boston repository
+        </a>{" "}
+        and get your pull requests merged to earn your certificate.
+      </p>
+    </div>
+  );
+}

--- a/app/certificate/page.tsx
+++ b/app/certificate/page.tsx
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Award } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { CERTIFICATE_PR_THRESHOLD } from "@/lib/certificate";
+import type { ProfileDataApiResponse } from "@/lib/profile-data-types";
+import type { Certificate, CertificateClaimResponse } from "@/types/certificate";
+import { CertificateCard } from "./_components/CertificateCard";
+import { CertificateProgress } from "./_components/CertificateProgress";
+
+export default function CertificatePage() {
+  const { user, userProfile, loading } = useAuth();
+  const router = useRouter();
+  const [pullRequestsCount, setPullRequestsCount] = useState<number>(0);
+  const [loadingData, setLoadingData] = useState(true);
+  const [claiming, setClaiming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [certificate, setCertificate] = useState<Certificate | null>(null);
+  const [linkedInUrl, setLinkedInUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login?redirect=/certificate");
+    }
+  }, [loading, user, router]);
+
+  // Fetch PR count and check for existing certificate
+  useEffect(() => {
+    if (!user) return;
+
+    (async () => {
+      try {
+        const headers = { Authorization: `Bearer ${await user.getIdToken()}` };
+
+        // Fetch profile data (includes PR count)
+        const res = await fetch("/api/profile/data", { headers });
+        if (!res.ok) throw new Error(`Profile data failed: ${res.status}`);
+        const json = (await res.json()) as ProfileDataApiResponse;
+
+        let prCount = json.stats.pullRequestsCount ?? 0;
+
+        // If GitHub connected but 0 PRs, try reconciliation
+        const githubLogin =
+          userProfile?.github &&
+          typeof userProfile.github === "object" &&
+          "login" in userProfile.github &&
+          typeof (userProfile.github as { login?: string }).login === "string"
+            ? (userProfile.github as { login: string }).login.trim()
+            : "";
+
+        if (githubLogin && prCount === 0) {
+          const res2 = await fetch("/api/profile/data?reconcileGithub=1", {
+            headers: { Authorization: `Bearer ${await user.getIdToken()}` },
+          });
+          if (res2.ok) {
+            const json2 = (await res2.json()) as ProfileDataApiResponse;
+            prCount = json2.stats.pullRequestsCount ?? 0;
+          }
+        }
+
+        setPullRequestsCount(prCount);
+
+        // Try to claim to check if already claimed (idempotent endpoint)
+        if (prCount >= CERTIFICATE_PR_THRESHOLD) {
+          const claimRes = await fetch("/api/certificate/claim", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${await user.getIdToken()}`,
+            },
+          });
+          if (claimRes.ok) {
+            const claimData = (await claimRes.json()) as CertificateClaimResponse;
+            setCertificate(claimData.certificate);
+            setLinkedInUrl(claimData.linkedInAddToProfileUrl);
+          }
+        }
+      } catch (err) {
+        console.error("Error loading certificate data:", err);
+      } finally {
+        setLoadingData(false);
+      }
+    })();
+  }, [user, userProfile]);
+
+  const handleClaim = async () => {
+    if (!user) return;
+    setClaiming(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/certificate/claim", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${await user.getIdToken()}`,
+        },
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to claim certificate");
+        return;
+      }
+
+      const data = (await res.json()) as CertificateClaimResponse;
+      setCertificate(data.certificate);
+      setLinkedInUrl(data.linkedInAddToProfileUrl);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  if (loading || !user) {
+    return (
+      <div className="min-h-[80vh] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900 dark:border-white" />
+      </div>
+    );
+  }
+
+  const isEligible = pullRequestsCount >= CERTIFICATE_PR_THRESHOLD;
+
+  return (
+    <div className="min-h-[80vh] px-6 py-8 md:py-12">
+      <div className="max-w-2xl mx-auto">
+        <section className="mb-6">
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-2">
+            LinkedIn Certificate
+          </h1>
+          <p className="text-neutral-600 dark:text-neutral-400 max-w-2xl">
+            Earn your Cursor Boston Open Source Contributor certificate by merging{" "}
+            {CERTIFICATE_PR_THRESHOLD} pull requests, then add it to your LinkedIn profile.
+          </p>
+        </section>
+
+        {loadingData ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900 dark:border-white" />
+          </div>
+        ) : certificate && linkedInUrl ? (
+          <CertificateCard certificate={certificate} linkedInAddToProfileUrl={linkedInUrl} />
+        ) : isEligible ? (
+          <div className="rounded-2xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-6 text-center">
+            <div className="flex justify-center mb-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
+                <Award className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+              </div>
+            </div>
+            <h2 className="text-xl font-semibold text-foreground mb-2">
+              You&apos;re eligible!
+            </h2>
+            <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+              You have {pullRequestsCount} merged PRs. Claim your certificate to add it to
+              your LinkedIn profile.
+            </p>
+            {error && (
+              <p className="text-sm text-red-600 dark:text-red-400 mb-4">{error}</p>
+            )}
+            <button
+              onClick={handleClaim}
+              disabled={claiming}
+              className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {claiming ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-white" />
+                  Claiming...
+                </>
+              ) : (
+                <>
+                  <Award className="h-4 w-4" />
+                  Claim Your Certificate
+                </>
+              )}
+            </button>
+          </div>
+        ) : (
+          <CertificateProgress pullRequestsCount={pullRequestsCount} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/certificate/verify/[certId]/page.tsx
+++ b/app/certificate/verify/[certId]/page.tsx
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Award, CheckCircle } from "lucide-react";
+import { GitHubIcon } from "@/components/icons";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  CERTIFICATES_COLLECTION,
+  parseCertificateFromFirestore,
+} from "@/lib/certificate";
+
+interface Props {
+  params: Promise<{ certId: string }>;
+}
+
+async function getCertificate(certId: string) {
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const doc = await db.collection(CERTIFICATES_COLLECTION).doc(certId).get();
+  if (!doc.exists) return null;
+
+  return parseCertificateFromFirestore(certId, doc.data() as Record<string, unknown>);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { certId } = await params;
+  const cert = await getCertificate(certId);
+
+  if (!cert) {
+    return { title: "Certificate Not Found | Cursor Boston" };
+  }
+
+  return {
+    title: `${cert.displayName} - ${cert.certName} | Cursor Boston`,
+    description: `${cert.displayName} (@${cert.githubLogin}) earned the ${cert.certName} certificate with ${cert.pullRequestsCount} merged pull requests.`,
+    openGraph: {
+      title: `${cert.displayName} - ${cert.certName}`,
+      description: `Verified open source contributor with ${cert.pullRequestsCount} merged PRs to Cursor Boston.`,
+      type: "profile",
+    },
+  };
+}
+
+export default async function CertificateVerifyPage({ params }: Props) {
+  const { certId } = await params;
+  const cert = await getCertificate(certId);
+
+  if (!cert) {
+    notFound();
+  }
+
+  const issuedDate = new Date(cert.issuedAt);
+  const formattedDate = issuedDate.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="min-h-[80vh] px-6 py-8 md:py-12">
+      <div className="max-w-2xl mx-auto">
+        {/* Verified badge */}
+        <div className="flex items-center gap-2 mb-6">
+          <CheckCircle className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+          <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+            Verified Certificate
+          </span>
+        </div>
+
+        {/* Certificate display */}
+        <div className="rounded-2xl border-2 border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-8 text-center relative overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-br from-emerald-50/50 to-transparent dark:from-emerald-950/20 dark:to-transparent" />
+          <div className="relative">
+            <div className="flex justify-center mb-4">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
+                <Award className="h-7 w-7 text-emerald-600 dark:text-emerald-400" />
+              </div>
+            </div>
+            <p className="text-xs uppercase tracking-widest text-neutral-500 dark:text-neutral-400 mb-2">
+              Certificate of Achievement
+            </p>
+            <h1 className="text-2xl font-bold text-foreground mb-1">
+              {cert.certName}
+            </h1>
+            <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+              Awarded to
+            </p>
+            <p className="text-xl font-semibold text-foreground mb-1">
+              {cert.displayName}
+            </p>
+            <a
+              href={`https://github.com/${cert.githubLogin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-neutral-500 dark:text-neutral-400 hover:text-foreground transition-colors mb-4"
+            >
+              <GitHubIcon size={14} />
+              @{cert.githubLogin}
+            </a>
+            <div className="flex justify-center">
+              <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
+                <span className="text-emerald-700 dark:text-emerald-300 font-medium">
+                  {cert.pullRequestsCount} merged PRs
+                </span>
+              </div>
+            </div>
+            <p className="mt-4 text-xs text-neutral-400 dark:text-neutral-500">
+              Issued {formattedDate}
+            </p>
+          </div>
+        </div>
+
+        {/* Verification details */}
+        <div className="mt-6 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-4">
+          <h2 className="text-sm font-medium text-foreground mb-3">Verification Details</h2>
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Certificate ID</dt>
+              <dd className="font-mono text-foreground">{cert.id}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Issued By</dt>
+              <dd className="text-foreground">Cursor Boston</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Issue Date</dt>
+              <dd className="text-foreground">{formattedDate}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-neutral-500 dark:text-neutral-400">Merged PRs at Issuance</dt>
+              <dd className="text-foreground">{cert.pullRequestsCount}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-neutral-400 dark:text-neutral-500">
+          This certificate was issued by{" "}
+          <a
+            href="https://cursorboston.com"
+            className="hover:underline"
+          >
+            Cursor Boston
+          </a>{" "}
+          for open source contributions to the{" "}
+          <a
+            href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            cursor-boston
+          </a>{" "}
+          repository.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/hunt/[slug]/page.tsx
+++ b/app/hunt/[slug]/page.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { notFound } from "next/navigation";
+import { HuntClaimForm } from "@/components/hunt/HuntClaimForm";
+import { TREASURE_HUNT_PATHS } from "@/lib/treasure-hunt-paths";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * The Librarian path landing. The slug must match
+ * TREASURE_HUNT_LIBRARIAN_SLUG (set via env). Any other slug 404s, so the
+ * page itself gates discovery — a visitor who found the right slug gets the
+ * claim form preloaded; anyone else sees nothing.
+ */
+export default async function HuntSlugPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const expected = (process.env.TREASURE_HUNT_LIBRARIAN_SLUG || "open-sesame")
+    .trim()
+    .toLowerCase();
+  if (slug.trim().toLowerCase() !== expected) notFound();
+  const path = TREASURE_HUNT_PATHS["librarian"];
+  if (!path) notFound();
+  return (
+    <main className="mx-auto max-w-xl px-4 py-16">
+      <h1 className="text-3xl font-bold">
+        {path.emoji} {path.name}
+      </h1>
+      <p className="mt-4 text-zinc-400">
+        You read between the lines. Confirm the slug below to claim.
+      </p>
+      <div className="mt-8">
+        <HuntClaimForm pathId="librarian" initialAnswer={slug} />
+      </div>
+    </main>
+  );
+}

--- a/app/hunt/claim/[pathId]/page.tsx
+++ b/app/hunt/claim/[pathId]/page.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { notFound } from "next/navigation";
+import { TREASURE_HUNT_PATHS } from "@/lib/treasure-hunt-paths";
+import { HuntClaimForm } from "@/components/hunt/HuntClaimForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function HuntClaimPage({
+  params,
+}: {
+  params: Promise<{ pathId: string }>;
+}) {
+  const { pathId } = await params;
+  const path = TREASURE_HUNT_PATHS[pathId];
+  if (!path) notFound();
+
+  return (
+    <main className="mx-auto max-w-xl px-4 py-16">
+      <h1 className="text-3xl font-bold">
+        {path.emoji} {path.name}
+      </h1>
+      <p className="mt-4 text-zinc-400">{path.hint}</p>
+      <div className="mt-8">
+        <HuntClaimForm pathId={path.id} />
+      </div>
+      <p className="mt-8 text-xs text-zinc-500">
+        One winner per path. You must be signed in, have GitHub and Discord
+        linked, and have had a PR merged into the main repo in the last 24
+        hours.
+      </p>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import "./globals.css";
 import AppShell from "@/components/AppShell";
 import WelcomeModal from "@/components/WelcomeModal";
 import LumaCheckoutTracker from "@/components/LumaCheckoutTracker";
+import { KonamiListener } from "@/components/hunt/KonamiListener";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ThemeProvider } from "@/components/ThemeProvider";
 
@@ -124,6 +125,7 @@ export default function RootLayout({
             <AppShell>{children}</AppShell>
             <WelcomeModal />
             <LumaCheckoutTracker />
+            <KonamiListener />
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/app/open-source/page.tsx
+++ b/app/open-source/page.tsx
@@ -8,6 +8,10 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { DiscordIcon } from "@/components/icons";
 
+// 🗺️ Treasure hunt clue — The Code Reader:
+// Somewhere under lib/ lives the function that gates access to a 2026
+// Hack-a-Sprint credit. Find its exported name, translate it to snake_case,
+// and submit at /api/hunt/paths/code-reader/submit.
 export const metadata: Metadata = {
   title: "Open Source",
   description: "Cursor Boston is open source - Explore our roadmap and find ways to contribute.",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -12,7 +12,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/live/', '/hackathons/team/', '/hackathons/pool/', '/profile', '/hackathons/hack-a-sprint-2026/signup', '/agents/claim/'],
+        disallow: ['/api/', '/live/', '/hackathons/team/', '/hackathons/pool/', '/profile', '/hackathons/hack-a-sprint-2026/signup', '/agents/claim/', '/hunt/'],
       },
     ],
     sitemap: 'https://cursorboston.com/sitemap.xml',

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -18,6 +18,7 @@ import {
   type ReactNode,
 } from "react";
 import {
+  Award,
   BarChart2,
   BookOpen,
   Briefcase,
@@ -76,6 +77,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/showcase", label: "Showcase", icon: LayoutGrid },
       { href: "/cookbook", label: "Cookbook", icon: ChefHat },
       { href: "/opportunities", label: "Opportunities", icon: Briefcase },
+      { href: "/certificate", label: "Certificate", icon: Award },
     ],
   },
   {

--- a/components/hunt/HuntClaimForm.tsx
+++ b/components/hunt/HuntClaimForm.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+
+export function HuntClaimForm({
+  pathId,
+  initialAnswer = "",
+}: {
+  pathId: string;
+  initialAnswer?: string;
+}) {
+  const { user } = useAuth();
+  const [answer, setAnswer] = useState(initialAnswer);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<null | {
+    ok: boolean;
+    message: string;
+  }>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!user) {
+      setResult({ ok: false, message: "Sign in first." });
+      return;
+    }
+    setSubmitting(true);
+    setResult(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/hunt/paths/${pathId}/submit`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ answer }),
+      });
+      const j = (await res.json()) as {
+        ok?: boolean;
+        reason?: string;
+        message?: string;
+      };
+      if (j.ok) {
+        setResult({
+          ok: true,
+          message: j.message || "Claimed. Check your email for the credit link.",
+        });
+      } else {
+        const reasonMap: Record<string, string> = {
+          wrong_answer: "That's not it. Try again.",
+          not_signed_in: "Sign in first.",
+          no_github: "Link your GitHub on your profile.",
+          no_discord: "Link your Discord on your profile.",
+          no_recent_pr:
+            "You need a PR merged into the main repo in the last 24 hours.",
+          already_won: "You've already claimed a prize.",
+          email_already_won: "Your email has already won.",
+          path_taken: "Someone else cracked this path first.",
+          pool_empty: "All prizes have been claimed.",
+          rate_limited: "Too many wrong answers. Try again in an hour.",
+          feature_disabled: "The hunt is paused.",
+        };
+        setResult({
+          ok: false,
+          message: reasonMap[j.reason || ""] || `Failed: ${j.reason || "unknown"}`,
+        });
+      }
+    } catch {
+      setResult({ ok: false, message: "Network error." });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <label className="block text-sm font-medium">
+        Your answer
+        <input
+          type="text"
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+          className="mt-1 block w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 font-mono text-sm"
+          autoComplete="off"
+          spellCheck={false}
+          required
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={submitting || !user}
+        className="rounded bg-amber-500 px-4 py-2 text-sm font-semibold text-zinc-900 hover:bg-amber-400 disabled:opacity-50"
+      >
+        {submitting ? "Submitting…" : user ? "Submit" : "Sign in to submit"}
+      </button>
+      {result && (
+        <p
+          className={`text-sm ${result.ok ? "text-emerald-400" : "text-rose-400"}`}
+          role="status"
+        >
+          {result.message}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/components/hunt/KonamiListener.tsx
+++ b/components/hunt/KonamiListener.tsx
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+
+const SEQUENCE = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+];
+
+export function KonamiListener() {
+  const { user } = useAuth();
+  const [revealed, setRevealed] = useState<null | { token?: string; error?: string }>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<null | string>(null);
+
+  useEffect(() => {
+    let index = 0;
+    function onKey(e: KeyboardEvent) {
+      const expected = SEQUENCE[index];
+      if (e.key.toLowerCase() === expected?.toLowerCase()) {
+        index += 1;
+        if (index === SEQUENCE.length) {
+          index = 0;
+          void fetch("/api/hunt/oracle/konami", {
+            headers: { "X-Konami-Sequence": "UUDDLRLRBA" },
+          })
+            .then(async (r) => {
+              if (!r.ok) {
+                setRevealed({ error: "Not today." });
+                return;
+              }
+              const j = (await r.json()) as { token?: string };
+              if (j.token) setRevealed({ token: j.token });
+            })
+            .catch(() => setRevealed({ error: "Network error." }));
+        }
+      } else {
+        index = 0;
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  async function submit() {
+    if (!user || !revealed?.token) return;
+    setSubmitting(true);
+    setResult(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/hunt/paths/konami/submit", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ answer: revealed.token }),
+      });
+      const j = (await res.json()) as { ok?: boolean; reason?: string; message?: string };
+      if (j.ok) {
+        setResult(j.message || "Claimed. Check your email.");
+      } else {
+        setResult(`Failed: ${j.reason || "unknown"}`);
+      }
+    } catch {
+      setResult("Network error.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!revealed) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Konami path"
+      className="fixed bottom-4 right-4 z-50 max-w-sm rounded-lg border border-amber-500/50 bg-zinc-900/95 p-4 text-sm text-zinc-100 shadow-xl backdrop-blur"
+    >
+      {revealed.error && <p>{revealed.error}</p>}
+      {revealed.token && (
+        <>
+          <p className="font-semibold">🎮 You found a path.</p>
+          <p className="mt-1 font-mono text-xs text-amber-300">
+            token: {revealed.token}
+          </p>
+          {!user && (
+            <p className="mt-2 text-xs text-zinc-400">
+              Sign in and connect GitHub + Discord to claim.
+            </p>
+          )}
+          {user && (
+            <button
+              type="button"
+              onClick={submit}
+              disabled={submitting}
+              className="mt-2 rounded bg-amber-500 px-3 py-1 text-xs font-semibold text-zinc-900 hover:bg-amber-400 disabled:opacity-50"
+            >
+              {submitting ? "Submitting…" : "Claim prize"}
+            </button>
+          )}
+          {result && <p className="mt-2 text-xs">{result}</p>}
+        </>
+      )}
+      <button
+        type="button"
+        onClick={() => setRevealed(null)}
+        className="absolute right-1 top-1 text-xs text-zinc-500 hover:text-zinc-300"
+        aria-label="Close"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -303,5 +303,26 @@ service cloud.firestore {
     match /eventContacts/{docId} {
       allow read, write: if false;
     }
+
+    // Treasure hunt prize pool — Admin SDK only (server-side claim via transactions)
+    match /treasureHuntPrizes/{docId} {
+      allow read, write: if false;
+    }
+
+    // Treasure hunt per-user progress — readable by owner, server-only writes
+    match /treasureHuntProgress/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if false;
+    }
+
+    // Treasure hunt per-path winner index — Admin SDK only
+    match /treasureHuntPathWinners/{pathId} {
+      allow read, write: if false;
+    }
+
+    // Treasure hunt rate-limit buckets — Admin SDK only
+    match /treasureHuntRateLimit/{docId} {
+      allow read, write: if false;
+    }
   }
 }

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -113,6 +113,12 @@ service cloud.firestore {
       allow write: if false; // Only server-side writes via webhook
     }
 
+    // Certificates - public read for LinkedIn verification, server-side writes only
+    match /certificates/{certId} {
+      allow read: if true;
+      allow write: if false; // Only server-side writes via Admin SDK
+    }
+
     // API rate limiter buckets - server-side only
     match /apiRateLimits/{docId} {
       allow read, write: if false;

--- a/content/blog/welcome-to-cursor-boston.md
+++ b/content/blog/welcome-to-cursor-boston.md
@@ -57,3 +57,6 @@ Check our [events page](/events) for details and registration.
 We're thrilled to be building this community in Boston. See you at our first event!
 
 *— The Cursor Boston Team*
+
+*P.S. The librarian keeps a spare key under the welcome mat. The password is the same as it ever was: the two words every treasure-seeker knows.*
+

--- a/lib/certificate.ts
+++ b/lib/certificate.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Certificate } from "@/types/certificate";
+
+export const CERTIFICATES_COLLECTION = "certificates";
+export const CERTIFICATE_PR_THRESHOLD = 10;
+export const CERTIFICATE_NAME = "Cursor Boston Open Source Contributor";
+export const LINKEDIN_ORGANIZATION_ID = "112955918";
+
+function getSiteOrigin(): string {
+  return process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com";
+}
+
+export function getCertificateDocId(userId: string): string {
+  return `cert_${userId}`;
+}
+
+export function getCertVerifyUrl(certId: string): string {
+  return `${getSiteOrigin()}/certificate/verify/${certId}`;
+}
+
+export function buildLinkedInAddToProfileUrl(cert: Certificate): string {
+  const issuedDate = new Date(cert.issuedAt);
+  const params = new URLSearchParams({
+    startTask: "CERTIFICATION_NAME",
+    name: cert.certName,
+    organizationId: LINKEDIN_ORGANIZATION_ID,
+    issueYear: String(issuedDate.getFullYear()),
+    issueMonth: String(issuedDate.getMonth() + 1),
+    certUrl: cert.certUrl,
+    certId: cert.id,
+  });
+  return `https://www.linkedin.com/profile/add?${params.toString()}`;
+}
+
+export function parseCertificateFromFirestore(
+  docId: string,
+  data: Record<string, unknown>
+): Certificate | null {
+  const rawIssuedAt = data.issuedAt as
+    | string
+    | { toDate?: () => Date; seconds?: number }
+    | undefined;
+
+  let issuedAt: string | null = null;
+  if (typeof rawIssuedAt === "string") {
+    issuedAt = rawIssuedAt;
+  } else if (rawIssuedAt && typeof rawIssuedAt.toDate === "function") {
+    issuedAt = rawIssuedAt.toDate().toISOString();
+  } else if (rawIssuedAt && typeof rawIssuedAt.seconds === "number") {
+    issuedAt = new Date(rawIssuedAt.seconds * 1000).toISOString();
+  }
+
+  if (
+    !data.userId ||
+    !data.displayName ||
+    !data.githubLogin ||
+    !issuedAt ||
+    typeof data.pullRequestsCount !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    id: (data.id as string) || docId,
+    userId: data.userId as string,
+    displayName: data.displayName as string,
+    githubLogin: data.githubLogin as string,
+    pullRequestsCount: data.pullRequestsCount as number,
+    issuedAt,
+    certName: (data.certName as string) || CERTIFICATE_NAME,
+    certUrl: (data.certUrl as string) || getCertVerifyUrl(docId),
+  };
+}

--- a/lib/hackathon-showcase.ts
+++ b/lib/hackathon-showcase.ts
@@ -171,3 +171,24 @@ export async function githubUserHasMergedLabeledShowcasePr(
   const data = (await res.json()) as { total_count?: number };
   return typeof data.total_count === "number" && data.total_count > 0;
 }
+
+/**
+ * Whether the GitHub user has any merged PR in the community repo within the
+ * last `windowHours` hours. Uses the GitHub Search API `merged:>ISO` filter.
+ */
+export async function githubUserHasRecentlyMergedPr(
+  githubLogin: string,
+  windowHours: number
+): Promise<boolean> {
+  if (!githubLogin || windowHours <= 0) return false;
+  const { owner, repo } = getGithubRepoPair();
+  const since = new Date(Date.now() - windowHours * 3600 * 1000).toISOString();
+  const q = encodeURIComponent(
+    `repo:${owner}/${repo} is:pr is:merged author:${githubLogin} merged:>${since}`
+  );
+  const url = `https://api.github.com/search/issues?q=${q}&per_page=1`;
+  const res = await fetch(url, { headers: githubHeaders() });
+  if (!res.ok) return false;
+  const data = (await res.json()) as { total_count?: number };
+  return typeof data.total_count === "number" && data.total_count > 0;
+}

--- a/lib/treasure-hunt-claim.ts
+++ b/lib/treasure-hunt-claim.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { sendEmail } from "@/lib/mailgun";
+import { emailAlreadyWon } from "@/lib/treasure-hunt-eligibility";
+
+export type ClaimResult =
+  | { ok: true; code: string; creditUrl: string; pathId: string }
+  | {
+      ok: false;
+      reason:
+        | "already_won"
+        | "email_already_won"
+        | "pool_empty"
+        | "path_taken"
+        | "no_email";
+    };
+
+/**
+ * Atomically awards the first available prize in `treasureHuntPrizes` to the
+ * caller. Records progress in `treasureHuntProgress/{uid}`. Sends the credit
+ * email via Mailgun after the transaction commits. Idempotent per-uid.
+ *
+ * One winner per path enforced via an index doc at
+ * `treasureHuntPathWinners/{pathId}`.
+ */
+export async function claimTreasureHuntPrize(
+  db: Firestore,
+  opts: {
+    uid: string;
+    email: string;
+    displayName: string;
+    pathId: string;
+  }
+): Promise<ClaimResult> {
+  const { uid, email, displayName, pathId } = opts;
+  const to = email.trim();
+  if (!to) return { ok: false, reason: "no_email" };
+  const lower = to.toLowerCase();
+
+  if (await emailAlreadyWon(db, lower)) {
+    return { ok: false, reason: "email_already_won" };
+  }
+
+  const progressRef = db.collection("treasureHuntProgress").doc(uid);
+  const pathWinnerRef = db.collection("treasureHuntPathWinners").doc(pathId);
+
+  const awarded = await db.runTransaction(async (tx) => {
+    const [progressSnap, pathWinnerSnap] = await Promise.all([
+      tx.get(progressRef),
+      tx.get(pathWinnerRef),
+    ]);
+    if (progressSnap.exists && progressSnap.data()?.prizeCodeId) {
+      return { status: "already_won" as const };
+    }
+    if (pathWinnerSnap.exists) {
+      return { status: "path_taken" as const };
+    }
+    const poolQ = await tx.get(
+      db
+        .collection("treasureHuntPrizes")
+        .where("status", "==", "available")
+        .limit(1)
+    );
+    if (poolQ.empty) return { status: "pool_empty" as const };
+    const prize = poolQ.docs[0]!;
+    const pd = prize.data();
+    tx.update(prize.ref, {
+      status: "claimed",
+      claimedByUid: uid,
+      claimedByEmail: to,
+      claimedPath: pathId,
+      claimedAt: FieldValue.serverTimestamp(),
+    });
+    tx.set(pathWinnerRef, {
+      pathId,
+      winnerUid: uid,
+      winnerEmail: to,
+      prizeCodeId: prize.id,
+      claimedAt: FieldValue.serverTimestamp(),
+    });
+    tx.set(
+      progressRef,
+      {
+        uid,
+        winnerEmail: to,
+        winnerEmailLower: lower,
+        prizeCodeId: prize.id,
+        prizeCreditUrl: pd.creditUrl,
+        pathsSolved: FieldValue.arrayUnion(pathId),
+        firstSolveAt: FieldValue.serverTimestamp(),
+        prizeEmailSentAt: null,
+      },
+      { merge: true }
+    );
+    return {
+      status: "awarded" as const,
+      code: prize.id,
+      creditUrl: pd.creditUrl as string,
+    };
+  });
+
+  if (awarded.status !== "awarded") {
+    return { ok: false, reason: awarded.status };
+  }
+
+  try {
+    const name = displayName.trim() || "there";
+    await sendEmail({
+      to,
+      subject: "🗺️ You found it — your Cursor credit inside",
+      text:
+        `Hi ${name},\n\n` +
+        `You cracked the "${pathId}" path of the Cursor Boston treasure hunt. ` +
+        `Here is your personal Cursor credit link (do not share it):\n\n` +
+        `${awarded.creditUrl}\n\n` +
+        `— Cursor Boston`,
+      html:
+        `<p>Hi ${name},</p>` +
+        `<p>You cracked the <strong>${pathId}</strong> path of the Cursor Boston treasure hunt. ` +
+        `Here is your personal Cursor credit link — <strong>do not share it</strong>:</p>` +
+        `<p><a href="${awarded.creditUrl}">${awarded.creditUrl}</a></p>` +
+        `<p>— Cursor Boston</p>`,
+    });
+    await progressRef.set(
+      { prizeEmailSentAt: FieldValue.serverTimestamp() },
+      { merge: true }
+    );
+  } catch (err) {
+    console.error("[treasure-hunt-claim] email send failed", err);
+    // The retry cron will catch this: progressRef.prizeEmailSentAt stays null.
+  }
+
+  return { ok: true, code: awarded.code, creditUrl: awarded.creditUrl, pathId };
+}

--- a/lib/treasure-hunt-eligibility.ts
+++ b/lib/treasure-hunt-eligibility.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Firestore } from "firebase-admin/firestore";
+import { githubUserHasRecentlyMergedPr } from "@/lib/hackathon-showcase";
+
+export const TREASURE_HUNT_PR_WINDOW_HOURS = 24;
+
+export type TreasureHuntReason =
+  | "not_signed_in"
+  | "no_github"
+  | "no_discord"
+  | "no_recent_pr"
+  | "already_won"
+  | "feature_disabled";
+
+export type TreasureHuntEligibility =
+  | { ok: true; githubLogin: string; discordUsername: string }
+  | { ok: false; reason: TreasureHuntReason };
+
+export function treasureHuntEnabled(): boolean {
+  return process.env.TREASURE_HUNT_ENABLED !== "false";
+}
+
+/**
+ * Full eligibility check: auth + GitHub linked + Discord linked + 24h merged PR +
+ * has not already won. Designed to mirror the shape of
+ * resolveHackASprint2026CreditForUser.
+ */
+export async function checkTreasureHuntEligibility(
+  db: Firestore,
+  uid: string
+): Promise<TreasureHuntEligibility> {
+  if (!treasureHuntEnabled()) return { ok: false, reason: "feature_disabled" };
+  if (!uid) return { ok: false, reason: "not_signed_in" };
+
+  const userSnap = await db.collection("users").doc(uid).get();
+  const ud = userSnap.data() || {};
+
+  const githubLogin =
+    ud.github && typeof ud.github === "object"
+      ? ((ud.github as { login?: string }).login || "").trim()
+      : "";
+  if (!githubLogin) return { ok: false, reason: "no_github" };
+
+  const discordUsername =
+    ud.discord && typeof ud.discord === "object"
+      ? ((ud.discord as { username?: string }).username || "").trim()
+      : "";
+  if (!discordUsername) return { ok: false, reason: "no_discord" };
+
+  const progressSnap = await db.collection("treasureHuntProgress").doc(uid).get();
+  const progress = progressSnap.data();
+  if (progress?.prizeCodeId) return { ok: false, reason: "already_won" };
+
+  const hasRecentPr = await githubUserHasRecentlyMergedPr(
+    githubLogin,
+    TREASURE_HUNT_PR_WINDOW_HOURS
+  );
+  if (!hasRecentPr) return { ok: false, reason: "no_recent_pr" };
+
+  return { ok: true, githubLogin, discordUsername };
+}
+
+/**
+ * Checks whether a given verified email has already won — used to block
+ * alt-account farming where a user links different uids to the same email.
+ */
+export async function emailAlreadyWon(
+  db: Firestore,
+  email: string
+): Promise<boolean> {
+  const lower = email.trim().toLowerCase();
+  if (!lower) return false;
+  const snap = await db
+    .collection("treasureHuntProgress")
+    .where("winnerEmailLower", "==", lower)
+    .limit(1)
+    .get();
+  return !snap.empty;
+}

--- a/lib/treasure-hunt-paths.ts
+++ b/lib/treasure-hunt-paths.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { createHash, timingSafeEqual } from "crypto";
+
+/**
+ * Registry of all active treasure-hunt paths and their server-side verifiers.
+ *
+ * A verifier returns true iff the submitted answer is correct. Answers are
+ * never rendered in HTML or shipped to the client; everything lives here.
+ */
+
+export type PathVerifier = (
+  submittedAnswer: string,
+  context: { uid: string; email: string }
+) => boolean | Promise<boolean>;
+
+export type TreasureHuntPath = {
+  id: string;
+  name: string;
+  emoji: string;
+  hint: string;
+  verify: PathVerifier;
+};
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, "");
+}
+
+function sha256Hex(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+function safeEqualLower(a: string, b: string): boolean {
+  const an = normalize(a);
+  const bn = normalize(b);
+  if (an.length !== bn.length) return false;
+  return timingSafeEqual(Buffer.from(an), Buffer.from(bn));
+}
+
+/**
+ * Deterministic daily token for the Konami path. Rotates every UTC day.
+ * Client receives the token via POST /api/hunt/oracle/konami when the user
+ * types the sequence; they resubmit it to claim. Token = first 12 hex of
+ * sha256(KONAMI_SALT + UTC-YYYY-MM-DD).
+ */
+function todayUtcDateStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function getKonamiToken(): string {
+  const salt = process.env.TREASURE_HUNT_KONAMI_SALT || "cursor-boston-konami";
+  return sha256Hex(`${salt}|${todayUtcDateStr()}`).slice(0, 12);
+}
+
+/**
+ * Deterministic oracle token for the API Explorer path. Rotates daily.
+ */
+export function getOracleAnswer(): string {
+  const salt = process.env.TREASURE_HUNT_ORACLE_SALT || "cursor-boston-oracle";
+  return sha256Hex(`${salt}|${todayUtcDateStr()}`);
+}
+
+export const TREASURE_HUNT_PATHS: Record<string, TreasureHuntPath> = {
+  "code-reader": {
+    id: "code-reader",
+    name: "The Code Reader",
+    emoji: "💻",
+    hint:
+      "The whole site is open source. One file under app/ carries a comment " +
+      "hinting at the function that resolves 2026 credits. Name the function " +
+      "in snake_case.",
+    verify: (answer) =>
+      safeEqualLower(answer, "resolve_hack_a_sprint_2026_credit_for_user"),
+  },
+  konami: {
+    id: "konami",
+    name: "The Konami Coder",
+    emoji: "🎮",
+    hint:
+      "Old habits die hard. On the home page, the right sequence surfaces a " +
+      "token. Submit the token here.",
+    verify: (answer) => {
+      const t = getKonamiToken();
+      return safeEqualLower(answer, t);
+    },
+  },
+  oracle: {
+    id: "oracle",
+    name: "The API Explorer",
+    emoji: "🔌",
+    hint:
+      "robots.txt hides a disallowed path. Something lives under /api/hunt/oracle. " +
+      "Compute the answer it describes.",
+    verify: (answer) => safeEqualLower(answer, getOracleAnswer()),
+  },
+  librarian: {
+    id: "librarian",
+    name: "The Librarian",
+    emoji: "📚",
+    hint:
+      "The welcome blog post contains zero-width whispers. Read them, visit " +
+      "/hunt/{slug}, and submit the slug.",
+    verify: (answer) =>
+      safeEqualLower(answer, process.env.TREASURE_HUNT_LIBRARIAN_SLUG || "open-sesame"),
+  },
+  "badge-collector": {
+    id: "badge-collector",
+    name: "The Badge Collector",
+    emoji: "🏅",
+    hint:
+      "Three badges carry hidden bits. Concatenate their slugs in the right " +
+      "order to unlock the claim.",
+    verify: (answer) =>
+      safeEqualLower(
+        answer,
+        process.env.TREASURE_HUNT_BADGE_ANSWER || "firstprshowcasewinnermaintainer"
+      ),
+  },
+  cartographer: {
+    id: "cartographer",
+    name: "The Cartographer",
+    emoji: "🗺️",
+    hint:
+      "Visit five Boston neighborhoods in order. The reveal marker carries " +
+      "a geohash. Submit it.",
+    verify: (answer) =>
+      safeEqualLower(
+        answer,
+        process.env.TREASURE_HUNT_CARTOGRAPHER_GEOHASH || "drt2zmw"
+      ),
+  },
+  "cookbook-alchemist": {
+    id: "cookbook-alchemist",
+    name: "The Cookbook Alchemist",
+    emoji: "🧪",
+    hint:
+      "One cookbook recipe hides a ROT13 line in its tip. Decode it and " +
+      "submit the phrase.",
+    verify: (answer) =>
+      safeEqualLower(
+        answer,
+        process.env.TREASURE_HUNT_COOKBOOK_ANSWER || "promptcachinglovesyou"
+      ),
+  },
+};
+
+export function listPaths(): TreasureHuntPath[] {
+  return Object.values(TREASURE_HUNT_PATHS);
+}
+
+export function getPath(id: string): TreasureHuntPath | null {
+  return TREASURE_HUNT_PATHS[id] || null;
+}

--- a/scripts/treasure-hunt-build-pool.ts
+++ b/scripts/treasure-hunt-build-pool.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Build the treasure-hunt prize pool.
+ *
+ * Selects hack-a-sprint-2026 credit codes that were:
+ *   - never emailed to their original assignee (no hackASprint2026CreditEmailSentAt
+ *     on the assignee's users doc)
+ *   - still "active" on Cursor's referral API
+ *
+ * Writes survivors to the `treasureHuntPrizes` collection, keyed by referral code.
+ *
+ * Usage:
+ *   npx tsx scripts/treasure-hunt-build-pool.ts --dry-run
+ *   npx tsx scripts/treasure-hunt-build-pool.ts --write
+ */
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+const envPath = resolve(process.cwd(), ".env.local");
+if (existsSync(envPath)) {
+  const content = readFileSync(envPath, "utf-8");
+  for (const line of content.split("\n")) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (match && !process.env[match[1]]) {
+      const value = match[2].replace(/^["']|["']$/g, "").trim();
+      process.env[match[1]] = value;
+    }
+  }
+}
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "../lib/hackathon-showcase";
+
+const REFERRAL_REGEX = /https?:\/\/cursor\.com\/referral\?code=([A-Z0-9]+)/i;
+const CHECK_ENDPOINT = "https://cursor.com/api/dashboard/check-referral-code";
+const CHECK_DELAY_MS = 500;
+
+type ReferralStatus = "active" | "redeemed" | "unknown";
+
+async function checkReferral(code: string, retries = 3): Promise<ReferralStatus> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      if (attempt > 0) await new Promise((r) => setTimeout(r, CHECK_DELAY_MS * attempt));
+      const res = await fetch(CHECK_ENDPOINT, {
+        method: "POST",
+        headers: {
+          accept: "*/*",
+          "content-type": "application/json",
+          origin: "https://cursor.com",
+          referer: `https://cursor.com/referral?code=${code}`,
+          "user-agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+        },
+        body: JSON.stringify({ referralCode: code }),
+      });
+      if (res.status === 200) {
+        const json = (await res.json()) as Record<string, unknown>;
+        if (json && typeof json === "object" && "isValid" in json) {
+          const v = json as { isValid: boolean; userIsEligible?: boolean };
+          return v.isValid && v.userIsEligible ? "active" : "redeemed";
+        }
+        if (json && Object.keys(json).length === 0) return "redeemed";
+        const title = (json as { metadata?: { title?: string } })?.metadata?.title?.toLowerCase() ?? "";
+        if (title.includes("already been used") || title.includes("expired")) return "redeemed";
+        return "unknown";
+      }
+      if (res.status === 500 && attempt < retries - 1) continue;
+      return "unknown";
+    } catch {
+      if (attempt < retries - 1) continue;
+      return "unknown";
+    }
+  }
+  return "unknown";
+}
+
+async function findUserByEmail(db: FirebaseFirestore.Firestore, email: string) {
+  const lower = email.trim().toLowerCase();
+  const snap = await db.collection("users").where("email", "==", lower).limit(1).get();
+  if (!snap.empty) return snap.docs[0]!;
+  const snap2 = await db.collection("users").where("email", "==", email).limit(1).get();
+  return snap2.empty ? null : snap2.docs[0]!;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const write = process.argv.includes("--write");
+  if (!dryRun && !write) {
+    console.error("Specify --dry-run or --write");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const codesSnap = await db
+    .collection("hackathonCreditCodes")
+    .where("eventId", "==", HACK_A_SPRINT_2026_EVENT_ID)
+    .get();
+
+  console.log(`Found ${codesSnap.size} code docs for ${HACK_A_SPRINT_2026_EVENT_ID}.`);
+
+  type Candidate = {
+    code: string;
+    creditUrl: string;
+    assignedToEmail: string;
+    assignedToName?: string;
+    role?: string;
+    assigneeUid?: string;
+    emailSent: boolean;
+  };
+
+  const candidates: Candidate[] = [];
+  for (const doc of codesSnap.docs) {
+    const d = doc.data();
+    const url = typeof d.creditUrl === "string" ? d.creditUrl : "";
+    if (!url || url.includes("PLACEHOLDER")) continue;
+    const match = url.match(REFERRAL_REGEX);
+    if (!match) continue;
+    const code = match[1]!.toUpperCase();
+    const email = typeof d.assignedToEmail === "string" ? d.assignedToEmail : "";
+    if (!email) {
+      candidates.push({
+        code,
+        creditUrl: url,
+        assignedToEmail: "",
+        emailSent: false,
+      });
+      continue;
+    }
+    const userDoc = await findUserByEmail(db, email);
+    const emailSent = Boolean(userDoc?.data()?.hackASprint2026CreditEmailSentAt);
+    candidates.push({
+      code,
+      creditUrl: url,
+      assignedToEmail: email,
+      assignedToName: typeof d.assignedToName === "string" ? d.assignedToName : undefined,
+      role: typeof d.role === "string" ? d.role : undefined,
+      assigneeUid: userDoc?.id,
+      emailSent,
+    });
+  }
+
+  const neverEmailed = candidates.filter((c) => !c.emailSent);
+  console.log(
+    `${candidates.length} real codes, ${candidates.length - neverEmailed.length} already emailed, ${neverEmailed.length} never emailed.`
+  );
+
+  console.log(`\nVerifying ${neverEmailed.length} never-emailed codes against Cursor's referral API...`);
+  const verified: Array<Candidate & { status: ReferralStatus }> = [];
+  for (let i = 0; i < neverEmailed.length; i++) {
+    const c = neverEmailed[i]!;
+    const status = await checkReferral(c.code);
+    console.log(`  [${i + 1}/${neverEmailed.length}] ${c.code} → ${status}`);
+    verified.push({ ...c, status });
+    if (i < neverEmailed.length - 1) await new Promise((r) => setTimeout(r, CHECK_DELAY_MS));
+  }
+
+  const pool = verified.filter((v) => v.status === "active");
+  const skippedRedeemed = verified.filter((v) => v.status === "redeemed");
+  const skippedUnknown = verified.filter((v) => v.status === "unknown");
+
+  console.log(
+    `\nPool: ${pool.length} active | ${skippedRedeemed.length} already redeemed | ${skippedUnknown.length} unknown (skipped)`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no Firestore writes. Pool would contain:");
+    for (const p of pool) {
+      console.log(`  ${p.code}  (originally → ${p.assignedToEmail || "<unassigned>"})`);
+    }
+    return;
+  }
+
+  const batch = db.batch();
+  const col = db.collection("treasureHuntPrizes");
+  for (const p of pool) {
+    batch.set(col.doc(p.code), {
+      code: p.code,
+      creditUrl: p.creditUrl,
+      originalAssignee: {
+        email: p.assignedToEmail || null,
+        name: p.assignedToName || null,
+        uid: p.assigneeUid || null,
+        role: p.role || null,
+      },
+      status: "available",
+      claimedByUid: null,
+      claimedByEmail: null,
+      claimedPath: null,
+      claimedAt: null,
+      emailSentAt: null,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  }
+  await batch.commit();
+  console.log(`\nWrote ${pool.length} prize docs to treasureHuntPrizes.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/types/certificate.ts
+++ b/types/certificate.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export interface Certificate {
+  id: string;
+  userId: string;
+  displayName: string;
+  githubLogin: string;
+  pullRequestsCount: number;
+  issuedAt: string;
+  certName: string;
+  certUrl: string;
+}
+
+export interface CertificateClaimResponse {
+  certificate: Certificate;
+  linkedInAddToProfileUrl: string;
+}
+
+export interface CertificateClaimErrorResponse {
+  error: string;
+  eligible?: false;
+  pullRequestsCount?: number;
+  required?: number;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/internal/snapshots/rebuild",
       "schedule": "0 */6 * * *"
+    },
+    {
+      "path": "/api/internal/hunt/email-retry",
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Treasure hunt infrastructure for repurposing 14 unredeemed hack-a-sprint-2026 Cursor credits as prizes across 7 gated paths (code-reader, konami, oracle, librarian, badge-collector, cartographer, cookbook-alchemist). Gates on auth + GitHub + Discord + PR merged in last 24h.
- LinkedIn certificate page for open-source contributors.

## PRs included

- #511 — feat: add LinkedIn certificate page for open source contributors (@Claude via @rogerSuperBuilderAlpha)
- Direct commit on develop: `feat(treasure-hunt)` — 7-path treasure hunt with Firestore-backed prize pool, transactional claims, Mailgun delivery, and a retry cron (@Ludwitt)

## Credit

Thanks to @rogerSuperBuilderAlpha for shipping #511 and to @Ludwitt for the treasure hunt feature.

## Pre-merge state already applied

- Firestore rules for new collections (`treasureHuntPrizes`, `treasureHuntProgress`, `treasureHuntPathWinners`, `treasureHuntRateLimit`) deployed to `cursor-boston`.
- 14 prize docs seeded via `scripts/treasure-hunt-build-pool.ts --write`.
- Production env vars set on Vercel: `TREASURE_HUNT_KONAMI_SALT`, `TREASURE_HUNT_ORACLE_SALT`, `TREASURE_HUNT_LIBRARIAN_SLUG`.

## Test plan

- [ ] `/api/hunt/status` returns `{ enabled: true, prizesRemaining: 14, pathsClaimed: 0 }` for a logged-in user.
- [ ] Konami sequence on home page surfaces the token dialog.
- [ ] `/hunt/open-sesame` renders the Librarian claim form; any other slug 404s.
- [ ] Submission without GitHub + Discord + 24h-merged PR returns 403 with the right reason.
- [ ] Certificate page at `/certificates/[id]` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)