### PR TITLE
feat(auth): add validated input helper

### DIFF
--- a/__tests__/components/ui/ValidatedInput.test.tsx
+++ b/__tests__/components/ui/ValidatedInput.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ValidatedInput } from "@/components/ui/ValidatedInput";
+
+describe("ValidatedInput", () => {
+  it("connects the label to the input", () => {
+    render(<ValidatedInput id="email" label="Email" />);
+
+    expect(screen.getByLabelText("Email")).toHaveAttribute("id", "email");
+  });
+
+  it("connects helper text and error text with aria-describedby", () => {
+    render(
+      <ValidatedInput
+        id="password"
+        label="Password"
+        helperText="Use at least 8 characters."
+        error="Password is too short"
+      />,
+    );
+
+    expect(screen.getByLabelText("Password")).toHaveAttribute(
+      "aria-describedby",
+      "password-helper password-error",
+    );
+    expect(screen.getByText("Use at least 8 characters.")).toHaveAttribute("id", "password-helper");
+    expect(screen.getByRole("alert")).toHaveAttribute("id", "password-error");
+  });
+
+  it("marks the input invalid only when an error is present", () => {
+    const { rerender } = render(<ValidatedInput id="name" label="Name" />);
+
+    expect(screen.getByLabelText("Name")).not.toHaveAttribute("aria-invalid");
+
+    rerender(<ValidatedInput id="name" label="Name" error="Name is required" />);
+
+    expect(screen.getByLabelText("Name")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("preserves caller-provided aria-describedby values", () => {
+    render(
+      <ValidatedInput
+        id="email"
+        label="Email"
+        aria-describedby="form-error"
+        error="Please enter a valid email"
+      />,
+    );
+
+    expect(screen.getByLabelText("Email")).toHaveAttribute(
+      "aria-describedby",
+      "form-error email-error",
+    );
+  });
+
+  it("keeps computed accessibility attributes authoritative", () => {
+    render(
+      <ValidatedInput
+        id="email"
+        label="Email"
+        aria-describedby="form-error"
+        aria-invalid={false}
+        error="Please enter a valid email"
+      />,
+    );
+
+    const input = screen.getByLabelText("Email");
+    expect(input).toHaveAttribute("aria-describedby", "form-error email-error");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("passes through standard input props", () => {
+    render(<ValidatedInput id="email" label="Email" type="email" placeholder="you@example.com" required />);
+
+    const input = screen.getByPlaceholderText("you@example.com");
+    expect(input).toHaveAttribute("type", "email");
+    expect(input).toBeRequired();
+  });
+});

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -12,11 +12,12 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { AuthFormSkeleton } from "@/components/skeletons/AuthFormSkeleton";
 import { getLudwittErrorMessage } from "./_lib/ludwitt-errors";
+import { ValidatedInput } from "@/components/ui/ValidatedInput";
 
 // Map Firebase error codes to user-friendly messages
 function getErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  
+
   if (message.includes("auth/invalid-credential") || message.includes("auth/wrong-password")) {
     return "Invalid email or password. Please try again.";
   }
@@ -41,8 +42,30 @@ function getErrorMessage(error: unknown): string {
   if (message.includes("auth/invalid-email")) {
     return "Please enter a valid email address.";
   }
-  
+
   return "Something went wrong. Please try again.";
+}
+
+function getLoginFieldErrors(error: string): {
+  emailError: string | null;
+  passwordError: string | null;
+  formError: string | null;
+} {
+  if (!error) {
+    return { emailError: null, passwordError: null, formError: null };
+  }
+
+  const normalizedError = error.toLowerCase();
+
+  if (
+    normalizedError.includes("email") &&
+    !normalizedError.includes("password") &&
+    !normalizedError.includes("invalid email or password")
+  ) {
+    return { emailError: error, passwordError: null, formError: null };
+  }
+
+  return { emailError: null, passwordError: null, formError: error };
 }
 
 // Resolve email to primary email (handles aliases)
@@ -77,6 +100,7 @@ function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user, loading: authLoading, signIn, signInWithGoogle, signInWithGithub, resetPassword } = useAuth();
+  const { emailError, passwordError, formError } = getLoginFieldErrors(error);
 
   // Get redirect URL from query params, default to home
   const redirectUrl = searchParams.get("redirect") || "/";
@@ -104,12 +128,12 @@ function LoginPageContent() {
     try {
       // Resolve email to primary (handles login with additional emails)
       const resolvedEmail = await resolveEmail(email);
-      
+
       // If the resolved email is different, show a message
       if (resolvedEmail.toLowerCase() !== email.toLowerCase().trim()) {
         setEmailAlias(email);
       }
-      
+
       await signIn(resolvedEmail, password);
       router.push(redirectUrl);
     } catch (err: unknown) {
@@ -192,14 +216,14 @@ function LoginPageContent() {
         </div>
 
         <div className="bg-white dark:bg-neutral-900 rounded-xl md:rounded-2xl p-5 md:p-8 border border-neutral-200 dark:border-neutral-800">
-          {error && (
+          {formError && (
             <div
               role="alert"
               aria-live="polite"
               id="form-error"
               className="mb-6 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm"
             >
-              {error}
+              {formError}
             </div>
           )}
 
@@ -214,7 +238,7 @@ function LoginPageContent() {
           )}
 
           {resetSent && (
-            <div 
+            <div
               role="status"
               aria-live="polite"
               className="mb-6 p-4 bg-emerald-500/10 border border-emerald-500/20 rounded-lg text-emerald-400 text-sm"
@@ -224,7 +248,7 @@ function LoginPageContent() {
           )}
 
           {emailAlias && (
-            <div 
+            <div
               role="status"
               aria-live="polite"
               className="mb-6 p-4 bg-blue-500/10 border border-blue-500/20 rounded-lg text-blue-400 text-sm"
@@ -312,45 +336,28 @@ function LoginPageContent() {
 
           {/* Email/Password Form */}
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-neutral-300 mb-2"
-              >
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                aria-describedby={error ? "form-error" : undefined}
-                aria-invalid={error ? "true" : undefined}
-                className="w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent"
-                placeholder="you@example.com"
-              />
-            </div>
+            <ValidatedInput
+              id="email"
+              label="Email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              error={emailError}
+              placeholder="you@example.com"
+              showStatusIcon
+            />
 
-            <div>
-              <label
-                htmlFor="password"
-                className="block text-sm font-medium text-neutral-300 mb-2"
-              >
-                Password
-              </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                aria-describedby={error ? "form-error" : undefined}
-                aria-invalid={error ? "true" : undefined}
-                className="w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent"
-                placeholder="Enter your password"
-              />
-            </div>
+            <ValidatedInput
+              id="password"
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              error={passwordError}
+              placeholder="Enter your password"
+            />
 
             <div className="flex justify-end">
               <button

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -11,11 +11,12 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { AuthFormSkeleton } from "@/components/skeletons/AuthFormSkeleton";
+import { ValidatedInput } from "@/components/ui/ValidatedInput";
 
 // Map Firebase error codes to user-friendly messages
 function getErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  
+
   if (message.includes("auth/email-already-in-use")) {
     return "An account with this email already exists. Please sign in instead.";
   }
@@ -37,8 +38,60 @@ function getErrorMessage(error: unknown): string {
   if (message.includes("auth/operation-not-allowed")) {
     return "This sign-in method is not enabled. Please try another method.";
   }
-  
+
   return "Something went wrong. Please try again.";
+}
+
+function getSignUpFieldErrors(error: string): {
+  emailError: string | null;
+  passwordError: string | null;
+  confirmPasswordError: string | null;
+  formError: string | null;
+} {
+  if (!error) {
+    return {
+      emailError: null,
+      passwordError: null,
+      confirmPasswordError: null,
+      formError: null,
+    };
+  }
+
+  if (error === "Passwords do not match") {
+    return {
+      emailError: null,
+      passwordError: null,
+      confirmPasswordError: error,
+      formError: null,
+    };
+  }
+
+  const normalizedError = error.toLowerCase();
+
+  if (normalizedError.includes("email")) {
+    return {
+      emailError: error,
+      passwordError: null,
+      confirmPasswordError: null,
+      formError: null,
+    };
+  }
+
+  if (normalizedError.includes("password")) {
+    return {
+      emailError: null,
+      passwordError: error,
+      confirmPasswordError: null,
+      formError: null,
+    };
+  }
+
+  return {
+    emailError: null,
+    passwordError: null,
+    confirmPasswordError: null,
+    formError: error,
+  };
 }
 
 function SignUpPageContent() {
@@ -51,6 +104,7 @@ function SignUpPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user, loading: authLoading, signUp, signInWithGoogle, signInWithGithub } = useAuth();
+  const { emailError, passwordError, confirmPasswordError, formError } = getSignUpFieldErrors(error);
 
   // Get redirect URL from query params, default to home
   const redirectUrl = searchParams.get("redirect") || "/";
@@ -137,14 +191,14 @@ function SignUpPageContent() {
         </div>
 
         <div className="bg-white dark:bg-neutral-900 rounded-xl md:rounded-2xl p-5 md:p-8 border border-neutral-200 dark:border-neutral-800">
-          {error && (
-            <div 
+          {formError && (
+            <div
               role="alert"
               aria-live="polite"
               id="form-error"
               className="mb-6 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm"
             >
-              {error}
+              {formError}
             </div>
           )}
 
@@ -205,77 +259,50 @@ function SignUpPageContent() {
 
           {/* Email/Password Form */}
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label
-                htmlFor="name"
-                className="block text-sm font-medium text-neutral-300 mb-2"
-              >
-                Name
-              </label>
-              <input
-                id="name"
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent"
-                placeholder="Your name"
-              />
-            </div>
+            <ValidatedInput
+              id="name"
+              label="Name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder="Your name"
+            />
 
-            <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-neutral-300 mb-2"
-              >
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent"
-                placeholder="you@example.com"
-              />
-            </div>
+            <ValidatedInput
+              id="email"
+              label="Email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              error={emailError}
+              placeholder="you@example.com"
+              showStatusIcon
+            />
 
-            <div>
-              <label
-                htmlFor="password"
-                className="block text-sm font-medium text-neutral-300 mb-2"
-              >
-                Password
-              </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent"
-                placeholder="At least 8 characters"
-              />
-            </div>
+            <ValidatedInput
+              id="password"
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              error={passwordError}
+              helperText="Use at least 8 characters."
+              placeholder="At least 8 characters"
+            />
 
-            <div>
-              <label
-                htmlFor="confirmPassword"
-                className="block text-sm font-medium text-neutral-300 mb-2"
-              >
-                Confirm Password
-              </label>
-              <input
-                id="confirmPassword"
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent"
-                placeholder="Confirm your password"
-              />
-            </div>
+            <ValidatedInput
+              id="confirmPassword"
+              label="Confirm Password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              error={confirmPasswordError}
+              placeholder="Confirm your password"
+            />
 
             <button
               type="submit"

--- a/components/ui/ValidatedInput.tsx
+++ b/components/ui/ValidatedInput.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { CheckCircle2, CircleAlert } from "lucide-react";
+
+interface ValidatedInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  label: string;
+  error?: string | null;
+  helperText?: ReactNode;
+  showStatusIcon?: boolean;
+}
+
+const baseInputClass =
+  "w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent";
+
+export function ValidatedInput({
+  id,
+  label,
+  error,
+  helperText,
+  showStatusIcon = false,
+  className,
+  "aria-describedby": ariaDescribedBy,
+  ...props
+}: ValidatedInputProps) {
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [ariaDescribedBy, helperId, errorId].filter(Boolean).join(" ") || undefined;
+  const hasSuccessIcon = showStatusIcon && !error && Boolean(props.value);
+
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-neutral-300 mb-2">
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          {...props}
+          id={id}
+          aria-describedby={describedBy}
+          aria-invalid={error ? "true" : undefined}
+          className={`${baseInputClass}${showStatusIcon ? " pr-11" : ""}${className ? ` ${className}` : ""}`}
+        />
+        {showStatusIcon && error && (
+          <CircleAlert
+            aria-hidden="true"
+            className="absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-red-400"
+          />
+        )}
+        {hasSuccessIcon && (
+          <CheckCircle2
+            aria-hidden="true"
+            className="absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-emerald-400"
+          />
+        )}
+      </div>
+      {helperText && (
+        <p id={helperId} className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+          {helperText}
+        </p>
+      )}
+      {error && (
+        <p id={errorId} role="alert" className="mt-2 text-sm text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Add a reusable `ValidatedInput` component for auth forms and refactor the login and signup pages to use it.

This reduces duplicated field markup and centralizes label, helper text, error messaging, and accessibility wiring (`aria-invalid`, `aria-describedby`) in one shared component.

The login and signup pages now also separate field-level validation from form-level auth errors so messages attach to the correct field.

Fixes #589

## Type of Change
- [x] Code refactoring
- [x] Accessibility improvement

## How Has This Been Tested?
- [x] Tested locally

Verification performed:
- `npm test`
- `npm run build`
- `npm run type-check`
- `npm test -- --runTestsByPath __tests__/components/ui/ValidatedInput.test.tsx`

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
No screenshots attached. Visual changes are limited to the existing auth form fields adopting the shared component.

## Additional Notes
- Full-repo lint currently reports pre-existing warnings in unrelated files; the staged-file lint gate for this change passed cleanly.
- The Vercel status on this PR requires team authorization for fork deployments and does not indicate an application failure.