### PR TITLE
docs: align branch prefix in FIRST_CONTRIBUTION with CONTRIBUTING

### DIFF
--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -35,7 +35,7 @@ git checkout -b docs/fix-typo-in-readme    # use type/short-description
 ```
 
 **Branch naming convention:** `type/short-description`
-- `feat/add-voting` for features
+- `feature/add-voting` for features
 - `fix/auth-redirect` for bug fixes
 - `docs/update-api-reference` for documentation
 


### PR DESCRIPTION
## Summary

`docs/FIRST_CONTRIBUTION.md` suggests `feat/add-voting` as the feature-branch prefix, but `.github/CONTRIBUTING.md:146` documents `feature/description` as the canonical convention. Aligning the beginner guide so new contributors learn the same prefix that the main contributing doc uses.

One-line change: `feat/add-voting` → `feature/add-voting` in `docs/FIRST_CONTRIBUTION.md:38`.

## Test plan
- [x] `git diff` shows only the single-word change
- [x] Commit is DCO signed-off