### PR TITLE
Release: develop → main (winner-commitments hosting rewrite with real free-tier numbers)

### DIFF
--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -104,6 +104,141 @@ interface CounterCardProps {
   pickedCohorts: SummerCohortId[];
 }
 
+interface PlatformRow {
+  name: string;
+  url: string;
+  notes: React.ReactNode;
+}
+
+/** Free-tier numbers verified against each provider's pricing page in May 2026.
+ *  These rot fast — when limits change, update the {name, notes} pair and the
+ *  date in the section copy below. */
+const HOST_PLATFORMS: readonly PlatformRow[] = [
+  {
+    name: "Vercel Hobby",
+    url: "https://vercel.com/pricing",
+    notes: (
+      <>
+        100 GB bandwidth/mo, 150K function invocations/mo, 60s function
+        duration. Hard cap — once you hit it, deploys and functions stop
+        until the next billing cycle. <strong>Non-commercial use only.</strong>
+      </>
+    ),
+  },
+  {
+    name: "Netlify Free",
+    url: "https://www.netlify.com/pricing/",
+    notes: (
+      <>
+        100 GB bandwidth/mo, 300 build minutes/mo, 125K serverless function
+        invocations/mo, 1M edge function invocations.
+      </>
+    ),
+  },
+  {
+    name: "Cloudflare Pages",
+    url: "https://pages.cloudflare.com/",
+    notes: (
+      <>
+        <strong>Unlimited bandwidth</strong>, 500 builds/mo, 1 concurrent
+        build, 100 custom domains. Pair with Cloudflare Workers (100K
+        requests/day free) for serverless logic. Most generous free tier of
+        the four.
+      </>
+    ),
+  },
+  {
+    name: "Render",
+    url: "https://render.com/pricing",
+    notes: (
+      <>
+        Static sites free with 100 GB bandwidth/mo. Free web services get
+        750 instance hours/mo but sleep after 15 min idle (~30s cold start).
+      </>
+    ),
+  },
+];
+
+const BACKEND_PLATFORMS: readonly PlatformRow[] = [
+  {
+    name: "Firebase Spark",
+    url: "https://firebase.google.com/pricing",
+    notes: (
+      <>
+        50K MAU (auth), 1 GB Firestore + 50K reads/day + 20K writes/day, 5
+        GB Cloud Storage, 10 GB Hosting. The per-day Firestore caps are the
+        thing to watch.
+      </>
+    ),
+  },
+  {
+    name: "Supabase Free",
+    url: "https://supabase.com/pricing",
+    notes: (
+      <>
+        500 MB Postgres, 1 GB file storage, 5 GB egress/mo, 50K MAU, 2
+        active projects. <strong>Auto-pauses after 7 days of inactivity</strong> —
+        you have to manually resume in the dashboard.
+      </>
+    ),
+  },
+  {
+    name: "Convex Free",
+    url: "https://www.convex.dev/pricing",
+    notes: (
+      <>
+        1M function calls/mo, 0.5 GB database, 1 GB file storage. Strong if
+        you want real-time queries baked in. Hard caps, no overage option.
+      </>
+    ),
+  },
+  {
+    name: "Neon Free",
+    url: "https://neon.com/pricing",
+    notes: (
+      <>
+        100 CU-hours/mo per project, 0.5 GB storage per project (5 GB
+        aggregate across up to 10 projects). Plain Postgres, no BaaS layer.
+      </>
+    ),
+  },
+];
+
+function PlatformTable({ rows, caption }: { rows: readonly PlatformRow[]; caption: string }) {
+  return (
+    <div className="mt-2 overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800">
+      <table className="w-full text-left text-sm">
+        <caption className="sr-only">{caption}</caption>
+        <thead className="bg-neutral-50 text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:bg-neutral-800/50">
+          <tr>
+            <th scope="col" className="px-3 py-2 align-top">Platform</th>
+            <th scope="col" className="px-3 py-2 align-top">Free tier (May 2026)</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
+          {rows.map((row) => (
+            <tr key={row.name} className="align-top">
+              <td className="w-1/3 px-3 py-3">
+                <a
+                  href={row.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500 dark:decoration-neutral-600 dark:hover:decoration-neutral-400"
+                >
+                  {row.name}
+                </a>
+              </td>
+              <td className="px-3 py-3 text-neutral-700 dark:text-neutral-300">
+                {row.notes}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 function WinnerCommitmentsCard() {
   return (
     <section className="mt-6 rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
@@ -111,38 +246,51 @@ function WinnerCommitmentsCard() {
         If you win a week-1/2/3 vote
       </h2>
       <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-        The week-1/2/3 winners maintain their platform for the rest of the
-        cohort — hosting it, dealing with real users, and doing a short demo.
-        Here&apos;s what that actually looks like.
+        Winners ship their platform somewhere public for the rest of the
+        cohort to use, deal with real users (your fellow participants), and
+        submit a short demo video at showcase time.
       </p>
 
-      <div className="mt-5 space-y-4 text-sm text-neutral-700 dark:text-neutral-300">
+      <div className="mt-5 space-y-6 text-sm text-neutral-700 dark:text-neutral-300">
         <div>
           <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            You self-host. Zero cost.
+            Hosting costs — likely $0 at cohort scale, but verify your stack
+          </h3>
+          <p className="mt-2">
+            You pick the stack and run the deploy. At cohort scale (~100
+            users), the major free tiers are very likely to keep you at $0 —
+            but limits exist, exceeding them is your responsibility, and we
+            don&apos;t reimburse hosting bills. Always check the current
+            pricing page before you commit; the figures below are accurate as
+            of May 2026.
+          </p>
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Pick a deploy/host
+          </h3>
+          <PlatformTable rows={HOST_PLATFORMS} caption="Frontend / deploy hosts and their May 2026 free tier limits" />
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Pick a backend / database (if you need one)
+          </h3>
+          <PlatformTable rows={BACKEND_PLATFORMS} caption="Backend and database providers and their May 2026 free tier limits" />
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Domain
           </h3>
           <p className="mt-1">
-            The program is free for everyone, including hosting for winners.
-            Free tiers handle it:
+            We&apos;ll hand you a{" "}
+            <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
+              yourthing.cursorboston.com
+            </code>{" "}
+            subdomain — no DNS service to buy.
           </p>
-          <ul className="mt-2 list-disc space-y-1 pl-5">
-            <li>
-              <strong>Vercel</strong> — free tier handles deploys; you
-              won&apos;t hit any limits at cohort scale unless you&apos;re
-              pushing 100+ times a day.
-            </li>
-            <li>
-              <strong>Firebase</strong> — free tier covers auth + Firestore +
-              storage; ~100 users won&apos;t come anywhere near the caps.
-            </li>
-            <li>
-              <strong>Domain</strong> — we&apos;ll hand you a{" "}
-              <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
-                yourthing.cursorboston.com
-              </code>{" "}
-              subdomain. No DNS service to buy.
-            </li>
-          </ul>
         </div>
 
         <div>
@@ -150,11 +298,11 @@ function WinnerCommitmentsCard() {
             Managing real users is half the value
           </h3>
           <p className="mt-1">
-            Whatever you build will have actual users — your cohort. Operating
-            a platform with real people on it (handling questions, fixing what
-            breaks, deciding what to ship next) is part of the educational
-            experience. If you&apos;re already a senior operator, treat it as
-            a portfolio piece.
+            Whatever you build will have actual users — your cohort.
+            Operating a platform with real people on it (handling questions,
+            fixing what breaks, deciding what to ship next) is part of the
+            educational experience. If you&apos;re already a senior operator,
+            treat it as a portfolio piece.
           </p>
         </div>
 
@@ -163,9 +311,9 @@ function WinnerCommitmentsCard() {
             Your demo can run locally
           </h3>
           <p className="mt-1">
-            For the showcase you submit a short Loom/Vidyard video.
-            You don&apos;t need to be live — running the platform on your
-            laptop during the demo is fine.
+            For the showcase you submit a short Loom/Vidyard video. You
+            don&apos;t need a live URL — running the platform on your laptop
+            during the demo is fine.
           </p>
         </div>
 
@@ -193,12 +341,6 @@ function WinnerCommitmentsCard() {
           </p>
         </div>
       </div>
-
-      <p className="mt-5 border-t border-neutral-200 pt-4 text-sm italic text-neutral-700 dark:border-neutral-800 dark:text-neutral-300">
-        It&apos;s like a pickup baseball game: bring your own bat and glove.
-        If the community elects you to lead, you also bring a few community
-        balls. That&apos;s it.
-      </p>
     </section>
   );
 }


### PR DESCRIPTION
## Included

One commit on `develop` since the last develop→main merge ([#622](https://github.com/rogerSuperBuilderAlpha/cursor-boston/pull/622)):

- **`feat(summer-cohort): rewrite winner-commitments hosting section with real free-tier comparisons`** (`b898018`) — @rogerSuperBuilderAlpha + Claude
  - Roger flagged the "If you win a week-1/2/3 vote" card as confusing and inaccurate — it claimed hosting is "free" and only mentioned Vercel + Firebase
  - Reframes hosting as **"likely \$0 at cohort scale, but verify your stack"** — explicitly notes that exceeding limits is on the winner and we don't reimburse hosting bills
  - Adds two **comparison tables** with real free-tier numbers verified against each provider's pricing page (May 2026):
    - **Deploy/host**: Vercel Hobby, Netlify Free, Cloudflare Pages, Render — each with hyperlink to pricing page
    - **Backend/database**: Firebase Spark, Supabase Free, Convex Free, Neon Free — same treatment
  - Calls out the gotchas: Vercel Hobby is non-commercial-only, Supabase auto-pauses after 7 days of inactivity, Render's free Postgres expires after 30 days (so I left Postgres-on-Render off the list)
  - Drops the pickup-baseball analogy — clearer copy without it
  - In-code comment notes that these numbers rot fast and where to update them

## Credit

- @rogerSuperBuilderAlpha — direction, called out the original copy as misleading
- Claude (Opus 4.7) — research (8 free-tier pricing pages) + implementation

## Test plan

- [x] Type-check clean (`npm run type-check`)
- [x] Full Jest suite green (135 suites / 1277 tests)
- [x] Lint clean for the changed file
- [ ] Manual: load `/summer-cohort` as an existing applicant, scroll to "If you win a week-1/2/3 vote" — confirm both tables render with sortable, scannable rows and the platform names are clickable links to pricing pages

## DCO note

Commit is signed-off. The DCO check should pass without `--admin`, though `BEHIND` topology may still require it (per the established pattern documented in memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)