### PR TITLE
docs(ecosystem): add UMass Lowell and AIM Society

### DIFF
--- a/content/ecosystem.json
+++ b/content/ecosystem.json
@@ -121,6 +121,16 @@
       "tags": ["CS", "public", "UMass"]
     },
     {
+      "id": "umass-lowell",
+      "name": "UMass Lowell",
+      "fullName": "University of Massachusetts Lowell",
+      "category": "university",
+      "location": "Lowell, MA",
+      "website": "https://www.uml.edu",
+      "description": "A public research university in Lowell, Massachusetts with strong programs in computer science, engineering, business, and applied research. Just introduced a new Interdisciplinary AI research hub called AICORE.",
+      "tags": ["university", "research", "computer science", "engineering"]
+    },
+    {
       "id": "wpi",
       "name": "WPI",
       "fullName": "Worcester Polytechnic Institute",
@@ -169,6 +179,16 @@
       "website": "https://maic.ai",
       "description": "Cross-industry coalition bringing together Massachusetts-based companies, academia, and government to shape AI policy and practice.",
       "tags": ["AI", "policy", "community"]
+    },
+    {
+      "id": "aim-society-umass-lowell",
+      "name": "AIM Society",
+      "fullName": "Artificial Intelligence Multidisciplinary Society at UMass Lowell",
+      "category": "ai_org",
+      "location": "Lowell, MA",
+      "website": "https://www.aimsociety.org/",
+      "description": "A student-led AI organization at UMass Lowell focused on making AI accessible across majors through projects, workshops, events, and interdisciplinary collaboration. AIM Society is part of the Massachusetts AI Coalition ecosystem.",
+      "tags": ["AI", "students", "community", "education", "Massachusetts AI Coalition"]
     },
     {
       "id": "massrobotics",


### PR DESCRIPTION
• ## Description

  Adds two Massachusetts tech ecosystem entries to `content/ecosystem.json`:

  - UMass Lowell as a university entry
  - AIM Society as an AI organization entry

  These additions expand the `/ecosystem` directory with Lowell-based university and student AI community representation.

  Related issue: N/A

  **Base branch:** `develop`

  ## Type of Change

  - [x] Documentation update

  ## How Has This Been Tested?

  Validated the JSON content locally:

  - [x] Tested locally

  ```bash
  python3 -m json.tool content/ecosystem.json > /tmp/ecosystem-check.json

  ## Checklist

  - [x] My code follows the code style of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] New and existing unit tests pass locally with my changes, or are not applicable for this content-only change

  ## Screenshots

  N/A

  ## Additional Notes

  This is a content-only update to the ecosystem data file.