### PR TITLE
fix(members): use horizontal layout for badge preview on MemberCard

### DIFF
--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -197,6 +197,7 @@ export function MemberCard({ member }: MemberCardProps) {
           eligibilityMap={badgeEligibilityMap}
           earnedBadgeIds={earnedBadgeIds}
           compact
+          layout="horizontal"
         />
       </div>
 


### PR DESCRIPTION
## Summary

On `/members`, each member card shows a badge preview strip that currently renders mangled — text wraps one word (or character) per line because the cards are squeezed to minimum intrinsic width.

## Root cause

`components/members/MemberCard.tsx` calls `<BadgeGrid ... compact />` without specifying `layout`. That defaults to `layout="grid"`, which applies `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4`. Inside the narrow member-card column, that grid collapses each cell and the badge description wraps badly.

`BadgeGrid` already has a purpose-built `layout="horizontal"` variant (see `components/badges/BadgeGrid.tsx:61-66`) that wraps each card in `min-w-[260px] shrink-0` and enables horizontal scroll — exactly what an embedded preview strip needs.

## Fix

One-line change: opt MemberCard into `layout="horizontal"`.

\`\`\`tsx
<BadgeGrid
  definitions={previewDefinitions}
  eligibilityMap={badgeEligibilityMap}
  earnedBadgeIds={earnedBadgeIds}
  compact
  layout=\"horizontal\"
/>
\`\`\`

No CSS changes; no new props; uses existing BadgeGrid API.

## Test plan
- [x] \`git diff\` shows a single added line
- [x] Commit is DCO signed-off
- [ ] Manually verify on \`/members\` that badge preview renders as a horizontal strip with readable text