### PR TITLE
Release: develop → main (Ludwitt connect/disconnect for existing users)

### DIFF
--- a/app/(auth)/profile/_components/ConnectionsSection.tsx
+++ b/app/(auth)/profile/_components/ConnectionsSection.tsx
@@ -6,6 +6,7 @@
 
 "use client";
 
+import { Sparkles } from "lucide-react";
 import {
   DiscordIcon,
   GitHubIcon,
@@ -20,10 +21,12 @@ export function ConnectionsSection() {
     data: { connectedAgents },
     discord,
     github,
+    ludwitt,
   } = useProfileContext();
 
   const discordInfo = discord.discordInfo;
   const githubInfo = github.githubInfo;
+  const ludwittInfo = ludwitt.ludwittInfo;
 
   return (
     <div className="mb-8">
@@ -98,6 +101,42 @@ export function ConnectionsSection() {
             </button>
           )}
         </div>
+
+        {/* Ludwitt */}
+        <div className="bg-neutral-900 rounded-xl p-4 border border-neutral-800 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-indigo-500/20 to-purple-500/20 flex items-center justify-center">
+              <Sparkles size={18} className="text-indigo-400" strokeWidth={2.25} />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-white">Ludwitt</p>
+              {ludwittInfo ? (
+                <p className="text-xs text-neutral-400">
+                  {ludwittInfo.email || ludwittInfo.name || "Connected"}
+                </p>
+              ) : (
+                <p className="text-xs text-neutral-500">Not connected</p>
+              )}
+            </div>
+          </div>
+          {ludwittInfo ? (
+            <button
+              onClick={ludwitt.disconnect}
+              disabled={ludwitt.disconnecting}
+              className="text-xs text-neutral-400 hover:text-red-400 transition-colors disabled:opacity-50"
+            >
+              {ludwitt.disconnecting ? "..." : "Disconnect"}
+            </button>
+          ) : (
+            <button
+              onClick={ludwitt.connect}
+              disabled={ludwitt.connecting}
+              className="text-xs text-emerald-400 hover:text-emerald-300 font-medium transition-colors disabled:opacity-50"
+            >
+              {ludwitt.connecting ? "..." : "Connect"}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Status badges */}
@@ -131,8 +170,10 @@ export function ConnectionsSection() {
         </div>
       )}
 
-      {(discord.error || github.error) && (
-        <p className="text-red-400 text-xs mt-2">{discord.error || github.error}</p>
+      {(discord.error || github.error || ludwitt.error) && (
+        <p className="text-red-400 text-xs mt-2">
+          {discord.error || github.error || ludwitt.error}
+        </p>
       )}
     </div>
   );

--- a/app/(auth)/profile/_contexts/ProfileContext.tsx
+++ b/app/(auth)/profile/_contexts/ProfileContext.tsx
@@ -18,6 +18,7 @@ import { useBadges } from "../_hooks/useBadges";
 import { useDiscordConnection } from "../_hooks/useDiscordConnection";
 import { useGithubConnection } from "../_hooks/useGithubConnection";
 import { useGoogleConnection } from "../_hooks/useGoogleConnection";
+import { useLudwittConnection } from "../_hooks/useLudwittConnection";
 import { useMfaEnrollment } from "../_hooks/useMfaEnrollment";
 import { useEmailManagement } from "../_hooks/useEmailManagement";
 import { useProfileSettings } from "../_hooks/useProfileSettings";
@@ -39,6 +40,7 @@ export interface ProfileContextValue {
 
   discord: ReturnType<typeof useDiscordConnection>;
   github: ReturnType<typeof useGithubConnection>;
+  ludwitt: ReturnType<typeof useLudwittConnection>;
   google: ReturnType<typeof useGoogleConnection>;
   mfa: ReturnType<typeof useMfaEnrollment>;
   email: ReturnType<typeof useEmailManagement>;
@@ -85,6 +87,11 @@ export function ProfileProvider({
     user,
     userProfile?.github,
     userProfile?.provider,
+    refreshUserProfile
+  );
+  const ludwitt = useLudwittConnection(
+    user,
+    userProfile?.ludwitt,
     refreshUserProfile
   );
   const google = useGoogleConnection(user);
@@ -152,6 +159,7 @@ export function ProfileProvider({
     badges,
     discord,
     github,
+    ludwitt,
     google,
     mfa,
     email: emailMgmt,

--- a/app/(auth)/profile/_hooks/useLudwittConnection.ts
+++ b/app/(auth)/profile/_hooks/useLudwittConnection.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { User } from "firebase/auth";
+import { getLudwittErrorMessage } from "../../login/_lib/ludwitt-errors";
+
+export interface LudwittInfo {
+  sub: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+}
+
+export function useLudwittConnection(
+  user: User | null,
+  userProfileLudwitt?: LudwittInfo | null,
+  refreshUserProfile?: () => Promise<void>,
+  returnTo?: string
+) {
+  const router = useRouter();
+  const fallbackPath = returnTo || "/profile";
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [wasDisconnected, setWasDisconnected] = useState(false);
+  const [localInfo, setLocalInfo] = useState<LudwittInfo | null>(null);
+
+  const ludwittInfo = wasDisconnected
+    ? null
+    : (localInfo || userProfileLudwitt || null);
+
+  const connect = async () => {
+    if (!user) {
+      setError("Please sign in first.");
+      return;
+    }
+    setConnecting(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/ludwitt/connect-start", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ returnTo: fallbackPath }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setError(
+          (j as { error?: string }).error === "not_configured"
+            ? "Ludwitt sign-in isn't configured."
+            : "Couldn't start the Ludwitt connection. Please try again."
+        );
+        return;
+      }
+      const { authorizeUrl } = (await res.json()) as { authorizeUrl: string };
+      window.location.href = authorizeUrl;
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const disconnect = async () => {
+    if (!user) return;
+    setDisconnecting(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/ludwitt/disconnect", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        setError("Failed to disconnect Ludwitt. Please try again.");
+        return;
+      }
+      setWasDisconnected(true);
+      setLocalInfo(null);
+      if (refreshUserProfile) await refreshUserProfile();
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  // Connect-flow callback redirects to returnTo with ?ludwitt=success.
+  // The page-level useOAuthCallbacks calls these on detection.
+  const handleOAuthSuccess = async () => {
+    setWasDisconnected(false);
+    if (refreshUserProfile) await refreshUserProfile();
+    router.replace(fallbackPath, { scroll: false });
+  };
+
+  const handleOAuthError = (message: string | null) => {
+    setError(getLudwittErrorMessage(message));
+    router.replace(fallbackPath, { scroll: false });
+  };
+
+  return {
+    ludwittInfo,
+    connecting,
+    disconnecting,
+    error,
+    setError,
+    connect,
+    disconnect,
+    handleOAuthSuccess,
+    handleOAuthError,
+  };
+}

--- a/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
+++ b/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
@@ -11,6 +11,7 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import type { useDiscordConnection } from "./useDiscordConnection";
 import type { useGithubConnection } from "./useGithubConnection";
+import type { useLudwittConnection } from "./useLudwittConnection";
 import type { useEmailManagement } from "./useEmailManagement";
 import type { Tab } from "../_types";
 
@@ -20,6 +21,7 @@ interface OAuthCallbackDeps {
   router: AppRouterInstance;
   discord: ReturnType<typeof useDiscordConnection>;
   github: ReturnType<typeof useGithubConnection>;
+  ludwitt: ReturnType<typeof useLudwittConnection>;
   email: ReturnType<typeof useEmailManagement>;
   refreshUserProfile: () => Promise<void>;
   setActiveTab: (tab: Tab) => void;
@@ -31,6 +33,7 @@ export function useOAuthCallbacks({
   router,
   discord,
   github,
+  ludwitt,
   email,
   refreshUserProfile,
   setActiveTab,
@@ -58,6 +61,14 @@ export function useOAuthCallbacks({
       } else if (githubStatus === "error") {
         github.handleOAuthError();
       }
+    }
+
+    // Ludwitt callback (connect-flow only — sign-in flow doesn't land here).
+    const ludwittStatus = searchParams.get("ludwitt");
+    if (ludwittStatus === "success") {
+      ludwitt.handleOAuthSuccess();
+    } else if (ludwittStatus === "error") {
+      ludwitt.handleOAuthError(searchParams.get("message"));
     }
 
     // Email verification callback

--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -32,6 +32,7 @@ function ProfilePageContent() {
     data: { connectedAgents, loadingAgents },
     discord,
     github,
+    ludwitt,
     google,
     profileSettings,
     password,
@@ -72,6 +73,7 @@ function ProfilePageContent() {
     router,
     discord,
     github,
+    ludwitt,
     email: ctx.email,
     refreshUserProfile: ctx.refreshUserProfile,
     setActiveTab: (tab) => {

--- a/app/api/ludwitt/connect-start/route.ts
+++ b/app/api/ludwitt/connect-start/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { createHash, randomBytes } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  LUDWITT_AUTHORIZE_URL,
+  LUDWITT_LINK_UID_COOKIE,
+  LUDWITT_PKCE_COOKIE,
+  LUDWITT_RETURN_TO_COOKIE,
+  LUDWITT_SCOPES,
+  LUDWITT_STATE_COOKIE,
+  getLudwittClientId,
+  getLudwittRedirectUri,
+} from "@/lib/ludwitt-config";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function sanitizeReturnTo(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
+function base64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function handleConnectStart(request: NextRequest): Promise<NextResponse> {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  const clientId = getLudwittClientId();
+  if (!clientId) {
+    return NextResponse.json({ error: "not_configured" }, { status: 500 });
+  }
+
+  let body: unknown = {};
+  try {
+    body = await request.json();
+  } catch {
+    // optional body
+  }
+  const returnTo =
+    sanitizeReturnTo((body as { returnTo?: unknown })?.returnTo) ?? "/profile";
+
+  const redirectUri = getLudwittRedirectUri(request);
+  const state = randomBytes(32).toString("base64url");
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: LUDWITT_SCOPES,
+    state,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+  });
+  const authorizeUrl = `${LUDWITT_AUTHORIZE_URL}?${params.toString()}`;
+
+  const response = NextResponse.json({ authorizeUrl });
+
+  const cookieOpts = {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 10 * 60,
+  };
+
+  response.cookies.set(LUDWITT_STATE_COOKIE, state, cookieOpts);
+  response.cookies.set(LUDWITT_PKCE_COOKIE, verifier, cookieOpts);
+  response.cookies.set(LUDWITT_RETURN_TO_COOKIE, returnTo, cookieOpts);
+  response.cookies.set(LUDWITT_LINK_UID_COOKIE, user.uid, cookieOpts);
+
+  return response;
+}
+
+export const POST = withMiddleware(rateLimitConfigs.standard, handleConnectStart);

--- a/app/api/ludwitt/disconnect/route.ts
+++ b/app/api/ludwitt/disconnect/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { deleteLudwittTokens } from "@/lib/ludwitt-tokens";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function handleDisconnect(request: NextRequest): Promise<NextResponse> {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "not_configured" }, { status: 500 });
+  }
+
+  try {
+    await deleteLudwittTokens(user.uid);
+    await db
+      .collection("users")
+      .doc(user.uid)
+      .set({ ludwitt: FieldValue.delete() }, { merge: true });
+    return NextResponse.json({ disconnected: true });
+  } catch (err) {
+    logger.logError(err, { stage: "ludwitt_disconnect", uid: user.uid });
+    return NextResponse.json({ error: "disconnect_failed" }, { status: 500 });
+  }
+}
+
+export const POST = withMiddleware(rateLimitConfigs.standard, handleDisconnect);

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -11,6 +11,7 @@ import { logger } from "@/lib/logger";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
 import {
   LUDWITT_FINALIZE_COOKIE,
+  LUDWITT_LINK_UID_COOKIE,
   LUDWITT_PKCE_COOKIE,
   LUDWITT_RETURN_TO_COOKIE,
   LUDWITT_STATE_COOKIE,
@@ -43,12 +44,23 @@ function clearOauthCookies(response: NextResponse) {
   response.cookies.set(LUDWITT_STATE_COOKIE, "", { maxAge: 0, path: "/" });
   response.cookies.set(LUDWITT_PKCE_COOKIE, "", { maxAge: 0, path: "/" });
   response.cookies.set(LUDWITT_RETURN_TO_COOKIE, "", { maxAge: 0, path: "/" });
+  response.cookies.set(LUDWITT_LINK_UID_COOKIE, "", { maxAge: 0, path: "/" });
 }
 
-function redirectError(request: NextRequest, message: string): NextResponse {
-  const response = NextResponse.redirect(
-    new URL(`/login?ludwitt=error&message=${encodeURIComponent(message)}`, request.url)
-  );
+function redirectError(
+  request: NextRequest,
+  message: string,
+  options?: { connectReturnTo?: string | null }
+): NextResponse {
+  const target =
+    options?.connectReturnTo ??
+    `/login?ludwitt=error&message=${encodeURIComponent(message)}`;
+  // For connect-mode (returnTo provided), append the error to the returnTo URL
+  // so the page that initiated the link can render a banner.
+  const url = options?.connectReturnTo
+    ? `${target}${target.includes("?") ? "&" : "?"}ludwitt=error&message=${encodeURIComponent(message)}`
+    : target;
+  const response = NextResponse.redirect(new URL(url, request.url));
   clearOauthCookies(response);
   return response;
 }
@@ -82,26 +94,28 @@ async function handleLudwittCallback(request: NextRequest): Promise<NextResponse
   const state = sp.get("state");
   const providerError = sp.get("error");
 
-  if (providerError) {
-    return redirectError(request, providerError);
-  }
-
   const expectedState = request.cookies.get(LUDWITT_STATE_COOKIE)?.value;
   const verifier = request.cookies.get(LUDWITT_PKCE_COOKIE)?.value;
   const returnTo = sanitizeReturnTo(
     request.cookies.get(LUDWITT_RETURN_TO_COOKIE)?.value
   );
+  const linkUid = request.cookies.get(LUDWITT_LINK_UID_COOKIE)?.value;
+  const isConnectFlow = Boolean(linkUid);
+  const errorOpts = isConnectFlow
+    ? { connectReturnTo: returnTo || "/profile" }
+    : undefined;
 
-  if (!code || !state) return redirectError(request, "missing_params");
+  if (providerError) return redirectError(request, providerError, errorOpts);
+  if (!code || !state) return redirectError(request, "missing_params", errorOpts);
   if (!expectedState || expectedState !== state)
-    return redirectError(request, "invalid_state");
-  if (!verifier) return redirectError(request, "invalid_state");
+    return redirectError(request, "invalid_state", errorOpts);
+  if (!verifier) return redirectError(request, "invalid_state", errorOpts);
 
   const clientId = getLudwittClientId();
   const clientSecret = getLudwittClientSecret();
   if (!clientId || !clientSecret) {
     logger.error("Ludwitt OAuth not configured");
-    return redirectError(request, "not_configured");
+    return redirectError(request, "not_configured", errorOpts);
   }
 
   const redirectUri = getLudwittRedirectUri(request);
@@ -127,12 +141,12 @@ async function handleLudwittCallback(request: NextRequest): Promise<NextResponse
         status: tokenRes.status,
         body: body.slice(0, 300),
       });
-      return redirectError(request, "token_failed");
+      return redirectError(request, "token_failed", errorOpts);
     }
     tokens = (await tokenRes.json()) as LudwittTokenResponse;
   } catch (err) {
     logger.logError(err, { stage: "token_exchange" });
-    return redirectError(request, "token_failed");
+    return redirectError(request, "token_failed", errorOpts);
   }
 
   // 2. Fetch userinfo
@@ -143,34 +157,44 @@ async function handleLudwittCallback(request: NextRequest): Promise<NextResponse
     });
     if (!uiRes.ok) {
       logger.warn("Ludwitt userinfo failed", { status: uiRes.status });
-      return redirectError(request, "userinfo_failed");
+      return redirectError(request, "userinfo_failed", errorOpts);
     }
     userinfo = (await uiRes.json()) as LudwittUserInfo;
   } catch (err) {
     logger.logError(err, { stage: "userinfo" });
-    return redirectError(request, "userinfo_failed");
+    return redirectError(request, "userinfo_failed", errorOpts);
   }
 
   if (!userinfo.email) {
-    return redirectError(request, "no_email");
+    return redirectError(request, "no_email", errorOpts);
   }
 
-  // 3. Resolve / create Firebase user by email (silent merge)
+  // 3. Resolve target Firebase uid:
+  //    - Connect flow: link to the already-signed-in user (uid from cookie)
+  //    - Sign-in flow: silent merge by email (or createUser)
   let uid: string;
   try {
-    uid = await resolveFirebaseUid({
-      email: userinfo.email,
-      name: userinfo.name,
-      picture: userinfo.picture,
-    });
+    if (isConnectFlow && linkUid) {
+      const adminAuth = getAdminAuth();
+      if (!adminAuth) throw new Error("admin_auth_unavailable");
+      // Validate the cookie-borne uid actually exists. Throws if missing.
+      await adminAuth.getUser(linkUid);
+      uid = linkUid;
+    } else {
+      uid = await resolveFirebaseUid({
+        email: userinfo.email,
+        name: userinfo.name,
+        picture: userinfo.picture,
+      });
+    }
   } catch (err) {
     logger.logError(err, { stage: "firebase_user", email: userinfo.email });
-    return redirectError(request, "firebase_user_failed");
+    return redirectError(request, "firebase_user_failed", errorOpts);
   }
 
   // 4. Persist tokens (server-only) + identity (public-safe)
   const db = getAdminDb();
-  if (!db) return redirectError(request, "not_configured");
+  if (!db) return redirectError(request, "not_configured", errorOpts);
   try {
     await saveLudwittTokens(uid, tokens);
     await db
@@ -192,10 +216,23 @@ async function handleLudwittCallback(request: NextRequest): Promise<NextResponse
       );
   } catch (err) {
     logger.logError(err, { stage: "persist_tokens", uid });
-    return redirectError(request, "token_persist_failed");
+    return redirectError(request, "token_persist_failed", errorOpts);
   }
 
-  // 5. Mint Firebase custom token
+  // 5. Connect flow: user is already signed in. Skip custom-token mint and
+  // redirect straight to returnTo with a success indicator.
+  if (isConnectFlow) {
+    const target = returnTo || "/profile";
+    const url = new URL(
+      `${target}${target.includes("?") ? "&" : "?"}ludwitt=success`,
+      request.url
+    );
+    const response = NextResponse.redirect(url);
+    clearOauthCookies(response);
+    return response;
+  }
+
+  // 6. Sign-in flow: mint Firebase custom token and hand to finalize page.
   let customToken: string;
   try {
     const adminAuth = getAdminAuth();
@@ -205,10 +242,9 @@ async function handleLudwittCallback(request: NextRequest): Promise<NextResponse
     });
   } catch (err) {
     logger.logError(err, { stage: "custom_token", uid });
-    return redirectError(request, "custom_token_failed");
+    return redirectError(request, "custom_token_failed", errorOpts);
   }
 
-  // 6. Hand the custom token to the finalize page via httpOnly cookie
   const finalizeUrl = new URL("/auth/ludwitt-finalize", request.url);
   if (returnTo) finalizeUrl.searchParams.set("returnTo", returnTo);
   const response = NextResponse.redirect(finalizeUrl);

--- a/lib/ludwitt-config.ts
+++ b/lib/ludwitt-config.ts
@@ -21,6 +21,7 @@ export const LUDWITT_FINALIZE_COOKIE = "ludwitt_finalize_token";
 export const LUDWITT_STATE_COOKIE = "ludwitt_oauth_state";
 export const LUDWITT_PKCE_COOKIE = "ludwitt_oauth_pkce_verifier";
 export const LUDWITT_RETURN_TO_COOKIE = "ludwitt_oauth_return_to";
+export const LUDWITT_LINK_UID_COOKIE = "ludwitt_oauth_link_uid";
 
 export const LUDWITT_API_TIMEOUT_MS = 15_000;
 


### PR DESCRIPTION
## Included

- **feat(ludwitt): connect / disconnect for already-signed-in users** — @Ludwitt + Claude
  Lets users with an existing cursor-boston account link/unlink Ludwitt from `/profile`, the same UX as GitHub and Discord.
  - `POST /api/ludwitt/connect-start` (Firebase-auth required) — issues OAuth state + a `ludwitt_oauth_link_uid` httpOnly cookie carrying the verified Firebase uid; returns `{ authorizeUrl }`.
  - `POST /api/ludwitt/disconnect` (Firebase-auth required) — wipes both `ludwittTokens/{uid}` (server-only) and `users/{uid}.ludwitt`.
  - `/auth/callback` now branches on the link-uid cookie: connect-mode links to that uid (no email merge, no custom-token mint, redirects to returnTo with `?ludwitt=success`).
  - New `useLudwittConnection` hook + Ludwitt card in `ConnectionsSection`.
  - Sign-in flow on `/login` is unchanged.

## Test plan

- [x] Type-check + lint clean
- [x] Production build registers 2 new routes (`/api/ludwitt/connect-start`, `/api/ludwitt/disconnect`)
- [x] Connect-start without auth → 401
- [x] Disconnect without auth → 401
- [x] Callback with link-uid cookie + bad code → redirects to `/profile?ludwitt=error&message=token_failed` (NOT `/login`)
- [ ] Manual: sign in via Google → /profile → click Connect on Ludwitt → authorize → land on /profile, Ludwitt card shows email
- [ ] Manual: click Disconnect → card returns to "Not connected"
- [ ] Manual: re-connect → /cohort-ai works against the Ludwitt-billed account

🤖 Generated with [Claude Code](https://claude.com/claude-code)