### PR TITLE
fix(a11y): show skip link only on keyboard focus, anchor to viewport

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -117,7 +117,7 @@ export default function RootLayout({
       <body className="antialiased bg-background text-foreground min-h-screen flex flex-col">
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-100 focus:px-4 focus:py-2 focus:bg-foreground focus:text-background focus:rounded-lg focus:font-semibold"
+          className="sr-only focus-visible:not-sr-only focus-visible:fixed focus-visible:top-4 focus-visible:left-4 focus-visible:z-100 focus-visible:px-4 focus-visible:py-2 focus-visible:bg-foreground focus-visible:text-background focus-visible:rounded-lg focus-visible:font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           Skip to main content
         </a>


### PR DESCRIPTION
## Description

Closes #554.

The skip link to `#main-content` already existed in `app/layout.tsx`, but used the `focus:` variant — which also matches mouse focus, so a sighted user clicking around the header would briefly see the pill flash at the top-left. The audit's acceptance criteria explicitly says **\`:focus-visible\`**, which is the keyboard-only state we actually want.

### Changes

Single file: `app/layout.tsx`. Two semantic fixes plus a focus ring:

1. **\`focus:\` → \`focus-visible:\`** on every utility. The pill now only appears for keyboard navigation (Tab from the top of the page), never on mouse clicks.
2. **\`focus-visible:absolute\` → \`focus-visible:fixed\`.** \`absolute\` positions relative to the closest positioned ancestor; \`<body>\` has none, so it falls back to the initial containing block. \`fixed\` is unambiguously viewport-anchored — what a skip link should always be.
3. Added \`focus-visible:ring-*\` to put a visible focus ring around the pill, matching the \`focus-visible\` treatment used elsewhere in \`AppShell.tsx\` (sidebar links, theme toggle, etc.).

### Acceptance criteria

- [x] Skip link renders and is keyboard accessible — Tab from page top focuses the pill
- [x] Targets exist on all pages — verified `<main id="main-content" tabIndex={-1}>` in `components/AppShell.tsx:480`; layout wraps every route
- [x] Visible on `:focus-visible` — verified via `link.matches(':focus-visible')` and computed style after a real Tab press

## Type of Change

- [x] Accessibility improvement

## How Has This Been Tested?

Browser-tested locally with `npm run dev`:

| Test | Result |
|---|---|
| Tab from page top → pill appears at top-left | ✅ fixed, top-4 left-4, z-100, 187×40 px |
| Enter while focused → focus moves to `<main>` | ✅ \`document.activeElement.id === 'main-content'\` |
| Mouse click on sidebar link → skip link stays hidden | ✅ \`:focus-visible\` does not match mouse focus |
| Light mode rendering | ✅ black pill, white text |
| Dark mode rendering | ✅ white pill, black text (via \`bg-foreground\` / \`text-background\` token inversion) |

Also ran:

- `npm run lint` → 0 errors, 0 new warnings (the 42 warnings on `develop` in `hooks/useFeed.ts` etc. are pre-existing; verified by stashing and re-running)
- `npm run type-check` → clean

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes