### PR TITLE
release: generals v2 PR 6c — frontier explore + artifact use + 25-tile spawn

### DIFF
--- a/__tests__/lib/game/exploration.test.ts
+++ b/__tests__/lib/game/exploration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  distanceToNearestOwned,
+  hexCentroid,
+  hostileSpawnProbability,
+  riskScore,
+  ringCoords,
+  sampleFrontierTile,
+} from "@/lib/game/exploration";
+import { hexDistance, tileIdFromAxial } from "@/lib/game/world-gen";
+import { makeSeededRng } from "@/lib/game/combat";
+
+describe("hexCentroid", () => {
+  it("returns origin for empty input", () => {
+    expect(hexCentroid([])).toEqual({ q: 0, r: 0 });
+  });
+
+  it("averages and rounds", () => {
+    const c = hexCentroid(["0_0", "2_0", "0_2"]);
+    expect(c.q).toBe(1);
+    expect(c.r).toBe(1);
+  });
+});
+
+describe("distanceToNearestOwned", () => {
+  it("returns Infinity when ownedTileIds is empty", () => {
+    const d = distanceToNearestOwned({ q: 0, r: 0 }, []);
+    expect(d).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("finds the closest owned tile", () => {
+    const d = distanceToNearestOwned({ q: 5, r: 0 }, ["0_0", "3_0", "10_10"]);
+    expect(d).toBe(2);
+  });
+});
+
+describe("hostileSpawnProbability", () => {
+  it("starts at 5% for tilesHeld <= 25", () => {
+    expect(hostileSpawnProbability(0)).toBeCloseTo(0.05);
+    expect(hostileSpawnProbability(25)).toBeCloseTo(0.05);
+  });
+
+  it("ramps to ~40% at 200 tiles", () => {
+    expect(hostileSpawnProbability(200)).toBeCloseTo(0.3825, 3);
+  });
+
+  it("caps at 60%", () => {
+    expect(hostileSpawnProbability(10000)).toBe(0.6);
+  });
+
+  it("is monotonic in tilesHeld", () => {
+    let prev = hostileSpawnProbability(0);
+    for (let n = 25; n <= 1000; n += 25) {
+      const cur = hostileSpawnProbability(n);
+      expect(cur).toBeGreaterThanOrEqual(prev);
+      prev = cur;
+    }
+  });
+});
+
+describe("riskScore", () => {
+  it("zero risk for friendly far frontier", () => {
+    expect(riskScore({ hostileNeighbors: 0, distanceToCore: 0 })).toBe(0);
+  });
+
+  it("scales with hostile neighbors", () => {
+    const a = riskScore({ hostileNeighbors: 1, distanceToCore: 0 });
+    const b = riskScore({ hostileNeighbors: 3, distanceToCore: 0 });
+    const c = riskScore({ hostileNeighbors: 6, distanceToCore: 0 });
+    expect(a).toBeLessThan(b);
+    expect(b).toBeLessThan(c);
+    expect(c).toBeGreaterThan(50);
+  });
+
+  it("caps at 100", () => {
+    expect(
+      riskScore({ hostileNeighbors: 6, distanceToCore: 50 })
+    ).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("ringCoords", () => {
+  it("ring 0 is just the center", () => {
+    expect(ringCoords({ q: 0, r: 0 }, 0)).toEqual([{ q: 0, r: 0 }]);
+  });
+
+  it("ring r returns 6r coords for r >= 1", () => {
+    for (const r of [1, 2, 3, 5, 10]) {
+      const out = ringCoords({ q: 7, r: 7 }, r);
+      expect(out).toHaveLength(6 * r);
+    }
+  });
+
+  it("every coord on ring r is exactly distance r from center", () => {
+    const center = { q: 3, r: -1 };
+    for (const r of [1, 2, 4]) {
+      for (const c of ringCoords(center, r)) {
+        expect(hexDistance(center, c)).toBe(r);
+      }
+    }
+  });
+});
+
+describe("sampleFrontierTile", () => {
+  it("returns a sample on a sparse world", () => {
+    const owned = ["0_0", "1_0", "0_1"];
+    const result = sampleFrontierTile({
+      ownedTileIds: owned,
+      isClaimed: (id) => owned.includes(id),
+      isHostile: () => false,
+      tilesHeld: 3,
+      rng: makeSeededRng("frontier:1"),
+    });
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(owned).not.toContain(result.tileId);
+      expect(result.distanceToCore).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("seeded RNG is deterministic", () => {
+    const owned = ["0_0", "1_0"];
+    const a = sampleFrontierTile({
+      ownedTileIds: owned,
+      isClaimed: (id) => owned.includes(id),
+      isHostile: () => false,
+      tilesHeld: 2,
+      rng: makeSeededRng("seed:42"),
+    });
+    const b = sampleFrontierTile({
+      ownedTileIds: owned,
+      isClaimed: (id) => owned.includes(id),
+      isHostile: () => false,
+      tilesHeld: 2,
+      rng: makeSeededRng("seed:42"),
+    });
+    expect(a?.tileId).toBe(b?.tileId);
+  });
+
+  it("returns null when every coord within maxRings is claimed", () => {
+    // Mark every coord within 12 rings as claimed.
+    const claimed = new Set<string>();
+    for (let r = 0; r <= 12; r++) {
+      for (const c of ringCoords({ q: 0, r: 0 }, r)) {
+        claimed.add(tileIdFromAxial(c.q, c.r));
+      }
+    }
+    const result = sampleFrontierTile({
+      ownedTileIds: ["0_0"],
+      isClaimed: (id) => claimed.has(id),
+      isHostile: () => false,
+      tilesHeld: 1,
+      rng: makeSeededRng("dense:1"),
+      maxRings: 12,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/lib/game/turns.test.ts
+++ b/__tests__/lib/game/turns.test.ts
@@ -79,6 +79,26 @@ describe("currentEligibilityWindow", () => {
   });
 });
 
+describe("newPlayer with v2 options", () => {
+  it("accepts initialPhase, tilesHeld, tilesExplored overrides", () => {
+    const p = newPlayer("u-1", new Date("2026-05-06T00:00:00Z"), {
+      initialPhase: "distribute",
+      tilesHeld: 25,
+      tilesExplored: 25,
+    });
+    expect(p.phase).toBe("distribute");
+    expect(p.tilesExplored).toBe(25);
+    expect(p.stats.tilesHeld).toBe(25);
+  });
+
+  it("falls back to v1 defaults when no options passed", () => {
+    const p = newPlayer("u-1", new Date("2026-05-06T00:00:00Z"));
+    expect(p.phase).toBe("explore");
+    expect(p.tilesExplored).toBe(0);
+    expect(p.stats.tilesHeld).toBe(100);
+  });
+});
+
 describe("newPlayer", () => {
   it("starts at phase=explore with 100 turns and shield active", () => {
     const created = new Date("2026-05-01T12:00:00.000Z");

--- a/app/api/game/artifact/use/route.ts
+++ b/app/api/game/artifact/use/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { spendArtifactServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody<{
+      artifactId?: unknown;
+      targetTileId?: unknown;
+    }>(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const artifactId =
+      typeof bodyOrError.artifactId === "string"
+        ? bodyOrError.artifactId
+        : null;
+    const targetTileId =
+      typeof bodyOrError.targetTileId === "string"
+        ? bodyOrError.targetTileId
+        : null;
+    if (!artifactId) return apiError("artifactId is required", 400);
+
+    const result = await spendArtifactServer({
+      userId: user.uid,
+      artifactId,
+      targetTileId,
+    });
+    return apiSuccess({ artifact: result.artifact });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/explore/route.ts
+++ b/app/api/game/explore/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { parseBatchCount, runBatch } from "@/lib/game/api-batch";
+import { frontierExploreServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    let count = 1;
+    if (request.headers.get("content-length")) {
+      const body = await parseRequestBody<{ count?: unknown }>(request);
+      if (body instanceof NextResponse) return body;
+      count = parseBatchCount(body.count);
+    }
+
+    const { reports, lastResult, stoppedEarly } = await runBatch(count, () =>
+      frontierExploreServer(user.uid)
+    );
+    return apiSuccess({
+      player: lastResult.player,
+      tile: lastResult.tile,
+      report: lastResult.report,
+      reports,
+      frontier: lastResult.frontier,
+      stoppedEarly,
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/artifacts/page.tsx
+++ b/app/game/artifacts/page.tsx
@@ -58,6 +58,8 @@ export default function ArtifactsInventoryPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<"all" | ArtifactType>("all");
+  const [usingId, setUsingId] = useState<string | null>(null);
+  const [flash, setFlash] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     if (!user) {
@@ -91,6 +93,41 @@ export default function ArtifactsInventoryPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
     refresh();
   }, [authLoading, refresh]);
+
+  const spendArtifact = useCallback(
+    async (artifactId: string, name: string) => {
+      if (!user) return;
+      setUsingId(artifactId);
+      setError(null);
+      setFlash(null);
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/game/artifact/use", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ artifactId }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          const msg =
+            typeof data.error === "string"
+              ? data.error
+              : data.error?.message ?? "Use failed";
+          throw new Error(msg);
+        }
+        setFlash(`${name} expended.`);
+        await refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Use failed");
+      } finally {
+        setUsingId(null);
+      }
+    },
+    [user, refresh]
+  );
 
   if (authLoading || loading) {
     return (
@@ -156,13 +193,20 @@ export default function ArtifactsInventoryPage() {
             they&apos;re gone.
           </p>
           <p className="mt-2 text-xs text-neutral-600 dark:text-neutral-400">
-            Activation UI is being built — for now, this page tracks every
-            artifact you&apos;ve found.
+            Use an artifact to expend it from your inventory. Effect bonuses
+            (offense / defense / production multipliers) wire into combat and
+            spell math in the next slice — for now, &quot;Use&quot; just retires
+            the artifact so you can see the inventory drain coherently.
           </p>
         </div>
 
         {error && (
           <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+        {flash && (
+          <p className="mb-4 text-sm text-emerald-700 dark:text-emerald-400">
+            {flash}
+          </p>
         )}
 
         <div className="flex flex-wrap gap-2 mb-6">
@@ -231,12 +275,26 @@ export default function ArtifactsInventoryPage() {
                             <p className="text-xs italic text-neutral-500 mb-2">
                               {a.definition.flavorOnFind}
                             </p>
-                            <div className="text-xs text-neutral-500">
+                            <div className="text-xs text-neutral-500 mb-3">
                               Strength <strong>{a.definition.baseStrength}</strong>
                               {" · "}
                               Found turn {a.foundAtTurn}
                               {a.used && " · USED"}
                             </div>
+                            {!a.used && (
+                              <button
+                                onClick={() =>
+                                  spendArtifact(
+                                    a.id,
+                                    a.definition?.name ?? a.definitionId
+                                  )
+                                }
+                                disabled={usingId !== null}
+                                className="w-full px-3 py-1.5 text-xs font-semibold border border-neutral-400 dark:border-neutral-600 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 transition-colors"
+                              >
+                                {usingId === a.id ? "Using…" : "Use artifact"}
+                              </button>
+                            )}
                           </>
                         )}
                       </div>

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -9,7 +9,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import type { GamePlayer, GameTile } from "@/lib/game/types";
+import type { GamePlayer, GameTile, TurnReport } from "@/lib/game/types";
 
 interface PlayerResponse {
   success: boolean;
@@ -41,6 +41,9 @@ export default function GameDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [exploring, setExploring] = useState(false);
+  const [exploreCount, setExploreCount] = useState(1);
+  const [recentReports, setRecentReports] = useState<TurnReport[]>([]);
 
   const fetchPlayer = useCallback(async () => {
     setError(null);
@@ -107,6 +110,51 @@ export default function GameDashboardPage() {
     }
   }, [user, fetchPlayer]);
 
+  const handleFrontierExplore = useCallback(
+    async (count: number) => {
+      if (!user) return;
+      const safeCount = Math.max(1, Math.min(100, Math.floor(count)));
+      setExploring(true);
+      setError(null);
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/game/explore", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ count: safeCount }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          const msg =
+            typeof data.error === "string"
+              ? data.error
+              : data.error?.message ?? "Explore failed";
+          throw new Error(msg);
+        }
+        const fromBatch: TurnReport[] = Array.isArray(data.reports)
+          ? data.reports
+          : [];
+        if (fromBatch.length > 0) {
+          setRecentReports((prev) =>
+            [...fromBatch.slice().reverse(), ...prev].slice(0, 50)
+          );
+        }
+        if (data.stoppedEarly) {
+          setError(`Stopped: ${data.stoppedEarly}`);
+        }
+        await fetchPlayer();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Explore failed");
+      } finally {
+        setExploring(false);
+      }
+    },
+    [user, fetchPlayer]
+  );
+
   const handleAdminGrant = useCallback(async () => {
     if (!user) return;
     setError(null);
@@ -143,7 +191,7 @@ export default function GameDashboardPage() {
           <h1 className="text-3xl font-bold mb-4">Generals</h1>
           <p className="text-neutral-600 dark:text-neutral-300 mb-3">
             A turn-based strategy game for the cursor-boston community. Sign in,
-            claim a hundred lands, and contest the world map.
+            claim a starting cluster of lands, and push outward into the world.
           </p>
           <p className="text-neutral-500 dark:text-neutral-400 text-sm mb-6">
             <strong>The catch:</strong> turns are gated by PR merges. Merge a PR
@@ -170,9 +218,10 @@ export default function GameDashboardPage() {
             You haven&apos;t enlisted yet. Pressing the button below will:
           </p>
           <ul className="text-sm text-neutral-600 dark:text-neutral-400 mb-6 inline-block text-left list-disc ml-5">
-            <li>Claim 100 lands as your starting territory.</li>
-            <li>Grant you 100 starter turns to begin the setup ramp.</li>
+            <li>Claim a 25-tile starting cluster, all already revealed.</li>
+            <li>Grant you 100 starter turns to assign land types and pick a caste.</li>
             <li>Drop a 3-week shield over you so no one can attack until you&apos;ve had a chance to develop your forces.</li>
+            <li>From there: push the frontier, build armies, raid neighbors.</li>
           </ul>
           {error && (
             <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
@@ -210,25 +259,26 @@ export default function GameDashboardPage() {
           {player.phase === "explore" && (
             <p>
               <strong>You&apos;re in the explore phase.</strong> Each turn you
-              spend on the setup page reveals one of your 100 lands. After all
-              100 are revealed, the game auto-advances to the distribute phase.
+              spend on the setup page reveals one of your starting lands. Once
+              all are revealed, you&apos;ll auto-advance to the distribute phase.
             </p>
           )}
           {player.phase === "distribute" && (
             <p>
               <strong>You&apos;re in the distribute phase.</strong> Assign each
-              of your 100 lands a role: <em>military</em> (produces units),{" "}
+              of your lands a role: <em>military</em> (produces units),{" "}
               <em>food</em> (raises your unit cap), or <em>magic</em>{" "}
-              (multiplies spell strength). Each change costs 1 turn. Pick a
+              (multiplies spell strength). Each assignment costs 1 turn. Pick a
               caste from the setup page when you&apos;re ready to start playing.
             </p>
           )}
           {player.phase === "play" && (
             <p>
-              <strong>You&apos;re playing.</strong> Build units on military
-              tiles, arm defense spells, attack bordering enemies. Your shield
-              wall drops once <strong>both</strong> 3 weeks have passed since
-              you enlisted <strong>and</strong> you&apos;ve spent at least 300
+              <strong>You&apos;re playing.</strong> Spend turns to build units,
+              arm defense spells, attack bordering enemies, or push the frontier
+              for a new tile (and a chance at an artifact). Your shield wall
+              drops once <strong>both</strong> 3 weeks have passed since you
+              enlisted <strong>and</strong> you&apos;ve spent at least 300
               turns. After that, you can attack and be attacked.
             </p>
           )}
@@ -244,11 +294,27 @@ export default function GameDashboardPage() {
           />
           <Stat label="Caste" value={player.caste ?? "—"} />
           <Stat label="Lands held" value={String(tiles.length)} />
-          <Stat label="Tiles explored" value={`${revealed} / 100`} />
-          <Stat label="Tiles distributed" value={`${distributed} / 100`} />
+          <Stat
+            label="Tiles explored"
+            value={`${revealed} / ${tiles.length}`}
+          />
+          <Stat
+            label="Tiles distributed"
+            value={`${distributed} / ${tiles.length}`}
+          />
           <Stat label="Turns spent" value={String(player.turnsSpentTotal)} />
           <Stat label="Shield drops at turn" value={String(player.shieldDropAtTurn)} />
         </div>
+
+        {player.phase === "play" && (
+          <ExploreFrontier
+            count={exploreCount}
+            onCountChange={setExploreCount}
+            busy={exploring}
+            maxCount={Math.min(100, player.turnsRemaining)}
+            onExplore={() => handleFrontierExplore(exploreCount)}
+          />
+        )}
 
         <div className="flex flex-wrap gap-3">
           {player.phase !== "play" ? (
@@ -294,6 +360,8 @@ export default function GameDashboardPage() {
             Grant 100 turns (admin)
           </button>
         </div>
+
+        <DashboardReports reports={recentReports} />
       </div>
     </div>
   );
@@ -306,6 +374,112 @@ function Stat({ label, value }: { label: string; value: string }) {
         {label}
       </div>
       <div className="text-lg font-semibold capitalize">{value}</div>
+    </div>
+  );
+}
+
+function ExploreFrontier({
+  count,
+  onCountChange,
+  busy,
+  maxCount,
+  onExplore,
+}: {
+  count: number;
+  onCountChange: (n: number) => void;
+  busy: boolean;
+  maxCount: number;
+  onExplore: () => void;
+}) {
+  const safeMax = Math.max(1, maxCount);
+  return (
+    <div className="rounded-lg border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/50 dark:bg-emerald-900/10 p-4 mb-6">
+      <div className="flex items-baseline justify-between mb-2">
+        <h2 className="font-semibold">Push the frontier</h2>
+        <span className="text-xs text-neutral-500">1 turn / tile</span>
+      </div>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3 leading-relaxed">
+        Spend turns to claim brand-new tiles adjacent to your territory. The
+        further you push, the more likely your next tile spawns next to enemy
+        ground. Every spent turn rolls a 3% chance for an artifact.
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="text-sm">
+          Tiles to claim:{" "}
+          <input
+            type="number"
+            min={1}
+            max={Math.min(100, safeMax)}
+            value={count}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              if (Number.isFinite(n)) onCountChange(n);
+            }}
+            disabled={busy}
+            className="w-20 px-2 py-1 ml-2 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+          />
+        </label>
+        <button
+          onClick={onExplore}
+          disabled={busy || safeMax < 1}
+          className="px-5 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+        >
+          {busy ? "Exploring…" : `Explore ×${count}`}
+        </button>
+        <span className="text-xs text-neutral-500">
+          (you have {safeMax} turn{safeMax === 1 ? "" : "s"} available)
+        </span>
+      </div>
+    </div>
+  );
+}
+
+const REPORT_RARITY_TEXT: Record<string, string> = {
+  common: "text-neutral-500 dark:text-neutral-400",
+  rare: "text-blue-600 dark:text-blue-400",
+  epic: "text-purple-600 dark:text-purple-400",
+  legendary: "text-amber-600 dark:text-amber-400",
+};
+
+function DashboardReports({ reports }: { reports: TurnReport[] }) {
+  if (reports.length === 0) return null;
+  return (
+    <div className="mt-8">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">
+        Field reports (this session)
+      </h3>
+      <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg max-h-96 overflow-y-auto divide-y divide-neutral-200 dark:divide-neutral-800">
+        {reports.map((r, idx) => (
+          <div
+            key={`${r.action}-${r.turnIndex}-${idx}`}
+            className="px-4 py-3 text-sm leading-relaxed"
+          >
+            <div className="flex items-baseline justify-between mb-1">
+              <span className="font-medium">{r.summary}</span>
+              <span className="text-xs text-neutral-500 capitalize ml-2 shrink-0">
+                {r.action} · {r.cost}t
+              </span>
+            </div>
+            {r.narrative.length > 0 && (
+              <div className="text-neutral-600 dark:text-neutral-400 italic space-y-1">
+                {r.narrative.map((line, lineIdx) => (
+                  <p key={lineIdx}>{line}</p>
+                ))}
+              </div>
+            )}
+            {r.artifactFound && (
+              <div
+                className={`mt-2 text-xs font-semibold uppercase tracking-wide ${
+                  REPORT_RARITY_TEXT[r.artifactFound.rarity] ?? ""
+                }`}
+              >
+                {r.artifactFound.rarity} artifact found —{" "}
+                <span className="normal-case">{r.artifactFound.name}</span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/lib/game/api-error-map.ts
+++ b/lib/game/api-error-map.ts
@@ -9,7 +9,10 @@ import { apiError } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import {
   GameAlreadyRevealedError,
+  GameArtifactAlreadyUsedError,
+  GameArtifactNotFoundError,
   GameCasteAlreadySetError,
+  GameFrontierExhaustedError,
   GameInsufficientTurnsError,
   GameInsufficientUnitsError,
   GameInvalidCasteError,
@@ -33,7 +36,8 @@ import {
 export function mapGameError(error: unknown): NextResponse {
   if (
     error instanceof GamePlayerNotFoundError ||
-    error instanceof GameTileNotFoundError
+    error instanceof GameTileNotFoundError ||
+    error instanceof GameArtifactNotFoundError
   ) {
     return apiError(error.message, 404);
   }
@@ -54,7 +58,9 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameNoUnrevealedTilesError ||
     error instanceof GameTileFullError ||
     error instanceof GameUnitCapExceededError ||
-    error instanceof GameTileTypeError
+    error instanceof GameTileTypeError ||
+    error instanceof GameFrontierExhaustedError ||
+    error instanceof GameArtifactAlreadyUsedError
   ) {
     return apiError(error.message, 409);
   }

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -52,9 +52,18 @@ import type {
 import {
   axialFromTileId,
   neighborTileIds,
+  neighbors as axialNeighbors,
   spawnCenterForPlayerIndex,
   spawnPlayerLands,
+  tileIdFromAxial,
 } from "./world-gen";
+import {
+  type FrontierSample,
+  distanceToNearestOwned,
+  hexCentroid,
+  ringCoords,
+  riskScore,
+} from "./exploration";
 
 export const ATTACK_TURN_COST = 1;
 export const SPELL_TURN_COST = 5;
@@ -185,6 +194,26 @@ export class GameTileTypeError extends Error {
     this.name = "GameTileTypeError";
   }
 }
+export class GameFrontierExhaustedError extends Error {
+  constructor() {
+    super(
+      "Could not find an unclaimed tile on the frontier. The world is unusually crowded near you."
+    );
+    this.name = "GameFrontierExhaustedError";
+  }
+}
+export class GameArtifactNotFoundError extends Error {
+  constructor() {
+    super("Artifact not found");
+    this.name = "GameArtifactNotFoundError";
+  }
+}
+export class GameArtifactAlreadyUsedError extends Error {
+  constructor() {
+    super("Artifact has already been used");
+    this.name = "GameArtifactAlreadyUsedError";
+  }
+}
 
 const COLLECTIONS = {
   PLAYERS: "game_players",
@@ -278,8 +307,15 @@ export async function getTileServer(tileId: string): Promise<GameTile | null> {
   return snap.exists ? (snap.data() as GameTile) : null;
 }
 
-// Atomic spawn: claims 100 tiles for a brand-new player. Bumps a global
-// player-count cursor so two parallel spawns get different centers.
+// v2 — new players spawn with 25 already-revealed unassigned tiles, skipping
+// the v1 "explore" phase entirely. Existing v1 player records aren't touched.
+export const NEW_PLAYER_TILE_COUNT = 25;
+const NEW_PLAYER_CONTIGUOUS = 20;
+const NEW_PLAYER_EXCLAVES_MIN = 3;
+const NEW_PLAYER_EXCLAVES_MAX = 5;
+
+// Atomic spawn for a brand-new player. Bumps a global player-count cursor so
+// parallel spawns land on different centers.
 export async function createPlayerWithSpawnServer(
   userId: string,
   now: Date = new Date()
@@ -305,9 +341,19 @@ export async function createPlayerWithSpawnServer(
       center,
       claimedTileIds: new Set<string>(),
       rng: makeSeededRng(seed),
+      totalTiles: NEW_PLAYER_TILE_COUNT,
+      contiguousTarget: NEW_PLAYER_CONTIGUOUS,
+      exclavesMin: NEW_PLAYER_EXCLAVES_MIN,
+      exclavesMax: NEW_PLAYER_EXCLAVES_MAX,
     });
 
-    const player = newPlayer(userId, now);
+    const player = newPlayer(userId, now, {
+      // Skip the v1 "explore" phase entirely — new players land in
+      // distribute with all their tiles already revealed.
+      initialPhase: "distribute",
+      tilesHeld: spawn.tileIds.length,
+      tilesExplored: spawn.tileIds.length,
+    });
     tx.set(playerRef, player);
 
     for (const tileId of spawn.tileIds) {
@@ -318,12 +364,13 @@ export async function createPlayerWithSpawnServer(
         q,
         r,
         ownerId: userId,
-        type: "unrevealed" as LandType,
+        type: "unassigned" as LandType,
         level: 0,
         units: { ground: 0, siege: 0, air: 0 },
         armedDefenseSpellId: null,
         neighborTileIds: neighborTileIds(q, r),
         upgradeIds: [],
+        revealedAt: now,
         createdAt: now,
         updatedAt: now,
       });
@@ -1521,4 +1568,260 @@ export async function getPlayerEligibilityServer(
     nextRolloverIso: next.toISOString(),
     windowStartIso: window.start.toISOString(),
   };
+}
+
+// Maximum hex rings to scan when looking for an unclaimed frontier tile.
+// At our spacing this is roomy. If still nothing, refund the turn.
+const FRONTIER_MAX_RINGS = 12;
+
+/**
+ * Pick an unclaimed tile coord adjacent to the player's territory and return
+ * a FrontierSample describing it (distance, hostile-neighbor count, risk).
+ *
+ * The pre-fetch happens outside the transaction; the caller re-validates the
+ * pick is still unclaimed inside the transaction. Returns null if no
+ * unclaimed coord is found within FRONTIER_MAX_RINGS.
+ */
+async function pickFrontierCandidate(
+  db: Firestore,
+  userId: string,
+  ownedTileIds: ReadonlyArray<string>,
+  tilesHeld: number,
+  rng: () => number
+): Promise<FrontierSample | null> {
+  const center = hexCentroid([...ownedTileIds]);
+  const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
+
+  // Walk outward from minRing. For each ring, batch-getAll the coords and
+  // pick the first unclaimed one. Then a second getAll to count hostile
+  // neighbors at that coord.
+  for (let r = minRing; r <= FRONTIER_MAX_RINGS; r++) {
+    const coords = ringCoords(center, r);
+    // In-place shuffle so direction varies. Fisher-Yates with our seeded rng.
+    for (let i = coords.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [coords[i], coords[j]] = [coords[j], coords[i]];
+    }
+    if (coords.length === 0) continue;
+
+    const refs = coords.map((c) =>
+      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+    );
+    const snaps = await db.getAll(...refs);
+
+    for (let i = 0; i < snaps.length; i++) {
+      if (snaps[i].exists) continue;
+      const c = coords[i];
+      const tileId = tileIdFromAxial(c.q, c.r);
+
+      // Count hostile neighbors. getAll for the 6 neighbor refs.
+      const ns = axialNeighbors(c.q, c.r);
+      const neighborRefs = ns.map((n) =>
+        db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(n.q, n.r))
+      );
+      const neighborSnaps = await db.getAll(...neighborRefs);
+      let hostileCount = 0;
+      for (const ns of neighborSnaps) {
+        if (!ns.exists) continue;
+        const data = ns.data();
+        if (data && data.ownerId && data.ownerId !== userId) hostileCount++;
+      }
+
+      const distance = distanceToNearestOwned(c, [...ownedTileIds]);
+      const distanceFinite = Number.isFinite(distance) ? distance : 0;
+      return {
+        tile: c,
+        tileId,
+        distanceToCore: distanceFinite,
+        hostileNeighbors: hostileCount,
+        riskScore: riskScore({
+          hostileNeighbors: hostileCount,
+          distanceToCore: distanceFinite,
+        }),
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Play-phase generative explore. Spends 1 turn to claim a brand-new tile
+ * adjacent to (or near) the player's territory. The further out the player
+ * pushes, the more likely the tile spawns next to enemy territory.
+ */
+export async function frontierExploreServer(
+  userId: string,
+  now: Date = new Date()
+): Promise<{
+  player: GamePlayer;
+  tile: GameTile;
+  report: TurnReport;
+  frontier: FrontierSample;
+}> {
+  const db = adminDbOrThrow();
+
+  // Pre-fetch outside txn: player's owned tiles for centroid + tilesHeld.
+  const ownedSnap = await db
+    .collection(COLLECTIONS.TILES)
+    .where("ownerId", "==", userId)
+    .get();
+  const ownedTileIds = ownedSnap.docs.map((d) => d.id);
+
+  // Seeded RNG for candidate picking; includes turn count so identical state
+  // doesn't always pick the same direction.
+  const playerSnapPre = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .doc(userId)
+    .get();
+  if (!playerSnapPre.exists) throw new GamePlayerNotFoundError();
+  const playerPre = playerSnapPre.data() as GamePlayer;
+  const candidateRng = makeSeededRng(
+    `frontier:${userId}:${playerPre.turnsSpentTotal}`
+  );
+
+  const sample = await pickFrontierCandidate(
+    db,
+    userId,
+    ownedTileIds,
+    playerPre.stats.tilesHeld,
+    candidateRng
+  );
+  if (sample === null) throw new GameFrontierExhaustedError();
+
+  const tileRef = db.collection(COLLECTIONS.TILES).doc(sample.tileId);
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(userId);
+
+  return db.runTransaction(async (tx) => {
+    const [tileSnap, playerSnap] = await Promise.all([
+      tx.get(tileRef),
+      tx.get(playerRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+
+    const player = playerSnap.data() as GamePlayer;
+    if (player.phase !== "play") {
+      throw new GameInvalidPhaseError("play", player.phase);
+    }
+    if (player.turnsRemaining < 1) {
+      throw new GameInsufficientTurnsError(1, player.turnsRemaining);
+    }
+    // Race: the candidate may have been claimed since we picked it.
+    if (tileSnap.exists) {
+      throw new GameFrontierExhaustedError();
+    }
+
+    const turnsSpentTotal = player.turnsSpentTotal + 1;
+    const artifact = rollAndStageArtifact(
+      tx,
+      db,
+      userId,
+      turnsSpentTotal,
+      "explore",
+      now
+    );
+
+    const tile: GameTile = {
+      tileId: sample.tileId,
+      q: sample.tile.q,
+      r: sample.tile.r,
+      ownerId: userId,
+      type: "unassigned",
+      level: 0,
+      units: { ground: 0, siege: 0, air: 0 },
+      armedDefenseSpellId: null,
+      neighborTileIds: neighborTileIds(sample.tile.q, sample.tile.r),
+      upgradeIds: [],
+      revealedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+    tx.set(tileRef, tile);
+
+    const updatedStats = {
+      ...player.stats,
+      tilesHeld: player.stats.tilesHeld + 1,
+    };
+    tx.update(playerRef, {
+      turnsRemaining: player.turnsRemaining - 1,
+      turnsSpentTotal,
+      stats: updatedStats,
+      updatedAt: now,
+    });
+
+    const report = buildExploreReport(
+      turnsSpentTotal,
+      tile,
+      artifact,
+      makeNarrativeRng(userId, turnsSpentTotal, "explore")
+    );
+    // Append a small line surfacing the frontier risk so the player sees the
+    // strategic context inline with the prose.
+    const riskLine =
+      sample.hostileNeighbors > 0
+        ? `Risk ${sample.riskScore}/100 — ${sample.hostileNeighbors} hostile neighbor${sample.hostileNeighbors === 1 ? "" : "s"} (distance from your core: ${sample.distanceToCore} hex${sample.distanceToCore === 1 ? "" : "es"}).`
+        : `Risk ${sample.riskScore}/100 — quiet frontier (distance from your core: ${sample.distanceToCore} hex${sample.distanceToCore === 1 ? "" : "es"}).`;
+    const reportWithRisk: TurnReport = {
+      ...report,
+      narrative: [...report.narrative, riskLine],
+      outcome: { ...report.outcome, frontier: sample },
+    };
+
+    return {
+      player: {
+        ...player,
+        turnsRemaining: player.turnsRemaining - 1,
+        turnsSpentTotal,
+        stats: updatedStats,
+        updatedAt: now,
+      },
+      tile,
+      report: reportWithRisk,
+      frontier: sample,
+    };
+  });
+}
+
+/**
+ * Spend an unused artifact. v2 PR 6c: the artifact is marked used and a
+ * report is returned. Actual gameplay effects (attack/defense bonuses,
+ * production-cap boosts) are deferred to PR 6d — this slice exists so
+ * players can see their inventory drain and the "Use" button does
+ * something coherent. Cost is 0 turns; the artifact itself is the cost.
+ */
+export async function spendArtifactServer(args: {
+  userId: string;
+  artifactId: string;
+  targetTileId?: string | null;
+  now?: Date;
+}): Promise<{ artifact: GameArtifact }> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const artifactRef = db.collection(COLLECTIONS.ARTIFACTS).doc(args.artifactId);
+
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(artifactRef);
+    if (!snap.exists) throw new GameArtifactNotFoundError();
+    const artifact = snap.data() as GameArtifact;
+    if (artifact.ownerId !== args.userId) {
+      throw new GameArtifactNotFoundError();
+    }
+    if (artifact.used) throw new GameArtifactAlreadyUsedError();
+
+    // For now the only persisted effect is the used flag. PR 6d will branch
+    // on artifact.type and apply offense/defense/production effects.
+    const updated: GameArtifact = {
+      ...artifact,
+      used: true,
+      usedAtTurn: artifact.foundAtTurn,
+      usedOnTileId: args.targetTileId ?? undefined,
+      updatedAt: now,
+    };
+    tx.update(artifactRef, {
+      used: true,
+      usedAtTurn: artifact.foundAtTurn,
+      ...(args.targetTileId ? { usedOnTileId: args.targetTileId } : {}),
+      updatedAt: now,
+    });
+    return { artifact: updated };
+  });
 }

--- a/lib/game/exploration.ts
+++ b/lib/game/exploration.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { AxialCoord } from "./world-gen";
+import {
+  axialFromTileId,
+  hexDistance,
+  neighbors,
+  tileIdFromAxial,
+} from "./world-gen";
+
+// ───── Public types ─────
+
+export interface FrontierSample {
+  tile: AxialCoord;
+  tileId: string;
+  // Hex distance from the player's nearest owned tile to this candidate.
+  distanceToCore: number;
+  // Count of the 6 axial neighbors that are owned by some other player.
+  hostileNeighbors: number;
+  // 0..100 risk indicator surfaced to the player. Combines distance
+  // (further from your core = costlier to support) and hostile-neighbor
+  // count. Ground-truth combat outcome is unaffected.
+  riskScore: number;
+}
+
+// ───── Distance / centroid helpers ─────
+
+/**
+ * Average position of `tileIds` in axial space. Returns origin if empty.
+ * Output is rounded to the nearest integer hex.
+ */
+export function hexCentroid(tileIds: ReadonlyArray<string>): AxialCoord {
+  if (tileIds.length === 0) return { q: 0, r: 0 };
+  let sumQ = 0;
+  let sumR = 0;
+  for (const id of tileIds) {
+    const c = axialFromTileId(id);
+    sumQ += c.q;
+    sumR += c.r;
+  }
+  return {
+    q: Math.round(sumQ / tileIds.length),
+    r: Math.round(sumR / tileIds.length),
+  };
+}
+
+/**
+ * Smallest hex-distance from `target` to any tile in `ownedTileIds`.
+ * Returns `Number.POSITIVE_INFINITY` if the player owns nothing.
+ */
+export function distanceToNearestOwned(
+  target: AxialCoord,
+  ownedTileIds: ReadonlyArray<string>
+): number {
+  if (ownedTileIds.length === 0) return Number.POSITIVE_INFINITY;
+  let best = Number.POSITIVE_INFINITY;
+  for (const id of ownedTileIds) {
+    const c = axialFromTileId(id);
+    const d = hexDistance(c, target);
+    if (d < best) best = d;
+  }
+  return best;
+}
+
+// ───── Frontier sampling ─────
+
+/**
+ * Probability the next frontier tile is biased toward an enemy-adjacent
+ * coord. Smooth ramp from 5% at 25 tiles held to ~40% at 200, capped at 60%.
+ */
+export function hostileSpawnProbability(tilesHeld: number): number {
+  return Math.min(0.6, 0.05 + 0.0019 * Math.max(0, tilesHeld - 25));
+}
+
+/**
+ * Risk score 0..100. Hostile neighbors weigh heavily; distance from
+ * the player's core adds linearly. Pure presentation — gameplay outcomes
+ * are determined by combat resolution, not this number.
+ */
+export function riskScore(args: {
+  hostileNeighbors: number;
+  distanceToCore: number;
+}): number {
+  // Per-neighbor weight tuned so that 3 hostile neighbors with no distance
+  // already lands near 50; 6 hostile neighbors saturates closer to 90.
+  const fromHostiles = Math.min(70, args.hostileNeighbors * 12);
+  // Distance contributes more slowly; 5 hexes from core ≈ +15, 20 hexes ≈ +30.
+  const fromDistance = Math.min(30, args.distanceToCore * 1.5);
+  return Math.round(Math.min(100, fromHostiles + fromDistance));
+}
+
+/**
+ * Coords on the hex ring at exactly distance `r` from `center`. r=0 returns
+ * just the center; r=1 returns 6 coords; r=2 returns 12; r=N returns 6N.
+ *
+ * Implemented as a brute-force scan of the bounding diamond — fine because
+ * `r` is typically small (≤ 12).
+ */
+export function ringCoords(center: AxialCoord, r: number): AxialCoord[] {
+  if (r <= 0) return [{ ...center }];
+  const out: AxialCoord[] = [];
+  for (let dq = -r; dq <= r; dq++) {
+    const drMin = Math.max(-r, -dq - r);
+    const drMax = Math.min(r, -dq + r);
+    for (let dr = drMin; dr <= drMax; dr++) {
+      const candidate = { q: center.q + dq, r: center.r + dr };
+      if (hexDistance(center, candidate) === r) out.push(candidate);
+    }
+  }
+  return out;
+}
+
+export interface SampleFrontierArgs {
+  ownedTileIds: ReadonlyArray<string>;
+  isClaimed: (tileId: string) => boolean;
+  isHostile: (tileId: string) => boolean;
+  tilesHeld: number;
+  rng: () => number;
+  // Maximum rings to scan outward before giving up. Default 12 — at our
+  // spacing this is more than enough for any current player.
+  maxRings?: number;
+}
+
+/**
+ * Pick a candidate frontier tile to claim. Algorithm:
+ *
+ * 1. Find the centroid of the player's owned tiles.
+ * 2. Pick a target ring biased outward as `tilesHeld` grows
+ *    (`minRing = 1 + floor(tilesHeld/40)`, plus a small random spread).
+ * 3. With probability `hostileSpawnProbability(tilesHeld)`, prefer a coord
+ *    on or near the ring with at least one hostile neighbor.
+ * 4. Walk outward through rings until we find an unclaimed coord.
+ *
+ * Returns null if no unclaimed coord is found within `maxRings`. The caller
+ * should refund the turn / surface an error in that case.
+ */
+export function sampleFrontierTile(
+  args: SampleFrontierArgs
+): FrontierSample | null {
+  const center = hexCentroid(args.ownedTileIds);
+  const minRing = Math.max(1, 1 + Math.floor(args.tilesHeld / 40));
+  const ringSpread = 4;
+  const targetRing = minRing + Math.floor(args.rng() * ringSpread);
+  const wantHostile = args.rng() < hostileSpawnProbability(args.tilesHeld);
+  const maxRings = args.maxRings ?? 12;
+
+  // Build a search order: target ring first, then expand outward.
+  const ringOrder: number[] = [targetRing];
+  for (let r = targetRing + 1; r <= maxRings; r++) ringOrder.push(r);
+  for (let r = targetRing - 1; r >= 1; r--) ringOrder.push(r);
+
+  let bestNonHostile: FrontierSample | null = null;
+
+  for (const r of ringOrder) {
+    // Shuffle this ring's coords so we don't always pick the same direction.
+    const coords = ringCoords(center, r);
+    for (let i = coords.length - 1; i > 0; i--) {
+      const j = Math.floor(args.rng() * (i + 1));
+      [coords[i], coords[j]] = [coords[j], coords[i]];
+    }
+
+    for (const c of coords) {
+      const tileId = tileIdFromAxial(c.q, c.r);
+      if (args.isClaimed(tileId)) continue;
+
+      // Count hostile neighbors at this coord.
+      const ns = neighbors(c.q, c.r);
+      let hostileCount = 0;
+      for (const n of ns) {
+        if (args.isHostile(tileIdFromAxial(n.q, n.r))) hostileCount++;
+      }
+
+      const distance = distanceToNearestOwned(c, args.ownedTileIds);
+      const sample: FrontierSample = {
+        tile: c,
+        tileId,
+        distanceToCore: Number.isFinite(distance) ? distance : 0,
+        hostileNeighbors: hostileCount,
+        riskScore: riskScore({
+          hostileNeighbors: hostileCount,
+          distanceToCore: Number.isFinite(distance) ? distance : 0,
+        }),
+      };
+
+      if (wantHostile && hostileCount > 0) {
+        return sample;
+      }
+      if (!wantHostile) {
+        return sample;
+      }
+      // We wanted hostile but this is non-hostile — remember it as a
+      // fallback so we don't fail outright if the world is friendly here.
+      if (bestNonHostile === null) bestNonHostile = sample;
+    }
+  }
+
+  return bestNonHostile;
+}

--- a/lib/game/turns.ts
+++ b/lib/game/turns.ts
@@ -79,7 +79,17 @@ export function currentEligibilityWindow(
   return { start, end };
 }
 
-export function newPlayer(userId: string, createdAt: Date = new Date()): GamePlayer {
+export interface NewPlayerOptions {
+  initialPhase?: Phase;
+  tilesHeld?: number;
+  tilesExplored?: number;
+}
+
+export function newPlayer(
+  userId: string,
+  createdAt: Date = new Date(),
+  options: NewPlayerOptions = {}
+): GamePlayer {
   const shieldUntil = new Date(
     createdAt.getTime() + SHIELD_DURATION_WEEKS * 7 * MS_PER_DAY
   );
@@ -88,15 +98,15 @@ export function newPlayer(userId: string, createdAt: Date = new Date()): GamePla
     caste: null,
     turnsRemaining: WEEKLY_TURN_GRANT,
     turnsSpentTotal: 0,
-    phase: "explore",
-    tilesExplored: 0,
+    phase: options.initialPhase ?? "explore",
+    tilesExplored: options.tilesExplored ?? 0,
     shieldUntil,
     shieldDropAtTurn: SHIELD_TURN_THRESHOLD,
     productionSpellsActive: [],
     stats: {
       attacksWon: 0,
       attacksLost: 0,
-      tilesHeld: 100,
+      tilesHeld: options.tilesHeld ?? 100,
       unitsAlive: 0,
     },
     createdAt,


### PR DESCRIPTION
## Summary
Promotes #673 to main. Closes the v2 framework. PR 7 will scale content; v2 effects (artifact bonuses applied in combat/spell math) come later.

## Included PRs and authors
- #673 by @Ludwitt — feat(game): v2 PR 6c — generative play-phase explore, 25-tile new-player spawn, artifact use UI

## Test plan
- [ ] Smoke test on prod: dashboard shows "Push the frontier" panel, click Explore, see new tile + risk line + report
- [ ] Inventory page: Use button on unused artifact → it greys out and persists across reload
- [ ] Fresh test enlist → 25 tiles, phase=distribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)