### PR TITLE
release: scripts for cohort-1 push + May 26 attendee ranking

### DIFF
--- a/scripts/count-cohort.ts
+++ b/scripts/count-cohort.ts
@@ -1,0 +1,44 @@
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+import { getAdminDb } from "../lib/firebase-admin";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+  const snap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  let total = 0;
+  let cohort1 = 0;
+  let cohort1Admitted = 0;
+  let cohort1Pending = 0;
+  let cohort1Withdrawn = 0;
+  let cohort1Other: Record<string, number> = {};
+  let withdrawn = 0;
+  for (const doc of snap.docs) {
+    total++;
+    const d = doc.data();
+    const cohorts: string[] = Array.isArray(d.cohorts) ? d.cohorts : [];
+    const status: string = typeof d.status === "string" ? d.status : "";
+    if (status === "withdrawn") withdrawn++;
+    if (cohorts.includes("cohort-1")) {
+      cohort1++;
+      if (status === "admitted") cohort1Admitted++;
+      else if (status === "pending") cohort1Pending++;
+      else if (status === "withdrawn") cohort1Withdrawn++;
+      else cohort1Other[status || "<empty>"] = (cohort1Other[status || "<empty>"] || 0) + 1;
+    }
+  }
+  console.log(JSON.stringify({
+    total,
+    withdrawnAll: withdrawn,
+    cohort1,
+    cohort1Admitted,
+    cohort1Pending,
+    cohort1Withdrawn,
+    cohort1Other,
+  }, null, 2));
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/rank-may26-attendees.ts
+++ b/scripts/rank-may26-attendees.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+/**
+ * One-list ranking for the May 26 (sports-hack-2026) event.
+ *
+ * Sort key, in order:
+ *   1. Cohort-1 applicant (status in {pending, admitted}) — yes before no
+ *   2. Merged-PR count, descending
+ *   3. Website signup before Luma-only (rewards people who took the extra step)
+ *   4. Earliest signup wins
+ *
+ * Sources:
+ *   - hackathonLumaRegistrants — Luma RSVPs (post sync-may26 seed)
+ *   - hackathonEventSignups    — website signups for the event
+ *   - users                    — display name + GitHub login for website signups
+ *   - summerCohortApplications — cohort-1 lookup (by email, lowercased)
+ *   - GitHub merged PRs        — pulled via fetchMergedPrCountsForLogins
+ *
+ * Usage:
+ *   npx tsx scripts/rank-may26-attendees.ts
+ *   npx tsx scripts/rank-may26-attendees.ts --top 80
+ *   npx tsx scripts/rank-may26-attendees.ts --csv out.csv
+ */
+import { writeFileSync } from "fs";
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { fetchMergedPrCountsForLogins } from "../lib/github-merged-pr-count";
+import { getGithubRepoPair } from "../lib/github-recent-merged-prs";
+import {
+  getDeclinedEmailsForEvent,
+  getJudgeEmailsForEvent,
+} from "../lib/hackathon-event-signup";
+import {
+  SUMMER_COHORT_COLLECTION,
+  SUMMER_COHORT_IMMERSION,
+} from "../lib/summer-cohort";
+import { SPORTS_HACK_2026_CAPACITY } from "../lib/sports-hack-2026";
+
+const EVENT_ID = SUMMER_COHORT_IMMERSION.eventId;
+
+/** Inlined version of the bulk merged-PR search — the lib version sits behind
+ *  next/cache `unstable_cache`, which throws when called outside a request.
+ *  Same query and pagination as `fetchMergedPrCountByAuthorForRepoUncached`
+ *  in `lib/github-merged-pr-count.ts`. */
+async function fetchBulkMergedPrCounts(): Promise<Map<string, number> | null> {
+  const { owner, repo } = getGithubRepoPair();
+  const q = `repo:${owner}/${repo} type:pr is:merged`;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const counts = new Map<string, number>();
+  const PER_PAGE = 100;
+  const MAX_PAGES = 10;
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const url = new URL("https://api.github.com/search/issues");
+    url.searchParams.set("q", q);
+    url.searchParams.set("per_page", String(PER_PAGE));
+    url.searchParams.set("page", String(page));
+    const res = await fetch(url.toString(), { headers });
+    if (!res.ok) {
+      console.warn(
+        `GitHub search failed at page ${page}: ${res.status} ${res.statusText}`
+      );
+      return page === 1 ? null : counts;
+    }
+    const data = (await res.json()) as {
+      items?: Array<{ user?: { login?: string } }>;
+    };
+    const items = data.items ?? [];
+    if (items.length === 0) break;
+    for (const item of items) {
+      const login = item.user?.login;
+      if (!login) continue;
+      counts.set(
+        login.toLowerCase(),
+        (counts.get(login.toLowerCase()) ?? 0) + 1
+      );
+    }
+    if (items.length < PER_PAGE) break;
+  }
+  return counts;
+}
+
+interface RankedRow {
+  source: "website" | "luma";
+  email: string | null;
+  displayName: string | null;
+  githubLogin: string | null;
+  isCohort1: boolean;
+  cohort1Status: string | null;
+  mergedPrCount: number;
+  signedUpAtMs: number;
+  signedUpAtIso: string;
+}
+
+function parseArgs(argv: string[]) {
+  const topIdx = argv.indexOf("--top");
+  const top = topIdx >= 0 ? Number(argv[topIdx + 1]) : null;
+  const csvIdx = argv.indexOf("--csv");
+  const csvPath = csvIdx >= 0 ? argv[csvIdx + 1] : null;
+  return { top: top && top > 0 ? top : null, csvPath };
+}
+
+async function main() {
+  const { top, csvPath } = parseArgs(process.argv.slice(2));
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // 1. Cohort-1 applicant emails (pending + admitted only).
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const cohort1ByEmail = new Map<string, string>();
+  for (const doc of appsSnap.docs) {
+    const d = doc.data();
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    const status = typeof d.status === "string" ? d.status : "pending";
+    if (status !== "pending" && status !== "admitted") continue;
+    const email = (d.email || "").toString().trim().toLowerCase();
+    if (email) cohort1ByEmail.set(email, status);
+  }
+  console.log(
+    `Cohort-1 applicants (pending+admitted): ${cohort1ByEmail.size}`
+  );
+
+  // 2. Website signups (hackathonEventSignups → users).
+  const websiteSnap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  const websiteUserIds = websiteSnap.docs
+    .map((d) => d.data().userId as string | undefined)
+    .filter((u): u is string => Boolean(u));
+
+  const userMap = new Map<string, FirebaseFirestore.DocumentData>();
+  for (let i = 0; i < websiteUserIds.length; i += 10) {
+    const chunk = websiteUserIds.slice(i, i + 10);
+    const refs = chunk.map((id) => db.collection("users").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) {
+      if (s.exists) userMap.set(s.id, s.data() ?? {});
+    }
+  }
+
+  // 3. Luma registrants (post sync-may26 seed).
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+
+  const judgeEmails = getJudgeEmailsForEvent(EVENT_ID);
+  const declinedEmails = getDeclinedEmailsForEvent(EVENT_ID);
+
+  // Build website rows (deduped by user id; track their email + github so we
+  // can deduplicate against luma rows).
+  const rows: RankedRow[] = [];
+  const websiteEmails = new Set<string>();
+  const websiteGithubLogins = new Set<string>();
+
+  for (const doc of websiteSnap.docs) {
+    const data = doc.data();
+    const userId = data.userId as string | undefined;
+    if (!userId) continue;
+    const profile = userMap.get(userId) ?? {};
+    const email =
+      typeof profile.email === "string"
+        ? profile.email.trim().toLowerCase()
+        : null;
+    if (email && (judgeEmails.has(email) || declinedEmails.has(email))) {
+      continue;
+    }
+    const ghLogin =
+      profile.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login ?? null
+        : null;
+    if (email) websiteEmails.add(email);
+    if (ghLogin) websiteGithubLogins.add(ghLogin.toLowerCase());
+
+    const signedUpAt = data.signedUpAt;
+    let signedUpMs = 0;
+    if (
+      signedUpAt &&
+      typeof signedUpAt === "object" &&
+      "toMillis" in signedUpAt &&
+      typeof (signedUpAt as { toMillis: () => number }).toMillis === "function"
+    ) {
+      signedUpMs = (signedUpAt as { toMillis: () => number }).toMillis();
+    }
+
+    rows.push({
+      source: "website",
+      email,
+      displayName:
+        typeof profile.displayName === "string" ? profile.displayName : null,
+      githubLogin: ghLogin,
+      isCohort1: email ? cohort1ByEmail.has(email) : false,
+      cohort1Status: email ? cohort1ByEmail.get(email) ?? null : null,
+      mergedPrCount: 0, // filled in below
+      signedUpAtMs: signedUpMs,
+      signedUpAtIso: new Date(signedUpMs).toISOString(),
+    });
+  }
+
+  // Build luma-only rows (skip ones already covered by a website row).
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (d.email as string | undefined)?.trim().toLowerCase() ?? null;
+    if (email && (judgeEmails.has(email) || declinedEmails.has(email))) {
+      continue;
+    }
+    const ghLogin =
+      typeof d.githubLogin === "string" ? d.githubLogin : null;
+    if (email && websiteEmails.has(email)) continue;
+    if (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase())) continue;
+
+    const lumaCreatedAt =
+      typeof d.lumaCreatedAt === "string" ? d.lumaCreatedAt : "";
+    const signedUpMs = lumaCreatedAt ? new Date(lumaCreatedAt).getTime() : 0;
+
+    rows.push({
+      source: "luma",
+      email,
+      displayName: typeof d.name === "string" ? d.name : null,
+      githubLogin: ghLogin,
+      isCohort1: email ? cohort1ByEmail.has(email) : false,
+      cohort1Status: email ? cohort1ByEmail.get(email) ?? null : null,
+      mergedPrCount: 0, // filled in below
+      signedUpAtMs: signedUpMs,
+      signedUpAtIso: lumaCreatedAt,
+    });
+  }
+
+  // 4. Fetch merged-PR counts in one batch keyed by GitHub login.
+  const allLogins = rows
+    .map((r) => r.githubLogin)
+    .filter((l): l is string => Boolean(l));
+  const bulk = await fetchBulkMergedPrCounts();
+  const prCounts = await fetchMergedPrCountsForLogins(allLogins, bulk);
+  for (const r of rows) {
+    if (r.githubLogin) {
+      const c = prCounts.get(r.githubLogin.toLowerCase());
+      if (typeof c === "number") r.mergedPrCount = c;
+    }
+  }
+
+  // 5. Sort: cohort-1 first → merges desc → website-before-luma → earliest signup.
+  rows.sort((a, b) => {
+    if (a.isCohort1 !== b.isCohort1) return a.isCohort1 ? -1 : 1;
+    if (b.mergedPrCount !== a.mergedPrCount) {
+      return b.mergedPrCount - a.mergedPrCount;
+    }
+    const aWeb = a.source === "website" ? 1 : 0;
+    const bWeb = b.source === "website" ? 1 : 0;
+    if (bWeb !== aWeb) return bWeb - aWeb;
+    return a.signedUpAtMs - b.signedUpAtMs;
+  });
+
+  const cap = SPORTS_HACK_2026_CAPACITY;
+  const cohort1Total = rows.filter((r) => r.isCohort1).length;
+  const websiteTotal = rows.filter((r) => r.source === "website").length;
+
+  console.log(
+    `\nTotal attendees: ${rows.length} (cohort-1: ${cohort1Total}, website: ${websiteTotal}, luma-only: ${rows.length - websiteTotal})`
+  );
+  console.log(`Confirmed cap: ${cap} → first ${cap} are confirmed seats.\n`);
+
+  const limit = top ?? rows.length;
+  const printable = rows.slice(0, limit);
+
+  const padRank = String(limit).length;
+  const padPr = Math.max(
+    2,
+    String(Math.max(0, ...printable.map((r) => r.mergedPrCount))).length
+  );
+
+  // Header
+  console.log(
+    "rank".padStart(padRank) +
+      "  cohort  prs  src    name / github                       email"
+  );
+  console.log("-".repeat(120));
+  for (let i = 0; i < printable.length; i++) {
+    const r = printable[i]!;
+    const rank = String(i + 1).padStart(padRank);
+    const cohort = r.isCohort1 ? `c1` : `  `;
+    const prs = String(r.mergedPrCount).padStart(padPr);
+    const src = r.source === "website" ? "web " : "luma";
+    const cap80Marker = i === cap - 1 ? "  ←— cap" : "";
+    const name = (r.displayName || "(no name)").slice(0, 26).padEnd(26);
+    const gh = r.githubLogin ? `@${r.githubLogin}`.slice(0, 22).padEnd(22) : " ".repeat(22);
+    const email = r.email ?? "";
+    console.log(
+      `${rank}  ${cohort}      ${prs}  ${src}   ${name}  ${gh}  ${email}${cap80Marker}`
+    );
+    if (i === cap - 1 && i < printable.length - 1) {
+      console.log("-".repeat(120) + " (waitlist below)");
+    }
+  }
+
+  if (csvPath) {
+    const header =
+      "rank,confirmed,cohort1,cohort1_status,mergedPrCount,source,displayName,githubLogin,email,signedUpAt\n";
+    const lines = rows.map((r, i) => {
+      const rank = i + 1;
+      const confirmed = rank <= cap ? "yes" : "waitlist";
+      return [
+        rank,
+        confirmed,
+        r.isCohort1 ? "yes" : "no",
+        r.cohort1Status ?? "",
+        r.mergedPrCount,
+        r.source,
+        (r.displayName ?? "").replace(/[\n,"]/g, " "),
+        r.githubLogin ?? "",
+        r.email ?? "",
+        r.signedUpAtIso,
+      ].join(",");
+    });
+    writeFileSync(csvPath, header + lines.join("\n") + "\n", "utf8");
+    console.log(`\nCSV written: ${csvPath}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort-spots-and-may26-partiful.ts
+++ b/scripts/send-cohort-spots-and-may26-partiful.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Push to the broader event list with two asks:
+ *   1. Last ~40 cohort-1 spots are still open — apply now.
+ *   2. The May 26 Hult / Cursor Boston event is on the Boston Tech Week
+ *      Partiful — RSVPing there is required for Tech Week, and sharing
+ *      the link boosts our visibility during Tech Week.
+ *
+ * Recipients: every `eventContacts` doc that isn't unsubscribed.
+ *   - We do NOT exclude already-applied folks; the May 26 / Partiful
+ *     piece is relevant to them too.
+ *   - The cohort-1 CTA is framed as "if you haven't already" so
+ *     applicants don't get confused.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort-spots-and-may26-partiful.ts --dry-run
+ *   npx tsx scripts/send-cohort-spots-and-may26-partiful.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+}
+
+const APPLY_URL = "https://cursorboston.com/summer-cohort";
+const PARTIFUL_URL = "https://partiful.com/e/tuwaHOMgiJHvTfOFUJzA?c=EIywhmXE";
+const SPOTS_REMAINING = 39; // 100 cohort-1 cap minus 61 current applicants
+
+function buildEmail(contact: ContactData): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const firstHtml = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
+  );
+  const firstText =
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  const subject = `~${SPOTS_REMAINING} cohort 1 spots left + RSVP on Partiful for our Boston Tech Week day (5/26)`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${firstHtml},</p>
+
+<p>Two quick things before Boston Tech Week kicks off.</p>
+
+<h2 style="margin-top:28px;margin-bottom:6px;">1. ~${SPOTS_REMAINING} spots left in Cohort 1 of the Summer Cohort</h2>
+
+<p>Cohort 1 is filling up — out of <strong>100 seats</strong>, only about <strong>${SPOTS_REMAINING} are still open</strong>. If you&apos;ve been thinking about applying, this is the moment.</p>
+
+<p>It&apos;s a six-week ship-every-week program: project management → comms → marketing → AI for education → AI for startups → open source. Each week ends with a Friday voting call where the cohort picks a winner. If you win, you get to keep building — your repo, your roadmap, with the cohort behind you.</p>
+
+<p>Withdrawing later is one click, so applying is low-stakes.</p>
+
+<p><a href="${APPLY_URL}" style="display:inline-block;padding:10px 20px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">Apply for Cohort 1 →</a></p>
+
+<p style="font-size:14px;color:#555;">If you&apos;ve already applied — you&apos;re set, ignore this part. Skip to #2.</p>
+
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0;"/>
+
+<h2 style="margin-top:28px;margin-bottom:6px;">2. RSVP on Partiful for the May 26 Hult day — required for Boston Tech Week</h2>
+<p style="margin-top:0;color:#555;">Tuesday <strong>May 26</strong> · Hult International, Cambridge · kicks off Boston Tech Week</p>
+
+<p><strong>Boston Tech Week requires every event to be on Partiful</strong> to count toward the official Tech Week listing — so even if you already RSVP&apos;d on Luma or signed up on the website, please <strong>also RSVP on Partiful</strong>. It&apos;s the only way the event shows up in Tech Week&apos;s aggregated calendar.</p>
+
+<p><a href="${PARTIFUL_URL}" style="display:inline-block;padding:10px 20px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">RSVP on Partiful →</a></p>
+
+<p style="margin-top:24px;"><strong>And — share the Partiful link.</strong> The bigger the RSVP count on Partiful, the more visible Cursor Boston is during Tech Week. Forward this email, post the link on X / LinkedIn / your group chats, drop it in any Boston-tech Slack you&apos;re in:</p>
+
+<p style="margin:8px 0;padding:8px 12px;background:#f5f5f5;border-radius:6px;font-family:ui-monospace,Menlo,monospace;font-size:13px;word-break:break-all;"><a href="${PARTIFUL_URL}">${PARTIFUL_URL}</a></p>
+
+<p>Every share helps us look like a real Tech Week presence — which is the whole point.</p>
+
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0;"/>
+
+<p>Thanks — see you at Hult on the 26th.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a> · <a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you registered for a Cursor Boston event on Luma.<br/>
+Don&apos;t want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Two quick things before Boston Tech Week kicks off.
+
+
+1. ~${SPOTS_REMAINING} SPOTS LEFT IN COHORT 1 OF THE SUMMER COHORT
+
+Cohort 1 is filling up — out of 100 seats, only about ${SPOTS_REMAINING} are still open. If you've been thinking about applying, this is the moment.
+
+It's a six-week ship-every-week program: project management → comms → marketing → AI for education → AI for startups → open source. Each week ends with a Friday voting call where the cohort picks a winner. If you win, you get to keep building — your repo, your roadmap, with the cohort behind you.
+
+Withdrawing later is one click, so applying is low-stakes.
+
+Apply for Cohort 1:
+→ ${APPLY_URL}
+
+(If you've already applied — you're set, ignore this part and skip to #2.)
+
+
+---
+
+
+2. RSVP ON PARTIFUL FOR THE MAY 26 HULT DAY — REQUIRED FOR BOSTON TECH WEEK
+Tuesday May 26 · Hult International, Cambridge · kicks off Boston Tech Week
+
+Boston Tech Week requires every event to be on Partiful to count toward the official Tech Week listing — so even if you already RSVP'd on Luma or signed up on the website, please also RSVP on Partiful. It's the only way the event shows up in Tech Week's aggregated calendar.
+
+RSVP on Partiful:
+→ ${PARTIFUL_URL}
+
+And — share the Partiful link. The bigger the RSVP count on Partiful, the more visible Cursor Boston is during Tech Week. Forward this email, post the link on X / LinkedIn / your group chats, drop it in any Boston-tech Slack you're in:
+
+   ${PARTIFUL_URL}
+
+Every share helps us look like a real Tech Week presence — which is the whole point.
+
+
+---
+
+Thanks — see you at Hult on the 26th.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+---
+You're receiving this because you registered for a Cursor Boston event on Luma.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  // Snapshot of cohort-1 application count for context only — we do NOT
+  // exclude applied folks, since the Partiful CTA matters for them too.
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  let cohort1Count = 0;
+  for (const doc of appsSnap.docs) {
+    const cohorts = doc.data().cohorts;
+    if (Array.isArray(cohorts) && cohorts.includes("cohort-1")) cohort1Count++;
+  }
+  console.log(
+    `Cohort 1 applicant count: ${cohort1Count} (cap 100, ~${100 - cohort1Count} spots open)`
+  );
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    const email = (data.email || doc.id || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+
+    contacts.push({
+      email,
+      name: data.name || "",
+      firstName: data.firstName || "",
+    });
+  }
+
+  console.log(
+    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed} | Skipped no-email: ${skippedNoEmail}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = contacts[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample email to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(
+        `\n---- TEXT preview ----\n${text}\n---- end TEXT ----\n`
+      );
+      console.log(
+        `\n---- HTML preview (first 2400 chars) ----\n${html.slice(0, 2400)}\n…`
+      );
+    }
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(
+    `\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed + skippedNoEmail}.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Promotes the three new admin/ops scripts from `develop` to `main`.

## Included commits

- cceb285 — chore(scripts): cohort-1 capacity push, may26 attendee ranking, count helper (Ludwitt)

## Scripts

- \`scripts/send-cohort-spots-and-may26-partiful.ts\` — broad email blast about cohort-1 capacity + Partiful CTA for Boston Tech Week.
- \`scripts/rank-may26-attendees.ts\` — one-list attendee ranking (cohort-1 first → merges desc → website-before-luma → earliest signup).
- \`scripts/count-cohort.ts\` — quick cohort-1 applicant counter by status.

## Test plan

- [x] Type check + lint clean (husky pre-commit ran)
- [x] Email blast already executed: 625 sent, 0 failed
- [x] Ranking script already executed against current data: 27 cohort-1 + 66 non-cohort, top 80 confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)