### PR TITLE
release: bulk-distribute panel + live explore progress counter

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -9,7 +9,12 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import type { GamePlayer, GameTile, TurnReport } from "@/lib/game/types";
+import type {
+  GamePlayer,
+  GameTile,
+  LandType,
+  TurnReport,
+} from "@/lib/game/types";
 
 interface PlayerResponse {
   success: boolean;
@@ -43,7 +48,20 @@ export default function GameDashboardPage() {
   const [error, setError] = useState<string | null>(null);
   const [exploring, setExploring] = useState(false);
   const [exploreCount, setExploreCount] = useState(1);
+  const [exploreProgress, setExploreProgress] = useState<{
+    done: number;
+    total: number;
+    artifactsFound: number;
+  } | null>(null);
   const [recentReports, setRecentReports] = useState<TurnReport[]>([]);
+  const [distributing, setDistributing] = useState(false);
+  const [distributeType, setDistributeType] = useState<LandType>("military");
+  const [distributeCount, setDistributeCount] = useState(10);
+  const [distributeProgress, setDistributeProgress] = useState<{
+    done: number;
+    total: number;
+    artifactsFound: number;
+  } | null>(null);
 
   const fetchPlayer = useCallback(async () => {
     setError(null);
@@ -113,46 +131,109 @@ export default function GameDashboardPage() {
   const handleFrontierExplore = useCallback(
     async (count: number) => {
       if (!user) return;
-      const safeCount = Math.max(1, Math.min(100, Math.floor(count)));
+      const total = Math.max(1, Math.min(100, Math.floor(count)));
       setExploring(true);
       setError(null);
+      setExploreProgress({ done: 0, total, artifactsFound: 0 });
+      // Fire one request per tile so the user sees a live counter and each
+      // narrative + artifact roll lands as it happens. The server-side batch
+      // exists for scripting/API callers; the UI prefers per-tile feedback.
+      let artifactsFound = 0;
+      const collected: TurnReport[] = [];
       try {
         const token = await user.getIdToken();
-        const res = await fetch("/api/game/explore", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ count: safeCount }),
-        });
-        const data = await res.json();
-        if (!data.success) {
-          const msg =
-            typeof data.error === "string"
-              ? data.error
-              : data.error?.message ?? "Explore failed";
-          throw new Error(msg);
-        }
-        const fromBatch: TurnReport[] = Array.isArray(data.reports)
-          ? data.reports
-          : [];
-        if (fromBatch.length > 0) {
-          setRecentReports((prev) =>
-            [...fromBatch.slice().reverse(), ...prev].slice(0, 50)
-          );
-        }
-        if (data.stoppedEarly) {
-          setError(`Stopped: ${data.stoppedEarly}`);
+        for (let i = 0; i < total; i++) {
+          const res = await fetch("/api/game/explore", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ count: 1 }),
+          });
+          const data = await res.json();
+          if (!data.success) {
+            const msg =
+              typeof data.error === "string"
+                ? data.error
+                : data.error?.message ?? "Explore failed";
+            setError(`Stopped at ${i} / ${total}: ${msg}`);
+            break;
+          }
+          if (data.report) {
+            collected.push(data.report as TurnReport);
+            if ((data.report as TurnReport).artifactFound) artifactsFound++;
+            // Push the new report onto the head of the visible log live, not
+            // at the end — the user gets to watch the prose appear.
+            setRecentReports((prev) =>
+              [data.report as TurnReport, ...prev].slice(0, 50)
+            );
+          }
+          setExploreProgress({ done: i + 1, total, artifactsFound });
         }
         await fetchPlayer();
       } catch (e) {
         setError(e instanceof Error ? e.message : "Explore failed");
       } finally {
         setExploring(false);
+        setExploreProgress(null);
       }
     },
     [user, fetchPlayer]
+  );
+
+  const handleBulkDistribute = useCallback(
+    async (type: LandType, count: number) => {
+      if (!user) return;
+      const unassigned = tiles
+        .filter((t) => t.type === "unassigned")
+        .map((t) => t.tileId);
+      const total = Math.min(unassigned.length, Math.max(1, Math.floor(count)));
+      if (total === 0) {
+        setError("No unassigned tiles to distribute.");
+        return;
+      }
+      setDistributing(true);
+      setError(null);
+      setDistributeProgress({ done: 0, total, artifactsFound: 0 });
+      let artifactsFound = 0;
+      try {
+        const token = await user.getIdToken();
+        for (let i = 0; i < total; i++) {
+          const tileId = unassigned[i];
+          const res = await fetch("/api/game/setup/distribute", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ tileId, type }),
+          });
+          const data = await res.json();
+          if (!data.success) {
+            const msg =
+              typeof data.error === "string"
+                ? data.error
+                : data.error?.message ?? "Distribute failed";
+            setError(`Stopped at ${i} / ${total}: ${msg}`);
+            break;
+          }
+          if (data.report) {
+            const report = data.report as TurnReport;
+            if (report.artifactFound) artifactsFound++;
+            setRecentReports((prev) => [report, ...prev].slice(0, 50));
+          }
+          setDistributeProgress({ done: i + 1, total, artifactsFound });
+        }
+        await fetchPlayer();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Distribute failed");
+      } finally {
+        setDistributing(false);
+        setDistributeProgress(null);
+      }
+    },
+    [user, tiles, fetchPlayer]
   );
 
   const handleAdminGrant = useCallback(async () => {
@@ -311,10 +392,28 @@ export default function GameDashboardPage() {
             count={exploreCount}
             onCountChange={setExploreCount}
             busy={exploring}
+            progress={exploreProgress}
             maxCount={Math.min(100, player.turnsRemaining)}
             onExplore={() => handleFrontierExplore(exploreCount)}
           />
         )}
+
+        {(player.phase === "distribute" || player.phase === "play") &&
+          tiles.some((t) => t.type === "unassigned") && (
+            <BulkDistribute
+              unassignedCount={
+                tiles.filter((t) => t.type === "unassigned").length
+              }
+              turnsRemaining={player.turnsRemaining}
+              type={distributeType}
+              onTypeChange={setDistributeType}
+              count={distributeCount}
+              onCountChange={setDistributeCount}
+              busy={distributing}
+              progress={distributeProgress}
+              onRun={() => handleBulkDistribute(distributeType, distributeCount)}
+            />
+          )}
 
         <div className="flex flex-wrap gap-3">
           {player.phase !== "play" ? (
@@ -382,16 +481,21 @@ function ExploreFrontier({
   count,
   onCountChange,
   busy,
+  progress,
   maxCount,
   onExplore,
 }: {
   count: number;
   onCountChange: (n: number) => void;
   busy: boolean;
+  progress: { done: number; total: number; artifactsFound: number } | null;
   maxCount: number;
   onExplore: () => void;
 }) {
   const safeMax = Math.max(1, maxCount);
+  const pct = progress
+    ? Math.round((progress.done / Math.max(1, progress.total)) * 100)
+    : 0;
   return (
     <div className="rounded-lg border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/50 dark:bg-emerald-900/10 p-4 mb-6">
       <div className="flex items-baseline justify-between mb-2">
@@ -424,12 +528,143 @@ function ExploreFrontier({
           disabled={busy || safeMax < 1}
           className="px-5 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
         >
-          {busy ? "Exploring…" : `Explore ×${count}`}
+          {busy
+            ? progress
+              ? `Exploring ${progress.done} / ${progress.total}…`
+              : "Exploring…"
+            : `Explore ×${count}`}
         </button>
         <span className="text-xs text-neutral-500">
           (you have {safeMax} turn{safeMax === 1 ? "" : "s"} available)
         </span>
       </div>
+      {progress && (
+        <div className="mt-3 space-y-1">
+          <div className="h-2 w-full bg-emerald-100 dark:bg-emerald-950/40 rounded overflow-hidden">
+            <div
+              className="h-full bg-emerald-500 transition-all duration-200"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <div className="text-xs text-neutral-600 dark:text-neutral-400 flex justify-between">
+            <span>
+              {progress.done} / {progress.total} tiles claimed
+            </span>
+            <span>
+              {progress.artifactsFound} artifact
+              {progress.artifactsFound === 1 ? "" : "s"} found
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BulkDistribute({
+  unassignedCount,
+  turnsRemaining,
+  type,
+  onTypeChange,
+  count,
+  onCountChange,
+  busy,
+  progress,
+  onRun,
+}: {
+  unassignedCount: number;
+  turnsRemaining: number;
+  type: LandType;
+  onTypeChange: (t: LandType) => void;
+  count: number;
+  onCountChange: (n: number) => void;
+  busy: boolean;
+  progress: { done: number; total: number; artifactsFound: number } | null;
+  onRun: () => void;
+}) {
+  const max = Math.min(unassignedCount, turnsRemaining);
+  const safeCount = Math.max(1, Math.min(max || 1, Math.floor(count)));
+  const pct = progress
+    ? Math.round((progress.done / Math.max(1, progress.total)) * 100)
+    : 0;
+  return (
+    <div className="rounded-lg border-2 border-amber-300 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-900/10 p-4 mb-6">
+      <div className="flex items-baseline justify-between mb-2">
+        <h2 className="font-semibold">Bulk-assign land types</h2>
+        <span className="text-xs text-neutral-500">1 turn / tile</span>
+      </div>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3 leading-relaxed">
+        You have{" "}
+        <strong>
+          {unassignedCount} unassigned tile{unassignedCount === 1 ? "" : "s"}
+        </strong>
+        . Pick a role and a count, and the next N unassigned tiles will be
+        assigned to that role one at a time. Each assignment costs 1 turn and
+        rolls a 3% chance for an artifact.
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="text-sm">
+          Assign:{" "}
+          <select
+            value={type}
+            onChange={(e) => onTypeChange(e.target.value as LandType)}
+            disabled={busy}
+            className="ml-2 px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent capitalize"
+          >
+            <option value="military">military</option>
+            <option value="food">food</option>
+            <option value="magic">magic</option>
+          </select>
+        </label>
+        <label className="text-sm">
+          Count:{" "}
+          <input
+            type="number"
+            min={1}
+            max={Math.max(1, max)}
+            value={count}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              if (Number.isFinite(n)) onCountChange(n);
+            }}
+            disabled={busy}
+            className="w-20 px-2 py-1 ml-2 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+          />
+        </label>
+        <button
+          onClick={onRun}
+          disabled={busy || max === 0}
+          className="px-5 py-2 bg-amber-500 text-white rounded-lg hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+        >
+          {busy
+            ? progress
+              ? `Assigning ${progress.done} / ${progress.total}…`
+              : "Assigning…"
+            : `Assign ${safeCount} → ${type}`}
+        </button>
+        <span className="text-xs text-neutral-500">
+          (cap: {max} — limited by turns or unassigned tiles)
+        </span>
+      </div>
+      {progress && (
+        <div className="mt-3 space-y-1">
+          <div className="h-2 w-full bg-amber-100 dark:bg-amber-950/40 rounded overflow-hidden">
+            <div
+              className="h-full bg-amber-500 transition-all duration-200"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <div className="text-xs text-neutral-600 dark:text-neutral-400 flex justify-between">
+            <span>
+              {progress.done} / {progress.total} tiles assigned
+            </span>
+            <span>
+              {progress.artifactsFound} artifact
+              {progress.artifactsFound === 1 ? "" : "s"} found
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Promotes #677 to main.

## Included PRs and authors
- #677 by @Ludwitt — feat(game): bulk-distribute panel + live explore progress counter

## Test plan
- [ ] Smoke after deploy: 50-tile frontier explore shows live counter; bulk-distribute panel appears when unassigned tiles exist and works against military/food/magic with progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)