### PR TITLE
Release: develop → main (Sign in with Ludwitt + AI credit proxy)

### DIFF
--- a/app/(auth)/login/_lib/ludwitt-errors.ts
+++ b/app/(auth)/login/_lib/ludwitt-errors.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export function getLudwittErrorMessage(code: string | null): string {
+  switch (code) {
+    case "missing_params":
+      return "Ludwitt sign-in was incomplete. Please try again.";
+    case "invalid_state":
+      return "Ludwitt sign-in expired before you finished. Please try again.";
+    case "not_configured":
+      return "Ludwitt sign-in isn't set up on this site yet.";
+    case "token_failed":
+      return "Couldn't reach Ludwitt to finish signing you in. Please try again.";
+    case "userinfo_failed":
+      return "Ludwitt didn't return your account details. Please try again.";
+    case "no_email":
+      return "Your Ludwitt account doesn't have an email on file. Please add one and try again.";
+    case "firebase_user_failed":
+      return "We couldn't create your account on our side. Please try again.";
+    case "token_persist_failed":
+      return "We couldn't save your Ludwitt session. Please try again.";
+    case "custom_token_failed":
+      return "We couldn't establish your sign-in session. Please try again.";
+    case "finalize_failed":
+      return "Sign-in expired before it finished. Please try again.";
+    case "access_denied":
+      return "You declined the Ludwitt sign-in. No problem — try again whenever.";
+    default:
+      return "Ludwitt sign-in failed. Please try again.";
+  }
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { AuthFormSkeleton } from "@/components/skeletons/AuthFormSkeleton";
+import { getLudwittErrorMessage } from "./_lib/ludwitt-errors";
 
 // Map Firebase error codes to user-friendly messages
 function getErrorMessage(error: unknown): string {
@@ -79,6 +80,12 @@ function LoginPageContent() {
 
   // Get redirect URL from query params, default to home
   const redirectUrl = searchParams.get("redirect") || "/";
+
+  // Show a friendly banner if the Ludwitt OAuth flow bounced us back with an error
+  const ludwittError =
+    searchParams.get("ludwitt") === "error"
+      ? getLudwittErrorMessage(searchParams.get("message"))
+      : null;
 
   // Redirect authenticated users away from login page
   useEffect(() => {
@@ -186,13 +193,23 @@ function LoginPageContent() {
 
         <div className="bg-white dark:bg-neutral-900 rounded-xl md:rounded-2xl p-5 md:p-8 border border-neutral-200 dark:border-neutral-800">
           {error && (
-            <div 
+            <div
               role="alert"
               aria-live="polite"
               id="form-error"
               className="mb-6 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm"
             >
               {error}
+            </div>
+          )}
+
+          {ludwittError && (
+            <div
+              role="alert"
+              aria-live="polite"
+              className="mb-6 p-4 bg-amber-500/10 border border-amber-500/20 rounded-lg text-amber-400 text-sm"
+            >
+              {ludwittError}
             </div>
           )}
 
@@ -258,6 +275,28 @@ function LoginPageContent() {
               </svg>
               Continue with GitHub
             </button>
+
+            <a
+              href={`/api/ludwitt/authorize?returnTo=${encodeURIComponent(redirectUrl)}`}
+              className="w-full flex items-center justify-center gap-3 px-4 py-3 bg-gradient-to-r from-indigo-600 to-purple-600 text-white rounded-lg font-medium hover:opacity-90 transition-opacity"
+              aria-label="Sign in with Ludwitt"
+            >
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2.25}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 2L2 7l10 5 10-5-10-5z" />
+                <path d="M2 17l10 5 10-5" />
+                <path d="M2 12l10 5 10-5" />
+              </svg>
+              Continue with Ludwitt
+            </a>
           </div>
 
           <div className="relative mb-6">

--- a/app/api/ludwitt/ai/messages/route.ts
+++ b/app/api/ludwitt/ai/messages/route.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  LUDWITT_AI_MESSAGES_URL,
+  LUDWITT_TOPUP_URL,
+  fetchLudwittWithTimeout,
+} from "@/lib/ludwitt-config";
+import {
+  deleteLudwittTokens,
+  withFreshLudwittAccessToken,
+} from "@/lib/ludwitt-tokens";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | unknown;
+}
+
+interface AnthropicRequest {
+  model: string;
+  max_tokens: number;
+  messages: AnthropicMessage[];
+  system?: string;
+  temperature?: number;
+}
+
+function validateBody(input: unknown): AnthropicRequest | null {
+  if (!input || typeof input !== "object") return null;
+  const r = input as Record<string, unknown>;
+  if (typeof r.model !== "string" || !r.model) return null;
+  if (typeof r.max_tokens !== "number" || r.max_tokens <= 0) return null;
+  if (!Array.isArray(r.messages) || r.messages.length === 0) return null;
+  for (const m of r.messages) {
+    if (!m || typeof m !== "object") return null;
+    const role = (m as { role?: unknown }).role;
+    if (role !== "user" && role !== "assistant") return null;
+  }
+  return r as unknown as AnthropicRequest;
+}
+
+async function handleAiMessages(request: NextRequest): Promise<NextResponse> {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const validated = validateBody(body);
+  if (!validated) {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  let result: { status: number; body: unknown; headers: Headers };
+  try {
+    result = await withFreshLudwittAccessToken(user.uid, async (accessToken) => {
+      const upstream = await fetchLudwittWithTimeout(LUDWITT_AI_MESSAGES_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(validated),
+      });
+      const json = await upstream.json().catch(() => null);
+      return { status: upstream.status, body: json, headers: upstream.headers };
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg === "ludwitt_not_connected") {
+      return NextResponse.json(
+        { error: "ludwitt_not_connected", connectUrl: "/api/ludwitt/authorize" },
+        { status: 412 }
+      );
+    }
+    logger.logError(err, { stage: "ludwitt_ai_messages", uid: user.uid });
+    return NextResponse.json({ error: "upstream_failed" }, { status: 502 });
+  }
+
+  // 401 after refresh-retry → session genuinely dead, force re-sign-in
+  if (result.status === 401) {
+    await deleteLudwittTokens(user.uid).catch(() => {});
+    return NextResponse.json(
+      { error: "ludwitt_session_expired" },
+      { status: 401 }
+    );
+  }
+
+  if (result.status === 402) {
+    return NextResponse.json(
+      { error: "out_of_credits", topUpUrl: LUDWITT_TOPUP_URL },
+      { status: 402 }
+    );
+  }
+
+  if (result.status >= 400) {
+    return NextResponse.json(
+      {
+        error: "upstream_error",
+        upstreamStatus: result.status,
+        upstreamBody: result.body,
+      },
+      { status: result.status >= 500 ? 502 : result.status }
+    );
+  }
+
+  // Success — forward body and credit metadata header
+  const credits = result.headers.get("x-ludwitt-credits");
+  const headers: Record<string, string> = {};
+  if (credits) headers["x-ludwitt-credits"] = credits;
+  return NextResponse.json(result.body, { status: 200, headers });
+}
+
+export const POST = withMiddleware(rateLimitConfigs.standard, handleAiMessages);

--- a/app/api/ludwitt/authorize/route.ts
+++ b/app/api/ludwitt/authorize/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { createHash, randomBytes } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  LUDWITT_AUTHORIZE_URL,
+  LUDWITT_PKCE_COOKIE,
+  LUDWITT_RETURN_TO_COOKIE,
+  LUDWITT_SCOPES,
+  LUDWITT_STATE_COOKIE,
+  getLudwittClientId,
+  getLudwittRedirectUri,
+} from "@/lib/ludwitt-config";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function sanitizeReturnTo(value: string | null): string | null {
+  if (!value) return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export async function GET(request: NextRequest) {
+  const clientId = getLudwittClientId();
+  if (!clientId) {
+    return NextResponse.redirect(
+      new URL("/login?ludwitt=error&message=not_configured", request.url)
+    );
+  }
+
+  const redirectUri = getLudwittRedirectUri(request);
+  const state = randomBytes(32).toString("base64url");
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  const returnTo = sanitizeReturnTo(request.nextUrl.searchParams.get("returnTo"));
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: LUDWITT_SCOPES,
+    state,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+  });
+
+  const response = NextResponse.redirect(
+    `${LUDWITT_AUTHORIZE_URL}?${params.toString()}`
+  );
+
+  const cookieOpts = {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 10 * 60,
+  };
+
+  response.cookies.set(LUDWITT_STATE_COOKIE, state, cookieOpts);
+  response.cookies.set(LUDWITT_PKCE_COOKIE, verifier, cookieOpts);
+  if (returnTo) {
+    response.cookies.set(LUDWITT_RETURN_TO_COOKIE, returnTo, cookieOpts);
+  }
+
+  return response;
+}

--- a/app/api/ludwitt/finalize-token/route.ts
+++ b/app/api/ludwitt/finalize-token/route.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { LUDWITT_FINALIZE_COOKIE } from "@/lib/ludwitt-config";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function handleFinalize(request: NextRequest): Promise<NextResponse> {
+  const token = request.cookies.get(LUDWITT_FINALIZE_COOKIE)?.value;
+  if (!token) {
+    return NextResponse.json({ error: "expired" }, { status: 410 });
+  }
+  const response = NextResponse.json({ token });
+  response.cookies.set(LUDWITT_FINALIZE_COOKIE, "", { maxAge: 0, path: "/" });
+  return response;
+}
+
+export const POST = withMiddleware(rateLimitConfigs.standard, handleFinalize);

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
+import {
+  LUDWITT_FINALIZE_COOKIE,
+  LUDWITT_PKCE_COOKIE,
+  LUDWITT_RETURN_TO_COOKIE,
+  LUDWITT_STATE_COOKIE,
+  LUDWITT_TOKEN_URL,
+  LUDWITT_USERINFO_URL,
+  fetchLudwittWithTimeout,
+  getLudwittClientId,
+  getLudwittClientSecret,
+  getLudwittRedirectUri,
+} from "@/lib/ludwitt-config";
+import { saveLudwittTokens, type LudwittTokenResponse } from "@/lib/ludwitt-tokens";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface LudwittUserInfo {
+  sub: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+}
+
+function sanitizeReturnTo(value: string | undefined): string | null {
+  if (!value) return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
+function clearOauthCookies(response: NextResponse) {
+  response.cookies.set(LUDWITT_STATE_COOKIE, "", { maxAge: 0, path: "/" });
+  response.cookies.set(LUDWITT_PKCE_COOKIE, "", { maxAge: 0, path: "/" });
+  response.cookies.set(LUDWITT_RETURN_TO_COOKIE, "", { maxAge: 0, path: "/" });
+}
+
+function redirectError(request: NextRequest, message: string): NextResponse {
+  const response = NextResponse.redirect(
+    new URL(`/login?ludwitt=error&message=${encodeURIComponent(message)}`, request.url)
+  );
+  clearOauthCookies(response);
+  return response;
+}
+
+async function resolveFirebaseUid(args: {
+  email: string;
+  name?: string;
+  picture?: string;
+}): Promise<string> {
+  const adminAuth = getAdminAuth();
+  if (!adminAuth) throw new Error("admin_auth_unavailable");
+  try {
+    const existing = await adminAuth.getUserByEmail(args.email);
+    return existing.uid;
+  } catch (e: unknown) {
+    const code = (e as { code?: string })?.code;
+    if (code !== "auth/user-not-found") throw e;
+  }
+  const created = await adminAuth.createUser({
+    email: args.email,
+    emailVerified: true,
+    displayName: args.name,
+    photoURL: args.picture,
+  });
+  return created.uid;
+}
+
+async function handleLudwittCallback(request: NextRequest): Promise<NextResponse> {
+  const sp = request.nextUrl.searchParams;
+  const code = sp.get("code");
+  const state = sp.get("state");
+  const providerError = sp.get("error");
+
+  if (providerError) {
+    return redirectError(request, providerError);
+  }
+
+  const expectedState = request.cookies.get(LUDWITT_STATE_COOKIE)?.value;
+  const verifier = request.cookies.get(LUDWITT_PKCE_COOKIE)?.value;
+  const returnTo = sanitizeReturnTo(
+    request.cookies.get(LUDWITT_RETURN_TO_COOKIE)?.value
+  );
+
+  if (!code || !state) return redirectError(request, "missing_params");
+  if (!expectedState || expectedState !== state)
+    return redirectError(request, "invalid_state");
+  if (!verifier) return redirectError(request, "invalid_state");
+
+  const clientId = getLudwittClientId();
+  const clientSecret = getLudwittClientSecret();
+  if (!clientId || !clientSecret) {
+    logger.error("Ludwitt OAuth not configured");
+    return redirectError(request, "not_configured");
+  }
+
+  const redirectUri = getLudwittRedirectUri(request);
+
+  // 1. Exchange code for tokens
+  let tokens: LudwittTokenResponse;
+  try {
+    const tokenRes = await fetchLudwittWithTimeout(LUDWITT_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        client_secret: clientSecret,
+        code_verifier: verifier,
+      }),
+    });
+    if (!tokenRes.ok) {
+      const body = await tokenRes.text().catch(() => "");
+      logger.warn("Ludwitt token exchange failed", {
+        status: tokenRes.status,
+        body: body.slice(0, 300),
+      });
+      return redirectError(request, "token_failed");
+    }
+    tokens = (await tokenRes.json()) as LudwittTokenResponse;
+  } catch (err) {
+    logger.logError(err, { stage: "token_exchange" });
+    return redirectError(request, "token_failed");
+  }
+
+  // 2. Fetch userinfo
+  let userinfo: LudwittUserInfo;
+  try {
+    const uiRes = await fetchLudwittWithTimeout(LUDWITT_USERINFO_URL, {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    });
+    if (!uiRes.ok) {
+      logger.warn("Ludwitt userinfo failed", { status: uiRes.status });
+      return redirectError(request, "userinfo_failed");
+    }
+    userinfo = (await uiRes.json()) as LudwittUserInfo;
+  } catch (err) {
+    logger.logError(err, { stage: "userinfo" });
+    return redirectError(request, "userinfo_failed");
+  }
+
+  if (!userinfo.email) {
+    return redirectError(request, "no_email");
+  }
+
+  // 3. Resolve / create Firebase user by email (silent merge)
+  let uid: string;
+  try {
+    uid = await resolveFirebaseUid({
+      email: userinfo.email,
+      name: userinfo.name,
+      picture: userinfo.picture,
+    });
+  } catch (err) {
+    logger.logError(err, { stage: "firebase_user", email: userinfo.email });
+    return redirectError(request, "firebase_user_failed");
+  }
+
+  // 4. Persist tokens (server-only) + identity (public-safe)
+  const db = getAdminDb();
+  if (!db) return redirectError(request, "not_configured");
+  try {
+    await saveLudwittTokens(uid, tokens);
+    await db
+      .collection("users")
+      .doc(uid)
+      .set(
+        {
+          ludwitt: {
+            sub: userinfo.sub,
+            email: userinfo.email,
+            name: userinfo.name ?? null,
+            picture: userinfo.picture ?? null,
+            scope: tokens.scope,
+            connectedAt: FieldValue.serverTimestamp(),
+            lastSignInAt: FieldValue.serverTimestamp(),
+          },
+        },
+        { merge: true }
+      );
+  } catch (err) {
+    logger.logError(err, { stage: "persist_tokens", uid });
+    return redirectError(request, "token_persist_failed");
+  }
+
+  // 5. Mint Firebase custom token
+  let customToken: string;
+  try {
+    const adminAuth = getAdminAuth();
+    if (!adminAuth) throw new Error("admin_auth_unavailable");
+    customToken = await adminAuth.createCustomToken(uid, {
+      ludwitt_sub: userinfo.sub,
+    });
+  } catch (err) {
+    logger.logError(err, { stage: "custom_token", uid });
+    return redirectError(request, "custom_token_failed");
+  }
+
+  // 6. Hand the custom token to the finalize page via httpOnly cookie
+  const finalizeUrl = new URL("/auth/ludwitt-finalize", request.url);
+  if (returnTo) finalizeUrl.searchParams.set("returnTo", returnTo);
+  const response = NextResponse.redirect(finalizeUrl);
+  clearOauthCookies(response);
+  response.cookies.set(LUDWITT_FINALIZE_COOKIE, customToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 120,
+  });
+
+  return response;
+}
+
+export const GET = withMiddleware(rateLimitConfigs.oauthCallback, handleLudwittCallback);

--- a/app/auth/ludwitt-finalize/page.tsx
+++ b/app/auth/ludwitt-finalize/page.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { signInWithCustomToken } from "firebase/auth";
+import { auth } from "@/lib/firebase";
+
+function Finalizer() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    let cancelled = false;
+    const returnTo = searchParams.get("returnTo") || "/";
+    (async () => {
+      try {
+        const res = await fetch("/api/ludwitt/finalize-token", { method: "POST" });
+        if (!res.ok) throw new Error("finalize_failed");
+        const { token } = (await res.json()) as { token?: string };
+        if (!token) throw new Error("finalize_failed");
+        if (!auth) throw new Error("firebase_not_initialized");
+        await signInWithCustomToken(auth, token);
+        if (!cancelled) router.replace(returnTo);
+      } catch {
+        if (!cancelled) {
+          router.replace("/login?ludwitt=error&message=finalize_failed");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [router, searchParams]);
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <div className="text-sm text-neutral-500 dark:text-neutral-400">
+        Signing you in with Ludwitt…
+      </div>
+    </div>
+  );
+}
+
+export default function LudwittFinalizePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-[60vh] flex items-center justify-center px-4 text-sm text-neutral-500">
+          Signing you in with Ludwitt…
+        </div>
+      }
+    >
+      <Finalizer />
+    </Suspense>
+  );
+}

--- a/app/cohort-ai/page.tsx
+++ b/app/cohort-ai/page.tsx
@@ -1,0 +1,251 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState, type FormEvent } from "react";
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+
+interface Turn {
+  role: "user" | "assistant";
+  text: string;
+  credits?: { chargedCostCents?: number; newBalance?: number };
+}
+
+const MODEL_ID = "claude-sonnet-4-6";
+const MAX_TOKENS = 1024;
+const TOPUP_URL = "https://pitchrise.ludwitt.com/account/credits";
+
+function ConnectCta() {
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+      <h2 className="text-lg font-semibold">Sign in with Ludwitt to use this</h2>
+      <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+        The cohort assistant runs on your Ludwitt credits. Sign in once and
+        you&apos;re set.
+      </p>
+      <a
+        href={`/api/ludwitt/authorize?returnTo=${encodeURIComponent("/cohort-ai")}`}
+        className="mt-4 inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+      >
+        Sign in with Ludwitt
+      </a>
+    </div>
+  );
+}
+
+function CreditsFooter({ credits }: { credits?: Turn["credits"] }) {
+  if (!credits) return null;
+  const cost =
+    typeof credits.chargedCostCents === "number"
+      ? `$${(credits.chargedCostCents / 100).toFixed(4)}`
+      : "—";
+  const balance =
+    typeof credits.newBalance === "number"
+      ? `$${(credits.newBalance / 100).toFixed(2)}`
+      : "—";
+  return (
+    <div className="mt-1 text-xs text-neutral-500">
+      cost: {cost} · balance: {balance}
+    </div>
+  );
+}
+
+export default function CohortAiPage() {
+  const { user, userProfile, loading } = useAuth();
+  const [prompt, setPrompt] = useState("");
+  const [turns, setTurns] = useState<Turn[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [outOfCredits, setOutOfCredits] = useState(false);
+
+  const submit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!user) return;
+    const text = prompt.trim();
+    if (!text) return;
+
+    const next: Turn[] = [...turns, { role: "user", text }];
+    setTurns(next);
+    setPrompt("");
+    setError(null);
+    setOutOfCredits(false);
+    setSubmitting(true);
+
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/ludwitt/ai/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          model: MODEL_ID,
+          max_tokens: MAX_TOKENS,
+          messages: next.map((t) => ({ role: t.role, content: t.text })),
+        }),
+      });
+
+      if (res.status === 402) {
+        setOutOfCredits(true);
+        return;
+      }
+      if (res.status === 412) {
+        window.location.href = `/api/ludwitt/authorize?returnTo=${encodeURIComponent("/cohort-ai")}`;
+        return;
+      }
+      if (res.status === 401) {
+        setError("Your Ludwitt session expired. Please sign in again.");
+        return;
+      }
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setError(`Error ${res.status}: ${(j as { error?: string }).error ?? "request_failed"}`);
+        return;
+      }
+
+      const data = (await res.json()) as {
+        content?: Array<{ type?: string; text?: string }>;
+      };
+      const assistantText =
+        data.content?.find((c) => c.type === "text")?.text ?? "(no content)";
+
+      let credits: Turn["credits"] | undefined;
+      const creditsHeader = res.headers.get("x-ludwitt-credits");
+      if (creditsHeader) {
+        try {
+          credits = JSON.parse(creditsHeader);
+        } catch {
+          // ignore parse failures
+        }
+      }
+
+      setTurns([...next, { role: "assistant", text: assistantText, credits }]);
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-4 py-10 text-sm text-neutral-500">
+        Loading…
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-4 py-10 md:py-14">
+        <header className="mb-6">
+          <h1 className="text-3xl font-bold md:text-4xl">Cohort assistant</h1>
+          <p className="mt-2 text-neutral-600 dark:text-neutral-400">
+            An AI assistant for cohort members, powered by your Ludwitt credits.
+          </p>
+        </header>
+        <div className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+          <p className="text-sm">
+            Please{" "}
+            <Link href="/login?redirect=/cohort-ai" className="underline">
+              sign in
+            </Link>{" "}
+            to continue.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const ludwittConnected = Boolean(userProfile?.ludwitt?.sub);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      <header className="mb-6">
+        <div className="inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-indigo-700 dark:text-indigo-300">
+          <Sparkles className="h-3.5 w-3.5" strokeWidth={2.25} />
+          Cohort assistant
+        </div>
+        <h1 className="mt-3 text-3xl font-bold md:text-4xl">
+          Ask the cohort assistant
+        </h1>
+        <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+          Powered by your Ludwitt credits. Each call deducts based on actual
+          token usage.
+        </p>
+      </header>
+
+      {!ludwittConnected ? (
+        <ConnectCta />
+      ) : (
+        <>
+          {turns.length > 0 ? (
+            <div className="mb-6 space-y-4">
+              {turns.map((t, i) => (
+                <div
+                  key={i}
+                  className={
+                    t.role === "user"
+                      ? "rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/60"
+                      : "rounded-lg border border-indigo-200 bg-indigo-50 p-4 dark:border-indigo-900 dark:bg-indigo-950/30"
+                  }
+                >
+                  <div className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                    {t.role}
+                  </div>
+                  <div className="mt-1 whitespace-pre-wrap text-sm">{t.text}</div>
+                  <CreditsFooter credits={t.credits} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {outOfCredits ? (
+            <div className="mb-4 rounded-lg border-l-4 border-amber-500 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-400 dark:bg-amber-950/40 dark:text-amber-200">
+              You&apos;re out of Ludwitt credits.{" "}
+              <a
+                href={TOPUP_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold underline"
+              >
+                Top up at Ludwitt →
+              </a>
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="mb-4 rounded-lg border-l-4 border-red-500 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+              {error}
+            </div>
+          ) : null}
+
+          <form onSubmit={submit} className="space-y-3">
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              rows={4}
+              required
+              placeholder="Ask anything…"
+              className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+            />
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-indigo-600 to-purple-600 px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {submitting ? "Asking…" : "Ask"}
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -124,6 +124,13 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // Ludwitt OAuth access/refresh tokens - server-side only (Admin SDK).
+    // Tokens NEVER reach the browser; only the public-safe ludwitt
+    // sub-object on users/{uid} is client-readable.
+    match /ludwittTokens/{uid} {
+      allow read, write: if false;
+    }
+
     // Materialized read models (analytics + public members directory) — Admin SDK only
     match /analytics_snapshots/{docId} {
       allow read, write: if false;

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -88,6 +88,15 @@ interface UserProfile {
     html_url: string;
     connectedAt: Date;
   };
+  ludwitt?: {
+    sub: string;
+    email: string;
+    name?: string;
+    picture?: string;
+    scope: string;
+    connectedAt: Date;
+    lastSignInAt?: Date;
+  };
   eduBadge?: boolean;
   /** Server-set when a merged PR adds the user's Hack-a-Sprint 2026 showcase submission. */
   hackASprint2026ShowcaseBadge?: boolean;
@@ -211,6 +220,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     // If auth is not configured, just set loading to false
     if (!auth) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing "no external system" into React state
       setLoading(false);
       return;
     }

--- a/lib/ludwitt-config.ts
+++ b/lib/ludwitt-config.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { NextRequest } from "next/server";
+
+export const LUDWITT_AUTHORIZE_URL = "https://pitchrise.ludwitt.com/oauth/authorize";
+export const LUDWITT_TOKEN_URL = "https://pitchrise.ludwitt.com/api/oauth/token";
+export const LUDWITT_USERINFO_URL = "https://pitchrise.ludwitt.com/api/oauth/userinfo";
+export const LUDWITT_AI_MESSAGES_URL =
+  "https://pitchrise.ludwitt.com/api/v1/ai/messages";
+export const LUDWITT_BALANCE_URL = "https://pitchrise.ludwitt.com/api/v1/credits/balance";
+export const LUDWITT_TOPUP_URL = "https://pitchrise.ludwitt.com/account/credits";
+
+export const LUDWITT_SCOPES = "profile credits:read credits:spend";
+
+export const LUDWITT_TOKENS_COLLECTION = "ludwittTokens";
+export const LUDWITT_FINALIZE_COOKIE = "ludwitt_finalize_token";
+export const LUDWITT_STATE_COOKIE = "ludwitt_oauth_state";
+export const LUDWITT_PKCE_COOKIE = "ludwitt_oauth_pkce_verifier";
+export const LUDWITT_RETURN_TO_COOKIE = "ludwitt_oauth_return_to";
+
+export const LUDWITT_API_TIMEOUT_MS = 15_000;
+
+export function getLudwittClientId(): string | null {
+  return process.env.NEXT_PUBLIC_LUDWITT_CLIENT_ID || null;
+}
+
+export function getLudwittClientSecret(): string | null {
+  return process.env.LUDWITT_CLIENT_SECRET || null;
+}
+
+export function getLudwittRedirectUri(request: NextRequest): string {
+  const fromEnv = process.env.NEXT_PUBLIC_LUDWITT_REDIRECT_URI;
+  if (fromEnv) return fromEnv;
+  const url = new URL(request.url);
+  return `${url.origin}/auth/callback`;
+}
+
+export function fetchLudwittWithTimeout(
+  url: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LUDWITT_API_TIMEOUT_MS);
+  return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+    clearTimeout(timeout)
+  );
+}

--- a/lib/ludwitt-tokens.ts
+++ b/lib/ludwitt-tokens.ts
@@ -1,0 +1,219 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { randomBytes } from "crypto";
+import { FieldValue, type Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "./firebase-admin";
+import { logger } from "./logger";
+import {
+  LUDWITT_TOKEN_URL,
+  LUDWITT_TOKENS_COLLECTION,
+  fetchLudwittWithTimeout,
+  getLudwittClientId,
+  getLudwittClientSecret,
+} from "./ludwitt-config";
+
+export interface LudwittTokens {
+  accessToken: string;
+  refreshToken: string;
+  scope: string;
+  accessExpiresAt: Date;
+}
+
+export interface LudwittTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  scope: string;
+}
+
+interface LudwittTokenDoc {
+  accessToken: string;
+  refreshToken: string;
+  scope: string;
+  tokenType: string;
+  accessExpiresAt: FirebaseFirestore.Timestamp;
+  refreshLockId?: string;
+  refreshLockExpiresAt?: FirebaseFirestore.Timestamp;
+  refreshedAt?: FirebaseFirestore.Timestamp;
+  createdAt?: FirebaseFirestore.Timestamp;
+  updatedAt?: FirebaseFirestore.Timestamp;
+}
+
+const LOCK_TTL_MS = 15_000;
+const LOCK_WAIT_POLL_MS = 800;
+const LOCK_WAIT_MAX_ATTEMPTS = 5;
+
+function requireDb(): Firestore {
+  const db = getAdminDb();
+  if (!db) {
+    throw new Error("Firebase Admin not configured");
+  }
+  return db;
+}
+
+function readDoc(snap: FirebaseFirestore.DocumentSnapshot): LudwittTokens | null {
+  if (!snap.exists) return null;
+  const data = snap.data() as LudwittTokenDoc | undefined;
+  if (!data?.accessToken || !data?.refreshToken) return null;
+  return {
+    accessToken: data.accessToken,
+    refreshToken: data.refreshToken,
+    scope: data.scope || "",
+    accessExpiresAt: data.accessExpiresAt?.toDate?.() ?? new Date(0),
+  };
+}
+
+export async function getLudwittTokens(uid: string): Promise<LudwittTokens | null> {
+  const snap = await requireDb().collection(LUDWITT_TOKENS_COLLECTION).doc(uid).get();
+  return readDoc(snap);
+}
+
+export async function saveLudwittTokens(
+  uid: string,
+  raw: LudwittTokenResponse
+): Promise<void> {
+  const accessExpiresAt = new Date(Date.now() + raw.expires_in * 1000);
+  await requireDb()
+    .collection(LUDWITT_TOKENS_COLLECTION)
+    .doc(uid)
+    .set(
+      {
+        accessToken: raw.access_token,
+        refreshToken: raw.refresh_token,
+        scope: raw.scope,
+        tokenType: raw.token_type,
+        accessExpiresAt,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+}
+
+export async function deleteLudwittTokens(uid: string): Promise<void> {
+  await requireDb().collection(LUDWITT_TOKENS_COLLECTION).doc(uid).delete();
+}
+
+async function postRefresh(refreshToken: string): Promise<LudwittTokenResponse> {
+  const clientId = getLudwittClientId();
+  const clientSecret = getLudwittClientSecret();
+  if (!clientId || !clientSecret) {
+    throw new Error("Ludwitt OAuth not configured");
+  }
+  const res = await fetchLudwittWithTimeout(LUDWITT_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    logger.warn("Ludwitt refresh failed", { status: res.status, body: body.slice(0, 200) });
+    throw new Error(`refresh_failed:${res.status}`);
+  }
+  return (await res.json()) as LudwittTokenResponse;
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Refresh tokens with a soft Firestore lock. Single-flight: if another caller
+ * is already refreshing, wait briefly and re-read the fresh tokens.
+ */
+export async function refreshLudwittTokens(uid: string): Promise<LudwittTokens> {
+  const db = requireDb();
+  const ref = db.collection(LUDWITT_TOKENS_COLLECTION).doc(uid);
+  const lockId = randomBytes(8).toString("hex");
+
+  const claimed = await db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) throw new Error("ludwitt_tokens_missing");
+    const data = snap.data() as LudwittTokenDoc;
+    const existingLock = data.refreshLockId;
+    const lockExpiresMs = data.refreshLockExpiresAt?.toMillis?.() ?? 0;
+    if (existingLock && lockExpiresMs > Date.now()) {
+      return false;
+    }
+    tx.update(ref, {
+      refreshLockId: lockId,
+      refreshLockExpiresAt: new Date(Date.now() + LOCK_TTL_MS),
+    });
+    return true;
+  });
+
+  if (!claimed) {
+    for (let i = 0; i < LOCK_WAIT_MAX_ATTEMPTS; i++) {
+      await sleep(LOCK_WAIT_POLL_MS);
+      const snap = await ref.get();
+      const data = snap.data() as LudwittTokenDoc | undefined;
+      if (!data) throw new Error("ludwitt_tokens_missing");
+      if (!data.refreshLockId || (data.refreshLockExpiresAt?.toMillis?.() ?? 0) < Date.now()) {
+        const tokens = readDoc(snap);
+        if (tokens) return tokens;
+      }
+    }
+    throw new Error("ludwitt_refresh_lock_timeout");
+  }
+
+  try {
+    const snap = await ref.get();
+    const data = snap.data() as LudwittTokenDoc;
+    const fresh = await postRefresh(data.refreshToken);
+    const accessExpiresAt = new Date(Date.now() + fresh.expires_in * 1000);
+    await ref.update({
+      accessToken: fresh.access_token,
+      refreshToken: fresh.refresh_token,
+      scope: fresh.scope,
+      tokenType: fresh.token_type,
+      accessExpiresAt,
+      refreshLockId: FieldValue.delete(),
+      refreshLockExpiresAt: FieldValue.delete(),
+      refreshedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return {
+      accessToken: fresh.access_token,
+      refreshToken: fresh.refresh_token,
+      scope: fresh.scope,
+      accessExpiresAt,
+    };
+  } catch (err) {
+    await ref
+      .update({
+        refreshLockId: FieldValue.delete(),
+        refreshLockExpiresAt: FieldValue.delete(),
+      })
+      .catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * Run a Ludwitt API call with a fresh access token, refreshing once on 401.
+ */
+export async function withFreshLudwittAccessToken<T>(
+  uid: string,
+  call: (
+    accessToken: string
+  ) => Promise<{ status: number; body: T; headers: Headers }>
+): Promise<{ status: number; body: T; headers: Headers }> {
+  const tokens = await getLudwittTokens(uid);
+  if (!tokens) throw new Error("ludwitt_not_connected");
+
+  const first = await call(tokens.accessToken);
+  if (first.status !== 401) return first;
+
+  const refreshed = await refreshLudwittTokens(uid);
+  return call(refreshed.accessToken);
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,6 +20,7 @@ Licensed GPL-3.0-only.
     /accessibility
     /agents/claim/[token]
     /analytics
+    /auth/ludwitt-finalize
     /badges
     /blog
     /blog/[slug]
@@ -27,6 +28,7 @@ Licensed GPL-3.0-only.
     /certificate/verify/[certId]
     /cfp
     /code-of-conduct
+    /cohort-ai
     /cookbook
     /cookies
     /disclaimer


### PR DESCRIPTION
## Included

- **feat(ludwitt): Sign in with Ludwitt + AI credit proxy** — @Ludwitt + Claude
  - **Sign-in flow**: `/api/ludwitt/authorize` (PKCE S256) → Ludwitt OAuth → `/auth/callback` → email-based silent merge with Firebase user → Firebase custom token → `/auth/ludwitt-finalize` finishes the session.
  - **AI proxy**: `POST /api/ludwitt/ai/messages` — server-side Anthropic-shaped pass-through to Ludwitt's AI endpoint with the user's stored access token. Refreshes once on 401 (single-flight Firestore lock). Surfaces 402 (out of credits) + forwards `x-ludwitt-credits`.
  - **Demo / smoke test**: `/cohort-ai` — minimal chat that proves the full round-trip works. Shows per-call cost and balance from `x-ludwitt-credits`.
  - **Token isolation**: tokens stored in server-only `ludwittTokens/{uid}` (Firestore rules deny ALL client read/write). Public-safe identity (sub, email, name, picture, scope, connectedAt) on `users/{uid}.ludwitt` for UI display.
  - **Login page**: third sign-in button (indigo→purple gradient) + friendly error banner for `?ludwitt=error&message=...` codes.

Env vars set in Vercel (Production + Preview/develop) and `.env.local`. The Ludwitt-side `https://www.cursorboston.com/auth/callback` redirect URI is already registered. Local dev URI registered too.

## Test plan

- [x] Type-check + lint clean
- [x] Production build registers all 6 new routes (4 dynamic, 2 static)
- [x] Authorize → 307 to Ludwitt with PKCE challenge + 3 cookies
- [x] Callback failure modes redirect to `/login?ludwitt=error&message=…` (no 500s)
- [x] AI proxy w/o auth → 401; finalize-token w/o cookie → 410
- [x] `/login` renders the friendly Ludwitt error banner
- [ ] Manual: full local OAuth round-trip on a real Ludwitt account → land in Firebase session → ask `/cohort-ai` a question → see response + cost/balance footer
- [ ] Manual: force `accessExpiresAt` past in Firestore, re-ask → confirm transparent refresh (`refreshedAt` advances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)