### PR TITLE
feat(game): v2 PR 7 — bulk content drop (narratives + artifacts)

### DIFF
--- a/lib/game/content/artifacts/common.ts
+++ b/lib/game/content/artifacts/common.ts
@@ -127,4 +127,56 @@ export const COMMON_ARTIFACTS: ArtifactDefinition[] = [
     flavorOnFind:
       "Tossed at your feet by a one-eyed traveler who simply nods and walks on.",
   },
+  {
+    id: "common-watchmans-whistle",
+    name: "Watchman's Whistle",
+    rarity: "common",
+    type: "defense",
+    baseStrength: 32,
+    description:
+      "A bone whistle whose note carries a mile and turns three corners.",
+    flavorOnFind:
+      "It hangs from a leather cord on a nail in an empty guardhouse. The cord is dry but the nail is fresh.",
+  },
+  {
+    id: "common-mendicants-mantle",
+    name: "Mendicant's Mantle",
+    rarity: "common",
+    type: "utility",
+    baseStrength: 26,
+    description: "A patched cloak that makes the wearer easier to overlook.",
+    flavorOnFind:
+      "A wandering monk leaves it folded on a roadside bench. He is not there to take it back.",
+  },
+  {
+    id: "common-quenchers-flask",
+    name: "Quencher's Flask",
+    rarity: "common",
+    type: "production",
+    baseStrength: 31,
+    description:
+      "A leather flask that fills itself with cold water by morning, every morning.",
+    flavorOnFind:
+      "An old beekeeper presses it into your hand without explanation and asks no payment.",
+  },
+  {
+    id: "common-chipped-warhammer",
+    name: "Chipped Warhammer",
+    rarity: "common",
+    type: "offense",
+    baseStrength: 37,
+    description: "An old hammer with a notch in the head that hits truer than it looks.",
+    flavorOnFind:
+      "It leans against a doorpost in an abandoned smithy, the haft still warm where someone gripped it last.",
+  },
+  {
+    id: "common-strawmans-cloak",
+    name: "Strawman's Cloak",
+    rarity: "common",
+    type: "defense",
+    baseStrength: 34,
+    description: "A scarecrow's cloak, threadbare but oddly bullet-shy.",
+    flavorOnFind:
+      "Hanging from a pole in an empty field. The crows give it a wide berth.",
+  },
 ];

--- a/lib/game/content/artifacts/epic.ts
+++ b/lib/game/content/artifacts/epic.ts
@@ -57,4 +57,26 @@ export const EPIC_ARTIFACTS: ArtifactDefinition[] = [
     flavorOnFind:
       "Floating an inch above a stone altar, slowly rotating. It descends into your palm without resistance.",
   },
+  {
+    id: "epic-warding-of-elahor",
+    name: "Warding of Elahor",
+    rarity: "epic",
+    type: "defense",
+    baseStrength: 142,
+    description:
+      "A stone disc carved with a name no living tongue still pronounces.",
+    flavorOnFind:
+      "It is set into the floor of a chapel with no door. Walking out, you find the chapel has no walls either.",
+  },
+  {
+    id: "epic-stewards-key",
+    name: "Steward's Key",
+    rarity: "epic",
+    type: "production",
+    baseStrength: 128,
+    description:
+      "A small iron key that opens any granary it has been blessed for.",
+    flavorOnFind:
+      "Wrapped in oiled cloth, hanging from a peg in a granary that no one has used for forty years. The grain inside is fresh.",
+  },
 ];

--- a/lib/game/content/artifacts/legendary.ts
+++ b/lib/game/content/artifacts/legendary.ts
@@ -29,4 +29,26 @@ export const LEGENDARY_ARTIFACTS: ArtifactDefinition[] = [
     flavorOnFind:
       "Planted in the center of an empty battlefield. Whatever battle was fought here, the histories do not record it. The banner welcomes you like an old friend.",
   },
+  {
+    id: "legendary-stillborn-storm",
+    name: "Stillborn Storm",
+    rarity: "legendary",
+    type: "offense",
+    baseStrength: 240,
+    description:
+      "A glass shard from a storm that never finished forming. The shard hums when held.",
+    flavorOnFind:
+      "It falls into your captain's hand from a clear sky. Three witnesses see it; only one of them tells the story.",
+  },
+  {
+    id: "legendary-aegis-of-the-quiet-king",
+    name: "Aegis of the Quiet King",
+    rarity: "legendary",
+    type: "defense",
+    baseStrength: 230,
+    description:
+      "A round shield bearing the crest of a king who never spoke a word and never lost a battle.",
+    flavorOnFind:
+      "It hangs above a stone bench in an empty hall. The hall has no doors and no roof, and the sun does not seem to move while you are inside it.",
+  },
 ];

--- a/lib/game/content/artifacts/rare.ts
+++ b/lib/game/content/artifacts/rare.ts
@@ -87,4 +87,48 @@ export const RARE_ARTIFACTS: ArtifactDefinition[] = [
     flavorOnFind:
       "Found neatly placed beside a road, as if their owner had simply stepped out of them. Your size, somehow.",
   },
+  {
+    id: "rare-iron-pact-collar",
+    name: "Iron Pact Collar",
+    rarity: "rare",
+    type: "defense",
+    baseStrength: 80,
+    description:
+      "A black-iron collar bound by an oath that survives the wearer.",
+    flavorOnFind:
+      "It rests on a velvet cushion in a glass case in a wayside chapel. The chapel is empty; the case is unlocked.",
+  },
+  {
+    id: "rare-firebreath-amulet",
+    name: "Firebreath Amulet",
+    rarity: "rare",
+    type: "offense",
+    baseStrength: 76,
+    description:
+      "A copper amulet that warms the wearer's tongue when held to the mouth.",
+    flavorOnFind:
+      "A man in a red cloak hands it to you wordlessly at a crossroads and walks on without looking back.",
+  },
+  {
+    id: "rare-greenkeepers-trowel",
+    name: "Greenkeeper's Trowel",
+    rarity: "rare",
+    type: "production",
+    baseStrength: 72,
+    description:
+      "A small steel trowel with a green-tinted blade that never dulls.",
+    flavorOnFind:
+      "Stuck in the dirt of a vegetable patch tended by no one your scouts can find. The vegetables are remarkably good.",
+  },
+  {
+    id: "rare-true-north-pendant",
+    name: "True-North Pendant",
+    rarity: "rare",
+    type: "utility",
+    baseStrength: 64,
+    description:
+      "A pendant whose stone always points home — wherever home happens to be.",
+    flavorOnFind:
+      "An old soldier ties it around the neck of your captain's horse and slips off into the trees.",
+  },
 ];

--- a/lib/game/content/narratives/attack-fragments.ts
+++ b/lib/game/content/narratives/attack-fragments.ts
@@ -29,6 +29,13 @@ export const ATTACK_OPENINGS: string[] = [
   "The advance crossed the river before the enemy could raise an alarm.",
   "Your forward squads engaged before the main body had finished forming up.",
   "The column moved with the patience of a tide and the speed of a hawk.",
+  "The drums beat once, twice, and your forward line was already at a run.",
+  "A trumpet sounded at the camp's edge and the column was on the road inside the minute.",
+  "The captain raised her hand, dropped it, and the line stepped forward as one.",
+  "Your archers loosed the first volley before the enemy's banners had finished raising.",
+  "The vanguard crossed the boundary stones at a quiet jog and the rest followed.",
+  "Your column hit the road in a long thin line and accelerated as it went.",
+  "The senior captain gave the order from horseback and the line moved without hesitation.",
 ];
 
 export const ATTACK_MIDDLES: string[] = [
@@ -46,6 +53,12 @@ export const ATTACK_MIDDLES: string[] = [
   "After a bitter contest of inches that neither side enjoyed",
   "After a swift and decisive engagement",
   "After a battle that the historians will argue over for a generation",
+  "After a punishing exchange that neither captain expected to last so long",
+  "After a coordinated push from three angles that left the defenders no clean reply",
+  "After your siege machines did their work and the rest of the line stepped in",
+  "After the cavalry's first charge and the infantry's slow follow-up",
+  "After a long noon that neither side could call a victory until late",
+  "After your archers' second volley dropped the enemy line back a pace",
 ];
 
 export const ATTACK_CAPTURED_CLOSERS: string[] = [

--- a/lib/game/content/narratives/build.ts
+++ b/lib/game/content/narratives/build.ts
@@ -9,8 +9,9 @@
 // outcome (which unit type, how many, on which tile). Lines are intentionally
 // neutral about unit type so they fit ground / siege / air without rewrite.
 //
-// PR 6b seed: ~60 lines per action. PR 7 will scale to ~1000.
-export const BUILD_NARRATIVES: string[] = [
+// HUMAN_BUILD_NARRATIVES + AI_BUILD_NARRATIVES are concatenated into the
+// final BUILD_NARRATIVES export. Replace AI lines with curated ones over time.
+const HUMAN_BUILD_NARRATIVES: string[] = [
   "Forges run hot through the night and the captains call out names from the muster roll.",
   "A line of new recruits steps forward in the mud, takes the oath, and is given a number.",
   "The drill yard rings with iron and shouted orders until the new banners are raised over the parade ground.",
@@ -71,4 +72,42 @@ export const BUILD_NARRATIVES: string[] = [
   "A wagon throws a wheel; the smith fixes it before sundown and the column moves on.",
   "Tonight's password is the captain's youngest daughter's name. Tomorrow it will change.",
   "The new company is fed, clothed, armed, and named. The captain considers it a good day's work.",
+];
+
+const AI_BUILD_NARRATIVES: string[] = [
+  "Your captains hand out tabards stitched the night before by half the village.",
+  "The new soldiers march for the first time in step on the third try; the captain accepts it.",
+  "An armorer's wife brings a basket of bread to the new line; it disappears before sundown.",
+  "A line of recruits sharpens new blades on a single grindstone, taking turns through the morning.",
+  "The drill yard's old hitching post is replaced; the new one is twice as thick and twice as long.",
+  "Three carts of new shafts arrive from the lumberyard, each shaft straight enough for a captain's spear.",
+  "The forge's bellows-boy is promoted to bellows-man; he stands a little taller for the rest of the day.",
+  "An old soldier teaches the new line how to brace a shield against a horse-charge; he does it twice and walks away.",
+  "Boots line up in pairs along the parade ground while their owners drill in stocking feet.",
+  "The captain hands out new sashes; one recruit ties hers wrong twice before the sergeant fixes it without comment.",
+  "A wagon of arrowheads is unloaded by the line of new archers; each picks up one and weighs it in his palm.",
+  "The blacksmith's hammer rings until the moon is up; nobody asks him to stop.",
+  "A young recruit polishes his helm until he can see his own face in it; he does not look pleased.",
+  "An old scout teaches the new line the three signals for retreat; he repeats the third one twice.",
+  "Three new banners snap in the wind over the parade ground, each a different color, all of them yours.",
+  "The captain inspects the new soldiers' boots; she finds three pairs that need re-soling and orders it done by morning.",
+  "An armorer hauls a sack of helmets onto the parade ground and starts handing them out by size.",
+  "The new line stands at attention for an hour while the captain walks the line in silence.",
+  "A line of carts brings provisions for the new company; the cooks have been baking since before dawn.",
+  "The drill-master shouts orders from a barrel; the new line follows them, mostly.",
+  "An old veteran sits in the shade with a whetstone, working it across each new blade in turn.",
+  "The senior captain rides the line of new soldiers and stops to fix one man's stance with a tap of her riding crop.",
+  "A new banner is raised and then immediately lowered to be re-stitched; the second hoisting is more solemn.",
+  "Your standards are placed at the corners of the parade ground; the new line forms up between them without being told.",
+  "An old soldier shows the new line how to clean their gear at the end of the day; he is patient about it.",
+  "A village girl brings a basket of plums to the new line; the captain shares them out one per soldier.",
+  "Three new wagons arrive with armor enough for the next company too; the quartermaster signs for them gravely.",
+  "The drill yard is muddy by sundown; the new line is muddy by nightfall; the captain is satisfied.",
+  "A young apprentice hammers his first horseshoe under the smith's eye; the smith nods once.",
+  "By dawn the new company has marched once, eaten twice, and slept too little; nobody complains.",
+];
+
+export const BUILD_NARRATIVES: string[] = [
+  ...HUMAN_BUILD_NARRATIVES,
+  ...AI_BUILD_NARRATIVES,
 ];

--- a/lib/game/content/narratives/distribute.ts
+++ b/lib/game/content/narratives/distribute.ts
@@ -7,7 +7,7 @@
 // Stock narrative lines for assigning a tile its land type. The structured
 // outcome carries which type was chosen — these lines are intentionally
 // neutral about military / food / magic so they don't have to be split.
-export const DISTRIBUTE_NARRATIVES: string[] = [
+const HUMAN_DISTRIBUTE_NARRATIVES: string[] = [
   "Surveyors stake out the boundary and hammer in the markers before the dew has burned off.",
   "Your stewards walk the land before noon and decide what it will be by the evening fire.",
   "An old farmer is asked his opinion on the soil; he gives it freely and at length.",
@@ -57,4 +57,32 @@ export const DISTRIBUTE_NARRATIVES: string[] = [
   "By dusk the land has a new name on the map and a new line in the ledger.",
   "An old man tells the story of the land's previous use, but no one is taking notes.",
   "The steward seals the writ with her ring and tucks it into the inside pocket of her coat.",
+];
+
+const AI_DISTRIBUTE_NARRATIVES: string[] = [
+  "A measuring chain is dragged across the field; the steward marks the corners with white stones.",
+  "The new charter is read out loud at the boundary, and a few villagers nod as if they expected it.",
+  "Workers carry the writ in a small wooden box from the manor to the boundary post.",
+  "The steward signs the assignment book with deliberate care; her clerk dusts it twice.",
+  "A small ceremony at the boundary; a single bell is rung, the writ is sealed, and the work begins.",
+  "The land's purpose is decided, the marker is placed, and the steward goes home to a hot supper.",
+  "An old shepherd watches from a stone wall and gives no opinion; the steward takes it as approval.",
+  "A line of carts brings tools to the new posting before the writ has fully dried.",
+  "The blacksmith brings a new hinge for the boundary gate; it is mounted before the writ is signed.",
+  "A boy is sent to fetch the manor's seal; he runs both ways and arrives back panting but proud.",
+  "The steward's seal cracks the wax in the shape of a small wheel; the writ is filed.",
+  "A hand-cart of stakes and rope is unloaded at the boundary; the laying-out begins immediately.",
+  "An apothecary tests the soil one last time, finds it suitable, and signs the second clause of the writ.",
+  "Three farmers from the village offer to do the boundary fencing; the steward writes their names down.",
+  "A pair of oxen is led onto the new field for the first ploughing; they accept the work without fuss.",
+  "The senior steward inspects the new posting and finds it acceptable; she says so without smiling.",
+  "A stack of timber is unloaded at the corner of the new field; the framing crew arrives within the hour.",
+  "An old veteran salutes the new boundary marker on his way past; the steward returns the salute.",
+  "The clerk records the new use in the regional ledger and signs it twice for the records department's pleasure.",
+  "A small dog watches the steward sign the writ; the steward gives it a piece of bread and the dog leaves.",
+];
+
+export const DISTRIBUTE_NARRATIVES: string[] = [
+  ...HUMAN_DISTRIBUTE_NARRATIVES,
+  ...AI_DISTRIBUTE_NARRATIVES,
 ];

--- a/lib/game/content/narratives/explore.ts
+++ b/lib/game/content/narratives/explore.ts
@@ -8,9 +8,10 @@
 // one line at random (seeded) and may layer on additional structured detail
 // (artifact found, hostile neighbors, etc.) before returning to the client.
 //
-// PR 6a seed: ~60 lines. PR 7 will scale to ~1000 via AI-generated bulk +
-// hand-curated contributor PRs.
-export const EXPLORE_NARRATIVES: string[] = [
+// HUMAN_EXPLORE_NARRATIVES + AI_EXPLORE_NARRATIVES are concatenated into the
+// final EXPLORE_NARRATIVES export. Contributor PRs are encouraged to replace
+// lines from the AI block with hand-curated ones in the HUMAN block.
+const HUMAN_EXPLORE_NARRATIVES: string[] = [
   "Your scouts crest a low ridge and look down on a stretch of land no banner has claimed in living memory.",
   "A trail of cold ash leads your party into a clearing where a single tree grows in the middle of a stone circle.",
   "The fog parts as your column rides through it, revealing a long valley still carrying the morning's first frost.",
@@ -71,4 +72,42 @@ export const EXPLORE_NARRATIVES: string[] = [
   "Your scouts find a stack of cut firewood, neatly arranged, beside a hearth that has not been used in a generation.",
   "The land here is gentle, well-watered, and oddly empty — the kind of place that should have been settled, and wasn't.",
   "Your party crosses an old battlefield. The grass grows greener on certain patches, and your captain insists everyone ride single file.",
+];
+
+const AI_EXPLORE_NARRATIVES: string[] = [
+  "A field of barley stands waist-high in the wind, planted by no one your scouts can name.",
+  "Three crossed pikes lean against a tree, polished to a soft shine. No one is in sight.",
+  "Your column tops a rise and finds the road below split in three; only one branch shows fresh wear.",
+  "A salt road runs east-west through this land, narrower than a cart-width and beaten flat.",
+  "The captain's horse pauses at the boundary line, then walks on without urging.",
+  "A wooden idol with a flat-eyed face watches the road from a wayside post; your scouts give it a wide berth.",
+  "Snowmelt has cut a new channel through the meadow; a heron stands in it, waiting.",
+  "An apple core sits on a fencepost. No tree in sight, and the core is fresh.",
+  "A flat stone in the center of the meadow has lines carved in it that look like a calendar.",
+  "Your scouts find a wooden crow nailed to a tree and decide not to ask.",
+  "A line of swallows skims the road ahead of your column, marking the way for as long as the road runs straight.",
+  "The land here used to be terraced. The terraces have softened with time but not disappeared.",
+  "A coil of fishing-line is wrapped around a thornbush at the side of the road, neat as a present.",
+  "The captain's scout returns with a cracked clay pipe; she keeps it for luck.",
+  "An old cow grazes at the boundary; she watches your column pass without blinking, chewing slowly.",
+  "A trail of brass thimbles leads from the wood to the road. The captain has theories.",
+  "A goat trail switchbacks up the western face of this land, used recently and often.",
+  "Your scouts report a three-pace ring of mushrooms in the meadow that wasn't there yesterday.",
+  "The wind here is so steady that the grass leans the same direction even at midday.",
+  "A child's chalk drawing on a flat rock shows a sun, a horse, and a man with a sword. The drawing is fresh.",
+  "Two roads cross at the heart of this land. Only one is on any of your maps.",
+  "An iron-bound trunk sits half-buried at the foot of an oak; you mark its position and leave it.",
+  "A spring rises here in three small jets that hit the same arc of stones each time.",
+  "The captain finds a clay tile inscribed with a single word in a script no one in the column can read.",
+  "A flock of geese rises from the marsh as your column passes; they fly a perfect V northwest.",
+  "An empty wagon-wheel sits on the side of the road, oiled, ready, and waiting for a wagon that hasn't come.",
+  "Your scouts find an iron horseshoe on a stump; the nails are new, the shoe is old.",
+  "A line of bees crosses the road every quarter mile, all heading the same direction.",
+  "Three willow saplings have been planted at the corner of a field, marking something that no longer needs a marker.",
+  "The captain's lead rider waves the column to a halt: a small herd of deer crossing in single file, taking their time.",
+];
+
+export const EXPLORE_NARRATIVES: string[] = [
+  ...HUMAN_EXPLORE_NARRATIVES,
+  ...AI_EXPLORE_NARRATIVES,
 ];

--- a/lib/game/content/narratives/spell-arm.ts
+++ b/lib/game/content/narratives/spell-arm.ts
@@ -6,7 +6,7 @@
 
 // Stock narrative lines for arming a defense spell on a tile. The line is
 // followed by structured outcome (which spell, which tile).
-export const SPELL_ARM_NARRATIVES: string[] = [
+const HUMAN_SPELL_ARM_NARRATIVES: string[] = [
   "Your battlemages walk the perimeter and chant the syllables that turn dirt into ward.",
   "A circle of salt is laid down by hand; it does not blow away in the wind.",
   "The mage-captain inscribes a sigil into the keystone of the tile and steps back without looking.",
@@ -57,4 +57,37 @@ export const SPELL_ARM_NARRATIVES: string[] = [
   "A child's drawing of a dragon is found tucked under the warded stone. The captain leaves it there.",
   "The captain's hands shake briefly as she finishes the binding. She closes her fist and the trembling stops.",
   "By morning the dew on the warded tile has formed a perfect ring. The villagers know not to step on it.",
+];
+
+const AI_SPELL_ARM_NARRATIVES: string[] = [
+  "An apprentice mage drops her chalk; the captain catches it before it touches the ground and nods her on.",
+  "A copper coin is buried at each of the four corners. None of them tarnish over the course of the binding.",
+  "The mage-captain hums under her breath through the entire working; the apprentices match her on the third measure.",
+  "A torch is lit at sundown and burns through the binding without growing shorter.",
+  "Three runes are carved into a beam above the door; the carver wets her thumb and presses it into the last cut.",
+  "A small boy is sent away with a coin and a warning; he comes back the next morning with both.",
+  "The mage-captain's apprentice reads the third line wrong; the captain corrects her with one finger to the page.",
+  "A wreath of holly is laid against the warded post; it does not wither for the next week.",
+  "The wind around the tile dies as the binding takes; the trees go absolutely still for the count of seven.",
+  "A line of salt is poured along the threshold; it does not blow away even when a cart passes.",
+  "The mage-captain places a single gold coin on the warded stone; it darkens to the color of pewter and stays.",
+  "An owl in a nearby tree hoots three times during the binding; the captain notes the time.",
+  "A scrap of parchment is burned at the corner of the tile; the smoke writes a word in the air, then fades.",
+  "The captain whispers to the warded post; the post is silent, but the captain seems satisfied.",
+  "A bell is rung once at the start of the binding and once at the end; in between there is no sound at all.",
+  "Six candles are lit and arranged in a hexagon; they burn down at exactly the same rate.",
+  "A loop of horsehair is laid over the threshold; the apprentice swears she sees it tighten when the binding takes.",
+  "An iron nail is driven into the post; the smith's apprentice does it on the third strike and the captain nods.",
+  "The mage-captain reads the last line aloud; the air seems to thicken for a heartbeat and then resume its color.",
+  "A small dish of milk is left at the warded stone; in the morning it is dry but not spilled.",
+  "Three colored ribbons are tied to a branch above the post; the colors are red, white, and a green so dark it is almost black.",
+  "An old veteran walks the perimeter once with his hand on the hilt of his sword; he does not draw it.",
+  "The mage-captain unlaces her sleeves to her elbows for the binding; she relaces them after.",
+  "A flat stone is set at the threshold; the captain steps over it and the air resists for an instant.",
+  "Two apprentices hold a length of cord taut across the doorway; the captain cuts it with a single word.",
+];
+
+export const SPELL_ARM_NARRATIVES: string[] = [
+  ...HUMAN_SPELL_ARM_NARRATIVES,
+  ...AI_SPELL_ARM_NARRATIVES,
 ];

--- a/lib/game/content/narratives/spell-produce.ts
+++ b/lib/game/content/narratives/spell-produce.ts
@@ -7,7 +7,7 @@
 // Stock narrative lines for casting a production spell. Production spells
 // affect the player globally for 100 turns, so the narrative leans toward
 // "something has shifted" rather than "this specific tile."
-export const SPELL_PRODUCE_NARRATIVES: string[] = [
+const HUMAN_SPELL_PRODUCE_NARRATIVES: string[] = [
   "Your battlemages convene at dusk and read the working aloud, voices rising and falling in unison.",
   "A great brass bell is rung once at the capital, and the mages take this as the moment the spell takes hold.",
   "Tonight the lamps in your camp burn a little brighter, and no one is quite sure why.",
@@ -58,4 +58,37 @@ export const SPELL_PRODUCE_NARRATIVES: string[] = [
   "A storm in the distance flickers but does not arrive. The mages have many such storms to thank.",
   "The chief mage walks home in the rain and is not wet when she arrives.",
   "By dawn the working is laid; by dusk the world has shifted by one small notch in your favor.",
+];
+
+const AI_SPELL_PRODUCE_NARRATIVES: string[] = [
+  "The chief mage burns a single page from the great working-book; the ash drifts upward instead of down.",
+  "A line of bells in the temple courtyard ring once each in sequence as the working settles.",
+  "The mage-council closes the casting with a single word; everyone in the room exhales at the same moment.",
+  "A faint smell of cedar fills the temple as the working takes; the smell lingers for a day.",
+  "The chief mage sets down her staff and stretches her hands until the knuckles crack; she smiles.",
+  "A trio of apprentices watches the casting from the doorway; one of them is clearly keeping notes.",
+  "The temple's torches burn pale gold through the binding and return to amber when the working is done.",
+  "A messenger arrives at the temple just as the casting ends; he is told to come back tomorrow.",
+  "The chief mage's familiar — a small grey cat — sleeps through the entire working and wakes the moment it ends.",
+  "Tonight the kitchen-fires hold their heat longer than usual; the cooks notice without comment.",
+  "Your standards across the territory all turn south at once for a single heartbeat, then resume their previous direction.",
+  "The temple's water-clock skips a tick during the binding; the chief mage notes this in her log.",
+  "A small bird flies through the temple window during the casting; it lands on the chief mage's shoulder and stays.",
+  "Wax from the working candles pools in a perfect six-pointed star; it stays that shape until morning.",
+  "The chief mage's apprentices wash the casting tools in cold water; the water steams faintly.",
+  "Smoke from the temple's brazier rises in a tight spiral for the duration of the working.",
+  "A line of footprints appears in the dust of the temple floor and is gone by the next morning.",
+  "An old story-teller in the city pauses mid-sentence as the working takes; he resumes a moment later in a different tale.",
+  "The chief mage rests her hand on the temple's central stone; the stone is warm where it should be cool.",
+  "A flock of pigeons rises from the temple roof at the moment of binding and circles three times.",
+  "The temple's bells ring once on their own; the bell-ringer is asleep in his quarters.",
+  "An apprentice falls asleep during the binding; the chief mage covers her with a cloak and continues without comment.",
+  "A page in the working-book glows faintly for an instant; only the chief mage sees it, and she does not say so.",
+  "The casting ends and the chief mage opens the temple doors; outside, the air is fresh and the night is clear.",
+  "A scribe records the casting in three separate ledgers; she signs each one with a different pen.",
+];
+
+export const SPELL_PRODUCE_NARRATIVES: string[] = [
+  ...HUMAN_SPELL_PRODUCE_NARRATIVES,
+  ...AI_SPELL_PRODUCE_NARRATIVES,
 ];


### PR DESCRIPTION
## Summary

Pure data PR. Scales narrative volumes and grows the artifact pool. Each narrative file now has a HUMAN_* / AI_* split (concatenated into the public export) so contributor PRs can systematically replace AI-generated lines.

| Category | Before | After |
| --- | --- | --- |
| explore | 60 | 90 |
| build | 60 | 90 |
| spell-arm | 50 | 75 |
| spell-produce | 50 | 75 |
| distribute | 49 | 69 |
| attack openings | 15 | 22 |
| attack middles | 14 | 20 |
| artifacts | 27 | 40 |

## Containment
Pure-data PR. Only \`lib/game/content/\` touched.

## Test plan
- [x] \`npx jest --config=config/jest.config.js __tests__/lib/game\` → 125 passed
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint --max-warnings=0\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)