### PR TITLE
release: develop -> main (generals onboarding copy)

### DIFF
--- a/app/game/attacks/page.tsx
+++ b/app/game/attacks/page.tsx
@@ -88,6 +88,14 @@ export default function AttackLogPage() {
           </Link>
         </div>
 
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed">
+          <p>
+            Every attack you launched (<em>sent</em>) or received (<em>received</em>).
+            Each row shows the units sent, the outcome (captured / repelled /
+            stalemate), and casualties on both sides.
+          </p>
+        </div>
+
         <div className="flex gap-2 mb-6">
           {(["all", "sent", "received"] as Side[]).map((s) => (
             <button

--- a/app/game/leaderboard/page.tsx
+++ b/app/game/leaderboard/page.tsx
@@ -95,6 +95,14 @@ export default function LeaderboardPage() {
           <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
 
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed">
+          <p>
+            Top 50 generals ranked by tiles held. Conquering a tile bumps your
+            number and drops your opponent&apos;s by the same amount. Your row
+            is highlighted.
+          </p>
+        </div>
+
         {rows.length === 0 ? (
           <p className="text-center text-neutral-500 py-12">No generals yet.</p>
         ) : (

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -110,11 +110,16 @@ export default function GameDashboardPage() {
   if (!user) {
     return (
       <div className="min-h-screen flex items-center justify-center px-6">
-        <div className="max-w-md w-full text-center">
+        <div className="max-w-lg w-full text-center">
           <h1 className="text-3xl font-bold mb-4">Generals</h1>
-          <p className="text-neutral-600 dark:text-neutral-300 mb-6">
-            A turn-based campaign for the cursor-boston community. Sign in to
-            claim a hundred lands and begin building your army.
+          <p className="text-neutral-600 dark:text-neutral-300 mb-3">
+            A turn-based strategy game for the cursor-boston community. Sign in,
+            claim a hundred lands, and contest the world map.
+          </p>
+          <p className="text-neutral-500 dark:text-neutral-400 text-sm mb-6">
+            <strong>The catch:</strong> turns are gated by PR merges. Merge a PR
+            into this repo any time during a week and you&apos;ll receive 100
+            turns the following Sunday at midnight EST. No PR, no turns.
           </p>
           <Link
             href="/login"
@@ -130,12 +135,16 @@ export default function GameDashboardPage() {
   if (!player) {
     return (
       <div className="min-h-screen flex items-center justify-center px-6">
-        <div className="max-w-lg w-full text-center">
+        <div className="max-w-xl w-full text-center">
           <h1 className="text-3xl font-bold mb-4">Begin your campaign</h1>
-          <p className="text-neutral-600 dark:text-neutral-300 mb-6">
-            You haven&apos;t enlisted yet. Pressing the button below will spawn
-            your soul-bond region and seed it with 100 lands.
+          <p className="text-neutral-600 dark:text-neutral-300 mb-3">
+            You haven&apos;t enlisted yet. Pressing the button below will:
           </p>
+          <ul className="text-sm text-neutral-600 dark:text-neutral-400 mb-6 inline-block text-left list-disc ml-5">
+            <li>Claim 100 lands as your starting territory.</li>
+            <li>Grant you 100 starter turns to begin the setup ramp.</li>
+            <li>Drop a 3-week shield over you so no one can attack until you&apos;ve had a chance to develop your forces.</li>
+          </ul>
           {error && (
             <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
           )}
@@ -167,6 +176,34 @@ export default function GameDashboardPage() {
         {error && (
           <p className="mb-6 text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
+
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-6 text-sm leading-relaxed">
+          {player.phase === "explore" && (
+            <p>
+              <strong>You&apos;re in the explore phase.</strong> Each turn you
+              spend on the setup page reveals one of your 100 lands. After all
+              100 are revealed, the game auto-advances to the distribute phase.
+            </p>
+          )}
+          {player.phase === "distribute" && (
+            <p>
+              <strong>You&apos;re in the distribute phase.</strong> Assign each
+              of your 100 lands a role: <em>military</em> (produces units),{" "}
+              <em>food</em> (raises your unit cap), or <em>magic</em>{" "}
+              (multiplies spell strength). Each change costs 1 turn. Pick a
+              caste from the setup page when you&apos;re ready to start playing.
+            </p>
+          )}
+          {player.phase === "play" && (
+            <p>
+              <strong>You&apos;re playing.</strong> Build units on military
+              tiles, arm defense spells, attack bordering enemies. Your shield
+              wall drops once <strong>both</strong> 3 weeks have passed since
+              you enlisted <strong>and</strong> you&apos;ve spent at least 300
+              turns. After that, you can attack and be attacked.
+            </p>
+          )}
+        </div>
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
           <Stat label="Phase" value={player.phase} />

--- a/app/game/setup/page.tsx
+++ b/app/game/setup/page.tsx
@@ -191,8 +191,18 @@ function ExplorePanel({
   const unrevealed = tiles.filter((t) => t.type === "unrevealed").length;
   return (
     <div>
-      <p className="mb-4 text-neutral-600 dark:text-neutral-300">
-        Each turn spent reveals one of your unrevealed lands. {unrevealed} remain.
+      <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed">
+        <p className="font-semibold mb-1">Step 1 of 3 — Explore</p>
+        <p>
+          You spawned with 100 lands hidden under fog. Each click below burns 1
+          turn and reveals one of them. You won&apos;t see which tile gets
+          revealed in advance — exploration is blind, just like first-time
+          scouts. Once all 100 are revealed, you&apos;ll automatically move on
+          to the distribute phase.
+        </p>
+      </div>
+      <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-300">
+        {unrevealed} land{unrevealed === 1 ? "" : "s"} remain unrevealed.
       </p>
       <button
         onClick={onExplore}
@@ -226,6 +236,19 @@ function DistributePanel({
 
   return (
     <div>
+      <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed space-y-2">
+        <p className="font-semibold">Step 2 of 3 — Distribute</p>
+        <p>Assign each tile a role. Each change (including re-changes) costs 1 turn:</p>
+        <ul className="list-disc ml-5">
+          <li><strong>Military (M)</strong> — the only tiles that can produce units. More military = faster army-building.</li>
+          <li><strong>Food (F)</strong> — raises your <em>total</em> unit cap. Soft-capped: each food tile is +5 cap up to 50 tiles, then +2.5 each.</li>
+          <li><strong>Magic (G)</strong> — multiplies your spell strength when you cast. Same soft-cap shape.</li>
+        </ul>
+        <p className="text-neutral-600 dark:text-neutral-400">
+          A balanced empire usually wants ~30 military, ~30 food, ~30 magic. But specialize if you want — heavy military rushes early, heavy magic dominates spell-heavy castes.
+        </p>
+      </div>
+
       <div className="grid grid-cols-4 gap-3 mb-6 text-center text-sm">
         <Counter label="Military" value={counts.military} />
         <Counter label="Food" value={counts.food} />
@@ -234,6 +257,18 @@ function DistributePanel({
       </div>
 
       <div className="mb-6">
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed space-y-2">
+          <p className="font-semibold">Step 3 of 3 — Pick a caste (permanent)</p>
+          <p>Each caste tilts your unit and spell strengths. You cannot change later.</p>
+          <ul className="list-disc ml-5">
+            <li><strong>White</strong> — defense / order. Strong ground units, strongest defense spells. Good for turtling.</li>
+            <li><strong>Blue</strong> — control / magic. Strong air units, strongest production spells (food cap boosts). Good for tempo.</li>
+            <li><strong>Black</strong> — sacrifice / swarm. Cheap balanced units, strong offense spells. Good for grinding wars.</li>
+            <li><strong>Red</strong> — aggression / fire. Strong siege, strongest offense spells. Good for blitzing.</li>
+            <li><strong>Green</strong> — growth. +20% tile capacity (so your tiles hold more units), strong ground swarms. Good for fortified expansion.</li>
+          </ul>
+        </div>
+
         <h2 className="font-semibold mb-3">Choose your caste to start playing</h2>
         <div className="flex flex-wrap gap-2">
           {CASTES.map((c) => (
@@ -248,8 +283,7 @@ function DistributePanel({
           ))}
         </div>
         <p className="text-xs text-neutral-500 mt-2">
-          Caste choice is permanent. You can keep distributing tiles after, but
-          choosing the caste advances you into the play phase.
+          You can keep redistributing tiles after picking a caste — but caste itself is locked permanently.
         </p>
       </div>
 

--- a/app/game/tiles/[tileId]/page.tsx
+++ b/app/game/tiles/[tileId]/page.tsx
@@ -256,6 +256,19 @@ function OwnTilePanel({
     <div className="space-y-6">
       <section>
         <h2 className="font-semibold mb-3">Build units</h2>
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-3 mb-3 text-sm leading-relaxed space-y-1">
+          <p>
+            Each click spends 5 turns and produces 10 units of the chosen type
+            on this tile. Your <strong>total</strong> unit cap is the sum of
+            food-tile contributions plus any active production spells. If
+            you&apos;re at the cap, build will return an error.
+          </p>
+          <p className="text-xs text-neutral-500">
+            <strong>Unit RPS:</strong> Air beats Ground, Ground beats Siege,
+            Siege beats Air. Build a mix or specialize based on what your
+            opponents tend to field.
+          </p>
+        </div>
         {tile.type !== "military" ? (
           <p className="text-sm text-neutral-500">
             Only military tiles can build units. This tile is{" "}
@@ -279,6 +292,15 @@ function OwnTilePanel({
 
       <section>
         <h2 className="font-semibold mb-3">Arm a defense spell</h2>
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-3 mb-3 text-sm leading-relaxed">
+          <p>
+            Pre-arming a defense spell costs 5 turns. The spell sits dormant on
+            this tile and triggers <em>automatically</em> the next time the tile
+            is attacked, then is consumed. Spell strength scales with your
+            magic-tile count. Tiles you expect to be attacked are good
+            candidates.
+          </p>
+        </div>
         {tile.type === "unrevealed" ? (
           <p className="text-sm text-neutral-500">Reveal this tile first.</p>
         ) : myDefenseSpells.length === 0 ? (
@@ -369,9 +391,34 @@ function EnemyTilePanel({
   return (
     <div className="space-y-4">
       <h2 className="font-semibold">Launch attack</h2>
+      <div className="rounded-lg border border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-900/10 p-3 text-sm leading-relaxed space-y-1">
+        <p>
+          Pick a source tile that borders this enemy, choose how many ground /
+          siege / air units to send, optionally attach an offense spell.
+          Resolution is instant.
+        </p>
+        <p>
+          <strong>Composition matters most.</strong> Air beats Ground, Ground
+          beats Siege, Siege beats Air; the advantaged type does +50% damage
+          and takes 25% less. So if the defender is heavy siege, send air. If
+          they&apos;re heavy air, send ground. Mirror-matching is usually a bad
+          trade.
+        </p>
+        <p>
+          <strong>Capacity caps your force.</strong> A tile holds at most a
+          fixed number of units (base 500 + adjustments). You can only send up
+          to <em>(target capacity − defender units already there)</em>. Stuffed
+          tiles are unattackable.
+        </p>
+        <p>
+          <strong>If you win,</strong> the tile becomes yours and your
+          surviving attackers garrison it. <strong>If you lose or stalemate,</strong>{" "}
+          your survivors return to the source.
+        </p>
+      </div>
       {profile && (
         <p className="text-xs text-neutral-500">
-          You are <strong className="capitalize">{player.caste}</strong>. Air &gt; Ground &gt; Siege &gt; Air. Compose accordingly.
+          You are <strong className="capitalize">{player.caste}</strong>. Your caste tilts unit and spell strengths.
         </p>
       )}
 

--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -94,6 +94,14 @@ export default function TilesListPage() {
           </Link>
         </div>
 
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed">
+          <p>
+            Every tile you own. Click any tile to manage it: build units (military
+            tiles only), arm a defense spell, or scout neighbors. The filter
+            chips below show how your tiles are distributed.
+          </p>
+        </div>
+
         <div className="flex flex-wrap gap-2 mb-6">
           {LAND_FILTERS.map((t) => (
             <button

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -116,6 +116,11 @@ export default function Footer() {
                       Partners
                     </Link>
                   </li>
+                  <li>
+                    <Link href="/game" className="text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white text-sm transition-colors focus-visible:outline-none focus-visible:text-foreground focus-visible:underline">
+                      Generals
+                    </Link>
+                  </li>
                 </ul>
               </div>
 


### PR DESCRIPTION
## Summary
Single follow-up PR landing on main this release: footer link + step-by-step UX copy for the generals game.

## Included PRs
- **#663** — feat(generals): footer link + step-by-step UX copy — @rogerSuperBuilderAlpha (with Claude as co-author)

## Contributors
- @rogerSuperBuilderAlpha

## Notes
- Footer.tsx edit is the one game-related change outside the lib/game namespace; it's the user-requested footer placement.
- No mechanics changes. Pure UX copy plus one nav link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)