### PR TITLE
Release: develop → main (withdraw button + #613 profile fix)

### DIFF
--- a/__tests__/app/profile/OnboardingChecklist.test.tsx
+++ b/__tests__/app/profile/OnboardingChecklist.test.tsx
@@ -108,6 +108,19 @@ describe("OnboardingChecklist", () => {
     expect(mockContextValue.github.connect).toHaveBeenCalled();
   });
 
+  it("calls onWriteBio when Write a short bio is clicked", async () => {
+    const user = userEvent.setup();
+    const onWriteBio = jest.fn();
+    render(<OnboardingChecklist onWriteBio={onWriteBio} />);
+
+    const bioButton = screen.getByText("Write a short bio").closest("button");
+    expect(bioButton).toBeInTheDocument();
+    expect(bioButton).toHaveTextContent("Open");
+
+    await user.click(bioButton!);
+    expect(onWriteBio).toHaveBeenCalled();
+  });
+
   it("shows connected status for GitHub when linked", () => {
     mockContextValue = makeContext({
       github: { githubInfo: { login: "octocat" }, connect: jest.fn() } as unknown as ProfileContextValue["github"],

--- a/app/(auth)/profile/_components/OnboardingChecklist.tsx
+++ b/app/(auth)/profile/_components/OnboardingChecklist.tsx
@@ -13,11 +13,16 @@ interface ChecklistItem {
   label: string;
   done: boolean;
   action?: () => void;
+  actionLabel?: string;
   href?: string;
   description: string;
 }
 
-export function OnboardingChecklist() {
+interface OnboardingChecklistProps {
+  onWriteBio?: () => void;
+}
+
+export function OnboardingChecklist({ onWriteBio }: OnboardingChecklistProps) {
   const {
     user,
     userProfile,
@@ -41,6 +46,8 @@ export function OnboardingChecklist() {
     {
       label: "Write a short bio",
       done: Boolean(userProfile?.bio?.trim()),
+      action: userProfile?.bio?.trim() ? undefined : onWriteBio,
+      actionLabel: "Open",
       description: "Tell people what you're building",
     },
     {
@@ -135,7 +142,7 @@ export function OnboardingChecklist() {
 
               {!item.done && (item.action || item.href) && (
                 <span className="shrink-0 text-xs text-emerald-400 font-medium mt-0.5">
-                  {item.href ? "Open" : "Connect"} &rarr;
+                  {item.actionLabel ?? (item.href ? "Open" : "Connect")} &rarr;
                 </span>
               )}
             </div>

--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useEffect, Suspense, useState } from "react";
+import { useEffect, Suspense, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -45,6 +45,17 @@ function ProfilePageContent() {
   const initialSection = searchParams.get("section");
   const [settingsOpen, setSettingsOpen] = useState(initialSection === "settings");
   const [securityOpen, setSecurityOpen] = useState(initialSection === "security");
+  const settingsSectionRef = useRef<HTMLDivElement>(null);
+
+  const openProfileSettings = () => {
+    setSettingsOpen(true);
+    window.requestAnimationFrame(() => {
+      settingsSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  };
 
   // Google reconnection reset
   useEffect(() => {
@@ -72,16 +83,18 @@ function ProfilePageContent() {
     <div className="min-h-[80vh] px-6 py-8 md:py-12">
       <div className="max-w-3xl mx-auto">
         <ProfileHeader onEditProfile={() => setIsEditModalOpen(true)} />
-        <OnboardingChecklist />
+        <OnboardingChecklist onWriteBio={openProfileSettings} />
         <ConnectionsSection />
         <StatsGrid />
         <EarnedBadgesSection />
         <ActivitySection />
 
         {/* Settings — collapsible */}
-        <div className="mb-8">
+        <div id="profile-settings" ref={settingsSectionRef} className="mb-8 scroll-mt-8">
           <button
             onClick={() => setSettingsOpen(!settingsOpen)}
+            aria-expanded={settingsOpen}
+            aria-controls="profile-settings-panel"
             className="w-full flex items-center justify-between text-sm font-semibold text-neutral-400 uppercase tracking-wider mb-3 hover:text-neutral-300 transition-colors"
           >
             <span>Profile Settings</span>
@@ -93,15 +106,17 @@ function ProfilePageContent() {
             </svg>
           </button>
           {settingsOpen && (
-            <SettingsTab
-              settings={profileSettings.settings}
-              setSettings={profileSettings.setSettings}
-              saving={profileSettings.saving}
-              error={profileSettings.error}
-              success={profileSettings.success}
-              onSave={profileSettings.save}
-              onToggleAllVisibility={profileSettings.toggleAllVisibility}
-            />
+            <div id="profile-settings-panel">
+              <SettingsTab
+                settings={profileSettings.settings}
+                setSettings={profileSettings.setSettings}
+                saving={profileSettings.saving}
+                error={profileSettings.error}
+                success={profileSettings.success}
+                onSave={profileSettings.save}
+                onToggleAllVisibility={profileSettings.toggleAllVisibility}
+              />
+            </div>
           )}
         </div>
 

--- a/app/api/summer-cohort/apply/route.ts
+++ b/app/api/summer-cohort/apply/route.ts
@@ -173,6 +173,37 @@ async function handlePost(request: NextRequest) {
   }
 }
 
+async function handleDelete(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  try {
+    const ref = db.collection(SUMMER_COHORT_COLLECTION).doc(user.uid);
+    const existing = await ref.get();
+    if (!existing.exists) {
+      return NextResponse.json({ withdrawn: false });
+    }
+    await ref.delete();
+    return NextResponse.json({ withdrawn: true });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/summer-cohort/apply",
+      method: "DELETE",
+    });
+    return NextResponse.json(
+      { error: "Failed to withdraw application" },
+      { status: 500 }
+    );
+  }
+}
+
 interface ApplicantRow {
   name: string;
   email: string;
@@ -316,3 +347,4 @@ async function sendNewApplicationEmail(
 
 export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);
 export const POST = withMiddleware(rateLimitConfigs.standard, handlePost);
+export const DELETE = withMiddleware(rateLimitConfigs.standard, handleDelete);

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -89,6 +89,8 @@ function SummerCohortPageInner() {
   );
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [withdrawing, setWithdrawing] = useState(false);
+  const [withdrawError, setWithdrawError] = useState<string | null>(null);
 
   // Default name from auth profile once it loads.
   useEffect(() => {
@@ -214,6 +216,42 @@ function SummerCohortPageInner() {
     }
   };
 
+  const withdraw = async () => {
+    if (!user) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        "Withdraw your Summer Cohort application? This will remove your application from our system."
+      )
+    ) {
+      return;
+    }
+    setWithdrawError(null);
+    setWithdrawing(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/summer-cohort/apply", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        setWithdrawError(
+          typeof json.error === "string" ? json.error : "Failed to withdraw."
+        );
+        return;
+      }
+      setApplication(null);
+      setName(user.displayName || "");
+      setPhone("");
+      setPickedCohorts(new Set(SUMMER_COHORTS.map((c) => c.id)));
+    } catch {
+      setWithdrawError("Network error. Please try again.");
+    } finally {
+      setWithdrawing(false);
+    }
+  };
+
   const cohortLabel = useMemo(() => {
     const map = new Map(SUMMER_COHORTS.map((c) => [c.id, c.label] as const));
     return (id: SummerCohortId) => map.get(id) || id;
@@ -292,6 +330,21 @@ function SummerCohortPageInner() {
             <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
               {KICKOFF_NOTE}
             </p>
+            <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-emerald-200 pt-4 dark:border-emerald-900">
+              <button
+                type="button"
+                onClick={withdraw}
+                disabled={withdrawing}
+                className="inline-flex items-center gap-2 rounded-lg border border-red-300 bg-white px-3 py-2 text-xs font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:bg-transparent dark:text-red-400 dark:hover:bg-red-950/30"
+              >
+                {withdrawing ? "Withdrawing…" : "Withdraw application"}
+              </button>
+              {withdrawError ? (
+                <span className="text-xs text-red-600 dark:text-red-400">
+                  {withdrawError}
+                </span>
+              ) : null}
+            </div>
           </section>
           <CohortProgramBreakdown />
         </>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -67,6 +67,7 @@ Licensed GPL-3.0-only.
     /questions/ask
     /showcase
     /signup
+    /summer-cohort
     /talks
     /talks/submit
     /terms


### PR DESCRIPTION
## Included changes

- **#613** [codex] fix profile bio checklist link — @HarryJ12
  Wires the dormant "Write a short bio" onboarding checklist row to actually open the Profile Settings accordion and scroll to it.

- **feat(summer-cohort): allow applicants to withdraw their application** — @Ludwitt + Claude
  Adds a "Withdraw application" button to the Pending panel on `/summer-cohort` backed by a new `DELETE /api/summer-cohort/apply` handler. Confirms with the user, removes the Firestore doc, and resets the form so they can re-apply.

## Test plan

- [x] CI green on develop (all #613 checks passed; withdraw change is type-clean)
- [ ] Spot-check `/profile` onboarding "Write a short bio" row opens the accordion
- [ ] Spot-check `/summer-cohort` Withdraw button on a pending applicant account

🤖 Generated with [Claude Code](https://claude.com/claude-code)