### PR TITLE
release: summer cohort dashboard + submissions module + voting

### DIFF
--- a/app/api/summer-cohort/submissions/[weekId]/route.ts
+++ b/app/api/summer-cohort/submissions/[weekId]/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextResponse } from "next/server";
+import {
+  fetchSummerCohortSubmissions,
+  getVoteWeekById,
+} from "@/lib/summer-cohort-submissions";
+
+interface RouteParams {
+  params: Promise<{ weekId: string }>;
+}
+
+/**
+ * Public read-only feed of merged submissions on a Cohort 1 vote-format week.
+ * Source of truth is the week's submission branch in GitHub; this route just
+ * caches the GitHub Contents API call so the client tab can render counts.
+ */
+export async function GET(_req: Request, { params }: RouteParams) {
+  const { weekId } = await params;
+  const week = getVoteWeekById(weekId);
+  if (!week) {
+    return NextResponse.json(
+      { error: "Unknown weekId — vote-format weeks are week-1, week-2, week-3." },
+      { status: 404 }
+    );
+  }
+
+  const summary = await fetchSummerCohortSubmissions(week, weekId);
+  return NextResponse.json(summary, {
+    headers: {
+      // Mirror the upstream cache window — clients can re-fetch every minute.
+      "Cache-Control": "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+    },
+  });
+}

--- a/app/api/summer-cohort/votes/route.ts
+++ b/app/api/summer-cohort/votes/route.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { SUMMER_COHORT_VOTES_COLLECTION } from "@/lib/summer-cohort";
+
+const VALID_WEEK_IDS = new Set(["week-1", "week-2", "week-3"]);
+
+/**
+ * Simple, deterministic doc ID so a (weekId, submitterHandle, voterUid) triple
+ * resolves to exactly one Firestore document. Toggling = create-if-absent /
+ * delete-if-present.
+ */
+function voteDocId(
+  weekId: string,
+  submitterHandle: string,
+  voterUid: string
+): string {
+  return `${weekId}__${submitterHandle.toLowerCase()}__${voterUid}`;
+}
+
+function isValidHandle(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 80) return false;
+  // GitHub handles are alphanumeric + hyphens; allow underscores for safety
+  // since our test fixtures and JSON files use lowercase ascii.
+  return /^[a-zA-Z0-9_-]+$/.test(trimmed);
+}
+
+function isValidWeekId(value: unknown): value is string {
+  return typeof value === "string" && VALID_WEEK_IDS.has(value);
+}
+
+/**
+ * GET /api/summer-cohort/votes?weekId=week-1
+ *
+ * Auth optional. Returns aggregate vote counts per submitterHandle for the
+ * given week. If the requester is signed in, also returns their own list of
+ * voted handles for that week.
+ */
+export async function GET(request: NextRequest) {
+  const weekId = request.nextUrl.searchParams.get("weekId");
+  if (!isValidWeekId(weekId)) {
+    return NextResponse.json(
+      { error: "weekId must be one of week-1, week-2, week-3" },
+      { status: 400 }
+    );
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  const user = await getVerifiedUser(request).catch(() => null);
+
+  const snap = await db
+    .collection(SUMMER_COHORT_VOTES_COLLECTION)
+    .where("weekId", "==", weekId)
+    .get();
+
+  const counts: Record<string, number> = {};
+  const myVotes: string[] = [];
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const handle =
+      typeof data.submitterHandle === "string"
+        ? data.submitterHandle.toLowerCase()
+        : null;
+    if (!handle) continue;
+    counts[handle] = (counts[handle] ?? 0) + 1;
+    if (user && data.voterUid === user.uid) {
+      myVotes.push(handle);
+    }
+  }
+
+  return NextResponse.json(
+    {
+      weekId,
+      counts,
+      myVotes: user ? myVotes : [],
+      authenticated: Boolean(user),
+    },
+    {
+      headers: {
+        // Counts are dynamic but a few seconds of cache absorbs hot bursts.
+        "Cache-Control": "private, max-age=0, must-revalidate",
+      },
+    }
+  );
+}
+
+/**
+ * POST /api/summer-cohort/votes
+ * Body: { weekId, submitterHandle }
+ *
+ * Toggles the requester's vote for the submission. Returns the new state.
+ * Auth required.
+ */
+export async function POST(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const obj =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const weekId = obj.weekId;
+  const submitterHandle = obj.submitterHandle;
+
+  if (!isValidWeekId(weekId)) {
+    return NextResponse.json(
+      { error: "weekId must be one of week-1, week-2, week-3" },
+      { status: 400 }
+    );
+  }
+  if (!isValidHandle(submitterHandle)) {
+    return NextResponse.json(
+      { error: "submitterHandle must be a valid GitHub handle" },
+      { status: 400 }
+    );
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  const docId = voteDocId(weekId, submitterHandle, user.uid);
+  const ref = db.collection(SUMMER_COHORT_VOTES_COLLECTION).doc(docId);
+  const existing = await ref.get();
+
+  let voted: boolean;
+  if (existing.exists) {
+    await ref.delete();
+    voted = false;
+  } else {
+    await ref.set({
+      weekId,
+      submitterHandle: submitterHandle.toLowerCase(),
+      voterUid: user.uid,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    voted = true;
+  }
+
+  // Recount this submission for the response so the client gets an authoritative
+  // post-toggle number rather than relying on optimistic estimation.
+  const countSnap = await db
+    .collection(SUMMER_COHORT_VOTES_COLLECTION)
+    .where("weekId", "==", weekId)
+    .where("submitterHandle", "==", submitterHandle.toLowerCase())
+    .count()
+    .get();
+
+  return NextResponse.json({
+    weekId,
+    submitterHandle: submitterHandle.toLowerCase(),
+    voted,
+    count: countSnap.data().count,
+  });
+}

--- a/app/summer-cohort/_components/CohortTabs.tsx
+++ b/app/summer-cohort/_components/CohortTabs.tsx
@@ -23,14 +23,14 @@ interface TabSpec {
 }
 
 const TABS: readonly TabSpec[] = [
-  { id: "info", label: "Info", shortLabel: "Info" },
+  { id: "info", label: "Cohort Info", shortLabel: "Cohort" },
+  { id: "my-info", label: "My Info", shortLabel: "Me" },
   { id: "week-1", label: "Week 1: PM", shortLabel: "W1" },
   { id: "week-2", label: "Week 2: Comms", shortLabel: "W2" },
   { id: "week-3", label: "Week 3: Marketing", shortLabel: "W3" },
   { id: "week-4", label: "Week 4: Ludwitt", shortLabel: "W4" },
   { id: "week-5", label: "Week 5: Startup", shortLabel: "W5" },
   { id: "week-6", label: "Week 6: OSS PR", shortLabel: "W6" },
-  { id: "my-info", label: "My info", shortLabel: "Me" },
 ];
 
 interface CohortTabsProps {

--- a/app/summer-cohort/_components/InfoTabPanel.tsx
+++ b/app/summer-cohort/_components/InfoTabPanel.tsx
@@ -6,20 +6,41 @@
 
 "use client";
 
-import { Calendar, Trophy, Users, Video } from "lucide-react";
 import {
+  Calendar,
+  CheckCircle2,
+  ExternalLink,
+  MessageCircle,
+  Trophy,
+  Users,
+  Video,
+} from "lucide-react";
+import {
+  SUMMER_COHORTS,
+  SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER,
   SUMMER_COHORT_DEMO_DAY,
   SUMMER_COHORT_IMMERSION,
   SUMMER_COHORT_MEETING_CADENCE,
   SUMMER_COHORT_PHILOSOPHY,
   SUMMER_COHORT_WEEKS,
 } from "@/lib/summer-cohort";
+import { WinnerCommitmentsCard } from "./WinnerCommitmentsCard";
+
+interface CompletedSetupApplication {
+  isLocal: boolean | null;
+  wantsToPresent: boolean | null;
+  mayImmersionRsvped: boolean;
+}
 
 interface InfoTabPanelProps {
   cohort1Count: number;
+  /** When provided, renders a small "setup recorded" summary at the top of
+   *  the tab — mirrors the "done" rows previously shown in the What's-next
+   *  card above the tabs, once those rows are all green. */
+  application?: CompletedSetupApplication;
 }
 
-export function InfoTabPanel({ cohort1Count }: InfoTabPanelProps) {
+export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
   return (
     <div
       role="tabpanel"
@@ -27,7 +48,118 @@ export function InfoTabPanel({ cohort1Count }: InfoTabPanelProps) {
       aria-labelledby="tab-info"
       className="space-y-6"
     >
-      {/* Top: at-a-glance */}
+      {application ? (
+        <section className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900 dark:bg-emerald-950/20">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-800 dark:text-emerald-300">
+            <CheckCircle2
+              className="h-3.5 w-3.5"
+              strokeWidth={2.25}
+              aria-hidden="true"
+            />
+            Setup recorded
+          </div>
+          <ul className="mt-2 space-y-1 text-sm text-emerald-900 dark:text-emerald-200">
+            <li>
+              Locality: <strong>{application.isLocal ? "yes" : "no"}</strong> ·
+              Comfortable presenting + maintaining if you win:{" "}
+              <strong>{application.wantsToPresent ? "yes" : "no"}</strong>
+            </li>
+            <li>
+              May 26 immersion event: <strong>RSVP confirmed</strong>
+            </li>
+          </ul>
+        </section>
+      ) : null}
+
+      {/* Cohort Discord channel — direct join */}
+      <section className="rounded-xl border border-[#5865F2]/40 bg-[#5865F2]/5 p-4 dark:border-[#5865F2]/40 dark:bg-[#5865F2]/10">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-[#5865F2]">
+              <MessageCircle
+                className="h-3.5 w-3.5"
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+              Cohort Discord
+            </div>
+            <p className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+              The cohort lives in #cohort-1 on Discord.
+            </p>
+            <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">
+              Day-to-day questions, build help, voting-call prep, and demos
+              all happen there. Connect Discord on the My Info tab if you
+              haven&apos;t — then jump in.
+            </p>
+          </div>
+          <a
+            href={SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#4752C4]"
+          >
+            Join channel
+            <ExternalLink
+              className="h-3.5 w-3.5"
+              strokeWidth={2.25}
+              aria-hidden="true"
+            />
+          </a>
+        </div>
+        <p className="mt-2 text-xs text-neutral-500">
+          Stand-in invite — we&apos;ll swap in the real Discord URL before
+          kickoff.
+        </p>
+      </section>
+
+      {/* Dates */}
+      <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+          Dates
+        </h2>
+        <ul className="mt-3 space-y-2">
+          {SUMMER_COHORTS.map((cohort) => (
+            <li
+              key={cohort.id}
+              className="rounded-lg border border-neutral-200 bg-neutral-100 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-semibold">{cohort.label}</span>
+                <span className="text-xs text-neutral-600 dark:text-neutral-300">
+                  {cohort.startLabel} – {cohort.endLabel}
+                </span>
+              </div>
+              <div className="mt-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                {cohort.graduationLabel}
+              </div>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+          First Zoom kickoffs: Cohort 1 on Mon May 11, Cohort 2 on Mon Jun 29.
+          Watch your email and the Week tabs above for meeting links.
+        </p>
+      </section>
+
+      {/* What to expect */}
+      <section className="rounded-xl border border-neutral-200 bg-neutral-50 p-6 dark:border-neutral-800 dark:bg-neutral-900/40">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+          What to expect
+        </h2>
+        <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
+          Each cohort runs <strong>six weeks</strong>, with twice-weekly Zoom
+          for demos and Q&amp;A and periodic in-person sessions in Boston.
+          You&apos;ll build, present, vote on each other&apos;s work, ship to
+          real users, and close with a demo day in front of hiring partners.
+        </p>
+        <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
+          It&apos;s free. The only guarantee is the community itself — no jobs
+          promised, no specific outcomes. The full week-by-week breakdown is
+          in the Week tabs above.
+        </p>
+      </section>
+
+      {/* How the cohort works (philosophy + at-a-glance stats) */}
       <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
         <h2 className="text-base font-semibold">How the cohort works</h2>
         <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
@@ -157,45 +289,7 @@ export function InfoTabPanel({ cohort1Count }: InfoTabPanelProps) {
         </div>
       </section>
 
-      {/* Winner commitments — preserved verbatim from the legacy card. */}
-      <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
-        <h3 className="text-base font-semibold">If you win a week-1/2/3 vote</h3>
-        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-          Winners ship their platform somewhere public for the rest of the
-          cohort to use, deal with real users (your fellow participants), and
-          submit a short demo video at showcase time.
-        </p>
-        <ul className="mt-4 space-y-3 text-sm text-neutral-700 dark:text-neutral-300">
-          <li>
-            <strong>Hosting at $0.</strong> At cohort scale (~100 users), every
-            major free tier (Vercel, Netlify, Cloudflare Pages, Supabase,
-            Neon, etc.) keeps you at $0 if you stay inside the limits. We
-            don&apos;t reimburse hosting bills if you blow them.
-          </li>
-          <li>
-            <strong>Domain.</strong> We&apos;ll hand you a{" "}
-            <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
-              yourthing.cursorboston.com
-            </code>{" "}
-            subdomain — no DNS service to buy.
-          </li>
-          <li>
-            <strong>Real users are part of the value.</strong> Whatever you
-            build will have actual users (your cohort). Operating it —
-            answering questions, shipping fixes, deciding what&apos;s next —
-            is part of the educational experience.
-          </li>
-          <li>
-            <strong>You own the code.</strong> Win or not, the repo is yours.
-            Keep it private, open it, evolve it.
-          </li>
-          <li>
-            <strong>Submitting to win is optional.</strong> Build, vote, and
-            attend everything without putting yourself up. You don&apos;t lose
-            anything — just skip the &quot;submit to win&quot; step.
-          </li>
-        </ul>
-      </section>
+      <WinnerCommitmentsCard />
     </div>
   );
 }

--- a/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
+++ b/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
@@ -1,0 +1,682 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ChevronDown,
+  ChevronUp,
+  CheckCircle2,
+  ExternalLink,
+  GitPullRequest,
+  ThumbsUp,
+  Trophy,
+} from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { SummerCohortVoteWeek } from "@/lib/summer-cohort";
+
+interface SubmissionRow {
+  githubHandle: string;
+  repoUrl: string | null;
+  loomUrl: string | null;
+  liveUrl: string | null;
+  pitch: string | null;
+  competeForWin: boolean;
+  allFieldsPresent: boolean;
+  displayName: string | null;
+  photoUrl: string | null;
+}
+
+interface SubmissionsResponse {
+  weekId: string;
+  branch: string;
+  path: string;
+  merged: number;
+  tryingToWin: number;
+  submissions: SubmissionRow[];
+}
+
+interface VotesResponse {
+  weekId: string;
+  counts: Record<string, number>;
+  myVotes: string[];
+  authenticated: boolean;
+}
+
+interface WeekSubmissionsCollapsibleProps {
+  week: SummerCohortVoteWeek;
+  tabId: string;
+  /** Logged-in user's GitHub login (lowercased), if connected. Used to surface
+   *  "you're submitted" / "not yet" status and to gate expansion. */
+  currentUserGithubHandle: string | null;
+  /** From userProfile.displayName — used to pre-populate the JSON example. */
+  currentUserDisplayName: string | null;
+  /** From userProfile.photoURL — used to pre-populate the JSON example. */
+  currentUserPhotoUrl: string | null;
+  /** Switches the parent CohortTabs to "my-info" so the user can connect
+   *  GitHub. Called from the gating CTA. */
+  onSwitchToMyInfo: () => void;
+}
+
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+function buildExampleJson(
+  week: SummerCohortVoteWeek,
+  githubHandle: string | null,
+  displayName: string | null,
+  photoUrl: string | null
+): string {
+  const handle = githubHandle ?? "your-handle";
+  const name = (displayName ?? "Your Name").replace(/"/g, '\\"');
+  const photo = photoUrl ?? "https://example.com/your-photo.jpg";
+  const liveLine = week.liveUrlRequired
+    ? `\n  "liveUrl": "https://yourthing.example.com",`
+    : "";
+  return `{
+  "githubHandle": "${handle}",
+  "name": "${name}",
+  "photoUrl": "${photo}",
+  "repoUrl": "https://github.com/${handle}/your-week-${week.week}-build",${liveLine}
+  "loomUrl": "https://www.loom.com/share/...",
+  "pitch": "One sentence on why you should win this week.",
+  "competeForWin": true
+}`;
+}
+
+function buildSubmissionPath(
+  week: SummerCohortVoteWeek,
+  githubHandle: string | null
+): string {
+  if (!githubHandle) return week.submissionPath;
+  return week.submissionPath.replace("<github-handle>", githubHandle);
+}
+
+function statusForUser(
+  data: SubmissionsResponse | null,
+  handle: string | null
+):
+  | { kind: "no-handle" }
+  | { kind: "loading" }
+  | { kind: "submitted"; row: SubmissionRow }
+  | { kind: "not-submitted" } {
+  if (!handle) return { kind: "no-handle" };
+  if (!data) return { kind: "loading" };
+  const row = data.submissions.find(
+    (s) => s.githubHandle.toLowerCase() === handle.toLowerCase()
+  );
+  if (row) return { kind: "submitted", row };
+  return { kind: "not-submitted" };
+}
+
+export function WeekSubmissionsCollapsible({
+  week,
+  tabId,
+  currentUserGithubHandle,
+  currentUserDisplayName,
+  currentUserPhotoUrl,
+  onSwitchToMyInfo,
+}: WeekSubmissionsCollapsibleProps) {
+  const githubConnected = Boolean(currentUserGithubHandle);
+  const { user } = useAuth();
+  const [expanded, setExpanded] = useState(false);
+  const [data, setData] = useState<SubmissionsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [voteCounts, setVoteCounts] = useState<Record<string, number>>({});
+  const [myVotes, setMyVotes] = useState<Set<string>>(new Set());
+  const [pendingVotes, setPendingVotes] = useState<Set<string>>(new Set());
+  const [voteError, setVoteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/summer-cohort/submissions/${tabId}`, { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return (await res.json()) as SubmissionsResponse;
+      })
+      .then((json) => {
+        if (cancelled) return;
+        setData(json);
+        setError(null);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Fetch failed");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tabId]);
+
+  // Fetch vote tallies. Refetch when auth state changes so signed-in users
+  // see their `myVotes` populated, and signed-out users get a clean view.
+  useEffect(() => {
+    let cancelled = false;
+    const headers: Record<string, string> = {};
+    const fetchVotes = async () => {
+      if (user) {
+        try {
+          const token = await user.getIdToken();
+          headers.Authorization = `Bearer ${token}`;
+        } catch {
+          // Fall back to unauthenticated read.
+        }
+      }
+      const res = await fetch(
+        `/api/summer-cohort/votes?weekId=${encodeURIComponent(tabId)}`,
+        { cache: "no-store", headers }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return (await res.json()) as VotesResponse;
+    };
+    fetchVotes()
+      .then((json) => {
+        if (cancelled) return;
+        setVoteCounts(json.counts ?? {});
+        setMyVotes(new Set(json.myVotes ?? []));
+      })
+      .catch(() => {
+        // Silent: votes are a soft enhancement; failure shouldn't block the
+        // main submissions UI.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tabId, user]);
+
+  const toggleVote = useCallback(
+    async (submitterHandle: string) => {
+      if (!user) return;
+      const handleKey = submitterHandle.toLowerCase();
+      if (pendingVotes.has(handleKey)) return;
+
+      const wasVoted = myVotes.has(handleKey);
+      // Optimistic update.
+      setMyVotes((prev) => {
+        const next = new Set(prev);
+        if (wasVoted) next.delete(handleKey);
+        else next.add(handleKey);
+        return next;
+      });
+      setVoteCounts((prev) => ({
+        ...prev,
+        [handleKey]: Math.max(0, (prev[handleKey] ?? 0) + (wasVoted ? -1 : 1)),
+      }));
+      setPendingVotes((prev) => new Set(prev).add(handleKey));
+      setVoteError(null);
+
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/summer-cohort/votes", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ weekId: tabId, submitterHandle: handleKey }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as {
+          voted: boolean;
+          count: number;
+        };
+        // Reconcile with the server.
+        setMyVotes((prev) => {
+          const next = new Set(prev);
+          if (json.voted) next.add(handleKey);
+          else next.delete(handleKey);
+          return next;
+        });
+        setVoteCounts((prev) => ({ ...prev, [handleKey]: json.count }));
+      } catch (err) {
+        // Roll back the optimistic update.
+        setMyVotes((prev) => {
+          const next = new Set(prev);
+          if (wasVoted) next.add(handleKey);
+          else next.delete(handleKey);
+          return next;
+        });
+        setVoteCounts((prev) => ({
+          ...prev,
+          [handleKey]: Math.max(
+            0,
+            (prev[handleKey] ?? 0) + (wasVoted ? 1 : -1)
+          ),
+        }));
+        setVoteError(err instanceof Error ? err.message : "Vote failed");
+      } finally {
+        setPendingVotes((prev) => {
+          const next = new Set(prev);
+          next.delete(handleKey);
+          return next;
+        });
+      }
+    },
+    [user, myVotes, pendingVotes, tabId]
+  );
+
+  const yourStatus = useMemo(
+    () => statusForUser(data, currentUserGithubHandle),
+    [data, currentUserGithubHandle]
+  );
+
+  const merged = data?.merged ?? null;
+  const tryingToWin = data?.tryingToWin ?? null;
+  const branchUrl = `${REPO_URL}/tree/${week.submissionBranch}`;
+  const dirUrl = data
+    ? `${REPO_URL}/tree/${week.submissionBranch}/${data.path}`
+    : null;
+  const submissionPath = buildSubmissionPath(week, currentUserGithubHandle);
+  const exampleJson = buildExampleJson(
+    week,
+    currentUserGithubHandle,
+    currentUserDisplayName,
+    currentUserPhotoUrl
+  );
+
+  const headerSummary = (
+    <div className="min-w-0 flex-1">
+      <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+        <GitPullRequest
+          className="h-4 w-4"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        Submissions — the focus of the week
+      </div>
+      <p className="mt-1 text-base font-semibold text-neutral-900 dark:text-neutral-100">
+        {merged === null ? (
+          error ? (
+            <span className="text-amber-700 dark:text-amber-400">
+              Couldn&apos;t load — refresh to retry.
+            </span>
+          ) : (
+            <span className="text-neutral-500">Loading counts…</span>
+          )
+        ) : (
+          <>
+            <span className="tabular-nums">{merged}</span> merged ·{" "}
+            <span className="tabular-nums">{tryingToWin}</span> trying to win
+          </>
+        )}
+      </p>
+      {yourStatus.kind === "submitted" ? (
+        <p className="mt-1 inline-flex items-center gap-1 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+          <CheckCircle2
+            className="h-3 w-3"
+            strokeWidth={2.5}
+            aria-hidden="true"
+          />
+          Your submission is merged
+          {yourStatus.row.competeForWin && yourStatus.row.allFieldsPresent
+            ? " · trying to win"
+            : ""}
+        </p>
+      ) : yourStatus.kind === "not-submitted" ? (
+        <p className="mt-1 text-xs text-neutral-700 dark:text-neutral-300">
+          No submission from <strong>@{currentUserGithubHandle}</strong> yet —
+          expand for the merge instructions.
+        </p>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div className="rounded-xl border-2 border-emerald-500 bg-emerald-50/40 shadow-sm dark:border-emerald-600 dark:bg-emerald-950/20">
+      {githubConnected ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-controls={`submissions-${tabId}-body`}
+          onClick={() => setExpanded((v) => !v)}
+          className="flex w-full items-center justify-between gap-3 rounded-xl px-5 py-4 text-left transition-colors hover:bg-emerald-100/40 dark:hover:bg-emerald-900/20"
+        >
+          {headerSummary}
+          <span className="shrink-0 text-emerald-700 dark:text-emerald-400">
+            {expanded ? (
+              <ChevronUp className="h-5 w-5" strokeWidth={2.25} aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-5 w-5" strokeWidth={2.25} aria-hidden="true" />
+            )}
+          </span>
+        </button>
+      ) : (
+        <div className="flex w-full flex-wrap items-center justify-between gap-3 px-5 py-4">
+          {headerSummary}
+          <button
+            type="button"
+            onClick={onSwitchToMyInfo}
+            className="shrink-0 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+          >
+            Connect GitHub
+            <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          </button>
+        </div>
+      )}
+      {!githubConnected ? (
+        <p className="border-t border-emerald-200 px-5 py-3 text-xs text-emerald-900 dark:border-emerald-900 dark:text-emerald-200">
+          Connect your GitHub on the My Info tab so we can match your
+          submission to your profile and surface the merge instructions
+          pre-populated with your name + photo.
+        </p>
+      ) : null}
+
+      {expanded ? (
+        <div
+          id={`submissions-${tabId}-body`}
+          className="border-t border-neutral-200 px-4 py-4 dark:border-neutral-800"
+        >
+          {/* Merge instructions — full set, pre-populated with your profile */}
+          <div className="rounded-lg border border-neutral-200 bg-white p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950/40 dark:text-neutral-300">
+            <p className="text-base font-semibold text-neutral-900 dark:text-neutral-100">
+              How to get on this list
+            </p>
+            <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+              Required fields: repo URL, Loom URL
+              {week.liveUrlRequired ? ", live URL" : ""}, and a one-sentence
+              pitch. Set <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">competeForWin: true</code> to
+              be counted as <em>trying to win</em>.
+            </p>
+
+            <ol className="mt-4 space-y-3">
+              <li className="flex gap-3">
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+                  1
+                </span>
+                <div className="min-w-0">
+                  <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                    Open a PR against{" "}
+                    <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
+                      {week.submissionBranch}
+                    </code>
+                  </p>
+                  <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+                    Base branch on{" "}
+                    <a
+                      href={REPO_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600"
+                    >
+                      rogerSuperBuilderAlpha/cursor-boston
+                      <ExternalLink
+                        className="ml-1 inline-block h-3 w-3"
+                        strokeWidth={2.25}
+                        aria-hidden="true"
+                      />
+                    </a>
+                    .
+                  </p>
+                </div>
+              </li>
+
+              <li className="flex gap-3">
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+                  2
+                </span>
+                <div className="min-w-0">
+                  <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                    Add one JSON file
+                  </p>
+                  <p className="mt-1 break-all text-xs text-neutral-600 dark:text-neutral-400">
+                    <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
+                      {submissionPath}
+                    </code>
+                  </p>
+                </div>
+              </li>
+
+              <li className="flex gap-3">
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+                  3
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                    File contents — pre-filled with your profile
+                  </p>
+                  <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+                    Your name and photo are pulled from your Cursor Boston
+                    profile so submissions render with your face. Tweak the
+                    repo / Loom / pitch fields, then commit.
+                  </p>
+                  <pre className="mt-2 overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-3 text-xs leading-relaxed text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+                    <code>{exampleJson}</code>
+                  </pre>
+                </div>
+              </li>
+
+              <li className="flex gap-3">
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+                  4
+                </span>
+                <div className="min-w-0">
+                  <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                    Sign your commit (DCO)
+                  </p>
+                  <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+                    Use{" "}
+                    <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
+                      git commit -s
+                    </code>{" "}
+                    so the Developer Certificate of Origin trailer is added.
+                    See{" "}
+                    <a
+                      href={`${REPO_URL}/blob/develop/docs/FIRST_CONTRIBUTION.md`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600"
+                    >
+                      FIRST_CONTRIBUTION.md
+                    </a>{" "}
+                    if you&apos;re new to this repo.
+                  </p>
+                </div>
+              </li>
+
+              <li className="flex gap-3">
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+                  5
+                </span>
+                <div className="min-w-0">
+                  <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+                    Once merged, you appear here
+                  </p>
+                  <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+                    Roger merges your PR; your file lands on{" "}
+                    <a
+                      href={dirUrl ?? branchUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500 dark:decoration-neutral-600 dark:hover:decoration-neutral-400"
+                    >
+                      the submissions directory
+                      <ExternalLink
+                        className="ml-1 inline-block h-3 w-3"
+                        strokeWidth={2.25}
+                        aria-hidden="true"
+                      />
+                    </a>
+                    , and the count above ticks up.
+                  </p>
+                </div>
+              </li>
+            </ol>
+
+            <p className="mt-4 rounded-md bg-emerald-50 px-3 py-2 text-xs text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200">
+              <strong>Voting:</strong> anyone signed in can upvote any
+              trying-to-win submission below — vote for all, some, or none.
+              The submission with the most votes at the end wins the week.
+            </p>
+          </div>
+
+          {/* List */}
+          <div className="mt-4">
+            {error ? (
+              <p className="text-sm text-amber-700 dark:text-amber-400">
+                Couldn&apos;t load submissions: {error}.
+              </p>
+            ) : !data ? (
+              <p className="text-sm text-neutral-500">Loading…</p>
+            ) : data.submissions.length === 0 ? (
+              <p className="text-sm text-neutral-500">
+                No merged submissions yet — be the first.
+              </p>
+            ) : (<>
+
+              <ul className="space-y-2">
+                {data.submissions.map((s) => {
+                  const isCompeting = s.allFieldsPresent && s.competeForWin;
+                  const handleKey = s.githubHandle.toLowerCase();
+                  const voteCount = voteCounts[handleKey] ?? 0;
+                  const haveVoted = myVotes.has(handleKey);
+                  const isPending = pendingVotes.has(handleKey);
+                  const initial = (s.displayName || s.githubHandle || "?")
+                    .trim()
+                    .charAt(0)
+                    .toUpperCase();
+                  return (
+                    <li
+                      key={s.githubHandle}
+                      className="flex flex-wrap items-center gap-3 rounded-lg border border-neutral-200 px-3 py-2 text-sm dark:border-neutral-800"
+                    >
+                      {s.photoUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element -- avatar URLs come from arbitrary OAuth providers (GitHub, Google), not the configured Next image domain list
+                        <img
+                          src={s.photoUrl}
+                          alt=""
+                          width={32}
+                          height={32}
+                          className="h-8 w-8 shrink-0 rounded-full bg-neutral-200 object-cover dark:bg-neutral-800"
+                        />
+                      ) : (
+                        <span
+                          aria-hidden="true"
+                          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-neutral-200 text-xs font-semibold text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
+                        >
+                          {initial}
+                        </span>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                          {s.displayName || `@${s.githubHandle}`}
+                        </p>
+                        <a
+                          href={`https://github.com/${s.githubHandle}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-neutral-500 underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500 dark:decoration-neutral-700"
+                        >
+                          @{s.githubHandle}
+                        </a>
+                      </div>
+                      {isCompeting ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+                          <Trophy
+                            className="h-3 w-3"
+                            strokeWidth={2.25}
+                            aria-hidden="true"
+                          />
+                          trying to win
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center rounded-full bg-neutral-200/60 px-2 py-0.5 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
+                          submitted
+                        </span>
+                      )}
+                      <div className="ml-auto flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+                        {s.repoUrl ? (
+                          <a
+                            href={s.repoUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500"
+                          >
+                            repo
+                          </a>
+                        ) : null}
+                        {s.loomUrl ? (
+                          <a
+                            href={s.loomUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500"
+                          >
+                            loom
+                          </a>
+                        ) : null}
+                        {s.liveUrl ? (
+                          <a
+                            href={s.liveUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500"
+                          >
+                            live
+                          </a>
+                        ) : null}
+                        {isCompeting ? (
+                          user ? (
+                            <button
+                              type="button"
+                              onClick={() => toggleVote(s.githubHandle)}
+                              disabled={isPending}
+                              aria-pressed={haveVoted}
+                              aria-label={
+                                haveVoted
+                                  ? `Remove your vote for ${s.githubHandle}`
+                                  : `Upvote ${s.githubHandle}`
+                              }
+                              className={
+                                haveVoted
+                                  ? "inline-flex items-center gap-1 rounded-full border border-emerald-400 bg-emerald-500/10 px-2.5 py-0.5 text-xs font-semibold text-emerald-700 transition-colors hover:bg-emerald-500/20 disabled:opacity-50 dark:border-emerald-700 dark:text-emerald-400"
+                                  : "inline-flex items-center gap-1 rounded-full border border-neutral-300 bg-white px-2.5 py-0.5 text-xs font-semibold text-neutral-700 transition-colors hover:border-emerald-400 hover:text-emerald-700 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:border-emerald-700 dark:hover:text-emerald-400"
+                              }
+                            >
+                              <ThumbsUp
+                                className="h-3 w-3"
+                                strokeWidth={2.5}
+                                aria-hidden="true"
+                              />
+                              <span className="tabular-nums">{voteCount}</span>
+                            </button>
+                          ) : (
+                            <span
+                              className="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-2.5 py-0.5 text-xs font-semibold text-neutral-600 dark:border-neutral-800 dark:text-neutral-400"
+                              title="Sign in to vote"
+                            >
+                              <ThumbsUp
+                                className="h-3 w-3"
+                                strokeWidth={2.5}
+                                aria-hidden="true"
+                              />
+                              <span className="tabular-nums">{voteCount}</span>
+                            </span>
+                          )
+                        ) : null}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+              {voteError ? (
+                <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+                  Vote couldn&apos;t be saved: {voteError}.
+                </p>
+              ) : null}
+              {!user ? (
+                <p className="mt-2 text-xs text-neutral-500">
+                  Sign in to upvote submissions you want to win.
+                </p>
+              ) : null}
+              </>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/summer-cohort/_components/WeekVotePanel.tsx
+++ b/app/summer-cohort/_components/WeekVotePanel.tsx
@@ -9,7 +9,7 @@
 import {
   Calendar,
   ExternalLink,
-  GitPullRequest,
+  Lightbulb,
   Trophy,
   Video,
 } from "lucide-react";
@@ -18,31 +18,35 @@ import {
   SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
   type SummerCohortVoteWeek,
 } from "@/lib/summer-cohort";
+import { WeekSubmissionsCollapsible } from "./WeekSubmissionsCollapsible";
 
 const PRESENT_MINUTES = SUMMER_COHORT_C1_WEEK_1.presentMinutes;
 const TOP_N = SUMMER_COHORT_C1_WEEK_1.topNFromAi;
 const WILDCARDS = SUMMER_COHORT_C1_WEEK_1.wildcardSlots;
 
-function buildExampleJson(week: SummerCohortVoteWeek) {
-  const liveLine = week.liveUrlRequired
-    ? `\n  "liveUrl": "https://yourthing.example.com",`
-    : "";
-  return `{
-  "githubHandle": "your-handle",
-  "repoUrl": "https://github.com/your-handle/your-week-${week.week}-build",${liveLine}
-  "loomUrl": "https://www.loom.com/share/...",
-  "pitch": "One sentence on why you should win this week."
-}`;
-}
-
 interface WeekVotePanelProps {
   week: SummerCohortVoteWeek;
   tabId: string;
+  /** Lower-cased GitHub handle of the signed-in user, if connected — used by
+   *  the submissions collapsible to render "you're submitted" status. */
+  currentUserGithubHandle: string | null;
+  /** Display name from the user's Cursor Boston profile (userProfile.displayName). */
+  currentUserDisplayName: string | null;
+  /** Photo URL from the user's Cursor Boston profile (userProfile.photoURL). */
+  currentUserPhotoUrl: string | null;
+  /** Switches the parent CohortTabs to "my-info" so the user can connect GitHub. */
+  onSwitchToMyInfo: () => void;
 }
 
-export function WeekVotePanel({ week, tabId }: WeekVotePanelProps) {
+export function WeekVotePanel({
+  week,
+  tabId,
+  currentUserGithubHandle,
+  currentUserDisplayName,
+  currentUserPhotoUrl,
+  onSwitchToMyInfo,
+}: WeekVotePanelProps) {
   const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
-  const requiredCount = week.liveUrlRequired ? 3 : 2;
 
   return (
     <section
@@ -51,7 +55,32 @@ export function WeekVotePanel({ week, tabId }: WeekVotePanelProps) {
       aria-labelledby={`tab-${tabId}`}
       className="rounded-xl border-2 border-emerald-400 bg-white p-6 dark:border-emerald-700 dark:bg-neutral-900"
     >
-      <div className="flex flex-wrap items-center gap-2">
+      {/* Kickoff Zoom — top of the module */}
+      <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          Kickoff Zoom · {week.kickoffLabel}
+        </div>
+        <a
+          href={zoomUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+        >
+          <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+          Join the Zoom
+          <ExternalLink
+            className="h-3.5 w-3.5"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+        </a>
+        <p className="mt-2 text-xs text-neutral-500">
+          Stand-in link — we&apos;ll swap in the real Zoom URL before kickoff.
+        </p>
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
           Cohort 1 · Week {week.week}
         </span>
@@ -72,160 +101,59 @@ export function WeekVotePanel({ week, tabId }: WeekVotePanelProps) {
         </div>
       ) : null}
 
-      {/* Kickoff */}
-      <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
-        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
-          <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
-          Kickoff Zoom
-        </div>
-        <p className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-          {week.kickoffLabel}
-        </p>
-        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-          We walk through the week, the rubric, and answer questions. Add it to
-          your calendar.
-        </p>
-        <a
-          href={zoomUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
-        >
-          <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
-          Join the Zoom
-          <ExternalLink
-            className="h-3.5 w-3.5"
-            strokeWidth={2.25}
-            aria-hidden="true"
-          />
-        </a>
-        <p className="mt-2 text-xs text-neutral-500">
-          Stand-in link — we&apos;ll swap in the real Zoom URL before kickoff.
-        </p>
+      {/* Submissions list (collapsible) — the focus of the week */}
+      <div className="mt-6">
+        <WeekSubmissionsCollapsible
+          week={week}
+          tabId={tabId}
+          currentUserGithubHandle={currentUserGithubHandle}
+          currentUserDisplayName={currentUserDisplayName}
+          currentUserPhotoUrl={currentUserPhotoUrl}
+          onSwitchToMyInfo={onSwitchToMyInfo}
+        />
       </div>
 
-      {/* What you submit */}
-      <div className="mt-6">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
-          What you submit
-        </h3>
-        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-          {requiredCount === 3
-            ? "All three are required to be considered for the week's win:"
-            : "Both are required to be considered for the week's win:"}
-        </p>
-        <ol className="mt-3 space-y-2 text-sm text-neutral-700 dark:text-neutral-300">
-          <li className="flex gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
-            <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
-              1
-            </span>
-            <div>
-              <p className="font-semibold text-neutral-900 dark:text-neutral-100">
-                Repo URL
-              </p>
-              <p className="mt-0.5">A public GitHub repo of your build.</p>
-            </div>
-          </li>
-          <li className="flex gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
-            <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
-              2
-            </span>
-            <div>
-              <p className="font-semibold text-neutral-900 dark:text-neutral-100">
-                Loom URL
-              </p>
-              <p className="mt-0.5">A short demo video of your build running.</p>
-            </div>
-          </li>
-          {week.liveUrlRequired ? (
-            <li className="flex gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
-              <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
-                3
-              </span>
-              <div>
-                <p className="font-semibold text-neutral-900 dark:text-neutral-100">
-                  Live URL
-                </p>
-                <p className="mt-0.5">
-                  Your deployed app, reachable on the public web.
-                </p>
-              </div>
-            </li>
-          ) : null}
-        </ol>
-      </div>
-
-      {/* PR mechanics */}
-      <div className="mt-6">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
-          How to submit
-        </h3>
-        <ol className="mt-3 space-y-2 text-sm text-neutral-700 dark:text-neutral-300">
-          <li className="flex gap-3">
-            <GitPullRequest
-              className="mt-0.5 h-4 w-4 shrink-0 text-neutral-500"
+      {/* Inspiration */}
+      {week.inspirationPlatforms.length > 0 ? (
+        <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+            <Lightbulb
+              className="h-3.5 w-3.5"
               strokeWidth={2.25}
               aria-hidden="true"
             />
-            <span>
-              Open a PR against the{" "}
-              <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
-                {week.submissionBranch}
-              </code>{" "}
-              base branch of{" "}
-              <a
-                href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-semibold underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600"
+            Inspiration — what to study, not rebuild
+          </div>
+          <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+            {week.inspirationScopeNote}
+          </p>
+          <ul className="mt-3 space-y-2 text-sm text-neutral-700 dark:text-neutral-300">
+            {week.inspirationPlatforms.map((platform) => (
+              <li
+                key={platform.name}
+                className="rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900"
               >
-                rogerSuperBuilderAlpha/cursor-boston
-              </a>
-              .
-            </span>
-          </li>
-          <li className="flex gap-3">
-            <span className="mt-0.5 h-4 w-4 shrink-0 text-neutral-500" aria-hidden="true">
-              ↳
-            </span>
-            <span>
-              Add a single JSON file at{" "}
-              <code className="break-all rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
-                {week.submissionPath}
-              </code>
-              .
-            </span>
-          </li>
-          <li className="flex gap-3">
-            <span className="mt-0.5 h-4 w-4 shrink-0 text-neutral-500" aria-hidden="true">
-              ↳
-            </span>
-            <span>
-              Sign your commit with DCO (
-              <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
-                git commit -s
-              </code>
-              ) — see{" "}
-              <a
-                href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/FIRST_CONTRIBUTION.md"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-semibold underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600"
-              >
-                FIRST_CONTRIBUTION.md
-              </a>{" "}
-              if you&apos;re new to this repo.
-            </span>
-          </li>
-        </ol>
-
-        <p className="mt-4 text-xs font-semibold uppercase tracking-wider text-neutral-500">
-          File contents
-        </p>
-        <pre className="mt-2 overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-3 text-xs leading-relaxed text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
-          <code>{buildExampleJson(week)}</code>
-        </pre>
-      </div>
+                <a
+                  href={platform.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-semibold underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500 dark:decoration-neutral-600 dark:hover:decoration-neutral-400"
+                >
+                  {platform.name}
+                  <ExternalLink
+                    className="ml-1 inline-block h-3 w-3"
+                    strokeWidth={2.25}
+                    aria-hidden="true"
+                  />
+                </a>
+                <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                  {platform.takeaway}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
       {/* Deadline */}
       <div className="mt-6 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50/60 p-4 dark:border-amber-900 dark:bg-amber-950/20">

--- a/app/summer-cohort/_components/WinnerCommitmentsCard.tsx
+++ b/app/summer-cohort/_components/WinnerCommitmentsCard.tsx
@@ -1,0 +1,266 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import type React from "react";
+
+interface PlatformRow {
+  name: string;
+  url: string;
+  notes: React.ReactNode;
+}
+
+/** Free-tier numbers verified against each provider's pricing page in May 2026.
+ *  These rot fast — when limits change, update the {name, notes} pair and the
+ *  date in the section copy below. */
+const HOST_PLATFORMS: readonly PlatformRow[] = [
+  {
+    name: "Vercel Hobby",
+    url: "https://vercel.com/pricing",
+    notes: (
+      <>
+        100 GB bandwidth/mo, 150K function invocations/mo, 60s function
+        duration. Hard cap — once you hit it, deploys and functions stop
+        until the next billing cycle. <strong>Non-commercial use only.</strong>
+      </>
+    ),
+  },
+  {
+    name: "Netlify Free",
+    url: "https://www.netlify.com/pricing/",
+    notes: (
+      <>
+        100 GB bandwidth/mo, 300 build minutes/mo, 125K serverless function
+        invocations/mo, 1M edge function invocations.
+      </>
+    ),
+  },
+  {
+    name: "Cloudflare Pages",
+    url: "https://pages.cloudflare.com/",
+    notes: (
+      <>
+        <strong>Unlimited bandwidth</strong>, 500 builds/mo, 1 concurrent
+        build, 100 custom domains. Pair with Cloudflare Workers (100K
+        requests/day free) for serverless logic. Most generous free tier of
+        the four.
+      </>
+    ),
+  },
+  {
+    name: "Render",
+    url: "https://render.com/pricing",
+    notes: (
+      <>
+        Static sites free with 100 GB bandwidth/mo. Free web services get
+        750 instance hours/mo but sleep after 15 min idle (~30s cold start).
+      </>
+    ),
+  },
+];
+
+const BACKEND_PLATFORMS: readonly PlatformRow[] = [
+  {
+    name: "Firebase Spark",
+    url: "https://firebase.google.com/pricing",
+    notes: (
+      <>
+        50K MAU (auth), 1 GB Firestore + 50K reads/day + 20K writes/day, 5
+        GB Cloud Storage, 10 GB Hosting. The per-day Firestore caps are the
+        thing to watch.
+      </>
+    ),
+  },
+  {
+    name: "Supabase Free",
+    url: "https://supabase.com/pricing",
+    notes: (
+      <>
+        500 MB Postgres, 1 GB file storage, 5 GB egress/mo, 50K MAU, 2
+        active projects. <strong>Auto-pauses after 7 days of inactivity</strong> —
+        you have to manually resume in the dashboard.
+      </>
+    ),
+  },
+  {
+    name: "Convex Free",
+    url: "https://www.convex.dev/pricing",
+    notes: (
+      <>
+        1M function calls/mo, 0.5 GB database, 1 GB file storage. Strong if
+        you want real-time queries baked in. Hard caps, no overage option.
+      </>
+    ),
+  },
+  {
+    name: "Neon Free",
+    url: "https://neon.com/pricing",
+    notes: (
+      <>
+        100 CU-hours/mo per project, 0.5 GB storage per project (5 GB
+        aggregate across up to 10 projects). Plain Postgres, no BaaS layer.
+      </>
+    ),
+  },
+];
+
+function PlatformTable({
+  rows,
+  caption,
+}: {
+  rows: readonly PlatformRow[];
+  caption: string;
+}) {
+  return (
+    <div className="mt-2 overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800">
+      <table className="w-full text-left text-sm">
+        <caption className="sr-only">{caption}</caption>
+        <thead className="bg-neutral-50 text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:bg-neutral-800/50">
+          <tr>
+            <th scope="col" className="px-3 py-2 align-top">
+              Platform
+            </th>
+            <th scope="col" className="px-3 py-2 align-top">
+              Free tier (May 2026)
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
+          {rows.map((row) => (
+            <tr key={row.name} className="align-top">
+              <td className="w-1/3 px-3 py-3">
+                <a
+                  href={row.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500 dark:decoration-neutral-600 dark:hover:decoration-neutral-400"
+                >
+                  {row.name}
+                </a>
+              </td>
+              <td className="px-3 py-3 text-neutral-700 dark:text-neutral-300">
+                {row.notes}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function WinnerCommitmentsCard() {
+  return (
+    <section className="mt-6 rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+      <h2 className="text-base font-semibold">
+        If you win a week-1/2/3 vote
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        Winners ship their platform somewhere public for the rest of the
+        cohort to use, deal with real users (your fellow participants), and
+        submit a short demo video at showcase time.
+      </p>
+
+      <div className="mt-5 space-y-6 text-sm text-neutral-700 dark:text-neutral-300">
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Hosting costs — likely $0 at cohort scale, but verify your stack
+          </h3>
+          <p className="mt-2">
+            You pick the stack and run the deploy. At cohort scale (~100
+            users), the major free tiers are very likely to keep you at $0 —
+            but limits exist, exceeding them is your responsibility, and we
+            don&apos;t reimburse hosting bills. Always check the current
+            pricing page before you commit; the figures below are accurate as
+            of May 2026.
+          </p>
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Pick a deploy/host
+          </h3>
+          <PlatformTable
+            rows={HOST_PLATFORMS}
+            caption="Frontend / deploy hosts and their May 2026 free tier limits"
+          />
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Pick a backend / database (if you need one)
+          </h3>
+          <PlatformTable
+            rows={BACKEND_PLATFORMS}
+            caption="Backend and database providers and their May 2026 free tier limits"
+          />
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Domain
+          </h3>
+          <p className="mt-1">
+            We&apos;ll hand you a{" "}
+            <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
+              yourthing.cursorboston.com
+            </code>{" "}
+            subdomain — no DNS service to buy.
+          </p>
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Managing real users is half the value
+          </h3>
+          <p className="mt-1">
+            Whatever you build will have actual users — your cohort.
+            Operating a platform with real people on it (handling questions,
+            fixing what breaks, deciding what to ship next) is part of the
+            educational experience. If you&apos;re already a senior operator,
+            treat it as a portfolio piece.
+          </p>
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Your demo can run locally
+          </h3>
+          <p className="mt-1">
+            For the showcase you submit a short Loom/Vidyard video. You
+            don&apos;t need a live URL — running the platform on your laptop
+            during the demo is fine.
+          </p>
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            You own everything you build
+          </h3>
+          <p className="mt-1">
+            Whether or not you submit to win, the code is yours. Keep it
+            private, open it, or evolve it into something else — your call.
+          </p>
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Totally fine to not submit to win
+          </h3>
+          <p className="mt-1">
+            You can participate fully without putting yourself up for the
+            vote. There are 60+ people in Cohort 1 — we&apos;re not going to
+            run short of volunteers. Everything else (building, voting, the
+            in-person events, the demo day with hiring partners) is still
+            yours. The only thing to skip is the &quot;submit to win&quot;
+            step.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -37,6 +37,7 @@ import { Week4LudwittPanel } from "./_components/Week4LudwittPanel";
 import { Week5StartupPanel } from "./_components/Week5StartupPanel";
 import { Week6OssPanel } from "./_components/Week6OssPanel";
 import { WeekVotePanel } from "./_components/WeekVotePanel";
+import { WinnerCommitmentsCard } from "./_components/WinnerCommitmentsCard";
 
 interface ApplicationDto {
   userId: string | null;
@@ -112,247 +113,6 @@ interface CounterCardProps {
   pickedCohorts: SummerCohortId[];
 }
 
-interface PlatformRow {
-  name: string;
-  url: string;
-  notes: React.ReactNode;
-}
-
-/** Free-tier numbers verified against each provider's pricing page in May 2026.
- *  These rot fast — when limits change, update the {name, notes} pair and the
- *  date in the section copy below. */
-const HOST_PLATFORMS: readonly PlatformRow[] = [
-  {
-    name: "Vercel Hobby",
-    url: "https://vercel.com/pricing",
-    notes: (
-      <>
-        100 GB bandwidth/mo, 150K function invocations/mo, 60s function
-        duration. Hard cap — once you hit it, deploys and functions stop
-        until the next billing cycle. <strong>Non-commercial use only.</strong>
-      </>
-    ),
-  },
-  {
-    name: "Netlify Free",
-    url: "https://www.netlify.com/pricing/",
-    notes: (
-      <>
-        100 GB bandwidth/mo, 300 build minutes/mo, 125K serverless function
-        invocations/mo, 1M edge function invocations.
-      </>
-    ),
-  },
-  {
-    name: "Cloudflare Pages",
-    url: "https://pages.cloudflare.com/",
-    notes: (
-      <>
-        <strong>Unlimited bandwidth</strong>, 500 builds/mo, 1 concurrent
-        build, 100 custom domains. Pair with Cloudflare Workers (100K
-        requests/day free) for serverless logic. Most generous free tier of
-        the four.
-      </>
-    ),
-  },
-  {
-    name: "Render",
-    url: "https://render.com/pricing",
-    notes: (
-      <>
-        Static sites free with 100 GB bandwidth/mo. Free web services get
-        750 instance hours/mo but sleep after 15 min idle (~30s cold start).
-      </>
-    ),
-  },
-];
-
-const BACKEND_PLATFORMS: readonly PlatformRow[] = [
-  {
-    name: "Firebase Spark",
-    url: "https://firebase.google.com/pricing",
-    notes: (
-      <>
-        50K MAU (auth), 1 GB Firestore + 50K reads/day + 20K writes/day, 5
-        GB Cloud Storage, 10 GB Hosting. The per-day Firestore caps are the
-        thing to watch.
-      </>
-    ),
-  },
-  {
-    name: "Supabase Free",
-    url: "https://supabase.com/pricing",
-    notes: (
-      <>
-        500 MB Postgres, 1 GB file storage, 5 GB egress/mo, 50K MAU, 2
-        active projects. <strong>Auto-pauses after 7 days of inactivity</strong> —
-        you have to manually resume in the dashboard.
-      </>
-    ),
-  },
-  {
-    name: "Convex Free",
-    url: "https://www.convex.dev/pricing",
-    notes: (
-      <>
-        1M function calls/mo, 0.5 GB database, 1 GB file storage. Strong if
-        you want real-time queries baked in. Hard caps, no overage option.
-      </>
-    ),
-  },
-  {
-    name: "Neon Free",
-    url: "https://neon.com/pricing",
-    notes: (
-      <>
-        100 CU-hours/mo per project, 0.5 GB storage per project (5 GB
-        aggregate across up to 10 projects). Plain Postgres, no BaaS layer.
-      </>
-    ),
-  },
-];
-
-function PlatformTable({ rows, caption }: { rows: readonly PlatformRow[]; caption: string }) {
-  return (
-    <div className="mt-2 overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800">
-      <table className="w-full text-left text-sm">
-        <caption className="sr-only">{caption}</caption>
-        <thead className="bg-neutral-50 text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:bg-neutral-800/50">
-          <tr>
-            <th scope="col" className="px-3 py-2 align-top">Platform</th>
-            <th scope="col" className="px-3 py-2 align-top">Free tier (May 2026)</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-neutral-200 dark:divide-neutral-800">
-          {rows.map((row) => (
-            <tr key={row.name} className="align-top">
-              <td className="w-1/3 px-3 py-3">
-                <a
-                  href={row.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-semibold underline decoration-neutral-300 underline-offset-2 hover:decoration-neutral-500 dark:decoration-neutral-600 dark:hover:decoration-neutral-400"
-                >
-                  {row.name}
-                </a>
-              </td>
-              <td className="px-3 py-3 text-neutral-700 dark:text-neutral-300">
-                {row.notes}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function WinnerCommitmentsCard() {
-  return (
-    <section className="mt-6 rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
-      <h2 className="text-base font-semibold">
-        If you win a week-1/2/3 vote
-      </h2>
-      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-        Winners ship their platform somewhere public for the rest of the
-        cohort to use, deal with real users (your fellow participants), and
-        submit a short demo video at showcase time.
-      </p>
-
-      <div className="mt-5 space-y-6 text-sm text-neutral-700 dark:text-neutral-300">
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            Hosting costs — likely $0 at cohort scale, but verify your stack
-          </h3>
-          <p className="mt-2">
-            You pick the stack and run the deploy. At cohort scale (~100
-            users), the major free tiers are very likely to keep you at $0 —
-            but limits exist, exceeding them is your responsibility, and we
-            don&apos;t reimburse hosting bills. Always check the current
-            pricing page before you commit; the figures below are accurate as
-            of May 2026.
-          </p>
-        </div>
-
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            Pick a deploy/host
-          </h3>
-          <PlatformTable rows={HOST_PLATFORMS} caption="Frontend / deploy hosts and their May 2026 free tier limits" />
-        </div>
-
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            Pick a backend / database (if you need one)
-          </h3>
-          <PlatformTable rows={BACKEND_PLATFORMS} caption="Backend and database providers and their May 2026 free tier limits" />
-        </div>
-
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            Domain
-          </h3>
-          <p className="mt-1">
-            We&apos;ll hand you a{" "}
-            <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
-              yourthing.cursorboston.com
-            </code>{" "}
-            subdomain — no DNS service to buy.
-          </p>
-        </div>
-
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            Managing real users is half the value
-          </h3>
-          <p className="mt-1">
-            Whatever you build will have actual users — your cohort.
-            Operating a platform with real people on it (handling questions,
-            fixing what breaks, deciding what to ship next) is part of the
-            educational experience. If you&apos;re already a senior operator,
-            treat it as a portfolio piece.
-          </p>
-        </div>
-
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            Your demo can run locally
-          </h3>
-          <p className="mt-1">
-            For the showcase you submit a short Loom/Vidyard video. You
-            don&apos;t need a live URL — running the platform on your laptop
-            during the demo is fine.
-          </p>
-        </div>
-
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            You own everything you build
-          </h3>
-          <p className="mt-1">
-            Whether or not you submit to win, the code is yours. Keep it
-            private, open it, or evolve it into something else — your call.
-          </p>
-        </div>
-
-        <div>
-          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
-            Totally fine to not submit to win
-          </h3>
-          <p className="mt-1">
-            You can participate fully without putting yourself up for the
-            vote. There are 60+ people in Cohort 1 — we&apos;re not going to
-            run short of volunteers. Everything else (building, voting, the
-            in-person events, the demo day with hiring partners) is still
-            yours. The only thing to skip is the &quot;submit to win&quot;
-            step.
-          </p>
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function ApplicationCounterCard({ counts, pickedCohorts }: CounterCardProps) {
   const pickedSet = new Set(pickedCohorts);
   const missingCohort = SUMMER_COHORTS.find((c) => !pickedSet.has(c.id));
@@ -425,10 +185,12 @@ function NextStepsCard({
   application,
   needsDiscord,
   onEditDetails,
+  hideDoneItems = false,
 }: {
   application: ApplicationDto;
   needsDiscord: boolean;
   onEditDetails: () => void;
+  hideDoneItems?: boolean;
 }) {
   const status = application.status;
   const isInCohort1 = application.cohorts.includes("cohort-1");
@@ -527,7 +289,11 @@ function NextStepsCard({
     });
   }
 
-  const allDone = items.every((i) => i.state === "done");
+  const visibleItems = hideDoneItems
+    ? items.filter((i) => i.state === "todo")
+    : items;
+  if (hideDoneItems && visibleItems.length === 0) return null;
+  const allDone = visibleItems.every((i) => i.state === "done");
 
   return (
     <section className="mt-6 rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
@@ -541,7 +307,7 @@ function NextStepsCard({
         </p>
       ) : null}
       <ul className="mt-4 space-y-3">
-        {items.map((item, idx) => (
+        {visibleItems.map((item, idx) => (
           <li
             key={idx}
             className={`flex gap-3 rounded-lg border p-3 ${
@@ -583,6 +349,29 @@ function NextStepsCard({
           </li>
         ))}
       </ul>
+    </section>
+  );
+}
+
+function CohortCodeOfConductFooter() {
+  return (
+    <section
+      aria-label="Code of conduct"
+      className="mt-6 rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm dark:border-neutral-800 dark:bg-neutral-900/40"
+    >
+      <p className="text-neutral-700 dark:text-neutral-300">
+        <strong>Code of conduct.</strong> Building together only works if
+        everyone feels welcome. By participating in the cohort you agree to
+        the{" "}
+        <Link
+          href="/code-of-conduct"
+          className="font-semibold underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600"
+        >
+          Cursor Boston Code of Conduct
+        </Link>
+        . If something feels off — to you or anyone else — flag it to the
+        organizers.
+      </p>
     </section>
   );
 }
@@ -918,6 +707,11 @@ function SummerCohortPageInner() {
   const myInfoVisible = !showTabs || activeTab === "my-info";
   const cohort1Count = applicationCounts["cohort-1"] ?? 0;
 
+  const localityDone =
+    application?.isLocal !== null && application?.wantsToPresent !== null;
+  const rsvpDone = application?.mayImmersionRsvped === true;
+  const moveCompletedSetupToInfo = showTabs && localityDone && rsvpDone;
+
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
       <header className="mb-8">
@@ -991,6 +785,7 @@ function SummerCohortPageInner() {
                   application={application}
                   needsDiscord={!discord.discordInfo}
                   onEditDetails={openEditDetails}
+                  hideDoneItems={moveCompletedSetupToInfo}
                 />
                 <CohortTabs
                   activeTab={activeTab}
@@ -998,21 +793,50 @@ function SummerCohortPageInner() {
                 />
                 <div className="mt-4">
                   {activeTab === "info" ? (
-                    <InfoTabPanel cohort1Count={cohort1Count} />
+                    <InfoTabPanel
+                      cohort1Count={cohort1Count}
+                      application={
+                        moveCompletedSetupToInfo ? application : undefined
+                      }
+                    />
                   ) : activeTab === "week-1" ? (
                     <WeekVotePanel
                       week={SUMMER_COHORT_C1_VOTE_WEEKS[0]}
                       tabId="week-1"
+                      currentUserGithubHandle={
+                        github.githubInfo?.login ?? null
+                      }
+                      currentUserDisplayName={
+                        userProfile?.displayName ?? null
+                      }
+                      currentUserPhotoUrl={userProfile?.photoURL ?? null}
+                      onSwitchToMyInfo={() => setActiveTab("my-info")}
                     />
                   ) : activeTab === "week-2" ? (
                     <WeekVotePanel
                       week={SUMMER_COHORT_C1_VOTE_WEEKS[1]}
                       tabId="week-2"
+                      currentUserGithubHandle={
+                        github.githubInfo?.login ?? null
+                      }
+                      currentUserDisplayName={
+                        userProfile?.displayName ?? null
+                      }
+                      currentUserPhotoUrl={userProfile?.photoURL ?? null}
+                      onSwitchToMyInfo={() => setActiveTab("my-info")}
                     />
                   ) : activeTab === "week-3" ? (
                     <WeekVotePanel
                       week={SUMMER_COHORT_C1_VOTE_WEEKS[2]}
                       tabId="week-3"
+                      currentUserGithubHandle={
+                        github.githubInfo?.login ?? null
+                      }
+                      currentUserDisplayName={
+                        userProfile?.displayName ?? null
+                      }
+                      currentUserPhotoUrl={userProfile?.photoURL ?? null}
+                      onSwitchToMyInfo={() => setActiveTab("my-info")}
                     />
                   ) : activeTab === "week-4" ? (
                     <Week4LudwittPanel />
@@ -1022,6 +846,7 @@ function SummerCohortPageInner() {
                     <Week6OssPanel />
                   ) : null}
                 </div>
+                <CohortCodeOfConductFooter />
               </>
             ) : (
               <>

--- a/lib/summer-cohort-submissions.ts
+++ b/lib/summer-cohort-submissions.ts
@@ -1,0 +1,330 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { getAdminDb } from "./firebase-admin";
+import { getGithubRepoPair } from "./github-recent-merged-prs";
+import { logger } from "./logger";
+import {
+  SUMMER_COHORT_C1_VOTE_WEEKS,
+  type SummerCohortVoteWeek,
+} from "./summer-cohort";
+
+export interface SummerCohortSubmissionFile {
+  githubHandle: string;
+  repoUrl?: string;
+  loomUrl?: string;
+  liveUrl?: string;
+  pitch?: string;
+  competeForWin?: boolean;
+}
+
+export interface SummerCohortSubmissionsSummary {
+  weekId: string;
+  branch: string;
+  path: string;
+  merged: number;
+  tryingToWin: number;
+  /** Sorted by githubHandle for stable ordering. */
+  submissions: ReadonlyArray<{
+    githubHandle: string;
+    repoUrl: string | null;
+    loomUrl: string | null;
+    liveUrl: string | null;
+    pitch: string | null;
+    competeForWin: boolean;
+    allFieldsPresent: boolean;
+    /** Looked up from the `users` collection by `github.login` (lowercased). */
+    displayName: string | null;
+    photoUrl: string | null;
+  }>;
+}
+
+/** Strip leading slashes / `<github-handle>.json` placeholder so we can use the
+ *  path as a directory listing target on the GitHub Contents API. */
+function getDirectoryPath(submissionPath: string): string {
+  // submissionPath looks like:
+  //   "content/summer-cohort/c1/w1-pm/submissions/<github-handle>.json"
+  const idx = submissionPath.lastIndexOf("/");
+  return idx >= 0 ? submissionPath.slice(0, idx) : submissionPath;
+}
+
+const VOTE_WEEK_BY_ID: Record<string, SummerCohortVoteWeek> = {
+  "week-1": SUMMER_COHORT_C1_VOTE_WEEKS[0],
+  "week-2": SUMMER_COHORT_C1_VOTE_WEEKS[1],
+  "week-3": SUMMER_COHORT_C1_VOTE_WEEKS[2],
+};
+
+export function getVoteWeekById(weekId: string): SummerCohortVoteWeek | null {
+  return VOTE_WEEK_BY_ID[weekId] ?? null;
+}
+
+interface ContentsApiItem {
+  name?: unknown;
+  path?: unknown;
+  type?: unknown;
+  download_url?: unknown;
+}
+
+function isJsonFileItem(item: ContentsApiItem): boolean {
+  return (
+    item.type === "file" &&
+    typeof item.name === "string" &&
+    item.name.endsWith(".json")
+  );
+}
+
+interface RawSubmission {
+  githubHandle: string;
+  repoUrl: string | null;
+  loomUrl: string | null;
+  liveUrl: string | null;
+  pitch: string | null;
+  competeForWin: boolean;
+  allFieldsPresent: boolean;
+  /** Fallback identity if no Firebase user matches by github.login. */
+  jsonName: string | null;
+  jsonPhotoUrl: string | null;
+}
+
+function normalizeSubmission(
+  raw: unknown,
+  fallbackHandle: string
+): RawSubmission | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const githubHandle =
+    typeof obj.githubHandle === "string" && obj.githubHandle.trim().length > 0
+      ? obj.githubHandle.trim()
+      : fallbackHandle;
+  const repoUrl =
+    typeof obj.repoUrl === "string" && obj.repoUrl.trim().length > 0
+      ? obj.repoUrl.trim()
+      : null;
+  const loomUrl =
+    typeof obj.loomUrl === "string" && obj.loomUrl.trim().length > 0
+      ? obj.loomUrl.trim()
+      : null;
+  const liveUrl =
+    typeof obj.liveUrl === "string" && obj.liveUrl.trim().length > 0
+      ? obj.liveUrl.trim()
+      : null;
+  const pitch =
+    typeof obj.pitch === "string" && obj.pitch.trim().length > 0
+      ? obj.pitch.trim()
+      : null;
+  const competeForWin = obj.competeForWin === true;
+  const jsonName =
+    typeof obj.name === "string" && obj.name.trim().length > 0
+      ? obj.name.trim()
+      : null;
+  const jsonPhotoUrl =
+    typeof obj.photoUrl === "string" && obj.photoUrl.trim().length > 0
+      ? obj.photoUrl.trim()
+      : null;
+  // Baseline = the always-required fields. Caller layers in the
+  // liveUrlRequired check from the week config.
+  const allFieldsBaseline = Boolean(repoUrl && loomUrl && pitch && githubHandle);
+
+  return {
+    githubHandle,
+    repoUrl,
+    loomUrl,
+    liveUrl,
+    pitch,
+    competeForWin,
+    allFieldsPresent: allFieldsBaseline,
+    jsonName,
+    jsonPhotoUrl,
+  };
+}
+
+/**
+ * Fetch the merged-submissions list for a vote-format week from GitHub.
+ *
+ * Source of truth: JSON files on the week's submission branch under the week's
+ * submissions directory. "Merged" = file exists on the branch. "Trying to win"
+ * = all required fields are present AND `competeForWin: true`.
+ */
+export async function fetchSummerCohortSubmissions(
+  week: SummerCohortVoteWeek,
+  weekId: string
+): Promise<SummerCohortSubmissionsSummary> {
+  const { owner, repo } = getGithubRepoPair();
+  const dirPath = getDirectoryPath(week.submissionPath);
+  const token = process.env.GITHUB_TOKEN;
+
+  const empty: SummerCohortSubmissionsSummary = {
+    weekId,
+    branch: week.submissionBranch,
+    path: dirPath,
+    merged: 0,
+    tryingToWin: 0,
+    submissions: [],
+  };
+
+  const listUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${dirPath}?ref=${encodeURIComponent(
+    week.submissionBranch
+  )}`;
+
+  let listRes: Response;
+  try {
+    listRes = await fetch(listUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      next: { revalidate: 60 },
+    });
+  } catch (error) {
+    logger.warn("fetchSummerCohortSubmissions: contents-list fetch failed", {
+      weekId,
+      branch: week.submissionBranch,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return empty;
+  }
+
+  // 404 = branch or directory doesn't exist yet (program hasn't started, or
+  // no submissions merged). Return empty without erroring.
+  if (listRes.status === 404) return empty;
+  if (!listRes.ok) {
+    logger.warn("fetchSummerCohortSubmissions: contents-list non-OK", {
+      weekId,
+      branch: week.submissionBranch,
+      status: listRes.status,
+    });
+    return empty;
+  }
+
+  let listJson: unknown;
+  try {
+    listJson = await listRes.json();
+  } catch {
+    return empty;
+  }
+  if (!Array.isArray(listJson)) return empty;
+
+  const fileItems = (listJson as ContentsApiItem[]).filter(isJsonFileItem);
+
+  const submissions = await Promise.all(
+    fileItems.map(async (item) => {
+      const downloadUrl =
+        typeof item.download_url === "string" ? item.download_url : null;
+      const name = typeof item.name === "string" ? item.name : "";
+      const fallbackHandle = name.replace(/\.json$/, "");
+      if (!downloadUrl) return null;
+      try {
+        const fileRes = await fetch(downloadUrl, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          next: { revalidate: 60 },
+        });
+        if (!fileRes.ok) return null;
+        const fileJson = await fileRes.json();
+        return normalizeSubmission(fileJson, fallbackHandle);
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  const cleaned = submissions
+    .filter((s): s is RawSubmission => s !== null)
+    .sort((a, b) => a.githubHandle.localeCompare(b.githubHandle));
+
+  // Apply week-specific live-URL requirement to the all-fields baseline, and
+  // enrich with Firebase user identity (displayName + photoURL) by looking up
+  // the `users` collection by github.login.
+  const handlesLower = cleaned.map((s) => s.githubHandle.toLowerCase());
+  const userIdentities = await fetchUserIdentitiesByGithubLogin(handlesLower);
+
+  const finalized = cleaned.map((s) => {
+    const identity = userIdentities.get(s.githubHandle.toLowerCase());
+    // Strip the JSON-fallback fields from the public payload — they exist
+    // only to source a displayName/photoUrl when the submitter isn't a
+    // Firebase user.
+    const { jsonName, jsonPhotoUrl, ...rest } = s;
+    return {
+      ...rest,
+      allFieldsPresent: week.liveUrlRequired
+        ? s.allFieldsPresent && Boolean(s.liveUrl)
+        : s.allFieldsPresent,
+      displayName: identity?.displayName ?? jsonName ?? null,
+      photoUrl: identity?.photoUrl ?? jsonPhotoUrl ?? null,
+    };
+  });
+
+  const merged = finalized.length;
+  const tryingToWin = finalized.filter(
+    (s) => s.allFieldsPresent && s.competeForWin
+  ).length;
+
+  return {
+    weekId,
+    branch: week.submissionBranch,
+    path: dirPath,
+    merged,
+    tryingToWin,
+    submissions: finalized,
+  };
+}
+
+interface UserIdentity {
+  displayName: string | null;
+  photoUrl: string | null;
+}
+
+/** Look up Firebase user records (displayName + photoURL) by github.login.
+ *  Falls back to an empty map on any error — submissions still render, just
+ *  without enrichment. */
+async function fetchUserIdentitiesByGithubLogin(
+  handlesLower: ReadonlyArray<string>
+): Promise<Map<string, UserIdentity>> {
+  const result = new Map<string, UserIdentity>();
+  if (handlesLower.length === 0) return result;
+  const db = getAdminDb();
+  if (!db) return result;
+
+  // Firestore "in" queries cap at 30 values; chunk to be safe.
+  const chunkSize = 25;
+  const unique = Array.from(new Set(handlesLower));
+  try {
+    for (let i = 0; i < unique.length; i += chunkSize) {
+      const chunk = unique.slice(i, i + chunkSize);
+      const snap = await db
+        .collection("users")
+        .where("github.login", "in", chunk)
+        .get();
+      for (const doc of snap.docs) {
+        const data = doc.data() || {};
+        const githubInfo =
+          data.github && typeof data.github === "object"
+            ? (data.github as Record<string, unknown>)
+            : null;
+        const handle =
+          githubInfo && typeof githubInfo.login === "string"
+            ? githubInfo.login.toLowerCase()
+            : null;
+        if (!handle) continue;
+        const displayName =
+          typeof data.displayName === "string" && data.displayName.trim().length > 0
+            ? data.displayName.trim()
+            : null;
+        const photoUrl =
+          typeof data.photoURL === "string" && data.photoURL.trim().length > 0
+            ? data.photoURL.trim()
+            : null;
+        result.set(handle, { displayName, photoUrl });
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      "fetchUserIdentitiesByGithubLogin: lookup failed, returning partial map",
+      { error: error instanceof Error ? error.message : String(error) }
+    );
+  }
+  return result;
+}

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -10,6 +10,7 @@ import { SPORTS_HACK_2026_EVENT_ID, SPORTS_HACK_2026_LUMA_URL } from "./sports-h
 
 export const SUMMER_COHORT_SITE_ID = "cursor-boston";
 export const SUMMER_COHORT_COLLECTION = "summerCohortApplications";
+export const SUMMER_COHORT_VOTES_COLLECTION = "summerCohortVotes";
 export const SUMMER_COHORT_NOTIFY_EMAIL = "roger@cursorboston.com";
 export const SUMMER_COHORT_LOCALSTORAGE_KEY =
   "cursor-boston-summer-cohort-modal-shown-date";
@@ -157,6 +158,10 @@ export const SUMMER_COHORT_DEMO_DAY = {
 export const SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER =
   "https://zoom.us/j/PLACEHOLDER";
 
+// TODO: swap in the real Discord invite link before kickoff.
+export const SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER =
+  "https://discord.gg/PLACEHOLDER";
+
 export const SUMMER_COHORT_C1_WEEK_1 = {
   title: "Project Management Build",
   kickoffLabel: "Mon, May 11 · 6–7pm EST",
@@ -174,6 +179,12 @@ export const SUMMER_COHORT_C1_WEEK_1 = {
 // shape: open a PR adding a JSON pointer file, get AI-scored, top 5 + 3
 // wildcards present on Friday for the cohort vote. Dates and Zoom links are
 // placeholders for weeks 2 and 3 — finalize closer to date.
+export interface SummerCohortInspirationPlatform {
+  name: string;
+  url: string;
+  takeaway: string;
+}
+
 export interface SummerCohortVoteWeek {
   week: number;
   title: string;
@@ -187,6 +198,10 @@ export interface SummerCohortVoteWeek {
   winnerCommitment: string;
   /** Free-form note rendered above the kickoff block (e.g. holiday / immersion overlap). */
   weekNotes?: string;
+  /** Reference platforms participants can study. Frame is "what's worth
+   *  borrowing", not "rebuild this." */
+  inspirationScopeNote: string;
+  inspirationPlatforms: readonly SummerCohortInspirationPlatform[];
 }
 
 export const SUMMER_COHORT_C1_VOTE_WEEKS: readonly SummerCohortVoteWeek[] = [
@@ -203,6 +218,40 @@ export const SUMMER_COHORT_C1_VOTE_WEEKS: readonly SummerCohortVoteWeek[] = [
     liveUrlRequired: true,
     winnerCommitment:
       "Winner maintains the cohort PM tool through the rest of the program — fixes bugs, ships changes the cohort asks for, keeps it running.",
+    inspirationScopeNote:
+      "Don't try to rebuild Linear or Asana. The cohort is ~100 people shipping for 6 weeks — think \"how do we track who's shipping what each week and prep for Friday voting calls?\" Skip Gantt charts, time tracking, sprint estimation, and billing.",
+    inspirationPlatforms: [
+      {
+        name: "Linear",
+        url: "https://linear.app",
+        takeaway:
+          "Keyboard-first UX, fast issue triage, opinionated state model. Borrow the speed and the clarity, not the feature surface.",
+      },
+      {
+        name: "Trello",
+        url: "https://trello.com",
+        takeaway:
+          "Kanban as the whole product. Lean on this if your wedge is \"see at a glance who's shipping where.\"",
+      },
+      {
+        name: "Notion",
+        url: "https://notion.so",
+        takeaway:
+          "Docs and databases in one. Useful if cohort updates and project tracking want to live next to each other.",
+      },
+      {
+        name: "GitHub Projects",
+        url: "https://github.com/features/issues",
+        takeaway:
+          "Already where the code lives. The bar to beat is \"why open another tab?\"",
+      },
+      {
+        name: "Height",
+        url: "https://height.app",
+        takeaway:
+          "AI-first PM tool — auto-triage, smart filters. Shows what an LLM-native PM tool looks like.",
+      },
+    ],
   },
   {
     week: 2,
@@ -218,6 +267,40 @@ export const SUMMER_COHORT_C1_VOTE_WEEKS: readonly SummerCohortVoteWeek[] = [
     liveUrlRequired: true,
     winnerCommitment:
       "Winner maintains the cohort comms platform for the remaining weeks — onboarding new threads, fixing what breaks, keeping conversation flowing.",
+    inspirationScopeNote:
+      "Discord is already the cohort's chat backbone. Don't try to be Slack or Telegram from scratch. The bar to beat is \"what does a 100-person cohort need that Discord doesn't deliver?\" — maybe that's persistent project threads, peer-review queues, kudos, weekly digest. Pick a wedge.",
+    inspirationPlatforms: [
+      {
+        name: "Slack",
+        url: "https://slack.com",
+        takeaway:
+          "Channel + thread model, search, integrations. Borrow the clarity of channel taxonomy, not the enterprise feature pile.",
+      },
+      {
+        name: "Discord",
+        url: "https://discord.com",
+        takeaway:
+          "Already where the cohort hangs out. Study what's good — voice, presence, server identity — and what's bad — hard to thread, weak search.",
+      },
+      {
+        name: "Telegram",
+        url: "https://telegram.org",
+        takeaway:
+          "Mobile-first messaging at scale. Useful if your wedge is \"works great on a phone during commute.\"",
+      },
+      {
+        name: "Mattermost",
+        url: "https://mattermost.com",
+        takeaway:
+          "Open-source Slack analog. Worth a look if you want to study how a chat surface is structured under the hood.",
+      },
+      {
+        name: "Circle",
+        url: "https://circle.so",
+        takeaway:
+          "Community-platform feel — posts + threads + events, less \"chat,\" more \"forum.\" A different shape entirely.",
+      },
+    ],
   },
   {
     week: 3,
@@ -235,6 +318,40 @@ export const SUMMER_COHORT_C1_VOTE_WEEKS: readonly SummerCohortVoteWeek[] = [
       "Winner maintains the cohort marketing site through demo day — keeping it up to date with what the cohort is shipping.",
     weekNotes:
       "Heads up: Mon May 25 is Memorial Day (US holiday) and Tue May 26 is the in-person immersion event at Hult. Plan your build time around both.",
+    inspirationScopeNote:
+      "You're marketing 100 people and 6 weeks of builds — not running a media company. Skip A/B testing, lead-scoring, full CMS. The bar to beat is \"where does a hiring partner go on demo day to see what the cohort shipped?\"",
+    inspirationPlatforms: [
+      {
+        name: "Vercel",
+        url: "https://vercel.com",
+        takeaway:
+          "Easy deploys + MDX-friendly. The default if your wedge is \"a fast, content-rich public site I can keep editing.\"",
+      },
+      {
+        name: "Framer",
+        url: "https://framer.com",
+        takeaway:
+          "Design-led no-code. Lean on this if visual polish is your differentiator.",
+      },
+      {
+        name: "Notion (public pages)",
+        url: "https://notion.so",
+        takeaway:
+          "Quick wins for content-heavy cohort directories — every participant gets a page, no CMS needed.",
+      },
+      {
+        name: "Read.cv",
+        url: "https://read.cv",
+        takeaway:
+          "Profile-aggregator vibe — clean, opinionated. Useful if your wedge is \"the cohort's people page.\"",
+      },
+      {
+        name: "Substack",
+        url: "https://substack.com",
+        takeaway:
+          "Newsletter + article focus. Worth studying if you want \"weekly cohort digest\" to be your wedge.",
+      },
+    ],
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

Promotes the summer-cohort tabbed dashboard work from `develop` to `main`.

## Included commits

- 18f9b7f — feat(summer-cohort): submissions module + voting + per-week dashboard (Ludwitt)
- 2c58cc8 — feat(summer-cohort): tabbed dashboard for admitted cohort-1 users (Ludwitt)

## Highlights

- New per-week submissions module: emerald-ringed card, full merge instructions in the expanded body, JSON example pre-filled with the user's display name + photo + GitHub handle
- New `/api/summer-cohort/submissions/[weekId]` (public GET, GitHub Contents API + Firebase identity enrichment)
- New `/api/summer-cohort/votes` (auth-required POST toggle, public GET tally + myVotes)
- Kickoff Zoom moved to the top of each week panel
- Submissions module collapsing is gated on a connected GitHub account; otherwise the user gets a "Connect GitHub" CTA that switches them to the My Info tab
- Tabbed dashboard (Cohort Info | My Info | Week 1–6), code of conduct footer, shared WinnerCommitmentsCard

## Test plan

- [x] Type check + lint clean
- [x] Production build succeeds
- [x] Manual: `/summer-cohort` admitted-cohort-1 view renders new module with profile pre-fill
- [ ] Post-merge: spot-check production build on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)