### PR TITLE
test: c1 w1 PM trying-to-win submission

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/test-trying-to-win.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/test-trying-to-win.json
@@ -1,0 +1,8 @@
+{
+  "githubHandle": "test-trying-to-win",
+  "repoUrl": "https://github.com/example/test-pm-tool-trying-to-win",
+  "liveUrl": "https://test-trying-to-win.example.com",
+  "loomUrl": "https://www.loom.com/share/test-trying-to-win-loom",
+  "pitch": "Test submission with all required fields filled in and competeForWin set to true. Should appear in the Submissions list with the 'trying to win' badge.",
+  "competeForWin": true
+}


### PR DESCRIPTION
## Test fixture

Adds a JSON submission to verify the new Submissions collapsible on the Week 1 PM tab. **competeForWin: true** with all required fields filled — should appear as **\"trying to win\"** in the merged-counts endpoint and the participant list once merged.

## File

\`content/summer-cohort/c1/w1-pm/submissions/test-trying-to-win.json\`

## Verification

After merge, the \`X merged · Y trying to win\` count on the Week 1 tab should bump by 1 in both columns, and \`@test-trying-to-win\` should appear in the expanded list with the trophy badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)