### PR TITLE
feat(pydata-2026): conditional Luma button; default to site registration only

### DIFF
--- a/app/api/events/pydata-2026/luma-status/route.ts
+++ b/app/api/events/pydata-2026/luma-status/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { PYDATA_2026_LUMA_EVENT_NAME } from "@/lib/pydata-2026";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function handleGet(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ signedIn: false, onLumaList: false });
+  }
+  const email = (user.email || "").trim().toLowerCase();
+  if (!email) {
+    return NextResponse.json({ signedIn: true, onLumaList: false });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+  const snap = await db.collection("eventContacts").doc(email).get();
+  if (!snap.exists) {
+    return NextResponse.json({ signedIn: true, onLumaList: false });
+  }
+  const data = snap.data() || {};
+  const eventNames: unknown = data.eventNames;
+  const onLumaList =
+    Array.isArray(eventNames) &&
+    eventNames.some(
+      (n) => typeof n === "string" && n === PYDATA_2026_LUMA_EVENT_NAME
+    );
+  return NextResponse.json({ signedIn: true, onLumaList });
+}
+
+export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
   PYDATA_2026_EVENT_SLUG,
   PYDATA_2026_REGISTRATION_PATH,
 } from "@/lib/pydata-2026";
+import { PyDataLumaButton } from "@/components/events/PyDataLumaButton";
 
 // Type definitions for event data
 interface AgendaItem {
@@ -411,22 +412,16 @@ export default async function EventPage({
                   href={PYDATA_2026_REGISTRATION_PATH}
                   className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black w-full sm:w-auto"
                 >
-                  Register for badge
+                  Register for door access
                   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M5 12h14" /><path d="m12 5 7 7-7 7" /></svg>
                 </Link>
-                <a
-                  href={getLumaCheckoutHref(event)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-white/20 text-white/80 rounded-lg text-sm font-medium hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black w-full sm:w-auto luma-checkout--button"
-                  data-luma-action="checkout"
-                  data-luma-event-id={getLumaCheckoutEventId(event)}
-                >
-                  RSVP on Luma (for door entry)
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M7 17l9.2-9.2M17 17V7H7" /></svg>
-                </a>
+                <PyDataLumaButton
+                  variant="outline"
+                  label="Also RSVP on Luma"
+                  className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-white/20 text-white/80 rounded-lg text-sm font-medium hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black w-full sm:w-auto"
+                />
                 <p className="text-sm text-amber-600 dark:text-amber-400 mt-1 font-medium">
-                  Both required: register here so we can hand your name to Moderna for badge issuance, then RSVP on Luma to receive the Envoy NDA email.
+                  Moderna requires us to hand them a CSV of confirmed attendees. Registering here is what gets your name on the door list — no site registration, no entry.
                 </p>
               </div>
             ) : (
@@ -807,7 +802,30 @@ export default async function EventPage({
       {/* Final CTA */}
       <section className="py-20 px-6">
         <div className="max-w-3xl mx-auto text-center">
-          {websiteRegistration ? (
+          {isPyData ? (
+            <>
+              <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
+                Ready to be on the door list?
+              </h2>
+              <p className="text-neutral-600 dark:text-neutral-400 text-lg mb-2">
+                Registering on cursorboston.com is what gets your name to Moderna. Without it you won&apos;t be admitted.
+              </p>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-6">
+                <Link
+                  href={PYDATA_2026_REGISTRATION_PATH}
+                  className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-emerald-500 text-white rounded-lg text-lg font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                >
+                  Register for door access
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M5 12h14" /><path d="m12 5 7 7-7 7" /></svg>
+                </Link>
+                <PyDataLumaButton
+                  variant="outline"
+                  label="Also RSVP on Luma"
+                  className="inline-flex items-center justify-center gap-2 px-8 py-4 border border-neutral-300 dark:border-white/20 text-neutral-700 dark:text-white/80 rounded-lg text-base font-medium hover:bg-neutral-100 dark:hover:bg-white/10 transition-colors"
+                />
+              </div>
+            </>
+          ) : websiteRegistration ? (
             <>
               <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
                 Ready to compete?

--- a/app/events/cursor-boston-pydata-2026/register/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/register/page.tsx
@@ -12,10 +12,10 @@ import { useAuth } from "@/contexts/AuthContext";
 import {
   PYDATA_2026_CAPACITY,
   PYDATA_2026_EVENT_SLUG,
-  PYDATA_2026_LUMA_URL,
   PYDATA_2026_REGISTRATION_PATH,
   type PydataRegistration,
 } from "@/lib/pydata-2026";
+import { PyDataLumaButton } from "@/components/events/PyDataLumaButton";
 
 const API_PATH = "/api/events/pydata-2026/registration";
 const CAPACITY_API_PATH = "/api/events/pydata-2026/capacity";
@@ -184,17 +184,8 @@ export default function PyDataRegisterPage() {
         </h1>
         <p className="mt-4 text-base text-neutral-600 dark:text-neutral-400">
           Wednesday May 13 · Moderna HQ, Cambridge. Confirm here so we can hand
-          your name to Moderna for Envoy registration and badge issuance. You
-          still need to RSVP on{" "}
-          <a
-            href={PYDATA_2026_LUMA_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-emerald-600 underline hover:text-emerald-500 dark:text-emerald-400"
-          >
-            Luma
-          </a>{" "}
-          for the door list.
+          your name to Moderna for Envoy registration and badge issuance. This
+          form is what gets you on the door list.
         </p>
         <CapacityBanner capacity={capacity} />
 
@@ -262,20 +253,12 @@ const PROCESS_STEPS: Step[] = [
   {
     when: "Now",
     actor: "you",
-    title: "Confirm attendance + RSVP on Luma",
+    title: "Confirm attendance",
     body: (
       <>
         Fill out the form below with the name on your government-issued ID,
-        plus your email and (optionally) phone and company. Then RSVP on{" "}
-        <a
-          href={PYDATA_2026_LUMA_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-emerald-600 underline hover:text-emerald-500 dark:text-emerald-400"
-        >
-          Luma
-        </a>{" "}
-        if you haven&apos;t already — that&apos;s the door list.
+        plus your email and (optionally) phone and company. Submitting this
+        form is what puts you on the door list — Luma alone won&apos;t.
       </>
     ),
   },
@@ -776,30 +759,10 @@ function AwaitingBadge({
             you can still sign the NDA on paper at the door — but if your name
             isn&apos;t on the list, you won&apos;t be admitted.
           </li>
-          <li>
-            Don&apos;t forget to RSVP on{" "}
-            <a
-              href={PYDATA_2026_LUMA_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
-              Luma
-            </a>{" "}
-            if you haven&apos;t already.
-          </li>
         </ol>
       </div>
 
       <div className="mt-6 flex flex-wrap gap-3">
-        <a
-          href={PYDATA_2026_LUMA_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
-        >
-          Open Luma RSVP
-        </a>
         <button
           type="button"
           onClick={onEdit}
@@ -807,6 +770,7 @@ function AwaitingBadge({
         >
           Edit details
         </button>
+        <PyDataLumaButton variant="outline" label="Also RSVP on Luma" />
         <Link
           href={`/events/${PYDATA_2026_EVENT_SLUG}`}
           className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"

--- a/components/events/EventsBrowse.tsx
+++ b/components/events/EventsBrowse.tsx
@@ -16,6 +16,7 @@ import {
   PYDATA_2026_EVENT_SLUG,
   PYDATA_2026_REGISTRATION_PATH,
 } from "@/lib/pydata-2026";
+import { PyDataLumaButton } from "./PyDataLumaButton";
 import styles from "./EventsBrowse.module.css";
 
 type Props = {
@@ -203,9 +204,13 @@ export function EventsBrowse({ events, listingTodayYmd }: Props) {
 
 /** Large hero-style card; register uses a normal Luma link (no checkout embed) so clicks always navigate. */
 function FeaturedEventCard({ event }: { event: Event }) {
-  const registerHref =
-    event.lumaUrl?.trim() || getLumaCheckoutHref(event);
   const isPyData = event.slug === PYDATA_2026_EVENT_SLUG;
+  // For PyData, hide the public Luma button — Moderna door access requires
+  // site registration. <PyDataLumaButton> conditionally re-shows the Luma
+  // link to signed-in users who aren't on the Luma list yet.
+  const registerHref = isPyData
+    ? null
+    : event.lumaUrl?.trim() || getLumaCheckoutHref(event);
 
   return (
     <div className="bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800">
@@ -321,29 +326,37 @@ function FeaturedEventCard({ event }: { event: Event }) {
                 <path d="M5 12h14M12 5l7 7-7 7" />
               </svg>
             </Link>
-            <a
-              href={registerHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`Register for ${event.title} (opens in new tab)`}
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 border border-neutral-300 dark:border-neutral-700 text-foreground rounded-lg text-base font-semibold hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
-            >
-              Register on Luma
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
+            {isPyData ? (
+              <PyDataLumaButton
+                variant="outline"
+                label="Also RSVP on Luma"
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 border border-neutral-300 dark:border-neutral-700 text-foreground rounded-lg text-base font-semibold hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
+              />
+            ) : registerHref ? (
+              <a
+                href={registerHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Register for ${event.title} (opens in new tab)`}
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 border border-neutral-300 dark:border-neutral-700 text-foreground rounded-lg text-base font-semibold hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
               >
-                <path d="M7 17l9.2-9.2M17 17V7H7" />
-              </svg>
-            </a>
+                Register on Luma
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M7 17l9.2-9.2M17 17V7H7" />
+                </svg>
+              </a>
+            ) : null}
           </div>
         </div>
       </div>

--- a/components/events/PyDataLumaButton.tsx
+++ b/components/events/PyDataLumaButton.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { PYDATA_2026_LUMA_URL } from "@/lib/pydata-2026";
+
+type Variant = "primary" | "outline" | "inline";
+
+type Props = {
+  /** Visual style. Defaults to outline (the most common usage). */
+  variant?: Variant;
+  /** Override label; defaults match each variant. */
+  label?: string;
+  className?: string;
+};
+
+const STATUS_PATH = "/api/events/pydata-2026/luma-status";
+
+/**
+ * Renders a "Register on Luma" link only when the viewer is signed in and
+ * NOT already on the PyData Luma list. The site registration is the
+ * primary path for door access; this is the secondary nudge for the
+ * minority who skipped Luma.
+ *
+ * Returns null in all other cases (signed-out, on-list, errored). That
+ * keeps the default UX uncluttered with the now-misleading Luma button.
+ */
+export function PyDataLumaButton({
+  variant = "outline",
+  label,
+  className = "",
+}: Props) {
+  const { user, loading: authLoading } = useAuth();
+  const [onLumaList, setOnLumaList] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot reset on sign-out
+      setOnLumaList(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(STATUS_PATH, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          if (!cancelled) setOnLumaList(true); // fail closed: hide the button
+          return;
+        }
+        const json = (await res.json()) as { onLumaList?: boolean };
+        if (!cancelled) setOnLumaList(Boolean(json.onLumaList));
+      } catch {
+        if (!cancelled) setOnLumaList(true); // fail closed
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  if (authLoading) return null;
+  if (!user) return null;
+  if (onLumaList === null) return null; // status not yet known
+  if (onLumaList) return null;
+
+  const text = label ?? "Also RSVP on Luma";
+
+  if (variant === "inline") {
+    return (
+      <a
+        href={PYDATA_2026_LUMA_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={
+          className ||
+          "text-emerald-600 underline hover:text-emerald-500 dark:text-emerald-400"
+        }
+      >
+        {text}
+      </a>
+    );
+  }
+
+  if (variant === "primary") {
+    return (
+      <a
+        href={PYDATA_2026_LUMA_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={
+          className ||
+          "inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-black w-full sm:w-auto"
+        }
+      >
+        {text}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M7 17l9.2-9.2M17 17V7H7" />
+        </svg>
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={PYDATA_2026_LUMA_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={
+        className ||
+        "inline-flex items-center justify-center gap-2 px-5 py-2.5 border border-neutral-300 dark:border-neutral-700 text-foreground rounded-lg text-sm font-semibold hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white"
+      }
+    >
+      {text}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M7 17l9.2-9.2M17 17V7H7" />
+      </svg>
+    </a>
+  );
+}

--- a/content/events.json
+++ b/content/events.json
@@ -14,8 +14,8 @@
         "mapUrl": null
       },
       "type": "hackathon",
-      "description": "Hands-on evening hackathon at Moderna HQ co-hosted by Cursor Boston and PyData Boston. A short talk from Eric Ma, then a focused build session on data-science workflows with Cursor. Pizza and Cursor credits. Wednesday May 13 in Cambridge — register on Luma; host approval and Envoy NDA sign-in required.",
-      "longDescription": "Cursor Boston and PyData Boston team up for an evening of data-science building at Moderna HQ in Cambridge.\n\nThe Format\n\nDoors open at 6:30 with networking and pizza. Welcome at 7:00, then a talk from Eric Ma at 7:15 on a practical data-science topic. At ~8:05 we break into the hack — build and explore data-science workflows in Cursor. Optional demos at ~9:10 and we wrap by 9:30.\n\nWhat You'll Get\n\nCommunity, learning, pizza, and Cursor credits (details TBA).\n\nImportant: Security & Access\n\nSign-up closes 48 hours prior — no sign-up, no entry. Moderna has tight security.\n\nRSVPs must include first name, last name, email, and organization. After approval you'll get an email from no-reply@envoy.com. Complete the Envoy sign-in including NDA and signature before arriving — you'll receive a QR code. No QR code, no access. When taking photos, do not include the Moderna logo or branding.\n\nPreparation\n\nBring a laptop, charger, Cursor IDE installed, and a registered Cursor account.\n\nHosts\n\nRoger Hunt, Jacqueline Valeri, Sebastian Wallkötter, Alexander Commodore.",
+      "description": "Hands-on evening hackathon at Moderna HQ co-hosted by Cursor Boston and PyData Boston. A short talk from Eric Ma, then a focused build session on data-science workflows with Cursor. Pizza and Cursor credits. Wednesday May 13 in Cambridge — register on cursorboston.com for Moderna door access; Envoy NDA sign-in required before arrival.",
+      "longDescription": "Cursor Boston and PyData Boston team up for an evening of data-science building at Moderna HQ in Cambridge.\n\nThe Format\n\nDoors open at 6:30 with networking and pizza. Welcome at 7:00, then a talk from Eric Ma at 7:15 on a practical data-science topic. At ~8:05 we break into the hack — build and explore data-science workflows in Cursor. Optional demos at ~9:10 and we wrap by 9:30.\n\nWhat You'll Get\n\nCommunity, learning, pizza, and Cursor credits (details TBA).\n\nImportant: Security & Access\n\nSign-up closes 48 hours prior — no sign-up, no entry. Moderna has tight security.\n\nRegistration on cursorboston.com is what gets you on the Moderna door list — full legal name, email, and organization. About 48 hours before the event we send Moderna a final attendee CSV; you'll then get an email from no-reply@envoy.com. Complete the Envoy sign-in including NDA and signature before arriving — you'll receive a QR code. No QR code, no access. When taking photos, do not include the Moderna logo or branding.\n\nPreparation\n\nBring a laptop, charger, Cursor IDE installed, and a registered Cursor account.\n\nHosts\n\nRoger Hunt, Jacqueline Valeri, Sebastian Wallkötter, Alexander Commodore.",
       "lumaCheckoutEventId": "evt-9PHCTsttlDD5wYW",
       "lumaEmbedSrc": "https://luma.com/embed/event/evt-9PHCTsttlDD5wYW/simple",
       "image": "/cursor-boston-logo.png",
@@ -77,7 +77,7 @@
         },
         {
           "question": "What's the Envoy / NDA step?",
-          "answer": "After your Luma approval you'll get an email from no-reply@envoy.com. Complete the sign-in (including NDA and signature) before the event. That generates the QR code you need to enter Moderna."
+          "answer": "After we send Moderna the final attendee CSV (48 hours before the event), you'll get an email from no-reply@envoy.com. Complete the sign-in (including NDA and signature) before the event. That generates the QR code you need to enter Moderna."
         },
         {
           "question": "Can I take photos?",

--- a/lib/pydata-2026.ts
+++ b/lib/pydata-2026.ts
@@ -21,6 +21,13 @@ export const PYDATA_2026_REGISTRATION_PATH = `/events/${PYDATA_2026_EVENT_SLUG}/
 export const PYDATA_2026_REGISTRATIONS_COLLECTION = "pydataHack2026Registrations";
 
 /**
+ * Event name written into eventContacts.eventNames by the Luma sync scripts
+ * (sync-event-contacts.ts derives this from the CSV filename). Lookups for
+ * "is this email on the pydata Luma list?" must match this string exactly.
+ */
+export const PYDATA_2026_LUMA_EVENT_NAME = "Cursor Boston-PyData Data Science Hack";
+
+/**
  * Hard cap on attendees Moderna will admit. We hand Moderna the first
  * PYDATA_2026_CAPACITY non-cancelled registrations sorted by createdAt;
  * everyone else lands on a waitlist. Luma RSVPs do NOT count.


### PR DESCRIPTION
## Summary

- Removes the always-on **"Register on Luma"** button from the pydata listing card, detail page, and `/events/cursor-boston-pydata-2026/register` page. Door access requires registration on cursorboston.com (we ship Moderna a CSV; Luma RSVPs don't feed it), and the parallel Luma button was sending people down a path that wouldn't get them in.
- Adds `<PyDataLumaButton>` — a client component that **conditionally** re-shows "Also RSVP on Luma" only when the viewer is **signed in AND not yet on the pydata Luma list**.
- New endpoint `GET /api/events/pydata-2026/luma-status` returns `{ signedIn, onLumaList }`. "On Luma list" is read from `eventContacts.eventNames` (populated by `sync-event-contacts.ts` from the Luma CSV exports).
- New constant `PYDATA_2026_LUMA_EVENT_NAME` so the API and the Luma sync script agree on the exact `eventNames` key.
- Final CTA on the event detail page had a bug for pydata: it fell into the "Luma-only" branch since pydata isn't in `WEBSITE_REGISTRATION_CONFIG`. Added a pydata-specific branch.
- Copy fixes: amber note + FAQ + longDescription now describe the Envoy email as coming after **we send Moderna the CSV** (48h prior), not after "Luma approval."

### Behavior

| viewer state | door-access button | Luma button |
| --- | --- | --- |
| logged out | ✅ "Register for door access" | hidden |
| logged in, on Luma list | ✅ "Register for door access" | hidden |
| logged in, not on Luma list | ✅ "Register for door access" | ✅ "Also RSVP on Luma" |

### Data prep (already applied)

Backfilled `eventContacts` for 192 May 6 Luma registrants so existing contacts have `"Cursor Boston-PyData Data Science Hack"` in their `eventNames` array (the lookup key used by the new API).

## Test plan

- [ ] Logged-out: visit `/events`, `/events/cursor-boston-pydata-2026`, `/events/cursor-boston-pydata-2026/register` — no Luma buttons anywhere on pydata; only "Register for door access".
- [ ] Logged in as a user already on the May 6 Luma list — same as above (no Luma button).
- [ ] Logged in as a user NOT on Luma list — secondary "Also RSVP on Luma" button appears alongside "Register for door access" in all three locations.
- [ ] Other (non-pydata) events still show their original "Register on Luma" button.
- [ ] `GET /api/events/pydata-2026/luma-status` returns `{signedIn:false, onLumaList:false}` unauthenticated; correct values when authed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)