### PR TITLE
feat(partners): $150k engineer profile — Likert + open requirements

### DIFF
--- a/app/api/hiring-partners/apply/route.ts
+++ b/app/api/hiring-partners/apply/route.ts
@@ -16,7 +16,10 @@ import {
   HIRING_PARTNERS_COLLECTION,
   HIRING_PARTNERS_MAX,
   HIRING_PARTNERS_NOTIFY_EMAIL,
+  PARTNER_ENGINEER_EXPECTATION_ITEMS,
+  sanitizeEngineerExpectations,
   type HiringPartnerStatus,
+  type PartnerEngineerExpectationKey,
 } from "@/lib/hiring-partners";
 
 export const runtime = "nodejs";
@@ -32,6 +35,8 @@ interface PartnerApplicationDto {
   contactRole: string | null;
   rolesHiring: string | null;
   notes: string | null;
+  engineerExpectations: Record<PartnerEngineerExpectationKey, number> | Record<string, never>;
+  engineerRequirements: string | null;
   status: HiringPartnerStatus;
   createdAt: number | null;
   updatedAt: number | null;
@@ -56,6 +61,9 @@ function serializeApplication(data: Record<string, unknown>): PartnerApplication
     contactRole: typeof data.contactRole === "string" ? data.contactRole : null,
     rolesHiring: typeof data.rolesHiring === "string" ? data.rolesHiring : null,
     notes: typeof data.notes === "string" ? data.notes : null,
+    engineerExpectations: sanitizeEngineerExpectations(data.engineerExpectations),
+    engineerRequirements:
+      typeof data.engineerRequirements === "string" ? data.engineerRequirements : null,
     status,
     createdAt: toMillis(data.createdAt),
     updatedAt: toMillis(data.updatedAt),
@@ -115,6 +123,11 @@ async function handlePost(request: NextRequest) {
   const contactRole = trimOrEmpty(raw.contactRole, HIRING_PARTNERS_MAX.contactRole);
   const rolesHiring = trimOrEmpty(raw.rolesHiring, HIRING_PARTNERS_MAX.rolesHiring);
   const notes = trimOrEmpty(raw.notes, HIRING_PARTNERS_MAX.notes);
+  const engineerExpectations = sanitizeEngineerExpectations(raw.engineerExpectations);
+  const engineerRequirements = trimOrEmpty(
+    raw.engineerRequirements,
+    HIRING_PARTNERS_MAX.engineerRequirements
+  );
 
   if (!contactName) {
     return NextResponse.json({ error: "Please enter your name." }, { status: 400 });
@@ -141,6 +154,8 @@ async function handlePost(request: NextRequest) {
       contactRole,
       rolesHiring,
       notes,
+      engineerExpectations,
+      engineerRequirements,
       updatedAt: FieldValue.serverTimestamp(),
     };
     if (existing.exists) {
@@ -163,6 +178,8 @@ async function handlePost(request: NextRequest) {
         contactRole,
         rolesHiring,
         notes,
+        engineerExpectations,
+        engineerRequirements,
       }).catch((error) => {
         logger.logError(error, {
           endpoint: "/api/hiring-partners/apply",
@@ -203,6 +220,21 @@ interface NewApplicantPayload {
   contactRole: string;
   rolesHiring: string;
   notes: string;
+  engineerExpectations: Record<PartnerEngineerExpectationKey, number> | Record<string, never>;
+  engineerRequirements: string;
+}
+
+function formatEngineerExpectations(
+  exp: Record<PartnerEngineerExpectationKey, number> | Record<string, never>
+): string {
+  const lines = PARTNER_ENGINEER_EXPECTATION_ITEMS
+    .map((item) => {
+      const score = (exp as Record<string, number>)[item.key];
+      if (typeof score !== "number") return null;
+      return `    ${score}/7 — ${item.label}`;
+    })
+    .filter((s): s is string => s != null);
+  return lines.length === 0 ? "(skipped)" : "\n" + lines.join("\n");
 }
 
 async function sendNewApplicationEmail(applicant: NewApplicantPayload): Promise<void> {
@@ -215,6 +247,8 @@ async function sendNewApplicationEmail(applicant: NewApplicantPayload): Promise<
     ["Role / title", applicant.contactRole || "(not provided yet)"],
     ["Roles hiring", applicant.rolesHiring || "(not provided yet)"],
     ["Notes", applicant.notes || "(none)"],
+    ["$150k engineer profile", formatEngineerExpectations(applicant.engineerExpectations)],
+    ["Specific hiring requirements", applicant.engineerRequirements || "(none)"],
   ];
 
   const textLines = ["New Cursor Boston hiring partner application:", ""];

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -13,7 +13,9 @@ import {
   HIRING_PARTNERS_CALENDLY_URL,
   HIRING_PARTNERS_MAX,
   HIRING_PARTNERS_RETURN_TO,
+  PARTNER_ENGINEER_EXPECTATION_ITEMS,
   type HiringPartnerStatus,
+  type PartnerEngineerExpectationKey,
 } from "@/lib/hiring-partners";
 
 interface PartnerApplicationDto {
@@ -26,6 +28,8 @@ interface PartnerApplicationDto {
   contactRole: string | null;
   rolesHiring: string | null;
   notes: string | null;
+  engineerExpectations: Partial<Record<PartnerEngineerExpectationKey, number>>;
+  engineerRequirements: string | null;
   status: HiringPartnerStatus;
   createdAt: number | null;
   updatedAt: number | null;
@@ -126,6 +130,10 @@ export default function PartnersPage() {
   const [contactRole, setContactRole] = useState("");
   const [rolesHiring, setRolesHiring] = useState("");
   const [notes, setNotes] = useState("");
+  const [engineerExpectations, setEngineerExpectations] = useState<
+    Partial<Record<PartnerEngineerExpectationKey, number>>
+  >({});
+  const [engineerRequirements, setEngineerRequirements] = useState("");
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -162,6 +170,8 @@ export default function PartnersPage() {
           setContactRole(json.application.contactRole || "");
           setRolesHiring(json.application.rolesHiring || "");
           setNotes(json.application.notes || "");
+          setEngineerExpectations(json.application.engineerExpectations || {});
+          setEngineerRequirements(json.application.engineerRequirements || "");
         }
       } catch {
         if (!cancelled) setAppLoadError("Couldn't load your application.");
@@ -207,6 +217,8 @@ export default function PartnersPage() {
           contactRole: contactRole.trim(),
           rolesHiring: rolesHiring.trim(),
           notes: notes.trim(),
+          engineerExpectations,
+          engineerRequirements: engineerRequirements.trim(),
         }),
       });
       const json = await res.json();
@@ -410,6 +422,87 @@ export default function PartnersPage() {
                       className="mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
                     />
                   </div>
+                </div>
+              </div>
+
+              {/* $150k engineer profile — optional Likert + open requirements */}
+              <div className="rounded-lg border border-dashed border-neutral-300 p-4 dark:border-neutral-700">
+                <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                  $150k engineer profile — optional
+                </p>
+                <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+                  What does a $150k/year engineer look like to you? Rate how
+                  important each of the following is when evaluating a candidate
+                  at that level. <span className="font-medium">1 = nice to have</span>,{" "}
+                  <span className="font-medium">7 = critical</span>.
+                </p>
+
+                <div className="mt-4 space-y-3">
+                  {PARTNER_ENGINEER_EXPECTATION_ITEMS.map((item) => {
+                    const value = engineerExpectations[item.key];
+                    return (
+                      <div
+                        key={item.key}
+                        className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4"
+                      >
+                        <span className="flex-1 text-sm text-neutral-800 dark:text-neutral-200">
+                          {item.label}
+                        </span>
+                        <div className="flex items-center gap-1 text-xs text-neutral-500">
+                          <span className="hidden sm:inline">1</span>
+                          {[1, 2, 3, 4, 5, 6, 7].map((n) => (
+                            <label
+                              key={n}
+                              className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-neutral-300 hover:border-emerald-500 dark:border-neutral-700"
+                              style={
+                                value === n
+                                  ? { backgroundColor: "#10b981", color: "white", borderColor: "#10b981" }
+                                  : undefined
+                              }
+                            >
+                              <input
+                                type="radio"
+                                name={`hp-exp-${item.key}`}
+                                value={n}
+                                checked={value === n}
+                                onChange={() =>
+                                  setEngineerExpectations((prev) => ({
+                                    ...prev,
+                                    [item.key]: n,
+                                  }))
+                                }
+                                className="sr-only"
+                              />
+                              <span className="text-xs font-medium">{n}</span>
+                            </label>
+                          ))}
+                          <span className="hidden sm:inline">7</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="mt-6">
+                  <label
+                    htmlFor="hp-engineer-requirements"
+                    className="block text-sm font-medium"
+                  >
+                    Specific hiring requirements at this level
+                  </label>
+                  <p className="mt-1 text-xs text-neutral-500">
+                    Anything not captured above — must-have technologies,
+                    certifications, dealbreakers, comp band specifics,
+                    location/visa constraints, etc.
+                  </p>
+                  <textarea
+                    id="hp-engineer-requirements"
+                    rows={4}
+                    maxLength={HIRING_PARTNERS_MAX.engineerRequirements}
+                    value={engineerRequirements}
+                    onChange={(e) => setEngineerRequirements(e.target.value)}
+                    className="mt-2 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 dark:border-neutral-700 dark:bg-neutral-950"
+                  />
                 </div>
               </div>
 

--- a/lib/hiring-partners.ts
+++ b/lib/hiring-partners.ts
@@ -19,4 +19,83 @@ export const HIRING_PARTNERS_MAX = {
   contactRole: 200,
   rolesHiring: 2000,
   notes: 4000,
+  engineerRequirements: 4000,
 } as const;
+
+/**
+ * Likert items for the "what does a $150k/year engineer look like to you?"
+ * survey. Captured per-partner so we can compare what each partner weights
+ * when matching cohort builders to roles.
+ *
+ * Scale: 1 = nice to have, 7 = critical. Stored as a `Record<key, number>`
+ * on the partner application; missing keys mean the partner skipped.
+ */
+export const PARTNER_ENGINEER_EXPECTATION_ITEMS = [
+  {
+    key: "yearsExperience",
+    label: "Years of professional engineering experience",
+  },
+  {
+    key: "csFundamentals",
+    label: "CS fundamentals (algorithms, data structures, systems)",
+  },
+  {
+    key: "systemDesign",
+    label: "System design / architecture chops",
+  },
+  {
+    key: "aiToolFluency",
+    label: "AI-assisted coding fluency (Cursor, Claude Code, Copilot)",
+  },
+  {
+    key: "shipsEndToEnd",
+    label: "Ships features end-to-end with minimal supervision",
+  },
+  {
+    key: "productionDebugging",
+    label: "Production debugging + on-call ability",
+  },
+  {
+    key: "communication",
+    label: "Communication with non-engineers (PMs, founders, customers)",
+  },
+  {
+    key: "domainExpertise",
+    label: "Domain expertise in your stack or industry",
+  },
+  {
+    key: "mentorship",
+    label: "Mentoring or technical leadership",
+  },
+  {
+    key: "businessImpact",
+    label: "Track record of measurable business impact",
+  },
+] as const;
+
+export type PartnerEngineerExpectationKey =
+  (typeof PARTNER_ENGINEER_EXPECTATION_ITEMS)[number]["key"];
+
+/**
+ * Coerce a raw expectations payload into a `{ key: 1..7 }` map. Drops
+ * unknown keys, non-integer values, and out-of-range numbers. Safe to call
+ * on `unknown` from a request body.
+ */
+export function sanitizeEngineerExpectations(
+  raw: unknown
+): Record<PartnerEngineerExpectationKey, number> {
+  const out = {} as Record<PartnerEngineerExpectationKey, number>;
+  if (!raw || typeof raw !== "object") return out;
+  const obj = raw as Record<string, unknown>;
+  const validKeys = new Set<string>(
+    PARTNER_ENGINEER_EXPECTATION_ITEMS.map((i) => i.key)
+  );
+  for (const [k, v] of Object.entries(obj)) {
+    if (!validKeys.has(k)) continue;
+    if (typeof v !== "number" || !Number.isFinite(v)) continue;
+    const n = Math.round(v);
+    if (n < 1 || n > 7) continue;
+    out[k as PartnerEngineerExpectationKey] = n;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Adds a third optional section to the hiring partners apply form: a 10-item Likert (1 = nice to have, 7 = critical) capturing what each partner weights when evaluating a candidate at the \$150k/year level, plus an open-text field for specific hiring requirements (technologies, certifications, dealbreakers, comp band, location/visa, etc.).

The 10 items: years of professional experience, CS fundamentals, system design, AI-assisted coding fluency, ships features end-to-end with minimal supervision, production debugging, communication with non-engineers, domain expertise, mentorship, measurable business impact.

**Why:** lets us match cohort builders to partner roles using each partner's own weighting, not our assumptions about what "senior" means at their company. Captures partner-specific must-haves we'd otherwise have to ask for in the intro call.

### Files
- \`lib/hiring-partners.ts\` — \`PARTNER_ENGINEER_EXPECTATION_ITEMS\` (10 keyed items + labels), \`sanitizeEngineerExpectations()\` that drops unknown keys / non-int / out-of-range values, \`engineerRequirements\` maxLength.
- \`app/api/hiring-partners/apply/route.ts\` — accept + persist the new fields, include both in the new-application notification email (Likert formatted as \`5/7 — Years of professional engineering experience\`).
- \`app/partners/page.tsx\` — rendered as a new dashed-border section after Company info. Likert items use a 7-button radio grid with selected-state fill. Section is optional — submit still works with everything blank.

## Test plan
- [x] tsc clean, lint clean
- [x] All 19 hiring-partners tests still pass
- [x] Local build runs at http://localhost:3000/partners
- [ ] After deploy: fill the form on prod, verify roger receives notification email with the rendered Likert profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)