### PR TITLE
[codex] fix profile bio checklist link

### DIFF
--- a/__tests__/app/profile/OnboardingChecklist.test.tsx
+++ b/__tests__/app/profile/OnboardingChecklist.test.tsx
@@ -108,6 +108,19 @@ describe("OnboardingChecklist", () => {
     expect(mockContextValue.github.connect).toHaveBeenCalled();
   });
 
+  it("calls onWriteBio when Write a short bio is clicked", async () => {
+    const user = userEvent.setup();
+    const onWriteBio = jest.fn();
+    render(<OnboardingChecklist onWriteBio={onWriteBio} />);
+
+    const bioButton = screen.getByText("Write a short bio").closest("button");
+    expect(bioButton).toBeInTheDocument();
+    expect(bioButton).toHaveTextContent("Open");
+
+    await user.click(bioButton!);
+    expect(onWriteBio).toHaveBeenCalled();
+  });
+
   it("shows connected status for GitHub when linked", () => {
     mockContextValue = makeContext({
       github: { githubInfo: { login: "octocat" }, connect: jest.fn() } as unknown as ProfileContextValue["github"],

--- a/app/(auth)/profile/_components/OnboardingChecklist.tsx
+++ b/app/(auth)/profile/_components/OnboardingChecklist.tsx
@@ -13,11 +13,16 @@ interface ChecklistItem {
   label: string;
   done: boolean;
   action?: () => void;
+  actionLabel?: string;
   href?: string;
   description: string;
 }
 
-export function OnboardingChecklist() {
+interface OnboardingChecklistProps {
+  onWriteBio?: () => void;
+}
+
+export function OnboardingChecklist({ onWriteBio }: OnboardingChecklistProps) {
   const {
     user,
     userProfile,
@@ -41,6 +46,8 @@ export function OnboardingChecklist() {
     {
       label: "Write a short bio",
       done: Boolean(userProfile?.bio?.trim()),
+      action: userProfile?.bio?.trim() ? undefined : onWriteBio,
+      actionLabel: "Open",
       description: "Tell people what you're building",
     },
     {
@@ -135,7 +142,7 @@ export function OnboardingChecklist() {
 
               {!item.done && (item.action || item.href) && (
                 <span className="shrink-0 text-xs text-emerald-400 font-medium mt-0.5">
-                  {item.href ? "Open" : "Connect"} &rarr;
+                  {item.actionLabel ?? (item.href ? "Open" : "Connect")} &rarr;
                 </span>
               )}
             </div>

--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useEffect, Suspense, useState } from "react";
+import { useEffect, Suspense, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -45,6 +45,17 @@ function ProfilePageContent() {
   const initialSection = searchParams.get("section");
   const [settingsOpen, setSettingsOpen] = useState(initialSection === "settings");
   const [securityOpen, setSecurityOpen] = useState(initialSection === "security");
+  const settingsSectionRef = useRef<HTMLDivElement>(null);
+
+  const openProfileSettings = () => {
+    setSettingsOpen(true);
+    window.requestAnimationFrame(() => {
+      settingsSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  };
 
   // Google reconnection reset
   useEffect(() => {
@@ -72,16 +83,18 @@ function ProfilePageContent() {
     <div className="min-h-[80vh] px-6 py-8 md:py-12">
       <div className="max-w-3xl mx-auto">
         <ProfileHeader onEditProfile={() => setIsEditModalOpen(true)} />
-        <OnboardingChecklist />
+        <OnboardingChecklist onWriteBio={openProfileSettings} />
         <ConnectionsSection />
         <StatsGrid />
         <EarnedBadgesSection />
         <ActivitySection />
 
         {/* Settings — collapsible */}
-        <div className="mb-8">
+        <div id="profile-settings" ref={settingsSectionRef} className="mb-8 scroll-mt-8">
           <button
             onClick={() => setSettingsOpen(!settingsOpen)}
+            aria-expanded={settingsOpen}
+            aria-controls="profile-settings-panel"
             className="w-full flex items-center justify-between text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3 hover:text-neutral-300 transition-colors"
           >
             <span>Profile Settings</span>
@@ -93,15 +106,17 @@ function ProfilePageContent() {
             </svg>
           </button>
           {settingsOpen && (
-            <SettingsTab
-              settings={profileSettings.settings}
-              setSettings={profileSettings.setSettings}
-              saving={profileSettings.saving}
-              error={profileSettings.error}
-              success={profileSettings.success}
-              onSave={profileSettings.save}
-              onToggleAllVisibility={profileSettings.toggleAllVisibility}
-            />
+            <div id="profile-settings-panel">
+              <SettingsTab
+                settings={profileSettings.settings}
+                setSettings={profileSettings.setSettings}
+                saving={profileSettings.saving}
+                error={profileSettings.error}
+                success={profileSettings.success}
+                onSave={profileSettings.save}
+                onToggleAllVisibility={profileSettings.toggleAllVisibility}
+              />
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

Fixes the inactive "Write a short bio" onboarding checklist row on the profile page.

## Changes

- Adds an `onWriteBio` action to the onboarding checklist item.
- Opens the Profile Settings accordion and smooth-scrolls to it from the checklist row.
- Adds accordion accessibility attributes for the Profile Settings panel.
- Covers the new checklist action with a focused component test.

## Root Cause

The checklist item displayed like an actionable incomplete task, but it had no `action` or `href`, so clicking it did nothing.

## Validation

- `npm test -- --runTestsByPath __tests__/app/profile/OnboardingChecklist.test.tsx`
- `npm run type-check`
- `git diff --check`
