### PR TITLE
release: auto-admit on PR-merge for pending Cohort 1 applicants

### DIFF
--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -19,6 +19,7 @@ import {
 import { MERGED_PR_COUNTS_CACHE_TAG } from "@/lib/github-merged-pr-count";
 import { ensureHackASprint2026ScoreDoc } from "@/lib/hackathon-asprint-2026-scores";
 import { awardHackASprint2026ShowcaseBadge } from "@/lib/hackathon-showcase-admin";
+import { maybeAutoAdmitOnPRMerge } from "@/lib/summer-cohort-auto-admit";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { notifyPROpened, notifyPRMerged, notifyHackASprintSubmissionMerged } from "@/lib/discord";
 import { withLoggingMiddleware, withRateLimitMiddleware, rateLimitConfigs } from "@/lib/middleware";
@@ -219,6 +220,18 @@ async function handleWebhook(request: NextRequest) {
           });
         } catch {
           // non-fatal
+        }
+
+        // Auto-admit-on-PR-merge: pending Cohort 1 applicants who get a PR
+        // merged before the May 9 deadline get promoted immediately. Helper
+        // is non-throwing — flow continues regardless.
+        try {
+          await maybeAutoAdmitOnPRMerge({
+            authorLogin: pr.user.login,
+            prNumber: pr.number,
+          });
+        } catch {
+          // non-fatal — helper already swallows + logs internally
         }
       }
     }

--- a/app/summer-cohort/_components/ClaimSpotByPRCard.tsx
+++ b/app/summer-cohort/_components/ClaimSpotByPRCard.tsx
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { GitPullRequest, Sparkles, Trophy, ExternalLink } from "lucide-react";
+import {
+  SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_LABEL,
+  SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS,
+  isWithinSummerCohortC1AutoAdmitWindow,
+} from "@/lib/summer-cohort";
+
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const FIRST_CONTRIB_URL = `${REPO_URL}/blob/develop/docs/FIRST_CONTRIBUTION.md`;
+const ISSUES_URL = `${REPO_URL}/issues`;
+
+/**
+ * Shown to pending Cohort 1 applicants while we're inside the
+ * auto-admit-on-PR-merge window (≤ May 9, 2026 11:59pm ET).
+ *
+ * The actual promotion happens server-side: when GitHub fires a `pull_request
+ * closed + merged` webhook on the community repo, the webhook calls
+ * `maybeAutoAdmitOnPRMerge`, which flips a matching pending application to
+ * admitted. This card is the user-facing surface for that flow.
+ */
+export function ClaimSpotByPRCard() {
+  if (!isWithinSummerCohortC1AutoAdmitWindow()) return null;
+
+  const deadlineDate = new Date(SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS);
+  const deadlineIso = deadlineDate.toISOString();
+
+  return (
+    <section className="mt-6 rounded-xl border-2 border-amber-400 bg-gradient-to-br from-amber-50 to-emerald-50/40 p-6 shadow-sm dark:border-amber-700 dark:from-amber-950/30 dark:to-emerald-950/20">
+      <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-amber-700 dark:text-amber-400">
+        <Sparkles className="h-3.5 w-3.5" strokeWidth={2.5} aria-hidden="true" />
+        Claim your spot now
+      </div>
+      <h3 className="mt-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+        Skip the queue — get a PR merged by{" "}
+        <time dateTime={deadlineIso}>
+          {SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_LABEL}
+        </time>
+      </h3>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        Get one PR merged into the community repo before the deadline and
+        you&apos;re <strong>auto-admitted to Cohort 1 immediately</strong> —
+        no need to wait for the May 10 admit round. The next time you load
+        this page, your status will read <em>Admitted</em>.
+      </p>
+
+      <ol className="mt-4 space-y-2 text-sm text-neutral-700 dark:text-neutral-300">
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+            1
+          </span>
+          <div className="min-w-0">
+            <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+              Pick something to ship
+            </p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              Open issues are a good shopping list. Or fix a typo, tighten a
+              doc, polish a component — small + correct beats big + half-done.
+            </p>
+            <p className="mt-2 flex flex-wrap gap-3 text-xs">
+              <a
+                href={ISSUES_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-semibold text-emerald-700 underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600 dark:text-emerald-400"
+              >
+                Browse open issues
+                <ExternalLink
+                  className="h-3 w-3"
+                  strokeWidth={2.25}
+                  aria-hidden="true"
+                />
+              </a>
+              <a
+                href={FIRST_CONTRIB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-semibold text-emerald-700 underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600 dark:text-emerald-400"
+              >
+                FIRST_CONTRIBUTION.md
+                <ExternalLink
+                  className="h-3 w-3"
+                  strokeWidth={2.25}
+                  aria-hidden="true"
+                />
+              </a>
+            </p>
+          </div>
+        </li>
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+            2
+          </span>
+          <div className="min-w-0">
+            <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+              Open a PR against{" "}
+              <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
+                develop
+              </code>
+            </p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              Sign your commits with{" "}
+              <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs font-semibold dark:bg-neutral-800">
+                git commit -s
+              </code>{" "}
+              (DCO is required) and link any related issue.
+            </p>
+          </div>
+        </li>
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+            3
+          </span>
+          <div className="min-w-0">
+            <p className="font-semibold text-neutral-900 dark:text-neutral-100">
+              Once merged →{" "}
+              <span className="text-emerald-700 dark:text-emerald-400">
+                you&apos;re in
+              </span>
+            </p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              The merge fires a webhook that flips your status to{" "}
+              <em>Admitted</em> automatically. No email needed; no waiting on
+              us. Refresh the page after the merge to see it land.
+            </p>
+          </div>
+        </li>
+      </ol>
+
+      <a
+        href={FIRST_CONTRIB_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-5 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+      >
+        <GitPullRequest className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+        Read the contributor guide
+        <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+      </a>
+
+      <p className="mt-4 flex items-start gap-2 text-xs text-neutral-600 dark:text-neutral-400">
+        <Trophy
+          className="mt-0.5 h-3.5 w-3.5 shrink-0 text-neutral-500"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        <span>
+          Even if you don&apos;t make the deadline — we&apos;re still admitting
+          more people in the regular round on May 10. The PR-merge route is
+          just a fast lane.
+        </span>
+      </p>
+    </section>
+  );
+}

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -30,6 +30,7 @@ import {
   SUMMER_COHORT_RETURN_TO,
   type SummerCohortId,
 } from "@/lib/summer-cohort";
+import { ClaimSpotByPRCard } from "./_components/ClaimSpotByPRCard";
 import { CohortProgramBreakdown } from "./_components/CohortProgramBreakdown";
 import { CohortTabs, type CohortTabId } from "./_components/CohortTabs";
 import { InfoTabPanel } from "./_components/InfoTabPanel";
@@ -854,6 +855,10 @@ function SummerCohortPageInner() {
                   application={application}
                   cohortLabel={cohortLabel}
                 />
+                {application.status === "pending" &&
+                application.cohorts.includes("cohort-1") ? (
+                  <ClaimSpotByPRCard />
+                ) : null}
                 <NextStepsCard
                   application={application}
                   needsDiscord={!discord.discordInfo}

--- a/lib/summer-cohort-auto-admit.ts
+++ b/lib/summer-cohort-auto-admit.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "./firebase-admin";
+import { logger } from "./logger";
+import {
+  SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS,
+  SUMMER_COHORT_C1_CAP,
+  SUMMER_COHORT_COLLECTION,
+  isWithinSummerCohortC1AutoAdmitWindow,
+} from "./summer-cohort";
+
+export type AutoAdmitOutcome =
+  | { kind: "skipped"; reason: string }
+  | { kind: "promoted"; userId: string; applicationId: string };
+
+/**
+ * Hook called from the GitHub PR-merge webhook. If the PR author has a
+ * pending Cohort 1 application and we're still within the auto-admit window
+ * (≤ May 9, 2026), flip their status to admitted.
+ *
+ * Side effects on success:
+ *   - summerCohortApplications/{uid}.status: "pending" → "admitted"
+ *   - .admittedAt: serverTimestamp
+ *   - .admittedVia: "pr-merge"
+ *   - .admittedFromPR: PR number (for traceability)
+ *
+ * Idempotent — second merged PR for the same user is a no-op (already admitted).
+ * Non-throwing — failures are logged and returned, not re-raised, so the
+ * webhook flow is unaffected.
+ */
+export async function maybeAutoAdmitOnPRMerge(args: {
+  authorLogin: string;
+  prNumber: number;
+}): Promise<AutoAdmitOutcome> {
+  const { authorLogin, prNumber } = args;
+
+  if (!authorLogin) {
+    return { kind: "skipped", reason: "no-author-login" };
+  }
+
+  if (!isWithinSummerCohortC1AutoAdmitWindow()) {
+    return {
+      kind: "skipped",
+      reason: "outside-auto-admit-window",
+    };
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return { kind: "skipped", reason: "no-admin-db" };
+  }
+
+  try {
+    // 1. github.login → userId via the users collection.
+    const usersSnap = await db
+      .collection("users")
+      .where("github.login", "==", authorLogin)
+      .limit(5)
+      .get();
+
+    // GitHub login matching is case-insensitive in practice. The Firestore
+    // exact-equality query is case-sensitive — also try the lowercase form
+    // if the first lookup misses.
+    let userDocs = usersSnap.docs;
+    if (userDocs.length === 0 && authorLogin !== authorLogin.toLowerCase()) {
+      const fallback = await db
+        .collection("users")
+        .where("github.login", "==", authorLogin.toLowerCase())
+        .limit(5)
+        .get();
+      userDocs = fallback.docs;
+    }
+
+    if (userDocs.length === 0) {
+      return { kind: "skipped", reason: "no-user-with-this-github-login" };
+    }
+
+    // 2. Find the cohort-1 pending application across matching users.
+    let promotedFor: { userId: string; applicationId: string } | null = null;
+    for (const userDoc of userDocs) {
+      const userId = userDoc.id;
+      const appRef = db.collection(SUMMER_COHORT_COLLECTION).doc(userId);
+
+      const result = await db.runTransaction(async (tx) => {
+        const appSnap = await tx.get(appRef);
+        if (!appSnap.exists) {
+          return { changed: false as const, reason: "no-application" };
+        }
+        const data = appSnap.data() ?? {};
+        const status = typeof data.status === "string" ? data.status : "pending";
+        if (status !== "pending") {
+          return { changed: false as const, reason: `status-is-${status}` };
+        }
+        const cohorts = Array.isArray(data.cohorts) ? data.cohorts : [];
+        if (!cohorts.includes("cohort-1")) {
+          return { changed: false as const, reason: "not-in-cohort-1" };
+        }
+
+        // Re-check the deadline inside the transaction in case we're racing
+        // close to midnight. Belt-and-suspenders.
+        if (!isWithinSummerCohortC1AutoAdmitWindow()) {
+          return { changed: false as const, reason: "deadline-passed" };
+        }
+
+        // Cap check — count current admitted in cohort-1 inside the txn.
+        // The aggregation count() is the cheap path here.
+        const admittedCountSnap = await db
+          .collection(SUMMER_COHORT_COLLECTION)
+          .where("cohorts", "array-contains", "cohort-1")
+          .where("status", "==", "admitted")
+          .count()
+          .get();
+        const admittedCount = admittedCountSnap.data().count;
+        if (admittedCount >= SUMMER_COHORT_C1_CAP) {
+          return { changed: false as const, reason: "cohort-1-full" };
+        }
+
+        tx.update(appRef, {
+          status: "admitted",
+          admittedAt: FieldValue.serverTimestamp(),
+          admittedVia: "pr-merge",
+          admittedFromPR: prNumber,
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+        return { changed: true as const };
+      });
+
+      if (result.changed) {
+        promotedFor = { userId, applicationId: userId };
+        break;
+      } else {
+        logger.info("auto-admit: skipped a candidate user", {
+          authorLogin,
+          userId,
+          reason: result.reason,
+        });
+      }
+    }
+
+    if (!promotedFor) {
+      return { kind: "skipped", reason: "no-eligible-application" };
+    }
+
+    logger.info("auto-admit: promoted pending → admitted", {
+      authorLogin,
+      prNumber,
+      userId: promotedFor.userId,
+      deadlineMs: SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS,
+    });
+
+    return { kind: "promoted", ...promotedFor };
+  } catch (error) {
+    logger.warn("auto-admit: failed (non-fatal)", {
+      authorLogin,
+      prNumber,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { kind: "skipped", reason: "exception" };
+  }
+}

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -162,6 +162,32 @@ export const SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER =
 export const SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER =
   "https://discord.gg/PLACEHOLDER";
 
+/** Hard cap on Cohort 1 admits. Auto-admit-on-PR-merge respects this. */
+export const SUMMER_COHORT_C1_CAP = 100;
+
+/** PR-merge auto-admit deadline.
+ *  Pending Cohort 1 applicants who get a PR merged into the community repo
+ *  before this timestamp are automatically promoted to "admitted" — no need
+ *  to wait for the May 10 manual admit round.
+ *
+ *  May 9, 2026 11:59:59 PM ET (EDT = UTC-4) → 03:59:59 UTC on May 10. */
+export const SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS = Date.UTC(
+  2026,
+  4, // May (0-indexed)
+  10,
+  3,
+  59,
+  59
+);
+export const SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_LABEL =
+  "Fri, May 9 · 11:59pm ET";
+
+export function isWithinSummerCohortC1AutoAdmitWindow(
+  now: number = Date.now()
+): boolean {
+  return now <= SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS;
+}
+
 export const SUMMER_COHORT_C1_WEEK_1 = {
   title: "Project Management Build",
   kickoffLabel: "Mon, May 11 · 6–7pm EST",

--- a/scripts/reset-roger-to-pending.ts
+++ b/scripts/reset-roger-to-pending.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * One-off: flip regorhunt02052@gmail.com's summerCohortApplications doc back
+ * to status: "pending" so the new ClaimSpotByPRCard UI is visible during
+ * local preview.
+ *
+ * Idempotent — re-running on a doc that's already pending is a no-op.
+ *
+ * Usage:
+ *   npx tsx scripts/reset-roger-to-pending.ts
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const TARGET_EMAIL = "regorhunt02052@gmail.com";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .where("email", "==", TARGET_EMAIL)
+    .get();
+
+  if (snap.empty) {
+    console.error(`No application found for ${TARGET_EMAIL}.`);
+    process.exit(1);
+  }
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const before = data.status ?? "(unset)";
+    if (before === "pending") {
+      console.log(`${doc.id}: already pending, skipping.`);
+      continue;
+    }
+    await doc.ref.update({
+      status: "pending",
+      // Keep the prior admit timestamps as breadcrumbs, but clear the active
+      // admit metadata so a future PR-merge auto-admit fires cleanly.
+      admittedAt: FieldValue.delete(),
+      admittedVia: FieldValue.delete(),
+      admittedFromPR: FieldValue.delete(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    console.log(`${doc.id}: status ${before} → pending.`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-pr-fast-lane.ts
+++ b/scripts/send-cohort1-pr-fast-lane.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * One-off push to every PENDING Cohort 1 applicant about the new
+ * "merge a PR before May 9 → auto-admitted" fast lane.
+ *
+ * Recipients: summerCohortApplications where status === "pending" AND
+ *   cohorts contains "cohort-1" AND prFastLaneEmailedAt is unset.
+ *
+ * The idempotency flag (`prFastLaneEmailedAt` on the application doc) lets
+ * this script be re-run safely after late applicants come in — already-
+ * emailed pending folks are skipped.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-pr-fast-lane.ts --dry-run
+ *   npx tsx scripts/send-cohort1-pr-fast-lane.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import {
+  SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_LABEL,
+  SUMMER_COHORT_COLLECTION,
+} from "../lib/summer-cohort";
+
+const PAGE_URL = "https://cursorboston.com/summer-cohort";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const FIRST_CONTRIB_URL = `${REPO_URL}/blob/develop/docs/FIRST_CONTRIBUTION.md`;
+const ISSUES_URL = `${REPO_URL}/issues`;
+
+interface PendingApp {
+  uid: string;
+  name: string;
+  email: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(app: PendingApp): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(app.name?.split(" ")[0]?.trim() || "there");
+  const firstText = app.name?.split(" ")[0]?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(app.email);
+
+  const subject = `Skip the queue — lock in your Cohort 1 spot by ${SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_LABEL}`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick update for you as a pending Cohort 1 applicant — we just shipped a way to <strong>claim your spot now</strong>, before the May 10 admit round.</p>
+
+<h2 style="margin-top:24px;margin-bottom:6px;">The deal</h2>
+<p style="margin-top:0;">
+Get <strong>one PR merged into the cursor-boston community repo by ${escapeHtml(SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_LABEL)}</strong>, and you&apos;re <strong>auto-admitted to Cohort 1 immediately</strong>.
+No need to wait. Refresh the application page after the merge — your status will read <em>Admitted</em>.
+</p>
+
+<p>It&apos;s small + correct that wins, not big + half-done. Fix a typo, tighten a doc, polish a component, ship a small feature off an open issue. The bar is real-PR-that-gets-merged, not "biggest PR".</p>
+
+<h2 style="margin-top:24px;margin-bottom:6px;">How to start</h2>
+<ol style="margin:8px 0;padding-left:20px;">
+  <li><a href="${ISSUES_URL}">Browse open issues</a> — or pick anything that bugs you on the site or in docs.</li>
+  <li>Read the <a href="${FIRST_CONTRIB_URL}">FIRST_CONTRIBUTION.md</a> guide (DCO sign-off, branch, PR conventions).</li>
+  <li>Open a PR against <code>develop</code>. Roger reviews and merges fast.</li>
+</ol>
+
+<p style="margin-top:16px;">
+  <a href="${PAGE_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Open my application →</a>
+</p>
+
+<h2 style="margin-top:24px;margin-bottom:6px;">A few caveats</h2>
+<ul style="margin:8px 0;padding-left:20px;">
+  <li>Cohort 1 is capped at 100 seats. Auto-admit stops if we hit the cap.</li>
+  <li>If you don&apos;t make the deadline — <strong>that&apos;s fine</strong>. The regular admit round still runs on May 10. This is just a fast lane.</li>
+  <li>Already getting started on a PR? Make sure your GitHub login is connected on your <a href="${PAGE_URL}">profile</a> so the auto-admit can match the merge to you.</li>
+</ul>
+
+<p>Reply with any questions.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you applied to Cohort 1 of the Cursor Boston Summer Cohort.<br/>
+Don&apos;t want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick update for you as a pending Cohort 1 applicant — we just shipped a way to CLAIM YOUR SPOT NOW, before the May 10 admit round.
+
+
+THE DEAL
+
+Get one PR merged into the cursor-boston community repo by ${SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_LABEL}, and you're AUTO-ADMITTED to Cohort 1 immediately. No need to wait. Refresh the application page after the merge — your status will read "Admitted".
+
+It's small + correct that wins, not big + half-done. Fix a typo, tighten a doc, polish a component, ship a small feature off an open issue. The bar is real-PR-that-gets-merged, not "biggest PR".
+
+
+HOW TO START
+
+  1. Browse open issues — or pick anything that bugs you on the site or in docs.
+     ${ISSUES_URL}
+  2. Read the FIRST_CONTRIBUTION.md guide (DCO sign-off, branch, PR conventions).
+     ${FIRST_CONTRIB_URL}
+  3. Open a PR against \`develop\`. Roger reviews and merges fast.
+
+Open my application:
+  ${PAGE_URL}
+
+
+A FEW CAVEATS
+
+  • Cohort 1 is capped at 100 seats. Auto-admit stops if we hit the cap.
+  • If you don't make the deadline — that's fine. The regular admit round still runs on May 10. This is just a fast lane.
+  • Already getting started on a PR? Make sure your GitHub login is connected on your profile so the auto-admit can match the merge to you.
+
+Reply with any questions.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you applied to Cohort 1 of the Cursor Boston Summer Cohort.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if (dryRun === send) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .where("status", "==", "pending")
+    .get();
+
+  let totalPending = 0;
+  let skippedNotCohort1 = 0;
+  let alreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  const queue: PendingApp[] = [];
+
+  for (const doc of snap.docs) {
+    totalPending++;
+    const data = doc.data();
+    const cohorts = Array.isArray(data.cohorts) ? data.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (data.prFastLaneEmailedAt) {
+      alreadyEmailed++;
+      continue;
+    }
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    queue.push({
+      uid: (data.userId || doc.id).toString(),
+      name: typeof data.name === "string" ? data.name : "",
+      email,
+    });
+  }
+
+  console.log(
+    `Pending applications: ${totalPending} | not in cohort-1: ${skippedNotCohort1} | already emailed: ${alreadyEmailed} | no email: ${skippedNoEmail}`
+  );
+  console.log(`To email now: ${queue.length}`);
+
+  if (dryRun) {
+    const sample = queue[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(
+        `\n=== Sample email ===\nTo: ${sample.email} (${sample.name || "(no name)"})\nSubject: ${subject}\n`
+      );
+      console.log(`---- TEXT ----\n${text}\n`);
+      console.log(
+        `---- HTML preview (first 2000 chars) ----\n${html.slice(0, 2000)}\n…`
+      );
+    } else {
+      console.log("\n(no eligible recipients)");
+    }
+    console.log("\n--dry-run: no emails sent, no writes.");
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const app of queue) {
+    const { subject, html, text } = buildEmail(app);
+    try {
+      await sendEmail({ to: app.email, subject, html, text });
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(app.uid).set(
+        { prFastLaneEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      sent++;
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${queue.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${app.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(
+    `\nDone. Sent ${sent}, failed ${failed}, already-emailed ${alreadyEmailed}.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Promotes the PR-merge fast-lane feature for the Summer Cohort from \`develop\` to \`main\`.

## Included commits

- 6586fbe — feat(summer-cohort): auto-admit on PR-merge for pending Cohort 1 applicants (Ludwitt)

## What ships

- **Server**: \`lib/summer-cohort-auto-admit.ts\` + GitHub webhook hook. When a PR is merged on the community repo, the author is matched by \`github.login\` to a pending Cohort 1 application, and a Firestore transaction flips status to \`admitted\` (with \`admittedAt\`, \`admittedVia: "pr-merge"\`, \`admittedFromPR\`). Re-checks deadline + cap inside the txn. Idempotent + non-throwing.
- **Constants**: \`SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS\` = May 9, 2026 11:59pm ET. \`SUMMER_COHORT_C1_CAP\` = 100.
- **UI**: \`ClaimSpotByPRCard\` shown to pending cohort-1 applicants on \`/summer-cohort\` during the auto-admit window. Auto-hides after the deadline.
- **Email**: \`scripts/send-cohort1-pr-fast-lane.ts\` (already sent — 63 to 63 cohort-1 pending applicants, 0 failed).
- **Dev helper**: \`scripts/reset-roger-to-pending.ts\` for local preview.

## Test plan

- [x] Type check + lint clean (husky pre-commit ran)
- [x] Production build succeeds
- [x] Local preview confirmed card renders for a pending cohort-1 applicant
- [x] Email blast already sent successfully
- [ ] Post-merge: manually merge a small PR for a pending cohort-1 applicant and verify their status flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)