### PR TITLE
feat(summer-cohort): intake survey gates the admitted dashboard

### DIFF
--- a/app/api/summer-cohort/intake-survey/route.ts
+++ b/app/api/summer-cohort/intake-survey/route.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import { SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
+import {
+  SUMMER_COHORT_INTAKE_COLLECTION,
+  SUMMER_COHORT_INTAKE_VERSION,
+  validateIntakeSurvey,
+  type IntakeSurveyDoc,
+} from "@/lib/summer-cohort-intake";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function serializeDoc(uid: string, data: Record<string, unknown>): IntakeSurveyDoc | null {
+  const submittedAt = data.submittedAt;
+  const lastUpdatedAt = data.lastUpdatedAt;
+  const submittedMs =
+    submittedAt && typeof (submittedAt as { toMillis?: () => number }).toMillis === "function"
+      ? (submittedAt as { toMillis: () => number }).toMillis()
+      : null;
+  const updatedMs =
+    lastUpdatedAt && typeof (lastUpdatedAt as { toMillis?: () => number }).toMillis === "function"
+      ? (lastUpdatedAt as { toMillis: () => number }).toMillis()
+      : null;
+  if (!submittedMs) return null;
+  return {
+    ...(data as unknown as Omit<IntakeSurveyDoc, "uid" | "submittedAt" | "lastUpdatedAt">),
+    uid,
+    submittedAt: submittedMs,
+    lastUpdatedAt: updatedMs ?? submittedMs,
+  };
+}
+
+async function handleGet(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+  const snap = await db
+    .collection(SUMMER_COHORT_INTAKE_COLLECTION)
+    .doc(user.uid)
+    .get();
+  if (!snap.exists) {
+    return NextResponse.json({ completed: false, response: null });
+  }
+  const doc = serializeDoc(user.uid, snap.data() || {});
+  return NextResponse.json({
+    completed: doc !== null,
+    response: doc,
+  });
+}
+
+async function handlePost(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  // Gate: only admitted Cohort 1 applicants can submit. Anyone else
+  // POSTing is either a stale tab or someone poking at the API.
+  const appSnap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .doc(user.uid)
+    .get();
+  if (!appSnap.exists) {
+    return NextResponse.json(
+      { error: "No application on file" },
+      { status: 403 }
+    );
+  }
+  const app = appSnap.data() || {};
+  const status = typeof app.status === "string" ? app.status : "pending";
+  if (status !== "admitted") {
+    return NextResponse.json(
+      { error: "Only admitted applicants can submit the intake survey" },
+      { status: 403 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = validateIntakeSurvey(body);
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: "Validation failed", missingFields: result.errors },
+      { status: 400 }
+    );
+  }
+
+  const docRef = db
+    .collection(SUMMER_COHORT_INTAKE_COLLECTION)
+    .doc(user.uid);
+  const existing = await docRef.get();
+  const isFirstSubmission = !existing.exists;
+
+  await docRef.set(
+    {
+      ...result.data,
+      uid: user.uid,
+      surveyVersion: SUMMER_COHORT_INTAKE_VERSION,
+      // Preserve the original submittedAt on re-submit so we always know
+      // when the respondent first cleared the gate. lastUpdatedAt tracks edits.
+      ...(isFirstSubmission ? { submittedAt: FieldValue.serverTimestamp() } : {}),
+      lastUpdatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  logger.info("[summer-cohort/intake-survey] submission", {
+    uid: user.uid,
+    isFirstSubmission,
+    version: SUMMER_COHORT_INTAKE_VERSION,
+  });
+
+  return NextResponse.json({ ok: true, isFirstSubmission });
+}
+
+export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);
+export const POST = withMiddleware(rateLimitConfigs.standard, handlePost);

--- a/app/summer-cohort/_components/IntakeSurveyForm.tsx
+++ b/app/summer-cohort/_components/IntakeSurveyForm.tsx
@@ -6,7 +6,8 @@
 
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
 import {
   AI_TOOL_OPTIONS,
   CS_CREDENTIAL_OPTIONS,
@@ -19,6 +20,7 @@ import {
   LLM_FREQUENCY_OPTIONS,
   PROGRAMMING_LANGUAGE_OPTIONS,
   SOCIAL_PLATFORM_OPTIONS,
+  SUMMER_COHORT_INTAKE_VERSION,
   YEARS_PROGRAMMING_OPTIONS,
   type CsCredential,
   type CursorExperience,
@@ -30,6 +32,46 @@ import {
   type LlmFrequency,
   type YearsProgramming,
 } from "@/lib/summer-cohort-intake";
+
+// localStorage draft persistence — saves on every change so a refresh or
+// accidental nav doesn't lose the work. Keyed by uid + survey version so
+// stale drafts from a prior schema don't hydrate into a new form.
+function draftStorageKey(uid: string): string {
+  return `summer-cohort-intake-draft:${SUMMER_COHORT_INTAKE_VERSION}:${uid}`;
+}
+
+function loadDraft(uid: string): Partial<IntakeSurveyResponse> | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(draftStorageKey(uid));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as Partial<IntakeSurveyResponse>;
+    }
+  } catch {
+    // Corrupt JSON — fall through and ignore.
+  }
+  return null;
+}
+
+function saveDraft(uid: string, draft: IntakeSurveyResponse): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(draftStorageKey(uid), JSON.stringify(draft));
+  } catch {
+    // Quota exceeded or storage disabled — silently drop. Survey still works.
+  }
+}
+
+function clearDraft(uid: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(draftStorageKey(uid));
+  } catch {
+    // ignore
+  }
+}
 
 // Display labels for the enum string values. Keep these in the form layer —
 // the lib is data-only.
@@ -155,6 +197,7 @@ const EMPTY: IntakeSurveyResponse = {
 };
 
 export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) {
+  const { user } = useAuth();
   const [r, setR] = useState<IntakeSurveyResponse>(() => ({
     ...EMPTY,
     email: defaultEmail,
@@ -163,6 +206,31 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [missingFields, setMissingFields] = useState<string[]>([]);
+  // Tracks whether we've already attempted to hydrate from localStorage so
+  // subsequent uid-stable renders don't re-overwrite user edits.
+  const hydratedRef = useRef(false);
+  const [hasDraft, setHasDraft] = useState(false);
+
+  // Hydrate from localStorage on mount once the uid is available. Defaults
+  // (defaultEmail, cohortId) stay as the fallback for fields the draft
+  // doesn't carry.
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    if (!user?.uid) return;
+    const draft = loadDraft(user.uid);
+    hydratedRef.current = true;
+    if (!draft) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot hydration on mount, not a sync loop
+    setHasDraft(true);
+    setR((prev) => ({ ...prev, ...draft }));
+  }, [user?.uid]);
+
+  // Persist on every change once we've hydrated. Skipping pre-hydration
+  // prevents the initial empty state from overwriting a saved draft.
+  useEffect(() => {
+    if (!hydratedRef.current || !user?.uid) return;
+    saveDraft(user.uid, r);
+  }, [r, user?.uid]);
 
   const update = <K extends keyof IntakeSurveyResponse>(
     key: K,
@@ -183,13 +251,21 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!user) {
+      setError("You must be signed in to submit.");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     setMissingFields([]);
     try {
+      const token = await user.getIdToken();
       const res = await fetch("/api/summer-cohort/intake-survey", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(r),
       });
       if (!res.ok) {
@@ -202,6 +278,9 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
         }
         return;
       }
+      // Submission landed — drop the local draft so a future re-fill (e.g.
+      // an edit pass) doesn't restore stale answers from the previous wave.
+      if (user?.uid) clearDraft(user.uid);
       onComplete();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Submit failed");
@@ -231,8 +310,14 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
         <p className="mt-2 text-xs text-neutral-500">
           You can update your answers later from this page if anything changes
           before kickoff. Required fields are marked with{" "}
-          <span className="text-red-500">*</span>.
+          <span className="text-red-500">*</span>. Your in-progress answers
+          are saved in this browser so a refresh won&apos;t lose them.
         </p>
+        {hasDraft ? (
+          <p className="mt-2 inline-flex items-center gap-2 rounded-md bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300">
+            Draft restored from this browser.
+          </p>
+        ) : null}
       </div>
 
       <form onSubmit={submit} className="space-y-10">

--- a/app/summer-cohort/_components/IntakeSurveyForm.tsx
+++ b/app/summer-cohort/_components/IntakeSurveyForm.tsx
@@ -1,0 +1,901 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  AI_TOOL_OPTIONS,
+  CS_CREDENTIAL_OPTIONS,
+  CURSOR_EXPERIENCE_OPTIONS,
+  EMPLOYMENT_OPTIONS,
+  ENGLISH_PROFICIENCY_OPTIONS,
+  GENDER_OPTIONS,
+  HIGHEST_DEGREE_OPTIONS,
+  INTAKE_LIMITS,
+  LLM_FREQUENCY_OPTIONS,
+  PROGRAMMING_LANGUAGE_OPTIONS,
+  SOCIAL_PLATFORM_OPTIONS,
+  YEARS_PROGRAMMING_OPTIONS,
+  type CsCredential,
+  type CursorExperience,
+  type EmploymentStatus,
+  type EnglishProficiency,
+  type GenderOption,
+  type HighestDegree,
+  type IntakeSurveyResponse,
+  type LlmFrequency,
+  type YearsProgramming,
+} from "@/lib/summer-cohort-intake";
+
+// Display labels for the enum string values. Keep these in the form layer —
+// the lib is data-only.
+const ENUM_LABELS = {
+  gender: {
+    woman: "Woman",
+    man: "Man",
+    "non-binary": "Non-binary",
+    "prefer-self-describe": "Prefer to self-describe",
+    "prefer-not-to-say": "Prefer not to say",
+  } satisfies Record<GenderOption, string>,
+  englishProficiency: {
+    beginner: "Beginner",
+    intermediate: "Intermediate",
+    advanced: "Advanced",
+    native: "Native",
+  } satisfies Record<EnglishProficiency, string>,
+  highestDegree: {
+    none: "None",
+    "high-school": "High school",
+    associate: "Associate",
+    bachelors: "Bachelor's",
+    masters: "Master's",
+    doctorate: "Doctorate",
+    other: "Other",
+  } satisfies Record<HighestDegree, string>,
+  employment: {
+    yes: "Yes",
+    no: "No",
+    "part-time": "Part-time",
+  } satisfies Record<EmploymentStatus, string>,
+  yearsProgramming: {
+    none: "None",
+    "less-than-1": "Less than 1",
+    "1-3": "1–3",
+    "3-5": "3–5",
+    "5-10": "5–10",
+    "more-than-10": "More than 10",
+  } satisfies Record<YearsProgramming, string>,
+  csCredential: {
+    none: "None",
+    "self-taught": "Self-taught",
+    bootcamp: "Bootcamp",
+    undergraduate: "Undergraduate",
+    graduate: "Graduate",
+    "industry-cert": "Industry certification",
+  } satisfies Record<CsCredential, string>,
+  llmFrequency: {
+    never: "Never",
+    monthly: "Monthly",
+    weekly: "Weekly",
+    "several-times-week": "Several times a week",
+    daily: "Daily",
+    "multi-hours-day": "Multiple hours per day",
+  } satisfies Record<LlmFrequency, string>,
+  cursorExperience: {
+    never: "Never used",
+    tried: "Tried it",
+    regular: "Regular use",
+    daily: "Daily user",
+  } satisfies Record<CursorExperience, string>,
+};
+
+const INPUT_CLASS =
+  "mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950";
+const READONLY_INPUT_CLASS =
+  "mt-1 w-full cursor-not-allowed rounded-lg border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm text-neutral-600 dark:border-neutral-800 dark:bg-neutral-800/60 dark:text-neutral-400";
+
+type Props = {
+  /** Email pre-filled from the user's auth profile (editable). */
+  defaultEmail: string;
+  /** Cohort id from the application (read-only display). */
+  cohortId: string;
+  /** Called after a successful submit so the parent can re-fetch + show the dashboard. */
+  onComplete: () => void;
+};
+
+const EMPTY: IntakeSurveyResponse = {
+  email: "",
+  participantCode: "",
+  cohort: "",
+  consentToResearch: false,
+
+  age: null,
+  gender: null,
+  genderSelfDescribed: null,
+  countryOfResidence: "",
+  countryOfBirth: "",
+  nativeLanguages: "",
+  englishProficiency: null,
+  highestDegree: null,
+  highestDegreeOther: null,
+  degreeField: "",
+  employmentStatus: null,
+
+  yearsProgramming: null,
+  programmingLanguages: [],
+  programmingLanguagesOther: null,
+  priorEngineerEmployment: null,
+  priorEngineerYears: null,
+  csCredential: null,
+
+  firstAiYear: null,
+  llmFrequency: null,
+  aiToolsUsed: [],
+  aiToolsOther: null,
+  cursorExperience: null,
+  shippedWithAi: null,
+  shippedWithAiDescription: null,
+  hoursPerWeekAi: null,
+
+  hoursPerWeekSocial: null,
+  postedAsCreator: null,
+  postedAsCreatorWhich: null,
+  gigPlatformWork: null,
+  gigPlatformDetails: null,
+  algorithmUnderstanding: null,
+
+  baselineEffective: null,
+  baselineUnderstanding: null,
+
+  whyJoined: "",
+  eightWeekGoal: "",
+};
+
+export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) {
+  const [r, setR] = useState<IntakeSurveyResponse>(() => ({
+    ...EMPTY,
+    email: defaultEmail,
+    cohort: cohortId,
+  }));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [missingFields, setMissingFields] = useState<string[]>([]);
+
+  const update = <K extends keyof IntakeSurveyResponse>(
+    key: K,
+    value: IntakeSurveyResponse[K]
+  ) => {
+    setR((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const toggleInArray = (key: "programmingLanguages" | "aiToolsUsed", value: string) => {
+    setR((prev) => {
+      const arr = prev[key];
+      const next = arr.includes(value)
+        ? arr.filter((v) => v !== value)
+        : [...arr, value];
+      return { ...prev, [key]: next };
+    });
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setMissingFields([]);
+    try {
+      const res = await fetch("/api/summer-cohort/intake-survey", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(r),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        if (Array.isArray(j.missingFields)) {
+          setMissingFields(j.missingFields);
+          setError(`Missing or invalid: ${j.missingFields.join(", ")}`);
+        } else {
+          setError(j.error || `Submit failed (${res.status})`);
+        }
+        return;
+      }
+      onComplete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Submit failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isMissing = useMemo(
+    () => (field: string) => missingFields.includes(field),
+    [missingFields]
+  );
+
+  return (
+    <section className="rounded-xl border border-emerald-300 bg-emerald-50/50 p-6 dark:border-emerald-900 dark:bg-emerald-950/20">
+      <div className="mb-6">
+        <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+          Required before kickoff
+        </div>
+        <h2 className="mt-3 text-xl font-bold">Intake Survey</h2>
+        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+          You&apos;ve been admitted to Cohort 1. Before you see the cohort
+          dashboard, we need ~5 minutes for an intake survey. This is a research
+          instrument — your responses help us study how the program changes
+          participants&apos; experience with AI tools.
+        </p>
+        <p className="mt-2 text-xs text-neutral-500">
+          You can update your answers later from this page if anything changes
+          before kickoff. Required fields are marked with{" "}
+          <span className="text-red-500">*</span>.
+        </p>
+      </div>
+
+      <form onSubmit={submit} className="space-y-10">
+        {/* ----------------------------------------------------------------
+            Section 1: Linkage and consent
+           ---------------------------------------------------------------- */}
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            1. Linkage &amp; consent
+          </legend>
+
+          <FieldEmail
+            value={r.email}
+            onChange={(v) => update("email", v)}
+            invalid={isMissing("email")}
+          />
+
+          <Field label="Self-generated participant code" required invalid={isMissing("participantCode")}>
+            <input
+              type="text"
+              required
+              maxLength={INTAKE_LIMITS.participantCode}
+              value={r.participantCode}
+              onChange={(e) => update("participantCode", e.target.value)}
+              placeholder="e.g. last 4 of phone + first 2 letters of mother's first name"
+              className={INPUT_CLASS}
+            />
+            <p className="mt-1 text-xs text-neutral-500">
+              Pick a rule and use the same code on every wave so we can match
+              your responses across the program even if your email changes.
+            </p>
+          </Field>
+
+          <Field label="Cohort" required invalid={isMissing("cohort")}>
+            <input
+              type="text"
+              value={r.cohort}
+              readOnly
+              className={READONLY_INPUT_CLASS}
+            />
+          </Field>
+
+          <label className={`flex items-start gap-2 rounded-lg border p-3 text-sm ${isMissing("consentToResearch") ? "border-red-400 bg-red-50 dark:bg-red-950/30" : "border-neutral-300 dark:border-neutral-700"}`}>
+            <input
+              type="checkbox"
+              checked={r.consentToResearch}
+              onChange={(e) => update("consentToResearch", e.target.checked)}
+              className="mt-1"
+            />
+            <span>
+              <span className="font-medium">I consent to research use of program data.</span>{" "}
+              <span className="text-neutral-600 dark:text-neutral-400">
+                Responses are aggregated and de-identified for analysis. The IRB
+                protocol summary will be shared with respondents before
+                publication.
+              </span>{" "}
+              <span className="text-red-500">*</span>
+            </span>
+          </label>
+        </fieldset>
+
+        {/* ----------------------------------------------------------------
+            Section 2: Demographics
+           ---------------------------------------------------------------- */}
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            2. Demographics
+          </legend>
+
+          <Field label="Age" required invalid={isMissing("age")}>
+            <input
+              type="number"
+              min={INTAKE_LIMITS.minAge}
+              max={INTAKE_LIMITS.maxAge}
+              value={r.age ?? ""}
+              onChange={(e) => update("age", e.target.value === "" ? null : Number(e.target.value))}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field label="Gender" required invalid={isMissing("gender")}>
+            <select
+              value={r.gender ?? ""}
+              onChange={(e) => update("gender", (e.target.value || null) as GenderOption | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {GENDER_OPTIONS.map((g) => (
+                <option key={g} value={g}>{ENUM_LABELS.gender[g]}</option>
+              ))}
+            </select>
+          </Field>
+          {r.gender === "prefer-self-describe" ? (
+            <Field label="Self-describe" required invalid={isMissing("genderSelfDescribed")}>
+              <input
+                type="text"
+                maxLength={INTAKE_LIMITS.shortText}
+                value={r.genderSelfDescribed ?? ""}
+                onChange={(e) => update("genderSelfDescribed", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+          ) : null}
+
+          <Field label="Country of residence" required invalid={isMissing("countryOfResidence")}>
+            <input
+              type="text"
+              maxLength={INTAKE_LIMITS.shortText}
+              value={r.countryOfResidence}
+              onChange={(e) => update("countryOfResidence", e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field label="Country of birth" required invalid={isMissing("countryOfBirth")}>
+            <input
+              type="text"
+              maxLength={INTAKE_LIMITS.shortText}
+              value={r.countryOfBirth}
+              onChange={(e) => update("countryOfBirth", e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field label="Native language(s)" required invalid={isMissing("nativeLanguages")}>
+            <input
+              type="text"
+              maxLength={INTAKE_LIMITS.shortText}
+              value={r.nativeLanguages}
+              onChange={(e) => update("nativeLanguages", e.target.value)}
+              placeholder="Comma-separated if multiple"
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field label="English proficiency (self-rated)" required invalid={isMissing("englishProficiency")}>
+            <select
+              value={r.englishProficiency ?? ""}
+              onChange={(e) => update("englishProficiency", (e.target.value || null) as EnglishProficiency | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {ENGLISH_PROFICIENCY_OPTIONS.map((p) => (
+                <option key={p} value={p}>{ENUM_LABELS.englishProficiency[p]}</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Highest degree completed" required invalid={isMissing("highestDegree")}>
+            <select
+              value={r.highestDegree ?? ""}
+              onChange={(e) => update("highestDegree", (e.target.value || null) as HighestDegree | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {HIGHEST_DEGREE_OPTIONS.map((d) => (
+                <option key={d} value={d}>{ENUM_LABELS.highestDegree[d]}</option>
+              ))}
+            </select>
+          </Field>
+          {r.highestDegree === "other" ? (
+            <Field label="Specify other degree" required invalid={isMissing("highestDegreeOther")}>
+              <input
+                type="text"
+                maxLength={INTAKE_LIMITS.shortText}
+                value={r.highestDegreeOther ?? ""}
+                onChange={(e) => update("highestDegreeOther", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+          ) : null}
+
+          <Field label="Field of that degree" required invalid={isMissing("degreeField")}>
+            <input
+              type="text"
+              maxLength={INTAKE_LIMITS.shortText}
+              value={r.degreeField}
+              onChange={(e) => update("degreeField", e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field label="Currently employed full-time" required invalid={isMissing("employmentStatus")}>
+            <select
+              value={r.employmentStatus ?? ""}
+              onChange={(e) => update("employmentStatus", (e.target.value || null) as EmploymentStatus | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {EMPLOYMENT_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>{ENUM_LABELS.employment[opt]}</option>
+              ))}
+            </select>
+          </Field>
+        </fieldset>
+
+        {/* ----------------------------------------------------------------
+            Section 3: Programming background
+           ---------------------------------------------------------------- */}
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            3. Programming background
+          </legend>
+
+          <Field label="Years of programming experience" required invalid={isMissing("yearsProgramming")}>
+            <select
+              value={r.yearsProgramming ?? ""}
+              onChange={(e) => update("yearsProgramming", (e.target.value || null) as YearsProgramming | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {YEARS_PROGRAMMING_OPTIONS.map((y) => (
+                <option key={y} value={y}>{ENUM_LABELS.yearsProgramming[y]}</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Primary programming languages used in the past year">
+            <CheckboxGrid
+              options={PROGRAMMING_LANGUAGE_OPTIONS}
+              selected={r.programmingLanguages}
+              onToggle={(v) => toggleInArray("programmingLanguages", v)}
+            />
+            <input
+              type="text"
+              maxLength={INTAKE_LIMITS.shortText}
+              value={r.programmingLanguagesOther ?? ""}
+              onChange={(e) => update("programmingLanguagesOther", e.target.value)}
+              placeholder="Other (free text, comma-separated)"
+              className={`${INPUT_CLASS} mt-3`}
+            />
+          </Field>
+
+          <YesNo
+            label="Prior employment as a software engineer or developer"
+            required
+            invalid={isMissing("priorEngineerEmployment")}
+            value={r.priorEngineerEmployment}
+            onChange={(v) => update("priorEngineerEmployment", v)}
+          />
+          {r.priorEngineerEmployment === true ? (
+            <Field label="Total years of engineering employment" required invalid={isMissing("priorEngineerYears")}>
+              <input
+                type="number"
+                min={0}
+                max={INTAKE_LIMITS.maxYearsExperience}
+                value={r.priorEngineerYears ?? ""}
+                onChange={(e) => update("priorEngineerYears", e.target.value === "" ? null : Number(e.target.value))}
+                className={INPUT_CLASS}
+              />
+            </Field>
+          ) : null}
+
+          <Field label="Highest CS-related credential" required invalid={isMissing("csCredential")}>
+            <select
+              value={r.csCredential ?? ""}
+              onChange={(e) => update("csCredential", (e.target.value || null) as CsCredential | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {CS_CREDENTIAL_OPTIONS.map((c) => (
+                <option key={c} value={c}>{ENUM_LABELS.csCredential[c]}</option>
+              ))}
+            </select>
+          </Field>
+        </fieldset>
+
+        {/* ----------------------------------------------------------------
+            Section 4: AI tool exposure
+           ---------------------------------------------------------------- */}
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            4. AI tool exposure
+          </legend>
+
+          <Field label="Year you first used a generative AI tool" required invalid={isMissing("firstAiYear")}>
+            <input
+              type="number"
+              min={INTAKE_LIMITS.minFirstAiYear}
+              max={INTAKE_LIMITS.maxFirstAiYear}
+              value={r.firstAiYear ?? ""}
+              onChange={(e) => update("firstAiYear", e.target.value === "" ? null : Number(e.target.value))}
+              placeholder="e.g. 2022"
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field label="Frequency of LLM use over the past 6 months" required invalid={isMissing("llmFrequency")}>
+            <select
+              value={r.llmFrequency ?? ""}
+              onChange={(e) => update("llmFrequency", (e.target.value || null) as LlmFrequency | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {LLM_FREQUENCY_OPTIONS.map((f) => (
+                <option key={f} value={f}>{ENUM_LABELS.llmFrequency[f]}</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Primary AI tools used regularly">
+            <CheckboxGrid
+              options={AI_TOOL_OPTIONS}
+              selected={r.aiToolsUsed}
+              onToggle={(v) => toggleInArray("aiToolsUsed", v)}
+            />
+            <input
+              type="text"
+              maxLength={INTAKE_LIMITS.shortText}
+              value={r.aiToolsOther ?? ""}
+              onChange={(e) => update("aiToolsOther", e.target.value)}
+              placeholder="Other (free text, comma-separated)"
+              className={`${INPUT_CLASS} mt-3`}
+            />
+          </Field>
+
+          <Field label="Cursor experience entering the program" required invalid={isMissing("cursorExperience")}>
+            <select
+              value={r.cursorExperience ?? ""}
+              onChange={(e) => update("cursorExperience", (e.target.value || null) as CursorExperience | null)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Select…</option>
+              {CURSOR_EXPERIENCE_OPTIONS.map((c) => (
+                <option key={c} value={c}>{ENUM_LABELS.cursorExperience[c]}</option>
+              ))}
+            </select>
+          </Field>
+
+          <YesNo
+            label="Have you shipped a working product built with substantial AI assistance?"
+            required
+            invalid={isMissing("shippedWithAi")}
+            value={r.shippedWithAi}
+            onChange={(v) => update("shippedWithAi", v)}
+          />
+          {r.shippedWithAi === true ? (
+            <Field label="Brief description">
+              <textarea
+                maxLength={INTAKE_LIMITS.longText}
+                rows={3}
+                value={r.shippedWithAiDescription ?? ""}
+                onChange={(e) => update("shippedWithAiDescription", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+          ) : null}
+
+          <Field label="Hours/week using AI tools (work or projects) — past month" required invalid={isMissing("hoursPerWeekAi")}>
+            <input
+              type="number"
+              min={0}
+              max={INTAKE_LIMITS.maxHoursPerWeek}
+              value={r.hoursPerWeekAi ?? ""}
+              onChange={(e) => update("hoursPerWeekAi", e.target.value === "" ? null : Number(e.target.value))}
+              className={INPUT_CLASS}
+            />
+          </Field>
+        </fieldset>
+
+        {/* ----------------------------------------------------------------
+            Section 5: Algorithmic platform exposure
+           ---------------------------------------------------------------- */}
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            5. Algorithmic platform exposure
+          </legend>
+
+          <Field label="Hours/week, average across social platforms — past 3 months" required invalid={isMissing("hoursPerWeekSocial")}>
+            <input
+              type="number"
+              min={0}
+              max={INTAKE_LIMITS.maxHoursPerWeek}
+              value={r.hoursPerWeekSocial ?? ""}
+              onChange={(e) => update("hoursPerWeekSocial", e.target.value === "" ? null : Number(e.target.value))}
+              className={INPUT_CLASS}
+            />
+            <p className="mt-1 text-xs text-neutral-500">
+              {SOCIAL_PLATFORM_OPTIONS.join(", ")}, etc.
+            </p>
+          </Field>
+
+          <YesNo
+            label="Posted content as a creator on any algorithmic platform in the past 2 years"
+            required
+            invalid={isMissing("postedAsCreator")}
+            value={r.postedAsCreator}
+            onChange={(v) => update("postedAsCreator", v)}
+          />
+          {r.postedAsCreator === true ? (
+            <Field label="Which platforms?">
+              <input
+                type="text"
+                maxLength={INTAKE_LIMITS.shortText}
+                value={r.postedAsCreatorWhich ?? ""}
+                onChange={(e) => update("postedAsCreatorWhich", e.target.value)}
+                placeholder="Comma-separated"
+                className={INPUT_CLASS}
+              />
+            </Field>
+          ) : null}
+
+          <YesNo
+            label="Worked on a gig labor platform (Uber, Lyft, DoorDash, Instacart, Upwork, Fiverr, etc.) in the past 3 years"
+            required
+            invalid={isMissing("gigPlatformWork")}
+            value={r.gigPlatformWork}
+            onChange={(v) => update("gigPlatformWork", v)}
+          />
+          {r.gigPlatformWork === true ? (
+            <Field label="Which platforms + approximate hours?">
+              <textarea
+                rows={2}
+                maxLength={INTAKE_LIMITS.longText}
+                value={r.gigPlatformDetails ?? ""}
+                onChange={(e) => update("gigPlatformDetails", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+          ) : null}
+
+          <LikertField
+            label="Self-rated understanding of how recommendation algorithms decide what to show users"
+            leftLabel="No understanding"
+            rightLabel="Expert understanding"
+            value={r.algorithmUnderstanding}
+            onChange={(v) => update("algorithmUnderstanding", v)}
+            invalid={isMissing("algorithmUnderstanding")}
+          />
+        </fieldset>
+
+        {/* ----------------------------------------------------------------
+            Section 6: Self-rated baseline (single items, NOT a scale)
+           ---------------------------------------------------------------- */}
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            6. Self-rated baseline
+          </legend>
+          <p className="text-xs text-neutral-500">
+            Two single items, kept deliberately separate from construct
+            measurement. 1 = strongly disagree, 7 = strongly agree.
+          </p>
+
+          <LikertField
+            label='"I am effective at getting useful results from AI tools."'
+            leftLabel="Strongly disagree"
+            rightLabel="Strongly agree"
+            value={r.baselineEffective}
+            onChange={(v) => update("baselineEffective", v)}
+            invalid={isMissing("baselineEffective")}
+          />
+
+          <LikertField
+            label='"I understand what AI tools can and cannot do."'
+            leftLabel="Strongly disagree"
+            rightLabel="Strongly agree"
+            value={r.baselineUnderstanding}
+            onChange={(v) => update("baselineUnderstanding", v)}
+            invalid={isMissing("baselineUnderstanding")}
+          />
+        </fieldset>
+
+        {/* ----------------------------------------------------------------
+            Section 7: Program intent
+           ---------------------------------------------------------------- */}
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            7. Program intent
+          </legend>
+
+          <Field label="Why did you join the program? (one paragraph)" required invalid={isMissing("whyJoined")}>
+            <textarea
+              rows={4}
+              maxLength={INTAKE_LIMITS.longText}
+              value={r.whyJoined}
+              onChange={(e) => update("whyJoined", e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field label="Your primary goal at the end of 8 weeks (1–2 sentences)" required invalid={isMissing("eightWeekGoal")}>
+            <textarea
+              rows={3}
+              maxLength={INTAKE_LIMITS.longText}
+              value={r.eightWeekGoal}
+              onChange={(e) => update("eightWeekGoal", e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+        </fieldset>
+
+        {/* ----------------------------------------------------------------
+            Submit
+           ---------------------------------------------------------------- */}
+        {error ? (
+          <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? "Submitting…" : "Submit & unlock dashboard"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function Field({
+  label,
+  required,
+  invalid,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  invalid?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={invalid ? "rounded-lg border border-red-400 bg-red-50/40 p-2 dark:bg-red-950/20" : ""}>
+      <label className="block text-sm font-medium">
+        {label}
+        {required ? <span className="text-red-500"> *</span> : null}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function FieldEmail({
+  value,
+  onChange,
+  invalid,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  invalid: boolean;
+}) {
+  return (
+    <Field label="Email address" required invalid={invalid}>
+      <input
+        type="email"
+        required
+        maxLength={INTAKE_LIMITS.email}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={INPUT_CLASS}
+      />
+      <p className="mt-1 text-xs text-neutral-500">
+        Pre-filled from your account. Edit if a different address is better for
+        research correspondence.
+      </p>
+    </Field>
+  );
+}
+
+function YesNo({
+  label,
+  required,
+  invalid,
+  value,
+  onChange,
+}: {
+  label: string;
+  required?: boolean;
+  invalid?: boolean;
+  value: boolean | null;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <Field label={label} required={required} invalid={invalid}>
+      <div className="mt-1 flex gap-4 text-sm">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="radio"
+            checked={value === true}
+            onChange={() => onChange(true)}
+          />
+          Yes
+        </label>
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="radio"
+            checked={value === false}
+            onChange={() => onChange(false)}
+          />
+          No
+        </label>
+      </div>
+    </Field>
+  );
+}
+
+function CheckboxGrid({
+  options,
+  selected,
+  onToggle,
+}: {
+  options: readonly string[];
+  selected: readonly string[];
+  onToggle: (value: string) => void;
+}) {
+  return (
+    <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
+      {options.map((opt) => (
+        <label key={opt} className="inline-flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={selected.includes(opt)}
+            onChange={() => onToggle(opt)}
+          />
+          {opt}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function LikertField({
+  label,
+  leftLabel,
+  rightLabel,
+  value,
+  onChange,
+  invalid,
+}: {
+  label: string;
+  leftLabel: string;
+  rightLabel: string;
+  value: number | null;
+  onChange: (v: number) => void;
+  invalid?: boolean;
+}) {
+  return (
+    <Field label={label} required invalid={invalid}>
+      <div className="mt-2 flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
+        <span className="w-32 text-right">{leftLabel}</span>
+        <div className="flex flex-1 justify-between">
+          {[1, 2, 3, 4, 5, 6, 7].map((n) => (
+            <label key={n} className="flex flex-col items-center gap-1">
+              <input
+                type="radio"
+                checked={value === n}
+                onChange={() => onChange(n)}
+              />
+              <span className="text-xs text-neutral-500">{n}</span>
+            </label>
+          ))}
+        </div>
+        <span className="w-32">{rightLabel}</span>
+      </div>
+    </Field>
+  );
+}

--- a/app/summer-cohort/_components/IntakeSurveyForm.tsx
+++ b/app/summer-cohort/_components/IntakeSurveyForm.tsx
@@ -109,7 +109,6 @@ type Props = {
 
 const EMPTY: IntakeSurveyResponse = {
   email: "",
-  participantCode: "",
   cohort: "",
   consentToResearch: false,
 
@@ -250,22 +249,6 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
             onChange={(v) => update("email", v)}
             invalid={isMissing("email")}
           />
-
-          <Field label="Self-generated participant code" required invalid={isMissing("participantCode")}>
-            <input
-              type="text"
-              required
-              maxLength={INTAKE_LIMITS.participantCode}
-              value={r.participantCode}
-              onChange={(e) => update("participantCode", e.target.value)}
-              placeholder="e.g. last 4 of phone + first 2 letters of mother's first name"
-              className={INPUT_CLASS}
-            />
-            <p className="mt-1 text-xs text-neutral-500">
-              Pick a rule and use the same code on every wave so we can match
-              your responses across the program even if your email changes.
-            </p>
-          </Field>
 
           <Field label="Cohort" required invalid={isMissing("cohort")}>
             <input

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -34,6 +34,7 @@ import { ClaimSpotByPRCard } from "./_components/ClaimSpotByPRCard";
 import { CohortProgramBreakdown } from "./_components/CohortProgramBreakdown";
 import { CohortTabs, type CohortTabId } from "./_components/CohortTabs";
 import { InfoTabPanel } from "./_components/InfoTabPanel";
+import { IntakeSurveyForm } from "./_components/IntakeSurveyForm";
 import { Week4LudwittPanel } from "./_components/Week4LudwittPanel";
 import { Week5StartupPanel } from "./_components/Week5StartupPanel";
 import { Week6OssPanel } from "./_components/Week6OssPanel";
@@ -463,6 +464,11 @@ function SummerCohortPageInner() {
   const [applicationCounts, setApplicationCounts] = useState<ApplicationCounts>({});
   const [appLoading, setAppLoading] = useState(false);
   const [appLoadError, setAppLoadError] = useState<string | null>(null);
+  // Intake survey gate state. Admitted Cohort 1 applicants must complete
+  // the intake survey before the tabbed dashboard is rendered.
+  const [intakeStatus, setIntakeStatus] = useState<
+    "unknown" | "loading" | "completed" | "incomplete" | "error"
+  >("unknown");
 
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
@@ -544,6 +550,39 @@ function SummerCohortPageInner() {
       cancelled = true;
     };
   }, [loading, user]);
+
+  // Fetch intake-survey status whenever the user is an admitted Cohort 1
+  // applicant. Non-admitted users never see the gate, so the effect short-
+  // circuits without touching state — `showSurveyGate` already requires
+  // `showTabs`, so a stale `intakeStatus` can't leak through to the UI.
+  useEffect(() => {
+    if (loading || !user) return;
+    if (
+      application?.status !== "admitted" ||
+      !application.cohorts.includes("cohort-1")
+    ) {
+      return;
+    }
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
+    setIntakeStatus("loading");
+    (async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/summer-cohort/intake-survey", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error(`status_${res.status}`);
+        const json = (await res.json()) as { completed: boolean };
+        if (!cancelled) setIntakeStatus(json.completed ? "completed" : "incomplete");
+      } catch {
+        if (!cancelled) setIntakeStatus("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loading, user, application]);
 
   // Handle OAuth callbacks landed on this page.
   useEffect(() => {
@@ -705,7 +744,11 @@ function SummerCohortPageInner() {
   const showTabs =
     application?.status === "admitted" &&
     application.cohorts.includes("cohort-1");
-  const myInfoVisible = !showTabs || activeTab === "my-info";
+  // Tabs only render once the intake survey is completed. The gate is the
+  // form; treating "unknown" as gating prevents a flash of the dashboard
+  // before the intake-survey GET resolves.
+  const showSurveyGate = showTabs && intakeStatus !== "completed";
+  const myInfoVisible = (!showTabs && !showSurveyGate) || activeTab === "my-info";
   const cohort1Count = applicationCounts["cohort-1"] ?? 0;
 
   const localityDone =
@@ -776,7 +819,31 @@ function SummerCohortPageInner() {
       ) : (
         <>
           {application ? (
-            showTabs ? (
+            showSurveyGate ? (
+              <>
+                <ApplicationStatusPanel
+                  application={application}
+                  cohortLabel={cohortLabel}
+                />
+                {intakeStatus === "loading" || intakeStatus === "unknown" ? (
+                  <div className="mt-6 rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500 dark:border-neutral-800">
+                    Loading intake survey…
+                  </div>
+                ) : intakeStatus === "error" ? (
+                  <div className="mt-6 rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+                    Couldn&apos;t load the intake survey. Refresh the page.
+                  </div>
+                ) : (
+                  <div className="mt-6">
+                    <IntakeSurveyForm
+                      defaultEmail={user?.email ?? application.email ?? ""}
+                      cohortId={application.cohorts[0] ?? "cohort-1"}
+                      onComplete={() => setIntakeStatus("completed")}
+                    />
+                  </div>
+                )}
+              </>
+            ) : showTabs ? (
               <>
                 <ApplicationStatusPanel
                   application={application}

--- a/lib/summer-cohort-intake.ts
+++ b/lib/summer-cohort-intake.ts
@@ -138,7 +138,6 @@ export const SOCIAL_PLATFORM_OPTIONS = [
 // ---------------------------------------------------------------------------
 
 export const INTAKE_LIMITS = {
-  participantCode: 64,
   email: 320,
   shortText: 200,
   longText: 2000,
@@ -157,7 +156,6 @@ export const INTAKE_LIMITS = {
 export type IntakeSurveyResponse = {
   // Section 1: Linkage and consent
   email: string;
-  participantCode: string;
   cohort: string;
   consentToResearch: boolean;
 
@@ -277,7 +275,6 @@ export function validateIntakeSurvey(
 
   const data: IntakeSurveyResponse = {
     email: clampStr(r.email, INTAKE_LIMITS.email).toLowerCase(),
-    participantCode: clampStr(r.participantCode, INTAKE_LIMITS.participantCode),
     cohort: clampStr(r.cohort, 64),
     consentToResearch: r.consentToResearch === true,
 
@@ -339,7 +336,6 @@ export function validateIntakeSurvey(
   // conditional follow-ups is required so the dataset is analyzable.
   const errors: string[] = [];
   if (!data.email) errors.push("email");
-  if (!data.participantCode) errors.push("participantCode");
   if (!data.cohort) errors.push("cohort");
   if (!data.consentToResearch) errors.push("consentToResearch");
   if (data.age == null) errors.push("age");

--- a/lib/summer-cohort-intake.ts
+++ b/lib/summer-cohort-intake.ts
@@ -1,0 +1,382 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Summer Cohort intake survey — pilot instrument (c1-v1).
+ *
+ * Three jobs at intake (per the research design):
+ *   1. Linkage — reconnect each respondent across waves
+ *   2. Antecedent conditions the variance puzzle predicts will matter
+ *   3. Demographic controls a scale-validation reviewer will demand
+ *
+ * Construct measurement (algorithmacy item pool, AI literacy scales,
+ * coordination self-ratings, personality controls) is intentionally OUT.
+ * Those belong at later waves once content review is done.
+ *
+ * Target completion time: 4–7 minutes for the median respondent.
+ */
+
+export const SUMMER_COHORT_INTAKE_COLLECTION = "summerCohortIntakeSurveys";
+export const SUMMER_COHORT_INTAKE_VERSION = "c1-v1";
+
+// ---------------------------------------------------------------------------
+// Enums (string literal unions)
+// ---------------------------------------------------------------------------
+
+export const GENDER_OPTIONS = [
+  "woman",
+  "man",
+  "non-binary",
+  "prefer-self-describe",
+  "prefer-not-to-say",
+] as const;
+export type GenderOption = (typeof GENDER_OPTIONS)[number];
+
+export const ENGLISH_PROFICIENCY_OPTIONS = [
+  "beginner",
+  "intermediate",
+  "advanced",
+  "native",
+] as const;
+export type EnglishProficiency = (typeof ENGLISH_PROFICIENCY_OPTIONS)[number];
+
+export const HIGHEST_DEGREE_OPTIONS = [
+  "none",
+  "high-school",
+  "associate",
+  "bachelors",
+  "masters",
+  "doctorate",
+  "other",
+] as const;
+export type HighestDegree = (typeof HIGHEST_DEGREE_OPTIONS)[number];
+
+export const EMPLOYMENT_OPTIONS = ["yes", "no", "part-time"] as const;
+export type EmploymentStatus = (typeof EMPLOYMENT_OPTIONS)[number];
+
+export const YEARS_PROGRAMMING_OPTIONS = [
+  "none",
+  "less-than-1",
+  "1-3",
+  "3-5",
+  "5-10",
+  "more-than-10",
+] as const;
+export type YearsProgramming = (typeof YEARS_PROGRAMMING_OPTIONS)[number];
+
+export const CS_CREDENTIAL_OPTIONS = [
+  "none",
+  "self-taught",
+  "bootcamp",
+  "undergraduate",
+  "graduate",
+  "industry-cert",
+] as const;
+export type CsCredential = (typeof CS_CREDENTIAL_OPTIONS)[number];
+
+export const LLM_FREQUENCY_OPTIONS = [
+  "never",
+  "monthly",
+  "weekly",
+  "several-times-week",
+  "daily",
+  "multi-hours-day",
+] as const;
+export type LlmFrequency = (typeof LLM_FREQUENCY_OPTIONS)[number];
+
+export const CURSOR_EXPERIENCE_OPTIONS = [
+  "never",
+  "tried",
+  "regular",
+  "daily",
+] as const;
+export type CursorExperience = (typeof CURSOR_EXPERIENCE_OPTIONS)[number];
+
+// Suggested options for multi-select fields. Form also includes "other" free text.
+export const PROGRAMMING_LANGUAGE_OPTIONS = [
+  "Python",
+  "JavaScript",
+  "TypeScript",
+  "Java",
+  "C/C++",
+  "C#",
+  "Go",
+  "Rust",
+  "Ruby",
+  "PHP",
+  "Swift",
+  "Kotlin",
+  "SQL",
+  "R",
+  "MATLAB",
+  "Shell/Bash",
+] as const;
+
+export const AI_TOOL_OPTIONS = [
+  "ChatGPT",
+  "Claude",
+  "Gemini",
+  "Copilot",
+  "Claude Code",
+  "Cursor",
+] as const;
+
+export const SOCIAL_PLATFORM_OPTIONS = [
+  "Instagram",
+  "TikTok",
+  "YouTube",
+  "X",
+  "Reddit",
+  "LinkedIn",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Field length / range limits — server-side validation enforces these
+// ---------------------------------------------------------------------------
+
+export const INTAKE_LIMITS = {
+  participantCode: 64,
+  email: 320,
+  shortText: 200,
+  longText: 2000,
+  maxAge: 120,
+  minAge: 13,
+  maxYearsExperience: 80,
+  minFirstAiYear: 1990,
+  maxFirstAiYear: 2030,
+  maxHoursPerWeek: 168,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Wire shape — what the client POSTs and what we persist (sans timestamps)
+// ---------------------------------------------------------------------------
+
+export type IntakeSurveyResponse = {
+  // Section 1: Linkage and consent
+  email: string;
+  participantCode: string;
+  cohort: string;
+  consentToResearch: boolean;
+
+  // Section 2: Demographics
+  age: number | null;
+  gender: GenderOption | null;
+  genderSelfDescribed: string | null;
+  countryOfResidence: string;
+  countryOfBirth: string;
+  nativeLanguages: string;
+  englishProficiency: EnglishProficiency | null;
+  highestDegree: HighestDegree | null;
+  highestDegreeOther: string | null;
+  degreeField: string;
+  employmentStatus: EmploymentStatus | null;
+
+  // Section 3: Programming background
+  yearsProgramming: YearsProgramming | null;
+  programmingLanguages: string[];
+  programmingLanguagesOther: string | null;
+  priorEngineerEmployment: boolean | null;
+  priorEngineerYears: number | null;
+  csCredential: CsCredential | null;
+
+  // Section 4: AI tool exposure
+  firstAiYear: number | null;
+  llmFrequency: LlmFrequency | null;
+  aiToolsUsed: string[];
+  aiToolsOther: string | null;
+  cursorExperience: CursorExperience | null;
+  shippedWithAi: boolean | null;
+  shippedWithAiDescription: string | null;
+  hoursPerWeekAi: number | null;
+
+  // Section 5: Algorithmic platform exposure
+  hoursPerWeekSocial: number | null;
+  postedAsCreator: boolean | null;
+  postedAsCreatorWhich: string | null;
+  gigPlatformWork: boolean | null;
+  gigPlatformDetails: string | null;
+  algorithmUnderstanding: number | null; // 1–7
+
+  // Section 6: Self-rated baseline (single items, NOT a scale)
+  baselineEffective: number | null; // 1–7
+  baselineUnderstanding: number | null; // 1–7
+
+  // Section 7: Program intent
+  whyJoined: string;
+  eightWeekGoal: string;
+};
+
+export type IntakeSurveyDoc = IntakeSurveyResponse & {
+  uid: string;
+  surveyVersion: string;
+  submittedAt: number; // ms
+  lastUpdatedAt: number; // ms
+};
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function isStr(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+function clampStr(v: unknown, max: number): string {
+  if (!isStr(v)) return "";
+  return v.trim().slice(0, max);
+}
+
+function intOrNull(v: unknown, min: number, max: number): number | null {
+  if (typeof v !== "number" || !Number.isFinite(v)) return null;
+  const n = Math.round(v);
+  if (n < min || n > max) return null;
+  return n;
+}
+
+function likertOrNull(v: unknown): number | null {
+  return intOrNull(v, 1, 7);
+}
+
+function inEnum<T extends string>(
+  v: unknown,
+  options: readonly T[]
+): T | null {
+  if (!isStr(v)) return null;
+  return (options as readonly string[]).includes(v) ? (v as T) : null;
+}
+
+function boolOrNull(v: unknown): boolean | null {
+  return typeof v === "boolean" ? v : null;
+}
+
+function strArrayClamped(v: unknown, maxItems: number, maxLen: number): string[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter(isStr)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .slice(0, maxItems)
+    .map((s) => s.slice(0, maxLen));
+}
+
+/**
+ * Coerce + validate a wire payload into an IntakeSurveyResponse. Returns
+ * { ok: true, data } on success, or { ok: false, errors } with a list of
+ * required-field violations so the client can highlight them.
+ */
+export function validateIntakeSurvey(
+  raw: unknown
+): { ok: true; data: IntakeSurveyResponse } | { ok: false; errors: string[] } {
+  if (!raw || typeof raw !== "object") {
+    return { ok: false, errors: ["Invalid payload"] };
+  }
+  const r = raw as Record<string, unknown>;
+
+  const data: IntakeSurveyResponse = {
+    email: clampStr(r.email, INTAKE_LIMITS.email).toLowerCase(),
+    participantCode: clampStr(r.participantCode, INTAKE_LIMITS.participantCode),
+    cohort: clampStr(r.cohort, 64),
+    consentToResearch: r.consentToResearch === true,
+
+    age: intOrNull(r.age, INTAKE_LIMITS.minAge, INTAKE_LIMITS.maxAge),
+    gender: inEnum(r.gender, GENDER_OPTIONS),
+    genderSelfDescribed: r.gender === "prefer-self-describe"
+      ? clampStr(r.genderSelfDescribed, INTAKE_LIMITS.shortText) || null
+      : null,
+    countryOfResidence: clampStr(r.countryOfResidence, INTAKE_LIMITS.shortText),
+    countryOfBirth: clampStr(r.countryOfBirth, INTAKE_LIMITS.shortText),
+    nativeLanguages: clampStr(r.nativeLanguages, INTAKE_LIMITS.shortText),
+    englishProficiency: inEnum(r.englishProficiency, ENGLISH_PROFICIENCY_OPTIONS),
+    highestDegree: inEnum(r.highestDegree, HIGHEST_DEGREE_OPTIONS),
+    highestDegreeOther: r.highestDegree === "other"
+      ? clampStr(r.highestDegreeOther, INTAKE_LIMITS.shortText) || null
+      : null,
+    degreeField: clampStr(r.degreeField, INTAKE_LIMITS.shortText),
+    employmentStatus: inEnum(r.employmentStatus, EMPLOYMENT_OPTIONS),
+
+    yearsProgramming: inEnum(r.yearsProgramming, YEARS_PROGRAMMING_OPTIONS),
+    programmingLanguages: strArrayClamped(r.programmingLanguages, 30, 64),
+    programmingLanguagesOther: clampStr(r.programmingLanguagesOther, INTAKE_LIMITS.shortText) || null,
+    priorEngineerEmployment: boolOrNull(r.priorEngineerEmployment),
+    priorEngineerYears: r.priorEngineerEmployment === true
+      ? intOrNull(r.priorEngineerYears, 0, INTAKE_LIMITS.maxYearsExperience)
+      : null,
+    csCredential: inEnum(r.csCredential, CS_CREDENTIAL_OPTIONS),
+
+    firstAiYear: intOrNull(r.firstAiYear, INTAKE_LIMITS.minFirstAiYear, INTAKE_LIMITS.maxFirstAiYear),
+    llmFrequency: inEnum(r.llmFrequency, LLM_FREQUENCY_OPTIONS),
+    aiToolsUsed: strArrayClamped(r.aiToolsUsed, 30, 64),
+    aiToolsOther: clampStr(r.aiToolsOther, INTAKE_LIMITS.shortText) || null,
+    cursorExperience: inEnum(r.cursorExperience, CURSOR_EXPERIENCE_OPTIONS),
+    shippedWithAi: boolOrNull(r.shippedWithAi),
+    shippedWithAiDescription: r.shippedWithAi === true
+      ? clampStr(r.shippedWithAiDescription, INTAKE_LIMITS.longText) || null
+      : null,
+    hoursPerWeekAi: intOrNull(r.hoursPerWeekAi, 0, INTAKE_LIMITS.maxHoursPerWeek),
+
+    hoursPerWeekSocial: intOrNull(r.hoursPerWeekSocial, 0, INTAKE_LIMITS.maxHoursPerWeek),
+    postedAsCreator: boolOrNull(r.postedAsCreator),
+    postedAsCreatorWhich: r.postedAsCreator === true
+      ? clampStr(r.postedAsCreatorWhich, INTAKE_LIMITS.shortText) || null
+      : null,
+    gigPlatformWork: boolOrNull(r.gigPlatformWork),
+    gigPlatformDetails: r.gigPlatformWork === true
+      ? clampStr(r.gigPlatformDetails, INTAKE_LIMITS.longText) || null
+      : null,
+    algorithmUnderstanding: likertOrNull(r.algorithmUnderstanding),
+
+    baselineEffective: likertOrNull(r.baselineEffective),
+    baselineUnderstanding: likertOrNull(r.baselineUnderstanding),
+
+    whyJoined: clampStr(r.whyJoined, INTAKE_LIMITS.longText),
+    eightWeekGoal: clampStr(r.eightWeekGoal, INTAKE_LIMITS.longText),
+  };
+
+  // Required-field check. The instrument is short; everything except the
+  // conditional follow-ups is required so the dataset is analyzable.
+  const errors: string[] = [];
+  if (!data.email) errors.push("email");
+  if (!data.participantCode) errors.push("participantCode");
+  if (!data.cohort) errors.push("cohort");
+  if (!data.consentToResearch) errors.push("consentToResearch");
+  if (data.age == null) errors.push("age");
+  if (!data.gender) errors.push("gender");
+  if (data.gender === "prefer-self-describe" && !data.genderSelfDescribed) {
+    errors.push("genderSelfDescribed");
+  }
+  if (!data.countryOfResidence) errors.push("countryOfResidence");
+  if (!data.countryOfBirth) errors.push("countryOfBirth");
+  if (!data.nativeLanguages) errors.push("nativeLanguages");
+  if (!data.englishProficiency) errors.push("englishProficiency");
+  if (!data.highestDegree) errors.push("highestDegree");
+  if (data.highestDegree === "other" && !data.highestDegreeOther) {
+    errors.push("highestDegreeOther");
+  }
+  if (!data.degreeField) errors.push("degreeField");
+  if (!data.employmentStatus) errors.push("employmentStatus");
+  if (!data.yearsProgramming) errors.push("yearsProgramming");
+  if (data.priorEngineerEmployment === null) errors.push("priorEngineerEmployment");
+  if (data.priorEngineerEmployment === true && data.priorEngineerYears === null) {
+    errors.push("priorEngineerYears");
+  }
+  if (!data.csCredential) errors.push("csCredential");
+  if (data.firstAiYear == null) errors.push("firstAiYear");
+  if (!data.llmFrequency) errors.push("llmFrequency");
+  if (!data.cursorExperience) errors.push("cursorExperience");
+  if (data.shippedWithAi === null) errors.push("shippedWithAi");
+  if (data.hoursPerWeekAi == null) errors.push("hoursPerWeekAi");
+  if (data.hoursPerWeekSocial == null) errors.push("hoursPerWeekSocial");
+  if (data.postedAsCreator === null) errors.push("postedAsCreator");
+  if (data.gigPlatformWork === null) errors.push("gigPlatformWork");
+  if (data.algorithmUnderstanding == null) errors.push("algorithmUnderstanding");
+  if (data.baselineEffective == null) errors.push("baselineEffective");
+  if (data.baselineUnderstanding == null) errors.push("baselineUnderstanding");
+  if (!data.whyJoined) errors.push("whyJoined");
+  if (!data.eightWeekGoal) errors.push("eightWeekGoal");
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, data };
+}


### PR DESCRIPTION
## Summary

Pilot research instrument (\`c1-v1\`) for admitted Cohort 1 applicants. Once admitted, applicants must complete a 4–7 minute intake survey before they can see the tabbed dashboard.

The survey does three jobs (per the research design): linkage across waves, captures antecedent conditions the variance puzzle predicts will matter, and loads the demographic controls a scale-validation reviewer will demand. Construct measurement (algorithmacy item pool, AI-literacy scales, etc.) is intentionally out — those belong at later waves once Paper 2's content review is done.

### Included commits

- \`b08206d\` **intake survey gates the admitted dashboard** — new \`lib/summer-cohort-intake.ts\` (types + validation), \`/api/summer-cohort/intake-survey\` (GET + POST, gated to \`status === "admitted"\`), \`IntakeSurveyForm.tsx\` with conditional follow-ups + Likert items, gate wired into \`/summer-cohort\` page. Stored in new \`summerCohortIntakeSurveys/{uid}\` collection with \`surveyVersion: "c1-v1"\`.
- \`cfdff31\` **drop participant code** — over-engineered for a pilot; email already gives us linkage.
- \`7d9778a\` **authorize POST + localStorage drafts** — wires the Bearer token (was returning 401), adds per-keystroke \`localStorage\` persistence keyed by \`<surveyVersion>:<uid>\` so refreshes don't lose the work, "Draft restored" pill on hydration, draft cleared on successful submit.

### Sections

1. Linkage & consent (email + cohort + IRB consent)
2. Demographics (age, gender, country of residence/birth, languages, English proficiency, degree + field, employment)
3. Programming background (years, languages multi-select, prior engineer employment, CS credential)
4. AI tool exposure (first-AI year, LLM frequency, tools used, Cursor experience, shipped-with-AI yes/no, hours/week)
5. Algorithmic platform exposure (social hours/week, posted-as-creator, gig platform work, algorithm understanding 1–7)
6. Self-rated baseline (two single items, NOT a scale — effective + understanding 1–7)
7. Program intent (why joined, 8-week goal)

## Test plan
- [x] tsc clean
- [x] lint clean
- [x] Local prod build runs at http://localhost:3000 — admitted Cohort 1 user sees survey gate, submits, lands on dashboard
- [ ] After deploy: same flow on production
- [ ] After deploy: refresh mid-fill restores draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)