### PR TITLE
security: close 8 CodeQL alerts + postcss bump

### DIFF
--- a/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
+++ b/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
@@ -71,20 +71,19 @@ function buildExampleJson(
   photoUrl: string | null
 ): string {
   const handle = githubHandle ?? "your-handle";
-  const name = (displayName ?? "Your Name").replace(/"/g, '\\"');
-  const photo = photoUrl ?? "https://example.com/your-photo.jpg";
-  const liveLine = week.liveUrlRequired
-    ? `\n  "liveUrl": "https://yourthing.example.com",`
-    : "";
-  return `{
-  "githubHandle": "${handle}",
-  "name": "${name}",
-  "photoUrl": "${photo}",
-  "repoUrl": "https://github.com/${handle}/your-week-${week.week}-build",${liveLine}
-  "loomUrl": "https://www.loom.com/share/...",
-  "pitch": "One sentence on why you should win this week.",
-  "competeForWin": true
-}`;
+  const obj: Record<string, unknown> = {
+    githubHandle: handle,
+    name: displayName ?? "Your Name",
+    photoUrl: photoUrl ?? "https://example.com/your-photo.jpg",
+    repoUrl: `https://github.com/${handle}/your-week-${week.week}-build`,
+    ...(week.liveUrlRequired
+      ? { liveUrl: "https://yourthing.example.com" }
+      : {}),
+    loomUrl: "https://www.loom.com/share/...",
+    pitch: "One sentence on why you should win this week.",
+    competeForWin: true,
+  };
+  return JSON.stringify(obj, null, 2);
 }
 
 function buildSubmissionPath(

--- a/package-lock.json
+++ b/package-lock.json
@@ -18526,34 +18526,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -19853,9 +19825,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
       "react": "$react",
       "react-dom": "$react-dom"
     },
-    "http-proxy-agent": "^7.0.0"
+    "http-proxy-agent": "^7.0.0",
+    "postcss": "^8.5.12"
   },
   "lint-staged": {
     "**/*.{ts,tsx}": [

--- a/scripts/_lib/parse-github-login.ts
+++ b/scripts/_lib/parse-github-login.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Shared helper for the script tools that parse a GitHub login from a free-form
+ * CSV cell — accepts a bare login (`octocat`, `@octocat`), a profile URL
+ * (`https://github.com/octocat`), or an unprefixed form (`github.com/octocat`).
+ *
+ * Strict hostname check (`github.com` / `www.github.com` only) — the previous
+ * `hostname.includes("github.com")` and `lower.includes("github.com")` patterns
+ * matched `evilgithub.com` and `something.com/github.com/foo` respectively
+ * (CodeQL js/incomplete-url-substring-sanitization).
+ */
+
+const INVALID_LOGIN_TOKENS = new Set([
+  "",
+  "n",
+  "no",
+  "none",
+  "na",
+  "n/a",
+  "-",
+  ".",
+  "unknown",
+]);
+
+function isGithubHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return h === "github.com" || h === "www.github.com";
+}
+
+function loginFromUrl(candidate: string): string | null {
+  try {
+    const u = new URL(candidate);
+    if (!isGithubHostname(u.hostname)) return null;
+    const parts = u.pathname.split("/").filter(Boolean);
+    return parts[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseGithubLogin(raw: string | undefined | null): string | null {
+  if (!raw || typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+
+  let login: string | null = null;
+  if (lower.startsWith("http://") || lower.startsWith("https://")) {
+    login = loginFromUrl(trimmed);
+  } else if (/^(www\.)?github\.com[/:@]/i.test(trimmed)) {
+    // Unprefixed form like "github.com/foo" — prepend a scheme so the URL
+    // parser can do strict hostname validation.
+    login = loginFromUrl(`https://${trimmed.replace(/^\/+/, "")}`);
+  } else {
+    // Treat as bare login.
+    login = trimmed;
+  }
+
+  if (!login) return null;
+  const cleaned = login.replace(/^@+/, "");
+  if (INVALID_LOGIN_TOKENS.has(cleaned.toLowerCase()) || cleaned.length < 2) {
+    return null;
+  }
+  return cleaned;
+}

--- a/scripts/ai-evaluate-submissions.ts
+++ b/scripts/ai-evaluate-submissions.ts
@@ -81,7 +81,8 @@ function githubHeaders(): Record<string, string> {
 async function fetchRepoReadme(repoUrl: string): Promise<string | null> {
   try {
     const url = new URL(repoUrl);
-    if (!url.hostname.includes("github.com")) return null;
+    const host = url.hostname.toLowerCase();
+    if (host !== "github.com" && host !== "www.github.com") return null;
     const parts = url.pathname.split("/").filter(Boolean);
     if (parts.length < 2) return null;
     const [owner, repo] = parts;

--- a/scripts/build-hack-a-sprint-ranking.ts
+++ b/scripts/build-hack-a-sprint-ranking.ts
@@ -18,6 +18,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join, resolve } from "path";
 import { DECLINED_EMAILS, JUDGE_EMAILS } from "../lib/hackathon-event-signup";
+import { parseGithubLogin } from "./_lib/parse-github-login";
 
 const REPO_OWNER = "rogerSuperBuilderAlpha";
 const REPO_NAME = "cursor-boston";
@@ -37,10 +38,6 @@ const GITHUB_LOGIN_CORRECTIONS: Record<string, string> = {
   aakashmkj: "aakashm1712",
   dannygarciadev: "DannyGarciaDEV",
 };
-
-const INVALID_LOGIN_TOKENS = new Set([
-  "", "n", "no", "none", "na", "n/a", "-", ".", "unknown",
-]);
 
 type CsvRow = Record<string, string>;
 
@@ -71,30 +68,6 @@ function parseCsv(content: string): CsvRow[] {
     for (let j = 0; j < header.length; j++) obj[header[j]!] = (line[j] ?? "").trim();
     return obj;
   });
-}
-
-function parseGithubLogin(raw: string): string | null {
-  if (!raw) return null;
-  let s = raw.trim();
-  const lower = s.toLowerCase();
-  if (lower.startsWith("http://") || lower.startsWith("https://")) {
-    try {
-      const u = new URL(s);
-      if (!u.hostname.includes("github.com")) return null;
-      const parts = u.pathname.split("/").filter(Boolean);
-      if (parts.length === 0) return null;
-      s = parts[0]!;
-    } catch { return null; }
-  } else if (lower.includes("github.com")) {
-    const idx = lower.indexOf("github.com");
-    const rest = s.slice(idx + "github.com".length).replace(/^[/:]+/, "");
-    const parts = rest.split("/").filter(Boolean);
-    if (parts.length === 0) return null;
-    s = parts[0]!;
-  }
-  s = s.replace(/^@+/, "");
-  if (INVALID_LOGIN_TOKENS.has(s.toLowerCase()) || s.length < 2) return null;
-  return s;
 }
 
 function resolveGithubLogin(lumaLogin: string): string {

--- a/scripts/seed-luma-registrants.ts
+++ b/scripts/seed-luma-registrants.ts
@@ -29,12 +29,9 @@ import {
   isHackathonEventSignupId,
 } from "../lib/hackathon-event-signup";
 import { getAdminDb } from "../lib/firebase-admin";
+import { parseGithubLogin } from "./_lib/parse-github-login";
 
 const GITHUB_COL_KEY = "What is your GitHub username?";
-
-const INVALID_LOGIN_TOKENS = new Set([
-  "", "n", "no", "none", "na", "n/a", "-", ".", "unknown",
-]);
 
 type CsvRow = Record<string, string>;
 
@@ -67,31 +64,6 @@ function parseCsv(content: string): CsvRow[] {
     out.push(obj);
   }
   return out;
-}
-
-function parseGithubLogin(raw: string | undefined): string | null {
-  if (!raw || typeof raw !== "string") return null;
-  let s = raw.trim();
-  if (!s) return null;
-  const lower = s.toLowerCase();
-  if (lower.startsWith("http://") || lower.startsWith("https://")) {
-    try {
-      const u = new URL(s.startsWith("http") ? s : `https://${s}`);
-      if (!u.hostname.includes("github.com")) return null;
-      const parts = u.pathname.split("/").filter(Boolean);
-      if (parts.length === 0) return null;
-      s = parts[0]!;
-    } catch { return null; }
-  } else if (lower.includes("github.com")) {
-    const idx = lower.indexOf("github.com");
-    const rest = s.slice(idx + "github.com".length).replace(/^[/:]+/, "");
-    const parts = rest.split("/").filter(Boolean);
-    if (parts.length === 0) return null;
-    s = parts[0]!;
-  }
-  s = s.replace(/^@+/, "");
-  if (INVALID_LOGIN_TOKENS.has(s.toLowerCase()) || s.length < 2) return null;
-  return s;
 }
 
 function parseArgs(argv: string[]) {

--- a/scripts/send-hack-a-sprint-emails.ts
+++ b/scripts/send-hack-a-sprint-emails.ts
@@ -68,6 +68,7 @@ import {
 import { getGithubRepoPair, getGithubRepoWebBaseUrl } from "../lib/github-recent-merged-prs";
 import { getAdminAuth, getAdminDb } from "../lib/firebase-admin";
 import { sendEmail } from "../lib/mailgun";
+import { parseGithubLogin } from "./_lib/parse-github-login";
 
 const SITE_ORIGIN = process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com";
 const SIGNUP_PATH = "/hackathons/hack-a-sprint-2026/signup";
@@ -95,17 +96,6 @@ const USER_ID_IN_CHUNK = 10;
 /** Update before send if the open PR queue size changed (see GitHub pulls tab). */
 const DAYOF_OPEN_PR_QUEUE_COUNT = 16;
 
-const INVALID_LOGIN_TOKENS = new Set([
-  "",
-  "n",
-  "no",
-  "none",
-  "na",
-  "n/a",
-  "-",
-  ".",
-  "unknown",
-]);
 
 type RegistrantTier =
   | "DECLINED"
@@ -172,33 +162,6 @@ function parseCsv(content: string): CsvRow[] {
 }
 
 /** Extract GitHub login from URL or bare login; returns null if unusable. */
-function parseGithubLogin(raw: string | undefined): string | null {
-  if (!raw || typeof raw !== "string") return null;
-  let s = raw.trim();
-  if (!s) return null;
-  const lower = s.toLowerCase();
-  if (lower.startsWith("http://") || lower.startsWith("https://")) {
-    try {
-      const u = new URL(s.startsWith("http") ? s : `https://${s}`);
-      if (!u.hostname.includes("github.com")) return null;
-      const parts = u.pathname.split("/").filter(Boolean);
-      if (parts.length === 0) return null;
-      s = parts[0]!;
-    } catch {
-      return null;
-    }
-  } else if (lower.includes("github.com")) {
-    const idx = lower.indexOf("github.com");
-    const rest = s.slice(idx + "github.com".length).replace(/^[/:]+/, "");
-    const parts = rest.split("/").filter(Boolean);
-    if (parts.length === 0) return null;
-    s = parts[0]!;
-  }
-  s = s.replace(/^@+/, "");
-  if (INVALID_LOGIN_TOKENS.has(s.toLowerCase()) || s.length < 2) return null;
-  return s;
-}
-
 function signedUpAtToMs(value: unknown): number {
   if (
     value &&


### PR DESCRIPTION
## Summary

Closes 8 CodeQL alerts and 1 Dependabot alert. The remaining one (uuid) gets dismissed separately with rationale — see below.

### Code-scanning fixes

- **#16, #17, #19, #20, #21, #22, #23** \`js/incomplete-url-substring-sanitization\` — extracted the duplicated \`parseGithubLogin\` helper from 3 scripts into \`scripts/_lib/parse-github-login.ts\` with strict hostname validation (\`github.com\` / \`www.github.com\` only). The previous \`url.includes("github.com")\` and \`hostname.includes("github.com")\` patterns matched \`evilgithub.com\` and \`something.com/github.com/foo\`. Also fixed the inline check in \`scripts/ai-evaluate-submissions.ts\`.
- **#26** \`js/incomplete-sanitization\` (\`WeekSubmissionsCollapsible.tsx\`) — replaced the manual \`name.replace(/"/g, '\\\\"')\` template with \`JSON.stringify(obj, null, 2)\`. The old code didn't escape backslashes first, so a name like \`abc\\\` produced broken example JSON.

### Dependabot fix

- **#58** \`postcss <8.5.10\` — added a \`postcss\` override in \`package.json\`. \`next.js@16.2.4\` ships a nested \`postcss@8.4.31\`; the override deduplicates the whole tree to \`postcss@8.5.13\` (verified with \`npm ls postcss\`).

### To be dismissed (not fixed)

- **#55** \`uuid <14.0.0\` — the vuln (\`Missing buffer bounds check in v3/v5/v6 when buf is provided\`) only triggers when calling \`uuid.v3/v5/v6\` with a caller-provided buffer. Nothing in our tree does that. The patched v14 has API changes that would force \`firebase-admin\` major downgrade, which is unacceptable. I'll dismiss this in the security tab with the same rationale post-merge.

## Test plan

- [ ] \`npm ls postcss\` shows all instances at \`^8.5.13\` after merge
- [ ] CodeQL re-scan auto-closes alerts #16, #17, #19, #20, #21, #22, #23, #26
- [ ] Dependabot re-evaluates and closes #58
- [ ] CI green
- [ ] Smoke-check: \`npx tsx scripts/build-hack-a-sprint-ranking.ts --csv ...\` still works (parseGithubLogin behavior should be identical for valid github.com URLs)

Authored by @ludwitt with Claude Opus 4.7 as co-author.