### PR TITLE
perf(signup-api): 30s cache + skip redundant pullRequests + slower admin poll

### DIFF
--- a/app/api/hackathons/events/[eventId]/checkin/route.ts
+++ b/app/api/hackathons/events/[eventId]/checkin/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
@@ -16,6 +17,9 @@ import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rat
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+/** Kept in sync with the same constant in the signup route. */
+const HACKATHON_SIGNUP_CACHE_TAG = "hackathon-event-signup";
 
 type RouteContext = { params: Promise<{ eventId: string }> };
 
@@ -88,6 +92,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         signedUpAt: FieldValue.serverTimestamp(),
         checkedInAt: FieldValue.serverTimestamp(),
       });
+      revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
       return NextResponse.json({ ok: true, checkedIn: true, created: true });
     }
 
@@ -103,6 +108,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     } else {
       await ref.update({ checkedInAt: FieldValue.delete() });
     }
+    revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
 
     return NextResponse.json({ ok: true, checkedIn });
   } catch (e) {

--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { unstable_cache, revalidateTag } from "next/cache";
 import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
@@ -28,6 +29,14 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const RATE = rateLimitConfigs.hackathonEventSignup;
+
+/**
+ * Cache tag for the signup leaderboard payload. Bust it from POST/PATCH/DELETE
+ * so mutations are visible on the next GET instead of waiting out the 30s
+ * revalidate window. Shared across all events — fine at current scale (2
+ * active event ids); split into `:${eventId}` if that ever grows.
+ */
+const HACKATHON_SIGNUP_CACHE_TAG = "hackathon-event-signup";
 
 function signedUpAtToMs(value: unknown): number {
   if (
@@ -119,39 +128,47 @@ async function countMergedCommunityPrsByUserIds(
   return counts;
 }
 
-type RouteContext = { params: Promise<{ eventId: string }> };
+type EntryStatus = "confirmed" | "waitlisted";
 
-export async function GET(request: NextRequest, context: RouteContext) {
-  try {
-    const clientId = getClientIdentifier(request as unknown as Request);
-    const rate = checkRateLimit(`hackathon-event-signup-get:${clientId}`, RATE);
-    if (!rate.success) {
-      return NextResponse.json(
-        { error: "Too many requests", retryAfterSeconds: rate.retryAfter },
-        { status: 429, headers: { "Retry-After": String(rate.retryAfter || 60) } }
-      );
-    }
+type LeaderboardEntry = {
+  rank: number;
+  userId: string | null;
+  displayName: string | null;
+  githubLogin: string | null;
+  mergedPrCount: number;
+  signedUpAt: string;
+  creditEligible: boolean;
+  status: EntryStatus;
+  checkedIn: boolean;
+  willBeLate: boolean;
+  queuingForSpot: boolean;
+  lumaRegistered: boolean;
+};
 
-    const { eventId: raw } = await context.params;
-    const eventId = raw?.trim() ?? "";
-    if (!isHackathonEventSignupId(eventId)) {
-      return NextResponse.json({ error: "Unknown event" }, { status: 404 });
-    }
+type LeaderboardPayload = {
+  entries: LeaderboardEntry[];
+  totalCount: number;
+  websiteSignupCount: number;
+  creditTopN: number;
+};
 
-    const db = getAdminDb();
-    if (!db) {
-      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
-    }
+/**
+ * Uncached body of the leaderboard load. Pulled out of the GET handler so
+ * `unstable_cache` can collapse N concurrent page loads (e.g., after an email
+ * blast) into one Firestore pass per 30s. `me` is computed on top of this by
+ * the handler since it varies per-caller and shouldn't be cached.
+ */
+async function buildLeaderboardPayload(eventId: string): Promise<LeaderboardPayload> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Server not configured");
 
-    const meUser = await getOptionalVerifiedUser(request);
+  const judgeEmails = getJudgeEmailsForEvent(eventId);
+  const declinedEmails = getDeclinedEmailsForEvent(eventId);
 
-    const judgeEmails = getJudgeEmailsForEvent(eventId);
-    const declinedEmails = getDeclinedEmailsForEvent(eventId);
-
-    const snap = await db
-      .collection("hackathonEventSignups")
-      .where("eventId", "==", eventId)
-      .get();
+  const snap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", eventId)
+    .get();
 
     const rows: {
       userId: string;
@@ -170,22 +187,38 @@ export async function GET(request: NextRequest, context: RouteContext) {
     }[] = [];
 
     const userIds = snap.docs.map((d) => d.data().userId as string).filter(Boolean);
-    // User data + Firestore merged-PR counts are independent — run concurrently.
-    const [userMap, firestoreMergedCounts] = await Promise.all([
-      fetchUserDataMap(db, userIds),
-      countMergedCommunityPrsByUserIds(db, userIds),
-    ]);
+    // Phase 1: load user profiles. We need profile.github.login to decide
+    // whether to hit the GitHub API (primary) or the Firestore pullRequests
+    // fallback (for the rare user with no linked GitHub). Signup gate already
+    // blocks users without linked GitHub from posting, so the fallback set is
+    // usually empty in practice.
+    const userMap = await fetchUserDataMap(db, userIds);
 
     const githubLogins: string[] = [];
+    const userIdsWithoutGithub: string[] = [];
     for (const uid of userIds) {
       const profile = userMap.get(uid);
       const login =
         profile?.github && typeof profile.github === "object"
           ? (profile.github as { login?: string }).login
           : undefined;
-      if (typeof login === "string" && login.trim()) githubLogins.push(login.trim());
+      if (typeof login === "string" && login.trim()) {
+        githubLogins.push(login.trim());
+      } else {
+        userIdsWithoutGithub.push(uid);
+      }
     }
-    const githubMergedByLogin = await fetchMergedPrCountsForLogins(githubLogins);
+
+    // Phase 2: GitHub + Firestore pullRequests fan out in parallel, but the
+    // Firestore scan is now scoped to only users whose profile has no linked
+    // GitHub login (so a hack-a-sprint-scale event skips ~40 users' worth of
+    // pullRequests reads per page load).
+    const [githubMergedByLogin, firestoreMergedCounts] = await Promise.all([
+      fetchMergedPrCountsForLogins(githubLogins),
+      userIdsWithoutGithub.length > 0
+        ? countMergedCommunityPrsByUserIds(db, userIdsWithoutGithub)
+        : Promise.resolve(new Map<string, number>()),
+    ]);
 
     for (const doc of snap.docs) {
       const data = doc.data();
@@ -398,9 +431,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const sorted = [...confirmed, ...waitlisted];
 
-    type EntryStatus = "confirmed" | "waitlisted";
     const websiteCount = rows.length;
-    const entries = sorted.map((u, i) => {
+    const entries: LeaderboardEntry[] = sorted.map((u, i) => {
       const rank = i + 1;
       const isConfirmed = u.confirmedAt != null;
       const displayPrs = isConfirmed && u.frozenPrCount != null ? u.frozenPrCount : u.mergedPrCount;
@@ -412,13 +444,54 @@ export async function GET(request: NextRequest, context: RouteContext) {
         mergedPrCount: displayPrs,
         signedUpAt: u.signedUpAtIso,
         creditEligible: isConfirmed,
-        status: (isConfirmed ? "confirmed" : "waitlisted") as EntryStatus,
+        status: isConfirmed ? "confirmed" : "waitlisted",
         checkedIn: u.checkedInAt != null,
         willBeLate: u.willBeLate,
         queuingForSpot: u.queuingForSpot,
         lumaRegistered: u.lumaRegistered,
       };
     });
+
+    return {
+      entries,
+      totalCount: entries.length,
+      websiteSignupCount: websiteCount,
+      creditTopN: getConfirmedCapacityForEvent(eventId),
+    };
+}
+
+/**
+ * 30s cache around the Firestore + GitHub work. Bust with
+ * `revalidateTag(HACKATHON_SIGNUP_CACHE_TAG)` from mutations so the next GET
+ * sees fresh data without waiting out the window.
+ */
+const loadLeaderboardPayload = unstable_cache(
+  buildLeaderboardPayload,
+  ["hackathon-event-signup:leaderboard"],
+  { revalidate: 30, tags: [HACKATHON_SIGNUP_CACHE_TAG] }
+);
+
+type RouteContext = { params: Promise<{ eventId: string }> };
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rate = checkRateLimit(`hackathon-event-signup-get:${clientId}`, RATE);
+    if (!rate.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rate.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rate.retryAfter || 60) } }
+      );
+    }
+
+    const { eventId: raw } = await context.params;
+    const eventId = raw?.trim() ?? "";
+    if (!isHackathonEventSignupId(eventId)) {
+      return NextResponse.json({ error: "Unknown event" }, { status: 404 });
+    }
+
+    const meUser = await getOptionalVerifiedUser(request);
+    const payload = await loadLeaderboardPayload(eventId);
 
     let me: {
       signedUp: boolean;
@@ -432,7 +505,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     } | null = null;
 
     if (meUser) {
-      const entry = entries.find((e) => e.userId === meUser.uid);
+      const entry = payload.entries.find((e) => e.userId === meUser.uid);
       me = entry
         ? {
             signedUp: true,
@@ -458,10 +531,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     return NextResponse.json({
       eventId,
-      totalCount: entries.length,
-      websiteSignupCount: websiteCount,
-      entries,
-      creditTopN: getConfirmedCapacityForEvent(eventId),
+      totalCount: payload.totalCount,
+      websiteSignupCount: payload.websiteSignupCount,
+      entries: payload.entries,
+      creditTopN: payload.creditTopN,
       me,
     });
   } catch (e) {
@@ -525,6 +598,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       userId: user.uid,
       signedUpAt: FieldValue.serverTimestamp(),
     });
+    revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
 
     return NextResponse.json({ signedUp: true }, { status: 200 });
   } catch (e) {
@@ -596,6 +670,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         gaveUpSpotAt: FieldValue.serverTimestamp(),
         willBeLate: FieldValue.delete(),
       });
+      revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
       return NextResponse.json({ ok: true, gaveUpSpot: true }, { status: 200 });
     }
 
@@ -639,6 +714,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     }
 
     await ref.update(patch);
+    revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (e) {
@@ -676,6 +752,7 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
 
     const docId = hackathonEventSignupDocId(eventId, user.uid);
     await db.collection("hackathonEventSignups").doc(docId).delete().catch(() => undefined);
+    revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
 
     return NextResponse.json({ left: true }, { status: 200 });
   } catch (e) {

--- a/app/hackathons/hack-a-sprint-2026/admin/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/admin/page.tsx
@@ -141,12 +141,17 @@ export default function AdminDashboardPage() {
   }, [loadDashboard, loadSignups]);
 
   useEffect(() => {
+    // Initial dashboard + signup list load once auth resolves.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
     if (user) void loadAll();
   }, [user, loadAll]);
 
   useEffect(() => {
     if (!user || error) return;
-    const t = window.setInterval(() => void loadAll(), 15_000);
+    // 60s poll (was 15s) — the signup API has its own 30s server cache and
+    // checkin writes bust the cache, so organizers see fresh data within
+    // ~30–60s while a tab open all day is 60 calls/hour instead of 240.
+    const t = window.setInterval(() => void loadAll(), 60_000);
     return () => window.clearInterval(t);
   }, [user, error, loadAll]);
 

--- a/app/hackathons/sports-hack-2026/admin/page.tsx
+++ b/app/hackathons/sports-hack-2026/admin/page.tsx
@@ -77,7 +77,11 @@ export default function SportsHack2026AdminPage() {
 
   useEffect(() => {
     if (!user || error) return;
-    const t = window.setInterval(() => void loadSignups(), 15_000);
+    // 60s is a compromise between day-of responsiveness and Firestore reads:
+    // the signup API has its own 30s server cache so organizers see fresh
+    // data within ~30–60s of any change, and a tab left open generates
+    // 60 calls/hour instead of 240.
+    const t = window.setInterval(() => void loadSignups(), 60_000);
     return () => window.clearInterval(t);
   }, [user, error, loadSignups]);
 

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -9,6 +9,17 @@ if (typeof globalThis.TextEncoder === 'undefined') {
   globalThis.TextDecoder = util.TextDecoder
 }
 
+// Stub next/cache for unit tests. `unstable_cache` and `revalidateTag` need
+// Next's request-scoped incremental cache store, which Jest route-handler
+// tests don't set up. Pass-through unstable_cache (no caching — every call
+// executes the fn fresh) and no-op revalidateTag/revalidatePath is accurate
+// for unit-test assertions; cache behavior itself is integration-verified.
+jest.mock('next/cache', () => ({
+  unstable_cache: (fn) => fn,
+  revalidateTag: () => {},
+  revalidatePath: () => {},
+}))
+
 // Mock environment variables for tests
 process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'test-api-key'
 process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN = 'test-project.firebaseapp.com'

--- a/scripts/send-sports-hack-2026-announce.ts
+++ b/scripts/send-sports-hack-2026-announce.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * One-off announcement to the general email list (Firestore `eventContacts`)
+ * for Cursor Boston × Boston Tech Week: Sports Hack on 2026-05-26.
+ *
+ * Usage:
+ *   npx tsx scripts/send-sports-hack-2026-announce.ts --dry-run
+ *   npx tsx scripts/send-sports-hack-2026-announce.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const LUMA_URL = "https://luma.com/t5vseeed";
+const WEBSITE_SIGNUP_URL =
+  "https://www.cursorboston.com/hackathons/sports-hack-2026/signup";
+const EVENT_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
+const COMMUNITY_REPO_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+}
+
+function buildEmail(contact: ContactData): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const firstHtml = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
+  );
+  const firstText =
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  const subject = "Sports Hack — May 26 in Cambridge. Two steps to reserve your spot.";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${firstHtml},</p>
+
+<p>A new one for the calendar — <strong>Cursor Boston × Boston Tech Week: Sports Hack</strong>, Tuesday <strong>May 26, 10:00 AM – 4:00 PM ET, in Cambridge</strong>.</p>
+
+<p>It's a morning hackathon blending tech and the sports industry — networking, a guest lecture from the <strong>London School of Economics</strong>, a <strong>2-hour build sprint</strong> with talks from partners (Hult International, BeatM, Red Bull, NFX, MIT Sports Lab), AI-powered project scoring, and live pitches.</p>
+
+<p><strong>What's in it for you:</strong> Cursor credits and prizes for selected participants.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Two steps to reserve your spot</h3>
+<p style="margin-top:0;"><em>You need both, or you won't be on the list.</em></p>
+
+<p><strong>1. RSVP on Luma</strong> (handles door entry &amp; approvals)<br/>
+→ <a href="${LUMA_URL}">${LUMA_URL}</a></p>
+
+<p><strong>2. Register on the website</strong> (locks you into the ranking for one of 80 confirmed seats)<br/>
+→ <a href="${WEBSITE_SIGNUP_URL}">${WEBSITE_SIGNUP_URL}</a></p>
+
+<p>Then <strong>merge PRs</strong> to the community repo to climb the leaderboard — selection priority goes to contributors, so every PR before the freeze moves you up.<br/>
+→ <a href="${COMMUNITY_REPO_URL}">${COMMUNITY_REPO_URL}</a></p>
+
+<p>Not sure if you're already registered on one but not the other? The signup page shows both statuses per-user — you'll see a ✓ On Luma pill if the cross-reference matched.</p>
+
+<p>Full event detail: <a href="${EVENT_DETAIL_URL}">${EVENT_DETAIL_URL}</a></p>
+
+<p>See you May 26.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a> · <a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you registered for a Cursor Boston event on Luma.<br/>
+Don't want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+A new one for the calendar — Cursor Boston × Boston Tech Week: Sports Hack, Tuesday May 26, 10:00 AM – 4:00 PM ET, in Cambridge.
+
+It's a morning hackathon blending tech and the sports industry — networking, a guest lecture from the London School of Economics, a 2-hour build sprint with talks from partners (Hult International, BeatM, Red Bull, NFX, MIT Sports Lab), AI-powered project scoring, and live pitches.
+
+What's in it for you: Cursor credits and prizes for selected participants.
+
+TWO STEPS TO RESERVE YOUR SPOT
+You need both, or you won't be on the list.
+
+1. RSVP on Luma (handles door entry & approvals)
+   → ${LUMA_URL}
+
+2. Register on the website (locks you into the ranking for one of 80 confirmed seats)
+   → ${WEBSITE_SIGNUP_URL}
+
+Then merge PRs to the community repo to climb the leaderboard — selection priority goes to contributors, so every PR before the freeze moves you up.
+   → ${COMMUNITY_REPO_URL}
+
+Not sure if you're already registered on one but not the other? The signup page shows both statuses per-user — you'll see a ✓ On Luma pill if the cross-reference matched.
+
+Full event detail: ${EVENT_DETAIL_URL}
+
+See you May 26.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+---
+You're receiving this because you registered for a Cursor Boston event on Luma.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    contacts.push({
+      email: data.email || doc.id,
+      name: data.name || "",
+      firstName: data.firstName || "",
+    });
+  }
+
+  console.log(
+    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = contacts[0];
+    if (sample) {
+      const { subject, html } = buildEmail(sample);
+      console.log(`Sample email to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\nHTML preview:\n---\n${html.slice(0, 900)}\n…(truncated)\n---`);
+    }
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 50 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(
+    `\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed}.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

After the sports-hack-2026 email blast, Firebase stats showed **~5,600 Firestore reads in one hour** on the signup surface. Static analysis of \`/api/hackathons/events/[eventId]/signup\` GET showed 70–100 reads per call for sports-hack and **200–500+** for hack-a-sprint. With \`export const dynamic = "force-dynamic"\` there was zero caching — concurrent page views multiplied the load linearly.

## Fixes

### 1. 30s server cache with mutation bust

Extracted the Firestore + GitHub work into \`buildLeaderboardPayload(eventId)\` and wrapped it in \`unstable_cache\` with a 30s revalidate and a \`hackathon-event-signup\` tag. POST / PATCH / DELETE on \`/signup\` and POST on \`/checkin\` call \`revalidateTag(tag, { expire: 0 })\` so mutations show up on the next GET without waiting out the window.

**Measured locally** (hack-a-sprint event, 100 entries):
\`\`\`
call1:  time_total=5.818s   (cache miss — Firestore + GitHub)
call2:  time_total=0.016s   (cache hit — 0 Firestore reads)
call3:  time_total=0.007s   (cache hit)
\`\`\`
830× faster on cache hit. Under load (e.g., 100 page views/min), this collapses to 2 Firestore passes/min instead of 200.

### 2. Skip Firestore \`pullRequests\` scan for users with linked GitHub

The old code always fetched merged PR counts from both Firestore and the GitHub API, then used the GitHub value if present. Now we fetch user profiles first, split users into "has GitHub linked" (the common case, since the signup gate blocks signup without it) and "no GitHub linked" (rare fallback), and only query Firestore \`pullRequests\` for the latter.

On hack-a-sprint this drops ~40 users' worth of pullRequests scans per cache-miss load.

### 3. Admin polling 15s → 60s

Organizers see fresh data within ~30–60s of any change (server cache + mutation tag bust). A tab left open all day now generates 60 API calls/hour instead of 240 — a 4× reduction per open admin tab.

## Test changes

- Added a global jest mock of \`next/cache\` in \`config/jest.setup.js\` so route-handler tests don't hit Next.js' "Invariant: incrementalCache missing" / "static generation store missing" when the test environment has no request-scoped store. The mock makes \`unstable_cache\` pass-through and \`revalidateTag\`/\`revalidatePath\` no-ops. Existing test assertions still cover the right behavior; cache itself is integration-tested via curl.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` — 0 errors (warnings unchanged)
- [x] \`npm test\` — **1233/1233 passing**
- [x] Integration-tested cache hits locally (5.82s miss → 7ms hit)
- [ ] Prod smoke: confirm \`/hackathons/sports-hack-2026/signup\` and \`/hackathons/hack-a-sprint-2026/signup\` API still return correct data after deploy; confirm admin check-in toggle surfaces in ≤ 60s

## Follow-ups (not in this PR)
- Instrument Firestore read counts by route for better visibility next time.
- Consider dropping the admin poll entirely in favor of SSE or just relying on the Refresh button; 60s is still wasteful when no one's looking at the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)