### PR TITLE
Release: develop → main (cohort apply email notifications)

### DIFF
--- a/app/api/summer-cohort/apply/route.ts
+++ b/app/api/summer-cohort/apply/route.ts
@@ -5,13 +5,16 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { FieldValue } from "firebase-admin/firestore";
+import { FieldValue, type Firestore } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import { logger } from "@/lib/logger";
+import { sendEmail } from "@/lib/mailgun";
 import {
+  SUMMER_COHORTS,
   SUMMER_COHORT_COLLECTION,
+  SUMMER_COHORT_NOTIFY_EMAIL,
   SUMMER_COHORT_SITE_ID,
   isValidCohortId,
   type SummerCohortId,
@@ -142,6 +145,21 @@ async function handlePost(request: NextRequest) {
       });
     }
     const fresh = await ref.get();
+    const isNew = !existing.exists;
+    if (isNew) {
+      // Fire-and-forget — never let a Mailgun blip fail the user's submission.
+      sendNewApplicationEmail(db, {
+        name,
+        email: user.email,
+        phone,
+        cohorts,
+      }).catch((error) => {
+        logger.logError(error, {
+          endpoint: "/api/summer-cohort/apply",
+          stage: "notify_email",
+        });
+      });
+    }
     return NextResponse.json({ application: serializeApplication(fresh.data() || {}) });
   } catch (error) {
     logger.logError(error, {
@@ -153,6 +171,147 @@ async function handlePost(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+interface ApplicantRow {
+  name: string;
+  email: string;
+  phone: string;
+  cohorts: SummerCohortId[];
+  appliedAtMs: number | null;
+}
+
+function formatAppliedAt(ms: number | null): string {
+  if (!ms) return "(unknown)";
+  const d = new Date(ms);
+  return d.toLocaleString("en-US", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+async function sendNewApplicationEmail(
+  db: Firestore,
+  applicant: { name: string; email: string; phone: string; cohorts: SummerCohortId[] }
+): Promise<void> {
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const all: ApplicantRow[] = snap.docs.map((doc) => {
+    const data = doc.data();
+    const createdAt = data.createdAt as { toMillis?: () => number } | undefined;
+    return {
+      name: typeof data.name === "string" ? data.name : "",
+      email: typeof data.email === "string" ? data.email : "",
+      phone: typeof data.phone === "string" ? data.phone : "",
+      cohorts: Array.isArray(data.cohorts)
+        ? data.cohorts.filter(isValidCohortId)
+        : [],
+      appliedAtMs:
+        createdAt && typeof createdAt.toMillis === "function"
+          ? createdAt.toMillis()
+          : null,
+    };
+  });
+
+  const cohortLabel = new Map(SUMMER_COHORTS.map((c) => [c.id, c.label] as const));
+  const dateRange = new Map(
+    SUMMER_COHORTS.map(
+      (c) => [c.id, `${c.startLabel} – ${c.endLabel}`] as const
+    )
+  );
+
+  const cohortBuckets = SUMMER_COHORTS.map((cohort) => ({
+    id: cohort.id,
+    label: cohort.label,
+    range: dateRange.get(cohort.id) || "",
+    rows: all.filter((row) => row.cohorts.includes(cohort.id)),
+  }));
+
+  // ---- Plain-text body
+  const textLines: string[] = [];
+  textLines.push("New Cursor Boston Summer Cohort application:");
+  textLines.push("");
+  textLines.push(`  Name:    ${applicant.name}`);
+  textLines.push(`  Email:   ${applicant.email}`);
+  textLines.push(`  Phone:   ${applicant.phone}`);
+  textLines.push(
+    `  Cohorts: ${applicant.cohorts
+      .map((id) => cohortLabel.get(id) || id)
+      .join(", ")}`
+  );
+  textLines.push("");
+  textLines.push(`Total applications: ${all.length}`);
+  textLines.push("");
+  for (const bucket of cohortBuckets) {
+    textLines.push(`---- ${bucket.label} (${bucket.range}) — ${bucket.rows.length} ----`);
+    if (bucket.rows.length === 0) {
+      textLines.push("  (no applicants yet)");
+    } else {
+      for (const row of bucket.rows) {
+        textLines.push(
+          `  • ${row.name} <${row.email}> — applied ${formatAppliedAt(row.appliedAtMs)}`
+        );
+      }
+    }
+    textLines.push("");
+  }
+
+  // ---- HTML body
+  const htmlSections = cohortBuckets
+    .map((bucket) => {
+      const rowsHtml =
+        bucket.rows.length === 0
+          ? `<li style="color:#888">(no applicants yet)</li>`
+          : bucket.rows
+              .map(
+                (row) =>
+                  `<li><strong>${escapeHtml(row.name)}</strong> &lt;${escapeHtml(row.email)}&gt; — applied ${escapeHtml(formatAppliedAt(row.appliedAtMs))}</li>`
+              )
+              .join("");
+      return `
+        <h3 style="margin:24px 0 4px">${escapeHtml(bucket.label)} <span style="color:#666;font-weight:normal">(${escapeHtml(bucket.range)}) — ${bucket.rows.length}</span></h3>
+        <ul style="margin:4px 0 0;padding-left:20px;line-height:1.6">${rowsHtml}</ul>
+      `;
+    })
+    .join("");
+
+  const html = `
+    <div style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;color:#111;max-width:640px">
+      <h2 style="margin:0 0 12px">New Summer Cohort application</h2>
+      <table style="border-collapse:collapse;font-size:14px">
+        <tr><td style="padding:2px 12px 2px 0;color:#666">Name</td><td><strong>${escapeHtml(applicant.name)}</strong></td></tr>
+        <tr><td style="padding:2px 12px 2px 0;color:#666">Email</td><td>${escapeHtml(applicant.email)}</td></tr>
+        <tr><td style="padding:2px 12px 2px 0;color:#666">Phone</td><td>${escapeHtml(applicant.phone)}</td></tr>
+        <tr><td style="padding:2px 12px 2px 0;color:#666">Cohorts</td><td>${escapeHtml(applicant.cohorts.map((id) => cohortLabel.get(id) || id).join(", "))}</td></tr>
+      </table>
+      <p style="margin:20px 0 0;color:#444">Total applications: <strong>${all.length}</strong></p>
+      ${htmlSections}
+    </div>
+  `;
+
+  await sendEmail({
+    to: SUMMER_COHORT_NOTIFY_EMAIL,
+    subject: `Summer Cohort application: ${applicant.name}`,
+    text: textLines.join("\n"),
+    html,
+  });
 }
 
 export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -8,6 +8,7 @@ import type { Timestamp } from "firebase/firestore";
 
 export const SUMMER_COHORT_SITE_ID = "cursor-boston";
 export const SUMMER_COHORT_COLLECTION = "summerCohortApplications";
+export const SUMMER_COHORT_NOTIFY_EMAIL = "roger@cursorboston.com";
 export const SUMMER_COHORT_LOCALSTORAGE_KEY =
   "cursor-boston-summer-cohort-modal-shown-date";
 export const SUMMER_COHORT_RETURN_TO = "/summer-cohort";


### PR DESCRIPTION
## Summary

Adds email notifications when someone submits a Summer Cohort application.

## Included

- `4c9a96a` — feat(summer-cohort): email `roger@cursorboston.com` on each new application — by **@Ludwitt**

Each notification email includes:
- The new applicant's name, email, phone, and selected cohorts
- The total current applicant count
- A breakdown by cohort (Cohort 1 / Cohort 2) — applicants on both cohorts appear in both lists
- Applied-at timestamps in America/New_York

Send is fire-and-forget (try/catch on the email call) so a Mailgun outage never fails the user's submission. Email is only sent on **new** applications, not on edits to an existing one. Recipient is exposed via `SUMMER_COHORT_NOTIFY_EMAIL` in `lib/summer-cohort.ts` for easy future changes.

## Test plan

- [ ] Submit a fresh application from a test account → roger@cursorboston.com receives an email
- [ ] Email contains the new applicant + breakdown by cohort with timestamps
- [ ] Re-submitting (editing) the same user's application does NOT trigger another email
- [ ] If a user is on both cohorts, they appear in both lists
- [ ] Vercel build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)