### PR TITLE
release: PyData 2026 — 150-person hard cap, cap-aware admin + capacity API

### DIFF
--- a/app/api/events/pydata-2026/admin/list/route.ts
+++ b/app/api/events/pydata-2026/admin/list/route.ts
@@ -9,6 +9,7 @@ import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import {
+  PYDATA_2026_CAPACITY,
   PYDATA_2026_REGISTRATIONS_COLLECTION,
   type PydataRegistration,
   type PydataRegistrationStatus,
@@ -84,10 +85,25 @@ async function handleGet(request: NextRequest) {
     {} as Record<PydataRegistrationStatus, number>
   );
 
+  // First PYDATA_2026_CAPACITY non-cancelled rows (already sorted createdAt asc)
+  // are inside the cap; the rest are waitlist. Cancelled rows are skipped.
+  const eligibleSorted = registrations.filter((r) => r.status !== "cancelled");
+  const inCapEmails = new Set(
+    eligibleSorted.slice(0, PYDATA_2026_CAPACITY).map((r) => r.email)
+  );
+  const inCapCount = inCapEmails.size;
+  const waitlistCount = Math.max(0, eligibleSorted.length - inCapCount);
+
   return NextResponse.json({
     total: registrations.length,
     counts,
-    registrations,
+    capacity: PYDATA_2026_CAPACITY,
+    inCapCount,
+    waitlistCount,
+    registrations: registrations.map((r) => ({
+      ...r,
+      inCap: inCapEmails.has(r.email),
+    })),
   });
 }
 

--- a/app/api/events/pydata-2026/capacity/route.ts
+++ b/app/api/events/pydata-2026/capacity/route.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  PYDATA_2026_CAPACITY,
+  PYDATA_2026_REGISTRATIONS_COLLECTION,
+} from "@/lib/pydata-2026";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Public, unauthenticated endpoint: just the cap-vs-registered numbers so the
+ * /register page can show "X / 150 spots claimed". Doesn't expose names.
+ */
+export async function GET() {
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+  // Could be cached but the volume is low; query each time keeps it fresh.
+  const snap = await db
+    .collection(PYDATA_2026_REGISTRATIONS_COLLECTION)
+    .where("status", "in", ["awaiting-badge", "badge-ready", "checked-in"])
+    .count()
+    .get();
+  const claimed = snap.data().count;
+  const remaining = Math.max(0, PYDATA_2026_CAPACITY - claimed);
+  const full = claimed >= PYDATA_2026_CAPACITY;
+  return NextResponse.json({
+    capacity: PYDATA_2026_CAPACITY,
+    claimed,
+    remaining,
+    full,
+  });
+}

--- a/app/events/cursor-boston-pydata-2026/admin/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/admin/page.tsx
@@ -15,6 +15,8 @@ import {
   type PydataRegistrationStatus,
 } from "@/lib/pydata-2026";
 
+type RegistrationWithCap = PydataRegistration & { inCap: boolean };
+
 const API_PATH = "/api/events/pydata-2026/admin/list";
 
 const STATUS_LABEL: Record<PydataRegistrationStatus, string> = {
@@ -38,7 +40,10 @@ const STATUS_PILL: Record<PydataRegistrationStatus, string> = {
 type Response = {
   total: number;
   counts: Partial<Record<PydataRegistrationStatus, number>>;
-  registrations: PydataRegistration[];
+  capacity: number;
+  inCapCount: number;
+  waitlistCount: number;
+  registrations: RegistrationWithCap[];
 };
 
 function formatDate(ms: number): string {
@@ -68,10 +73,12 @@ function csvEscape(value: string): string {
  * two optional. Order and column names matter — don't reshuffle without
  * checking with her first.
  */
-function toModernaCsv(registrations: PydataRegistration[]): string {
+function toModernaCsv(registrations: RegistrationWithCap[]): string {
   const header = ["Full name", "Email", "Phone", "Company"].join(",");
+  // Only people inside the cap go to Moderna. inCap is server-computed:
+  // first PYDATA_2026_CAPACITY non-cancelled rows by createdAt asc.
   const rows = registrations
-    .filter((r) => r.status !== "cancelled")
+    .filter((r) => r.inCap)
     .map((r) =>
       [
         csvEscape(`${r.firstName} ${r.lastName}`.trim()),
@@ -84,7 +91,7 @@ function toModernaCsv(registrations: PydataRegistration[]): string {
 }
 
 /** Internal CSV with everything — for our own bookkeeping. */
-function toFullCsv(registrations: PydataRegistration[]): string {
+function toFullCsv(registrations: RegistrationWithCap[]): string {
   const header = [
     "First name",
     "Last name",
@@ -92,6 +99,7 @@ function toFullCsv(registrations: PydataRegistration[]): string {
     "Phone",
     "Organization",
     "Status",
+    "Cap status",
     "Confirmed at (ET)",
   ].join(",");
   const rows = registrations.map((r) =>
@@ -102,6 +110,7 @@ function toFullCsv(registrations: PydataRegistration[]): string {
       csvEscape(r.phone),
       csvEscape(r.organization),
       csvEscape(STATUS_LABEL[r.status]),
+      csvEscape(r.inCap ? "in-cap" : "waitlist"),
       csvEscape(formatDate(r.createdAt)),
     ].join(",")
   );
@@ -273,14 +282,29 @@ export default function PyDataAdminPage() {
         ) : data ? (
           <>
             <section className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              <Stat label="Total registered" value={data.total} />
+              <Stat
+                label={`In cap (top ${data.capacity})`}
+                value={data.inCapCount}
+                accent={
+                  data.inCapCount >= data.capacity
+                    ? "rose"
+                    : data.inCapCount >= data.capacity - 25
+                      ? "amber"
+                      : "emerald"
+                }
+              />
+              <Stat label="Waitlist" value={data.waitlistCount} accent="amber" />
               <Stat
                 label="Awaiting badge"
                 value={data.counts["awaiting-badge"] ?? 0}
               />
-              <Stat label="Badge ready" value={data.counts["badge-ready"] ?? 0} />
               <Stat label="Checked in" value={data.counts["checked-in"] ?? 0} />
             </section>
+            <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+              Cap of {data.capacity} is enforced by registration time
+              (createdAt asc). The &quot;CSV for Moderna&quot; download includes
+              only in-cap rows.
+            </p>
 
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <input
@@ -332,11 +356,24 @@ export default function PyDataAdminPage() {
                         <td className="px-4 py-3 tabular-nums">{r.phone || "—"}</td>
                         <td className="px-4 py-3">{r.organization || "—"}</td>
                         <td className="px-4 py-3">
-                          <span
-                            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${STATUS_PILL[r.status]}`}
-                          >
-                            {STATUS_LABEL[r.status]}
-                          </span>
+                          <div className="flex flex-col items-start gap-1">
+                            <span
+                              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${STATUS_PILL[r.status]}`}
+                            >
+                              {STATUS_LABEL[r.status]}
+                            </span>
+                            {r.status !== "cancelled" ? (
+                              r.inCap ? (
+                                <span className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+                                  In cap
+                                </span>
+                              ) : (
+                                <span className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-400">
+                                  Waitlist
+                                </span>
+                              )
+                            ) : null}
+                          </div>
                         </td>
                         <td className="px-4 py-3 text-neutral-600 dark:text-neutral-400 tabular-nums">
                           {formatDate(r.createdAt)}
@@ -354,9 +391,25 @@ export default function PyDataAdminPage() {
   );
 }
 
-function Stat({ label, value }: { label: string; value: number }) {
+function Stat({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent?: "emerald" | "amber" | "rose";
+}) {
+  const accentClass =
+    accent === "rose"
+      ? "border-rose-500/30 bg-rose-500/5 dark:bg-rose-500/10"
+      : accent === "amber"
+        ? "border-amber-500/30 bg-amber-500/5 dark:bg-amber-500/10"
+        : accent === "emerald"
+          ? "border-emerald-500/30 bg-emerald-500/5 dark:bg-emerald-500/10"
+          : "border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900";
   return (
-    <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+    <div className={`rounded-xl border p-4 ${accentClass}`}>
       <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
         {label}
       </p>

--- a/app/events/cursor-boston-pydata-2026/register/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/register/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import {
+  PYDATA_2026_CAPACITY,
   PYDATA_2026_EVENT_SLUG,
   PYDATA_2026_LUMA_URL,
   PYDATA_2026_REGISTRATION_PATH,
@@ -17,6 +18,14 @@ import {
 } from "@/lib/pydata-2026";
 
 const API_PATH = "/api/events/pydata-2026/registration";
+const CAPACITY_API_PATH = "/api/events/pydata-2026/capacity";
+
+type CapacityState = {
+  capacity: number;
+  claimed: number;
+  remaining: number;
+  full: boolean;
+};
 
 type FormState = {
   firstName: string;
@@ -57,6 +66,23 @@ export default function PyDataRegisterPage() {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [capacity, setCapacity] = useState<CapacityState | null>(null);
+
+  const loadCapacity = useCallback(async () => {
+    try {
+      const res = await fetch(CAPACITY_API_PATH);
+      if (!res.ok) return;
+      const json = (await res.json()) as CapacityState;
+      setCapacity(json);
+    } catch {
+      // Non-critical: banner just won't show live numbers
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot fetch on mount
+    void loadCapacity();
+  }, [loadCapacity]);
 
   const load = useCallback(async () => {
     if (!user) {
@@ -127,6 +153,7 @@ export default function PyDataRegisterPage() {
         throw new Error(json.error || "Could not submit");
       }
       await load();
+      void loadCapacity();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not submit");
     } finally {
@@ -169,6 +196,8 @@ export default function PyDataRegisterPage() {
           </a>{" "}
           for the door list.
         </p>
+        <CapacityBanner capacity={capacity} />
+
         <p className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
           <strong>Use your full legal name</strong> exactly as it appears on the
           government-issued ID you&apos;ll bring to the door (driver&apos;s
@@ -253,13 +282,17 @@ const PROCESS_STEPS: Step[] = [
   {
     when: "48 hours before the event",
     actor: "us",
-    title: "We send the registration list to Moderna",
+    title: "We send the top 150 registrations to Moderna",
     body: (
       <>
-        Your name + email get handed to Jacqueline at Moderna in a CSV. After
-        this cutoff, no new registrations can be added. <strong>If you&apos;re
-        not on the list 48 hours ahead of time, you will be turned away at the
-        door</strong> with no chance to sign in.
+        We sort everyone by the time they hit submit on this page and send the
+        first <strong>{PYDATA_2026_CAPACITY}</strong> to Jacqueline at Moderna
+        in a CSV. After this cutoff, no new registrations can be added.{" "}
+        <strong>
+          If you&apos;re not on that list 48 hours ahead of time, you will be
+          turned away at the door
+        </strong>{" "}
+        with no chance to sign in. Luma RSVPs do not count toward the cap.
       </>
     ),
   },
@@ -310,6 +343,79 @@ const PROCESS_STEPS: Step[] = [
     ),
   },
 ];
+
+function CapacityBanner({ capacity }: { capacity: CapacityState | null }) {
+  // Always render a baseline cap banner — when live numbers haven't loaded
+  // yet (or the API hiccups), fall back to the static cap from the constant.
+  const claimed = capacity?.claimed ?? 0;
+  const cap = capacity?.capacity ?? PYDATA_2026_CAPACITY;
+  const remaining = capacity?.remaining ?? cap;
+  const full = capacity?.full ?? false;
+  const showLive = capacity !== null;
+  const lowSpots = showLive && !full && remaining <= 25;
+
+  const tone = full
+    ? {
+        wrap: "border-rose-500/40 bg-rose-500/10 text-rose-900 dark:bg-rose-500/15 dark:text-rose-200",
+        bar: "bg-rose-500",
+      }
+    : lowSpots
+      ? {
+          wrap: "border-amber-500/40 bg-amber-500/10 text-amber-900 dark:bg-amber-500/15 dark:text-amber-200",
+          bar: "bg-amber-500",
+        }
+      : {
+          wrap: "border-rose-500/40 bg-rose-500/5 text-rose-900 dark:bg-rose-500/10 dark:text-rose-200",
+          bar: "bg-rose-500",
+        };
+
+  const pct = Math.min(100, Math.round((claimed / cap) * 100));
+
+  return (
+    <div className={`mt-6 rounded-lg border px-4 py-4 ${tone.wrap}`}>
+      <p className="font-semibold">
+        Hard cap: {cap} attendees · first come, first served
+      </p>
+      <p className="mt-1 text-sm">
+        Spots are awarded by{" "}
+        <strong>order of registration on this page</strong> — Luma RSVPs do not
+        count toward the cap. Once we hit {cap}, the rest become a waitlist
+        even if they RSVP&apos;d on Luma months ago.
+      </p>
+      {showLive ? (
+        <div className="mt-3">
+          <div className="flex items-baseline justify-between gap-3 text-sm tabular-nums">
+            <span className="font-mono">
+              <strong>{claimed}</strong> / {cap} spots claimed
+            </span>
+            <span>
+              {full ? (
+                <strong>Cap reached — registrations now go to the waitlist.</strong>
+              ) : (
+                <>
+                  <strong>{remaining}</strong> spot{remaining === 1 ? "" : "s"}{" "}
+                  left
+                </>
+              )}
+            </span>
+          </div>
+          <div
+            className="mt-2 h-2 w-full overflow-hidden rounded-full bg-black/10 dark:bg-white/10"
+            role="progressbar"
+            aria-valuenow={claimed}
+            aria-valuemin={0}
+            aria-valuemax={cap}
+          >
+            <div
+              className={`h-full ${tone.bar} transition-all`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 function ProcessExplainer() {
   return (

--- a/lib/pydata-2026.ts
+++ b/lib/pydata-2026.ts
@@ -20,6 +20,13 @@ export const PYDATA_2026_REGISTRATION_PATH = `/events/${PYDATA_2026_EVENT_SLUG}/
 
 export const PYDATA_2026_REGISTRATIONS_COLLECTION = "pydataHack2026Registrations";
 
+/**
+ * Hard cap on attendees Moderna will admit. We hand Moderna the first
+ * PYDATA_2026_CAPACITY non-cancelled registrations sorted by createdAt;
+ * everyone else lands on a waitlist. Luma RSVPs do NOT count.
+ */
+export const PYDATA_2026_CAPACITY = 150;
+
 export const PYDATA_2026_LIMITS = {
   firstName: 80,
   lastName: 80,

--- a/scripts/send-pydata-cap-correction.ts
+++ b/scripts/send-pydata-cap-correction.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * Short follow-up to the May 4 PyData Moderna-access blast clarifying that
+ * Moderna has a hard cap of 150 attendees, allocated by registration order
+ * on cursorboston.com (NOT by Luma RSVP order).
+ *
+ * Recipient set: same Luma CSV as the original blast, suppressed addresses
+ * skipped via the auto-mirror sync at the top of main().
+ *
+ * Usage:
+ *   npx tsx scripts/send-pydata-cap-correction.ts --csv <path> --dry-run
+ *   npx tsx scripts/send-pydata-cap-correction.ts --csv <path> --send
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { readFileSync } from "fs";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import {
+  PYDATA_2026_CAPACITY,
+  PYDATA_2026_REGISTRATIONS_COLLECTION,
+} from "../lib/pydata-2026";
+
+const REGISTER_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026/register";
+const EVENT_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026";
+const SUBMIT_DEADLINE_HUMAN = "Monday May 11, 11:59 PM ET";
+
+interface Recipient {
+  email: string;
+  firstName: string;
+  registeredOnSite: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function parseCsv(content: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      // ignore
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((c) => c.length > 0)) rows.push(row);
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  const out: Record<string, string>[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const obj: Record<string, string> = {};
+    for (let j = 0; j < header.length; j++)
+      obj[header[j]!] = (rows[r]![j] ?? "").trim();
+    out.push(obj);
+  }
+  return out;
+}
+
+function buildEmail(r: Recipient): { subject: string; text: string; html: string } {
+  const greet = r.firstName ? `Hi ${r.firstName},` : "Hi,";
+  const unsub = buildUnsubscribeUrl(r.email);
+
+  const subject = r.registeredOnSite
+    ? `PyData May 13 — your spot is locked in (${PYDATA_2026_CAPACITY}-person hard cap)`
+    : `PyData May 13 — ${PYDATA_2026_CAPACITY}-person HARD CAP, register on cursorboston.com to claim a spot`;
+
+  const statusBlockText = r.registeredOnSite
+    ? `Good news: you're already registered on cursorboston.com, so your spot is in the queue. Spots are awarded by order of registration on the website, so the earlier you registered, the safer you are.`
+    : `IMPORTANT: you have not yet registered on cursorboston.com. Spots fill in the order people register on the site — Luma RSVPs do not count. If we hit ${PYDATA_2026_CAPACITY} before you register, you go on the waitlist with no guarantee of admission.`;
+
+  const text = `${greet}
+
+Quick correction / clarification on this morning's email about the May 13 PyData × Cursor Boston event at Moderna:
+
+Moderna has a HARD CAP of ${PYDATA_2026_CAPACITY} attendees. Spots are first come, first served, allocated by the order of registrations on cursorboston.com — NOT by Luma RSVP order. A Luma RSVP from months ago does not put you ahead of someone who registers on the website today.
+
+${statusBlockText}
+
+Register here: ${REGISTER_URL}
+
+Deadline either way: ${SUBMIT_DEADLINE_HUMAN}. After that we send Moderna the top ${PYDATA_2026_CAPACITY} and stop.
+
+Everything else from this morning's email still applies (full process explainer at ${EVENT_DETAIL_URL}, Envoy NDA after the cutoff, government ID at the door, etc.).
+
+Sorry for the back-to-back emails — wanted you to have the cap policy clearly in writing.
+
+— Roger
+Cursor Boston
+
+---
+Unsubscribe: ${unsub}
+`;
+
+  const statusBlockHtml = r.registeredOnSite
+    ? `
+<div style="margin:24px 0;padding:16px;border-left:4px solid #10b981;background:#ecfdf5;border-radius:6px;color:#065f46;">
+  <p style="margin:0;"><strong>Good news: you're already registered on cursorboston.com</strong>, so your spot is in the queue.</p>
+  <p style="margin:8px 0 0 0;font-size:14px;">Spots are awarded by order of registration on the website, so the earlier you registered, the safer you are.</p>
+</div>`
+    : `
+<div style="margin:24px 0;padding:16px;border-left:4px solid #dc2626;background:#fef2f2;border-radius:6px;color:#991b1b;">
+  <p style="margin:0;font-size:16px;"><strong>You have not yet registered on cursorboston.com.</strong></p>
+  <p style="margin:8px 0 0 0;">Spots fill in the order people register on the site — Luma RSVPs do not count. If we hit ${PYDATA_2026_CAPACITY} before you register, you go on the waitlist with no guarantee of admission.</p>
+  <p style="margin:16px 0 0 0;"><a href="${REGISTER_URL}" style="display:inline-block;padding:12px 24px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Register now to claim a spot →</a></p>
+</div>`;
+
+  const html = `<!doctype html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111;max-width:640px;margin:0 auto;padding:24px;line-height:1.55;">
+  <p>${escapeHtml(greet)}</p>
+
+  <p>Quick correction / clarification on this morning's email about the <strong>May 13 PyData × Cursor Boston</strong> event at Moderna:</p>
+
+  <div style="margin:20px 0;padding:16px;border:2px solid #dc2626;border-radius:8px;background:#fff;">
+    <p style="margin:0;font-size:16px;color:#111;">
+      <strong>Moderna has a HARD CAP of ${PYDATA_2026_CAPACITY} attendees.</strong>
+    </p>
+    <p style="margin:8px 0 0 0;color:#444;">
+      Spots are first come, first served, allocated by the order of
+      registrations on <strong>cursorboston.com</strong> — NOT by Luma RSVP
+      order. A Luma RSVP from months ago does not put you ahead of someone
+      who registers on the website today.
+    </p>
+  </div>
+
+  ${statusBlockHtml}
+
+  <p style="margin-top:24px;">
+    <strong>Register here:</strong>
+    <a href="${REGISTER_URL}" style="color:#10b981;">${REGISTER_URL}</a>
+  </p>
+  <p>
+    <strong>Deadline either way:</strong> ${escapeHtml(SUBMIT_DEADLINE_HUMAN)}. After
+    that we send Moderna the top ${PYDATA_2026_CAPACITY} and stop.
+  </p>
+
+  <p style="color:#555;">Everything else from this morning's email still applies — full process explainer is on the <a href="${EVENT_DETAIL_URL}" style="color:#10b981;">event page</a>: Envoy NDA after the cutoff, government ID at the door, etc.</p>
+
+  <p style="color:#555;">Sorry for the back-to-back emails — wanted you to have the cap policy clearly in writing.</p>
+
+  <p>— Roger<br>Cursor Boston</p>
+
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0 16px;">
+  <p style="font-size:12px;color:#999;">
+    You're getting this because you RSVP'd on Luma for the May 13 PyData × Cursor Boston event.
+    <a href="${unsub}" style="color:#999;">Unsubscribe</a>
+  </p>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  const csvIdx = args.indexOf("--csv");
+  if (csvIdx === -1 || !args[csvIdx + 1]) {
+    console.error("Pass --csv <path-to-luma-export.csv>");
+    process.exit(1);
+  }
+  const csvPath = args[csvIdx + 1]!;
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  await syncMailgunSuppressions(db);
+
+  let raw = readFileSync(csvPath, "utf8");
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  const lumaRows = parseCsv(raw);
+  console.log(`Luma CSV: ${lumaRows.length} rows`);
+
+  const ec = await db.collection("eventContacts").get();
+  const unsubbed = new Set<string>();
+  const ecNameByEmail = new Map<string, string>();
+  for (const d of ec.docs) {
+    const data = d.data();
+    const email = (typeof data.email === "string" ? data.email : d.id).toLowerCase();
+    if (data.unsubscribed === true) unsubbed.add(email);
+    const fname = typeof data.firstName === "string" ? data.firstName : "";
+    if (fname) ecNameByEmail.set(email, fname);
+  }
+
+  const siteRegSnap = await db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).get();
+  const siteEmails = new Set<string>();
+  for (const d of siteRegSnap.docs) {
+    const e = (d.data().email || "").toLowerCase();
+    if (e) siteEmails.add(e);
+  }
+
+  const seen = new Set<string>();
+  const recipients: Recipient[] = [];
+  let skippedUnsub = 0;
+  let skippedDup = 0;
+
+  for (const r of lumaRows) {
+    const email = (r.email || "").trim().toLowerCase();
+    if (!email) continue;
+    if (seen.has(email)) {
+      skippedDup++;
+      continue;
+    }
+    seen.add(email);
+    if (unsubbed.has(email)) {
+      skippedUnsub++;
+      continue;
+    }
+    const firstName =
+      (r.first_name || "").trim() ||
+      ecNameByEmail.get(email) ||
+      ((r.name || "").split(" ")[0] || "").trim();
+    recipients.push({
+      email,
+      firstName,
+      registeredOnSite: siteEmails.has(email),
+    });
+  }
+
+  const onSite = recipients.filter((r) => r.registeredOnSite).length;
+  const notOnSite = recipients.filter((r) => !r.registeredOnSite).length;
+  console.log(
+    `Recipients: ${recipients.length} (on site: ${onSite}, not yet: ${notOnSite})`
+  );
+  console.log(`Skipped: ${skippedUnsub} suppressed, ${skippedDup} duplicates`);
+
+  if (dryRun) {
+    const sNot = recipients.find((r) => !r.registeredOnSite);
+    const sOn = recipients.find((r) => r.registeredOnSite);
+    if (sNot) {
+      const { subject, text } = buildEmail(sNot);
+      console.log(`\n--- sample to ${sNot.email} (NOT on site) ---`);
+      console.log(`Subject: ${subject}\n`);
+      console.log(text);
+    }
+    if (sOn) {
+      const { subject } = buildEmail(sOn);
+      console.log(`\n--- subject for already-on-site (${sOn.email}) ---`);
+      console.log(`Subject: ${subject}`);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  console.log(`\nSending to ${recipients.length} recipients…`);
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, text, html } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, text, html });
+      sent++;
+      if (sent % 25 === 0 || sent === recipients.length) {
+        console.log(`  sent ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  FAILED ${r.email}: ${e instanceof Error ? e.message : e}`);
+    }
+    await new Promise((res) => setTimeout(res, 80));
+  }
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-pydata-moderna-access.ts
+++ b/scripts/send-pydata-moderna-access.ts
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+/**
+ * Targeted email to every person on the May 13 PyData Luma list explaining
+ * the cursorboston.com → Moderna → Envoy → QR-code flow. Hard-line copy:
+ * if they don't register on cursorboston.com before the 48h cutoff, their
+ * name does not go to Moderna and they will be turned away at the door.
+ *
+ * Recipient set:
+ *   - Read the Luma CSV passed as --csv <path>
+ *   - Skip any address marked unsubscribed in eventContacts (Mailgun bounces
+ *     are auto-mirrored at the top of main() before we read the list)
+ *   - Personalize: greet by first name + flag whether they've already
+ *     registered on the site (only ~1 today; the other 167 haven't).
+ *
+ * Usage:
+ *   npx tsx scripts/send-pydata-moderna-access.ts --csv <path> --dry-run
+ *   npx tsx scripts/send-pydata-moderna-access.ts --csv <path> --send
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { readFileSync } from "fs";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { PYDATA_2026_REGISTRATIONS_COLLECTION } from "../lib/pydata-2026";
+
+const REGISTER_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026/register";
+const EVENT_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026";
+const LUMA_URL = "https://luma.com/ggjlxdnk";
+const SUBMIT_DEADLINE_HUMAN = "Monday May 11, 11:59 PM ET";
+
+interface Recipient {
+  email: string;
+  firstName: string;
+  registeredOnSite: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function parseCsv(content: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      // ignore
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((c) => c.length > 0)) rows.push(row);
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  const out: Record<string, string>[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const obj: Record<string, string> = {};
+    for (let j = 0; j < header.length; j++)
+      obj[header[j]!] = (rows[r]![j] ?? "").trim();
+    out.push(obj);
+  }
+  return out;
+}
+
+function buildEmail(r: Recipient): { subject: string; text: string; html: string } {
+  const greet = r.firstName ? `Hi ${r.firstName},` : "Hi,";
+  const unsub = buildUnsubscribeUrl(r.email);
+
+  // Two-block opening: hard requirement + "if you've already registered" reassurance.
+  const statusBlockText = r.registeredOnSite
+    ? `You're already registered on cursorboston.com — thank you. The rest of this email is for context, but you can stop reading after step 4 if you want. The key thing for you is: watch for the Envoy email after the cutoff.`
+    : `Action required: you have NOT yet registered on cursorboston.com. If you do not register before the ${SUBMIT_DEADLINE_HUMAN} cutoff, we will NOT send your name to Moderna, and you WILL NOT be admitted under any circumstance.`;
+
+  const subject = r.registeredOnSite
+    ? `PyData × Cursor Boston May 13 — what to expect (you're already registered on the site)`
+    : `ACTION REQUIRED: PyData × Cursor Boston May 13 — register on cursorboston.com or you can't get in`;
+
+  const text = `${greet}
+
+You RSVP'd on Luma for the Cursor Boston × PyData Data Science Hack on Wednesday May 13 at Moderna HQ in Cambridge. We're emailing every Luma RSVP because Moderna's security process is unusually strict and a Luma RSVP alone will not get you through the door.
+
+${statusBlockText}
+
+────────────────────────────────────────
+THE PROCESS — every step between now and the door
+────────────────────────────────────────
+
+1. NOW · Register on cursorboston.com
+   Go to: ${REGISTER_URL}
+   Enter your full legal name (matching your government ID — driver's license or passport), email, and optionally phone + company.
+   Why this exists: Moderna requires a CSV of confirmed attendees with names that match government ID. We can only send what you enter into this form.
+
+2. ${SUBMIT_DEADLINE_HUMAN} · 48-HOUR HARD CUTOFF
+   We send the registration list to Moderna. After this point, no new names can be added. Period.
+   If you are not on this list, Moderna will turn you away at the door with no chance to sign in.
+
+3. ~1-2 days after the cutoff · Envoy emails you NDA paperwork
+   You'll get an email from "Moderna HQ <no-reply@envoy.com>" with a link to sign their NDA online.
+   Check your spam folder if you don't see it within 48 hours of the cutoff.
+
+4. Before May 13 · Sign the NDA → receive your QR code
+   Click the Envoy link, sign the paperwork, submit. Envoy then emails you a UNIQUE QR CODE. Save it to your phone — that QR is your entry pass.
+
+5. Wednesday May 13, 6:30 PM ET · Show up at 325 Binney St, Cambridge
+   - Show the QR code on your phone
+   - Show a government-issued ID with the same name you submitted in step 1
+   If your ID name does not match the name we sent, you will be turned away.
+
+────────────────────────────────────────
+IF SOMETHING GOES SIDEWAYS
+────────────────────────────────────────
+
+- Envoy email never arrived: Check spam first. If it's still missing the day-of, you can sign the NDA on paper at the door — but ONLY if your name is on the CSV from step 2. No paper sign-in for walk-ups.
+- Lost your QR code: Same fallback — paper sign-in at the door, provided you're on the list.
+- Name on your ID doesn't match what you submitted: Click "Edit details" on your registration page (${REGISTER_URL}) before the cutoff and fix it.
+- Need to cancel: Reply to this email so we can free up the slot.
+
+────────────────────────────────────────
+A FEW EXTRA THINGS
+────────────────────────────────────────
+
+- Photos are fine, but don't include the Moderna logo or branding in anything you post.
+- Bring: laptop, charger, Cursor IDE installed, registered Cursor account.
+- Schedule: doors 6:30 PM, talk at 7:00, hack starts ~8:05, wrap by 9:30.
+
+Event details: ${EVENT_DETAIL_URL}
+Luma: ${LUMA_URL}
+
+Questions? Reply to this email.
+
+— Roger
+Cursor Boston
+
+---
+Unsubscribe: ${unsub}
+`;
+
+  // Status block coloring varies by whether they're already registered.
+  const statusBlockHtml = r.registeredOnSite
+    ? `
+<div style="margin:24px 0;padding:16px;border-left:4px solid #10b981;background:#ecfdf5;border-radius:6px;">
+  <p style="margin:0;color:#065f46;"><strong>You're already registered on cursorboston.com — thank you.</strong></p>
+  <p style="margin:8px 0 0 0;color:#065f46;font-size:14px;">The rest of this email is for context. The key thing for you is: watch for the Envoy email after the cutoff.</p>
+</div>`
+    : `
+<div style="margin:24px 0;padding:16px;border-left:4px solid #dc2626;background:#fef2f2;border-radius:6px;">
+  <p style="margin:0;color:#991b1b;font-size:16px;"><strong>Action required: you have NOT yet registered on cursorboston.com.</strong></p>
+  <p style="margin:8px 0 0 0;color:#991b1b;">If you do not register before the <strong>${SUBMIT_DEADLINE_HUMAN}</strong> cutoff, we will <strong>NOT</strong> send your name to Moderna, and you <strong>WILL NOT</strong> be admitted under any circumstance.</p>
+  <p style="margin:16px 0 0 0;"><a href="${REGISTER_URL}" style="display:inline-block;padding:12px 24px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Register now on cursorboston.com →</a></p>
+</div>`;
+
+  const html = `<!doctype html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111;max-width:640px;margin:0 auto;padding:24px;line-height:1.55;">
+  <p>${escapeHtml(greet)}</p>
+
+  <p>You RSVP'd on Luma for the <strong>Cursor Boston × PyData Data Science Hack</strong> on <strong>Wednesday May 13 at Moderna HQ in Cambridge</strong>. We're emailing every Luma RSVP because Moderna's security process is unusually strict and a Luma RSVP alone will not get you through the door.</p>
+
+  ${statusBlockHtml}
+
+  <h2 style="margin-top:32px;color:#111;font-size:18px;border-bottom:2px solid #111;padding-bottom:8px;">The process — every step between now and the door</h2>
+
+  <ol style="padding-left:20px;">
+    <li style="margin-bottom:16px;">
+      <strong>Now · Register on cursorboston.com</strong><br>
+      <a href="${REGISTER_URL}" style="color:#10b981;">${REGISTER_URL}</a><br>
+      <span style="color:#555;">Enter your full legal name (matching your government ID — driver's license or passport), email, and optionally phone + company. Moderna requires a CSV of confirmed attendees with names that match government ID. We can only send what you enter into this form.</span>
+    </li>
+
+    <li style="margin-bottom:16px;">
+      <strong style="color:#dc2626;">${escapeHtml(SUBMIT_DEADLINE_HUMAN)} · 48-hour hard cutoff</strong><br>
+      <span style="color:#555;">We send the registration list to Moderna. After this point, no new names can be added. Period. If you are not on this list, Moderna will turn you away at the door with no chance to sign in.</span>
+    </li>
+
+    <li style="margin-bottom:16px;">
+      <strong>~1–2 days after the cutoff · Envoy emails you NDA paperwork</strong><br>
+      <span style="color:#555;">From <code style="background:#f3f4f6;padding:2px 6px;border-radius:4px;">Moderna HQ &lt;no-reply@envoy.com&gt;</code>. Check spam if you don't see it within 48 hours of the cutoff.</span>
+    </li>
+
+    <li style="margin-bottom:16px;">
+      <strong>Before May 13 · Sign the NDA → receive your QR code</strong><br>
+      <span style="color:#555;">Click the Envoy link, sign the paperwork, submit. Envoy then emails you a unique QR code. Save it to your phone — that QR is your entry pass.</span>
+    </li>
+
+    <li style="margin-bottom:16px;">
+      <strong>Wednesday May 13, 6:30 PM ET · Show up at 325 Binney St, Cambridge</strong>
+      <ul style="margin:8px 0;color:#555;">
+        <li>Show the QR code on your phone</li>
+        <li>Show a <strong>government-issued ID</strong> with the same name you submitted in step 1</li>
+      </ul>
+      <span style="color:#555;">If your ID name does not match the name we sent, you will be turned away.</span>
+    </li>
+  </ol>
+
+  <h2 style="margin-top:32px;color:#111;font-size:18px;border-bottom:2px solid #111;padding-bottom:8px;">If something goes sideways</h2>
+  <ul style="color:#555;">
+    <li><strong>Envoy email never arrived:</strong> Check spam first. If it's still missing the day-of, you can sign the NDA on paper at the door — but only if your name is on the CSV from step 2. No paper sign-in for walk-ups.</li>
+    <li><strong>Lost your QR code:</strong> Same fallback — paper sign-in at the door, provided you're on the list.</li>
+    <li><strong>Name on your ID doesn't match what you submitted:</strong> Click "Edit details" on your registration page before the cutoff and fix it.</li>
+    <li><strong>Need to cancel:</strong> Reply to this email so we can free up the slot.</li>
+  </ul>
+
+  <h2 style="margin-top:32px;color:#111;font-size:18px;border-bottom:2px solid #111;padding-bottom:8px;">A few extra things</h2>
+  <ul style="color:#555;">
+    <li>Photos are fine, but don't include the Moderna logo or branding in anything you post.</li>
+    <li>Bring: laptop, charger, Cursor IDE installed, registered Cursor account.</li>
+    <li>Schedule: doors 6:30 PM, talk at 7:00, hack starts ~8:05, wrap by 9:30.</li>
+  </ul>
+
+  <p style="margin-top:32px;color:#555;">
+    Event details: <a href="${EVENT_DETAIL_URL}" style="color:#10b981;">cursorboston.com</a> · Luma: <a href="${LUMA_URL}" style="color:#10b981;">${LUMA_URL}</a>
+  </p>
+
+  <p>Questions? Reply to this email.</p>
+
+  <p>— Roger<br>Cursor Boston</p>
+
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0 16px;">
+  <p style="font-size:12px;color:#999;">
+    You're getting this because you RSVP'd on Luma for the May 13 PyData × Cursor Boston event.
+    <a href="${unsub}" style="color:#999;">Unsubscribe</a>
+  </p>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  const csvIdx = args.indexOf("--csv");
+  if (csvIdx === -1 || !args[csvIdx + 1]) {
+    console.error("Pass --csv <path-to-luma-export.csv>");
+    process.exit(1);
+  }
+  const csvPath = args[csvIdx + 1]!;
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // Sync Mailgun suppressions onto eventContacts before reading the list.
+  await syncMailgunSuppressions(db);
+
+  // Load Luma CSV
+  let raw = readFileSync(csvPath, "utf8");
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  const lumaRows = parseCsv(raw);
+  console.log(`Luma CSV: ${lumaRows.length} rows`);
+
+  // Load suppression set + site registration set
+  const ec = await db.collection("eventContacts").get();
+  const unsubbed = new Set<string>();
+  const ecNameByEmail = new Map<string, string>();
+  for (const d of ec.docs) {
+    const data = d.data();
+    const email = (typeof data.email === "string" ? data.email : d.id).toLowerCase();
+    if (data.unsubscribed === true) unsubbed.add(email);
+    const fname = typeof data.firstName === "string" ? data.firstName : "";
+    if (fname) ecNameByEmail.set(email, fname);
+  }
+
+  const siteRegSnap = await db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).get();
+  const siteEmails = new Set<string>();
+  for (const d of siteRegSnap.docs) {
+    const e = (d.data().email || "").toLowerCase();
+    if (e) siteEmails.add(e);
+  }
+
+  // Build dedup recipient list
+  const seen = new Set<string>();
+  const recipients: Recipient[] = [];
+  let skippedUnsub = 0;
+  let skippedDup = 0;
+  let skippedNoEmail = 0;
+
+  for (const r of lumaRows) {
+    const email = (r.email || "").trim().toLowerCase();
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (seen.has(email)) {
+      skippedDup++;
+      continue;
+    }
+    seen.add(email);
+    if (unsubbed.has(email)) {
+      skippedUnsub++;
+      continue;
+    }
+    const firstName =
+      (r.first_name || "").trim() ||
+      ecNameByEmail.get(email) ||
+      ((r.name || "").split(" ")[0] || "").trim();
+    recipients.push({
+      email,
+      firstName,
+      registeredOnSite: siteEmails.has(email),
+    });
+  }
+
+  const onSite = recipients.filter((r) => r.registeredOnSite).length;
+  const notOnSite = recipients.filter((r) => !r.registeredOnSite).length;
+  console.log(
+    `Recipients: ${recipients.length} (already on site: ${onSite}, not yet: ${notOnSite})`
+  );
+  console.log(
+    `Skipped: ${skippedUnsub} suppressed, ${skippedDup} duplicates, ${skippedNoEmail} blank-email`
+  );
+
+  if (dryRun) {
+    const sampleNotOnSite = recipients.find((r) => !r.registeredOnSite);
+    const sampleOnSite = recipients.find((r) => r.registeredOnSite);
+    if (sampleNotOnSite) {
+      const { subject, text } = buildEmail(sampleNotOnSite);
+      console.log(`\n--- sample to ${sampleNotOnSite.email} (NOT yet on site) ---`);
+      console.log(`Subject: ${subject}\n`);
+      console.log(text);
+    }
+    if (sampleOnSite) {
+      const { subject } = buildEmail(sampleOnSite);
+      console.log(`\n--- subject for already-on-site recipient (${sampleOnSite.email}) ---`);
+      console.log(`Subject: ${subject}`);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  console.log(`\nSending to ${recipients.length} recipients…`);
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, text, html } = buildEmail(r);
+    try {
+      await sendEmail({
+        to: r.email,
+        subject,
+        text,
+        html,
+      });
+      sent++;
+      if (sent % 25 === 0 || sent === recipients.length) {
+        console.log(`  sent ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  FAILED ${r.email}: ${e instanceof Error ? e.message : e}`);
+    }
+    // Light throttle to keep Mailgun happy.
+    await new Promise((res) => setTimeout(res, 80));
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

One-commit release. Wires the 150-person Moderna cap into the site so the registration page, admin viewer, and Moderna CSV export all enforce it consistently.

### Included

**Ludwitt + Claude**
- `feat(pydata-2026)` — 150-person hard cap by registration order:
  - `PYDATA_2026_CAPACITY = 150` constant.
  - Public `GET /api/events/pydata-2026/capacity` returns `{ capacity, claimed, remaining, full }` for the live counter.
  - `/register` page surfaces a prominent cap banner with a live progress bar and tone shifts (rose → amber → "cap reached").
  - `/admin` page shows in-cap vs waitlist split via stat tiles + per-row pills; "CSV for Moderna" is now restricted to the top 150 (server-computed by `createdAt asc`), full export gains a Cap-status column.
  - Two new email scripts shipped + already used today: `send-pydata-moderna-access.ts` (process explainer) and `send-pydata-cap-correction.ts` (cap clarification follow-up).

### Test plan
- [ ] `/api/events/pydata-2026/capacity` returns `{ capacity: 150, claimed, remaining, full }`
- [ ] `/register` shows the red "Hard cap: 150 attendees" banner + live progress bar
- [ ] `/admin` shows In cap / Waitlist tiles and per-row pills
- [ ] "CSV for Moderna" download contains at most 150 rows even with 150+ registrations
- [ ] Full export contains all rows + a "Cap status" column

🤖 Generated with [Claude Code](https://claude.com/claude-code)