### PR TITLE
release: tabbed cohort-1 dashboard

### DIFF
--- a/app/summer-cohort/_components/CohortTabs.tsx
+++ b/app/summer-cohort/_components/CohortTabs.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+export type CohortTabId =
+  | "info"
+  | "week-1"
+  | "week-2"
+  | "week-3"
+  | "week-4"
+  | "week-5"
+  | "week-6"
+  | "my-info";
+
+interface TabSpec {
+  id: CohortTabId;
+  label: string;
+  shortLabel: string;
+}
+
+const TABS: readonly TabSpec[] = [
+  { id: "info", label: "Info", shortLabel: "Info" },
+  { id: "week-1", label: "Week 1: PM", shortLabel: "W1" },
+  { id: "week-2", label: "Week 2: Comms", shortLabel: "W2" },
+  { id: "week-3", label: "Week 3: Marketing", shortLabel: "W3" },
+  { id: "week-4", label: "Week 4: Ludwitt", shortLabel: "W4" },
+  { id: "week-5", label: "Week 5: Startup", shortLabel: "W5" },
+  { id: "week-6", label: "Week 6: OSS PR", shortLabel: "W6" },
+  { id: "my-info", label: "My info", shortLabel: "Me" },
+];
+
+interface CohortTabsProps {
+  activeTab: CohortTabId;
+  onChange: (tab: CohortTabId) => void;
+}
+
+export function CohortTabs({ activeTab, onChange }: CohortTabsProps) {
+  return (
+    <nav
+      role="tablist"
+      aria-label="Cohort dashboard sections"
+      className="mt-6 -mx-1 overflow-x-auto"
+    >
+      <div className="flex min-w-max gap-1 px-1 pb-1">
+        {TABS.map((tab) => {
+          const isActive = tab.id === activeTab;
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              type="button"
+              id={`tab-${tab.id}`}
+              aria-selected={isActive}
+              aria-controls={`tabpanel-${tab.id}`}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => onChange(tab.id)}
+              className={
+                isActive
+                  ? "shrink-0 rounded-lg bg-emerald-500 px-3.5 py-2 text-xs font-semibold uppercase tracking-wider text-white shadow-sm transition-colors sm:text-sm sm:normal-case sm:tracking-normal"
+                  : "shrink-0 rounded-lg border border-neutral-200 bg-white px-3.5 py-2 text-xs font-semibold uppercase tracking-wider text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800 sm:text-sm sm:normal-case sm:tracking-normal"
+              }
+            >
+              <span className="sm:hidden">{tab.shortLabel}</span>
+              <span className="hidden sm:inline">{tab.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/app/summer-cohort/_components/InfoTabPanel.tsx
+++ b/app/summer-cohort/_components/InfoTabPanel.tsx
@@ -1,0 +1,201 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { Calendar, Trophy, Users, Video } from "lucide-react";
+import {
+  SUMMER_COHORT_DEMO_DAY,
+  SUMMER_COHORT_IMMERSION,
+  SUMMER_COHORT_MEETING_CADENCE,
+  SUMMER_COHORT_PHILOSOPHY,
+  SUMMER_COHORT_WEEKS,
+} from "@/lib/summer-cohort";
+
+interface InfoTabPanelProps {
+  cohort1Count: number;
+}
+
+export function InfoTabPanel({ cohort1Count }: InfoTabPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      id="tabpanel-info"
+      aria-labelledby="tab-info"
+      className="space-y-6"
+    >
+      {/* Top: at-a-glance */}
+      <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h2 className="text-base font-semibold">How the cohort works</h2>
+        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+          {SUMMER_COHORT_PHILOSOPHY}
+        </p>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              <Users className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+              In your cohort
+            </div>
+            <p className="mt-1 text-2xl font-bold tabular-nums">{cohort1Count}</p>
+            <p className="mt-0.5 text-xs text-neutral-500">people in Cohort 1</p>
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              <Calendar className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+              Program length
+            </div>
+            <p className="mt-1 text-2xl font-bold tabular-nums">6</p>
+            <p className="mt-0.5 text-xs text-neutral-500">
+              weeks · May 11 → Jun 19
+            </p>
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+              Cadence
+            </div>
+            <p className="mt-1 text-sm font-semibold leading-tight">
+              Twice-weekly Zoom
+            </p>
+            <p className="mt-0.5 text-xs text-neutral-500">
+              {SUMMER_COHORT_MEETING_CADENCE.replace(/\.$/, "")}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Week-by-week */}
+      <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h3 className="text-base font-semibold">Six weeks at a glance</h3>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+          Click any week tab above for the full kickoff / submission /
+          voting-call detail.
+        </p>
+        <ol className="mt-5 space-y-3">
+          {SUMMER_COHORT_WEEKS.map((week) => (
+            <li
+              key={week.week}
+              className="flex gap-4 rounded-lg border border-neutral-200 p-4 dark:border-neutral-800"
+            >
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-emerald-500/10 text-sm font-bold text-emerald-700 dark:text-emerald-400">
+                {week.week}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h4 className="text-sm font-semibold">{week.title}</h4>
+                  {week.winnerCert ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+                      <Trophy
+                        className="h-3 w-3"
+                        strokeWidth={2.25}
+                        aria-hidden="true"
+                      />
+                      Winner: {week.winnerCert} (LinkedIn cert)
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                  {week.description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Calendar anchors: immersion + demo day */}
+      <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h3 className="text-base font-semibold">Anchor events</h3>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+          Two dates that bracket the program. Block them on your calendar.
+        </p>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2">
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              <Calendar
+                className="h-3.5 w-3.5"
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+              {SUMMER_COHORT_IMMERSION.label}
+            </div>
+            <p className="mt-1 text-sm font-semibold">
+              {SUMMER_COHORT_IMMERSION.title}
+            </p>
+            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+              {SUMMER_COHORT_IMMERSION.description}
+            </p>
+            <a
+              href={SUMMER_COHORT_IMMERSION.lumaUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-2 text-xs font-semibold text-emerald-700 underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600 dark:text-emerald-400"
+            >
+              RSVP on Luma →
+            </a>
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              <Users
+                className="h-3.5 w-3.5"
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+              Fri, Jun 19 — closing
+            </div>
+            <p className="mt-1 text-sm font-semibold">
+              {SUMMER_COHORT_DEMO_DAY.title}
+            </p>
+            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+              {SUMMER_COHORT_DEMO_DAY.description}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Winner commitments — preserved verbatim from the legacy card. */}
+      <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h3 className="text-base font-semibold">If you win a week-1/2/3 vote</h3>
+        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+          Winners ship their platform somewhere public for the rest of the
+          cohort to use, deal with real users (your fellow participants), and
+          submit a short demo video at showcase time.
+        </p>
+        <ul className="mt-4 space-y-3 text-sm text-neutral-700 dark:text-neutral-300">
+          <li>
+            <strong>Hosting at $0.</strong> At cohort scale (~100 users), every
+            major free tier (Vercel, Netlify, Cloudflare Pages, Supabase,
+            Neon, etc.) keeps you at $0 if you stay inside the limits. We
+            don&apos;t reimburse hosting bills if you blow them.
+          </li>
+          <li>
+            <strong>Domain.</strong> We&apos;ll hand you a{" "}
+            <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
+              yourthing.cursorboston.com
+            </code>{" "}
+            subdomain — no DNS service to buy.
+          </li>
+          <li>
+            <strong>Real users are part of the value.</strong> Whatever you
+            build will have actual users (your cohort). Operating it —
+            answering questions, shipping fixes, deciding what&apos;s next —
+            is part of the educational experience.
+          </li>
+          <li>
+            <strong>You own the code.</strong> Win or not, the repo is yours.
+            Keep it private, open it, evolve it.
+          </li>
+          <li>
+            <strong>Submitting to win is optional.</strong> Build, vote, and
+            attend everything without putting yourself up. You don&apos;t lose
+            anything — just skip the &quot;submit to win&quot; step.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/summer-cohort/_components/Week4LudwittPanel.tsx
+++ b/app/summer-cohort/_components/Week4LudwittPanel.tsx
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { Calendar, ExternalLink, Sparkles, Video } from "lucide-react";
+import {
+  SUMMER_COHORT_C1_WEEK_4,
+  SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
+} from "@/lib/summer-cohort";
+
+export function Week4LudwittPanel() {
+  const week = SUMMER_COHORT_C1_WEEK_4;
+  const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
+
+  return (
+    <section
+      role="tabpanel"
+      id="tabpanel-week-4"
+      aria-labelledby="tab-week-4"
+      className="rounded-xl border-2 border-emerald-400 bg-white p-6 dark:border-emerald-700 dark:bg-neutral-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+          Cohort 1 · Week 4
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+          <Sparkles className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
+          Different format — no vote
+        </span>
+      </div>
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        {week.title}
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        {week.oneLiner}
+      </p>
+
+      {/* Kickoff */}
+      <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          Kickoff Zoom
+        </div>
+        <p className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          {week.kickoffLabel}
+        </p>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+          We walk through what makes a Ludwitt-mergeable tool, the technical
+          requirements, and the revenue-share mechanics.
+        </p>
+        <a
+          href={zoomUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+        >
+          <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+          Join the Zoom
+          <ExternalLink
+            className="h-3.5 w-3.5"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+        </a>
+      </div>
+
+      {/* How week 4 differs */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+          How this week is different
+        </h3>
+        <ul className="mt-3 space-y-3 text-sm text-neutral-700 dark:text-neutral-300">
+          <li className="flex gap-3">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              <strong>No vote, no presentations.</strong> Every shipped + merged
+              tool counts.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              <strong>You earn revenue per use.</strong> When users consume
+              Ludwitt credits via your tool, you take a revenue share — every
+              shipped tool earns its author fees in perpetuity.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              <strong>Submission target = Ludwitt.</strong> You open a PR
+              against the Ludwitt repo (not this one). Mergeability is the
+              acceptance criterion.
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      {/* Submission */}
+      <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+        <div className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          Submission mechanics
+        </div>
+        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+          The Ludwitt PR template, accepted-tool spec, and revenue-share terms
+          will be finalized at the Mon Jun 1 kickoff. By then you&apos;ll know
+          how the cohort PM tool, comms platform, and marketing site (built in
+          weeks 1–3) play into the workflow.
+        </p>
+        <p className="mt-3 text-xs text-neutral-500">
+          This section will be filled in before the week opens.
+        </p>
+      </div>
+
+      {/* Deadline */}
+      <div className="mt-4 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50/60 p-4 dark:border-amber-900 dark:bg-amber-950/20">
+        <Calendar
+          className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        <div className="text-sm">
+          <p className="font-semibold text-amber-900 dark:text-amber-200">
+            Target merge — {week.deadlineLabel}
+          </p>
+          <p className="mt-0.5 text-amber-900/90 dark:text-amber-200/90">
+            Aim to have your PR mergeable by Friday. We&apos;ll batch-merge
+            qualifying tools through the weekend.
+          </p>
+        </div>
+      </div>
+
+      <p className="mt-5 border-t border-neutral-200 pt-4 text-xs text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
+        You don&apos;t have to submit. If you&apos;d rather use this week to
+        push your own startup project (week 5&apos;s theme) early, that&apos;s
+        fine — just heads-up that revenue share only triggers on accepted
+        merges.
+      </p>
+    </section>
+  );
+}

--- a/app/summer-cohort/_components/Week5StartupPanel.tsx
+++ b/app/summer-cohort/_components/Week5StartupPanel.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { ExternalLink, Rocket, Video } from "lucide-react";
+import {
+  SUMMER_COHORT_C1_WEEK_5,
+  SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
+} from "@/lib/summer-cohort";
+
+export function Week5StartupPanel() {
+  const week = SUMMER_COHORT_C1_WEEK_5;
+  const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
+
+  return (
+    <section
+      role="tabpanel"
+      id="tabpanel-week-5"
+      aria-labelledby="tab-week-5"
+      className="rounded-xl border-2 border-emerald-400 bg-white p-6 dark:border-emerald-700 dark:bg-neutral-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+          Cohort 1 · Week 5
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+          <Rocket className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
+          Open week — your call
+        </span>
+      </div>
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        {week.title}
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        {week.oneLiner}
+      </p>
+
+      {/* Kickoff */}
+      <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          Kickoff Zoom
+        </div>
+        <p className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          {week.kickoffLabel}
+        </p>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+          We share-out what we&apos;re each working on this week. Quick
+          round-the-room: 60 seconds each — what you&apos;re building, what
+          help you need.
+        </p>
+        <a
+          href={zoomUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+        >
+          <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+          Join the Zoom
+          <ExternalLink
+            className="h-3.5 w-3.5"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+        </a>
+      </div>
+
+      {/* What this week is */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+          What this week is
+        </h3>
+        <ul className="mt-3 space-y-3 text-sm text-neutral-700 dark:text-neutral-300">
+          <li className="flex gap-3">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              <strong>Build whatever YOU want.</strong> Your own startup
+              project. The thing you&apos;d be working on if the cohort
+              didn&apos;t exist.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              <strong>No vote. No template. No PR to this repo.</strong> The
+              cohort tools (PM, comms, marketing) are still running — use them
+              to ship faster.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              <strong>Friday show-and-tell at {week.showAndTellLabel}.</strong>{" "}
+              Each person gets ~3 minutes. No formal pitch — just &quot;here&apos;s
+              what I built and what I&apos;m doing next.&quot; Optional.
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      {/* What good looks like */}
+      <div className="mt-6 rounded-lg border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900 dark:bg-emerald-950/20">
+        <div className="text-xs font-semibold uppercase tracking-wider text-emerald-800 dark:text-emerald-300">
+          What &quot;good&quot; looks like for this week
+        </div>
+        <p className="mt-2 text-sm text-emerald-900/90 dark:text-emerald-200/90">
+          End the week with something you can show — a working prototype, a
+          landing page with real signups, a public alpha. The bar is &quot;I
+          shipped something I&apos;m proud of,&quot; not &quot;I won a
+          vote.&quot;
+        </p>
+      </div>
+
+      <p className="mt-5 border-t border-neutral-200 pt-4 text-xs text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
+        Stuck on what to build? Bring it to office hours or post in the cohort
+        channel. The cohort is a great free pair of eyes for this.
+      </p>
+    </section>
+  );
+}

--- a/app/summer-cohort/_components/Week6OssPanel.tsx
+++ b/app/summer-cohort/_components/Week6OssPanel.tsx
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { ExternalLink, GitMerge, Trophy, Video } from "lucide-react";
+import {
+  SUMMER_COHORT_C1_WEEK_6,
+  SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
+  SUMMER_COHORT_DEMO_DAY,
+} from "@/lib/summer-cohort";
+
+export function Week6OssPanel() {
+  const week = SUMMER_COHORT_C1_WEEK_6;
+  const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
+
+  return (
+    <section
+      role="tabpanel"
+      id="tabpanel-week-6"
+      aria-labelledby="tab-week-6"
+      className="rounded-xl border-2 border-emerald-400 bg-white p-6 dark:border-emerald-700 dark:bg-neutral-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+          Cohort 1 · Week 6 — Final
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-400">
+          <GitMerge
+            className="h-3 w-3"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          One submission: a merged upstream PR
+        </span>
+      </div>
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        {week.title}
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        {week.oneLiner}
+      </p>
+
+      {/* Kickoff */}
+      <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          Kickoff Zoom
+        </div>
+        <p className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          {week.kickoffLabel}
+        </p>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+          Targeting strategy: how to pick a project, find a tractable issue,
+          submit a clean PR, and get it through review without burning a week.
+        </p>
+        <a
+          href={zoomUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+        >
+          <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+          Join the Zoom
+          <ExternalLink
+            className="h-3.5 w-3.5"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+        </a>
+      </div>
+
+      {/* What you do */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+          What you do
+        </h3>
+        <ol className="mt-3 space-y-3 text-sm text-neutral-700 dark:text-neutral-300">
+          <li className="flex gap-3">
+            <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+              1
+            </span>
+            <div>
+              <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                Pick a major OSS project
+              </p>
+              <p className="mt-0.5">
+                Something with real distribution — a popular framework, dev
+                tool, or library. Not your own side project.
+              </p>
+            </div>
+          </li>
+          <li className="flex gap-3">
+            <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+              2
+            </span>
+            <div>
+              <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                Land a merged PR
+              </p>
+              <p className="mt-0.5">
+                A doc fix counts if it&apos;s a real one. A feature counts.
+                Anything &quot;good first issue&quot; counts. Bar is the
+                upstream maintainer hits Merge.
+              </p>
+            </div>
+          </li>
+          <li className="flex gap-3">
+            <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+              3
+            </span>
+            <div>
+              <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                Bring the merged-PR URL to demo day
+              </p>
+              <p className="mt-0.5">
+                That&apos;s the submission. No JSON file, no PR to this repo.
+                Just the upstream PR link, ready to share.
+              </p>
+            </div>
+          </li>
+        </ol>
+      </div>
+
+      {/* Demo day */}
+      <div className="mt-6 rounded-lg border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900 dark:bg-emerald-950/20">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-800 dark:text-emerald-300">
+          <Trophy
+            className="h-3.5 w-3.5"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          Demo day — {week.demoDayLabel}
+        </div>
+        <p className="mt-2 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+          {SUMMER_COHORT_DEMO_DAY.title}
+        </p>
+        <p className="mt-1 text-sm text-emerald-900/90 dark:text-emerald-200/90">
+          {SUMMER_COHORT_DEMO_DAY.description}
+        </p>
+        <p className="mt-2 text-sm text-emerald-900/90 dark:text-emerald-200/90">
+          Friday is graduation. Bring your week-6 PR plus highlights from the
+          full 6 weeks — what you built, what you learned, what you&apos;re
+          shipping next.
+        </p>
+      </div>
+
+      <p className="mt-5 border-t border-neutral-200 pt-4 text-xs text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
+        Couldn&apos;t land a PR? Come anyway. Demo day isn&apos;t gated on the
+        OSS PR — it&apos;s the wrap-up for the whole cohort.
+      </p>
+    </section>
+  );
+}

--- a/app/summer-cohort/_components/WeekVotePanel.tsx
+++ b/app/summer-cohort/_components/WeekVotePanel.tsx
@@ -16,43 +16,61 @@ import {
 import {
   SUMMER_COHORT_C1_WEEK_1,
   SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
+  type SummerCohortVoteWeek,
 } from "@/lib/summer-cohort";
 
-const SUBMISSION_JSON_EXAMPLE = `{
-  "githubHandle": "your-handle",
-  "repoUrl": "https://github.com/your-handle/your-pm-tool",
-  "loomUrl": "https://www.loom.com/share/...",
-  "liveUrl": "https://yourthing.example.com",
-  "pitch": "One sentence on why you should win the PM week."
-}`;
+const PRESENT_MINUTES = SUMMER_COHORT_C1_WEEK_1.presentMinutes;
+const TOP_N = SUMMER_COHORT_C1_WEEK_1.topNFromAi;
+const WILDCARDS = SUMMER_COHORT_C1_WEEK_1.wildcardSlots;
 
-export function Week1BuildModule() {
-  const week = SUMMER_COHORT_C1_WEEK_1;
+function buildExampleJson(week: SummerCohortVoteWeek) {
+  const liveLine = week.liveUrlRequired
+    ? `\n  "liveUrl": "https://yourthing.example.com",`
+    : "";
+  return `{
+  "githubHandle": "your-handle",
+  "repoUrl": "https://github.com/your-handle/your-week-${week.week}-build",${liveLine}
+  "loomUrl": "https://www.loom.com/share/...",
+  "pitch": "One sentence on why you should win this week."
+}`;
+}
+
+interface WeekVotePanelProps {
+  week: SummerCohortVoteWeek;
+  tabId: string;
+}
+
+export function WeekVotePanel({ week, tabId }: WeekVotePanelProps) {
   const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
+  const requiredCount = week.liveUrlRequired ? 3 : 2;
 
   return (
     <section
-      aria-labelledby="c1-week-1-heading"
+      role="tabpanel"
+      id={`tabpanel-${tabId}`}
+      aria-labelledby={`tab-${tabId}`}
       className="rounded-xl border-2 border-emerald-400 bg-white p-6 dark:border-emerald-700 dark:bg-neutral-900"
     >
       <div className="flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
-          Cohort 1 · Week 1
+          Cohort 1 · Week {week.week}
         </span>
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
-          Live now
+          {week.deadlineLabel.split("·")[0]?.trim()} deadline
         </span>
       </div>
-      <h2
-        id="c1-week-1-heading"
-        className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100"
-      >
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
         {week.title}
       </h2>
       <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-        Everyone builds a project-management tool this week. Submit yours by
-        Friday and the cohort picks a winner on the Friday call.
+        {week.oneLiner}
       </p>
+
+      {week.weekNotes ? (
+        <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50/60 p-3 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950/20 dark:text-amber-200">
+          <strong>Note:</strong> {week.weekNotes}
+        </div>
+      ) : null}
 
       {/* Kickoff */}
       <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
@@ -64,8 +82,8 @@ export function Week1BuildModule() {
           {week.kickoffLabel}
         </p>
         <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-          We&apos;ll walk through the week, the rubric, and answer questions.
-          Add it to your calendar.
+          We walk through the week, the rubric, and answer questions. Add it to
+          your calendar.
         </p>
         <a
           href={zoomUrl}
@@ -75,10 +93,14 @@ export function Week1BuildModule() {
         >
           <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
           Join the Zoom
-          <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          <ExternalLink
+            className="h-3.5 w-3.5"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
         </a>
         <p className="mt-2 text-xs text-neutral-500">
-          Stand-in link — we&apos;ll swap in the real Zoom URL before May 11.
+          Stand-in link — we&apos;ll swap in the real Zoom URL before kickoff.
         </p>
       </div>
 
@@ -88,7 +110,9 @@ export function Week1BuildModule() {
           What you submit
         </h3>
         <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-          All three are required to be considered for the week-1 win:
+          {requiredCount === 3
+            ? "All three are required to be considered for the week's win:"
+            : "Both are required to be considered for the week's win:"}
         </p>
         <ol className="mt-3 space-y-2 text-sm text-neutral-700 dark:text-neutral-300">
           <li className="flex gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
@@ -99,9 +123,7 @@ export function Week1BuildModule() {
               <p className="font-semibold text-neutral-900 dark:text-neutral-100">
                 Repo URL
               </p>
-              <p className="mt-0.5">
-                A public GitHub repo of your build.
-              </p>
+              <p className="mt-0.5">A public GitHub repo of your build.</p>
             </div>
           </li>
           <li className="flex gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
@@ -112,30 +134,25 @@ export function Week1BuildModule() {
               <p className="font-semibold text-neutral-900 dark:text-neutral-100">
                 Loom URL
               </p>
-              <p className="mt-0.5">
-                A short demo video of your build running.
-              </p>
+              <p className="mt-0.5">A short demo video of your build running.</p>
             </div>
           </li>
-          <li className="flex gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
-            <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
-              3
-            </span>
-            <div>
-              <p className="font-semibold text-neutral-900 dark:text-neutral-100">
-                Live URL
-              </p>
-              <p className="mt-0.5">
-                Your deployed app, reachable on the public web.
-              </p>
-            </div>
-          </li>
+          {week.liveUrlRequired ? (
+            <li className="flex gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
+              <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+                3
+              </span>
+              <div>
+                <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                  Live URL
+                </p>
+                <p className="mt-0.5">
+                  Your deployed app, reachable on the public web.
+                </p>
+              </div>
+            </li>
+          ) : null}
         </ol>
-        <p className="mt-3 text-xs text-neutral-500">
-          Note: this is a higher bar than the showcase/demo-day &quot;your demo
-          can run locally&quot; rule — for the weekly win we want a live URL
-          your cohort can poke at.
-        </p>
       </div>
 
       {/* PR mechanics */}
@@ -168,10 +185,7 @@ export function Week1BuildModule() {
             </span>
           </li>
           <li className="flex gap-3">
-            <span
-              className="mt-0.5 h-4 w-4 shrink-0 text-neutral-500"
-              aria-hidden="true"
-            >
+            <span className="mt-0.5 h-4 w-4 shrink-0 text-neutral-500" aria-hidden="true">
               ↳
             </span>
             <span>
@@ -183,10 +197,7 @@ export function Week1BuildModule() {
             </span>
           </li>
           <li className="flex gap-3">
-            <span
-              className="mt-0.5 h-4 w-4 shrink-0 text-neutral-500"
-              aria-hidden="true"
-            >
+            <span className="mt-0.5 h-4 w-4 shrink-0 text-neutral-500" aria-hidden="true">
               ↳
             </span>
             <span>
@@ -212,7 +223,7 @@ export function Week1BuildModule() {
           File contents
         </p>
         <pre className="mt-2 overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-3 text-xs leading-relaxed text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
-          <code>{SUBMISSION_JSON_EXAMPLE}</code>
+          <code>{buildExampleJson(week)}</code>
         </pre>
       </div>
 
@@ -228,9 +239,9 @@ export function Week1BuildModule() {
             Deadline — {week.deadlineLabel}
           </p>
           <p className="mt-0.5 text-amber-900/90 dark:text-amber-200/90">
-            Your PR must be open with all three URLs filled in by 5pm Friday.
-            PRs opened after the deadline don&apos;t qualify for the week-1
-            win, but you&apos;re still welcome to ship.
+            Your PR must be open with all required URLs filled in by 5pm Friday.
+            Late PRs don&apos;t qualify for the win, but you&apos;re still
+            welcome to ship.
           </p>
         </div>
       </div>
@@ -245,22 +256,22 @@ export function Week1BuildModule() {
           <li className="flex gap-2">
             <span className="text-neutral-400" aria-hidden="true">•</span>
             <span>
-              Top <strong>{week.topNFromAi}</strong> AI-scored submissions
-              present automatically.
+              Top <strong>{TOP_N}</strong> AI-scored submissions present
+              automatically.
             </span>
           </li>
           <li className="flex gap-2">
             <span className="text-neutral-400" aria-hidden="true">•</span>
             <span>
-              <strong>{week.wildcardSlots}</strong> wildcard slots — self-nominate
-              live on the call.
+              <strong>{WILDCARDS}</strong> wildcard slots — self-nominate live on
+              the call.
             </span>
           </li>
           <li className="flex gap-2">
             <span className="text-neutral-400" aria-hidden="true">•</span>
             <span>
-              Each presenter gets <strong>{week.presentMinutes} minutes</strong>{" "}
-              to pitch why they should win the PM week.{" "}
+              Each presenter gets <strong>{PRESENT_MINUTES} minutes</strong> to
+              pitch why they should win.{" "}
               <strong>No demo on the call</strong> — the cohort can watch your
               Loom and try your live URL on the site once submissions are
               merged.
@@ -269,8 +280,8 @@ export function Week1BuildModule() {
           <li className="flex gap-2">
             <span className="text-neutral-400" aria-hidden="true">•</span>
             <span>
-              AI ranking is a starting point — the cohort vote on the call is
-              what picks the winner.
+              AI ranking is a starting point — the cohort vote on the call picks
+              the winner.
             </span>
           </li>
         </ul>
@@ -285,10 +296,26 @@ export function Week1BuildModule() {
         </a>
       </div>
 
+      {/* Winner commitment */}
+      <div className="mt-4 flex items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900 dark:bg-emerald-950/20">
+        <Trophy
+          className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700 dark:text-emerald-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        <div className="text-sm">
+          <p className="font-semibold text-emerald-900 dark:text-emerald-200">
+            If you win
+          </p>
+          <p className="mt-0.5 text-emerald-900/90 dark:text-emerald-200/90">
+            {week.winnerCommitment}
+          </p>
+        </div>
+      </div>
+
       <p className="mt-5 border-t border-neutral-200 pt-4 text-xs text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
-        Submitting to win is optional. If you&apos;d rather just ship and learn
-        without the vote, that&apos;s totally fine — you still get the
-        kickoff, the cohort, and demo day.
+        Submitting to win is optional. Build and ship without putting yourself
+        up for the vote — you still get the kickoff, the cohort, and demo day.
       </p>
     </section>
   );

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -23,13 +23,20 @@ import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnec
 import { useDiscordConnection } from "@/app/(auth)/profile/_hooks/useDiscordConnection";
 import {
   SUMMER_COHORTS,
+  SUMMER_COHORT_C1_DEFAULT_TAB,
+  SUMMER_COHORT_C1_VOTE_WEEKS,
   SUMMER_COHORT_GOAL_PER_COHORT,
   SUMMER_COHORT_IMMERSION,
   SUMMER_COHORT_RETURN_TO,
   type SummerCohortId,
 } from "@/lib/summer-cohort";
 import { CohortProgramBreakdown } from "./_components/CohortProgramBreakdown";
-import { Week1BuildModule } from "./_components/Week1BuildModule";
+import { CohortTabs, type CohortTabId } from "./_components/CohortTabs";
+import { InfoTabPanel } from "./_components/InfoTabPanel";
+import { Week4LudwittPanel } from "./_components/Week4LudwittPanel";
+import { Week5StartupPanel } from "./_components/Week5StartupPanel";
+import { Week6OssPanel } from "./_components/Week6OssPanel";
+import { WeekVotePanel } from "./_components/WeekVotePanel";
 
 interface ApplicationDto {
   userId: string | null;
@@ -683,6 +690,10 @@ function SummerCohortPageInner() {
    *  expanding shows the editable form. */
   const [editingDetails, setEditingDetails] = useState(false);
 
+  const [activeTab, setActiveTab] = useState<CohortTabId>(
+    SUMMER_COHORT_C1_DEFAULT_TAB
+  );
+
   const openEditDetails = useCallback(() => {
     setEditingDetails(true);
     // Defer scroll one tick so the form has mounted.
@@ -901,6 +912,12 @@ function SummerCohortPageInner() {
     return (id: SummerCohortId) => map.get(id) || id;
   }, []);
 
+  const showTabs =
+    application?.status === "admitted" &&
+    application.cohorts.includes("cohort-1");
+  const myInfoVisible = !showTabs || activeTab === "my-info";
+  const cohort1Count = applicationCounts["cohort-1"] ?? 0;
+
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
       <header className="mb-8">
@@ -917,6 +934,7 @@ function SummerCohortPageInner() {
         </p>
       </header>
 
+      {!showTabs ? (
       <section aria-labelledby="cohort-dates-heading" className="mb-8">
         <h2
           id="cohort-dates-heading"
@@ -929,6 +947,7 @@ function SummerCohortPageInner() {
           {KICKOFF_NOTE}
         </p>
       </section>
+      ) : null}
 
       {/* Pre-apply teaser — visible until the user submits an application. */}
       {!application ? <WhatToExpectTeaser /> : null}
@@ -962,28 +981,69 @@ function SummerCohortPageInner() {
       ) : (
         <>
           {application ? (
-            <>
-              {application.status === "admitted" &&
-              application.cohorts.includes("cohort-1") ? (
-                <Week1BuildModule />
-              ) : null}
-              <ApplicationStatusPanel
-                application={application}
-                cohortLabel={cohortLabel}
-              />
-              <NextStepsCard
-                application={application}
-                needsDiscord={!discord.discordInfo}
-                onEditDetails={openEditDetails}
-              />
-              <ApplicationCounterCard
-                counts={applicationCounts}
-                pickedCohorts={application.cohorts}
-              />
-              <CohortProgramBreakdown />
-              <WinnerCommitmentsCard />
-            </>
+            showTabs ? (
+              <>
+                <ApplicationStatusPanel
+                  application={application}
+                  cohortLabel={cohortLabel}
+                />
+                <NextStepsCard
+                  application={application}
+                  needsDiscord={!discord.discordInfo}
+                  onEditDetails={openEditDetails}
+                />
+                <CohortTabs
+                  activeTab={activeTab}
+                  onChange={setActiveTab}
+                />
+                <div className="mt-4">
+                  {activeTab === "info" ? (
+                    <InfoTabPanel cohort1Count={cohort1Count} />
+                  ) : activeTab === "week-1" ? (
+                    <WeekVotePanel
+                      week={SUMMER_COHORT_C1_VOTE_WEEKS[0]}
+                      tabId="week-1"
+                    />
+                  ) : activeTab === "week-2" ? (
+                    <WeekVotePanel
+                      week={SUMMER_COHORT_C1_VOTE_WEEKS[1]}
+                      tabId="week-2"
+                    />
+                  ) : activeTab === "week-3" ? (
+                    <WeekVotePanel
+                      week={SUMMER_COHORT_C1_VOTE_WEEKS[2]}
+                      tabId="week-3"
+                    />
+                  ) : activeTab === "week-4" ? (
+                    <Week4LudwittPanel />
+                  ) : activeTab === "week-5" ? (
+                    <Week5StartupPanel />
+                  ) : activeTab === "week-6" ? (
+                    <Week6OssPanel />
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <>
+                <ApplicationStatusPanel
+                  application={application}
+                  cohortLabel={cohortLabel}
+                />
+                <NextStepsCard
+                  application={application}
+                  needsDiscord={!discord.discordInfo}
+                  onEditDetails={openEditDetails}
+                />
+                <ApplicationCounterCard
+                  counts={applicationCounts}
+                  pickedCohorts={application.cohorts}
+                />
+                <CohortProgramBreakdown />
+                <WinnerCommitmentsCard />
+              </>
+            )
           ) : null}
+          {myInfoVisible ? (
           <section
             className={`${application ? "mt-6" : ""} rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900`}
           >
@@ -1276,11 +1336,12 @@ function SummerCohortPageInner() {
             </form>
             )}
           </section>
+          ) : null}
         </>
       )}
 
       {/* Connections panel — visible whenever the user is signed in. */}
-      {user ? (
+      {user && myInfoVisible ? (
         <section
           aria-labelledby="connections-heading"
           className="mt-8 rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -170,6 +170,105 @@ export const SUMMER_COHORT_C1_WEEK_1 = {
   wildcardSlots: 3,
 } as const;
 
+// Vote-format week metadata (weeks 1, 2, 3). Each is the same submission
+// shape: open a PR adding a JSON pointer file, get AI-scored, top 5 + 3
+// wildcards present on Friday for the cohort vote. Dates and Zoom links are
+// placeholders for weeks 2 and 3 — finalize closer to date.
+export interface SummerCohortVoteWeek {
+  week: number;
+  title: string;
+  oneLiner: string;
+  kickoffLabel: string;
+  deadlineLabel: string;
+  votingCallLabel: string;
+  submissionBranch: string;
+  submissionPath: string;
+  liveUrlRequired: boolean;
+  winnerCommitment: string;
+  /** Free-form note rendered above the kickoff block (e.g. holiday / immersion overlap). */
+  weekNotes?: string;
+}
+
+export const SUMMER_COHORT_C1_VOTE_WEEKS: readonly SummerCohortVoteWeek[] = [
+  {
+    week: 1,
+    title: "Project Management Build",
+    oneLiner:
+      "Everyone builds a PM tool. The cohort picks a winner on Friday; the winner runs the cohort PM tool for the rest of the program.",
+    kickoffLabel: SUMMER_COHORT_C1_WEEK_1.kickoffLabel,
+    deadlineLabel: SUMMER_COHORT_C1_WEEK_1.deadlineLabel,
+    votingCallLabel: SUMMER_COHORT_C1_WEEK_1.votingCallLabel,
+    submissionBranch: SUMMER_COHORT_C1_WEEK_1.submissionBranch,
+    submissionPath: SUMMER_COHORT_C1_WEEK_1.submissionPath,
+    liveUrlRequired: true,
+    winnerCommitment:
+      "Winner maintains the cohort PM tool through the rest of the program — fixes bugs, ships changes the cohort asks for, keeps it running.",
+  },
+  {
+    week: 2,
+    title: "Communications Build",
+    oneLiner:
+      "Everyone builds a comms platform for the cohort. Same vote-and-pick-a-winner format. Winner runs comms for the rest of the cohort.",
+    kickoffLabel: "Mon, May 18 · 6–7pm EST",
+    deadlineLabel: "Fri, May 22 · 5pm EST",
+    votingCallLabel: "Fri, May 22 · 6pm EST",
+    submissionBranch: "c1w2comms-submission",
+    submissionPath:
+      "content/summer-cohort/c1/w2-comms/submissions/<github-handle>.json",
+    liveUrlRequired: true,
+    winnerCommitment:
+      "Winner maintains the cohort comms platform for the remaining weeks — onboarding new threads, fixing what breaks, keeping conversation flowing.",
+  },
+  {
+    week: 3,
+    title: "Marketing Build",
+    oneLiner:
+      "Everyone builds a marketing platform — typically a public site that promotes the cohort and the work. Same vote format; winner maintains it.",
+    kickoffLabel: "Mon, May 25 · 6–7pm EST",
+    deadlineLabel: "Fri, May 29 · 5pm EST",
+    votingCallLabel: "Fri, May 29 · 6pm EST",
+    submissionBranch: "c1w3mkt-submission",
+    submissionPath:
+      "content/summer-cohort/c1/w3-mkt/submissions/<github-handle>.json",
+    liveUrlRequired: true,
+    winnerCommitment:
+      "Winner maintains the cohort marketing site through demo day — keeping it up to date with what the cohort is shipping.",
+    weekNotes:
+      "Heads up: Mon May 25 is Memorial Day (US holiday) and Tue May 26 is the in-person immersion event at Hult. Plan your build time around both.",
+  },
+] as const;
+
+export const SUMMER_COHORT_C1_WEEK_4 = {
+  week: 4,
+  title: "Ludwitt Education Tool",
+  oneLiner:
+    "Everyone ships an education tool that gets merged into Ludwitt. As users consume credits via your tool, you earn a revenue share — every shipped tool earns its author fees in perpetuity.",
+  kickoffLabel: "Mon, Jun 1 · 6–7pm EST",
+  deadlineLabel: "Fri, Jun 5 · 5pm EST",
+  // No vote — every shipped + merged tool counts.
+} as const;
+
+export const SUMMER_COHORT_C1_WEEK_5 = {
+  week: 5,
+  title: "Your Own Startup",
+  oneLiner:
+    "Build whatever YOU want this week — your own startup project. No vote, no submission template; bring it to the Friday call for show-and-tell.",
+  kickoffLabel: "Mon, Jun 8 · 6–7pm EST",
+  showAndTellLabel: "Fri, Jun 12 · 6pm EST",
+} as const;
+
+export const SUMMER_COHORT_C1_WEEK_6 = {
+  week: 6,
+  title: "Open-Source PR",
+  oneLiner:
+    "Pick a major open-source project and land a merged PR upstream. Friday is also demo day with hiring partners — bring your merged PR URL.",
+  kickoffLabel: "Mon, Jun 15 · 6–7pm EST",
+  demoDayLabel: "Fri, Jun 19 · time TBD",
+} as const;
+
+/** Default tab when an admitted cohort-1 user lands on /summer-cohort. */
+export const SUMMER_COHORT_C1_DEFAULT_TAB = "week-1" as const;
+
 export const SUMMER_COHORT_PHILOSOPHY =
   "The cohort succeeds or fails as a cohort. Goal: every participant lands a job offer. The tools each cohort builds are how they market themselves to hiring partners and the world.";
 


### PR DESCRIPTION
## Summary

Single-commit release: replaces the stacked-card admitted-state UI with an 8-tab dashboard (Info / Weeks 1–6 / My info), defaulting to Week 1.

## Included commits

- **2c58cc8** feat(summer-cohort): tabbed dashboard for admitted cohort-1 users — _Ludwitt_

## What ships

- New `CohortTabs` nav above the tab content for admitted cohort-1 users; mobile shows short labels (`W1`…`W6`).
- New panels: `InfoTabPanel` (program overview), `WeekVotePanel` (weeks 1–3, config-driven), `Week4LudwittPanel`, `Week5StartupPanel`, `Week6OssPanel`.
- `Week1BuildModule` removed (subsumed by `WeekVotePanel`).
- `lib/summer-cohort.ts` gains `SUMMER_COHORT_C1_VOTE_WEEKS`, `SUMMER_COHORT_C1_WEEK_4/5/6`, `SUMMER_COHORT_C1_DEFAULT_TAB`.
- Status panel + NextStepsCard stay above tabs as cross-cutting surfaces.
- Legacy flow preserved for non-admitted users and cohort-2-only admits.

## Test plan

- [ ] Sign in as an admitted cohort-1 user on production `/summer-cohort` and confirm tabs render below the status panel, default to Week 1, and switch correctly.
- [ ] Sign in as a non-admitted user (pending/waitlist/rejected/cohort-2-only) and confirm the legacy stacked-card layout still renders.
- [ ] Replace `SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER` with the real Zoom link before May 11 kickoff.
- [ ] Sanity-check weeks 2–6 dates against the actual program calendar and adjust as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)