### PR TITLE
release: hiring partners portal + sanitize.ts hardening

### DIFF
--- a/__tests__/lib/sanitize.test.ts
+++ b/__tests__/lib/sanitize.test.ts
@@ -19,32 +19,14 @@ describe("sanitizeText", () => {
     expect(sanitizeText(123 as unknown as string)).toBe("");
   });
 
-  it("strips HTML tags", () => {
-    expect(sanitizeText("<b>bold</b>")).toBe("bold");
-    expect(sanitizeText('<script>alert("xss")</script>')).toBe('alert("xss")');
-    expect(sanitizeText("<img src=x onerror=alert(1)>")).toBe("");
-  });
-
-  it("strips javascript: protocol", () => {
-    expect(sanitizeText("javascript:alert(1)")).toBe("alert(1)");
-    expect(sanitizeText("JAVASCRIPT:void(0)")).toBe("void(0)");
-  });
-
-  it("strips data: protocol", () => {
-    expect(sanitizeText("data:text/html,<h1>hi</h1>")).toBe("text/html,hi");
-  });
-
-  it("strips vbscript: protocol", () => {
-    expect(sanitizeText("vbscript:msgbox")).toBe("msgbox");
-  });
-
-  it("strips event handlers", () => {
-    expect(sanitizeText('onerror=alert(1)')).toBe("alert(1)");
-    expect(sanitizeText('onclick=doStuff()')).toBe("doStuff()");
-  });
-
-  it("removes null bytes", () => {
+  it("removes null bytes and other ASCII control characters", () => {
     expect(sanitizeText("hello\0world")).toBe("helloworld");
+    expect(sanitizeText("a\x01b\x07c\x1Fd\x7Fe")).toBe("abcde");
+  });
+
+  it("preserves newlines, tab, and carriage return", () => {
+    // \t and \r are normalized to spaces (next test); \n must survive.
+    expect(sanitizeText("line1\nline2")).toBe("line1\nline2");
   });
 
   it("normalizes tabs and carriage returns but preserves newlines", () => {
@@ -58,6 +40,22 @@ describe("sanitizeText", () => {
 
   it("passes through clean text", () => {
     expect(sanitizeText("Hello, World!")).toBe("Hello, World!");
+  });
+
+  // sanitizeText does not strip HTML — render-layer (JSX) auto-escapes.
+  // These cases document that the input is preserved verbatim, so callers
+  // that store and then JSX-render get the literal characters as text.
+  it("preserves angle brackets and HTML-like input verbatim", () => {
+    expect(sanitizeText("<b>bold</b>")).toBe("<b>bold</b>");
+    expect(sanitizeText('<script>alert("xss")</script>')).toBe(
+      '<script>alert("xss")</script>'
+    );
+    expect(sanitizeText("I love <Component />")).toBe("I love <Component />");
+  });
+
+  it("preserves URL-like content verbatim (callers must use sanitizeUrl for links)", () => {
+    expect(sanitizeText("javascript:alert(1)")).toBe("javascript:alert(1)");
+    expect(sanitizeText("data:text/html,hi")).toBe("data:text/html,hi");
   });
 });
 

--- a/app/api/hiring-partners/apply/route.ts
+++ b/app/api/hiring-partners/apply/route.ts
@@ -1,0 +1,263 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import { sendEmail } from "@/lib/mailgun";
+import {
+  HIRING_PARTNERS_CALENDLY_URL,
+  HIRING_PARTNERS_COLLECTION,
+  HIRING_PARTNERS_MAX,
+  HIRING_PARTNERS_NOTIFY_EMAIL,
+  type HiringPartnerStatus,
+} from "@/lib/hiring-partners";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface PartnerApplicationDto {
+  userId: string | null;
+  email: string | null;
+  contactName: string | null;
+  phone: string | null;
+  companyName: string | null;
+  companyWebsite: string | null;
+  contactRole: string | null;
+  rolesHiring: string | null;
+  notes: string | null;
+  status: HiringPartnerStatus;
+  createdAt: number | null;
+  updatedAt: number | null;
+}
+
+function toMillis(value: unknown): number | null {
+  if (value && typeof (value as { toMillis?: () => number }).toMillis === "function") {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  return null;
+}
+
+function serializeApplication(data: Record<string, unknown>): PartnerApplicationDto {
+  const status = (data.status as HiringPartnerStatus) || "pending";
+  return {
+    userId: typeof data.userId === "string" ? data.userId : null,
+    email: typeof data.email === "string" ? data.email : null,
+    contactName: typeof data.contactName === "string" ? data.contactName : null,
+    phone: typeof data.phone === "string" ? data.phone : null,
+    companyName: typeof data.companyName === "string" ? data.companyName : null,
+    companyWebsite: typeof data.companyWebsite === "string" ? data.companyWebsite : null,
+    contactRole: typeof data.contactRole === "string" ? data.contactRole : null,
+    rolesHiring: typeof data.rolesHiring === "string" ? data.rolesHiring : null,
+    notes: typeof data.notes === "string" ? data.notes : null,
+    status,
+    createdAt: toMillis(data.createdAt),
+    updatedAt: toMillis(data.updatedAt),
+  };
+}
+
+async function handleGet(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  const snap = await db.collection(HIRING_PARTNERS_COLLECTION).doc(user.uid).get();
+  if (!snap.exists) {
+    return NextResponse.json({ application: null });
+  }
+  return NextResponse.json({
+    application: serializeApplication(snap.data() || {}),
+  });
+}
+
+function trimOrEmpty(raw: unknown, max: number): string {
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  return trimmed.slice(0, max);
+}
+
+async function handlePost(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!user.email) {
+    return NextResponse.json(
+      { error: "Your account is missing an email address." },
+      { status: 400 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const raw = (body || {}) as Record<string, unknown>;
+  const contactName = trimOrEmpty(raw.contactName, HIRING_PARTNERS_MAX.contactName);
+  const phone = trimOrEmpty(raw.phone, HIRING_PARTNERS_MAX.phone);
+  const companyName = trimOrEmpty(raw.companyName, HIRING_PARTNERS_MAX.companyName);
+  const companyWebsite = trimOrEmpty(raw.companyWebsite, HIRING_PARTNERS_MAX.companyWebsite);
+  const contactRole = trimOrEmpty(raw.contactRole, HIRING_PARTNERS_MAX.contactRole);
+  const rolesHiring = trimOrEmpty(raw.rolesHiring, HIRING_PARTNERS_MAX.rolesHiring);
+  const notes = trimOrEmpty(raw.notes, HIRING_PARTNERS_MAX.notes);
+
+  if (!contactName) {
+    return NextResponse.json({ error: "Please enter your name." }, { status: 400 });
+  }
+  if (!phone) {
+    return NextResponse.json({ error: "Please enter a phone number." }, { status: 400 });
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  try {
+    const ref = db.collection(HIRING_PARTNERS_COLLECTION).doc(user.uid);
+    const existing = await ref.get();
+    const baseFields = {
+      userId: user.uid,
+      email: user.email,
+      contactName,
+      phone,
+      companyName,
+      companyWebsite,
+      contactRole,
+      rolesHiring,
+      notes,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    if (existing.exists) {
+      await ref.set(baseFields, { merge: true });
+    } else {
+      await ref.set({
+        ...baseFields,
+        status: "pending" satisfies HiringPartnerStatus,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    }
+    const fresh = await ref.get();
+    if (!existing.exists) {
+      sendNewApplicationEmail({
+        contactName,
+        email: user.email,
+        phone,
+        companyName,
+        companyWebsite,
+        contactRole,
+        rolesHiring,
+        notes,
+      }).catch((error) => {
+        logger.logError(error, {
+          endpoint: "/api/hiring-partners/apply",
+          stage: "notify_email",
+        });
+      });
+    }
+    return NextResponse.json({
+      application: serializeApplication(fresh.data() || {}),
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/hiring-partners/apply",
+      method: "POST",
+    });
+    return NextResponse.json(
+      { error: "Failed to save application" },
+      { status: 500 }
+    );
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+interface NewApplicantPayload {
+  contactName: string;
+  email: string;
+  phone: string;
+  companyName: string;
+  companyWebsite: string;
+  contactRole: string;
+  rolesHiring: string;
+  notes: string;
+}
+
+async function sendNewApplicationEmail(applicant: NewApplicantPayload): Promise<void> {
+  const fields: Array<[string, string]> = [
+    ["Name", applicant.contactName],
+    ["Email", applicant.email],
+    ["Phone", applicant.phone],
+    ["Company", applicant.companyName || "(not provided yet)"],
+    ["Website", applicant.companyWebsite || "(not provided yet)"],
+    ["Role / title", applicant.contactRole || "(not provided yet)"],
+    ["Roles hiring", applicant.rolesHiring || "(not provided yet)"],
+    ["Notes", applicant.notes || "(none)"],
+  ];
+
+  const textLines = ["New Cursor Boston hiring partner application:", ""];
+  for (const [label, value] of fields) {
+    textLines.push(`  ${label}: ${value}`);
+  }
+  textLines.push("");
+  textLines.push(`Their next step: book a call at ${HIRING_PARTNERS_CALENDLY_URL}`);
+  textLines.push("");
+  textLines.push("Approve via Firebase CLI when ready:");
+  textLines.push(
+    `  firebase firestore:documents:update ${HIRING_PARTNERS_COLLECTION}/<userId> --data '{"status":"approved"}'`
+  );
+
+  const rowsHtml = fields
+    .map(
+      ([label, value]) => `
+        <tr>
+          <td style="padding:4px 12px 4px 0;color:#666;vertical-align:top">${escapeHtml(label)}</td>
+          <td style="padding:4px 0;white-space:pre-wrap">${escapeHtml(value)}</td>
+        </tr>`
+    )
+    .join("");
+
+  const html = `
+    <div style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;color:#111;max-width:640px">
+      <h2 style="margin:0 0 12px">New hiring partner application</h2>
+      <table style="border-collapse:collapse;font-size:14px">${rowsHtml}</table>
+      <p style="margin:20px 0 0">
+        Their next step: book a call at
+        <a href="${HIRING_PARTNERS_CALENDLY_URL}">${escapeHtml(HIRING_PARTNERS_CALENDLY_URL)}</a>.
+      </p>
+      <p style="margin:12px 0 0;color:#444">Approve via Firebase CLI when ready.</p>
+    </div>
+  `;
+
+  await sendEmail({
+    to: HIRING_PARTNERS_NOTIFY_EMAIL,
+    subject: `Hiring partner application: ${applicant.contactName}${applicant.companyName ? ` (${applicant.companyName})` : ""}`,
+    text: textLines.join("\n"),
+    html,
+  });
+}
+
+export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);
+export const POST = withMiddleware(rateLimitConfigs.standard, handlePost);

--- a/app/api/internal/digest/weekly-hiring-partners/route.ts
+++ b/app/api/internal/digest/weekly-hiring-partners/route.ts
@@ -1,0 +1,232 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * Weekly digest of pending hiring partner applications.
+ * Invoke via Vercel cron with CRON_SECRET — never from user browsers.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logger } from "@/lib/logger";
+import { sendEmail } from "@/lib/mailgun";
+import {
+  HIRING_PARTNERS_CALENDLY_URL,
+  HIRING_PARTNERS_COLLECTION,
+  HIRING_PARTNERS_NOTIFY_EMAIL,
+} from "@/lib/hiring-partners";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+function getCronSecret(request: NextRequest): string | null {
+  return (
+    request.headers.get("x-cron-secret") ||
+    request.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ||
+    null
+  );
+}
+
+interface PendingRow {
+  userId: string;
+  contactName: string;
+  email: string;
+  phone: string;
+  companyName: string;
+  companyWebsite: string;
+  contactRole: string;
+  rolesHiring: string;
+  notes: string;
+  appliedAtMs: number | null;
+}
+
+function strField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function formatAppliedAt(ms: number | null): string {
+  if (!ms) return "(unknown date)";
+  return new Date(ms).toLocaleString("en-US", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+async function handleDigest(request: NextRequest): Promise<NextResponse> {
+  const invocationId = crypto.randomUUID();
+
+  if (!CRON_SECRET) {
+    logger.error("Hiring partners digest rejected: CRON_SECRET missing", {
+      endpoint: "/api/internal/digest/weekly-hiring-partners",
+      invocationId,
+    });
+    return NextResponse.json(
+      { error: "Server not configured: CRON_SECRET not set" },
+      { status: 500 }
+    );
+  }
+
+  const secret = getCronSecret(request);
+  if (!secret || secret !== CRON_SECRET) {
+    logger.warn("Hiring partners digest unauthorized", {
+      endpoint: "/api/internal/digest/weekly-hiring-partners",
+      invocationId,
+    });
+    return NextResponse.json(
+      { error: "Unauthorized: Invalid or missing cron secret" },
+      { status: 401 }
+    );
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  try {
+    const snap = await db
+      .collection(HIRING_PARTNERS_COLLECTION)
+      .where("status", "==", "pending")
+      .get();
+
+    const rows: PendingRow[] = snap.docs.map((doc) => {
+      const data = doc.data();
+      const createdAt = data.createdAt as { toMillis?: () => number } | undefined;
+      return {
+        userId: doc.id,
+        contactName: strField(data.contactName),
+        email: strField(data.email),
+        phone: strField(data.phone),
+        companyName: strField(data.companyName),
+        companyWebsite: strField(data.companyWebsite),
+        contactRole: strField(data.contactRole),
+        rolesHiring: strField(data.rolesHiring),
+        notes: strField(data.notes),
+        appliedAtMs:
+          createdAt && typeof createdAt.toMillis === "function"
+            ? createdAt.toMillis()
+            : null,
+      };
+    });
+    rows.sort((a, b) => (a.appliedAtMs ?? 0) - (b.appliedAtMs ?? 0));
+
+    if (rows.length === 0) {
+      return NextResponse.json({
+        ok: true,
+        invocationId,
+        pendingCount: 0,
+        emailSent: false,
+        reason: "no pending applications",
+      });
+    }
+
+    const textLines: string[] = [];
+    textLines.push(`Pending hiring partner applications: ${rows.length}`);
+    textLines.push("");
+    textLines.push(`Calendly (share with applicants): ${HIRING_PARTNERS_CALENDLY_URL}`);
+    textLines.push("");
+    for (const row of rows) {
+      textLines.push(
+        `• ${row.contactName || "(no name)"}${row.companyName ? ` — ${row.companyName}` : ""}`
+      );
+      textLines.push(`    Email:   ${row.email || "(none)"}`);
+      textLines.push(`    Phone:   ${row.phone || "(none)"}`);
+      if (row.contactRole) textLines.push(`    Role:    ${row.contactRole}`);
+      if (row.companyWebsite) textLines.push(`    Site:    ${row.companyWebsite}`);
+      if (row.rolesHiring) textLines.push(`    Hiring:  ${row.rolesHiring}`);
+      if (row.notes) textLines.push(`    Notes:   ${row.notes}`);
+      textLines.push(`    Applied: ${formatAppliedAt(row.appliedAtMs)}`);
+      textLines.push(`    Doc:     ${HIRING_PARTNERS_COLLECTION}/${row.userId}`);
+      textLines.push("");
+    }
+    textLines.push("Approve via Firebase CLI:");
+    textLines.push(
+      `  firebase firestore:documents:update ${HIRING_PARTNERS_COLLECTION}/<userId> --data '{"status":"approved"}'`
+    );
+
+    const rowsHtml = rows
+      .map(
+        (row) => `
+          <li style="margin-bottom:18px;padding:12px;border:1px solid #e5e5e5;border-radius:8px">
+            <div style="font-size:15px"><strong>${escapeHtml(row.contactName || "(no name)")}</strong>${row.companyName ? ` — ${escapeHtml(row.companyName)}` : ""}</div>
+            <table style="margin-top:6px;border-collapse:collapse;font-size:13px">
+              <tr><td style="padding:2px 12px 2px 0;color:#666">Email</td><td>${escapeHtml(row.email || "(none)")}</td></tr>
+              <tr><td style="padding:2px 12px 2px 0;color:#666">Phone</td><td>${escapeHtml(row.phone || "(none)")}</td></tr>
+              ${row.contactRole ? `<tr><td style="padding:2px 12px 2px 0;color:#666">Role</td><td>${escapeHtml(row.contactRole)}</td></tr>` : ""}
+              ${row.companyWebsite ? `<tr><td style="padding:2px 12px 2px 0;color:#666">Site</td><td><a href="${escapeHtml(row.companyWebsite)}">${escapeHtml(row.companyWebsite)}</a></td></tr>` : ""}
+              ${row.rolesHiring ? `<tr><td style="padding:2px 12px 2px 0;color:#666;vertical-align:top">Hiring</td><td style="white-space:pre-wrap">${escapeHtml(row.rolesHiring)}</td></tr>` : ""}
+              ${row.notes ? `<tr><td style="padding:2px 12px 2px 0;color:#666;vertical-align:top">Notes</td><td style="white-space:pre-wrap">${escapeHtml(row.notes)}</td></tr>` : ""}
+              <tr><td style="padding:2px 12px 2px 0;color:#666">Applied</td><td>${escapeHtml(formatAppliedAt(row.appliedAtMs))}</td></tr>
+              <tr><td style="padding:2px 12px 2px 0;color:#666">Doc</td><td><code>${escapeHtml(HIRING_PARTNERS_COLLECTION)}/${escapeHtml(row.userId)}</code></td></tr>
+            </table>
+          </li>`
+      )
+      .join("");
+
+    const html = `
+      <div style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;color:#111;max-width:720px">
+        <h2 style="margin:0 0 8px">Pending hiring partner applications: ${rows.length}</h2>
+        <p style="margin:0 0 16px;color:#444">
+          Calendly to share:
+          <a href="${HIRING_PARTNERS_CALENDLY_URL}">${escapeHtml(HIRING_PARTNERS_CALENDLY_URL)}</a>
+        </p>
+        <ul style="list-style:none;padding:0;margin:0">${rowsHtml}</ul>
+        <p style="margin:24px 0 0;color:#444">Approve via Firebase CLI when ready:</p>
+        <pre style="background:#f5f5f5;padding:10px;border-radius:6px;font-size:12px;overflow:auto">firebase firestore:documents:update ${escapeHtml(HIRING_PARTNERS_COLLECTION)}/&lt;userId&gt; --data '{"status":"approved"}'</pre>
+      </div>
+    `;
+
+    await sendEmail({
+      to: HIRING_PARTNERS_NOTIFY_EMAIL,
+      subject: `Hiring partners: ${rows.length} pending`,
+      text: textLines.join("\n"),
+      html,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      invocationId,
+      pendingCount: rows.length,
+      emailSent: true,
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/internal/digest/weekly-hiring-partners",
+      invocationId,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+        invocationId,
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return handleDigest(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handleDigest(request);
+}

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -1,0 +1,446 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { type FormEvent, useEffect, useState } from "react";
+import Link from "next/link";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  HIRING_PARTNERS_CALENDLY_URL,
+  HIRING_PARTNERS_MAX,
+  HIRING_PARTNERS_RETURN_TO,
+  type HiringPartnerStatus,
+} from "@/lib/hiring-partners";
+
+interface PartnerApplicationDto {
+  userId: string | null;
+  email: string | null;
+  contactName: string | null;
+  phone: string | null;
+  companyName: string | null;
+  companyWebsite: string | null;
+  contactRole: string | null;
+  rolesHiring: string | null;
+  notes: string | null;
+  status: HiringPartnerStatus;
+  createdAt: number | null;
+  updatedAt: number | null;
+}
+
+function CalendlyCard({ heading, body }: { heading: string; body: string }) {
+  return (
+    <section className="mt-6 rounded-xl border border-emerald-300 bg-emerald-50 p-6 dark:border-emerald-900 dark:bg-emerald-950/30">
+      <h2 className="text-lg font-semibold text-emerald-900 dark:text-emerald-200">
+        {heading}
+      </h2>
+      <p className="mt-2 text-sm text-emerald-900/90 dark:text-emerald-100/90">
+        {body}
+      </p>
+      <a
+        href={HIRING_PARTNERS_CALENDLY_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-4 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+      >
+        Book a call with Roger
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+        >
+          <path d="M7 17l9.2-9.2M17 17V7H7" />
+        </svg>
+      </a>
+    </section>
+  );
+}
+
+function StatusPanel({ application }: { application: PartnerApplicationDto }) {
+  const tone =
+    application.status === "approved"
+      ? {
+          panel:
+            "rounded-xl border border-emerald-400 bg-emerald-50 p-6 dark:border-emerald-700 dark:bg-emerald-950/40",
+          badge: "bg-emerald-500 text-white",
+          label: "Status: Approved",
+          headline: "You're an approved Cursor Boston hiring partner.",
+          body:
+            "Welcome aboard. Use the Calendly link below to set up a call whenever you'd like to talk through candidates, roles, or events.",
+        }
+      : application.status === "rejected"
+        ? {
+            panel:
+              "rounded-xl border border-neutral-300 bg-neutral-50 p-6 dark:border-neutral-700 dark:bg-neutral-900/60",
+            badge: "bg-neutral-500 text-white",
+            label: "Status: Not approved",
+            headline: "We weren't able to move forward right now.",
+            body:
+              "Thanks for the interest — feel free to reach out directly if anything changes on your end.",
+          }
+        : {
+            panel:
+              "rounded-xl border border-amber-300 bg-amber-50 p-6 dark:border-amber-800 dark:bg-amber-950/30",
+            badge: "bg-amber-500 text-white",
+            label: "Status: Pending",
+            headline: "We got your application.",
+            body:
+              "Next step is a quick call with Roger. Grab a slot below — and feel free to fill in the rest of your company info while you're here.",
+          };
+
+  return (
+    <section className={tone.panel}>
+      <span
+        className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${tone.badge}`}
+      >
+        {tone.label}
+      </span>
+      <p className="mt-3 text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+        {tone.headline}
+      </p>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        {tone.body}
+      </p>
+    </section>
+  );
+}
+
+export default function PartnersPage() {
+  const { user, loading } = useAuth();
+
+  const [application, setApplication] = useState<PartnerApplicationDto | null>(null);
+  const [appLoading, setAppLoading] = useState(false);
+  const [appLoadError, setAppLoadError] = useState<string | null>(null);
+
+  const [contactName, setContactName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [companyName, setCompanyName] = useState("");
+  const [companyWebsite, setCompanyWebsite] = useState("");
+  const [contactRole, setContactRole] = useState("");
+  const [rolesHiring, setRolesHiring] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user && !contactName) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- prefilling form once auth subject becomes available
+      setContactName(user.displayName || "");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  useEffect(() => {
+    if (loading || !user) return;
+    let cancelled = false;
+    (async () => {
+      setAppLoading(true);
+      setAppLoadError(null);
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/hiring-partners/apply", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error("load_failed");
+        const json = (await res.json()) as { application: PartnerApplicationDto | null };
+        if (cancelled) return;
+        setApplication(json.application);
+        if (json.application) {
+          setContactName(json.application.contactName || user.displayName || "");
+          setPhone(json.application.phone || "");
+          setCompanyName(json.application.companyName || "");
+          setCompanyWebsite(json.application.companyWebsite || "");
+          setContactRole(json.application.contactRole || "");
+          setRolesHiring(json.application.rolesHiring || "");
+          setNotes(json.application.notes || "");
+        }
+      } catch {
+        if (!cancelled) setAppLoadError("Couldn't load your application.");
+      } finally {
+        if (!cancelled) setAppLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loading, user]);
+
+  const submit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!user) return;
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    if (!contactName.trim()) {
+      setSubmitError("Please enter your name.");
+      return;
+    }
+    if (!phone.trim()) {
+      setSubmitError("Please enter a phone number.");
+      return;
+    }
+
+    const isUpdate = application !== null;
+    setSubmitting(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/hiring-partners/apply", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          contactName: contactName.trim(),
+          phone: phone.trim(),
+          companyName: companyName.trim(),
+          companyWebsite: companyWebsite.trim(),
+          contactRole: contactRole.trim(),
+          rolesHiring: rolesHiring.trim(),
+          notes: notes.trim(),
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setSubmitError(typeof json.error === "string" ? json.error : "Submit failed.");
+        return;
+      }
+      setApplication(json.application as PartnerApplicationDto);
+      setSubmitSuccess(isUpdate ? "Saved." : "Application received — see next steps below.");
+    } catch {
+      setSubmitError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      <header className="mb-8">
+        <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+          Hiring Partners
+        </p>
+        <h1 className="mt-2 text-3xl font-bold md:text-4xl">
+          Hire from the Cursor Boston community
+        </h1>
+        <p className="mt-2 text-neutral-600 dark:text-neutral-400">
+          Hiring partners get visibility into our cohorts, hackathons, and meetups, and a
+          direct line to Boston builders shipping with Cursor.
+        </p>
+      </header>
+
+      {loading ? (
+        <div className="rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500 dark:border-neutral-800">
+          Loading…
+        </div>
+      ) : !user ? (
+        <section className="rounded-xl border border-neutral-200 bg-neutral-50 p-6 dark:border-neutral-800 dark:bg-neutral-900/40">
+          <h2 className="text-lg font-semibold">Sign in to get started</h2>
+          <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+            We need an account on file to follow up on your application.
+          </p>
+          <Link
+            href={`/login?redirect=${encodeURIComponent(HIRING_PARTNERS_RETURN_TO)}`}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+          >
+            Sign in
+          </Link>
+        </section>
+      ) : appLoading ? (
+        <div className="rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500 dark:border-neutral-800">
+          Checking your application…
+        </div>
+      ) : appLoadError ? (
+        <div className="rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {appLoadError}
+        </div>
+      ) : (
+        <>
+          {application ? (
+            <>
+              <StatusPanel application={application} />
+              <CalendlyCard
+                heading={
+                  application.status === "approved"
+                    ? "Set up a call whenever"
+                    : "Book your intro call"
+                }
+                body={
+                  application.status === "approved"
+                    ? "Roger is your point of contact. Grab a slot whenever you want to talk through hiring or sponsorship."
+                    : "This is the next step. Pick a time that works — Roger will go through how the partnership works on the call."
+                }
+              />
+            </>
+          ) : null}
+
+          <section
+            className={`${application ? "mt-6" : ""} rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900`}
+          >
+            <h2 className="text-lg font-semibold">
+              {application ? "Your company profile" : "Get started"}
+            </h2>
+            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+              {application
+                ? "Fill in the rest whenever — we use this on our end to know what kinds of candidates and events to send your way."
+                : "Just your name, email, and phone to start. You can fill in the rest after."}
+            </p>
+
+            <form onSubmit={submit} className="mt-5 space-y-4">
+              <div>
+                <label htmlFor="hp-name" className="block text-sm font-medium">
+                  Your name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="hp-name"
+                  type="text"
+                  required
+                  maxLength={HIRING_PARTNERS_MAX.contactName}
+                  value={contactName}
+                  onChange={(e) => setContactName(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </div>
+              <div>
+                <label htmlFor="hp-email" className="block text-sm font-medium">
+                  Email
+                </label>
+                <input
+                  id="hp-email"
+                  type="email"
+                  value={user.email || ""}
+                  readOnly
+                  className="mt-1 w-full cursor-not-allowed rounded-lg border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm text-neutral-600 dark:border-neutral-800 dark:bg-neutral-800/60 dark:text-neutral-400"
+                />
+              </div>
+              <div>
+                <label htmlFor="hp-phone" className="block text-sm font-medium">
+                  Phone <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="hp-phone"
+                  type="tel"
+                  required
+                  maxLength={HIRING_PARTNERS_MAX.phone}
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </div>
+
+              <div className="rounded-lg border border-dashed border-neutral-300 p-4 dark:border-neutral-700">
+                <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                  Company info — optional, fill in anytime
+                </p>
+                <div className="mt-4 space-y-4">
+                  <div>
+                    <label htmlFor="hp-company" className="block text-sm font-medium">
+                      Company name
+                    </label>
+                    <input
+                      id="hp-company"
+                      type="text"
+                      maxLength={HIRING_PARTNERS_MAX.companyName}
+                      value={companyName}
+                      onChange={(e) => setCompanyName(e.target.value)}
+                      className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="hp-website" className="block text-sm font-medium">
+                      Company website
+                    </label>
+                    <input
+                      id="hp-website"
+                      type="url"
+                      maxLength={HIRING_PARTNERS_MAX.companyWebsite}
+                      placeholder="https://"
+                      value={companyWebsite}
+                      onChange={(e) => setCompanyWebsite(e.target.value)}
+                      className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="hp-role" className="block text-sm font-medium">
+                      Your role / title
+                    </label>
+                    <input
+                      id="hp-role"
+                      type="text"
+                      maxLength={HIRING_PARTNERS_MAX.contactRole}
+                      value={contactRole}
+                      onChange={(e) => setContactRole(e.target.value)}
+                      className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="hp-roles-hiring" className="block text-sm font-medium">
+                      What roles are you hiring for?
+                    </label>
+                    <textarea
+                      id="hp-roles-hiring"
+                      rows={3}
+                      maxLength={HIRING_PARTNERS_MAX.rolesHiring}
+                      placeholder="e.g. founding engineer, AI eng, internships…"
+                      value={rolesHiring}
+                      onChange={(e) => setRolesHiring(e.target.value)}
+                      className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="hp-notes" className="block text-sm font-medium">
+                      Anything else?
+                    </label>
+                    <textarea
+                      id="hp-notes"
+                      rows={3}
+                      maxLength={HIRING_PARTNERS_MAX.notes}
+                      placeholder="Sponsorship interest, comp range, anything that helps us route candidates."
+                      value={notes}
+                      onChange={(e) => setNotes(e.target.value)}
+                      className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {submitError ? (
+                <p className="text-sm text-red-600 dark:text-red-400">{submitError}</p>
+              ) : null}
+              {submitSuccess ? (
+                <p className="text-sm text-emerald-600 dark:text-emerald-400">
+                  {submitSuccess}
+                </p>
+              ) : null}
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 disabled:opacity-50"
+                >
+                  {submitting
+                    ? application
+                      ? "Saving…"
+                      : "Submitting…"
+                    : application
+                      ? "Save"
+                      : "Submit application"}
+                </button>
+              </div>
+            </form>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -111,6 +111,11 @@ export default function Footer() {
                       About
                     </Link>
                   </li>
+                  <li>
+                    <Link href="/partners" className="text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white text-sm transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
+                      Partners
+                    </Link>
+                  </li>
                 </ul>
               </div>
 

--- a/lib/hiring-partners.ts
+++ b/lib/hiring-partners.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export const HIRING_PARTNERS_COLLECTION = "hiringPartnerApplications";
+export const HIRING_PARTNERS_NOTIFY_EMAIL = "rogerhunt02052@gmail.com";
+export const HIRING_PARTNERS_CALENDLY_URL = "https://calendly.com/rogerhunt";
+export const HIRING_PARTNERS_RETURN_TO = "/partners";
+
+export type HiringPartnerStatus = "pending" | "approved" | "rejected";
+
+export const HIRING_PARTNERS_MAX = {
+  contactName: 200,
+  phone: 50,
+  companyName: 200,
+  companyWebsite: 500,
+  contactRole: 200,
+  rolesHiring: 2000,
+  notes: 4000,
+} as const;

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -12,30 +12,32 @@
  */
 
 /**
- * Sanitize plain text content by removing HTML tags and dangerous characters.
- * Preserves basic punctuation and whitespace.
- * @param input - The raw string to sanitize
- * @returns The sanitized string, or an empty string if input is not a string
+ * Normalize free-text user input for storage.
+ *
+ * Strips ASCII control characters (except newline), normalizes tabs and
+ * carriage returns to spaces, and trims surrounding whitespace. Does NOT
+ * strip HTML — values are expected to be rendered through React's JSX
+ * expressions, which auto-escape `<`, `>`, `"`, `'`, and `&`.
+ *
+ * Do NOT use the output of this function as:
+ *   - HTML (e.g. `dangerouslySetInnerHTML`) — use a dedicated HTML sanitizer.
+ *   - A URL (`href`, `src`) — use {@link sanitizeUrl}.
+ *   - A Firestore document ID — use {@link sanitizeDocId}.
+ *
+ * @param input - The raw string to normalize
+ * @returns The normalized string, or an empty string if input is not a string
  */
 export function sanitizeText(input: string): string {
   if (typeof input !== "string") {
     return "";
   }
-  
+
   return input
-    // Remove HTML tags
-    .replace(/<[^>]*>/g, "")
-    // Remove script-related content
-    .replace(/javascript:/gi, "")
-    .replace(/data:/gi, "")
-    .replace(/vbscript:/gi, "")
-    // Remove event handlers (onclick, onerror, etc.)
-    .replace(/on\w+\s*=/gi, "")
-    // Normalize whitespace (but preserve single spaces and newlines)
+    // Strip ASCII control chars except \t (0x09), \n (0x0A), \r (0x0D).
+    // Character class — no backtracking, no ReDoS.
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+    // Normalize tabs and carriage returns to spaces; preserve newlines.
     .replace(/[\t\r]+/g, " ")
-    // Remove null bytes
-    .replace(/\0/g, "")
-    // Trim leading/trailing whitespace
     .trim();
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,10 @@
     {
       "path": "/api/internal/hunt/email-retry",
       "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/internal/digest/weekly-hiring-partners",
+      "schedule": "0 13 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Releases two changes that landed on \`develop\` after PR #631:

- **5b4c6af** \`feat(hiring-partners)\`: low-friction Partners portal — new \`/partners\` dashboard linked from the footer, two-stage application (email/phone first, company info anytime), Mailgun notification on submit, weekly Vercel cron digest of pending applications. Approvals are manual via Firebase CLI for now.
- **5647b0b** \`fix(sanitize)\`: replaces the regex HTML-strip in \`lib/sanitize.ts\` (which was security theater + flagged by CodeQL #13/#14/#15 for incomplete sanitization and ReDoS) with honest text normalization. All 10 callers audited; no \`dangerouslySetInnerHTML\` site sinks user text. JSX auto-escaping is the actual XSS defense. 30/30 tests pass.

Both commits authored by @ludwitt with Claude Opus 4.7 as co-author.

## Behavior change to flag

Existing posts/bios that previously had angle brackets stripped at submit will now keep them. Render is still safe (JSX escapes); no DB migration. Future input like \`I love <Component />\` will no longer have \`<Component />\` silently dropped.

## Test plan

- [ ] Footer shows "Partners" link → \`/partners\`
- [ ] Logged-out: \`/partners\` shows sign-in CTA → \`/login?redirect=/partners\`
- [ ] First-time signed-in user: form shows; submitting with name+phone creates a pending application and triggers the email to rogerhunt02052@gmail.com
- [ ] After submit: status panel shows pending + Calendly card visible; extended profile editor still available
- [ ] Approve manually via \`firebase firestore:documents:update hiringPartnerApplications/<uid> --data '{"status":"approved"}'\` and reload — status panel flips to "Approved"
- [ ] Verify weekly cron route returns 200 with valid CRON_SECRET, 401 without
- [ ] Spot-check that community posts / Q&A / profile bios still save correctly with normal text