### PR TITLE
fix(sports-hack): include judges in leaderboard + always-insert Luma rows

### DIFF
--- a/__tests__/lib/sports-hack-2026.test.ts
+++ b/__tests__/lib/sports-hack-2026.test.ts
@@ -47,8 +47,11 @@ describe("sports-hack-2026 constants", () => {
     expect(SPORTS_HACK_2026_LOCATION).toMatch(/Cambridge/);
   });
 
-  it("seeds judge set with organizer email and keeps declined set empty until Luma exports arrive", () => {
-    expect(SPORTS_HACK_2026_JUDGE_EMAILS.has("regorhunt02052@gmail.com")).toBe(true);
+  it("starts with empty judge/declined sets (fresh event, no inherited filters)", () => {
+    // Intentionally empty until sports-hack picks named judges. See
+    // lib/sports-hack-2026.ts — seeding the hack-a-sprint organizer here
+    // caused Roger to be dropped from the Luma import, which was wrong.
+    expect(SPORTS_HACK_2026_JUDGE_EMAILS.size).toBe(0);
     expect(SPORTS_HACK_2026_DECLINED_EMAILS.size).toBe(0);
   });
 

--- a/lib/sports-hack-2026.ts
+++ b/lib/sports-hack-2026.ts
@@ -21,13 +21,12 @@ export const SPORTS_HACK_2026_END_HOUR_ET = 16;
 export const SPORTS_HACK_2026_LOCATION = "Cambridge, MA";
 
 /**
- * Organizer / judge emails — used to keep organizers off the participant list
- * and to bypass door check-in gates for their own accounts. Add more via the
- * `SPORTS_HACK_2026_JUDGE_EMAILS` env var (comma-separated, case-insensitive).
+ * Sports-hack-2026 keeps this set empty on purpose: this is a fresh event
+ * with fresh registrants, so nobody from the hack-a-sprint judge list should
+ * be auto-filtered from the leaderboard or the Luma import. If/when sports
+ * hack picks named judges, add them here.
  */
-export const SPORTS_HACK_2026_JUDGE_EMAILS: ReadonlySet<string> = new Set([
-  "regorhunt02052@gmail.com",
-]);
+export const SPORTS_HACK_2026_JUDGE_EMAILS: ReadonlySet<string> = new Set();
 
 /**
  * Luma registrants who have declined — excluded from participant list.

--- a/scripts/seed-luma-registrants.ts
+++ b/scripts/seed-luma-registrants.ts
@@ -163,7 +163,7 @@ async function main() {
   }
 
   let seeded = 0;
-  let skippedSignup = 0;
+  let alsoOnWebsite = 0;
   let skippedDeclined = 0;
   let skippedJudge = 0;
 
@@ -181,9 +181,13 @@ async function main() {
     }
     approvedEmailsForPrune.add(email);
 
-    // Check if already has a website signup
+    // Always insert the Luma row, even when the registrant also has a
+    // website signup. The unified leaderboard dedupes at API time (matched
+    // rows don't appear twice); keeping the Luma doc lets the signup API
+    // set `lumaRegistered = true` on the website row, which drives the
+    // "✓ On Luma" pill in the UI.
     const uid = usersByEmail.get(email);
-    if (uid && signupUserIds.has(uid)) { skippedSignup++; continue; }
+    if (uid && signupUserIds.has(uid)) alsoOnWebsite++;
 
     const name = [row.first_name, row.last_name].filter(Boolean).join(" ").trim() || row.name?.trim() || "";
     const githubLogin = parseGithubLogin(row[GITHUB_COL_KEY]);
@@ -192,7 +196,8 @@ async function main() {
     const docId = `${eventId}__${email}`;
 
     if (dryRun) {
-      console.log(`  WOULD SEED: ${email} | ${name} | gh:${githubLogin || "—"} | luma:${lumaCreatedAt.slice(0, 10)}`);
+      const tag = uid && signupUserIds.has(uid) ? " [also on website]" : "";
+      console.log(`  WOULD SEED: ${email} | ${name} | gh:${githubLogin || "—"} | luma:${lumaCreatedAt.slice(0, 10)}${tag}`);
     } else {
       await db.collection("hackathonLumaRegistrants").doc(docId).set({
         eventId,
@@ -223,7 +228,7 @@ async function main() {
   }
 
   console.log(
-    `\nSeeded: ${seeded}, skipped (already on website): ${skippedSignup}, declined: ${skippedDeclined}, skipped (judge/ops email): ${skippedJudge}` +
+    `\nSeeded: ${seeded} (${alsoOnWebsite} also have a website signup — still seeded so the "✓ On Luma" pill renders), declined: ${skippedDeclined}, skipped (judge/ops email): ${skippedJudge}` +
       (prune && !dryRun ? `, pruned stale Luma rows: ${pruned}` : "")
   );
   if (dryRun) console.log("--dry-run: nothing written to Firestore.");


### PR DESCRIPTION
Two fixes applied together because both surfaced from the new sports-hack Luma CSV import this afternoon.

## 1. Empty \`SPORTS_HACK_2026_JUDGE_EMAILS\`

The per-event judge filter was originally seeded with Roger's email so he'd bypass check-in gates (inherited pattern from hack-a-sprint). But sports-hack is a **fresh event with fresh names**, and filtering Roger from the Luma import meant he was dropped from the leaderboard even when legitimately Luma-registered.

Sports-hack has no named judges yet. Keep the set empty until there are. Named judges can be added here later.

## 2. Stop skipping Luma rows when the user also has a website signup

\`scripts/seed-luma-registrants.ts\` was skipping any CSV row whose email matched a user with an existing \`hackathonEventSignups\` doc. The *intent* was to keep \`hackathonLumaRegistrants\` from duplicating the leaderboard — but the signup API dedupes at fetch time (\`matchIdx\` logic in \`signup/route.ts:276\`) and *needs* the Luma doc to exist so it can cross-reference and set \`lumaRegistered = true\` on the matching website row.

Before this fix, every website signup whose email was in the Luma list was showing the "⚠ Not on Luma yet" pill instead of "✓ On Luma". After: all 5 current sports-hack website signups correctly show ✓ On Luma on prod.

## Verified

Re-imported the sports-hack Luma CSV:
- 39 CSV rows → 39 seeded (5 also have website signups, flagged in dry-run output as \`[also on website]\`)
- 0 judge/ops skips, 0 declined, 0 pruned
- Prod API now returns **38 leaderboard entries** (5 website + 33 Luma-only — the other 1 matches via GitHub login, not email), **all 5 website rows showing \`lumaRegistered: true\`**.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` 0 errors
- [x] Existing per-event scoping test still passes (sports-hack's judge set is empty; hack-a-sprint's is unchanged)
- [x] Verified via prod API that the pill state is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)