### PR TITLE
Release: develop → main (Summer Cohort signup)

### DIFF
--- a/app/(auth)/profile/_hooks/useDiscordConnection.ts
+++ b/app/(auth)/profile/_hooks/useDiscordConnection.ts
@@ -18,13 +18,19 @@ export interface DiscordInfo {
   avatar?: string;
 }
 
-export function useDiscordConnection(user: User | null, userProfileDiscord?: DiscordInfo | null) {
+export function useDiscordConnection(
+  user: User | null,
+  userProfileDiscord?: DiscordInfo | null,
+  returnTo?: string
+) {
   const router = useRouter();
   const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [connectedInfo, setConnectedInfo] = useState<DiscordInfo | null>(null);
   const [wasDisconnected, setWasDisconnected] = useState(false);
+
+  const fallbackPath = returnTo || "/profile";
 
   // Priority: explicit disconnection > local state > userProfile
   const discordInfo = wasDisconnected ? null : (connectedInfo || userProfileDiscord || null);
@@ -35,7 +41,10 @@ export function useDiscordConnection(user: User | null, userProfileDiscord?: Dis
       return;
     }
     setConnecting(true);
-    window.location.href = "/api/discord/authorize";
+    const authorizeUrl = returnTo
+      ? `/api/discord/authorize?returnTo=${encodeURIComponent(returnTo)}`
+      : "/api/discord/authorize";
+    window.location.href = authorizeUrl;
   };
 
   const disconnect = async () => {
@@ -57,7 +66,7 @@ export function useDiscordConnection(user: User | null, userProfileDiscord?: Dis
   const handleOAuthSuccess = async (data: Record<string, string>) => {
     if (!user || !db) {
       setError("Please sign in to finish connecting Discord.");
-      router.replace("/login?redirect=/profile");
+      router.replace(`/login?redirect=${encodeURIComponent(fallbackPath)}`);
       return;
     }
     try {
@@ -72,7 +81,7 @@ export function useDiscordConnection(user: User | null, userProfileDiscord?: Dis
       });
       setConnectedInfo(discordUserInfo);
       setWasDisconnected(false);
-      router.replace("/profile", { scroll: false });
+      router.replace(fallbackPath, { scroll: false });
     } catch {
       setError("Failed to save Discord connection");
     }
@@ -84,7 +93,7 @@ export function useDiscordConnection(user: User | null, userProfileDiscord?: Dis
     } else {
       setError("Failed to connect Discord. Please try again.");
     }
-    router.replace("/profile");
+    router.replace(fallbackPath);
   };
 
   return {

--- a/app/(auth)/profile/_hooks/useGithubConnection.ts
+++ b/app/(auth)/profile/_hooks/useGithubConnection.ts
@@ -24,7 +24,8 @@ export function useGithubConnection(
   user: User | null,
   userProfileGithub?: GithubInfo | null,
   userProvider?: string,
-  refreshUserProfile?: () => Promise<void>
+  refreshUserProfile?: () => Promise<void>,
+  returnTo?: string
 ) {
   const router = useRouter();
   const [connecting, setConnecting] = useState(false);
@@ -32,6 +33,8 @@ export function useGithubConnection(
   const [error, setError] = useState<string | null>(null);
   const [connectedInfo, setConnectedInfo] = useState<GithubInfo | null>(null);
   const [wasDisconnected, setWasDisconnected] = useState(false);
+
+  const fallbackPath = returnTo || "/profile";
 
   // Priority: explicit disconnection > local state > userProfile
   const githubInfo = wasDisconnected ? null : (connectedInfo || userProfileGithub || null);
@@ -43,7 +46,10 @@ export function useGithubConnection(
       return;
     }
     setConnecting(true);
-    window.location.href = "/api/github/authorize";
+    const authorizeUrl = returnTo
+      ? `/api/github/authorize?returnTo=${encodeURIComponent(returnTo)}`
+      : "/api/github/authorize";
+    window.location.href = authorizeUrl;
   };
 
   const disconnect = async () => {
@@ -65,7 +71,7 @@ export function useGithubConnection(
   const handleOAuthSuccess = async (data: Record<string, string>) => {
     if (!user || !db) {
       setError("Please sign in to finish connecting GitHub.");
-      router.replace("/login?redirect=/profile");
+      router.replace(`/login?redirect=${encodeURIComponent(fallbackPath)}`);
       return;
     }
     try {
@@ -100,7 +106,7 @@ export function useGithubConnection(
       await refreshUserProfile?.();
       setConnectedInfo(githubUserInfo);
       setWasDisconnected(false);
-      router.replace("/profile", { scroll: false });
+      router.replace(fallbackPath, { scroll: false });
     } catch {
       setError("Failed to save GitHub connection");
     }
@@ -108,7 +114,7 @@ export function useGithubConnection(
 
   const handleOAuthError = () => {
     setError("Failed to connect GitHub. Please try again.");
-    router.replace("/profile");
+    router.replace(fallbackPath);
   };
 
   return {

--- a/app/api/discord/authorize/route.ts
+++ b/app/api/discord/authorize/route.ts
@@ -21,6 +21,12 @@ function getDiscordRedirectUri(request: NextRequest): string {
   return `${url.origin}/api/discord/callback`;
 }
 
+function sanitizeReturnTo(value: string | null): string | null {
+  if (!value) return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
 export async function GET(request: NextRequest) {
   if (!DISCORD_CLIENT_ID) {
     return NextResponse.redirect(
@@ -30,6 +36,7 @@ export async function GET(request: NextRequest) {
 
   const redirectUri = getDiscordRedirectUri(request);
   const state = randomBytes(32).toString("base64url");
+  const returnTo = sanitizeReturnTo(request.nextUrl.searchParams.get("returnTo"));
   const params = new URLSearchParams({
     client_id: DISCORD_CLIENT_ID,
     redirect_uri: redirectUri,
@@ -49,6 +56,16 @@ export async function GET(request: NextRequest) {
     path: "/",
     maxAge: 10 * 60,
   });
+
+  if (returnTo) {
+    response.cookies.set("discord_oauth_return_to", returnTo, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 10 * 60,
+    });
+  }
 
   return response;
 }

--- a/app/api/discord/callback/route.ts
+++ b/app/api/discord/callback/route.ts
@@ -29,28 +29,48 @@ function getDiscordRedirectUri(request: NextRequest): string {
   return `${url.origin}/api/discord/callback`;
 }
 
+function sanitizeReturnTo(value: string | undefined): string | null {
+  if (!value) return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
+function buildCallbackRedirect(
+  request: NextRequest,
+  returnTo: string | null,
+  query: string
+): NextResponse {
+  const target = returnTo || "/profile";
+  const separator = target.includes("?") ? "&" : "?";
+  const response = NextResponse.redirect(
+    new URL(`${target}${separator}${query}`, request.url)
+  );
+  response.cookies.set("discord_oauth_state", "", { maxAge: 0, path: "/" });
+  response.cookies.set("discord_oauth_return_to", "", { maxAge: 0, path: "/" });
+  return response;
+}
+
 async function handleDiscordCallback(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const code = searchParams.get("code");
   const state = searchParams.get("state");
   const expectedState = request.cookies.get("discord_oauth_state")?.value;
+  const returnTo = sanitizeReturnTo(
+    request.cookies.get("discord_oauth_return_to")?.value
+  );
 
   if (!code || !state) {
-    return NextResponse.redirect(new URL("/profile?discord=error&message=missing_params", request.url));
+    return buildCallbackRedirect(request, returnTo, "discord=error&message=missing_params");
   }
 
   if (!expectedState || expectedState !== state) {
     logger.warn("Discord OAuth state mismatch", { endpoint: "/api/discord/callback" });
-    const response = NextResponse.redirect(
-      new URL("/profile?discord=error&message=invalid_state", request.url)
-    );
-    response.cookies.set("discord_oauth_state", "", { maxAge: 0, path: "/" });
-    return response;
+    return buildCallbackRedirect(request, returnTo, "discord=error&message=invalid_state");
   }
 
   if (!DISCORD_CLIENT_ID || !DISCORD_CLIENT_SECRET || !DISCORD_SERVER_ID) {
     logger.error("Discord OAuth not properly configured. Missing required environment variables.");
-    return NextResponse.redirect(new URL("/profile?discord=error&message=not_configured", request.url));
+    return buildCallbackRedirect(request, returnTo, "discord=error&message=not_configured");
   }
 
   const redirectUri = getDiscordRedirectUri(request);
@@ -75,7 +95,7 @@ async function handleDiscordCallback(request: NextRequest) {
     if (!tokenResponse.ok) {
       const errorText = await tokenResponse.text();
       logger.error("Discord token exchange failed", { status: tokenResponse.status, body: errorText, redirect_uri: redirectUri });
-      return NextResponse.redirect(new URL("/profile?discord=error&message=token_failed", request.url));
+      return buildCallbackRedirect(request, returnTo, "discord=error&message=token_failed");
     }
 
     const tokenData = await tokenResponse.json();
@@ -89,7 +109,7 @@ async function handleDiscordCallback(request: NextRequest) {
 
     if (!userResponse.ok) {
       logger.error("Discord user fetch failed", { status: userResponse.status });
-      return NextResponse.redirect(new URL("/profile?discord=error&message=user_fetch_failed", request.url));
+      return buildCallbackRedirect(request, returnTo, "discord=error&message=user_fetch_failed");
     }
 
     const discordUser = await userResponse.json();
@@ -103,7 +123,7 @@ async function handleDiscordCallback(request: NextRequest) {
 
     if (!guildsResponse.ok) {
       logger.error("Discord guilds fetch failed", { status: guildsResponse.status });
-      return NextResponse.redirect(new URL("/profile?discord=error&message=guilds_fetch_failed", request.url));
+      return buildCallbackRedirect(request, returnTo, "discord=error&message=guilds_fetch_failed");
     }
 
     const guilds = await guildsResponse.json();
@@ -111,7 +131,7 @@ async function handleDiscordCallback(request: NextRequest) {
 
     if (!isMember) {
       // User is not a member of the Cursor Boston Discord
-      return NextResponse.redirect(new URL("/profile?discord=error&message=not_member", request.url));
+      return buildCallbackRedirect(request, returnTo, "discord=error&message=not_member");
     }
 
     // Return success with Discord user data encoded in URL
@@ -123,21 +143,13 @@ async function handleDiscordCallback(request: NextRequest) {
       avatar: discordUser.avatar,
     }));
 
-    const response = NextResponse.redirect(
-      new URL(`/profile?discord=success&data=${discordData}`, request.url)
-    );
-    response.cookies.set("discord_oauth_state", "", { maxAge: 0, path: "/" });
-    return response;
+    return buildCallbackRedirect(request, returnTo, `discord=success&data=${discordData}`);
   } catch (error) {
     logger.logError(error, {
       endpoint: "/api/discord/callback",
       method: "GET",
     });
-    const response = NextResponse.redirect(
-      new URL("/profile?discord=error&message=unknown", request.url)
-    );
-    response.cookies.set("discord_oauth_state", "", { maxAge: 0, path: "/" });
-    return response;
+    return buildCallbackRedirect(request, returnTo, "discord=error&message=unknown");
   }
 }
 

--- a/app/api/github/authorize/route.ts
+++ b/app/api/github/authorize/route.ts
@@ -21,6 +21,13 @@ function getGitHubRedirectUri(request: NextRequest): string {
   return `${url.origin}/api/github/callback`;
 }
 
+function sanitizeReturnTo(value: string | null): string | null {
+  if (!value) return null;
+  // Same-origin relative path only: must start with "/" and not "//".
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
 export async function GET(request: NextRequest) {
   if (!GITHUB_CLIENT_ID) {
     return NextResponse.redirect(
@@ -30,6 +37,7 @@ export async function GET(request: NextRequest) {
 
   const redirectUri = getGitHubRedirectUri(request);
   const state = randomBytes(32).toString("base64url");
+  const returnTo = sanitizeReturnTo(request.nextUrl.searchParams.get("returnTo"));
   const params = new URLSearchParams({
     client_id: GITHUB_CLIENT_ID,
     redirect_uri: redirectUri,
@@ -48,6 +56,16 @@ export async function GET(request: NextRequest) {
     path: "/",
     maxAge: 10 * 60,
   });
+
+  if (returnTo) {
+    response.cookies.set("github_oauth_return_to", returnTo, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 10 * 60,
+    });
+  }
 
   return response;
 }

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -20,28 +20,48 @@ function getGitHubRedirectUri(request: NextRequest): string {
   return `${url.origin}/api/github/callback`;
 }
 
+function sanitizeReturnTo(value: string | undefined): string | null {
+  if (!value) return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
+function buildCallbackRedirect(
+  request: NextRequest,
+  returnTo: string | null,
+  query: string
+): NextResponse {
+  const target = returnTo || "/profile";
+  const separator = target.includes("?") ? "&" : "?";
+  const response = NextResponse.redirect(
+    new URL(`${target}${separator}${query}`, request.url)
+  );
+  response.cookies.set("github_oauth_state", "", { maxAge: 0, path: "/" });
+  response.cookies.set("github_oauth_return_to", "", { maxAge: 0, path: "/" });
+  return response;
+}
+
 async function handleGitHubCallback(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const code = searchParams.get("code");
   const state = searchParams.get("state");
   const expectedState = request.cookies.get("github_oauth_state")?.value;
+  const returnTo = sanitizeReturnTo(
+    request.cookies.get("github_oauth_return_to")?.value
+  );
 
   if (!code || !state) {
-    return NextResponse.redirect(new URL("/profile?github=error&message=missing_params", request.url));
+    return buildCallbackRedirect(request, returnTo, "github=error&message=missing_params");
   }
 
   if (!expectedState || expectedState !== state) {
     logger.warn("GitHub OAuth state mismatch", { endpoint: "/api/github/callback" });
-    const response = NextResponse.redirect(
-      new URL("/profile?github=error&message=invalid_state", request.url)
-    );
-    response.cookies.set("github_oauth_state", "", { maxAge: 0, path: "/" });
-    return response;
+    return buildCallbackRedirect(request, returnTo, "github=error&message=invalid_state");
   }
 
   if (!GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET) {
     logger.error("GitHub OAuth not properly configured. Missing required environment variables.");
-    return NextResponse.redirect(new URL("/profile?github=error&message=not_configured", request.url));
+    return buildCallbackRedirect(request, returnTo, "github=error&message=not_configured");
   }
 
   const redirectUri = getGitHubRedirectUri(request);
@@ -66,7 +86,7 @@ async function handleGitHubCallback(request: NextRequest) {
     if (!tokenResponse.ok) {
       const errorText = await tokenResponse.text();
       logger.error("GitHub token exchange failed", { status: tokenResponse.status, body: errorText });
-      return NextResponse.redirect(new URL("/profile?github=error&message=token_failed", request.url));
+      return buildCallbackRedirect(request, returnTo, "github=error&message=token_failed");
     }
 
     const tokenData = await tokenResponse.json();
@@ -78,7 +98,7 @@ async function handleGitHubCallback(request: NextRequest) {
         error_uri: tokenData.error_uri,
         redirect_uri_used: redirectUri,
       });
-      return NextResponse.redirect(new URL("/profile?github=error&message=token_failed", request.url));
+      return buildCallbackRedirect(request, returnTo, "github=error&message=token_failed");
     }
 
     // Get user info from GitHub
@@ -91,7 +111,7 @@ async function handleGitHubCallback(request: NextRequest) {
 
     if (!userResponse.ok) {
       logger.error("GitHub user fetch failed", { status: userResponse.status });
-      return NextResponse.redirect(new URL("/profile?github=error&message=user_fetch_failed", request.url));
+      return buildCallbackRedirect(request, returnTo, "github=error&message=user_fetch_failed");
     }
 
     const githubUser = await userResponse.json();
@@ -106,21 +126,13 @@ async function handleGitHubCallback(request: NextRequest) {
       html_url: githubUser.html_url,
     }));
 
-    const response = NextResponse.redirect(
-      new URL(`/profile?github=success&data=${githubData}`, request.url)
-    );
-    response.cookies.set("github_oauth_state", "", { maxAge: 0, path: "/" });
-    return response;
+    return buildCallbackRedirect(request, returnTo, `github=success&data=${githubData}`);
   } catch (error) {
     logger.logError(error, {
       endpoint: "/api/github/callback",
       method: "GET",
     });
-    const response = NextResponse.redirect(
-      new URL("/profile?github=error&message=unknown", request.url)
-    );
-    response.cookies.set("github_oauth_state", "", { maxAge: 0, path: "/" });
-    return response;
+    return buildCallbackRedirect(request, returnTo, "github=error&message=unknown");
   }
 }
 

--- a/app/api/summer-cohort/apply/route.ts
+++ b/app/api/summer-cohort/apply/route.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import {
+  SUMMER_COHORT_COLLECTION,
+  SUMMER_COHORT_SITE_ID,
+  isValidCohortId,
+  type SummerCohortId,
+} from "@/lib/summer-cohort";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_NAME = 200;
+const MAX_PHONE = 50;
+
+function serializeApplication(data: Record<string, unknown>) {
+  const createdAt = data.createdAt;
+  const updatedAt = data.updatedAt;
+  return {
+    userId: data.userId ?? null,
+    email: data.email ?? null,
+    name: data.name ?? null,
+    phone: data.phone ?? null,
+    cohorts: Array.isArray(data.cohorts) ? data.cohorts : [],
+    siteId: data.siteId ?? null,
+    status: data.status ?? "pending",
+    createdAt:
+      createdAt && typeof (createdAt as { toMillis?: () => number }).toMillis === "function"
+        ? (createdAt as { toMillis: () => number }).toMillis()
+        : null,
+    updatedAt:
+      updatedAt && typeof (updatedAt as { toMillis?: () => number }).toMillis === "function"
+        ? (updatedAt as { toMillis: () => number }).toMillis()
+        : null,
+  };
+}
+
+async function handleGet(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  const snap = await db.collection(SUMMER_COHORT_COLLECTION).doc(user.uid).get();
+  if (!snap.exists) {
+    return NextResponse.json({ application: null });
+  }
+  return NextResponse.json({ application: serializeApplication(snap.data() || {}) });
+}
+
+async function handlePost(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!user.email) {
+    return NextResponse.json(
+      { error: "Your account is missing an email address." },
+      { status: 400 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const raw = (body || {}) as Record<string, unknown>;
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  const phone = typeof raw.phone === "string" ? raw.phone.trim() : "";
+  const cohortsInput = Array.isArray(raw.cohorts) ? raw.cohorts : [];
+
+  if (!name || name.length > MAX_NAME) {
+    return NextResponse.json(
+      { error: `Name is required and must be 1-${MAX_NAME} characters.` },
+      { status: 400 }
+    );
+  }
+  if (!phone || phone.length > MAX_PHONE) {
+    return NextResponse.json(
+      { error: `Phone is required and must be 1-${MAX_PHONE} characters.` },
+      { status: 400 }
+    );
+  }
+
+  const cohorts: SummerCohortId[] = [];
+  const seen = new Set<SummerCohortId>();
+  for (const value of cohortsInput) {
+    if (isValidCohortId(value) && !seen.has(value)) {
+      seen.add(value);
+      cohorts.push(value);
+    }
+  }
+  if (cohorts.length === 0) {
+    return NextResponse.json(
+      { error: "Pick at least one cohort." },
+      { status: 400 }
+    );
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  try {
+    const ref = db.collection(SUMMER_COHORT_COLLECTION).doc(user.uid);
+    const existing = await ref.get();
+    const baseFields = {
+      userId: user.uid,
+      email: user.email,
+      name,
+      phone,
+      cohorts,
+      siteId: SUMMER_COHORT_SITE_ID,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    if (existing.exists) {
+      await ref.set(baseFields, { merge: true });
+    } else {
+      await ref.set({
+        ...baseFields,
+        status: "pending",
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    }
+    const fresh = await ref.get();
+    return NextResponse.json({ application: serializeApplication(fresh.data() || {}) });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/summer-cohort/apply",
+      method: "POST",
+    });
+    return NextResponse.json(
+      { error: "Failed to save application" },
+      { status: 500 }
+    );
+  }
+}
+
+export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);
+export const POST = withMiddleware(rateLimitConfigs.standard, handlePost);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import AppShell from "@/components/AppShell";
 import WelcomeModal from "@/components/WelcomeModal";
+import SummerCohortModal from "@/components/SummerCohortModal";
 import LumaCheckoutTracker from "@/components/LumaCheckoutTracker";
 import { KonamiListener } from "@/components/hunt/KonamiListener";
 import { AuthProvider } from "@/contexts/AuthContext";
@@ -124,6 +125,7 @@ export default function RootLayout({
           <AuthProvider>
             <AppShell>{children}</AppShell>
             <WelcomeModal />
+            <SummerCohortModal />
             <LumaCheckoutTracker />
             <KonamiListener />
           </AuthProvider>

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -1,0 +1,484 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Sun } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { DiscordIcon, GitHubIcon } from "@/components/icons";
+import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
+import { useDiscordConnection } from "@/app/(auth)/profile/_hooks/useDiscordConnection";
+import {
+  SUMMER_COHORTS,
+  SUMMER_COHORT_RETURN_TO,
+  type SummerCohortId,
+} from "@/lib/summer-cohort";
+
+interface ApplicationDto {
+  userId: string | null;
+  email: string | null;
+  name: string | null;
+  phone: string | null;
+  cohorts: SummerCohortId[];
+  siteId: string | null;
+  status: "pending" | "admitted" | "rejected" | "waitlist";
+  createdAt: number | null;
+  updatedAt: number | null;
+}
+
+const KICKOFF_NOTE =
+  "First Zoom kickoffs: Cohort 1 on Mon May 11, Cohort 2 on Mon Jun 29. Watch your email and check back here for the meeting link and next steps.";
+
+function CohortDatesList() {
+  return (
+    <ul className="space-y-2">
+      {SUMMER_COHORTS.map((cohort) => (
+        <li
+          key={cohort.id}
+          className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-neutral-100 border border-neutral-200 dark:bg-neutral-900 dark:border-neutral-800"
+        >
+          <span className="text-sm font-semibold">{cohort.label}</span>
+          <span className="text-xs text-neutral-600 dark:text-neutral-300">
+            {cohort.startLabel} – {cohort.endLabel}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function SummerCohortPage() {
+  const searchParams = useSearchParams();
+  const { user, userProfile, loading, refreshUserProfile } = useAuth();
+
+  const discord = useDiscordConnection(
+    user,
+    userProfile?.discord,
+    SUMMER_COHORT_RETURN_TO
+  );
+  const github = useGithubConnection(
+    user,
+    userProfile?.github,
+    userProfile?.provider,
+    refreshUserProfile,
+    SUMMER_COHORT_RETURN_TO
+  );
+
+  const [application, setApplication] = useState<ApplicationDto | null>(null);
+  const [appLoading, setAppLoading] = useState(false);
+  const [appLoadError, setAppLoadError] = useState<string | null>(null);
+
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [pickedCohorts, setPickedCohorts] = useState<Set<SummerCohortId>>(
+    new Set(SUMMER_COHORTS.map((c) => c.id))
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Default name from auth profile once it loads.
+  useEffect(() => {
+    if (user && !name) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- prefilling form once auth subject becomes available
+      setName(user.displayName || "");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  // Fetch existing application.
+  useEffect(() => {
+    if (loading || !user) return;
+    let cancelled = false;
+    (async () => {
+      setAppLoading(true);
+      setAppLoadError(null);
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/summer-cohort/apply", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          throw new Error("load_failed");
+        }
+        const json = (await res.json()) as { application: ApplicationDto | null };
+        if (!cancelled) setApplication(json.application);
+      } catch {
+        if (!cancelled) setAppLoadError("Couldn't load your application status.");
+      } finally {
+        if (!cancelled) setAppLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loading, user]);
+
+  // Handle OAuth callbacks landed on this page.
+  useEffect(() => {
+    if (loading) return;
+    const githubStatus = searchParams.get("github");
+    if (githubStatus) {
+      const data = searchParams.get("data");
+      if (githubStatus === "success" && data) {
+        try {
+          github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
+        } catch {
+          github.handleOAuthError();
+        }
+      } else if (githubStatus === "error") {
+        github.handleOAuthError();
+      }
+    }
+    const discordStatus = searchParams.get("discord");
+    if (discordStatus) {
+      const data = searchParams.get("data");
+      if (discordStatus === "success" && data) {
+        try {
+          discord.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
+        } catch {
+          discord.handleOAuthError(searchParams.get("message"));
+        }
+      } else if (discordStatus === "error") {
+        discord.handleOAuthError(searchParams.get("message"));
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, loading]);
+
+  const toggleCohort = useCallback((id: SummerCohortId) => {
+    setPickedCohorts((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const submit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!user) return;
+    setSubmitError(null);
+
+    const cohorts = Array.from(pickedCohorts);
+    if (cohorts.length === 0) {
+      setSubmitError("Pick at least one cohort.");
+      return;
+    }
+    if (!name.trim()) {
+      setSubmitError("Please enter your name.");
+      return;
+    }
+    if (!phone.trim()) {
+      setSubmitError("Please enter a phone number.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/summer-cohort/apply", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ name: name.trim(), phone: phone.trim(), cohorts }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setSubmitError(typeof json.error === "string" ? json.error : "Submit failed.");
+        return;
+      }
+      setApplication(json.application as ApplicationDto);
+    } catch {
+      setSubmitError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const cohortLabel = useMemo(() => {
+    const map = new Map(SUMMER_COHORTS.map((c) => [c.id, c.label] as const));
+    return (id: SummerCohortId) => map.get(id) || id;
+  }, []);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      <header className="mb-8">
+        <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+          <Sun className="h-3.5 w-3.5" strokeWidth={2.25} />
+          Summer Cohort
+        </div>
+        <h1 className="mt-3 text-3xl font-bold md:text-4xl">
+          Cursor Boston Summer Cohort
+        </h1>
+        <p className="mt-2 text-neutral-600 dark:text-neutral-400">
+          Two six-week sessions to build with Cursor alongside other Boston
+          developers, founders, and students.
+        </p>
+      </header>
+
+      <section aria-labelledby="cohort-dates-heading" className="mb-8">
+        <h2
+          id="cohort-dates-heading"
+          className="mb-3 text-sm font-semibold uppercase tracking-wider text-neutral-500"
+        >
+          Dates
+        </h2>
+        <CohortDatesList />
+        <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+          {KICKOFF_NOTE}
+        </p>
+      </section>
+
+      {/* Auth-gated states */}
+      {loading ? (
+        <div className="rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500 dark:border-neutral-800">
+          Loading…
+        </div>
+      ) : !user ? (
+        <section className="rounded-xl border border-neutral-200 bg-neutral-50 p-6 dark:border-neutral-800 dark:bg-neutral-900/40">
+          <h2 className="text-lg font-semibold">Sign in to apply</h2>
+          <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+            We need an account on file to follow up on your application.
+          </p>
+          <Link
+            href={`/login?redirect=${encodeURIComponent(SUMMER_COHORT_RETURN_TO)}`}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+          >
+            Sign in
+          </Link>
+        </section>
+      ) : appLoading ? (
+        <div className="rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500 dark:border-neutral-800">
+          Checking your application…
+        </div>
+      ) : appLoadError ? (
+        <div className="rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {appLoadError}
+        </div>
+      ) : application ? (
+        <section className="rounded-xl border border-emerald-300 bg-emerald-50 p-6 dark:border-emerald-900 dark:bg-emerald-950/30">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+              Status: Pending
+            </span>
+          </div>
+          <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
+            We received your application for{" "}
+            <strong>
+              {application.cohorts.map(cohortLabel).join(" and ")}
+            </strong>
+            . We&apos;ll review and follow up by email.
+          </p>
+          <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+            {KICKOFF_NOTE}
+          </p>
+        </section>
+      ) : (
+        <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+          <h2 className="text-lg font-semibold">Apply</h2>
+          <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+            Fill this out and we&apos;ll be in touch.
+          </p>
+          <form onSubmit={submit} className="mt-5 space-y-4">
+            <div>
+              <label
+                htmlFor="cohort-name"
+                className="block text-sm font-medium"
+              >
+                Name
+              </label>
+              <input
+                id="cohort-name"
+                type="text"
+                required
+                maxLength={200}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="cohort-email"
+                className="block text-sm font-medium"
+              >
+                Email
+              </label>
+              <input
+                id="cohort-email"
+                type="email"
+                value={user.email || ""}
+                readOnly
+                className="mt-1 w-full cursor-not-allowed rounded-lg border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm text-neutral-600 dark:border-neutral-800 dark:bg-neutral-800/60 dark:text-neutral-400"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="cohort-phone"
+                className="block text-sm font-medium"
+              >
+                Phone
+              </label>
+              <input
+                id="cohort-phone"
+                type="tel"
+                required
+                maxLength={50}
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+              />
+            </div>
+            <fieldset>
+              <legend className="block text-sm font-medium">
+                Which cohort(s)? Pick at least one.
+              </legend>
+              <div className="mt-2 space-y-2">
+                {SUMMER_COHORTS.map((cohort) => (
+                  <label
+                    key={cohort.id}
+                    className="flex items-center gap-3 rounded-lg border border-neutral-200 px-3 py-2.5 text-sm dark:border-neutral-800"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={pickedCohorts.has(cohort.id)}
+                      onChange={() => toggleCohort(cohort.id)}
+                      className="h-4 w-4 rounded border-neutral-300 text-emerald-500 focus:ring-emerald-500"
+                    />
+                    <span className="font-semibold">{cohort.label}</span>
+                    <span className="text-xs text-neutral-600 dark:text-neutral-400">
+                      {cohort.startLabel} – {cohort.endLabel}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+            {submitError ? (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                {submitError}
+              </p>
+            ) : null}
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 disabled:opacity-50"
+            >
+              {submitting ? "Submitting…" : "Submit application"}
+            </button>
+          </form>
+        </section>
+      )}
+
+      {/* Connections panel — visible whenever the user is signed in. */}
+      {user ? (
+        <section
+          aria-labelledby="connections-heading"
+          className="mt-8 rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+        >
+          <h2
+            id="connections-heading"
+            className="text-sm font-semibold uppercase tracking-wider text-neutral-500"
+          >
+            Connect your accounts
+          </h2>
+          <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+            Connect GitHub and Discord so we can verify membership and add you
+            to the cohort channel.
+          </p>
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+              <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-200 dark:bg-neutral-800">
+                  <GitHubIcon size={18} />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">GitHub</p>
+                  {github.githubInfo ? (
+                    <p className="text-xs text-emerald-600 dark:text-emerald-400">
+                      Connected as {github.githubInfo.login}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-neutral-500">Not connected</p>
+                  )}
+                </div>
+              </div>
+              {github.githubInfo ? (
+                <button
+                  onClick={github.disconnect}
+                  disabled={github.disconnecting}
+                  className="text-xs text-neutral-500 transition-colors hover:text-red-500 disabled:opacity-50"
+                >
+                  {github.disconnecting ? "…" : "Disconnect"}
+                </button>
+              ) : (
+                <button
+                  onClick={github.connect}
+                  disabled={github.connecting}
+                  className="text-xs font-semibold text-emerald-600 transition-colors hover:text-emerald-500 disabled:opacity-50 dark:text-emerald-400"
+                >
+                  {github.connecting ? "…" : "Connect"}
+                </button>
+              )}
+            </div>
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+              <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#5865F2]/10">
+                  <DiscordIcon size={18} className="text-[#5865F2]" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Discord</p>
+                  {discord.discordInfo ? (
+                    <p className="text-xs text-emerald-600 dark:text-emerald-400">
+                      Connected as {discord.discordInfo.username}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-neutral-500">Not connected</p>
+                  )}
+                </div>
+              </div>
+              {discord.discordInfo ? (
+                <button
+                  onClick={discord.disconnect}
+                  disabled={discord.disconnecting}
+                  className="text-xs text-neutral-500 transition-colors hover:text-red-500 disabled:opacity-50"
+                >
+                  {discord.disconnecting ? "…" : "Disconnect"}
+                </button>
+              ) : (
+                <button
+                  onClick={discord.connect}
+                  disabled={discord.connecting}
+                  className="text-xs font-semibold text-emerald-600 transition-colors hover:text-emerald-500 disabled:opacity-50 dark:text-emerald-400"
+                >
+                  {discord.connecting ? "…" : "Connect"}
+                </button>
+              )}
+            </div>
+          </div>
+          {(github.error || discord.error) ? (
+            <p className="mt-3 text-xs text-red-600 dark:text-red-400">
+              {github.error || discord.error}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -34,6 +34,7 @@ import {
   LogIn,
   Menu,
   MessageSquare,
+  Sun,
   Trophy,
   UserPlus,
   Users,
@@ -45,6 +46,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import Avatar from "@/components/Avatar";
 import Footer from "@/components/Footer";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { SUMMER_COHORT_OPEN_EVENT } from "@/lib/summer-cohort";
 
 const STORAGE_KEY = "cursor-boston-sidebar-collapsed";
 
@@ -52,6 +54,7 @@ interface NavItem {
   href: string;
   label: string;
   icon: LucideIcon;
+  highlight?: boolean;
 }
 
 interface NavGroup {
@@ -65,6 +68,12 @@ interface NavGroup {
  * stays standalone.
  */
 const NAV_GROUPS: NavGroup[] = [
+  {
+    label: "Summer Cohort",
+    items: [
+      { href: "/summer-cohort", label: "Summer Cohort", icon: Sun, highlight: true },
+    ],
+  },
   {
     label: "Live",
     items: [
@@ -98,8 +107,25 @@ function isGroupActive(group: NavGroup, pathname: string): boolean {
   return group.items.some((item) => pathname === item.href);
 }
 
-function navLinkClass(pathname: string, href: string, collapsed: boolean) {
+function navLinkClass(
+  pathname: string,
+  href: string,
+  collapsed: boolean,
+  highlight = false
+) {
   const active = pathname === href;
+  if (highlight) {
+    return [
+      "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-semibold transition-colors",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      collapsed ? "justify-center px-2" : "",
+      active
+        ? "bg-emerald-600 text-white shadow-sm"
+        : "bg-emerald-500 text-white hover:bg-emerald-400",
+    ]
+      .filter(Boolean)
+      .join(" ");
+  }
   return [
     "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
@@ -242,8 +268,15 @@ export default function AppShell({ children }: { children: ReactNode }) {
                       <li key={item.href}>
                         <Link
                           href={item.href}
-                          onClick={() => setMobileOpen(false)}
-                          className={navLinkClass(pathname, item.href, false)}
+                          onClick={() => {
+                            setMobileOpen(false);
+                            if (item.highlight) {
+                              window.dispatchEvent(
+                                new CustomEvent(SUMMER_COHORT_OPEN_EVENT)
+                              );
+                            }
+                          }}
+                          className={navLinkClass(pathname, item.href, false, item.highlight)}
                         >
                           <Icon className="h-[1.125rem] w-[1.125rem] shrink-0 opacity-90" strokeWidth={2} />
                           <span className="truncate">{item.label}</span>
@@ -307,8 +340,15 @@ export default function AppShell({ children }: { children: ReactNode }) {
                         <Link
                           href={item.href}
                           title={item.label}
-                          onClick={() => setMobileOpen(false)}
-                          className={navLinkClass(pathname, item.href, true)}
+                          onClick={() => {
+                            setMobileOpen(false);
+                            if (item.highlight) {
+                              window.dispatchEvent(
+                                new CustomEvent(SUMMER_COHORT_OPEN_EVENT)
+                              );
+                            }
+                          }}
+                          className={navLinkClass(pathname, item.href, true, item.highlight)}
                         >
                           <Icon className="h-[1.125rem] w-[1.125rem] shrink-0 opacity-90" strokeWidth={2} />
                         </Link>

--- a/components/SummerCohortModal.tsx
+++ b/components/SummerCohortModal.tsx
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import Link from "next/link";
+import {
+  SUMMER_COHORTS,
+  SUMMER_COHORT_LOCALSTORAGE_KEY,
+  SUMMER_COHORT_OPEN_EVENT,
+  SUMMER_COHORT_RETURN_TO,
+} from "@/lib/summer-cohort";
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default function SummerCohortModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    try {
+      const lastShown = localStorage.getItem(SUMMER_COHORT_LOCALSTORAGE_KEY);
+      if (lastShown !== todayKey()) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing with localStorage on mount
+        setIsOpen(true);
+      }
+    } catch {
+      /* localStorage unavailable; skip auto-open */
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleOpen = () => setIsOpen(true);
+    window.addEventListener(SUMMER_COHORT_OPEN_EVENT, handleOpen);
+    return () => window.removeEventListener(SUMMER_COHORT_OPEN_EVENT, handleOpen);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      closeButtonRef.current?.focus();
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    try {
+      localStorage.setItem(SUMMER_COHORT_LOCALSTORAGE_KEY, todayKey());
+    } catch {
+      /* ignore */
+    }
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        handleClose();
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, handleClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="summer-cohort-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      <div
+        ref={modalRef}
+        className="relative bg-neutral-900 border border-neutral-800 rounded-2xl p-6 md:p-8 max-w-md w-full shadow-2xl"
+      >
+        <button
+          ref={closeButtonRef}
+          onClick={handleClose}
+          className="absolute top-4 right-4 text-neutral-400 hover:text-white transition-colors p-1 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          aria-label="Close summer cohort message"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+
+        <div className="text-center">
+          <div className="w-16 h-16 bg-emerald-500/15 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-emerald-400"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="4" />
+              <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+            </svg>
+          </div>
+
+          <h2
+            id="summer-cohort-title"
+            className="text-2xl font-bold text-white mb-2"
+          >
+            Cursor Boston Summer Cohort
+          </h2>
+          <p className="text-neutral-400 mb-6">
+            Two six-week sessions to build with Cursor alongside other Boston
+            developers, founders, and students.
+          </p>
+
+          <ul className="space-y-2 mb-6 text-left">
+            {SUMMER_COHORTS.map((cohort) => (
+              <li
+                key={cohort.id}
+                className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-neutral-800/60 border border-neutral-800"
+              >
+                <span className="text-sm font-semibold text-white">
+                  {cohort.label}
+                </span>
+                <span className="text-xs text-neutral-300">
+                  {cohort.startLabel} – {cohort.endLabel}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <Link
+            href={SUMMER_COHORT_RETURN_TO}
+            onClick={handleClose}
+            className="flex items-center justify-center gap-2 w-full px-4 py-3 bg-emerald-500 text-white rounded-lg font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+          >
+            Apply
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14M13 5l7 7-7 7" />
+            </svg>
+          </Link>
+
+          <button
+            onClick={handleClose}
+            className="mt-4 text-neutral-500 hover:text-neutral-300 text-sm transition-colors focus-visible:outline-none focus-visible:text-white focus-visible:underline"
+          >
+            Maybe later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Timestamp } from "firebase/firestore";
+
+export const SUMMER_COHORT_SITE_ID = "cursor-boston";
+export const SUMMER_COHORT_COLLECTION = "summerCohortApplications";
+export const SUMMER_COHORT_LOCALSTORAGE_KEY =
+  "cursor-boston-summer-cohort-modal-shown-date";
+export const SUMMER_COHORT_RETURN_TO = "/summer-cohort";
+export const SUMMER_COHORT_OPEN_EVENT = "open-summer-cohort-modal";
+
+export type SummerCohortId = "cohort-1" | "cohort-2";
+
+export interface SummerCohort {
+  id: SummerCohortId;
+  label: string;
+  start: string;
+  end: string;
+  startLabel: string;
+  endLabel: string;
+}
+
+export const SUMMER_COHORTS: readonly SummerCohort[] = [
+  {
+    id: "cohort-1",
+    label: "Cohort 1",
+    start: "2026-05-11",
+    end: "2026-06-19",
+    startLabel: "Mon, May 11",
+    endLabel: "Fri, Jun 19",
+  },
+  {
+    id: "cohort-2",
+    label: "Cohort 2",
+    start: "2026-06-29",
+    end: "2026-08-07",
+    startLabel: "Mon, Jun 29",
+    endLabel: "Fri, Aug 7",
+  },
+] as const;
+
+export type SummerCohortStatus =
+  | "pending"
+  | "admitted"
+  | "rejected"
+  | "waitlist";
+
+export interface SummerCohortApplication {
+  userId: string;
+  email: string;
+  name: string;
+  phone: string;
+  cohorts: SummerCohortId[];
+  siteId: string;
+  status: SummerCohortStatus;
+  createdAt?: Timestamp | null;
+  updatedAt?: Timestamp | null;
+}
+
+export function isValidCohortId(value: unknown): value is SummerCohortId {
+  return value === "cohort-1" || value === "cohort-2";
+}


### PR DESCRIPTION
## Summary

Brings the **Cursor Boston Summer Cohort** signup flow to production.

- Daily-gated global popup + bright-emerald sidebar tab to reopen it
- New `/summer-cohort` page with dates, kickoff note, application form, and Pending status panel
- New `/api/summer-cohort/apply` route writes to `summerCohortApplications/{uid}` (Firebase Admin SDK, `siteId="cursor-boston"`, `status="pending"`)
- GitHub & Discord OAuth flows extended to accept a same-origin `returnTo`, so connect-from-cohort-page returns to `/summer-cohort` instead of `/profile` (existing `/profile` callers unchanged)

## Included commits

- `10e0a95` feat(summer-cohort): launch popup, sidebar tab, and application flow — **@Ludwitt** (co-authored with Claude Opus 4.7)

No upstream PRs to credit — this release contains a single direct commit on `develop`.

## Test plan

- [ ] `/summer-cohort` renders dates and Sign-in CTA when logged out
- [ ] After login, application form submits and persists; reload shows "Pending"
- [ ] Firestore: `summerCohortApplications/<uid>` doc has `siteId: "cursor-boston"`, `status: "pending"`, `cohorts`, `name`, `phone`, `email`
- [ ] GitHub & Discord "Connect" from `/summer-cohort` returns to `/summer-cohort` (not `/profile`)
- [ ] `/profile` connect/disconnect still returns to `/profile` (no regression)
- [ ] Sidebar tab visible at top in expanded + collapsed + mobile
- [ ] Popup auto-opens once per local day; sidebar tab reopens it any time

🤖 Generated with [Claude Code](https://claude.com/claude-code)