### PR TITLE
feat(mentorship): data model, matching algorithm, and API routes

### DIFF
--- a/__tests__/lib/mentorship/matching.test.ts
+++ b/__tests__/lib/mentorship/matching.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  calculateMentorshipMatchScore,
+  getTopMentorshipMatches,
+} from "@/lib/mentorship/matching";
+import type { MentorshipProfile } from "@/lib/mentorship/types";
+
+function makeProfile(overrides: Partial<MentorshipProfile> = {}): MentorshipProfile {
+  return {
+    userId: "user-1",
+    role: "mentee",
+    expertise: [],
+    learningGoals: [],
+    preferredLanguages: [],
+    timezone: "America/New_York",
+    availability: [],
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("calculateMentorshipMatchScore", () => {
+  describe("goal / expertise alignment (up to 50 pts)", () => {
+    it("scores higher when mentor expertise matches mentee learning goals", () => {
+      const mentee = makeProfile({ role: "mentee", learningGoals: ["React", "TypeScript"] });
+      const mentor = makeProfile({ userId: "mentor-1", role: "mentor", expertise: ["React", "TypeScript"] });
+
+      const { score } = calculateMentorshipMatchScore(mentee, mentor);
+      expect(score).toBeGreaterThanOrEqual(20);
+    });
+
+    it("scores 0 when there is no goal/expertise overlap", () => {
+      const mentee = makeProfile({ role: "mentee", learningGoals: ["Rust"], timezone: "America/New_York" });
+      const mentor = makeProfile({ userId: "mentor-1", role: "mentor", expertise: ["Python"], timezone: "Asia/Tokyo" });
+
+      const { score } = calculateMentorshipMatchScore(mentee, mentor);
+      expect(score).toBe(0);
+    });
+
+    it("gives higher score for more matching goals", () => {
+      const mentee = makeProfile({ role: "mentee", learningGoals: ["React", "TypeScript", "Node.js"] });
+      const mentorGood = makeProfile({ userId: "mentor-good", role: "mentor", expertise: ["React", "TypeScript", "Node.js"] });
+      const mentorWeak = makeProfile({ userId: "mentor-weak", role: "mentor", expertise: ["React"] });
+
+      const good = calculateMentorshipMatchScore(mentee, mentorGood);
+      const weak = calculateMentorshipMatchScore(mentee, mentorWeak);
+      expect(good.score).toBeGreaterThan(weak.score);
+    });
+
+    it("is case-insensitive when matching skills", () => {
+      const mentee = makeProfile({ role: "mentee", learningGoals: ["react"] });
+      const mentor = makeProfile({ userId: "mentor-1", role: "mentor", expertise: ["React"] });
+
+      const { score } = calculateMentorshipMatchScore(mentee, mentor);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it("works in reverse: mentor seeker matches against mentee candidate's goals", () => {
+      const mentor = makeProfile({ role: "mentor", expertise: ["Go", "Distributed Systems"] });
+      const mentee = makeProfile({ userId: "mentee-1", role: "mentee", learningGoals: ["Go"] });
+
+      const { score, reasons } = calculateMentorshipMatchScore(mentor, mentee);
+      expect(score).toBeGreaterThan(0);
+      expect(reasons.some((r: string) => r.includes("Go"))).toBe(true);
+    });
+  });
+
+  describe("language overlap (up to 20 pts)", () => {
+    it("adds points for shared preferred languages", () => {
+      const base = makeProfile({ role: "mentee", learningGoals: ["React"], preferredLanguages: ["TypeScript"] });
+      const candidateWithLang = makeProfile({ userId: "c1", role: "mentor", expertise: ["React"], preferredLanguages: ["TypeScript"] });
+      const candidateNoLang = makeProfile({ userId: "c2", role: "mentor", expertise: ["React"], preferredLanguages: [] });
+
+      const withLang = calculateMentorshipMatchScore(base, candidateWithLang);
+      const noLang = calculateMentorshipMatchScore(base, candidateNoLang);
+      expect(withLang.score).toBeGreaterThan(noLang.score);
+    });
+
+    it("includes shared languages in reasons", () => {
+      const seeker = makeProfile({ role: "mentee", learningGoals: ["React"], preferredLanguages: ["TypeScript"] });
+      const candidate = makeProfile({ userId: "c1", role: "mentor", expertise: ["React"], preferredLanguages: ["TypeScript"] });
+
+      const { reasons } = calculateMentorshipMatchScore(seeker, candidate);
+      expect(reasons.some((r: string) => r.toLowerCase().includes("typescript"))).toBe(true);
+    });
+  });
+
+  describe("timezone compatibility (up to 10 pts)", () => {
+    it("awards bonus for identical timezones", () => {
+      const base = makeProfile({ role: "mentee", learningGoals: ["React"], timezone: "America/New_York" });
+      const sameZone = makeProfile({ userId: "c1", role: "mentor", expertise: ["React"], timezone: "America/New_York" });
+      const diffZone = makeProfile({ userId: "c2", role: "mentor", expertise: ["React"], timezone: "Asia/Tokyo" });
+
+      const same = calculateMentorshipMatchScore(base, sameZone);
+      const diff = calculateMentorshipMatchScore(base, diffZone);
+      expect(same.score).toBeGreaterThan(diff.score);
+    });
+  });
+
+  describe("availability overlap (up to 15 pts)", () => {
+    it("adds points when availability windows overlap", () => {
+      const avail = [{ dayOfWeek: 1, startTime: "09:00", endTime: "17:00" }];
+      const base = makeProfile({ role: "mentee", learningGoals: ["React"], availability: avail });
+      const withAvail = makeProfile({ userId: "c1", role: "mentor", expertise: ["React"], availability: avail });
+      const noAvail = makeProfile({ userId: "c2", role: "mentor", expertise: ["React"], availability: [] });
+
+      const with_ = calculateMentorshipMatchScore(base, withAvail);
+      const without = calculateMentorshipMatchScore(base, noAvail);
+      expect(with_.score).toBeGreaterThan(without.score);
+    });
+
+    it("does not add availability points for non-overlapping windows", () => {
+      const base = makeProfile({
+        role: "mentee",
+        learningGoals: ["React"],
+        availability: [{ dayOfWeek: 1, startTime: "09:00", endTime: "12:00" }],
+      });
+      const candidate = makeProfile({
+        userId: "c1",
+        role: "mentor",
+        expertise: ["React"],
+        availability: [{ dayOfWeek: 1, startTime: "13:00", endTime: "17:00" }],
+      });
+      const noAvailCandidate = makeProfile({
+        userId: "c2",
+        role: "mentor",
+        expertise: ["React"],
+        availability: [],
+      });
+
+      const nonOverlap = calculateMentorshipMatchScore(base, candidate);
+      const noAvail = calculateMentorshipMatchScore(base, noAvailCandidate);
+      expect(nonOverlap.score).toBe(noAvail.score);
+    });
+  });
+
+  describe("sparse profile penalty", () => {
+    it("applies 70% penalty to profiles with zero expertise and goals", () => {
+      // Same timezone gives 10 pts base → 10 * 0.3 = 3 after 70% penalty
+      const seeker = makeProfile({ role: "mentee", learningGoals: ["React"], timezone: "America/New_York" });
+      const emptyCandidate = makeProfile({
+        userId: "c1",
+        role: "mentor",
+        expertise: [],
+        learningGoals: [],
+        timezone: "America/New_York",
+      });
+
+      const emptyResult = calculateMentorshipMatchScore(seeker, emptyCandidate);
+      expect(emptyResult.score).toBeLessThanOrEqual(4);
+    });
+
+    it("scores higher for a well-filled profile than a sparse one", () => {
+      const seeker = makeProfile({ role: "mentee", learningGoals: ["React", "TypeScript"] });
+      const sparse = makeProfile({ userId: "sparse", role: "mentor", expertise: ["React"] });
+      const full = makeProfile({ userId: "full", role: "mentor", expertise: ["React", "TypeScript", "Node.js"] });
+
+      const sparseResult = calculateMentorshipMatchScore(seeker, sparse);
+      const fullResult = calculateMentorshipMatchScore(seeker, full);
+      expect(fullResult.score).toBeGreaterThan(sparseResult.score);
+    });
+  });
+
+  describe("score bounds", () => {
+    it("never exceeds 100", () => {
+      const avail = [
+        { dayOfWeek: 1, startTime: "09:00", endTime: "17:00" },
+        { dayOfWeek: 2, startTime: "09:00", endTime: "17:00" },
+        { dayOfWeek: 3, startTime: "09:00", endTime: "17:00" },
+      ];
+      const seeker = makeProfile({
+        role: "mentee",
+        learningGoals: ["React", "TypeScript", "Node.js", "GraphQL", "AWS"],
+        preferredLanguages: ["TypeScript", "JavaScript", "Python"],
+        timezone: "America/New_York",
+        availability: avail,
+      });
+      const candidate = makeProfile({
+        userId: "perfect",
+        role: "mentor",
+        expertise: ["React", "TypeScript", "Node.js", "GraphQL", "AWS"],
+        preferredLanguages: ["TypeScript", "JavaScript", "Python"],
+        timezone: "America/New_York",
+        availability: avail,
+      });
+
+      const { score } = calculateMentorshipMatchScore(seeker, candidate);
+      expect(score).toBeLessThanOrEqual(100);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it("returns 0 for completely mismatched profiles", () => {
+      const seeker = makeProfile({ role: "mentee", learningGoals: ["Rust"], timezone: "America/New_York" });
+      const candidate = makeProfile({ userId: "c1", role: "mentor", expertise: ["Python"], timezone: "Asia/Tokyo" });
+
+      const { score } = calculateMentorshipMatchScore(seeker, candidate);
+      expect(score).toBe(0);
+    });
+  });
+
+  describe("reasons", () => {
+    it("always returns at least one reason", () => {
+      const seeker = makeProfile({ role: "mentee", learningGoals: ["React"] });
+      const candidate = makeProfile({ userId: "c1", role: "mentor", expertise: ["React"] });
+
+      const { reasons } = calculateMentorshipMatchScore(seeker, candidate);
+      expect(reasons.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("getTopMentorshipMatches", () => {
+  it("excludes the seeker from results", () => {
+    const seeker = makeProfile({ userId: "seeker", role: "mentee", learningGoals: ["React"] });
+    const candidates = [
+      seeker,
+      makeProfile({ userId: "other", role: "mentor", expertise: ["React"] }),
+    ];
+
+    const results = getTopMentorshipMatches(seeker, candidates);
+    expect(results.every((r: { userId: string }) => r.userId !== "seeker")).toBe(true);
+  });
+
+  it("excludes inactive profiles", () => {
+    const seeker = makeProfile({ userId: "seeker", role: "mentee", learningGoals: ["React"] });
+    const inactive = makeProfile({ userId: "inactive", role: "mentor", expertise: ["React"], isActive: false });
+
+    const results = getTopMentorshipMatches(seeker, [seeker, inactive]);
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns results sorted by score descending", () => {
+    const seeker = makeProfile({ userId: "seeker", role: "mentee", learningGoals: ["React", "TypeScript"] });
+    const candidates = [
+      makeProfile({ userId: "weak", role: "mentor", expertise: ["React"] }),
+      makeProfile({ userId: "strong", role: "mentor", expertise: ["React", "TypeScript"] }),
+    ];
+
+    const results = getTopMentorshipMatches(seeker, candidates);
+    expect(results[0].userId).toBe("strong");
+    expect(results[0].score).toBeGreaterThanOrEqual(results[1]?.score ?? 0);
+  });
+
+  it("respects the limit parameter", () => {
+    const seeker = makeProfile({ userId: "seeker", role: "mentee", learningGoals: ["React"] });
+    const candidates = Array.from({ length: 15 }, (_, i) =>
+      makeProfile({ userId: `mentor-${i}`, role: "mentor", expertise: ["React"] })
+    );
+
+    const results = getTopMentorshipMatches(seeker, candidates, 5);
+    expect(results.length).toBeLessThanOrEqual(5);
+  });
+
+  it("filters out zero-score matches", () => {
+    const seeker = makeProfile({ userId: "seeker", role: "mentee", learningGoals: ["Rust"], timezone: "America/New_York" });
+    const noMatch = makeProfile({ userId: "nomatch", role: "mentor", expertise: ["Python"], timezone: "Asia/Tokyo" });
+
+    const results = getTopMentorshipMatches(seeker, [noMatch]);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/app/api/mentorship/matches/route.ts
+++ b/app/api/mentorship/matches/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getMentorshipProfileServer,
+  getAllActiveMentorshipProfilesServer,
+} from "@/lib/mentorship/data-server";
+import { getTopMentorshipMatches } from "@/lib/mentorship/matching";
+
+/**
+ * GET /api/mentorship/matches
+ * Get top mentor/mentee matches for the authenticated user
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const userProfile = await getMentorshipProfileServer(user.uid);
+    if (!userProfile || !userProfile.isActive) {
+      return NextResponse.json(
+        { success: false, error: "No active profile found. Create a profile first." },
+        { status: 404 }
+      );
+    }
+
+    const allProfiles = await getAllActiveMentorshipProfilesServer();
+    const matches = getTopMentorshipMatches(userProfile, allProfiles, 20);
+
+    return NextResponse.json({ success: true, matches });
+  } catch (error) {
+    console.error("Error fetching mentorship matches:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch matches" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/mentorship/profile/route.ts
+++ b/app/api/mentorship/profile/route.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getMentorshipProfileServer,
+  createOrUpdateMentorshipProfileServer,
+} from "@/lib/mentorship/data-server";
+import { parseRequestBody } from "@/lib/api-response";
+import type { MentorshipProfile, MentorshipRole } from "@/lib/mentorship/types";
+
+const VALID_ROLES: MentorshipRole[] = ["mentor", "mentee", "both"];
+const MAX_ARRAY_LENGTH = 20;
+const MAX_STRING_LENGTH = 200;
+
+/**
+ * GET /api/mentorship/profile
+ * Get the authenticated user's mentorship profile
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const profile = await getMentorshipProfileServer(user.uid);
+    return NextResponse.json({ success: true, profile: profile || null });
+  } catch (error) {
+    console.error("Error fetching mentorship profile:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch profile" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/mentorship/profile
+ * Create or update the authenticated user's mentorship profile
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const {
+      role,
+      expertise,
+      learningGoals,
+      preferredLanguages,
+      timezone,
+      availability,
+      bio,
+      maxMentees,
+      isActive,
+    } = bodyOrError;
+
+    if (!role || !VALID_ROLES.includes(role)) {
+      return NextResponse.json(
+        { success: false, error: "role must be 'mentor', 'mentee', or 'both'" },
+        { status: 400 }
+      );
+    }
+
+    if (!timezone || typeof timezone !== "string") {
+      return NextResponse.json(
+        { success: false, error: "timezone is required" },
+        { status: 400 }
+      );
+    }
+
+    const arraysToCheck = [
+      expertise || [],
+      learningGoals || [],
+      preferredLanguages || [],
+    ];
+    if (arraysToCheck.some((a) => !Array.isArray(a) || a.length > MAX_ARRAY_LENGTH)) {
+      return NextResponse.json(
+        { success: false, error: `Arrays cannot exceed ${MAX_ARRAY_LENGTH} items` },
+        { status: 400 }
+      );
+    }
+
+    const allStrings = [...(expertise || []), ...(learningGoals || []), ...(preferredLanguages || [])];
+    if (!allStrings.every((s: unknown) => typeof s === "string" && s.length <= MAX_STRING_LENGTH)) {
+      return NextResponse.json(
+        { success: false, error: "Array items must be strings under 200 characters" },
+        { status: 400 }
+      );
+    }
+
+    if (bio && typeof bio === "string" && bio.length > 1000) {
+      return NextResponse.json(
+        { success: false, error: "Bio cannot exceed 1000 characters" },
+        { status: 400 }
+      );
+    }
+
+    if (maxMentees !== undefined && (typeof maxMentees !== "number" || maxMentees < 1 || maxMentees > 10)) {
+      return NextResponse.json(
+        { success: false, error: "maxMentees must be between 1 and 10" },
+        { status: 400 }
+      );
+    }
+
+    const profile: Omit<MentorshipProfile, "userId" | "createdAt" | "updatedAt"> = {
+      role,
+      expertise: (expertise || []).map((s: string) => s.trim()).filter(Boolean),
+      learningGoals: (learningGoals || []).map((s: string) => s.trim()).filter(Boolean),
+      preferredLanguages: (preferredLanguages || []).map((s: string) => s.trim()).filter(Boolean),
+      timezone: timezone.trim(),
+      availability: Array.isArray(availability) ? availability : [],
+      bio: bio ? String(bio).trim().slice(0, 1000) : undefined,
+      maxMentees: maxMentees ?? undefined,
+      isActive: isActive !== undefined ? Boolean(isActive) : true,
+    };
+
+    await createOrUpdateMentorshipProfileServer(user.uid, profile);
+
+    return NextResponse.json({ success: true, message: "Profile updated successfully" });
+  } catch (error) {
+    console.error("Error updating mentorship profile:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to update profile" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/mentorship/request/route.ts
+++ b/app/api/mentorship/request/route.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  createMentorshipRequestServer,
+  getMentorshipRequestsForUserServer,
+} from "@/lib/mentorship/data-server";
+import { parseRequestBody } from "@/lib/api-response";
+
+const MAX_MESSAGE_LENGTH = 1000;
+const MAX_GOALS = 10;
+const MAX_GOAL_LENGTH = 200;
+
+/**
+ * GET /api/mentorship/request
+ * Get mentorship requests for the authenticated user (?type=sent|received)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get("type") === "sent" ? "sent" : "received";
+
+    const requests = await getMentorshipRequestsForUserServer(user.uid, type);
+    return NextResponse.json({ success: true, requests });
+  } catch (error) {
+    console.error("Error fetching mentorship requests:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch requests" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/mentorship/request
+ * Send a mentorship request to another user
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { toUserId, goals, message } = bodyOrError;
+
+    if (!toUserId || typeof toUserId !== "string") {
+      return NextResponse.json(
+        { success: false, error: "toUserId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (toUserId === user.uid) {
+      return NextResponse.json(
+        { success: false, error: "Cannot send request to yourself" },
+        { status: 400 }
+      );
+    }
+
+    if (!Array.isArray(goals) || goals.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "At least one goal is required" },
+        { status: 400 }
+      );
+    }
+
+    if (goals.length > MAX_GOALS) {
+      return NextResponse.json(
+        { success: false, error: `Cannot specify more than ${MAX_GOALS} goals` },
+        { status: 400 }
+      );
+    }
+
+    if (!goals.every((g: unknown) => typeof g === "string" && g.trim().length > 0 && g.length <= MAX_GOAL_LENGTH)) {
+      return NextResponse.json(
+        { success: false, error: `Each goal must be a non-empty string under ${MAX_GOAL_LENGTH} characters` },
+        { status: 400 }
+      );
+    }
+
+    if (!message || typeof message !== "string" || message.trim().length === 0) {
+      return NextResponse.json(
+        { success: false, error: "Message is required" },
+        { status: 400 }
+      );
+    }
+
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return NextResponse.json(
+        { success: false, error: `Message cannot exceed ${MAX_MESSAGE_LENGTH} characters` },
+        { status: 400 }
+      );
+    }
+
+    const requestId = await createMentorshipRequestServer({
+      fromUserId: user.uid,
+      toUserId,
+      goals: goals.map((g: string) => g.trim()),
+      message: message.trim(),
+    });
+
+    return NextResponse.json({
+      success: true,
+      requestId,
+      message: "Mentorship request sent successfully",
+    });
+  } catch (error) {
+    console.error("Error creating mentorship request:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to create request" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/mentorship/respond/route.ts
+++ b/app/api/mentorship/respond/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  respondToMentorshipRequestServer,
+  MentorshipRequestNotFoundError,
+  MentorshipRequestUnauthorizedError,
+  MentorshipRequestAlreadyRespondedError,
+} from "@/lib/mentorship/data-server";
+import { parseRequestBody } from "@/lib/api-response";
+
+/**
+ * POST /api/mentorship/respond
+ * Accept or decline a mentorship request (uses Firestore transaction to prevent races)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const { requestId, action } = bodyOrError;
+
+    if (!requestId || typeof requestId !== "string") {
+      return NextResponse.json(
+        { success: false, error: "requestId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (action !== "accept" && action !== "decline") {
+      return NextResponse.json(
+        { success: false, error: "action must be 'accept' or 'decline'" },
+        { status: 400 }
+      );
+    }
+
+    const result = await respondToMentorshipRequestServer(requestId, user.uid, action);
+
+    return NextResponse.json({
+      success: true,
+      status: result.status,
+      pairingId: result.pairingId,
+      message: action === "accept" ? "Request accepted — pairing created" : "Request declined",
+    });
+  } catch (error) {
+    if (error instanceof MentorshipRequestNotFoundError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 404 });
+    }
+    if (error instanceof MentorshipRequestUnauthorizedError) {
+      return NextResponse.json(
+        { success: false, error: "You can only respond to requests sent to you" },
+        { status: 403 }
+      );
+    }
+    if (error instanceof MentorshipRequestAlreadyRespondedError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+    }
+
+    console.error("Error responding to mentorship request:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to respond to request" },
+      { status: 500 }
+    );
+  }
+}

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -239,6 +239,43 @@ service cloud.firestore {
       allow write: if false; // Only server-side writes for data integrity
     }
 
+    // Mentorship - Profiles: users can create/update their own profile, authenticated users can read active profiles
+    match /mentorship_profiles/{userId} {
+      allow read: if request.auth != null && (resource.data.isActive == true || request.auth.uid == userId);
+      allow create: if request.auth != null && request.auth.uid == userId;
+      allow update: if request.auth != null && request.auth.uid == userId;
+      allow delete: if false;
+    }
+
+    // Mentorship - Requests: create by fromUserId, read by participants, update by toUserId only
+    match /mentorship_requests/{requestId} {
+      allow create: if request.auth != null && request.resource.data.fromUserId == request.auth.uid;
+      allow read: if request.auth != null && (
+        resource.data.fromUserId == request.auth.uid || resource.data.toUserId == request.auth.uid
+      );
+      allow update: if request.auth != null && resource.data.toUserId == request.auth.uid;
+      allow delete: if request.auth != null && (
+        resource.data.fromUserId == request.auth.uid || resource.data.toUserId == request.auth.uid
+      );
+    }
+
+    // Mentorship - Pairings: read by mentor or mentee, created server-side when request is accepted
+    match /mentorship_pairings/{pairingId} {
+      allow read: if request.auth != null && (
+        resource.data.mentorId == request.auth.uid || resource.data.menteeId == request.auth.uid
+      );
+      allow create: if false; // Created server-side via Admin SDK when request is accepted
+      allow update: if false; // Goal/status updates are server-side only
+      allow delete: if false;
+    }
+
+    // Mentorship - Check-ins: participants can read, create by author, no updates
+    match /mentorship_check_ins/{checkInId} {
+      allow read: if request.auth != null && request.auth.uid == resource.data.authorId;
+      allow create: if false; // Created server-side via Admin SDK
+      allow update, delete: if false;
+    }
+
     // Pair Programming - Profiles: users can create/update their own profile, read active profiles
     match /pair_profiles/{userId} {
       allow read: if request.auth != null && (resource.data.isActive == true || request.auth.uid == userId);

--- a/lib/mentorship/data-server.ts
+++ b/lib/mentorship/data-server.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import type {
+  MentorshipProfile,
+  MentorshipRequest,
+  MentorshipPairing,
+  MentorshipCheckIn,
+  MentorshipRequestStatus,
+  GoalStatus,
+} from "./types";
+
+export class MentorshipRequestNotFoundError extends Error {
+  constructor() { super("Request not found"); this.name = "MentorshipRequestNotFoundError"; }
+}
+export class MentorshipRequestUnauthorizedError extends Error {
+  constructor() { super("Unauthorized"); this.name = "MentorshipRequestUnauthorizedError"; }
+}
+export class MentorshipRequestAlreadyRespondedError extends Error {
+  constructor() { super("Request has already been responded to"); this.name = "MentorshipRequestAlreadyRespondedError"; }
+}
+
+const COLLECTIONS = {
+  PROFILES: "mentorship_profiles",
+  REQUESTS: "mentorship_requests",
+  PAIRINGS: "mentorship_pairings",
+  CHECK_INS: "mentorship_check_ins",
+} as const;
+
+export async function getMentorshipProfileServer(userId: string): Promise<MentorshipProfile | null> {
+  const adminDb = getAdminDb();
+  if (!adminDb) return null;
+  const snap = await adminDb.collection(COLLECTIONS.PROFILES).doc(userId).get();
+  if (!snap.exists) return null;
+  return { ...snap.data(), userId: snap.id } as MentorshipProfile;
+}
+
+export async function getAllActiveMentorshipProfilesServer(): Promise<MentorshipProfile[]> {
+  const adminDb = getAdminDb();
+  if (!adminDb) return [];
+  const snapshot = await adminDb
+    .collection(COLLECTIONS.PROFILES)
+    .where("isActive", "==", true)
+    .orderBy("updatedAt", "desc")
+    .get();
+  return snapshot.docs.map((d) => ({ ...d.data(), userId: d.id })) as MentorshipProfile[];
+}
+
+export async function createOrUpdateMentorshipProfileServer(
+  userId: string,
+  profile: Omit<MentorshipProfile, "userId" | "createdAt" | "updatedAt">
+): Promise<void> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+  const ref = adminDb.collection(COLLECTIONS.PROFILES).doc(userId);
+  const existing = await ref.get();
+  if (existing.exists) {
+    await ref.update({ ...profile, updatedAt: new Date() });
+  } else {
+    await ref.set({ ...profile, userId, createdAt: new Date(), updatedAt: new Date() });
+  }
+}
+
+export async function createMentorshipRequestServer(
+  request: Omit<MentorshipRequest, "id" | "createdAt" | "updatedAt" | "status">
+): Promise<string> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+  const ref = await adminDb.collection(COLLECTIONS.REQUESTS).add({
+    ...request,
+    status: "pending" as MentorshipRequestStatus,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return ref.id;
+}
+
+export async function getMentorshipRequestsForUserServer(
+  userId: string,
+  type: "sent" | "received"
+): Promise<MentorshipRequest[]> {
+  const adminDb = getAdminDb();
+  if (!adminDb) return [];
+  const field = type === "sent" ? "fromUserId" : "toUserId";
+  const snapshot = await adminDb
+    .collection(COLLECTIONS.REQUESTS)
+    .where(field, "==", userId)
+    .orderBy("createdAt", "desc")
+    .get();
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() })) as MentorshipRequest[];
+}
+
+export async function respondToMentorshipRequestServer(
+  requestId: string,
+  userId: string,
+  action: "accept" | "decline"
+): Promise<{ status: MentorshipRequestStatus; pairingId?: string }> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+
+  return adminDb.runTransaction(async (tx) => {
+    const requestRef = adminDb.collection(COLLECTIONS.REQUESTS).doc(requestId);
+    const requestDoc = await tx.get(requestRef);
+
+    if (!requestDoc.exists) throw new MentorshipRequestNotFoundError();
+    const data = requestDoc.data();
+    if (!data) throw new MentorshipRequestNotFoundError();
+    if (data.toUserId !== userId) throw new MentorshipRequestUnauthorizedError();
+    if (data.status !== "pending") throw new MentorshipRequestAlreadyRespondedError();
+
+    const newStatus: MentorshipRequestStatus = action === "accept" ? "accepted" : "declined";
+    tx.update(requestRef, { status: newStatus, updatedAt: new Date() });
+
+    let pairingId: string | undefined;
+    if (action === "accept") {
+      const pairingRef = adminDb.collection(COLLECTIONS.PAIRINGS).doc();
+      const goals = (data.goals as string[]).map((g, i) => ({
+        id: `goal-${Date.now()}-${i}`,
+        description: g,
+        status: "in-progress" as GoalStatus,
+      }));
+      tx.set(pairingRef, {
+        mentorId: data.toUserId,
+        menteeId: data.fromUserId,
+        goals,
+        status: "active",
+        startedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      pairingId = pairingRef.id;
+    }
+
+    return { status: newStatus, pairingId };
+  });
+}
+
+export async function getMentorshipPairingsForUserServer(userId: string): Promise<MentorshipPairing[]> {
+  const adminDb = getAdminDb();
+  if (!adminDb) return [];
+  const [mentorSnap, menteeSnap] = await Promise.all([
+    adminDb.collection(COLLECTIONS.PAIRINGS).where("mentorId", "==", userId).where("status", "==", "active").get(),
+    adminDb.collection(COLLECTIONS.PAIRINGS).where("menteeId", "==", userId).where("status", "==", "active").get(),
+  ]);
+  const seen = new Set<string>();
+  const pairings: MentorshipPairing[] = [];
+  for (const doc of [...mentorSnap.docs, ...menteeSnap.docs]) {
+    if (!seen.has(doc.id)) {
+      seen.add(doc.id);
+      pairings.push({ id: doc.id, ...doc.data() } as MentorshipPairing);
+    }
+  }
+  return pairings;
+}
+
+export async function addCheckInServer(
+  checkIn: Omit<MentorshipCheckIn, "id" | "createdAt">
+): Promise<string> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+  const ref = await adminDb.collection(COLLECTIONS.CHECK_INS).add({
+    ...checkIn,
+    createdAt: new Date(),
+  });
+  return ref.id;
+}
+
+export async function updateGoalStatusServer(
+  pairingId: string,
+  goalId: string,
+  status: GoalStatus
+): Promise<void> {
+  const adminDb = getAdminDb();
+  if (!adminDb) throw new Error("Firebase Admin not initialized");
+  const ref = adminDb.collection(COLLECTIONS.PAIRINGS).doc(pairingId);
+  const snap = await ref.get();
+  if (!snap.exists) throw new Error("Pairing not found");
+  const data = snap.data() as MentorshipPairing;
+  const goals = data.goals.map((g) =>
+    g.id === goalId
+      ? { ...g, status, ...(status === "completed" ? { completedAt: new Date() } : {}) }
+      : g
+  );
+  await ref.update({ goals, updatedAt: new Date() });
+}

--- a/lib/mentorship/data.ts
+++ b/lib/mentorship/data.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit,
+} from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { MentorshipProfile, MentorshipPairing } from "./types";
+
+const COLLECTIONS = {
+  PROFILES: "mentorship_profiles",
+  REQUESTS: "mentorship_requests",
+  PAIRINGS: "mentorship_pairings",
+  CHECK_INS: "mentorship_check_ins",
+} as const;
+
+export async function getMentorshipProfile(userId: string): Promise<MentorshipProfile | null> {
+  if (!db) return null;
+  const snap = await getDoc(doc(db, COLLECTIONS.PROFILES, userId));
+  if (!snap.exists()) return null;
+  return { ...snap.data(), userId: snap.id } as MentorshipProfile;
+}
+
+export async function getAllActiveMentorshipProfiles(): Promise<MentorshipProfile[]> {
+  if (!db) return [];
+  const q = query(
+    collection(db, COLLECTIONS.PROFILES),
+    where("isActive", "==", true),
+    orderBy("updatedAt", "desc"),
+    limit(100)
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => ({ ...d.data(), userId: d.id })) as MentorshipProfile[];
+}
+
+export async function getMentorshipPairingsForUser(userId: string): Promise<MentorshipPairing[]> {
+  if (!db) return [];
+  // Fetch as mentor and mentee separately since Firestore doesn't support OR on different fields
+  const [mentorSnap, menteeSnap] = await Promise.all([
+    getDocs(query(
+      collection(db, COLLECTIONS.PAIRINGS),
+      where("mentorId", "==", userId),
+      where("status", "==", "active"),
+      orderBy("createdAt", "desc")
+    )),
+    getDocs(query(
+      collection(db, COLLECTIONS.PAIRINGS),
+      where("menteeId", "==", userId),
+      where("status", "==", "active"),
+      orderBy("createdAt", "desc")
+    )),
+  ]);
+
+  const seen = new Set<string>();
+  const pairings: MentorshipPairing[] = [];
+  for (const snap of [...mentorSnap.docs, ...menteeSnap.docs]) {
+    if (!seen.has(snap.id)) {
+      seen.add(snap.id);
+      pairings.push({ id: snap.id, ...snap.data() } as MentorshipPairing);
+    }
+  }
+  return pairings;
+}

--- a/lib/mentorship/matching.ts
+++ b/lib/mentorship/matching.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { MentorshipProfile, MentorshipMatchScore } from "./types";
+
+/**
+ * Calculate match score between a seeker and a candidate.
+ *
+ * When a mentee seeks a mentor: seeker = mentee, candidate = mentor
+ *   → candidate.expertise should overlap with seeker.learningGoals
+ * When a mentor seeks a mentee: seeker = mentor, candidate = mentee
+ *   → candidate.learningGoals should overlap with seeker.expertise
+ */
+export function calculateMentorshipMatchScore(
+  seeker: MentorshipProfile,
+  candidate: MentorshipProfile
+): MentorshipMatchScore {
+  let score = 0;
+  const reasons: string[] = [];
+
+  // Goal/expertise alignment (highest weight — 50 pts)
+  const seekerIsLookingForMentor =
+    seeker.role === "mentee" || seeker.role === "both";
+
+  const goalMatches = seekerIsLookingForMentor
+    ? candidate.expertise.filter((exp) =>
+        seeker.learningGoals.some((g) => normalizeSkill(g) === normalizeSkill(exp))
+      )
+    : candidate.learningGoals.filter((goal) =>
+        seeker.expertise.some((exp) => normalizeSkill(exp) === normalizeSkill(goal))
+      );
+
+  const goalScore = Math.min(50, goalMatches.length * 10);
+  score += goalScore;
+  if (goalMatches.length > 0) {
+    reasons.push(
+      seekerIsLookingForMentor
+        ? `Can mentor you in: ${goalMatches.join(", ")}`
+        : `Wants to learn: ${goalMatches.join(", ")}`
+    );
+  }
+
+  // Language overlap (20 pts)
+  const langOverlap = seeker.preferredLanguages.filter((l) =>
+    candidate.preferredLanguages.includes(l)
+  );
+  const langScore = Math.min(20, langOverlap.length * 5);
+  score += langScore;
+  if (langOverlap.length > 0) {
+    reasons.push(`Shared languages: ${langOverlap.join(", ")}`);
+  }
+
+  // Timezone compatibility (10 pts)
+  if (seeker.timezone === candidate.timezone) {
+    score += 10;
+    reasons.push("Same timezone — easier scheduling");
+  } else {
+    const diff = getTimezoneDifference(seeker.timezone, candidate.timezone);
+    if (diff !== null && Math.abs(diff) <= 3) {
+      score += 5;
+      reasons.push("Similar timezone");
+    }
+  }
+
+  // Availability overlap (15 pts)
+  const availScore = calculateAvailabilityOverlap(
+    seeker.availability,
+    candidate.availability
+  );
+  score += availScore;
+  if (availScore > 0) {
+    reasons.push("Overlapping availability");
+  }
+
+  // Profile completeness penalty — sparse profiles get a score reduction
+  const candidateDepth =
+    candidate.expertise.length +
+    candidate.learningGoals.length +
+    candidate.preferredLanguages.length;
+  if (candidateDepth === 0) {
+    score = Math.round(score * 0.3);
+    reasons.push("Limited profile");
+  } else if (candidateDepth < 2) {
+    score = Math.round(score * 0.6);
+  }
+
+  return {
+    userId: candidate.userId,
+    score: Math.min(100, Math.round(score)),
+    reasons: reasons.length > 0 ? reasons : ["Potential match based on profiles"],
+  };
+}
+
+function normalizeSkill(s: string): string {
+  return s.toLowerCase().trim();
+}
+
+function getTimezoneDifference(tz1: string, tz2: string): number | null {
+  try {
+    const now = new Date();
+    const d1 = new Date(now.toLocaleString("en-US", { timeZone: tz1 }));
+    const d2 = new Date(now.toLocaleString("en-US", { timeZone: tz2 }));
+    return (d2.getTime() - d1.getTime()) / (1000 * 60 * 60);
+  } catch {
+    return null;
+  }
+}
+
+function calculateAvailabilityOverlap(
+  avail1: MentorshipProfile["availability"],
+  avail2: MentorshipProfile["availability"]
+): number {
+  if (avail1.length === 0 || avail2.length === 0) return 0;
+  let count = 0;
+  for (const w1 of avail1) {
+    for (const w2 of avail2) {
+      if (w1.dayOfWeek === w2.dayOfWeek && timeRangesOverlap(w1.startTime, w1.endTime, w2.startTime, w2.endTime)) {
+        count++;
+      }
+    }
+  }
+  return Math.min(15, count * 3);
+}
+
+function timeRangesOverlap(s1: string, e1: string, s2: string, e2: string): boolean {
+  const toMins = (t: string) => {
+    const [h, m] = t.split(":").map(Number);
+    return h * 60 + m;
+  };
+  return toMins(s1) < toMins(e2) && toMins(s2) < toMins(e1);
+}
+
+/**
+ * Return top matches for a seeker from a pool of candidate profiles.
+ * Filters out the seeker and inactive profiles.
+ */
+export function getTopMentorshipMatches(
+  seeker: MentorshipProfile,
+  candidates: MentorshipProfile[],
+  limit = 10
+): MentorshipMatchScore[] {
+  return candidates
+    .filter((c) => c.userId !== seeker.userId && c.isActive)
+    .map((c) => calculateMentorshipMatchScore(seeker, c))
+    .filter((m) => m.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/lib/mentorship/types.ts
+++ b/lib/mentorship/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Timestamp } from "firebase/firestore";
+
+export type MentorshipRole = "mentor" | "mentee" | "both";
+
+export type MentorshipRequestStatus = "pending" | "accepted" | "declined" | "cancelled";
+
+export type PairingStatus = "active" | "completed" | "cancelled";
+
+export type GoalStatus = "in-progress" | "completed" | "dropped";
+
+export interface MentorshipAvailability {
+  dayOfWeek: number; // 0 = Sunday, 6 = Saturday
+  startTime: string; // HH:mm
+  endTime: string;   // HH:mm
+}
+
+export interface MentorshipProfile {
+  userId: string;
+  role: MentorshipRole;
+  // Topics/skills the mentor can teach
+  expertise: string[];
+  // What the mentee wants to learn
+  learningGoals: string[];
+  preferredLanguages: string[];
+  timezone: string;
+  availability: MentorshipAvailability[];
+  bio?: string;
+  // Max concurrent mentees a mentor is willing to take on
+  maxMentees?: number;
+  isActive: boolean;
+  createdAt: Timestamp | Date;
+  updatedAt: Timestamp | Date;
+}
+
+export interface MentorshipGoal {
+  id: string;
+  description: string;
+  status: GoalStatus;
+  completedAt?: Timestamp | Date;
+}
+
+export interface MentorshipRequest {
+  id?: string;
+  fromUserId: string;
+  toUserId: string;
+  // Goals the mentee wants to work toward in this pairing
+  goals: string[];
+  message: string;
+  status: MentorshipRequestStatus;
+  createdAt: Timestamp | Date;
+  updatedAt: Timestamp | Date;
+}
+
+export interface MentorshipPairing {
+  id?: string;
+  mentorId: string;
+  menteeId: string;
+  goals: MentorshipGoal[];
+  status: PairingStatus;
+  startedAt: Timestamp | Date;
+  completedAt?: Timestamp | Date;
+  createdAt: Timestamp | Date;
+  updatedAt: Timestamp | Date;
+}
+
+export interface MentorshipCheckIn {
+  id?: string;
+  pairingId: string;
+  authorId: string;
+  progress: string;
+  nextSteps?: string;
+  goalUpdates?: { goalId: string; status: GoalStatus }[];
+  createdAt: Timestamp | Date;
+}
+
+export interface MentorshipMatchScore {
+  userId: string;
+  score: number; // 0-100
+  reasons: string[];
+}


### PR DESCRIPTION
Closes #261 (partial — UI in follow-up PR)

## Summary

**Data layer (`lib/mentorship/`)**
- `types.ts` — `MentorshipProfile`, `MentorshipRequest`, `MentorshipPairing`, `MentorshipGoal`, `MentorshipCheckIn`, `MentorshipMatchScore` types
- `matching.ts` — role-aware scoring algorithm: goal/expertise alignment (50pts), language overlap (20pts), timezone (10pts), availability overlap (15pts), sparse-profile penalty
- `data.ts` — client-side Firestore reads
- `data-server.ts` — Admin SDK writes with Firestore transaction on accept/decline

**API routes (`app/api/mentorship/`)**
- `GET/POST /api/mentorship/profile` — upsert mentorship profile
- `GET /api/mentorship/matches` — top scored matches for the authenticated user
- `GET/POST /api/mentorship/request` — send / list mentorship requests
- `POST /api/mentorship/respond` — accept or decline a request (creates pairing on accept)

## Test plan
- [ ] `tsc --noEmit` passes (verified locally)
- [ ] Types cover role, goals, availability, pairings, and check-ins per issue #261
- [ ] Matching returns higher scores for closer goal/expertise alignment
- [ ] Profile endpoint rejects invalid roles, oversized arrays, missing timezone
- [ ] Request endpoint requires at least one goal and a non-empty message
- [ ] Respond endpoint uses a transaction — concurrent accepts can't create duplicate pairings

## Follow-up PR
UI (profile setup page, match browsing, request flow) will be in a separate PR once this is reviewed.