### PR TITLE
test: c1 w1 PM just-submitting submission

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/test-just-submitting.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/test-just-submitting.json
@@ -1,0 +1,8 @@
+{
+  "githubHandle": "test-just-submitting",
+  "repoUrl": "https://github.com/example/test-pm-tool-just-submitting",
+  "liveUrl": "https://test-just-submitting.example.com",
+  "loomUrl": "https://www.loom.com/share/test-just-submitting-loom",
+  "pitch": "Test submission with all required fields but competeForWin set to false. Should appear in the Submissions list with the plain 'submitted' badge — counted in merged total but not in the trying-to-win count.",
+  "competeForWin": false
+}


### PR DESCRIPTION
## Test fixture

Adds a JSON submission to verify the new Submissions collapsible on the Week 1 PM tab. **competeForWin: false** with all required fields filled — should appear as **\"submitted\"** (no trophy badge), counted in the merged total but NOT in the trying-to-win count.

## File

\`content/summer-cohort/c1/w1-pm/submissions/test-just-submitting.json\`

## Verification

After merge, the \`X merged · Y trying to win\` count on the Week 1 tab should bump merged +1 (trying to win unchanged), and \`@test-just-submitting\` should appear in the expanded list with the plain \"submitted\" badge (no trophy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)