### PR TITLE
fix(game): inventory 500 — drop orderBy, sort in memory

### DIFF
--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -400,13 +400,17 @@ export async function listArtifactsServer(
   userId: string
 ): Promise<GameArtifact[]> {
   const db = adminDbOrThrow();
+  // Single-field where + in-memory sort: avoids needing the composite index
+  // to be deployed before this code goes live. Inventories are small (player
+  // turn budgets cap them well below 1k) so the sort is trivial.
   const snap = await db
     .collection(COLLECTIONS.ARTIFACTS)
     .where("ownerId", "==", userId)
-    .orderBy("foundAtTurn", "desc")
-    .limit(200)
+    .limit(500)
     .get();
-  return snap.docs.map((d) => d.data() as GameArtifact);
+  const artifacts = snap.docs.map((d) => d.data() as GameArtifact);
+  artifacts.sort((a, b) => b.foundAtTurn - a.foundAtTurn);
+  return artifacts;
 }
 
 // Sets or changes a tile's type (military / food / magic). Costs 1 turn,


### PR DESCRIPTION
## Summary
The `/api/game/artifacts` endpoint returns 500 on production right now because the composite index for `game_artifacts(ownerId asc, foundAtTurn desc)` was added to `firestore.indexes.json` in #667 but Firestore indexes deploy separately from Vercel.

Quick fix: drop the `orderBy` from the query and sort in JS. Inventories are small (player turn budgets cap drops well below 500 even after months of play), so this is a no-op for performance. The composite index entry stays in the JSON file for an admin to deploy when convenient.

## Test plan
- [x] tsc + eslint clean
- [ ] Smoke test on prod after merge: load `/game/artifacts`, confirm no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)