### PR TITLE
release: develop → main (sports-hack Luma match + judge fix)

### DIFF
--- a/__tests__/lib/sports-hack-2026.test.ts
+++ b/__tests__/lib/sports-hack-2026.test.ts
@@ -47,8 +47,11 @@ describe("sports-hack-2026 constants", () => {
     expect(SPORTS_HACK_2026_LOCATION).toMatch(/Cambridge/);
   });
 
-  it("seeds judge set with organizer email and keeps declined set empty until Luma exports arrive", () => {
-    expect(SPORTS_HACK_2026_JUDGE_EMAILS.has("regorhunt02052@gmail.com")).toBe(true);
+  it("starts with empty judge/declined sets (fresh event, no inherited filters)", () => {
+    // Intentionally empty until sports-hack picks named judges. See
+    // lib/sports-hack-2026.ts — seeding the hack-a-sprint organizer here
+    // caused Roger to be dropped from the Luma import, which was wrong.
+    expect(SPORTS_HACK_2026_JUDGE_EMAILS.size).toBe(0);
     expect(SPORTS_HACK_2026_DECLINED_EMAILS.size).toBe(0);
   });
 

--- a/lib/sports-hack-2026.ts
+++ b/lib/sports-hack-2026.ts
@@ -21,13 +21,12 @@ export const SPORTS_HACK_2026_END_HOUR_ET = 16;
 export const SPORTS_HACK_2026_LOCATION = "Cambridge, MA";
 
 /**
- * Organizer / judge emails — used to keep organizers off the participant list
- * and to bypass door check-in gates for their own accounts. Add more via the
- * `SPORTS_HACK_2026_JUDGE_EMAILS` env var (comma-separated, case-insensitive).
+ * Sports-hack-2026 keeps this set empty on purpose: this is a fresh event
+ * with fresh registrants, so nobody from the hack-a-sprint judge list should
+ * be auto-filtered from the leaderboard or the Luma import. If/when sports
+ * hack picks named judges, add them here.
  */
-export const SPORTS_HACK_2026_JUDGE_EMAILS: ReadonlySet<string> = new Set([
-  "regorhunt02052@gmail.com",
-]);
+export const SPORTS_HACK_2026_JUDGE_EMAILS: ReadonlySet<string> = new Set();
 
 /**
  * Luma registrants who have declined — excluded from participant list.

--- a/scripts/seed-luma-registrants.ts
+++ b/scripts/seed-luma-registrants.ts
@@ -163,7 +163,7 @@ async function main() {
   }
 
   let seeded = 0;
-  let skippedSignup = 0;
+  let alsoOnWebsite = 0;
   let skippedDeclined = 0;
   let skippedJudge = 0;
 
@@ -181,9 +181,13 @@ async function main() {
     }
     approvedEmailsForPrune.add(email);
 
-    // Check if already has a website signup
+    // Always insert the Luma row, even when the registrant also has a
+    // website signup. The unified leaderboard dedupes at API time (matched
+    // rows don't appear twice); keeping the Luma doc lets the signup API
+    // set `lumaRegistered = true` on the website row, which drives the
+    // "✓ On Luma" pill in the UI.
     const uid = usersByEmail.get(email);
-    if (uid && signupUserIds.has(uid)) { skippedSignup++; continue; }
+    if (uid && signupUserIds.has(uid)) alsoOnWebsite++;
 
     const name = [row.first_name, row.last_name].filter(Boolean).join(" ").trim() || row.name?.trim() || "";
     const githubLogin = parseGithubLogin(row[GITHUB_COL_KEY]);
@@ -192,7 +196,8 @@ async function main() {
     const docId = `${eventId}__${email}`;
 
     if (dryRun) {
-      console.log(`  WOULD SEED: ${email} | ${name} | gh:${githubLogin || "—"} | luma:${lumaCreatedAt.slice(0, 10)}`);
+      const tag = uid && signupUserIds.has(uid) ? " [also on website]" : "";
+      console.log(`  WOULD SEED: ${email} | ${name} | gh:${githubLogin || "—"} | luma:${lumaCreatedAt.slice(0, 10)}${tag}`);
     } else {
       await db.collection("hackathonLumaRegistrants").doc(docId).set({
         eventId,
@@ -223,7 +228,7 @@ async function main() {
   }
 
   console.log(
-    `\nSeeded: ${seeded}, skipped (already on website): ${skippedSignup}, declined: ${skippedDeclined}, skipped (judge/ops email): ${skippedJudge}` +
+    `\nSeeded: ${seeded} (${alsoOnWebsite} also have a website signup — still seeded so the "✓ On Luma" pill renders), declined: ${skippedDeclined}, skipped (judge/ops email): ${skippedJudge}` +
       (prune && !dryRun ? `, pruned stale Luma rows: ${pruned}` : "")
   );
   if (dryRun) console.log("--dry-run: nothing written to Firestore.");


### PR DESCRIPTION
Ships a two-part fix to the sports-hack-2026 Luma import + leaderboard so pills render correctly and no registrants get silently dropped.

## PRs included (since [#541](https://github.com/rogerSuperBuilderAlpha/cursor-boston/pull/541))

- [#542](https://github.com/rogerSuperBuilderAlpha/cursor-boston/pull/542) \`fix(sports-hack)\`: include judges in leaderboard + always-insert Luma rows — @rogerSuperBuilderAlpha

## What's fixed

**1. Empty \`SPORTS_HACK_2026_JUDGE_EMAILS\`.** The set was previously seeded with Roger's email (inherited pattern from hack-a-sprint), which silently filtered him out of the leaderboard even when he's a valid Luma registrant. Sports-hack is a fresh event with fresh names — no inherited judge filters. Named sports-hack judges can be added later.

**2. Seed script always inserts Luma rows.** \`scripts/seed-luma-registrants.ts\` was skipping CSV rows for registrants who already had a website signup, which meant the signup API had nothing to cross-reference and the "✓ On Luma" pill was showing "⚠ Not on Luma yet" for every matched user. The API already dedupes matched rows at fetch time, so inserting the Luma doc doesn't duplicate leaderboard entries — it just lets cross-reference work.

Verified via the latest sports-hack Luma CSV: all 5 website signups whose emails are in the CSV now show ✓ On Luma on prod (was 0 of 5 before the fix).

## Credit

- **Roger Hunt** (@rogerSuperBuilderAlpha) — sports-hack Luma-match + judge-filter fix

## Rollback

Standard develop→main revert. No schema or Firestore rule changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)