### PR TITLE
release: PyData 2026 registration + Mailgun auto-suppression + Cohort partner profile

### DIFF
--- a/app/api/events/pydata-2026/admin/list/route.ts
+++ b/app/api/events/pydata-2026/admin/list/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import {
+  PYDATA_2026_REGISTRATIONS_COLLECTION,
+  type PydataRegistration,
+  type PydataRegistrationStatus,
+} from "@/lib/pydata-2026";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function tsToMs(value: unknown): number | null {
+  if (value && typeof (value as { toMillis?: () => number }).toMillis === "function") {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  return null;
+}
+
+const VALID_STATUSES: ReadonlyArray<PydataRegistrationStatus> = [
+  "awaiting-badge",
+  "badge-ready",
+  "checked-in",
+  "cancelled",
+];
+
+async function handleGet(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!user.isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  const snap = await db
+    .collection(PYDATA_2026_REGISTRATIONS_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const registrations: PydataRegistration[] = snap.docs
+    .map((doc) => {
+      const data = doc.data() || {};
+      const createdMs = tsToMs(data.createdAt);
+      if (createdMs === null) return null;
+      const updatedMs = tsToMs(data.updatedAt) ?? createdMs;
+      const rawStatus = typeof data.status === "string" ? data.status : "awaiting-badge";
+      const status: PydataRegistrationStatus = VALID_STATUSES.includes(
+        rawStatus as PydataRegistrationStatus
+      )
+        ? (rawStatus as PydataRegistrationStatus)
+        : "awaiting-badge";
+      return {
+        uid: doc.id,
+        firstName: typeof data.firstName === "string" ? data.firstName : "",
+        lastName: typeof data.lastName === "string" ? data.lastName : "",
+        email: typeof data.email === "string" ? data.email : "",
+        organization: typeof data.organization === "string" ? data.organization : "",
+        attendingConfirmed: true as const,
+        status,
+        createdAt: createdMs,
+        updatedAt: updatedMs,
+      };
+    })
+    .filter((r): r is PydataRegistration => r !== null);
+
+  const counts = registrations.reduce(
+    (acc, r) => {
+      acc[r.status] = (acc[r.status] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<PydataRegistrationStatus, number>
+  );
+
+  return NextResponse.json({
+    total: registrations.length,
+    counts,
+    registrations,
+  });
+}
+
+export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);

--- a/app/api/events/pydata-2026/registration/route.ts
+++ b/app/api/events/pydata-2026/registration/route.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import {
+  PYDATA_2026_REGISTRATIONS_COLLECTION,
+  validatePydataRegistration,
+  type PydataRegistration,
+  type PydataRegistrationStatus,
+} from "@/lib/pydata-2026";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function tsToMs(value: unknown): number | null {
+  if (value && typeof (value as { toMillis?: () => number }).toMillis === "function") {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  return null;
+}
+
+function serializeDoc(uid: string, data: Record<string, unknown>): PydataRegistration | null {
+  const createdMs = tsToMs(data.createdAt);
+  const updatedMs = tsToMs(data.updatedAt);
+  if (createdMs === null) return null;
+  const status = (typeof data.status === "string" ? data.status : "awaiting-badge") as
+    | PydataRegistrationStatus
+    | string;
+  return {
+    uid,
+    firstName: typeof data.firstName === "string" ? data.firstName : "",
+    lastName: typeof data.lastName === "string" ? data.lastName : "",
+    email: typeof data.email === "string" ? data.email : "",
+    organization: typeof data.organization === "string" ? data.organization : "",
+    attendingConfirmed: true,
+    status: (["awaiting-badge", "badge-ready", "checked-in", "cancelled"].includes(status)
+      ? status
+      : "awaiting-badge") as PydataRegistrationStatus,
+    createdAt: createdMs,
+    updatedAt: updatedMs ?? createdMs,
+  };
+}
+
+async function handleGet(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+  const snap = await db
+    .collection(PYDATA_2026_REGISTRATIONS_COLLECTION)
+    .doc(user.uid)
+    .get();
+  if (!snap.exists) {
+    return NextResponse.json({ registered: false, registration: null });
+  }
+  const reg = serializeDoc(user.uid, snap.data() || {});
+  return NextResponse.json({
+    registered: reg !== null,
+    registration: reg,
+  });
+}
+
+async function handlePost(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = validatePydataRegistration(body);
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: "Validation failed", missingFields: result.errors },
+      { status: 400 }
+    );
+  }
+
+  const docRef = db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).doc(user.uid);
+  const existing = await docRef.get();
+  const isFirstSubmission = !existing.exists;
+
+  await docRef.set(
+    {
+      ...result.data,
+      uid: user.uid,
+      // Preserve original createdAt + status across edits.
+      ...(isFirstSubmission
+        ? {
+            createdAt: FieldValue.serverTimestamp(),
+            status: "awaiting-badge",
+          }
+        : {}),
+      updatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  logger.info("[pydata-2026/registration] submission", {
+    uid: user.uid,
+    isFirstSubmission,
+    email: result.data.email,
+  });
+
+  return NextResponse.json({ ok: true, isFirstSubmission });
+}
+
+export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);
+export const POST = withMiddleware(rateLimitConfigs.standard, handlePost);

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -15,6 +15,10 @@ import {
   getLumaCheckoutEventId,
   getLumaCheckoutHref,
 } from "@/lib/luma-event";
+import {
+  PYDATA_2026_EVENT_SLUG,
+  PYDATA_2026_REGISTRATION_PATH,
+} from "@/lib/pydata-2026";
 
 // Type definitions for event data
 interface AgendaItem {
@@ -197,6 +201,7 @@ export default async function EventPage({
   }
 
   const websiteRegistration = WEBSITE_REGISTRATION_CONFIG[event.slug];
+  const isPyData = event.slug === PYDATA_2026_EVENT_SLUG;
 
   // Generate JSON-LD structured data
   const eventJsonLd = {
@@ -398,6 +403,30 @@ export default async function EventPage({
                 </div>
                 <p className="text-sm text-amber-600 dark:text-amber-400 mt-1 font-medium">
                   You must register on <strong>both</strong>: Luma (for door entry) <strong>and</strong> the website (for hackathon ranking &amp; prizes). One without the other won&apos;t get you in.
+                </p>
+              </div>
+            ) : isPyData ? (
+              <div className="flex flex-col gap-4">
+                <Link
+                  href={PYDATA_2026_REGISTRATION_PATH}
+                  className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black w-full sm:w-auto"
+                >
+                  Register for badge
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M5 12h14" /><path d="m12 5 7 7-7 7" /></svg>
+                </Link>
+                <a
+                  href={getLumaCheckoutHref(event)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-white/20 text-white/80 rounded-lg text-sm font-medium hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black w-full sm:w-auto luma-checkout--button"
+                  data-luma-action="checkout"
+                  data-luma-event-id={getLumaCheckoutEventId(event)}
+                >
+                  RSVP on Luma (for door entry)
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M7 17l9.2-9.2M17 17V7H7" /></svg>
+                </a>
+                <p className="text-sm text-amber-600 dark:text-amber-400 mt-1 font-medium">
+                  Both required: register here so we can hand your name to Moderna for badge issuance, then RSVP on Luma to receive the Envoy NDA email.
                 </p>
               </div>
             ) : (

--- a/app/events/cursor-boston-pydata-2026/admin/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/admin/page.tsx
@@ -1,0 +1,321 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  PYDATA_2026_EVENT_SLUG,
+  type PydataRegistration,
+  type PydataRegistrationStatus,
+} from "@/lib/pydata-2026";
+
+const API_PATH = "/api/events/pydata-2026/admin/list";
+
+const STATUS_LABEL: Record<PydataRegistrationStatus, string> = {
+  "awaiting-badge": "Awaiting badge",
+  "badge-ready": "Badge ready",
+  "checked-in": "Checked in",
+  cancelled: "Cancelled",
+};
+
+const STATUS_PILL: Record<PydataRegistrationStatus, string> = {
+  "awaiting-badge":
+    "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  "badge-ready":
+    "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-400",
+  "checked-in":
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  cancelled:
+    "border-neutral-500/30 bg-neutral-500/10 text-neutral-600 dark:text-neutral-400",
+};
+
+type Response = {
+  total: number;
+  counts: Partial<Record<PydataRegistrationStatus, number>>;
+  registrations: PydataRegistration[];
+};
+
+function formatDate(ms: number): string {
+  try {
+    return new Date(ms).toLocaleString("en-US", {
+      timeZone: "America/New_York",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return new Date(ms).toISOString();
+  }
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toCsv(registrations: PydataRegistration[]): string {
+  const header = [
+    "First name",
+    "Last name",
+    "Email",
+    "Organization",
+    "Status",
+    "Confirmed at (ET)",
+  ].join(",");
+  const rows = registrations.map((r) =>
+    [
+      csvEscape(r.firstName),
+      csvEscape(r.lastName),
+      csvEscape(r.email),
+      csvEscape(r.organization),
+      csvEscape(STATUS_LABEL[r.status]),
+      csvEscape(formatDate(r.createdAt)),
+    ].join(",")
+  );
+  return [header, ...rows].join("\n");
+}
+
+export default function PyDataAdminPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [data, setData] = useState<Response | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [lastRefresh, setLastRefresh] = useState<string>("");
+
+  const load = useCallback(async () => {
+    if (!user) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(API_PATH, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(json.error || `HTTP ${res.status}`);
+      }
+      setData(json as Response);
+      setLastRefresh(new Date().toLocaleTimeString());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not load");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (authLoading || !user) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot fetch on auth resolution
+    void load();
+  }, [authLoading, user, load]);
+
+  const filtered = useMemo(() => {
+    if (!data) return [];
+    const q = search.trim().toLowerCase();
+    if (!q) return data.registrations;
+    return data.registrations.filter((r) => {
+      const haystack = `${r.firstName} ${r.lastName} ${r.email} ${r.organization}`.toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [data, search]);
+
+  const downloadCsv = () => {
+    if (!data) return;
+    const csv = toCsv(data.registrations);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `pydata-2026-registrations-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <main className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <div className="mx-auto max-w-6xl px-6 py-12 md:py-16">
+        <nav className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+          <Link href="/events" className="hover:text-emerald-600 dark:hover:text-emerald-400">
+            Events
+          </Link>
+          <span className="mx-2">/</span>
+          <Link
+            href={`/events/${PYDATA_2026_EVENT_SLUG}`}
+            className="hover:text-emerald-600 dark:hover:text-emerald-400"
+          >
+            PyData × Cursor Boston
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-neutral-700 dark:text-neutral-300">Admin</span>
+        </nav>
+
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+              PyData × Cursor Boston — Registrations
+            </h1>
+            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+              Anyone who has confirmed attendance via{" "}
+              <code>/events/{PYDATA_2026_EVENT_SLUG}/register</code>. Hand this
+              list to Moderna for badge issuance.
+            </p>
+          </div>
+          {data ? (
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              <span className="text-neutral-500">
+                {lastRefresh ? `Updated ${lastRefresh}` : ""}
+              </span>
+              <button
+                type="button"
+                onClick={() => void load()}
+                className="rounded-lg border border-neutral-300 px-3 py-1.5 text-xs font-semibold hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+              >
+                Refresh
+              </button>
+              <button
+                type="button"
+                onClick={downloadCsv}
+                className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-400"
+              >
+                Download CSV
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        {authLoading || loading ? (
+          <div className="mt-10 rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+            <p className="text-sm text-neutral-500">Loading…</p>
+          </div>
+        ) : !user ? (
+          <div className="mt-10 rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+            <p className="mb-4 text-neutral-700 dark:text-neutral-300">
+              Sign in as an admin to view the registration list.
+            </p>
+            <Link
+              href={`/login?redirect=${encodeURIComponent(`/events/${PYDATA_2026_EVENT_SLUG}/admin`)}`}
+              className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+            >
+              Sign in
+            </Link>
+          </div>
+        ) : error ? (
+          <div className="mt-10 rounded-2xl border border-red-300 bg-red-50 p-6 dark:border-red-900/50 dark:bg-red-900/20">
+            <p className="text-sm font-medium text-red-700 dark:text-red-300">
+              {error === "Forbidden"
+                ? "Your account isn't an admin on this site. Ask in #cb-admin if this is wrong."
+                : error}
+            </p>
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="mt-3 rounded-lg border border-red-300 px-3 py-1.5 text-xs font-semibold hover:bg-red-100 dark:border-red-800 dark:hover:bg-red-900/30"
+            >
+              Retry
+            </button>
+          </div>
+        ) : data ? (
+          <>
+            <section className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <Stat label="Total registered" value={data.total} />
+              <Stat
+                label="Awaiting badge"
+                value={data.counts["awaiting-badge"] ?? 0}
+              />
+              <Stat label="Badge ready" value={data.counts["badge-ready"] ?? 0} />
+              <Stat label="Checked in" value={data.counts["checked-in"] ?? 0} />
+            </section>
+
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <input
+                type="search"
+                placeholder="Search name, email, or organization…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full max-w-md rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+              />
+              <span className="text-sm text-neutral-500">
+                Showing {filtered.length} of {data.total}
+              </span>
+            </div>
+
+            <div className="mt-4 overflow-x-auto rounded-xl border border-neutral-200 dark:border-neutral-800">
+              <table className="w-full min-w-[800px] text-left text-sm">
+                <thead className="bg-neutral-100 dark:bg-neutral-900/80">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Name</th>
+                    <th className="px-4 py-3 font-medium">Email</th>
+                    <th className="px-4 py-3 font-medium">Organization</th>
+                    <th className="px-4 py-3 font-medium">Status</th>
+                    <th className="px-4 py-3 font-medium">Confirmed (ET)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={5}
+                        className="px-4 py-10 text-center text-neutral-500"
+                      >
+                        {data.total === 0
+                          ? "No registrations yet."
+                          : "No matches for that search."}
+                      </td>
+                    </tr>
+                  ) : (
+                    filtered.map((r) => (
+                      <tr
+                        key={r.uid}
+                        className="border-t border-neutral-200 dark:border-neutral-800"
+                      >
+                        <td className="px-4 py-3">
+                          {r.firstName} {r.lastName}
+                        </td>
+                        <td className="px-4 py-3 break-all">{r.email}</td>
+                        <td className="px-4 py-3">{r.organization || "—"}</td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${STATUS_PILL[r.status]}`}
+                          >
+                            {STATUS_LABEL[r.status]}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400 tabular-nums">
+                          {formatDate(r.createdAt)}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+    </div>
+  );
+}

--- a/app/events/cursor-boston-pydata-2026/register/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/register/page.tsx
@@ -1,0 +1,452 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  PYDATA_2026_EVENT_SLUG,
+  PYDATA_2026_LUMA_URL,
+  PYDATA_2026_REGISTRATION_PATH,
+  type PydataRegistration,
+} from "@/lib/pydata-2026";
+
+const API_PATH = "/api/events/pydata-2026/registration";
+
+type FormState = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  organization: string;
+  attendingConfirmed: boolean;
+};
+
+const EMPTY_FORM: FormState = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  organization: "",
+  attendingConfirmed: false,
+};
+
+function splitDisplayName(displayName: string | null | undefined): {
+  firstName: string;
+  lastName: string;
+} {
+  const trimmed = (displayName ?? "").trim();
+  if (!trimmed) return { firstName: "", lastName: "" };
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return { firstName: parts[0], lastName: "" };
+  return {
+    firstName: parts[0],
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+export default function PyDataRegisterPage() {
+  const { user, userProfile, loading: authLoading } = useAuth();
+  const [registration, setRegistration] = useState<PydataRegistration | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!user) {
+      setRegistration(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(API_PATH, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = await res.json().catch(() => ({}));
+      if (res.ok && json.registered && json.registration) {
+        setRegistration(json.registration as PydataRegistration);
+      } else {
+        setRegistration(null);
+      }
+    } catch {
+      setRegistration(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot fetch on auth resolution
+    void load();
+  }, [authLoading, load]);
+
+  // Prefill form fields from the auth profile once we know nothing's saved yet.
+  useEffect(() => {
+    if (loading || registration) return;
+    const { firstName, lastName } = splitDisplayName(userProfile?.displayName ?? null);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot prefill once auth resolves
+    setForm((prev) => ({
+      firstName: prev.firstName || firstName,
+      lastName: prev.lastName || lastName,
+      email: prev.email || (user?.email ?? ""),
+      organization: prev.organization,
+      attendingConfirmed: prev.attendingConfirmed,
+    }));
+  }, [loading, registration, user?.email, userProfile?.displayName]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(API_PATH, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(form),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        if (Array.isArray(json.missingFields) && json.missingFields.length > 0) {
+          throw new Error(`Please fix: ${json.missingFields.join(", ")}`);
+        }
+        throw new Error(json.error || "Could not submit");
+      }
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not submit");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <div className="mx-auto max-w-2xl px-6 py-12 md:py-16">
+        <nav className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+          <Link href="/events" className="hover:text-emerald-600 dark:hover:text-emerald-400">
+            Events
+          </Link>
+          <span className="mx-2">/</span>
+          <Link
+            href={`/events/${PYDATA_2026_EVENT_SLUG}`}
+            className="hover:text-emerald-600 dark:hover:text-emerald-400"
+          >
+            PyData × Cursor Boston
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-neutral-700 dark:text-neutral-300">Register</span>
+        </nav>
+
+        <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+          PyData × Cursor Boston — Confirm attendance
+        </h1>
+        <p className="mt-4 text-base text-neutral-600 dark:text-neutral-400">
+          Wednesday May 13 · Moderna HQ, Cambridge. Confirm here so we can hand
+          your name to Moderna for badge issuance. You still need to RSVP on{" "}
+          <a
+            href={PYDATA_2026_LUMA_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-emerald-600 underline hover:text-emerald-500 dark:text-emerald-400"
+          >
+            Luma
+          </a>{" "}
+          for the door list and the Envoy NDA email.
+        </p>
+
+        <div className="mt-10">
+          {authLoading || loading ? (
+            <div className="rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+              <p className="text-sm text-neutral-500">Loading…</p>
+            </div>
+          ) : !user ? (
+            <SignInGate />
+          ) : registration ? (
+            <AwaitingBadge registration={registration} onEdit={() => setRegistration(null)} />
+          ) : (
+            <RegistrationForm
+              form={form}
+              setForm={setForm}
+              submitting={submitting}
+              error={error}
+              onSubmit={handleSubmit}
+            />
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function SignInGate() {
+  return (
+    <div className="rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+      <p className="text-neutral-700 dark:text-neutral-300 mb-4">
+        Sign in or create an account to confirm your attendance.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <Link
+          href={`/login?redirect=${encodeURIComponent(PYDATA_2026_REGISTRATION_PATH)}`}
+          className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+        >
+          Sign in
+        </Link>
+        <Link
+          href={`/signup?redirect=${encodeURIComponent(PYDATA_2026_REGISTRATION_PATH)}`}
+          className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+        >
+          Create account
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function RegistrationForm({
+  form,
+  setForm,
+  submitting,
+  error,
+  onSubmit,
+}: {
+  form: FormState;
+  setForm: React.Dispatch<React.SetStateAction<FormState>>;
+  submitting: boolean;
+  error: string | null;
+  onSubmit: (e: React.FormEvent) => void;
+}) {
+  const inputClass =
+    "mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100";
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+      noValidate
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block text-sm">
+          <span className="font-medium">First name</span>
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={form.firstName}
+            onChange={(e) => setForm((p) => ({ ...p, firstName: e.target.value }))}
+            className={inputClass}
+            autoComplete="given-name"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium">Last name</span>
+          <input
+            type="text"
+            required
+            maxLength={80}
+            value={form.lastName}
+            onChange={(e) => setForm((p) => ({ ...p, lastName: e.target.value }))}
+            className={inputClass}
+            autoComplete="family-name"
+          />
+        </label>
+        <label className="block text-sm sm:col-span-2">
+          <span className="font-medium">Email</span>
+          <input
+            type="email"
+            required
+            maxLength={320}
+            value={form.email}
+            onChange={(e) => setForm((p) => ({ ...p, email: e.target.value }))}
+            className={inputClass}
+            autoComplete="email"
+          />
+          <span className="mt-1 block text-xs text-neutral-500 dark:text-neutral-400">
+            Use the same email you used on Luma so Moderna can match you.
+          </span>
+        </label>
+        <label className="block text-sm sm:col-span-2">
+          <span className="font-medium">Organization</span>
+          <input
+            type="text"
+            required
+            maxLength={200}
+            value={form.organization}
+            onChange={(e) => setForm((p) => ({ ...p, organization: e.target.value }))}
+            className={inputClass}
+            placeholder="Company, university, or independent"
+            autoComplete="organization"
+          />
+        </label>
+      </div>
+
+      <label className="mt-6 flex items-start gap-3 text-sm">
+        <input
+          type="checkbox"
+          checked={form.attendingConfirmed}
+          onChange={(e) =>
+            setForm((p) => ({ ...p, attendingConfirmed: e.target.checked }))
+          }
+          className="mt-0.5 h-4 w-4 rounded border-neutral-400 text-emerald-500 focus:ring-emerald-500"
+          required
+        />
+        <span className="text-neutral-700 dark:text-neutral-300">
+          I confirm I&apos;ll attend on Wednesday May 13 at Moderna HQ. I understand
+          Moderna requires Envoy sign-in (NDA + signature) before I can enter and
+          that no QR code means no access.
+        </span>
+      </label>
+
+      {error ? (
+        <p className="mt-4 text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400 disabled:opacity-50"
+        >
+          {submitting ? "Submitting…" : "Confirm attendance"}
+        </button>
+        <Link
+          href={`/events/${PYDATA_2026_EVENT_SLUG}`}
+          className="text-sm text-neutral-500 underline hover:text-neutral-700 dark:hover:text-neutral-300"
+        >
+          Back to event details
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+function AwaitingBadge({
+  registration,
+  onEdit,
+}: {
+  registration: PydataRegistration;
+  onEdit: () => void;
+}) {
+  return (
+    <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-6 dark:bg-emerald-500/10">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/20">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-emerald-600 dark:text-emerald-400"
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold text-foreground">
+            You&apos;re confirmed — awaiting badge
+          </h2>
+          <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">
+            We&apos;ve recorded your attendance for the Cursor Boston × PyData
+            hack at Moderna on Wednesday May 13. Moderna will issue your badge
+            on arrival once Envoy sign-in is complete.
+          </p>
+        </div>
+      </div>
+
+      <dl className="mt-6 grid gap-4 rounded-xl border border-emerald-500/20 bg-white p-4 text-sm dark:bg-neutral-900 sm:grid-cols-2">
+        <div>
+          <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            Name
+          </dt>
+          <dd className="mt-1 text-neutral-900 dark:text-neutral-100">
+            {registration.firstName} {registration.lastName}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            Email
+          </dt>
+          <dd className="mt-1 break-all text-neutral-900 dark:text-neutral-100">
+            {registration.email}
+          </dd>
+        </div>
+        <div className="sm:col-span-2">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            Organization
+          </dt>
+          <dd className="mt-1 text-neutral-900 dark:text-neutral-100">
+            {registration.organization}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-6 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
+        <p className="font-semibold">Next: clear Moderna security</p>
+        <ol className="mt-2 list-decimal space-y-1 pl-5">
+          <li>
+            RSVP on{" "}
+            <a
+              href={PYDATA_2026_LUMA_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Luma
+            </a>{" "}
+            if you haven&apos;t already.
+          </li>
+          <li>
+            Watch for an email from <code>no-reply@envoy.com</code> after Luma
+            approval. Complete the Envoy sign-in including NDA and signature.
+          </li>
+          <li>
+            Show your Envoy QR code at the door on May 13. <strong>No QR code, no
+            access.</strong>
+          </li>
+        </ol>
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <a
+          href={PYDATA_2026_LUMA_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+        >
+          Open Luma RSVP
+        </a>
+        <button
+          type="button"
+          onClick={onEdit}
+          className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+        >
+          Edit details
+        </button>
+        <Link
+          href={`/events/${PYDATA_2026_EVENT_SLUG}`}
+          className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+        >
+          Back to event
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/events/EventsBrowse.tsx
+++ b/components/events/EventsBrowse.tsx
@@ -12,6 +12,10 @@ import { useId, useMemo } from "react";
 import type { Event } from "@/types/events";
 import { partitionEventsForBrowse } from "@/lib/events-calendar-buckets";
 import { getLumaCheckoutHref } from "@/lib/luma-event";
+import {
+  PYDATA_2026_EVENT_SLUG,
+  PYDATA_2026_REGISTRATION_PATH,
+} from "@/lib/pydata-2026";
 import styles from "./EventsBrowse.module.css";
 
 type Props = {
@@ -201,6 +205,7 @@ export function EventsBrowse({ events, listingTodayYmd }: Props) {
 function FeaturedEventCard({ event }: { event: Event }) {
   const registerHref =
     event.lumaUrl?.trim() || getLumaCheckoutHref(event);
+  const isPyData = event.slug === PYDATA_2026_EVENT_SLUG;
 
   return (
     <div className="bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800">
@@ -269,10 +274,36 @@ function FeaturedEventCard({ event }: { event: Event }) {
               <span>{event.location}</span>
             </div>
           </div>
-          <div className="flex flex-col sm:flex-row gap-3 relative z-10">
+          <div className="flex flex-col sm:flex-row gap-3 relative z-10 flex-wrap">
+            {isPyData ? (
+              <Link
+                href={PYDATA_2026_REGISTRATION_PATH}
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
+              >
+                Register for badge
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14M12 5l7 7-7 7" />
+                </svg>
+              </Link>
+            ) : null}
             <Link
               href={`/events/${event.slug}`}
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-neutral-900 text-white dark:bg-white dark:text-black rounded-lg text-base font-semibold hover:bg-neutral-700 dark:hover:bg-neutral-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
+              className={`inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 rounded-lg text-base font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto ${
+                isPyData
+                  ? "border border-neutral-300 dark:border-neutral-700 text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                  : "bg-neutral-900 text-white dark:bg-white dark:text-black hover:bg-neutral-700 dark:hover:bg-neutral-200"
+              }`}
             >
               View Details
               <svg

--- a/lib/mailgun-suppressions.ts
+++ b/lib/mailgun-suppressions.ts
@@ -1,0 +1,274 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Pull Mailgun bounces + complaints and mirror them onto our Firestore
+ * `eventContacts.unsubscribed` / `users.unsubscribed` flags. Bulk-send
+ * scripts call this at the top of main() so the recipient list never
+ * includes addresses Mailgun has already given up on.
+ *
+ * Memoized per process: repeat calls within a single script invocation
+ * skip the network round-trip and reuse the same result.
+ *
+ * Required for the network sync:
+ *   MAILGUN_PRIVATE_API_KEY  (sending key returns 401 on /bounces)
+ *   MAILGUN_DOMAIN
+ *
+ * If MAILGUN_PRIVATE_API_KEY is missing, the function logs a warning
+ * and returns an empty result — callers proceed without sync rather
+ * than crashing crons.
+ */
+import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+
+type SuppressionType = "bounces" | "complaints";
+
+interface SuppressionItem {
+  address: string;
+  code?: string | number;
+  error?: string;
+  created_at?: string;
+}
+
+export interface SyncResult {
+  /** Lowercased addresses Mailgun has flagged (bounce or complaint). */
+  allSuppressed: Set<string>;
+  bouncedCount: number;
+  complaintsCount: number;
+  /** New writes performed this run (zero on memoized re-calls). */
+  flaggedEventContacts: number;
+  flaggedUsers: number;
+  /** True when the sync was skipped (no key, or already ran this process). */
+  skipped: boolean;
+  skippedReason?: string;
+}
+
+const MAILGUN_API =
+  process.env.MAILGUN_EU === "true"
+    ? "https://api.eu.mailgun.net"
+    : "https://api.mailgun.net";
+
+let memo: Promise<SyncResult> | null = null;
+
+async function fetchAllSuppressions(
+  domain: string,
+  apiKey: string,
+  type: SuppressionType
+): Promise<SuppressionItem[]> {
+  const auth = "Basic " + Buffer.from(`api:${apiKey}`).toString("base64");
+  const all: SuppressionItem[] = [];
+  let url: string | undefined = `${MAILGUN_API}/v3/${domain}/${type}?limit=1000`;
+  let pages = 0;
+  while (url) {
+    pages++;
+    const res = await fetch(url, { headers: { Authorization: auth } });
+    if (!res.ok) {
+      throw new Error(
+        `Mailgun ${type} fetch failed: ${res.status} ${await res.text()}`
+      );
+    }
+    const json = (await res.json()) as {
+      items: SuppressionItem[];
+      paging?: { next?: string };
+    };
+    all.push(...(json.items ?? []));
+    const next = json.paging?.next;
+    if (!next || (json.items ?? []).length === 0) break;
+    url = next;
+    if (pages > 50) break;
+  }
+  return all;
+}
+
+interface SyncOptions {
+  /** Set true to refetch even if a previous call in this process succeeded. */
+  force?: boolean;
+  /** When false, suppress per-step console output. Defaults to true. */
+  verbose?: boolean;
+}
+
+export async function syncMailgunSuppressions(
+  db: Firestore,
+  opts: SyncOptions = {}
+): Promise<SyncResult> {
+  if (!opts.force && memo) return memo;
+  memo = doSync(db, opts);
+  try {
+    return await memo;
+  } catch (e) {
+    memo = null;
+    throw e;
+  }
+}
+
+async function doSync(db: Firestore, opts: SyncOptions): Promise<SyncResult> {
+  const verbose = opts.verbose !== false;
+  const log = (...args: unknown[]) => {
+    if (verbose) console.log(...args);
+  };
+
+  const apiKey = process.env.MAILGUN_PRIVATE_API_KEY;
+  const domain = process.env.MAILGUN_DOMAIN;
+  if (!apiKey || !domain) {
+    const reason = !apiKey
+      ? "MAILGUN_PRIVATE_API_KEY not set"
+      : "MAILGUN_DOMAIN not set";
+    log(`[mailgun-suppressions] Skipping sync: ${reason}.`);
+    return {
+      allSuppressed: new Set(),
+      bouncedCount: 0,
+      complaintsCount: 0,
+      flaggedEventContacts: 0,
+      flaggedUsers: 0,
+      skipped: true,
+      skippedReason: reason,
+    };
+  }
+
+  log(`[mailgun-suppressions] Fetching bounces + complaints for ${domain}…`);
+  const [bounces, complaints] = await Promise.all([
+    fetchAllSuppressions(domain, apiKey, "bounces"),
+    fetchAllSuppressions(domain, apiKey, "complaints"),
+  ]);
+  log(
+    `[mailgun-suppressions]   bounces=${bounces.length} complaints=${complaints.length}`
+  );
+
+  const byAddress = new Map<
+    string,
+    { reason: "bounce" | "complaint"; code: string; error: string }
+  >();
+  for (const b of bounces) {
+    const k = (b.address || "").trim().toLowerCase();
+    if (!k) continue;
+    byAddress.set(k, {
+      reason: "bounce",
+      code: String(b.code ?? ""),
+      error: String(b.error ?? "").slice(0, 200),
+    });
+  }
+  for (const c of complaints) {
+    const k = (c.address || "").trim().toLowerCase();
+    if (!k) continue;
+    if (!byAddress.has(k)) {
+      byAddress.set(k, {
+        reason: "complaint",
+        code: String(c.code ?? ""),
+        error: String(c.error ?? "").slice(0, 200),
+      });
+    }
+  }
+
+  const allSuppressed = new Set(byAddress.keys());
+
+  const eventContactWrites: Array<{
+    docId: string;
+    reason: "bounce" | "complaint";
+    code: string;
+    error: string;
+  }> = [];
+  const userWrites: Array<{ uid: string }> = [];
+
+  for (const [email, meta] of byAddress) {
+    let ecDoc = await db.collection("eventContacts").doc(email).get();
+    if (!ecDoc.exists) {
+      const q = await db
+        .collection("eventContacts")
+        .where("email", "==", email)
+        .limit(1)
+        .get();
+      if (!q.empty) ecDoc = q.docs[0];
+    }
+    if (ecDoc.exists) {
+      const d = ecDoc.data() ?? {};
+      if (d.unsubscribed !== true || !d.bouncedAt) {
+        eventContactWrites.push({
+          docId: ecDoc.id,
+          reason: meta.reason,
+          code: meta.code,
+          error: meta.error,
+        });
+      }
+    }
+
+    const uq = await db
+      .collection("users")
+      .where("email", "==", email)
+      .limit(1)
+      .get();
+    if (!uq.empty) {
+      const d = uq.docs[0].data() ?? {};
+      if (d.unsubscribed !== true) {
+        userWrites.push({ uid: uq.docs[0].id });
+      }
+    }
+  }
+
+  if (eventContactWrites.length === 0 && userWrites.length === 0) {
+    log(
+      `[mailgun-suppressions]   no new flags needed (${allSuppressed.size} already mirrored).`
+    );
+    return {
+      allSuppressed,
+      bouncedCount: bounces.length,
+      complaintsCount: complaints.length,
+      flaggedEventContacts: 0,
+      flaggedUsers: 0,
+      skipped: false,
+    };
+  }
+
+  log(
+    `[mailgun-suppressions]   flagging ${eventContactWrites.length} eventContact(s) + ${userWrites.length} user(s)…`
+  );
+
+  const ops: Array<() => Promise<void>> = [];
+  for (const r of eventContactWrites) {
+    ops.push(async () => {
+      await db.collection("eventContacts").doc(r.docId).set(
+        {
+          unsubscribed: true,
+          bouncedAt: FieldValue.serverTimestamp(),
+          suppressionReason:
+            r.reason === "bounce" ? "mailgun-bounce" : "mailgun-complaint",
+          suppressionCode: r.code || null,
+          suppressionError: r.error || null,
+        },
+        { merge: true }
+      );
+    });
+  }
+  for (const u of userWrites) {
+    ops.push(async () => {
+      await db.collection("users").doc(u.uid).set(
+        {
+          unsubscribed: true,
+          unsubscribedAt: FieldValue.serverTimestamp(),
+          unsubscribedReason: "mailgun-suppression",
+        },
+        { merge: true }
+      );
+    });
+  }
+  const concurrency = 10;
+  for (let i = 0; i < ops.length; i += concurrency) {
+    await Promise.all(ops.slice(i, i + concurrency).map((fn) => fn()));
+  }
+
+  return {
+    allSuppressed,
+    bouncedCount: bounces.length,
+    complaintsCount: complaints.length,
+    flaggedEventContacts: eventContactWrites.length,
+    flaggedUsers: userWrites.length,
+    skipped: false,
+  };
+}
+
+/** Test-only: clear the per-process memo. */
+export function __resetMailgunSuppressionsMemo(): void {
+  memo = null;
+}

--- a/lib/pydata-2026.ts
+++ b/lib/pydata-2026.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Constants + types for the May 13 Cursor Boston × PyData event at Moderna.
+ *
+ * The website registration captures the basics Moderna needs (first/last
+ * name, email, organization) so we can hand the list to the host for
+ * Envoy NDA + badge issuance. Status starts at "awaiting-badge" until
+ * an organizer flips it to "badge-ready" or "checked-in" on the day-of.
+ */
+
+export const PYDATA_2026_EVENT_ID = "cursor-boston-pydata-2026";
+export const PYDATA_2026_EVENT_SLUG = "cursor-boston-pydata-2026";
+export const PYDATA_2026_LUMA_URL = "https://luma.com/ggjlxdnk";
+export const PYDATA_2026_REGISTRATION_PATH = `/events/${PYDATA_2026_EVENT_SLUG}/register`;
+
+export const PYDATA_2026_REGISTRATIONS_COLLECTION = "pydataHack2026Registrations";
+
+export const PYDATA_2026_LIMITS = {
+  firstName: 80,
+  lastName: 80,
+  email: 320,
+  organization: 200,
+} as const;
+
+export type PydataRegistrationStatus =
+  | "awaiting-badge"
+  | "badge-ready"
+  | "checked-in"
+  | "cancelled";
+
+export interface PydataRegistration {
+  uid: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  organization: string;
+  attendingConfirmed: true;
+  status: PydataRegistrationStatus;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PydataRegistrationInput {
+  firstName: string;
+  lastName: string;
+  email: string;
+  organization: string;
+  attendingConfirmed: true;
+}
+
+export type PydataValidationError =
+  | "firstName-required"
+  | "lastName-required"
+  | "email-required"
+  | "email-invalid"
+  | "organization-required"
+  | "must-confirm-attendance";
+
+function clamp(s: unknown, max: number): string {
+  if (typeof s !== "string") return "";
+  return s.trim().slice(0, max);
+}
+
+export function validatePydataRegistration(
+  raw: unknown
+):
+  | { ok: true; data: PydataRegistrationInput }
+  | { ok: false; errors: PydataValidationError[] } {
+  const errors: PydataValidationError[] = [];
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+
+  const firstName = clamp(r.firstName, PYDATA_2026_LIMITS.firstName);
+  const lastName = clamp(r.lastName, PYDATA_2026_LIMITS.lastName);
+  const email = clamp(r.email, PYDATA_2026_LIMITS.email).toLowerCase();
+  const organization = clamp(r.organization, PYDATA_2026_LIMITS.organization);
+  const attendingConfirmed = r.attendingConfirmed === true;
+
+  if (!firstName) errors.push("firstName-required");
+  if (!lastName) errors.push("lastName-required");
+  if (!email) errors.push("email-required");
+  else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.push("email-invalid");
+  if (!organization) errors.push("organization-required");
+  if (!attendingConfirmed) errors.push("must-confirm-attendance");
+
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    data: { firstName, lastName, email, organization, attendingConfirmed: true },
+  };
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -35,6 +35,8 @@ Licensed GPL-3.0-only.
     /ecosystem
     /events
     /events/[slug]
+    /events/cursor-boston-pydata-2026/admin
+    /events/cursor-boston-pydata-2026/register
     /events/request
     /hackathons
     /hackathons/hack-a-sprint-2026
@@ -62,6 +64,7 @@ Licensed GPL-3.0-only.
     /pair
     /pair/[sessionId]
     /pair/requests
+    /partners
     /privacy
     /profile
     /questions

--- a/scripts/send-contact-list-email.ts
+++ b/scripts/send-contact-list-email.ts
@@ -16,6 +16,7 @@ loadEnvConfig(process.cwd());
 
 import { getAdminDb } from "../lib/firebase-admin";
 import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
 import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
 
 // ---------------------------------------------------------------------------
@@ -161,6 +162,10 @@ async function main() {
     );
     process.exit(1);
   }
+
+  // Mirror Mailgun bounces + complaints onto eventContacts.unsubscribed
+  // before reading the list. No-op if MAILGUN_PRIVATE_API_KEY is unset.
+  await syncMailgunSuppressions(db);
 
   console.log("Loading contacts from eventContacts…");
   const snap = await db.collection("eventContacts").get();

--- a/scripts/send-may-roundup.ts
+++ b/scripts/send-may-roundup.ts
@@ -1,0 +1,544 @@
+#!/usr/bin/env node
+/**
+ * General May roundup email to the whole list (Firestore `eventContacts`).
+ *
+ * Three sections:
+ *   1. May 11 — Summer Cohort 1 kickoff. PERSONALIZED per recipient with
+ *      their current application status and whether their CB profile has
+ *      GitHub linked. Recipients without a CB account see a "sign up first"
+ *      prompt instead.
+ *   2. May 13 — PyData Data Science Hack at Moderna.
+ *   3. May 26 — AIC × Hult International, Boston Tech Week kickoff.
+ *
+ * Usage:
+ *   npx tsx scripts/send-may-roundup.ts --dry-run
+ *   npx tsx scripts/send-may-roundup.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import type { Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+// PyData
+const PYDATA_LUMA_URL = "https://luma.com/ggjlxdnk";
+const PYDATA_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026";
+
+// Hult / May 26
+const HULT_LUMA_URL = "https://luma.com/t5vseeed";
+const HULT_WEBSITE_SIGNUP_URL =
+  "https://www.cursorboston.com/hackathons/sports-hack-2026/signup";
+const HULT_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
+
+// Cohort
+const COHORT_APPLY_URL = "https://www.cursorboston.com/summer-cohort";
+const SIGNUP_URL = "https://www.cursorboston.com/login";
+const COMMUNITY_REPO_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// ---------------------------------------------------------------------------
+// Per-recipient personalization
+// ---------------------------------------------------------------------------
+
+type CohortStatus =
+  | { kind: "no-cb-account" }
+  | { kind: "cb-no-app"; githubLogin: string | null }
+  | { kind: "applied-c1-pending"; githubLogin: string | null }
+  | { kind: "applied-c1-admitted"; githubLogin: string | null }
+  | { kind: "applied-c1-rejected"; githubLogin: string | null }
+  | { kind: "applied-c1-waitlist"; githubLogin: string | null }
+  | {
+      kind: "applied-c2-only";
+      status: "pending" | "admitted" | "rejected" | "waitlist";
+      githubLogin: string | null;
+    };
+
+async function resolveCohortStatus(
+  db: Firestore,
+  email: string
+): Promise<CohortStatus> {
+  const lower = email.trim().toLowerCase();
+  const userSnap = await db
+    .collection("users")
+    .where("email", "==", lower)
+    .limit(1)
+    .get();
+  if (userSnap.empty) {
+    // Some users have mixed-case emails stored — try the original too.
+    if (lower !== email) {
+      const fb = await db.collection("users").where("email", "==", email).limit(1).get();
+      if (!fb.empty) return resolveForUid(db, fb.docs[0].id, fb.docs[0].data());
+    }
+    return { kind: "no-cb-account" };
+  }
+  return resolveForUid(db, userSnap.docs[0].id, userSnap.docs[0].data());
+}
+
+async function resolveForUid(
+  db: Firestore,
+  uid: string,
+  userData: Record<string, unknown>
+): Promise<CohortStatus> {
+  const githubLogin =
+    userData.github && typeof userData.github === "object" &&
+    typeof (userData.github as { login?: string }).login === "string"
+      ? ((userData.github as { login: string }).login)
+      : null;
+
+  const appSnap = await db.collection("summerCohortApplications").doc(uid).get();
+  if (!appSnap.exists) {
+    return { kind: "cb-no-app", githubLogin };
+  }
+  const a = appSnap.data() ?? {};
+  const cohorts: string[] = Array.isArray(a.cohorts) ? a.cohorts : [];
+  const status = typeof a.status === "string" ? a.status : "pending";
+  const inC1 = cohorts.includes("cohort-1");
+  const inC2 = cohorts.includes("cohort-2");
+
+  if (inC1) {
+    if (status === "admitted") return { kind: "applied-c1-admitted", githubLogin };
+    if (status === "rejected") return { kind: "applied-c1-rejected", githubLogin };
+    if (status === "waitlist") return { kind: "applied-c1-waitlist", githubLogin };
+    return { kind: "applied-c1-pending", githubLogin };
+  }
+  if (inC2) {
+    return {
+      kind: "applied-c2-only",
+      status: status === "admitted" || status === "rejected" || status === "waitlist" ? status : "pending",
+      githubLogin,
+    };
+  }
+  return { kind: "cb-no-app", githubLogin };
+}
+
+function statusLines(status: CohortStatus): { html: string; text: string } {
+  // Status pill color choices map to the kind. Simple inline styles keep it
+  // email-client-safe.
+  const renderHtml = (label: string, body: string, color: string) => `
+<div style="margin:12px 0;padding:12px 14px;border-left:4px solid ${color};background:#f8fafc;border-radius:0 6px 6px 0;">
+  <div style="font-weight:600;color:${color};text-transform:uppercase;letter-spacing:0.04em;font-size:12px;">${escapeHtml(label)}</div>
+  <div style="margin-top:4px;font-size:14px;color:#111;">${body}</div>
+</div>`;
+  const renderText = (label: string, body: string) =>
+    `\n  [${label}] ${body}\n`;
+
+  const githubLine = (login: string | null) =>
+    login
+      ? `GitHub: connected as @${escapeHtml(login)}.`
+      : `GitHub: <strong>not connected.</strong> <a href="${COHORT_APPLY_URL}">Connect on the cohort page</a> so merged PRs auto-count toward your spot.`;
+  const githubLineText = (login: string | null) =>
+    login
+      ? `GitHub: connected as @${login}.`
+      : `GitHub: NOT connected. Connect on the cohort page (${COHORT_APPLY_URL}) so merged PRs auto-count toward your spot.`;
+
+  switch (status.kind) {
+    case "no-cb-account":
+      return {
+        html: renderHtml(
+          "Your status",
+          `<strong>You don&apos;t have a Cursor Boston account yet.</strong> Sign up at <a href="${SIGNUP_URL}">cursorboston.com</a>, link your GitHub, and apply to Cohort 1 — kickoff is Mon May 11.`,
+          "#6b7280"
+        ),
+        text: renderText(
+          "Your status",
+          `You don't have a Cursor Boston account yet. Sign up at ${SIGNUP_URL}, link GitHub, and apply at ${COHORT_APPLY_URL} — kickoff is Mon May 11.`
+        ),
+      };
+    case "cb-no-app":
+      return {
+        html: renderHtml(
+          "Your status",
+          `<strong>You haven&apos;t applied to the cohort yet.</strong> Apply at <a href="${COHORT_APPLY_URL}">cursorboston.com/summer-cohort</a> before kickoff Mon May 11.<br/>${githubLine(status.githubLogin)}`,
+          "#d97706"
+        ),
+        text: renderText(
+          "Your status",
+          `You haven't applied to the cohort yet. Apply at ${COHORT_APPLY_URL} before kickoff Mon May 11.\n  ${githubLineText(status.githubLogin)}`
+        ),
+      };
+    case "applied-c1-pending":
+      return {
+        html: renderHtml(
+          "Your status",
+          `<strong>Cohort 1 application: pending.</strong> Merge any PR to the <a href="${COMMUNITY_REPO_URL}">community repo</a> before May 9 to auto-admit.<br/>${githubLine(status.githubLogin)}`,
+          "#d97706"
+        ),
+        text: renderText(
+          "Your status",
+          `Cohort 1 application: PENDING. Merge any PR to the community repo (${COMMUNITY_REPO_URL}) before May 9 to auto-admit.\n  ${githubLineText(status.githubLogin)}`
+        ),
+      };
+    case "applied-c1-admitted":
+      return {
+        html: renderHtml(
+          "Your status",
+          `<strong>You&apos;re in Cohort 1.</strong> Kickoff Mon May 11 at 6:00 PM ET on Zoom — link goes out by email earlier that day.<br/>${githubLine(status.githubLogin)}`,
+          "#10b981"
+        ),
+        text: renderText(
+          "Your status",
+          `You're in Cohort 1. Kickoff Mon May 11 at 6:00 PM ET on Zoom — link goes out by email earlier that day.\n  ${githubLineText(status.githubLogin)}`
+        ),
+      };
+    case "applied-c1-waitlist":
+      return {
+        html: renderHtml(
+          "Your status",
+          `<strong>Cohort 1 application: waitlist.</strong> Merge a PR to the <a href="${COMMUNITY_REPO_URL}">community repo</a> to move up. Cohort 2 (June 29) is also still open.<br/>${githubLine(status.githubLogin)}`,
+          "#d97706"
+        ),
+        text: renderText(
+          "Your status",
+          `Cohort 1 application: WAITLIST. Merge a PR to the community repo (${COMMUNITY_REPO_URL}) to move up. Cohort 2 (June 29) is also still open.\n  ${githubLineText(status.githubLogin)}`
+        ),
+      };
+    case "applied-c1-rejected":
+      return {
+        html: renderHtml(
+          "Your status",
+          `Cohort 1 application not selected this round. Cohort 2 starts June 29 — happy to consider you again. The May 26 event is still open to you.<br/>${githubLine(status.githubLogin)}`,
+          "#6b7280"
+        ),
+        text: renderText(
+          "Your status",
+          `Cohort 1 application not selected this round. Cohort 2 starts June 29 — happy to consider you again. The May 26 event is still open to you.\n  ${githubLineText(status.githubLogin)}`
+        ),
+      };
+    case "applied-c2-only": {
+      const s = status.status;
+      const stext =
+        s === "admitted"
+          ? "You're in Cohort 2 (kicks off June 29)."
+          : s === "waitlist"
+          ? "You're on the Cohort 2 waitlist (June 29)."
+          : s === "rejected"
+          ? "Cohort 2 application not selected this round."
+          : "Cohort 2 application is pending (kicks off June 29).";
+      return {
+        html: renderHtml(
+          "Your status",
+          `<strong>${escapeHtml(stext)}</strong> Cohort 1 kicks off Mon May 11 — if you want to be considered for Cohort 1 instead, reply to this email.<br/>${githubLine(status.githubLogin)}`,
+          "#3b82f6"
+        ),
+        text: renderText(
+          "Your status",
+          `${stext} Cohort 1 kicks off Mon May 11 — if you want to be considered for Cohort 1 instead, reply to this email.\n  ${githubLineText(status.githubLogin)}`
+        ),
+      };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Email body
+// ---------------------------------------------------------------------------
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+  status: CohortStatus;
+}
+
+function buildEmail(contact: ContactData): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const firstHtml = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
+  );
+  const firstText =
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+  const status = statusLines(contact.status);
+
+  const subject =
+    "Cursor Boston this month — May 11 cohort kickoff + May 13 PyData + May 26 Tech Week";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${firstHtml},</p>
+
+<p>Three things on the Cursor Boston calendar this month. The first one is personal to you — your cohort status is at the top of section 1 below.</p>
+
+<h2 style="margin-top:28px;margin-bottom:6px;">1. Summer Cohort 1 — kickoff Mon May 11</h2>
+<p style="margin-top:0;color:#555;">Monday <strong>May 11, 6:00 PM ET</strong> · Zoom (link goes out by email)</p>
+
+<p>Six weeks of building with Cursor alongside other Boston devs, founders, and students. Each week ends with a live demo and a cohort vote. Winners maintain the platforms they shipped through demo day. PR contributions to the community repo can <strong>auto-admit</strong> pending applicants right up to May 9.</p>
+
+${status.html}
+
+<p><a href="${COHORT_APPLY_URL}" style="display:inline-block;padding:10px 20px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">Cohort dashboard →</a></p>
+
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0;"/>
+
+<h2 style="margin-top:28px;margin-bottom:6px;">2. Cursor Boston × PyData Data Science Hack — Wed May 13</h2>
+<p style="margin-top:0;color:#555;">Wednesday <strong>May 13, 6:30 PM – 9:30 PM ET</strong> · Moderna HQ, Cambridge (325 Binney St)</p>
+
+<p>Evening hackathon co-hosted with PyData Boston. Short talk from <strong>Eric Ma</strong>, then a focused build session on data-science workflows in Cursor. Pizza, community, and Cursor credits for the first 50 attendees.</p>
+
+<p><strong>Moderna security:</strong> Luma sign-up closes <strong>48 hours before the event</strong>. After Luma approval you&apos;ll get an email from <code>no-reply@envoy.com</code> — complete the Envoy NDA sign-in before arriving for your QR code. No QR, no entry.</p>
+
+<p><a href="${PYDATA_LUMA_URL}" style="display:inline-block;padding:10px 20px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">RSVP on Luma →</a></p>
+
+<p style="font-size:14px;color:#555;">Detail: <a href="${PYDATA_DETAIL_URL}">${PYDATA_DETAIL_URL}</a></p>
+
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0;"/>
+
+<h2 style="margin-top:28px;margin-bottom:6px;">3. Cursor Boston × Hult — Boston Tech Week kickoff — Tue May 26</h2>
+<p style="margin-top:0;color:#555;">Tuesday <strong>May 26, 10:00 AM – 4:00 PM ET</strong> · Hult International, Cambridge</p>
+
+<p>A full day kicking off Boston Tech Week with AIC and Hult. Coffee &amp; networking, a guest lecture from <strong>Antonio Mele (London School of Economics)</strong>, lunch, a 2-hour hackathon sprint, AI scoring, top-10 live presentations. Co-run with BeatM, Red Bull, NFX, and MIT Sports Lab.</p>
+
+<p><strong>$50 Cursor credits + Red Bull merch for selected participants. $1,200 prize pool.</strong> The room only fits 80 — selection is by website ranking, prioritizing PR contributors.</p>
+
+<p><strong>Two steps to reserve a seat — both required:</strong></p>
+
+<p><strong>1. RSVP on Luma</strong> (door entry &amp; approvals)<br/>
+→ <a href="${HULT_LUMA_URL}">${HULT_LUMA_URL}</a></p>
+
+<p><strong>2. Register on the website</strong> (locks you into the 80-seat ranking)<br/>
+→ <a href="${HULT_WEBSITE_SIGNUP_URL}">${HULT_WEBSITE_SIGNUP_URL}</a></p>
+
+<p>Then merge PRs to the <a href="${COMMUNITY_REPO_URL}">community repo</a> to climb the leaderboard.</p>
+
+<p style="font-size:14px;color:#555;">Detail: <a href="${HULT_DETAIL_URL}">${HULT_DETAIL_URL}</a></p>
+
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0;"/>
+
+<p><strong>One more thing — hiring managers, this is for you.</strong> If you have open roles at your company (engineers, founding eng, internships, anything), take 2 minutes to fill out our hiring-partner survey at <a href="https://www.cursorboston.com/partners">cursorboston.com/partners</a>. We&apos;re actively matching cohort builders to partner roles, and the survey captures what &quot;senior&quot; means at <em>your</em> company so we route candidates accordingly.</p>
+
+<p>See you in May.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a> · <a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you registered for a Cursor Boston event on Luma.<br/>
+Don&apos;t want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Three things on the Cursor Boston calendar this month. The first one is personal to you — your cohort status is at the top of section 1 below.
+
+
+1. SUMMER COHORT 1 — KICKOFF MON MAY 11
+Monday May 11, 6:00 PM ET · Zoom (link goes out by email)
+
+Six weeks of building with Cursor alongside other Boston devs, founders, and students. Each week ends with a live demo and a cohort vote. Winners maintain the platforms they shipped through demo day. PR contributions to the community repo can auto-admit pending applicants right up to May 9.
+${status.text}
+Cohort dashboard: ${COHORT_APPLY_URL}
+
+
+---
+
+
+2. CURSOR BOSTON × PYDATA DATA SCIENCE HACK — WED MAY 13
+Wednesday May 13, 6:30 PM – 9:30 PM ET · Moderna HQ, Cambridge (325 Binney St)
+
+Evening hackathon co-hosted with PyData Boston. Short talk from Eric Ma, then a focused build session on data-science workflows in Cursor. Pizza, community, and Cursor credits for the first 50 attendees.
+
+Moderna security: Luma sign-up closes 48 hours before the event. After Luma approval you'll get an email from no-reply@envoy.com — complete the Envoy NDA sign-in before arriving for your QR code. No QR, no entry.
+
+RSVP on Luma: ${PYDATA_LUMA_URL}
+Detail: ${PYDATA_DETAIL_URL}
+
+
+---
+
+
+3. CURSOR BOSTON × HULT — BOSTON TECH WEEK KICKOFF — TUE MAY 26
+Tuesday May 26, 10:00 AM – 4:00 PM ET · Hult International, Cambridge
+
+A full day kicking off Boston Tech Week with AIC and Hult. Coffee & networking, a guest lecture from Antonio Mele (London School of Economics), lunch, a 2-hour hackathon sprint, AI scoring, top-10 live presentations. Co-run with BeatM, Red Bull, NFX, and MIT Sports Lab.
+
+$50 Cursor credits + Red Bull merch for selected participants. $1,200 prize pool. The room only fits 80 — selection is by website ranking, prioritizing PR contributors.
+
+TWO STEPS — both required:
+
+1. RSVP on Luma (door entry & approvals)
+   → ${HULT_LUMA_URL}
+
+2. Register on the website (locks you into the 80-seat ranking)
+   → ${HULT_WEBSITE_SIGNUP_URL}
+
+Then merge PRs to the community repo to climb the leaderboard.
+   → ${COMMUNITY_REPO_URL}
+
+Detail: ${HULT_DETAIL_URL}
+
+
+---
+
+ONE MORE THING — HIRING MANAGERS, THIS IS FOR YOU
+If you have open roles at your company (engineers, founding eng, internships, anything), take 2 minutes to fill out our hiring-partner survey at https://www.cursorboston.com/partners. We're actively matching cohort builders to partner roles, and the survey captures what "senior" means at YOUR company so we route candidates accordingly.
+
+See you in May.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+---
+You're receiving this because you registered for a Cursor Boston event on Luma.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // Mirror Mailgun bounces + complaints onto eventContacts.unsubscribed
+  // before we read the list. No-ops if MAILGUN_PRIVATE_API_KEY is unset.
+  await syncMailgunSuppressions(db);
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  // Resolve cohort + GitHub status per contact.
+  const contacts: ContactData[] = [];
+  let skippedUnsub = 0;
+  let i = 0;
+  for (const doc of snap.docs) {
+    i++;
+    const data = doc.data();
+    if (data.unsubscribed === true) {
+      skippedUnsub++;
+      continue;
+    }
+    const email = (data.email as string) || doc.id;
+    const status = await resolveCohortStatus(db, email);
+    contacts.push({
+      email,
+      name: (data.name as string) || "",
+      firstName: (data.firstName as string) || "",
+      status,
+    });
+    if (i % 50 === 0) {
+      console.log(`  resolved ${i}/${snap.size}`);
+    }
+  }
+
+  console.log(
+    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsub}`
+  );
+
+  // Status breakdown
+  const tally: Record<string, number> = {};
+  for (const c of contacts) tally[c.status.kind] = (tally[c.status.kind] ?? 0) + 1;
+  console.log("\nStatus breakdown:");
+  for (const [k, n] of Object.entries(tally).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${k}: ${n}`);
+  }
+
+  if (dryRun) {
+    const sample = contacts.find((c) => c.status.kind === "applied-c1-admitted") ?? contacts[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample);
+      console.log(`\n--- sample email to ${sample.email} (kind=${sample.status.kind}) ---`);
+      console.log(`Subject: ${subject}\n`);
+      console.log(text);
+    }
+
+    // Write rendered HTML previews — one file per status kind — so the
+    // email can be opened in a browser to see what each segment receives.
+    const writeHtml = args.includes("--write-html");
+    if (writeHtml) {
+      const { writeFileSync, mkdirSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const dir = join(process.cwd(), "scripts", "data", "may-roundup-previews");
+      mkdirSync(dir, { recursive: true });
+      const seen = new Set<string>();
+      for (const c of contacts) {
+        if (seen.has(c.status.kind)) continue;
+        seen.add(c.status.kind);
+        const { html, subject } = buildEmail(c);
+        const file = join(dir, `${c.status.kind}.html`);
+        const wrapped = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${subject} — ${c.status.kind}</title></head><body style="margin:0;padding:24px;background:#f3f4f6;">
+<div style="max-width:680px;margin:0 auto;background:#fff;border-radius:8px;padding:24px;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+<div style="font-size:12px;color:#6b7280;border-bottom:1px solid #e5e7eb;padding-bottom:8px;margin-bottom:16px;">
+PREVIEW — kind: <code>${c.status.kind}</code> | recipient: <code>${escapeHtml(c.email)}</code> | subject: <code>${escapeHtml(subject)}</code>
+</div>
+${html}
+</div>
+</body></html>`;
+        writeFileSync(file, wrapped);
+        console.log(`  wrote ${file}`);
+      }
+    }
+
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-sports-hack-2026-over-cap.ts
+++ b/scripts/send-sports-hack-2026-over-cap.ts
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * Sports Hack 2026 — over-the-cap announcement.
+ *
+ * The May 26 list is now 96+ signups against an 80-person cap. Two ways to
+ * lock in a seat:
+ *   1. Apply to Summer Cohort 1 — cohort applicants are prioritized in the
+ *      May 26 immersion ranking (the in-person event for the cohort).
+ *   2. Merge PRs to the community repo — the leaderboard re-ranks live and
+ *      every merged PR moves you up.
+ *
+ * Recipient set: union of
+ *   - hackathonEventSignups where eventId=sports-hack-2026
+ *   - hackathonLumaRegistrants where eventId=sports-hack-2026
+ * Deduped by lowercased email. Judge/declined/unsubscribed filtered.
+ *
+ * Usage:
+ *   npx tsx scripts/send-sports-hack-2026-over-cap.ts --dry-run
+ *   npx tsx scripts/send-sports-hack-2026-over-cap.ts --send
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import {
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_CAPACITY,
+} from "../lib/sports-hack-2026";
+import {
+  getDeclinedEmailsForEvent,
+  getJudgeEmailsForEvent,
+} from "../lib/hackathon-event-signup";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const SIGNUP_URL =
+  "https://www.cursorboston.com/hackathons/sports-hack-2026/signup";
+const COHORT_APPLY_URL = "https://www.cursorboston.com/summer-cohort";
+const COMMUNITY_REPO_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const PARTIFUL_URL = "https://partiful.com/e/tuwaHOMgiJHvTfOFUJzA?c=EIywhmXE";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function firstNameOf(name: string | undefined, email: string): string {
+  if (name && name.trim()) return name.trim().split(/\s+/)[0]!;
+  const local = email.split("@")[0] || "there";
+  return local.split(/[._-]/)[0] || "there";
+}
+
+type Recipient = {
+  email: string;
+  firstName: string;
+  source: "website" | "luma" | "both";
+};
+
+function buildEmail(
+  to: Recipient,
+  totalCount: number
+): { subject: string; html: string; text: string } {
+  const first = escapeHtml(to.firstName);
+  const firstText = to.firstName;
+  const unsubUrl = buildUnsubscribeUrl(to.email);
+  const over = totalCount - SPORTS_HACK_2026_CAPACITY;
+
+  const subject = `${totalCount} on the May 26 list, ${SPORTS_HACK_2026_CAPACITY} seats — lock in your spot + RSVP on Partiful`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick update on Sports Hack (May 26 at Hult):</p>
+
+<p><strong>${totalCount} people are now on the list. The room only fits ${SPORTS_HACK_2026_CAPACITY}.</strong> That&apos;s ${over} people over capacity, and more are still signing up.</p>
+
+<p>Two things to do — one to lock in your seat, one to make sure you&apos;re actually counted for Boston Tech Week:</p>
+
+<p><strong>1. Lock in your seat — pick one (or both):</strong></p>
+
+<p style="margin-left:20px;"><strong>a. Apply to Summer Cohort 1, then merge a PR.</strong><br/>
+The May 26 event is the in-person kickoff for our 6-week summer cohort. Cohort 1 applicants get prioritized on the May 26 list — you&apos;ll see them at the top of the leaderboard with a violet "Cohort 1" pill. <strong>Apply, then merge any PR to the cursorboston.com repo and you&apos;re auto-admitted to Cohort 1 — that locks in your May 26 seat.</strong><br/>
+→ Apply: <a href="${COHORT_APPLY_URL}">${COHORT_APPLY_URL}</a><br/>
+→ Repo: <a href="${COMMUNITY_REPO_URL}">${COMMUNITY_REPO_URL}</a></p>
+
+<p style="margin-left:20px;"><strong>b. Or just merge PRs to the community repo.</strong><br/>
+Even without applying to the cohort, the leaderboard ranks by merged PRs and re-sorts in real time. One or two merged PRs jumps you past most people who signed up and stopped there:<br/>
+→ <a href="${COMMUNITY_REPO_URL}">${COMMUNITY_REPO_URL}</a></p>
+
+<p>Check your current spot any time:<br/>
+→ <a href="${SIGNUP_URL}">${SIGNUP_URL}</a></p>
+
+<p><strong>2. RSVP on Partiful — required for Boston Tech Week.</strong><br/>
+Partiful is the official source of truth for Boston Tech Week. Even if you&apos;re already on Luma or signed up on the website, you also need to RSVP on Partiful — it&apos;s the only way the event counts toward the official Tech Week listing:<br/>
+→ <a href="${PARTIFUL_URL}">RSVP on Partiful</a></p>
+
+<p>Selection freezes about a week before the event. Move now.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a> · <a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you signed up for Sports Hack 2026.<br/>
+Don&apos;t want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick update on Sports Hack (May 26 at Hult):
+
+${totalCount} people are now on the list. The room only fits ${SPORTS_HACK_2026_CAPACITY}. That's ${over} people over capacity, and more are still signing up.
+
+Two things to do — one to lock in your seat, one to make sure you're actually counted for Boston Tech Week:
+
+1. LOCK IN YOUR SEAT — pick one (or both):
+
+   a. Apply to Summer Cohort 1, then merge a PR.
+      The May 26 event is the in-person kickoff for our 6-week summer cohort.
+      Cohort 1 applicants get prioritized on the May 26 list — you'll see them
+      at the top of the leaderboard with a violet "Cohort 1" pill.
+      Apply, then merge any PR to the cursorboston.com repo and you're
+      auto-admitted to Cohort 1 — that locks in your May 26 seat.
+      → Apply: ${COHORT_APPLY_URL}
+      → Repo:  ${COMMUNITY_REPO_URL}
+
+   b. Or just merge PRs to the community repo.
+      Even without applying to the cohort, the leaderboard ranks by merged
+      PRs and re-sorts in real time. One or two merged PRs jumps you past
+      most people who signed up and stopped there:
+      → ${COMMUNITY_REPO_URL}
+
+   Check your current spot any time:
+   → ${SIGNUP_URL}
+
+2. RSVP ON PARTIFUL — required for Boston Tech Week.
+   Partiful is the official source of truth for Boston Tech Week. Even if
+   you're already on Luma or signed up on the website, you also need to
+   RSVP on Partiful — it's the only way the event counts toward the
+   official Tech Week listing:
+   → ${PARTIFUL_URL}
+
+Selection freezes about a week before the event. Move now.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+---
+You're receiving this because you signed up for Sports Hack 2026.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // Mirror Mailgun bounces + complaints before reading the list, so
+  // anything Mailgun has flagged since the last send gets skipped here.
+  // The Luma collection doesn't carry its own `unsubscribed` flag, so we
+  // also keep the address Set to filter that path explicitly.
+  const suppressionResult = await syncMailgunSuppressions(db);
+  const mailgunSuppressed = suppressionResult.allSuppressed;
+
+  const judgeEmails = getJudgeEmailsForEvent(SPORTS_HACK_2026_EVENT_ID);
+  const declinedEmails = getDeclinedEmailsForEvent(SPORTS_HACK_2026_EVENT_ID);
+
+  const byEmail = new Map<string, Recipient>();
+
+  // 1. Website signups
+  const signupSnap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", SPORTS_HACK_2026_EVENT_ID)
+    .get();
+
+  let skippedUnsubWebsite = 0;
+  let skippedJudgeWebsite = 0;
+  let missingEmailWebsite = 0;
+
+  for (const doc of signupSnap.docs) {
+    const uid = doc.data().userId as string | undefined;
+    if (!uid) continue;
+    const userDoc = await db.collection("users").doc(uid).get();
+    const x = userDoc.data() as Record<string, unknown> | undefined;
+    const email = (typeof x?.email === "string" ? x.email : "").toLowerCase();
+    if (!email) {
+      missingEmailWebsite++;
+      continue;
+    }
+    if (x?.unsubscribed === true) {
+      skippedUnsubWebsite++;
+      continue;
+    }
+    if (judgeEmails.has(email) || declinedEmails.has(email)) {
+      skippedJudgeWebsite++;
+      continue;
+    }
+    const displayName = typeof x?.displayName === "string" ? x.displayName : "";
+    byEmail.set(email, {
+      email,
+      firstName: firstNameOf(displayName, email),
+      source: "website",
+    });
+  }
+
+  // 2. Luma registrants
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", SPORTS_HACK_2026_EVENT_ID)
+    .get();
+
+  let skippedJudgeLuma = 0;
+  let skippedSuppressedLuma = 0;
+
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (typeof d.email === "string" ? d.email : "").toLowerCase();
+    if (!email) continue;
+    if (judgeEmails.has(email) || declinedEmails.has(email)) {
+      skippedJudgeLuma++;
+      continue;
+    }
+    if (mailgunSuppressed.has(email)) {
+      skippedSuppressedLuma++;
+      continue;
+    }
+    const existing = byEmail.get(email);
+    if (existing) {
+      existing.source = "both";
+      continue;
+    }
+    const name = typeof d.name === "string" ? d.name : "";
+    byEmail.set(email, {
+      email,
+      firstName: firstNameOf(name, email),
+      source: "luma",
+    });
+  }
+
+  const recipients = Array.from(byEmail.values()).sort((a, b) =>
+    a.email.localeCompare(b.email)
+  );
+  const totalCount = recipients.length;
+
+  console.log(
+    `Recipients: ${totalCount} total ` +
+      `(website-only: ${recipients.filter((r) => r.source === "website").length}, ` +
+      `luma-only: ${recipients.filter((r) => r.source === "luma").length}, ` +
+      `both: ${recipients.filter((r) => r.source === "both").length})`
+  );
+  console.log(
+    `Website skipped — unsubscribed: ${skippedUnsubWebsite}, judge/declined: ${skippedJudgeWebsite}, missing email: ${missingEmailWebsite}`
+  );
+  console.log(
+    `Luma skipped — judge/declined: ${skippedJudgeLuma}, mailgun-suppressed: ${skippedSuppressedLuma}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample, totalCount);
+      console.log(`--- sample email to ${sample.email} ---`);
+      console.log(`Subject: ${subject}\n`);
+      console.log(text);
+    }
+    console.log(`\nWould send to ${totalCount} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r, totalCount);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      sent++;
+      if (sent % 20 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (error) {
+      failed++;
+      console.error(`Failed: ${r.email}`, error);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/suppress-mailgun-bounces.ts
+++ b/scripts/suppress-mailgun-bounces.ts
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+/**
+ * Pull Mailgun's permanent-failure list (bounces + complaints) and mark
+ * those addresses as unsubscribed in our system so future sends skip them.
+ *
+ * Two source modes:
+ *   - API (default): delegates to lib/mailgun-suppressions.syncMailgunSuppressions.
+ *     Requires MAILGUN_PRIVATE_API_KEY (sending key returns 401 on /bounces)
+ *     and MAILGUN_DOMAIN. Bulk-send scripts call the same library at the
+ *     top of main(), so this script is mainly for ad-hoc inspection.
+ *   - CSV: when --csv-bounces / --csv-complaints are passed, reads files
+ *     exported from the Mailgun dashboard (Sending → Suppressions). Useful
+ *     when the API key isn't available.
+ *
+ * Marks:
+ *   eventContacts/<email>.unsubscribed = true (+ bouncedAt, suppressionReason)
+ *   users/<uid>.unsubscribed           = true (when email matches a CB user)
+ *
+ * Usage:
+ *   npx tsx scripts/suppress-mailgun-bounces.ts --dry-run
+ *   npx tsx scripts/suppress-mailgun-bounces.ts --apply
+ *   npx tsx scripts/suppress-mailgun-bounces.ts --dry-run --csv-bounces <path>
+ *   npx tsx scripts/suppress-mailgun-bounces.ts --apply --csv-bounces <path> --csv-complaints <path>
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { readFileSync } from "node:fs";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+
+interface SuppressionItem {
+  address: string;
+  code?: string | number;
+  error?: string;
+  created_at?: string;
+}
+
+function getArg(name: string): string | null {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i === -1) return null;
+  const v = process.argv[i + 1];
+  return v && !v.startsWith("--") ? v : null;
+}
+
+// CSV parser that handles quoted fields with embedded commas / newlines.
+function parseCsv(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') { field += '"'; i++; }
+        else { inQuotes = false; }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field); field = "";
+    } else if (c === "\n") {
+      row.push(field); field = "";
+      if (row.length > 0 && !(row.length === 1 && row[0] === "")) rows.push(row);
+      row = [];
+    } else if (c !== "\r") {
+      field += c;
+    }
+  }
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    if (!(row.length === 1 && row[0] === "")) rows.push(row);
+  }
+  return rows;
+}
+
+function loadSuppressionsFromCsv(path: string): SuppressionItem[] {
+  const content = readFileSync(path, "utf-8");
+  const rows = parseCsv(content);
+  if (rows.length === 0) return [];
+  const header = rows[0].map((h) => h.toLowerCase().trim());
+  const addrIdx = header.indexOf("address");
+  if (addrIdx === -1) {
+    throw new Error(`CSV at ${path} is missing an "address" column.`);
+  }
+  const codeIdx = header.indexOf("code");
+  const errorIdx = header.indexOf("error");
+  const createdIdx = header.indexOf("created_at");
+  const out: SuppressionItem[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const address = (r[addrIdx] || "").trim();
+    if (!address) continue;
+    out.push({
+      address,
+      code: codeIdx !== -1 ? r[codeIdx] : undefined,
+      error: errorIdx !== -1 ? r[errorIdx] : undefined,
+      created_at: createdIdx !== -1 ? r[createdIdx] : undefined,
+    });
+  }
+  return out;
+}
+
+async function applyCsv(
+  csvBouncesPath: string | null,
+  csvComplaintsPath: string | null,
+  dryRun: boolean
+) {
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const bounces = csvBouncesPath ? loadSuppressionsFromCsv(csvBouncesPath) : [];
+  const complaints = csvComplaintsPath
+    ? loadSuppressionsFromCsv(csvComplaintsPath)
+    : [];
+  console.log(
+    `Loaded from CSV: bounces=${bounces.length} (${csvBouncesPath ?? "none"}), complaints=${complaints.length} (${csvComplaintsPath ?? "none"})`
+  );
+
+  const byAddress = new Map<
+    string,
+    { reason: "bounce" | "complaint"; code: string; error: string }
+  >();
+  for (const b of bounces) {
+    const k = (b.address || "").trim().toLowerCase();
+    if (!k) continue;
+    byAddress.set(k, {
+      reason: "bounce",
+      code: String(b.code ?? ""),
+      error: String(b.error ?? "").slice(0, 200),
+    });
+  }
+  for (const c of complaints) {
+    const k = (c.address || "").trim().toLowerCase();
+    if (!k) continue;
+    if (!byAddress.has(k)) {
+      byAddress.set(k, {
+        reason: "complaint",
+        code: String(c.code ?? ""),
+        error: String(c.error ?? "").slice(0, 200),
+      });
+    }
+  }
+  console.log(`  unique addresses to suppress: ${byAddress.size}`);
+
+  const eventContactsToFlag: Array<{
+    docId: string;
+    email: string;
+    reason: "bounce" | "complaint";
+    code: string;
+    error: string;
+  }> = [];
+  const usersToFlag: Array<{ uid: string; email: string }> = [];
+
+  for (const [email, meta] of byAddress) {
+    let ecDoc = await db.collection("eventContacts").doc(email).get();
+    if (!ecDoc.exists) {
+      const q = await db
+        .collection("eventContacts")
+        .where("email", "==", email)
+        .limit(1)
+        .get();
+      if (!q.empty) ecDoc = q.docs[0];
+    }
+    if (ecDoc.exists) {
+      const d = ecDoc.data() ?? {};
+      if (d.unsubscribed !== true || !d.bouncedAt) {
+        eventContactsToFlag.push({
+          docId: ecDoc.id,
+          email,
+          reason: meta.reason,
+          code: meta.code,
+          error: meta.error,
+        });
+      }
+    }
+
+    const uq = await db
+      .collection("users")
+      .where("email", "==", email)
+      .limit(1)
+      .get();
+    if (!uq.empty) {
+      const d = uq.docs[0].data() ?? {};
+      if (d.unsubscribed !== true) {
+        usersToFlag.push({ uid: uq.docs[0].id, email });
+      }
+    }
+  }
+
+  console.log(
+    `  eventContacts to flag: ${eventContactsToFlag.length}\n  users to flag:         ${usersToFlag.length}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no Firestore writes.");
+    return;
+  }
+
+  const ops: Array<() => Promise<void>> = [];
+  for (const r of eventContactsToFlag) {
+    ops.push(async () => {
+      await db.collection("eventContacts").doc(r.docId).set(
+        {
+          unsubscribed: true,
+          bouncedAt: FieldValue.serverTimestamp(),
+          suppressionReason:
+            r.reason === "bounce" ? "mailgun-bounce" : "mailgun-complaint",
+          suppressionCode: r.code || null,
+          suppressionError: r.error || null,
+        },
+        { merge: true }
+      );
+    });
+  }
+  for (const u of usersToFlag) {
+    ops.push(async () => {
+      await db.collection("users").doc(u.uid).set(
+        {
+          unsubscribed: true,
+          unsubscribedAt: FieldValue.serverTimestamp(),
+          unsubscribedReason: "mailgun-suppression",
+        },
+        { merge: true }
+      );
+    });
+  }
+  const concurrency = 10;
+  for (let i = 0; i < ops.length; i += concurrency) {
+    await Promise.all(ops.slice(i, i + concurrency).map((fn) => fn()));
+  }
+  console.log(
+    `\nDone. ${eventContactsToFlag.length} eventContacts flagged, ${usersToFlag.length} users flagged.`
+  );
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const apply = args.includes("--apply");
+  if ((dryRun && apply) || (!dryRun && !apply)) {
+    console.error("Specify exactly one of: --dry-run | --apply");
+    process.exit(1);
+  }
+
+  const csvBouncesPath = getArg("csv-bounces");
+  const csvComplaintsPath = getArg("csv-complaints");
+  const useCsv = csvBouncesPath || csvComplaintsPath;
+
+  if (useCsv) {
+    await applyCsv(csvBouncesPath, csvComplaintsPath, dryRun);
+    return;
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+  if (!process.env.MAILGUN_PRIVATE_API_KEY || !process.env.MAILGUN_DOMAIN) {
+    console.error(
+      "MAILGUN_PRIVATE_API_KEY and MAILGUN_DOMAIN must be set, or pass --csv-bounces <path> [--csv-complaints <path>]."
+    );
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    // We don't have a no-write mode in the library — for inspection,
+    // just point the user at the CSV mode, which uses the same code path
+    // we'd otherwise use here.
+    console.error(
+      "API-source --dry-run is not supported (the library writes as it goes).\n" +
+        "Use --csv-bounces to inspect a dashboard export, or run --apply on the API."
+    );
+    process.exit(1);
+  }
+
+  const result = await syncMailgunSuppressions(db, { force: true });
+  if (result.skipped) {
+    console.log(`Skipped: ${result.skippedReason}`);
+    return;
+  }
+  console.log(
+    `\nDone. bounces=${result.bouncedCount} complaints=${result.complaintsCount} → ${result.flaggedEventContacts} eventContacts flagged, ${result.flaggedUsers} users flagged.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Cuts develop → main with the latest batch of work since the prior release.

### Included

**Today (Ludwitt + Claude)**
- `feat(pydata-2026)` — website registration page + admin viewer at `/events/cursor-boston-pydata-2026/{register,admin}`. POSTs to `pydataHack2026Registrations`; admin route is `isAdmin`-gated and exports CSV for handing to Moderna.
- `feat(mailgun-suppressions)` — new `lib/mailgun-suppressions.ts`. Bulk-send scripts now sync Mailgun bounces + complaints onto `eventContacts.unsubscribed` / `users.unsubscribed` before resolving recipients. The over-cap script also filters `hackathonLumaRegistrants` against the returned Set.

**Earlier on develop**
- `feat(partners)` — `$150k engineer profile` Likert + open-requirements field on the partners apply form (Ludwitt).
- `feat(partners)` — cc `aaron@cursorboston.com` on partner notification emails (Ludwitt).
- #638 — test(discord): GET `/api/discord/authorize` OAuth flow tests — thanks **@saiff7**.
- #640 — feat(a11y): skip-link improvements — **@iju-klaviyo** *(merged then reverted; not in this release)*.
- #641 — docs(sanitize): expanded JSDoc — **@mikayla-james** *(merged then reverted; not in this release)*.

### Test plan
- [ ] `npm run build` clean
- [ ] `/events/cursor-boston-pydata-2026/register` renders + POSTs while signed in
- [ ] `/events/cursor-boston-pydata-2026/admin` returns 403 for non-admins, list + CSV for admins
- [ ] `npx tsx scripts/send-may-roundup.ts --dry-run` shows the suppression sync running before recipient resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)