### PR TITLE
release: fix Week 1 module repo URL

### DIFF
--- a/app/summer-cohort/_components/Week1BuildModule.tsx
+++ b/app/summer-cohort/_components/Week1BuildModule.tsx
@@ -157,12 +157,12 @@ export function Week1BuildModule() {
               </code>{" "}
               base branch of{" "}
               <a
-                href="https://github.com/cursor-boston/cursor-boston"
+                href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-semibold underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600"
               >
-                cursor-boston/cursor-boston
+                rogerSuperBuilderAlpha/cursor-boston
               </a>
               .
             </span>
@@ -196,7 +196,7 @@ export function Week1BuildModule() {
               </code>
               ) — see{" "}
               <a
-                href="https://github.com/cursor-boston/cursor-boston/blob/develop/docs/FIRST_CONTRIBUTION.md"
+                href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/FIRST_CONTRIBUTION.md"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-semibold underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600"


### PR DESCRIPTION
## Summary

Single-commit hotfix release: corrects hardcoded GitHub URLs in `Week1BuildModule` from `cursor-boston/cursor-boston` (wrong namespace, doesn't exist) to `rogerSuperBuilderAlpha/cursor-boston`.

## Included commits

- **e354618** fix(summer-cohort): correct GitHub repo URL in week 1 module — _Ludwitt_

## Test plan

- [ ] After deploy, confirm the PR-target link and FIRST_CONTRIBUTION.md link in the Week 1 module on `/summer-cohort` resolve to the real repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)