### PR TITLE
release: PyData 2026 register page — Moderna CSV spec + detailed walkthrough

### DIFF
--- a/app/api/events/pydata-2026/admin/list/route.ts
+++ b/app/api/events/pydata-2026/admin/list/route.ts
@@ -66,6 +66,7 @@ async function handleGet(request: NextRequest) {
         firstName: typeof data.firstName === "string" ? data.firstName : "",
         lastName: typeof data.lastName === "string" ? data.lastName : "",
         email: typeof data.email === "string" ? data.email : "",
+        phone: typeof data.phone === "string" ? data.phone : "",
         organization: typeof data.organization === "string" ? data.organization : "",
         attendingConfirmed: true as const,
         status,

--- a/app/api/events/pydata-2026/registration/route.ts
+++ b/app/api/events/pydata-2026/registration/route.ts
@@ -39,6 +39,7 @@ function serializeDoc(uid: string, data: Record<string, unknown>): PydataRegistr
     firstName: typeof data.firstName === "string" ? data.firstName : "",
     lastName: typeof data.lastName === "string" ? data.lastName : "",
     email: typeof data.email === "string" ? data.email : "",
+    phone: typeof data.phone === "string" ? data.phone : "",
     organization: typeof data.organization === "string" ? data.organization : "",
     attendingConfirmed: true,
     status: (["awaiting-badge", "badge-ready", "checked-in", "cancelled"].includes(status)

--- a/app/events/cursor-boston-pydata-2026/admin/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/admin/page.tsx
@@ -62,11 +62,34 @@ function csvEscape(value: string): string {
   return value;
 }
 
-function toCsv(registrations: PydataRegistration[]): string {
+/**
+ * CSV format Jacqueline (Moderna PyData host) requires 48h before the event:
+ * 4 columns, "Full name | Email | Phone | Company". First two mandatory, last
+ * two optional. Order and column names matter — don't reshuffle without
+ * checking with her first.
+ */
+function toModernaCsv(registrations: PydataRegistration[]): string {
+  const header = ["Full name", "Email", "Phone", "Company"].join(",");
+  const rows = registrations
+    .filter((r) => r.status !== "cancelled")
+    .map((r) =>
+      [
+        csvEscape(`${r.firstName} ${r.lastName}`.trim()),
+        csvEscape(r.email),
+        csvEscape(r.phone),
+        csvEscape(r.organization),
+      ].join(",")
+    );
+  return [header, ...rows].join("\n");
+}
+
+/** Internal CSV with everything — for our own bookkeeping. */
+function toFullCsv(registrations: PydataRegistration[]): string {
   const header = [
     "First name",
     "Last name",
     "Email",
+    "Phone",
     "Organization",
     "Status",
     "Confirmed at (ET)",
@@ -76,6 +99,7 @@ function toCsv(registrations: PydataRegistration[]): string {
       csvEscape(r.firstName),
       csvEscape(r.lastName),
       csvEscape(r.email),
+      csvEscape(r.phone),
       csvEscape(r.organization),
       csvEscape(STATUS_LABEL[r.status]),
       csvEscape(formatDate(r.createdAt)),
@@ -125,23 +149,33 @@ export default function PyDataAdminPage() {
     const q = search.trim().toLowerCase();
     if (!q) return data.registrations;
     return data.registrations.filter((r) => {
-      const haystack = `${r.firstName} ${r.lastName} ${r.email} ${r.organization}`.toLowerCase();
+      const haystack = `${r.firstName} ${r.lastName} ${r.email} ${r.phone} ${r.organization}`.toLowerCase();
       return haystack.includes(q);
     });
   }, [data, search]);
 
-  const downloadCsv = () => {
-    if (!data) return;
-    const csv = toCsv(data.registrations);
+  const downloadFile = (filename: string, csv: string) => {
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `pydata-2026-registrations-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+  };
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  const downloadModernaCsv = () => {
+    if (!data) return;
+    downloadFile(`pydata-2026-moderna-${today}.csv`, toModernaCsv(data.registrations));
+  };
+
+  const downloadFullCsv = () => {
+    if (!data) return;
+    downloadFile(`pydata-2026-full-${today}.csv`, toFullCsv(data.registrations));
   };
 
   return (
@@ -187,10 +221,19 @@ export default function PyDataAdminPage() {
               </button>
               <button
                 type="button"
-                onClick={downloadCsv}
+                onClick={downloadModernaCsv}
                 className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-400"
+                title="4-column CSV (Full name, Email, Phone, Company) for Moderna's Envoy registration. Excludes cancelled."
               >
-                Download CSV
+                CSV for Moderna
+              </button>
+              <button
+                type="button"
+                onClick={downloadFullCsv}
+                className="rounded-lg border border-neutral-300 px-3 py-1.5 text-xs font-semibold hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+                title="Full export (status + timestamps) for our own records."
+              >
+                Full export
               </button>
             </div>
           ) : null}
@@ -258,6 +301,7 @@ export default function PyDataAdminPage() {
                   <tr>
                     <th className="px-4 py-3 font-medium">Name</th>
                     <th className="px-4 py-3 font-medium">Email</th>
+                    <th className="px-4 py-3 font-medium">Phone</th>
                     <th className="px-4 py-3 font-medium">Organization</th>
                     <th className="px-4 py-3 font-medium">Status</th>
                     <th className="px-4 py-3 font-medium">Confirmed (ET)</th>
@@ -267,7 +311,7 @@ export default function PyDataAdminPage() {
                   {filtered.length === 0 ? (
                     <tr>
                       <td
-                        colSpan={5}
+                        colSpan={6}
                         className="px-4 py-10 text-center text-neutral-500"
                       >
                         {data.total === 0
@@ -285,6 +329,7 @@ export default function PyDataAdminPage() {
                           {r.firstName} {r.lastName}
                         </td>
                         <td className="px-4 py-3 break-all">{r.email}</td>
+                        <td className="px-4 py-3 tabular-nums">{r.phone || "—"}</td>
                         <td className="px-4 py-3">{r.organization || "—"}</td>
                         <td className="px-4 py-3">
                           <span

--- a/app/events/cursor-boston-pydata-2026/register/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/register/page.tsx
@@ -22,6 +22,7 @@ type FormState = {
   firstName: string;
   lastName: string;
   email: string;
+  phone: string;
   organization: string;
   attendingConfirmed: boolean;
 };
@@ -30,6 +31,7 @@ const EMPTY_FORM: FormState = {
   firstName: "",
   lastName: "",
   email: "",
+  phone: "",
   organization: "",
   attendingConfirmed: false,
 };
@@ -96,6 +98,7 @@ export default function PyDataRegisterPage() {
       firstName: prev.firstName || firstName,
       lastName: prev.lastName || lastName,
       email: prev.email || (user?.email ?? ""),
+      phone: prev.phone,
       organization: prev.organization,
       attendingConfirmed: prev.attendingConfirmed,
     }));
@@ -154,7 +157,8 @@ export default function PyDataRegisterPage() {
         </h1>
         <p className="mt-4 text-base text-neutral-600 dark:text-neutral-400">
           Wednesday May 13 · Moderna HQ, Cambridge. Confirm here so we can hand
-          your name to Moderna for badge issuance. You still need to RSVP on{" "}
+          your name to Moderna for Envoy registration and badge issuance. You
+          still need to RSVP on{" "}
           <a
             href={PYDATA_2026_LUMA_URL}
             target="_blank"
@@ -163,7 +167,13 @@ export default function PyDataRegisterPage() {
           >
             Luma
           </a>{" "}
-          for the door list and the Envoy NDA email.
+          for the door list.
+        </p>
+        <p className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
+          <strong>Use your full legal name</strong> exactly as it appears on the
+          government-issued ID you&apos;ll bring to the door (driver&apos;s
+          license or passport). Moderna will turn you away if the names
+          don&apos;t match.
         </p>
 
         <div className="mt-10">
@@ -241,6 +251,7 @@ function RegistrationForm({
           <input
             type="text"
             required
+            minLength={2}
             maxLength={80}
             value={form.firstName}
             onChange={(e) => setForm((p) => ({ ...p, firstName: e.target.value }))}
@@ -253,6 +264,7 @@ function RegistrationForm({
           <input
             type="text"
             required
+            minLength={2}
             maxLength={80}
             value={form.lastName}
             onChange={(e) => setForm((p) => ({ ...p, lastName: e.target.value }))}
@@ -272,10 +284,25 @@ function RegistrationForm({
             autoComplete="email"
           />
           <span className="mt-1 block text-xs text-neutral-500 dark:text-neutral-400">
-            Use the same email you used on Luma so Moderna can match you.
+            Use the same email you used on Luma so Moderna can match you. The
+            Envoy NDA + QR code will be sent here from{" "}
+            <code>no-reply@envoy.com</code>.
           </span>
         </label>
-        <label className="block text-sm sm:col-span-2">
+        <label className="block text-sm">
+          <span className="font-medium">
+            Phone <span className="font-normal text-neutral-500">(optional)</span>
+          </span>
+          <input
+            type="tel"
+            maxLength={40}
+            value={form.phone}
+            onChange={(e) => setForm((p) => ({ ...p, phone: e.target.value }))}
+            className={inputClass}
+            autoComplete="tel"
+          />
+        </label>
+        <label className="block text-sm">
           <span className="font-medium">Organization</span>
           <input
             type="text"
@@ -388,7 +415,15 @@ function AwaitingBadge({
             {registration.email}
           </dd>
         </div>
-        <div className="sm:col-span-2">
+        <div>
+          <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            Phone
+          </dt>
+          <dd className="mt-1 text-neutral-900 dark:text-neutral-100">
+            {registration.phone || "—"}
+          </dd>
+        </div>
+        <div>
           <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
             Organization
           </dt>
@@ -399,10 +434,32 @@ function AwaitingBadge({
       </dl>
 
       <div className="mt-6 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
-        <p className="font-semibold">Next: clear Moderna security</p>
-        <ol className="mt-2 list-decimal space-y-1 pl-5">
+        <p className="font-semibold">What to expect next</p>
+        <ol className="mt-2 list-decimal space-y-2 pl-5">
           <li>
-            RSVP on{" "}
+            We send your name + email to Moderna 48 hours before the event.
+          </li>
+          <li>
+            Moderna registers you in Envoy. You&apos;ll get an email from{" "}
+            <code>Moderna HQ &lt;no-reply@envoy.com&gt;</code> with NDA paperwork
+            to sign.
+          </li>
+          <li>
+            After signing, Envoy emails you a unique QR code. <strong>Bring
+            that QR code on your phone</strong> on May 13.
+          </li>
+          <li>
+            <strong>Bring a government-issued ID</strong> (driver&apos;s license
+            or passport) with the name <strong>{registration.firstName} {registration.lastName}</strong>.
+            If it doesn&apos;t match, you&apos;ll be turned away.
+          </li>
+          <li>
+            If you don&apos;t get the Envoy email but you registered on time,
+            you can still sign the NDA on paper at the door — but if your name
+            isn&apos;t on the list, you won&apos;t be admitted.
+          </li>
+          <li>
+            Don&apos;t forget to RSVP on{" "}
             <a
               href={PYDATA_2026_LUMA_URL}
               target="_blank"
@@ -412,14 +469,6 @@ function AwaitingBadge({
               Luma
             </a>{" "}
             if you haven&apos;t already.
-          </li>
-          <li>
-            Watch for an email from <code>no-reply@envoy.com</code> after Luma
-            approval. Complete the Envoy sign-in including NDA and signature.
-          </li>
-          <li>
-            Show your Envoy QR code at the door on May 13. <strong>No QR code, no
-            access.</strong>
           </li>
         </ol>
       </div>

--- a/app/events/cursor-boston-pydata-2026/register/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/register/page.tsx
@@ -176,6 +176,8 @@ export default function PyDataRegisterPage() {
           don&apos;t match.
         </p>
 
+        {!registration ? <ProcessExplainer /> : null}
+
         <div className="mt-10">
           {authLoading || loading ? (
             <div className="rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
@@ -197,6 +199,216 @@ export default function PyDataRegisterPage() {
         </div>
       </div>
     </main>
+  );
+}
+
+type StepActor = "you" | "us" | "moderna";
+
+const ACTOR_PILL: Record<StepActor, { label: string; className: string }> = {
+  you: {
+    label: "You",
+    className:
+      "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  },
+  us: {
+    label: "Cursor Boston",
+    className:
+      "border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  },
+  moderna: {
+    label: "Moderna / Envoy",
+    className:
+      "border-violet-500/40 bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  },
+};
+
+type Step = {
+  when: string;
+  actor: StepActor;
+  title: string;
+  body: React.ReactNode;
+};
+
+const PROCESS_STEPS: Step[] = [
+  {
+    when: "Now",
+    actor: "you",
+    title: "Confirm attendance + RSVP on Luma",
+    body: (
+      <>
+        Fill out the form below with the name on your government-issued ID,
+        plus your email and (optionally) phone and company. Then RSVP on{" "}
+        <a
+          href={PYDATA_2026_LUMA_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-emerald-600 underline hover:text-emerald-500 dark:text-emerald-400"
+        >
+          Luma
+        </a>{" "}
+        if you haven&apos;t already — that&apos;s the door list.
+      </>
+    ),
+  },
+  {
+    when: "48 hours before the event",
+    actor: "us",
+    title: "We send the registration list to Moderna",
+    body: (
+      <>
+        Your name + email get handed to Jacqueline at Moderna in a CSV. After
+        this cutoff, no new registrations can be added. <strong>If you&apos;re
+        not on the list 48 hours ahead of time, you will be turned away at the
+        door</strong> with no chance to sign in.
+      </>
+    ),
+  },
+  {
+    when: "Within ~1–2 days after the cutoff",
+    actor: "moderna",
+    title: "Envoy emails you NDA paperwork",
+    body: (
+      <>
+        Watch your inbox for an email from{" "}
+        <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">
+          Moderna HQ &lt;no-reply@envoy.com&gt;
+        </code>
+        . Check spam if you don&apos;t see it. The email contains a link to
+        sign Moderna&apos;s NDA online.
+      </>
+    ),
+  },
+  {
+    when: "Before May 13",
+    actor: "you",
+    title: "Sign the NDA → receive your QR code",
+    body: (
+      <>
+        Click the link, sign the paperwork, and submit. Envoy will then email
+        you a <strong>unique QR code</strong>. Save it to your phone — that QR
+        is your entry pass.
+      </>
+    ),
+  },
+  {
+    when: "Wednesday May 13 · 6:30 PM ET",
+    actor: "you",
+    title: "Show up at Moderna with your QR code + ID",
+    body: (
+      <>
+        At the door of <strong>325 Binney St, Cambridge</strong>:
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>
+            Present the QR code on your phone (the one Envoy emailed you).
+          </li>
+          <li>
+            Show a <strong>government-issued ID</strong> (driver&apos;s
+            license, passport, etc.) with the same name you submitted here.
+          </li>
+        </ul>
+      </>
+    ),
+  },
+];
+
+function ProcessExplainer() {
+  return (
+    <section className="mt-10 rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+      <h2 className="text-xl font-semibold tracking-tight">
+        What to expect — full process
+      </h2>
+      <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+        Moderna runs tighter security than most venues. Here&apos;s every step
+        between submitting this form and walking through the door, plus what
+        to do if something goes wrong.
+      </p>
+
+      <ol className="mt-6 space-y-5">
+        {PROCESS_STEPS.map((step, i) => {
+          const actor = ACTOR_PILL[step.actor];
+          return (
+            <li key={i} className="flex gap-4">
+              <div className="relative flex flex-col items-center">
+                <div className="z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-emerald-500 bg-emerald-500/10 text-sm font-semibold text-emerald-700 dark:text-emerald-400">
+                  {i + 1}
+                </div>
+                {i < PROCESS_STEPS.length - 1 ? (
+                  <div className="absolute top-8 h-full w-px bg-emerald-500/30" />
+                ) : null}
+              </div>
+              <div className="min-w-0 pb-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                    {step.when}
+                  </span>
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${actor.className}`}
+                  >
+                    {actor.label}
+                  </span>
+                </div>
+                <h3 className="mt-1 text-base font-semibold text-foreground">
+                  {step.title}
+                </h3>
+                <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+                  {step.body}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="mt-8 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-amber-900 dark:bg-amber-500/10 dark:text-amber-200">
+        <p className="font-semibold">If something goes sideways</p>
+        <ul className="mt-2 list-disc space-y-1.5 pl-5">
+          <li>
+            <strong>Envoy email never arrived?</strong> Check spam. If
+            it&apos;s still missing the day-of, you can sign the NDA on paper
+            at the door — but only if your name is already on the CSV from 48
+            hours prior. No paper sign-in for walk-ups.
+          </li>
+          <li>
+            <strong>Lost your QR code?</strong> Same fallback — paper sign-in
+            at the door, provided you&apos;re on the list.
+          </li>
+          <li>
+            <strong>Name on your ID doesn&apos;t match?</strong> Moderna will
+            turn you away. If you typed your name wrong above, click{" "}
+            <em>Edit details</em> after submitting and fix it before the
+            48-hour cutoff.
+          </li>
+          <li>
+            <strong>Need to cancel?</strong> Email{" "}
+            <a
+              href="mailto:hello@cursorboston.com"
+              className="underline font-medium"
+            >
+              hello@cursorboston.com
+            </a>{" "}
+            so we can free up the slot.
+          </li>
+        </ul>
+      </div>
+
+      <div className="mt-6 rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950/50 dark:text-neutral-300">
+        <p className="font-semibold text-foreground">A few extra rules</p>
+        <ul className="mt-2 list-disc space-y-1.5 pl-5">
+          <li>
+            <strong>Photos are fine</strong>, but don&apos;t include the
+            Moderna logo or branding in anything you post.
+          </li>
+          <li>
+            Bring a laptop, charger, Cursor IDE installed, and a registered
+            Cursor account. We&apos;re building during the second half.
+          </li>
+          <li>
+            Doors at 6:30 PM, talk at 7:00, hack starts ~8:05. We wrap by
+            9:30.
+          </li>
+        </ul>
+      </div>
+    </section>
   );
 }
 

--- a/lib/pydata-2026.ts
+++ b/lib/pydata-2026.ts
@@ -7,10 +7,10 @@
 /**
  * Constants + types for the May 13 Cursor Boston × PyData event at Moderna.
  *
- * The website registration captures the basics Moderna needs (first/last
- * name, email, organization) so we can hand the list to the host for
- * Envoy NDA + badge issuance. Status starts at "awaiting-badge" until
- * an organizer flips it to "badge-ready" or "checked-in" on the day-of.
+ * Captures the four columns Moderna needs in their CSV (full name, email,
+ * phone, company). Name parts must each be ≥2 chars because government-ID
+ * matching is enforced at the door — single-letter "F. Lastname" fails.
+ * Status starts "awaiting-badge" until an organizer flips it.
  */
 
 export const PYDATA_2026_EVENT_ID = "cursor-boston-pydata-2026";
@@ -24,7 +24,9 @@ export const PYDATA_2026_LIMITS = {
   firstName: 80,
   lastName: 80,
   email: 320,
+  phone: 40,
   organization: 200,
+  nameMin: 2,
 } as const;
 
 export type PydataRegistrationStatus =
@@ -38,6 +40,7 @@ export interface PydataRegistration {
   firstName: string;
   lastName: string;
   email: string;
+  phone: string;
   organization: string;
   attendingConfirmed: true;
   status: PydataRegistrationStatus;
@@ -49,13 +52,16 @@ export interface PydataRegistrationInput {
   firstName: string;
   lastName: string;
   email: string;
+  phone: string;
   organization: string;
   attendingConfirmed: true;
 }
 
 export type PydataValidationError =
   | "firstName-required"
+  | "firstName-too-short"
   | "lastName-required"
+  | "lastName-too-short"
   | "email-required"
   | "email-invalid"
   | "organization-required"
@@ -77,11 +83,16 @@ export function validatePydataRegistration(
   const firstName = clamp(r.firstName, PYDATA_2026_LIMITS.firstName);
   const lastName = clamp(r.lastName, PYDATA_2026_LIMITS.lastName);
   const email = clamp(r.email, PYDATA_2026_LIMITS.email).toLowerCase();
+  const phone = clamp(r.phone, PYDATA_2026_LIMITS.phone);
   const organization = clamp(r.organization, PYDATA_2026_LIMITS.organization);
   const attendingConfirmed = r.attendingConfirmed === true;
 
   if (!firstName) errors.push("firstName-required");
+  else if (firstName.length < PYDATA_2026_LIMITS.nameMin)
+    errors.push("firstName-too-short");
   if (!lastName) errors.push("lastName-required");
+  else if (lastName.length < PYDATA_2026_LIMITS.nameMin)
+    errors.push("lastName-too-short");
   if (!email) errors.push("email-required");
   else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.push("email-invalid");
   if (!organization) errors.push("organization-required");
@@ -90,6 +101,13 @@ export function validatePydataRegistration(
   if (errors.length > 0) return { ok: false, errors };
   return {
     ok: true,
-    data: { firstName, lastName, email, organization, attendingConfirmed: true },
+    data: {
+      firstName,
+      lastName,
+      email,
+      phone,
+      organization,
+      attendingConfirmed: true,
+    },
   };
 }


### PR DESCRIPTION
## Summary

Two follow-up commits to PR #645 (PyData registration). Refinements driven by Jacqueline (Moderna PyData host) confirming the exact CSV format she needs and the door-of-Moderna process.

### Included

**Ludwitt + Claude**
- `feat(pydata-2026)` — match Moderna's Envoy CSV spec: phone field, ≥2-char name validation, government-ID warning banner, two CSV exports (Moderna's 4-column spec + a full internal export).
- `feat(pydata-2026)` — detailed "what to expect" walkthrough on `/register`: 5-step timeline with actor pills (You / Cursor Boston / Moderna+Envoy), a "if something goes sideways" panel, and an "extra rules" tile.

### Test plan
- [ ] `/events/cursor-boston-pydata-2026/register` shows the full 5-step process explainer + government-ID warning above the form
- [ ] Submitting with a 1-character first/last name returns a validation error
- [ ] Phone field accepts blank submission (optional)
- [ ] Admin page shows phone column + the "CSV for Moderna" download outputs exactly 4 columns: Full name, Email, Phone, Company
- [ ] Cancelled rows are excluded from the Moderna CSV but present in the full export

🤖 Generated with [Claude Code](https://claude.com/claude-code)