### PR TITLE
feat(ecosystem): add Mass AI ecosystem directory page

### DIFF
--- a/app/ecosystem/layout.tsx
+++ b/app/ecosystem/layout.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Mass AI Ecosystem",
+  description:
+    "Directory of universities, accelerators, AI organizations, research labs, nonprofits, and venture firms shaping AI and technology across Massachusetts.",
+  alternates: { canonical: "https://cursorboston.com/ecosystem" },
+};
+
+export default function EcosystemLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/ecosystem/page.tsx
+++ b/app/ecosystem/page.tsx
@@ -1,0 +1,241 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import ecosystemData from "@/content/ecosystem.json";
+
+type Category =
+  | "university"
+  | "accelerator"
+  | "ai_org"
+  | "vc"
+  | "research_lab"
+  | "nonprofit";
+
+interface EcosystemEntry {
+  id: string;
+  name: string;
+  fullName: string;
+  category: Category;
+  location: string;
+  website: string;
+  description: string;
+  tags: string[];
+}
+
+const CATEGORY_LABEL: Record<Category, string> = {
+  university: "Universities",
+  accelerator: "Accelerators",
+  ai_org: "AI organizations",
+  vc: "Venture capital",
+  research_lab: "Research labs",
+  nonprofit: "Nonprofits",
+};
+
+const CATEGORY_BADGE: Record<Category, string> = {
+  university: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  accelerator: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  ai_org: "bg-purple-500/10 text-purple-700 dark:text-purple-400",
+  vc: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
+  research_lab: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-400",
+  nonprofit: "bg-rose-500/10 text-rose-700 dark:text-rose-400",
+};
+
+const CATEGORY_ORDER: Category[] = [
+  "university",
+  "accelerator",
+  "ai_org",
+  "vc",
+  "research_lab",
+  "nonprofit",
+];
+
+export default function EcosystemPage() {
+  const entries = ecosystemData.entries as EcosystemEntry[];
+  const [activeCategory, setActiveCategory] = useState<Category | "all">("all");
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: entries.length };
+    for (const cat of CATEGORY_ORDER) {
+      c[cat] = entries.filter((e) => e.category === cat).length;
+    }
+    return c;
+  }, [entries]);
+
+  const visibleEntries = useMemo(() => {
+    if (activeCategory === "all") return entries;
+    return entries.filter((e) => e.category === activeCategory);
+  }, [entries, activeCategory]);
+
+  return (
+    <div className="flex flex-col">
+      {/* Hero */}
+      <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="max-w-4xl mx-auto text-center">
+          <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6">
+            Mass AI Ecosystem
+          </h1>
+          <p className="text-xl text-neutral-600 dark:text-neutral-400 max-w-2xl mx-auto">
+            Universities, accelerators, research labs, nonprofits, and venture
+            firms shaping AI and technology across Massachusetts.
+          </p>
+        </div>
+      </section>
+
+      {/* Contribute CTA */}
+      <section className="py-6 px-6 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 text-sm">
+          <p className="text-neutral-700 dark:text-neutral-300">
+            <strong>Is something missing?</strong> Add an entry by opening a PR that edits <code className="font-mono text-xs">content/ecosystem.json</code>.
+          </p>
+          <a
+            href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/ADD_CONTENT.md#add-an-ecosystem-entry"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-1.5 px-4 py-2 rounded-md bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 font-medium hover:bg-neutral-700 dark:hover:bg-neutral-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2"
+          >
+            How to add an entry →
+          </a>
+        </div>
+      </section>
+
+      {/* Category filter chips */}
+      <section className="py-6 px-6 bg-neutral-50 dark:bg-neutral-950 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="max-w-6xl mx-auto flex flex-wrap items-center gap-2">
+          <button
+            onClick={() => setActiveCategory("all")}
+            className={`px-4 py-2 rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 ${
+              activeCategory === "all"
+                ? "bg-foreground text-background"
+                : "bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 text-neutral-600 dark:text-neutral-400 hover:border-neutral-400 dark:hover:border-neutral-600"
+            }`}
+          >
+            All <span className="text-xs opacity-60 ml-1">({counts.all})</span>
+          </button>
+          {CATEGORY_ORDER.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(cat)}
+              disabled={counts[cat] === 0}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 disabled:opacity-40 disabled:cursor-not-allowed ${
+                activeCategory === cat
+                  ? "bg-foreground text-background"
+                  : "bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 text-neutral-600 dark:text-neutral-400 hover:border-neutral-400 dark:hover:border-neutral-600"
+              }`}
+            >
+              {CATEGORY_LABEL[cat]}
+              <span className="text-xs opacity-60 ml-1">({counts[cat] ?? 0})</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Entries grid */}
+      <section className="py-12 px-6">
+        <div className="max-w-6xl mx-auto">
+          {visibleEntries.length === 0 ? (
+            <p className="text-center text-neutral-600 dark:text-neutral-400 py-8">
+              No entries in this category yet.
+            </p>
+          ) : (
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {visibleEntries.map((e) => (
+                <article
+                  key={e.id}
+                  className="bg-white dark:bg-neutral-900 rounded-2xl p-6 border border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors flex flex-col"
+                >
+                  <div className="flex items-start justify-between gap-3 mb-3">
+                    <div className="min-w-0 flex-1">
+                      <h2 className="text-lg font-bold text-foreground leading-tight">
+                        {e.name}
+                      </h2>
+                      <p className="text-xs text-neutral-500 dark:text-neutral-500 mt-0.5 truncate">
+                        {e.fullName}
+                      </p>
+                    </div>
+                    <span
+                      className={`shrink-0 inline-block px-2 py-0.5 text-xs font-medium rounded-full ${CATEGORY_BADGE[e.category]}`}
+                    >
+                      {CATEGORY_LABEL[e.category].replace(/s$/, "")}
+                    </span>
+                  </div>
+
+                  <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed mb-4 flex-1">
+                    {e.description}
+                  </p>
+
+                  <div className="flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-500 mb-3">
+                    <span>{e.location}</span>
+                  </div>
+
+                  {e.tags.length > 0 ? (
+                    <div className="flex flex-wrap gap-1.5 mb-4">
+                      {e.tags.map((t) => (
+                        <span
+                          key={t}
+                          className="inline-block px-2 py-0.5 text-xs text-neutral-600 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-800 rounded"
+                        >
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  <a
+                    href={e.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm font-medium text-emerald-600 dark:text-emerald-400 hover:underline focus-visible:outline-none focus-visible:underline mt-auto"
+                  >
+                    Visit website
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                      <path d="M7 17l9.2-9.2M17 17V7H7" />
+                    </svg>
+                  </a>
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Related CTA */}
+      <section className="py-12 px-6 bg-neutral-50 dark:bg-neutral-950">
+        <div className="max-w-4xl mx-auto text-center">
+          <h2 className="text-xl md:text-2xl font-semibold text-foreground mb-3">
+            Looking for something else?
+          </h2>
+          <p className="text-neutral-600 dark:text-neutral-400 text-sm mb-6">
+            Check out active job listings, co-founder roles, and community events.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/opportunities"
+              className="inline-flex items-center gap-1.5 px-5 py-2 rounded-md border border-neutral-300 dark:border-neutral-700 text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 text-sm font-medium"
+            >
+              Opportunities →
+            </Link>
+            <Link
+              href="/events"
+              className="inline-flex items-center gap-1.5 px-5 py-2 rounded-md border border-neutral-300 dark:border-neutral-700 text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 text-sm font-medium"
+            >
+              Events →
+            </Link>
+            <Link
+              href="/about"
+              className="inline-flex items-center gap-1.5 px-5 py-2 rounded-md border border-neutral-300 dark:border-neutral-700 text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 text-sm font-medium"
+            >
+              About →
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/content/ecosystem.json
+++ b/content/ecosystem.json
@@ -1,0 +1,294 @@
+{
+  "entries": [
+    {
+      "id": "mit-csail",
+      "name": "MIT CSAIL",
+      "fullName": "MIT Computer Science and Artificial Intelligence Laboratory",
+      "category": "research_lab",
+      "location": "Cambridge, MA",
+      "website": "https://www.csail.mit.edu",
+      "description": "MIT's largest interdepartmental research lab — one of the original homes of AI research, now a hub for LLM, robotics, and systems work.",
+      "tags": ["AI", "research", "MIT"]
+    },
+    {
+      "id": "mit-sloan-ai",
+      "name": "MIT Sloan AI",
+      "fullName": "MIT Sloan School of Management — AI initiatives",
+      "category": "university",
+      "location": "Cambridge, MA",
+      "website": "https://mitsloan.mit.edu/",
+      "description": "Business-of-AI research and education at MIT Sloan, with a focus on enterprise AI adoption and management.",
+      "tags": ["AI", "business", "MIT"]
+    },
+    {
+      "id": "mit-engine",
+      "name": "The Engine",
+      "fullName": "The Engine, built by MIT",
+      "category": "accelerator",
+      "location": "Cambridge, MA",
+      "website": "https://engine.xyz",
+      "description": "Tough-tech accelerator spun out of MIT — backs startups in AI, biotech, advanced materials, and climate.",
+      "tags": ["accelerator", "deep tech", "MIT"]
+    },
+    {
+      "id": "harvard-seas",
+      "name": "Harvard SEAS",
+      "fullName": "Harvard John A. Paulson School of Engineering and Applied Sciences",
+      "category": "university",
+      "location": "Cambridge, MA",
+      "website": "https://www.seas.harvard.edu",
+      "description": "Harvard's engineering school with strong programs in applied ML, systems, and computational science.",
+      "tags": ["engineering", "research", "Harvard"]
+    },
+    {
+      "id": "harvard-innovation-labs",
+      "name": "Harvard Innovation Labs",
+      "fullName": "Harvard Innovation Labs (i-lab)",
+      "category": "accelerator",
+      "location": "Allston, MA",
+      "website": "https://innovationlabs.harvard.edu",
+      "description": "Harvard's student + alumni venture incubator. Free programming for early-stage Harvard-affiliated founders.",
+      "tags": ["accelerator", "students", "Harvard"]
+    },
+    {
+      "id": "northeastern-khoury",
+      "name": "Northeastern Khoury",
+      "fullName": "Khoury College of Computer Sciences, Northeastern University",
+      "category": "university",
+      "location": "Boston, MA",
+      "website": "https://www.khoury.northeastern.edu",
+      "description": "Northeastern's computing college — strong in AI, systems, cybersecurity, and the co-op model that ties students to local industry.",
+      "tags": ["CS", "co-op", "Northeastern"]
+    },
+    {
+      "id": "northeastern-roux",
+      "name": "Roux Institute",
+      "fullName": "The Roux Institute at Northeastern University",
+      "category": "research_lab",
+      "location": "Portland, ME",
+      "website": "https://roux.northeastern.edu",
+      "description": "Northeastern's graduate campus focused on AI, life sciences, and digital engineering in partnership with industry.",
+      "tags": ["AI", "research", "Northeastern"]
+    },
+    {
+      "id": "bu-hariri",
+      "name": "BU Hariri Institute",
+      "fullName": "Rafik B. Hariri Institute for Computing, Boston University",
+      "category": "research_lab",
+      "location": "Boston, MA",
+      "website": "https://www.bu.edu/hic/",
+      "description": "BU's interdisciplinary computing institute — funds and connects AI, data science, and computational research across campus.",
+      "tags": ["AI", "research", "BU"]
+    },
+    {
+      "id": "bu-spark",
+      "name": "BU Spark!",
+      "fullName": "BU Spark! — Computing & Data Sciences",
+      "category": "university",
+      "location": "Boston, MA",
+      "website": "https://www.bu.edu/spark/",
+      "description": "BU's technology incubator and experiential learning lab — students build real AI/data products for civic and nonprofit partners.",
+      "tags": ["students", "civic", "BU"]
+    },
+    {
+      "id": "tufts-engineering",
+      "name": "Tufts Engineering",
+      "fullName": "Tufts School of Engineering",
+      "category": "university",
+      "location": "Medford, MA",
+      "website": "https://engineering.tufts.edu",
+      "description": "Tufts' engineering school with strong robotics, human-robot interaction, and applied ML programs.",
+      "tags": ["engineering", "robotics", "Tufts"]
+    },
+    {
+      "id": "umass-amherst",
+      "name": "UMass Amherst",
+      "fullName": "University of Massachusetts Amherst — College of Information and Computer Sciences",
+      "category": "university",
+      "location": "Amherst, MA",
+      "website": "https://www.cics.umass.edu",
+      "description": "UMass's flagship CS program — a top-ranked public school for AI and NLP research.",
+      "tags": ["AI", "NLP", "UMass"]
+    },
+    {
+      "id": "umass-boston",
+      "name": "UMass Boston",
+      "fullName": "University of Massachusetts Boston — Department of Computer Science",
+      "category": "university",
+      "location": "Boston, MA",
+      "website": "https://www.umb.edu/academics/csm/computer-science",
+      "description": "UMass Boston's CS department — urban public university with AI/ML and data science programs.",
+      "tags": ["CS", "public", "UMass"]
+    },
+    {
+      "id": "wpi",
+      "name": "WPI",
+      "fullName": "Worcester Polytechnic Institute",
+      "category": "university",
+      "location": "Worcester, MA",
+      "website": "https://www.wpi.edu",
+      "description": "Project-based STEM university with strong robotics, AI, and interactive-media programs.",
+      "tags": ["engineering", "robotics", "WPI"]
+    },
+    {
+      "id": "bentley",
+      "name": "Bentley University",
+      "fullName": "Bentley University",
+      "category": "university",
+      "location": "Waltham, MA",
+      "website": "https://www.bentley.edu",
+      "description": "Business-tech university in the Boston suburbs — programs in data analytics, information systems, and AI for business.",
+      "tags": ["business", "analytics", "Bentley"]
+    },
+    {
+      "id": "babson",
+      "name": "Babson College",
+      "fullName": "Babson College",
+      "category": "university",
+      "location": "Wellesley, MA",
+      "website": "https://www.babson.edu",
+      "description": "Entrepreneurship-focused business school — top-ranked for startup founder development.",
+      "tags": ["entrepreneurship", "business", "Babson"]
+    },
+    {
+      "id": "olin",
+      "name": "Olin College",
+      "fullName": "Olin College of Engineering",
+      "category": "university",
+      "location": "Needham, MA",
+      "website": "https://www.olin.edu",
+      "description": "Small project-based engineering college — students build and ship real engineering projects from day one.",
+      "tags": ["engineering", "project-based", "Olin"]
+    },
+    {
+      "id": "maic",
+      "name": "MAIC",
+      "fullName": "Massachusetts AI Consortium",
+      "category": "ai_org",
+      "location": "Boston, MA",
+      "website": "https://maic.ai",
+      "description": "Cross-industry coalition bringing together Massachusetts-based companies, academia, and government to shape AI policy and practice.",
+      "tags": ["AI", "policy", "community"]
+    },
+    {
+      "id": "massrobotics",
+      "name": "MassRobotics",
+      "fullName": "MassRobotics",
+      "category": "nonprofit",
+      "location": "Boston, MA",
+      "website": "https://www.massrobotics.org",
+      "description": "Independent nonprofit hub for robotics startups — shared lab space, programs, and industry partnerships.",
+      "tags": ["robotics", "startups", "nonprofit"]
+    },
+    {
+      "id": "masschallenge",
+      "name": "MassChallenge",
+      "fullName": "MassChallenge",
+      "category": "accelerator",
+      "location": "Boston, MA",
+      "website": "https://masschallenge.org",
+      "description": "Equity-free global accelerator, headquartered in Boston. Year-long program for early-stage startups across industries.",
+      "tags": ["accelerator", "equity-free", "global"]
+    },
+    {
+      "id": "techstars-boston",
+      "name": "TechStars Boston",
+      "fullName": "Techstars Boston",
+      "category": "accelerator",
+      "location": "Boston, MA",
+      "website": "https://www.techstars.com/accelerators/boston",
+      "description": "Mentor-driven 13-week accelerator program with Boston-region focus.",
+      "tags": ["accelerator", "mentor-driven", "Techstars"]
+    },
+    {
+      "id": "greentown-labs",
+      "name": "Greentown Labs",
+      "fullName": "Greentown Labs",
+      "category": "accelerator",
+      "location": "Somerville, MA",
+      "website": "https://www.greentownlabs.com",
+      "description": "North America's largest climatetech startup incubator — lab and office space for energy, mobility, and materials startups.",
+      "tags": ["climatetech", "hardware", "incubator"]
+    },
+    {
+      "id": "learnlaunch",
+      "name": "LearnLaunch",
+      "fullName": "LearnLaunch",
+      "category": "accelerator",
+      "location": "Boston, MA",
+      "website": "https://learnlaunch.com",
+      "description": "Edtech-focused accelerator and community — programs for startups building at the intersection of learning and technology.",
+      "tags": ["edtech", "accelerator"]
+    },
+    {
+      "id": "masstlc",
+      "name": "MassTLC",
+      "fullName": "Mass Technology Leadership Council",
+      "category": "nonprofit",
+      "location": "Boston, MA",
+      "website": "https://www.masstlc.org",
+      "description": "Member-led industry association for Massachusetts technology companies — programs, advocacy, and executive peer groups.",
+      "tags": ["industry", "policy", "network"]
+    },
+    {
+      "id": "mass-tech-collaborative",
+      "name": "Mass Tech Collaborative",
+      "fullName": "Massachusetts Technology Collaborative",
+      "category": "nonprofit",
+      "location": "Westborough, MA",
+      "website": "https://masstech.org",
+      "description": "State public agency that invests in tech-driven economic growth across Massachusetts — grants, programs, and ecosystem work.",
+      "tags": ["public", "economic development", "Mass"]
+    },
+    {
+      "id": "mitre",
+      "name": "MITRE",
+      "fullName": "The MITRE Corporation",
+      "category": "research_lab",
+      "location": "Bedford, MA",
+      "website": "https://www.mitre.org",
+      "description": "Federally funded R&D center operating multiple FFRDCs for the U.S. government — significant AI, cybersecurity, and systems research footprint.",
+      "tags": ["research", "federal", "AI"]
+    },
+    {
+      "id": "underscore-vc",
+      "name": "Underscore VC",
+      "fullName": "Underscore VC",
+      "category": "vc",
+      "location": "Boston, MA",
+      "website": "https://underscore.vc",
+      "description": "Boston-based seed-stage venture firm known for its operator-investor Core Community model.",
+      "tags": ["VC", "seed", "Boston"]
+    },
+    {
+      "id": "pillar-vc",
+      "name": "Pillar VC",
+      "fullName": "Pillar VC",
+      "category": "vc",
+      "location": "Boston, MA",
+      "website": "https://www.pillar.vc",
+      "description": "Seed and pre-seed firm investing in Boston-area founders across enterprise software, biotech, and AI.",
+      "tags": ["VC", "seed", "Boston"]
+    },
+    {
+      "id": "general-catalyst",
+      "name": "General Catalyst",
+      "fullName": "General Catalyst (Cambridge office)",
+      "category": "vc",
+      "location": "Cambridge, MA",
+      "website": "https://www.generalcatalyst.com",
+      "description": "Multi-stage VC firm with deep Boston roots — invests across AI, healthcare, and enterprise software.",
+      "tags": ["VC", "multi-stage"]
+    },
+    {
+      "id": "flagship-pioneering",
+      "name": "Flagship Pioneering",
+      "fullName": "Flagship Pioneering",
+      "category": "vc",
+      "location": "Cambridge, MA",
+      "website": "https://www.flagshippioneering.com",
+      "description": "Venture firm and platform that originates, founds, and scales companies at the frontier of life sciences and AI.",
+      "tags": ["VC", "life sciences", "biotech"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New \`/ecosystem\` page: a filterable directory of the Massachusetts AI + tech ecosystem — universities, accelerators, AI orgs, research labs, nonprofits, and VC firms.

Companion to #521 which wires the nav link.

## Seed data (29 entries)

| Category | Entries |
|---|---|
| Universities (12) | MIT (CSAIL, Sloan AI), Harvard (SEAS, Innovation Labs), Northeastern (Khoury, Roux), BU (Hariri, Spark!), Tufts, UMass Amherst, UMass Boston, WPI, Bentley, Babson, Olin |
| Accelerators (6) | The Engine, MassChallenge, TechStars Boston, Greentown Labs, LearnLaunch, Harvard Innovation Labs |
| AI orgs / nonprofits (4) | **MAIC**, MassRobotics, MassTLC, Mass Tech Collaborative |
| Research labs (4) | MIT CSAIL, Roux Institute, BU Hariri, MITRE |
| VC (4) | Underscore VC, Pillar VC, General Catalyst, Flagship Pioneering |

Contributors can add or correct entries via PR to \`content/ecosystem.json\`. The page has a top-level "Is something missing?" CTA linking to the \`ADD_CONTENT.md\` anchor that lands in #521.

## UX

- Filter chips with live counts (All / Universities / Accelerators / AI orgs / VC / Research labs / Nonprofits)
- Card grid with category-colored badges, short description, location, tag chips, website link
- Cross-links at bottom to \`/opportunities\`, \`/events\`, \`/about\`

## Technical

- Page is a client component (filter state). Metadata split into a co-located \`layout.tsx\` so \`title\` + \`description\` ship for SEO.

## Verification

- \`npm test\` — 133 suites / 1260 tests pass
- \`npx tsc --noEmit\` — clean

## Test plan

- [ ] /ecosystem loads with 29 entries by default ("All" filter)
- [ ] Each filter chip narrows to the matching category and shows the right count
- [ ] Website links on cards open in new tab with \`noopener noreferrer\`
- [ ] "How to add an entry" CTA links to the ADD_CONTENT.md anchor on develop
- [ ] Page title shows "Mass AI Ecosystem" in the browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)