### PR TITLE
Release: develop → main (cohort admit-flow infra)

### DIFF
--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -61,6 +61,128 @@ function CohortDatesList() {
   );
 }
 
+function scrollToConnections() {
+  const el = document.getElementById("connections-heading");
+  if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+interface StatusPanelProps {
+  application: ApplicationDto;
+  cohortLabel: (id: SummerCohortId) => string;
+  withdrawing: boolean;
+  withdrawError: string | null;
+  onWithdraw: () => void;
+  needsDiscord: boolean;
+}
+
+function ApplicationStatusPanel({
+  application,
+  cohortLabel,
+  withdrawing,
+  withdrawError,
+  onWithdraw,
+  needsDiscord,
+}: StatusPanelProps) {
+  const status = application.status;
+  const cohortText = application.cohorts.map(cohortLabel).join(" and ");
+
+  const tone =
+    status === "admitted"
+      ? {
+          panel:
+            "rounded-xl border border-emerald-400 bg-emerald-50 p-6 dark:border-emerald-700 dark:bg-emerald-950/40",
+          badge: "bg-emerald-500 text-white",
+          divider: "border-emerald-200 dark:border-emerald-900",
+          label: "Status: Admitted",
+          headline: `You're in! Welcome to ${cohortText || "the cohort"}.`,
+          body:
+            "Watch for a separate email with the Zoom kickoff link. Until then, get ready by skimming the program breakdown below.",
+        }
+      : status === "waitlist"
+        ? {
+            panel:
+              "rounded-xl border border-amber-300 bg-amber-50 p-6 dark:border-amber-800 dark:bg-amber-950/30",
+            badge: "bg-amber-500 text-white",
+            divider: "border-amber-200 dark:border-amber-900",
+            label: "Status: Waitlist",
+            headline: `You're on the waitlist for ${cohortText || "the cohort"}.`,
+            body:
+              "We'll let you know by email if a spot opens up. In the meantime, the program breakdown below is what you'd be joining.",
+          }
+        : status === "rejected"
+          ? {
+              panel:
+                "rounded-xl border border-neutral-300 bg-neutral-50 p-6 dark:border-neutral-700 dark:bg-neutral-900/60",
+              badge: "bg-neutral-500 text-white",
+              divider: "border-neutral-200 dark:border-neutral-800",
+              label: "Status: Not selected",
+              headline: "We weren't able to fit you into this cohort round.",
+              body: "Thanks for applying — we'd love for you to apply to a future cohort.",
+            }
+          : {
+              panel:
+                "rounded-xl border border-emerald-300 bg-emerald-50 p-6 dark:border-emerald-900 dark:bg-emerald-950/30",
+              badge: "bg-emerald-500 text-white",
+              divider: "border-emerald-200 dark:border-emerald-900",
+              label: "Status: Pending",
+              headline: `We received your application for ${cohortText || "the cohort"}.`,
+              body: "We'll review and follow up by email. " + KICKOFF_NOTE,
+            };
+
+  const showDiscordCallout = status === "admitted" && needsDiscord;
+
+  return (
+    <section className={tone.panel}>
+      <div className="flex items-center gap-3">
+        <span
+          className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${tone.badge}`}
+        >
+          {tone.label}
+        </span>
+      </div>
+      <p className="mt-3 text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+        {tone.headline}
+      </p>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        {tone.body}
+      </p>
+
+      {showDiscordCallout ? (
+        <div className="mt-4 rounded-lg border-l-4 border-amber-500 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-400 dark:bg-amber-950/40 dark:text-amber-200">
+          <strong>Action needed:</strong> connect your Discord below so we can
+          add you to the cohort channel.{" "}
+          <button
+            type="button"
+            onClick={scrollToConnections}
+            className="underline decoration-amber-700/60 underline-offset-2 hover:decoration-amber-700 dark:decoration-amber-300/60"
+          >
+            Jump to connections
+          </button>
+          .
+        </div>
+      ) : null}
+
+      <div
+        className={`mt-4 flex flex-wrap items-center gap-3 border-t pt-4 ${tone.divider}`}
+      >
+        <button
+          type="button"
+          onClick={onWithdraw}
+          disabled={withdrawing}
+          className="inline-flex items-center gap-2 rounded-lg border border-red-300 bg-white px-3 py-2 text-xs font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:bg-transparent dark:text-red-400 dark:hover:bg-red-950/30"
+        >
+          {withdrawing ? "Withdrawing…" : "Withdraw application"}
+        </button>
+        {withdrawError ? (
+          <span className="text-xs text-red-600 dark:text-red-400">
+            {withdrawError}
+          </span>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
 function SummerCohortPageInner() {
   const searchParams = useSearchParams();
   const { user, userProfile, loading, refreshUserProfile } = useAuth();
@@ -314,38 +436,14 @@ function SummerCohortPageInner() {
         </div>
       ) : application ? (
         <>
-          <section className="rounded-xl border border-emerald-300 bg-emerald-50 p-6 dark:border-emerald-900 dark:bg-emerald-950/30">
-            <div className="flex items-center gap-3">
-              <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
-                Status: Pending
-              </span>
-            </div>
-            <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
-              We received your application for{" "}
-              <strong>
-                {application.cohorts.map(cohortLabel).join(" and ")}
-              </strong>
-              . We&apos;ll review and follow up by email.
-            </p>
-            <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-              {KICKOFF_NOTE}
-            </p>
-            <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-emerald-200 pt-4 dark:border-emerald-900">
-              <button
-                type="button"
-                onClick={withdraw}
-                disabled={withdrawing}
-                className="inline-flex items-center gap-2 rounded-lg border border-red-300 bg-white px-3 py-2 text-xs font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:bg-transparent dark:text-red-400 dark:hover:bg-red-950/30"
-              >
-                {withdrawing ? "Withdrawing…" : "Withdraw application"}
-              </button>
-              {withdrawError ? (
-                <span className="text-xs text-red-600 dark:text-red-400">
-                  {withdrawError}
-                </span>
-              ) : null}
-            </div>
-          </section>
+          <ApplicationStatusPanel
+            application={application}
+            cohortLabel={cohortLabel}
+            withdrawing={withdrawing}
+            withdrawError={withdrawError}
+            onWithdraw={withdraw}
+            needsDiscord={!discord.discordInfo}
+          />
           <CohortProgramBreakdown />
         </>
       ) : (

--- a/scripts/list-cohort-discord-ids.ts
+++ b/scripts/list-cohort-discord-ids.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * List Summer Cohort applicants and (where available) their connected
+ * Discord identity, so an admin can grant the new "Cohorts/S261" role
+ * in the cursor-boston Discord server.
+ *
+ * Usage:
+ *   npx tsx scripts/list-cohort-discord-ids.ts                # all cohorts, all statuses
+ *   npx tsx scripts/list-cohort-discord-ids.ts --cohort=cohort-1
+ *   npx tsx scripts/list-cohort-discord-ids.ts --status=admitted
+ *   npx tsx scripts/list-cohort-discord-ids.ts --cohort=cohort-1 --status=admitted
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import {
+  SUMMER_COHORT_COLLECTION,
+  SUMMER_COHORTS,
+  isValidCohortId,
+  type SummerCohortId,
+} from "../lib/summer-cohort";
+
+type Status = "pending" | "admitted" | "rejected" | "waitlist";
+const ALLOWED_STATUSES: ReadonlySet<Status> = new Set([
+  "pending",
+  "admitted",
+  "rejected",
+  "waitlist",
+]);
+
+interface Row {
+  name: string;
+  email: string;
+  uid: string;
+  cohorts: SummerCohortId[];
+  status: Status;
+  discordId: string | null;
+  discordUsername: string | null;
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s.slice(0, n) : s + " ".repeat(n - s.length);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const cohortArg = args.find((a) => a.startsWith("--cohort="));
+  const cohortFilter: SummerCohortId | null = cohortArg
+    ? (cohortArg.split("=")[1] as SummerCohortId)
+    : null;
+  if (cohortFilter && !isValidCohortId(cohortFilter)) {
+    console.error(
+      `Invalid --cohort value. Pick one of: ${SUMMER_COHORTS.map((c) => c.id).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  const statusArg = args.find((a) => a.startsWith("--status="));
+  const statusFilter: Status | null = statusArg
+    ? (statusArg.split("=")[1] as Status)
+    : null;
+  if (statusFilter && !ALLOWED_STATUSES.has(statusFilter)) {
+    console.error(
+      `Invalid --status value. Pick one of: ${Array.from(ALLOWED_STATUSES).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const rows: Row[] = [];
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const cohorts = Array.isArray(data.cohorts)
+      ? (data.cohorts.filter(isValidCohortId) as SummerCohortId[])
+      : [];
+    if (cohorts.length === 0) continue;
+    if (cohortFilter && !cohorts.includes(cohortFilter)) continue;
+
+    const status = ((data.status as string) || "pending") as Status;
+    if (statusFilter && status !== statusFilter) continue;
+
+    const uid = (data.userId || doc.id || "").toString();
+    let discordId: string | null = null;
+    let discordUsername: string | null = null;
+    if (uid) {
+      const userSnap = await db.collection("users").doc(uid).get();
+      const discord = userSnap.data()?.discord as
+        | { id?: string; username?: string }
+        | undefined;
+      if (discord?.id) discordId = discord.id;
+      if (discord?.username) discordUsername = discord.username;
+    }
+
+    rows.push({
+      name: typeof data.name === "string" ? data.name : "",
+      email: typeof data.email === "string" ? data.email : "",
+      uid,
+      cohorts,
+      status,
+      discordId,
+      discordUsername,
+    });
+  }
+
+  const connected = rows.filter((r) => r.discordId);
+  const missing = rows.filter((r) => !r.discordId);
+
+  const filterLabel = cohortFilter
+    ? `${cohortFilter} (${
+        SUMMER_COHORTS.find((c) => c.id === cohortFilter)?.label ?? cohortFilter
+      })`
+    : "all cohorts";
+
+  console.log(`Cohort:    ${filterLabel}`);
+  console.log(`Status:    ${statusFilter ?? "(any)"}`);
+  console.log(`Total:     ${rows.length}`);
+  console.log(`Connected: ${connected.length}`);
+  console.log(`Missing:   ${missing.length}\n`);
+
+  console.log("=== CONNECTED (ready to receive the role) ===");
+  if (connected.length === 0) {
+    console.log("  (none)");
+  } else {
+    console.log(
+      `  ${pad("NAME", 26)}  ${pad("EMAIL", 36)}  ${pad("STATUS", 9)}  ${pad("DISCORD", 24)}  DISCORD_ID`
+    );
+    for (const r of connected) {
+      console.log(
+        `  ${pad(r.name || "(no name)", 26)}  ${pad(r.email, 36)}  ${pad(r.status, 9)}  ${pad("@" + (r.discordUsername || ""), 24)}  ${r.discordId}`
+      );
+    }
+  }
+
+  console.log("\n=== NOT CONNECTED (need to connect Discord on /summer-cohort) ===");
+  if (missing.length === 0) {
+    console.log("  (none)");
+  } else {
+    console.log(`  ${pad("NAME", 26)}  ${pad("EMAIL", 36)}  STATUS`);
+    for (const r of missing) {
+      console.log(`  ${pad(r.name || "(no name)", 26)}  ${pad(r.email, 36)}  ${r.status}`);
+    }
+  }
+
+  if (connected.length > 0) {
+    console.log("\n=== Discord IDs only (one per line, copy/paste friendly) ===");
+    for (const r of connected) console.log(r.discordId);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort-admittance.ts
+++ b/scripts/send-cohort-admittance.ts
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * Send the "you're admitted!" email to every applicant whose application
+ * is currently `status: "admitted"` and who hasn't been emailed yet
+ * (no `admittanceEmailedAt` timestamp).
+ *
+ * Tracks `admittanceEmailedAt` so this script can be safely re-run after
+ * adding more admits later — already-emailed people will be skipped.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort-admittance.ts --dry-run
+ *   npx tsx scripts/send-cohort-admittance.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import {
+  SUMMER_COHORT_COLLECTION,
+  SUMMER_COHORTS,
+  isValidCohortId,
+  type SummerCohortId,
+} from "../lib/summer-cohort";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface Admit {
+  uid: string;
+  name: string;
+  email: string;
+  cohorts: SummerCohortId[];
+  hasDiscord: boolean;
+}
+
+const PAGE_URL = "https://cursorboston.com/summer-cohort";
+
+function buildEmail(admit: Admit): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(admit.name?.split(" ")[0]?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(admit.email);
+  const cohortLabels = admit.cohorts
+    .map(
+      (id) =>
+        SUMMER_COHORTS.find((c) => c.id === id)?.label ?? id
+    )
+    .join(" and ");
+
+  const inCohort1 = admit.cohorts.includes("cohort-1");
+  const inCohort2 = admit.cohorts.includes("cohort-2");
+
+  const subject = "You're in — Cursor Boston Summer Cohort";
+
+  const discordBlock = admit.hasDiscord
+    ? `<p>You've already connected Discord on the application page — we'll add you to the cohort channel before kickoff.</p>`
+    : `<p style="margin-top:12px;padding:12px 16px;border-left:4px solid #f59e0b;background:#fffbeb;color:#78350f;">
+  <strong>One thing left for you:</strong> head to <a href="${PAGE_URL}">${PAGE_URL}</a>
+  and click <strong>Connect</strong> on Discord so we can add you to the cohort channel.
+</p>`;
+
+  const discordTextBlock = admit.hasDiscord
+    ? `You've already connected Discord — we'll add you to the cohort channel before kickoff.`
+    : `>>> ONE THING LEFT FOR YOU: Head to ${PAGE_URL} and click "Connect" on Discord so we can add you to the cohort channel.`;
+
+  const kickoffLines: string[] = [];
+  if (inCohort1) {
+    kickoffLines.push(
+      "<li><strong>Mon, May 11</strong> — Cohort 1 kickoff Zoom (link sent separately)</li>"
+    );
+  }
+  if (inCohort1) {
+    kickoffLines.push(
+      "<li><strong>Tue, May 26</strong> — Hult / Cursor Boston in-person immersion event (Cohort 1 priority on the 80-person cap)</li>"
+    );
+  }
+  if (inCohort2) {
+    kickoffLines.push(
+      "<li><strong>Mon, Jun 29</strong> — Cohort 2 kickoff Zoom (link sent separately)</li>"
+    );
+  }
+
+  const kickoffText: string[] = [];
+  if (inCohort1) {
+    kickoffText.push(
+      "  • Mon, May 11  — Cohort 1 kickoff Zoom (link sent separately)"
+    );
+    kickoffText.push(
+      "  • Tue, May 26  — Hult / Cursor Boston in-person immersion event (Cohort 1 priority on the 80-person cap)"
+    );
+  }
+  if (inCohort2) {
+    kickoffText.push(
+      "  • Mon, Jun 29  — Cohort 2 kickoff Zoom (link sent separately)"
+    );
+  }
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Great news — <strong>you're in the Cursor Boston Summer Cohort</strong>. You're admitted to <strong>${escapeHtml(cohortLabels || "the cohort")}</strong>.</p>
+
+${discordBlock}
+
+<p style="margin-top:20px;"><strong>What's next:</strong></p>
+<ul style="margin:8px 0;padding-left:20px;">${kickoffLines.join("")}</ul>
+
+<p style="margin-top:16px;">The full week-by-week program is on your application page so you can plan ahead:</p>
+
+<p style="margin-top:12px;">
+  <a href="${PAGE_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Open my application →</a>
+</p>
+
+<p style="margin-top:16px;">If you can no longer commit, please hit the <strong>Withdraw</strong> button on the page so we can free up your spot. You can re-apply if your situation changes.</p>
+
+<p>Reply to this email with any questions.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you applied to the Cursor Boston Summer Cohort and were admitted.<br/>
+Don't want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${admit.name?.split(" ")[0]?.trim() || "there"},
+
+Great news — YOU'RE IN THE CURSOR BOSTON SUMMER COHORT. You're admitted to ${cohortLabels || "the cohort"}.
+
+${discordTextBlock}
+
+WHAT'S NEXT
+${kickoffText.join("\n")}
+
+The full week-by-week program is on your application page so you can plan ahead:
+${PAGE_URL}
+
+If you can no longer commit, please hit the "Withdraw" button on the page so we can free up your spot. You can re-apply if your situation changes.
+
+Reply to this email with any questions.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you applied to the Cursor Boston Summer Cohort and were admitted.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if (dryRun === send) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured");
+    process.exit(1);
+  }
+
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .where("status", "==", "admitted")
+    .get();
+
+  console.log(`Admitted applicants: ${snap.size}`);
+
+  const queue: Admit[] = [];
+  let alreadyEmailed = 0;
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (data.admittanceEmailedAt) {
+      alreadyEmailed++;
+      continue;
+    }
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) continue;
+    const cohorts = (Array.isArray(data.cohorts) ? data.cohorts : []).filter(
+      isValidCohortId
+    ) as SummerCohortId[];
+    if (cohorts.length === 0) continue;
+
+    let hasDiscord = false;
+    const uid = (data.userId || doc.id).toString();
+    if (uid) {
+      const userSnap = await db.collection("users").doc(uid).get();
+      hasDiscord = Boolean(userSnap.data()?.discord?.id);
+    }
+
+    queue.push({
+      uid,
+      name: typeof data.name === "string" ? data.name : "",
+      email,
+      cohorts,
+      hasDiscord,
+    });
+  }
+
+  console.log(`To email now: ${queue.length} | Already emailed: ${alreadyEmailed}`);
+
+  if (dryRun) {
+    const sample = queue[0];
+    if (sample) {
+      const { subject, html } = buildEmail(sample);
+      console.log(`\nSample to: ${sample.email} (${sample.name || "(no name)"})`);
+      console.log(`Discord connected: ${sample.hasDiscord}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- HTML preview (first 1800 chars) ----\n${html.slice(0, 1800)}\n…`);
+    } else {
+      console.log("\n(no admits to email — either none in 'admitted' status, or all already emailed)");
+    }
+    console.log(`\n--dry-run: no emails sent and no writes.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const admit of queue) {
+    const { subject, html, text } = buildEmail(admit);
+    try {
+      await sendEmail({ to: admit.email, subject, html, text });
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(admit.uid).set(
+        { admittanceEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      sent++;
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${queue.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${admit.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}, already-emailed ${alreadyEmailed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/set-cohort-status.ts
+++ b/scripts/set-cohort-status.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Admin script: flip the status field on Summer Cohort applications.
+ *
+ * Usage:
+ *   # show every applicant + current status
+ *   npx tsx scripts/set-cohort-status.ts --list
+ *
+ *   # flip a set of people to "admitted" (or waitlist / rejected / pending)
+ *   npx tsx scripts/set-cohort-status.ts --status=admitted \
+ *     --emails=alice@example.com,bob@example.com --dry-run
+ *   npx tsx scripts/set-cohort-status.ts --status=admitted \
+ *     --emails=alice@example.com,bob@example.com --apply
+ *
+ *   # or use a file (one email or uid per line, # comments allowed)
+ *   npx tsx scripts/set-cohort-status.ts --status=admitted \
+ *     --file=admit-may10.txt --apply
+ *
+ *   # match by uid instead of email
+ *   npx tsx scripts/set-cohort-status.ts --status=waitlist --uids=abc,def --apply
+ *
+ * Idempotent: if the status is already what you're setting, no write happens.
+ * Stamps `statusUpdatedAt` on every actual write.
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { readFileSync } from "node:fs";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+type Status = "pending" | "admitted" | "rejected" | "waitlist";
+const ALLOWED_STATUSES: ReadonlySet<Status> = new Set([
+  "pending",
+  "admitted",
+  "rejected",
+  "waitlist",
+]);
+
+function getArg(name: string): string | null {
+  const prefix = `--${name}=`;
+  const found = process.argv.find((a) => a.startsWith(prefix));
+  return found ? found.slice(prefix.length) : null;
+}
+
+function readIdentifiersFromFile(path: string): string[] {
+  const text = readFileSync(path, "utf8");
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.split("#")[0].trim())
+    .filter((line) => line.length > 0);
+}
+
+async function listAll() {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not configured");
+
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const counts: Record<string, number> = {};
+  console.log(`\n${snap.size} application(s):\n`);
+  console.log(
+    `  ${"NAME".padEnd(26)}  ${"EMAIL".padEnd(36)}  ${"COHORTS".padEnd(20)}  STATUS`
+  );
+  for (const doc of snap.docs) {
+    const d = doc.data();
+    const status = (d.status || "pending") as string;
+    counts[status] = (counts[status] || 0) + 1;
+    const name = (d.name || "").toString().slice(0, 26).padEnd(26);
+    const email = (d.email || "").toString().slice(0, 36).padEnd(36);
+    const cohorts = (Array.isArray(d.cohorts) ? d.cohorts : [])
+      .join(", ")
+      .padEnd(20);
+    console.log(`  ${name}  ${email}  ${cohorts}  ${status}`);
+  }
+  console.log("\nBy status:");
+  for (const [s, n] of Object.entries(counts)) console.log(`  ${s}: ${n}`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--list")) {
+    await listAll();
+    return;
+  }
+
+  const status = getArg("status") as Status | null;
+  if (!status || !ALLOWED_STATUSES.has(status)) {
+    console.error(
+      `--status is required and must be one of: ${Array.from(ALLOWED_STATUSES).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  const dryRun = args.includes("--dry-run");
+  const apply = args.includes("--apply");
+  if (dryRun === apply) {
+    console.error("Specify exactly one of: --dry-run | --apply");
+    process.exit(1);
+  }
+
+  const emailsArg = getArg("emails");
+  const uidsArg = getArg("uids");
+  const fileArg = getArg("file");
+  const identifiers = new Set<string>();
+  if (emailsArg) emailsArg.split(",").forEach((e) => identifiers.add(e.trim().toLowerCase()));
+  if (uidsArg) uidsArg.split(",").forEach((u) => identifiers.add(u.trim()));
+  if (fileArg) readIdentifiersFromFile(fileArg).forEach((v) => identifiers.add(v.trim().toLowerCase()));
+  if (identifiers.size === 0) {
+    console.error("Provide --emails=, --uids=, or --file=");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured");
+    process.exit(1);
+  }
+
+  const snap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const byEmail = new Map<string, FirebaseFirestore.QueryDocumentSnapshot>();
+  const byUid = new Map<string, FirebaseFirestore.QueryDocumentSnapshot>();
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = (data.email || "").toString().trim().toLowerCase();
+    if (email) byEmail.set(email, doc);
+    byUid.set(doc.id, doc);
+    if (typeof data.userId === "string") byUid.set(data.userId, doc);
+  }
+
+  const matched: { id: string; email: string; name: string; current: string }[] = [];
+  const missing: string[] = [];
+  for (const ident of identifiers) {
+    const doc = byEmail.get(ident) ?? byUid.get(ident);
+    if (!doc) {
+      missing.push(ident);
+      continue;
+    }
+    const d = doc.data();
+    matched.push({
+      id: doc.id,
+      email: (d.email || "").toString(),
+      name: (d.name || "").toString(),
+      current: (d.status || "pending").toString(),
+    });
+  }
+
+  console.log(`Target status: ${status}`);
+  console.log(`Identifiers given: ${identifiers.size}`);
+  console.log(`Matched: ${matched.length}`);
+  console.log(`Missing: ${missing.length}`);
+  if (missing.length > 0) {
+    console.log("\n  No matching application found for:");
+    for (const m of missing) console.log(`    - ${m}`);
+  }
+
+  const noChange = matched.filter((m) => m.current === status);
+  const willChange = matched.filter((m) => m.current !== status);
+
+  console.log(`\nAlready ${status}: ${noChange.length}`);
+  console.log(`Will change to ${status}: ${willChange.length}\n`);
+  for (const m of willChange) {
+    console.log(`  ${m.name || "(no name)"} <${m.email}>: ${m.current} → ${status}`);
+  }
+
+  if (dryRun) {
+    console.log(`\n--dry-run: no writes.`);
+    return;
+  }
+
+  let written = 0;
+  for (const m of willChange) {
+    await db.collection(SUMMER_COHORT_COLLECTION).doc(m.id).set(
+      { status, statusUpdatedAt: FieldValue.serverTimestamp() },
+      { merge: true }
+    );
+    written++;
+  }
+  console.log(`\nWrote ${written} update(s).`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Included changes

- **feat(summer-cohort): admit-flow infra** — @Ludwitt + Claude
  - `/summer-cohort` page reads the real `application.status` and renders Pending / Admitted / Waitlist / Rejected panels with appropriate copy. Admitted users without Discord get a "connect Discord" callout.
  - `scripts/set-cohort-status.ts` — admin tool to flip status (idempotent, dry-runnable).
  - `scripts/send-cohort-admittance.ts` — admit email sender (only emails admitted-but-not-yet-emailed; safe to re-run).
  - `scripts/list-cohort-discord-ids.ts` — gains `--status=admitted` filter.

No applicants are admitted; everyone stays `pending` until the May 10 admit run.

## Test plan

- [x] Type-check clean
- [x] `npm run build` — `/summer-cohort` still prerenders as `○ (Static)`
- [x] All three scripts dry-run cleanly against live Firestore
- [ ] Spot-check: admit a single test applicant on staging, confirm the page shows the Admitted panel and Discord callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)