### PR TITLE
release: hotfix /api/game/artifacts 500 (no-index sort)

### DIFF
--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -400,13 +400,17 @@ export async function listArtifactsServer(
   userId: string
 ): Promise<GameArtifact[]> {
   const db = adminDbOrThrow();
+  // Single-field where + in-memory sort: avoids needing the composite index
+  // to be deployed before this code goes live. Inventories are small (player
+  // turn budgets cap them well below 1k) so the sort is trivial.
   const snap = await db
     .collection(COLLECTIONS.ARTIFACTS)
     .where("ownerId", "==", userId)
-    .orderBy("foundAtTurn", "desc")
-    .limit(200)
+    .limit(500)
     .get();
-  return snap.docs.map((d) => d.data() as GameArtifact);
+  const artifacts = snap.docs.map((d) => d.data() as GameArtifact);
+  artifacts.sort((a, b) => b.foundAtTurn - a.foundAtTurn);
+  return artifacts;
 }
 
 // Sets or changes a tile's type (military / food / magic). Costs 1 turn,


### PR DESCRIPTION
## Summary
Promotes the inventory hotfix to main.

## Included PRs and authors
- #669 by @Ludwitt — fix(game): inventory query drops orderBy, sorts in memory (was returning 500 because the new composite index hadn't been deployed)

## Test plan
- [ ] Smoke test on prod after auto-deploy: load /game/artifacts, confirm 200 + empty state renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)