### PR TITLE
feat(partners): cc aaron@cursorboston.com on partner notifications

### DIFF
--- a/__tests__/app/api/hiring-partners/apply.test.ts
+++ b/__tests__/app/api/hiring-partners/apply.test.ts
@@ -127,7 +127,10 @@ describe("POST /api/hiring-partners/apply", () => {
     expect(mockSendEmail).toHaveBeenCalledTimes(1);
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "rogerhunt02052@gmail.com",
+        to: expect.arrayContaining([
+          "rogerhunt02052@gmail.com",
+          "aaron@cursorboston.com",
+        ]),
         subject: expect.stringContaining("Test Partner"),
       })
     );

--- a/__tests__/app/api/internal/digest/weekly-hiring-partners.test.ts
+++ b/__tests__/app/api/internal/digest/weekly-hiring-partners.test.ts
@@ -111,7 +111,12 @@ describe("GET /api/internal/digest/weekly-hiring-partners", () => {
     expect(json.emailSent).toBe(true);
     expect(mockSendEmail).toHaveBeenCalledTimes(1);
     const args = mockSendEmail.mock.calls[0][0];
-    expect(args.to).toBe("rogerhunt02052@gmail.com");
+    expect(args.to).toEqual(
+      expect.arrayContaining([
+        "rogerhunt02052@gmail.com",
+        "aaron@cursorboston.com",
+      ])
+    );
     expect(args.subject).toContain("2 pending");
     expect(args.text).toContain("Alice");
     expect(args.text).toContain("Bob");

--- a/lib/hiring-partners.ts
+++ b/lib/hiring-partners.ts
@@ -5,7 +5,10 @@
  */
 
 export const HIRING_PARTNERS_COLLECTION = "hiringPartnerApplications";
-export const HIRING_PARTNERS_NOTIFY_EMAIL = "rogerhunt02052@gmail.com";
+export const HIRING_PARTNERS_NOTIFY_EMAIL: string[] = [
+  "rogerhunt02052@gmail.com",
+  "aaron@cursorboston.com",
+];
 export const HIRING_PARTNERS_CALENDLY_URL = "https://calendly.com/rogerhunt";
 export const HIRING_PARTNERS_RETURN_TO = "/partners";
 


### PR DESCRIPTION
## Summary

Adds aaron@cursorboston.com as a recipient on both partner notification emails — the new-application notification (when a partner submits the apply form) and the weekly pending-applications digest cron.

\`HIRING_PARTNERS_NOTIFY_EMAIL\` is now a \`string[]\`; both call sites already pass it straight to \`sendEmail\`, which accepts \`string | string[]\`. One-line change at the constant covers both flows.

## Test plan
- [x] tsc clean, lint clean
- [x] All 19 hiring-partners tests still pass (assertions updated to arrayContaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)