### PR TITLE
release: /game/recruit + bulk-unassign + attack-log 500 fix

### DIFF
--- a/app/api/game/setup/distribute/route.ts
+++ b/app/api/game/setup/distribute/route.ts
@@ -12,7 +12,7 @@ import { distributeTileServer } from "@/lib/game/data-server";
 import type { LandType } from "@/lib/game/types";
 import { getVerifiedUser } from "@/lib/server-auth";
 
-const VALID_TYPES: LandType[] = ["military", "food", "magic"];
+const VALID_TYPES: LandType[] = ["military", "food", "magic", "unassigned"];
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/game/attacks/page.tsx
+++ b/app/game/attacks/page.tsx
@@ -14,7 +14,7 @@ import type { GameAttack } from "@/lib/game/types";
 interface AttacksResponse {
   success: boolean;
   attacks?: GameAttack[];
-  error?: string;
+  error?: { message?: string; code?: string } | string;
 }
 
 type Side = "all" | "sent" | "received";
@@ -40,7 +40,13 @@ export default function AttackLogPage() {
           headers: { Authorization: `Bearer ${token}` },
         });
         const data = (await res.json()) as AttacksResponse;
-        if (!data.success) throw new Error(data.error ?? "Failed to load");
+        if (!data.success) {
+          const msg =
+            typeof data.error === "string"
+              ? data.error
+              : data.error?.message ?? "Failed to load";
+          throw new Error(msg);
+        }
         setAttacks(data.attacks ?? []);
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load");

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -183,14 +183,17 @@ export default function GameDashboardPage() {
   );
 
   const handleBulkDistribute = useCallback(
-    async (type: LandType, count: number) => {
+    async (
+      targetType: LandType,
+      count: number,
+      sourceFilter: (t: GameTile) => boolean,
+      sourceLabel: string
+    ) => {
       if (!user) return;
-      const unassigned = tiles
-        .filter((t) => t.type === "unassigned")
-        .map((t) => t.tileId);
-      const total = Math.min(unassigned.length, Math.max(1, Math.floor(count)));
+      const sources = tiles.filter(sourceFilter).map((t) => t.tileId);
+      const total = Math.min(sources.length, Math.max(1, Math.floor(count)));
       if (total === 0) {
-        setError("No unassigned tiles to distribute.");
+        setError(`No ${sourceLabel} tiles to distribute.`);
         return;
       }
       setDistributing(true);
@@ -200,14 +203,14 @@ export default function GameDashboardPage() {
       try {
         const token = await user.getIdToken();
         for (let i = 0; i < total; i++) {
-          const tileId = unassigned[i];
+          const tileId = sources[i];
           const res = await fetch("/api/game/setup/distribute", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
               Authorization: `Bearer ${token}`,
             },
-            body: JSON.stringify({ tileId, type }),
+            body: JSON.stringify({ tileId, type: targetType }),
           });
           const data = await res.json();
           if (!data.success) {
@@ -411,7 +414,37 @@ export default function GameDashboardPage() {
               onCountChange={setDistributeCount}
               busy={distributing}
               progress={distributeProgress}
-              onRun={() => handleBulkDistribute(distributeType, distributeCount)}
+              onRun={() =>
+                handleBulkDistribute(
+                  distributeType,
+                  distributeCount,
+                  (t) => t.type === "unassigned",
+                  "unassigned"
+                )
+              }
+            />
+          )}
+
+        {player.phase === "play" &&
+          tiles.some(
+            (t) =>
+              t.type === "military" ||
+              t.type === "food" ||
+              t.type === "magic"
+          ) && (
+            <BulkUnassign
+              tiles={tiles}
+              turnsRemaining={player.turnsRemaining}
+              busy={distributing}
+              progress={distributeProgress}
+              onRun={(sourceType, count) =>
+                handleBulkDistribute(
+                  "unassigned",
+                  count,
+                  (t) => t.type === sourceType,
+                  sourceType
+                )
+              }
             />
           )}
 
@@ -440,12 +473,20 @@ export default function GameDashboardPage() {
             </>
           )}
           {player.phase === "play" && (
-            <Link
-              href="/game/spells"
-              className="px-5 py-2.5 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
-            >
-              Spells
-            </Link>
+            <>
+              <Link
+                href="/game/recruit"
+                className="px-5 py-2.5 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              >
+                Recruit
+              </Link>
+              <Link
+                href="/game/spells"
+                className="px-5 py-2.5 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              >
+                Spells
+              </Link>
+            </>
           )}
           <Link
             href="/game/artifacts"
@@ -665,6 +706,110 @@ function BulkDistribute({
           <div className="text-xs text-neutral-600 dark:text-neutral-400 flex justify-between">
             <span>
               {progress.done} / {progress.total} tiles assigned
+            </span>
+            <span>
+              {progress.artifactsFound} artifact
+              {progress.artifactsFound === 1 ? "" : "s"} found
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BulkUnassign({
+  tiles,
+  turnsRemaining,
+  busy,
+  progress,
+  onRun,
+}: {
+  tiles: GameTile[];
+  turnsRemaining: number;
+  busy: boolean;
+  progress: { done: number; total: number; artifactsFound: number } | null;
+  onRun: (sourceType: "military" | "food" | "magic", count: number) => void;
+}) {
+  const [sourceType, setSourceType] = useState<"military" | "food" | "magic">(
+    "military"
+  );
+  const [count, setCount] = useState(5);
+  const sourceCount = tiles.filter((t) => t.type === sourceType).length;
+  const max = Math.min(sourceCount, turnsRemaining);
+  const safeCount = Math.max(1, Math.min(max || 1, Math.floor(count)));
+  const pct = progress
+    ? Math.round((progress.done / Math.max(1, progress.total)) * 100)
+    : 0;
+  return (
+    <div className="rounded-lg border-2 border-rose-300 dark:border-rose-800 bg-rose-50/50 dark:bg-rose-900/10 p-4 mb-6">
+      <div className="flex items-baseline justify-between mb-2">
+        <h2 className="font-semibold">Bulk-revert tiles to unassigned</h2>
+        <span className="text-xs text-neutral-500">1 turn / tile</span>
+      </div>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3 leading-relaxed">
+        Reset assigned tiles back to <em>unassigned</em>. Each revert costs 1
+        turn and rolls for an artifact, just like a fresh assignment. You&apos;ll
+        pay another turn each to re-assign them later, so use this when you
+        actually want to redistribute the territory mix.
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="text-sm">
+          Source type:{" "}
+          <select
+            value={sourceType}
+            onChange={(e) =>
+              setSourceType(e.target.value as "military" | "food" | "magic")
+            }
+            disabled={busy}
+            className="ml-2 px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent capitalize"
+          >
+            <option value="military">military</option>
+            <option value="food">food</option>
+            <option value="magic">magic</option>
+          </select>
+        </label>
+        <label className="text-sm">
+          Count:{" "}
+          <input
+            type="number"
+            min={1}
+            max={Math.max(1, max)}
+            value={count}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              if (Number.isFinite(n)) setCount(n);
+            }}
+            disabled={busy}
+            className="w-20 px-2 py-1 ml-2 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+          />
+        </label>
+        <button
+          onClick={() => onRun(sourceType, safeCount)}
+          disabled={busy || max === 0}
+          className="px-5 py-2 bg-rose-500 text-white rounded-lg hover:bg-rose-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+        >
+          {busy
+            ? progress
+              ? `Reverting ${progress.done} / ${progress.total}…`
+              : "Reverting…"
+            : `Revert ${safeCount} ${sourceType} → unassigned`}
+        </button>
+        <span className="text-xs text-neutral-500">
+          ({sourceCount} {sourceType} tile{sourceCount === 1 ? "" : "s"} · cap {max})
+        </span>
+      </div>
+      {progress && (
+        <div className="mt-3 space-y-1">
+          <div className="h-2 w-full bg-rose-100 dark:bg-rose-950/40 rounded overflow-hidden">
+            <div
+              className="h-full bg-rose-500 transition-all duration-200"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <div className="text-xs text-neutral-600 dark:text-neutral-400 flex justify-between">
+            <span>
+              {progress.done} / {progress.total} tiles reverted
             </span>
             <span>
               {progress.artifactsFound} artifact

--- a/app/game/recruit/page.tsx
+++ b/app/game/recruit/page.tsx
@@ -1,0 +1,463 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { getCasteProfile } from "@/lib/game/content";
+import {
+  effectiveUnitCap,
+  PRODUCTION_SPELL_DURATION_TURNS,
+} from "@/lib/game/turns";
+import type {
+  GamePlayer,
+  GameTile,
+  TurnReport,
+  UnitType,
+} from "@/lib/game/types";
+
+interface PlayerResponseError {
+  message?: string;
+  code?: string;
+}
+
+interface PlayerResponse {
+  success: boolean;
+  player: GamePlayer | null;
+  tiles: GameTile[];
+  error?: PlayerResponseError | string;
+}
+
+const UNITS_PER_CYCLE = 10;
+const TURNS_PER_CYCLE = 5;
+
+export default function RecruitPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [player, setPlayer] = useState<GamePlayer | null>(null);
+  const [tiles, setTiles] = useState<GameTile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [unitType, setUnitType] = useState<UnitType>("ground");
+  const [requestedUnits, setRequestedUnits] = useState(50);
+  const [progress, setProgress] = useState<{
+    done: number;
+    total: number;
+    unitsBuilt: number;
+    artifactsFound: number;
+  } | null>(null);
+  const [recentReports, setRecentReports] = useState<TurnReport[]>([]);
+
+  const refresh = useCallback(async () => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/player", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as PlayerResponse;
+      if (!data.success) {
+        const msg =
+          typeof data.error === "string"
+            ? data.error
+            : data.error?.message ?? "Failed to load";
+        throw new Error(msg);
+      }
+      setPlayer(data.player);
+      setTiles(data.tiles ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
+    refresh();
+  }, [authLoading, refresh]);
+
+  const militaryTiles = tiles.filter((t) => t.type === "military");
+  const foodTiles = tiles.filter((t) => t.type === "food");
+  const magicTiles = tiles.filter((t) => t.type === "magic");
+
+  // Compute the player's current effective unit cap. This mirrors what the
+  // server uses inside buildUnitsServer so the displayed numbers match what
+  // will actually go through.
+  const cap = player
+    ? effectiveUnitCap(player, foodTiles.length, magicTiles.length)
+    : 0;
+  const unitsAlive = player?.stats.unitsAlive ?? 0;
+  const availableCap = Math.max(0, cap - unitsAlive);
+  const turnsRemaining = player?.turnsRemaining ?? 0;
+  // How many BUILD CYCLES the player can afford right now.
+  const maxCyclesByCap = Math.floor(availableCap / UNITS_PER_CYCLE);
+  const maxCyclesByTurns = Math.floor(turnsRemaining / TURNS_PER_CYCLE);
+  const maxCycles = Math.min(maxCyclesByCap, maxCyclesByTurns);
+  const maxUnits = maxCycles * UNITS_PER_CYCLE;
+
+  const handleRecruit = useCallback(async () => {
+    if (!user || !player) return;
+    if (militaryTiles.length === 0) {
+      setError("You have no military tiles to recruit from.");
+      return;
+    }
+    const units = Math.max(
+      UNITS_PER_CYCLE,
+      Math.min(maxUnits, Math.floor(requestedUnits / UNITS_PER_CYCLE) * UNITS_PER_CYCLE)
+    );
+    const totalCycles = Math.floor(units / UNITS_PER_CYCLE);
+    if (totalCycles === 0) {
+      setError("Not enough turns or capacity to recruit any units.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setProgress({
+      done: 0,
+      total: totalCycles,
+      unitsBuilt: 0,
+      artifactsFound: 0,
+    });
+    let unitsBuilt = 0;
+    let artifactsFound = 0;
+    try {
+      const token = await user.getIdToken();
+      // Round-robin across military tiles so units distribute evenly.
+      for (let i = 0; i < totalCycles; i++) {
+        const tileId = militaryTiles[i % militaryTiles.length].tileId;
+        const res = await fetch("/api/game/build", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ tileId, unitType }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          const msg =
+            typeof data.error === "string"
+              ? data.error
+              : data.error?.message ?? "Recruit failed";
+          setError(`Stopped at ${i} / ${totalCycles}: ${msg}`);
+          break;
+        }
+        unitsBuilt += UNITS_PER_CYCLE;
+        if (data.report) {
+          const report = data.report as TurnReport;
+          if (report.artifactFound) artifactsFound++;
+          setRecentReports((prev) => [report, ...prev].slice(0, 25));
+        }
+        setProgress({
+          done: i + 1,
+          total: totalCycles,
+          unitsBuilt,
+          artifactsFound,
+        });
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Recruit failed");
+    } finally {
+      setBusy(false);
+      setProgress(null);
+    }
+  }, [user, player, militaryTiles, maxUnits, requestedUnits, unitType, refresh]);
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-emerald-500" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <Link href="/login" className="px-6 py-3 bg-emerald-500 text-white rounded-lg">
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  if (!player) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <Link href="/game" className="px-6 py-3 bg-emerald-500 text-white rounded-lg">
+          Enlist first
+        </Link>
+      </div>
+    );
+  }
+
+  const casteProfile = player.caste ? getCasteProfile(player.caste) : null;
+
+  return (
+    <div className="min-h-screen py-12 px-6">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-baseline justify-between mb-6">
+          <h1 className="text-3xl font-bold">Recruit forces</h1>
+          <Link
+            href="/game"
+            className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+          >
+            ← Dashboard
+          </Link>
+        </div>
+
+        <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-6 text-sm leading-relaxed">
+          <p>
+            Each recruit cycle trains <strong>{UNITS_PER_CYCLE} units</strong>{" "}
+            of one type on a military tile, costing{" "}
+            <strong>{TURNS_PER_CYCLE} turns</strong>. Bulk recruit fires cycles
+            round-robin across all your military tiles so units distribute
+            evenly. Each cycle rolls a 3% chance for an artifact.
+          </p>
+          <p className="mt-2">
+            Your unit cap is set by your{" "}
+            <strong>food lands</strong> (+5 cap each up to 50, then +2.5),
+            multiplied by any active production spells. Your{" "}
+            <strong>caste</strong> shifts which unit type you build best
+            (
+            {casteProfile
+              ? Object.entries(casteProfile.unitTypeBonuses)
+                  .map(([k, v]) => `${k} ×${v}`)
+                  .join(", ")
+              : "—"}
+            ).
+          </p>
+        </div>
+
+        {error && (
+          <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
+          <Stat label="Military tiles" value={String(militaryTiles.length)} />
+          <Stat label="Unit cap" value={String(cap)} />
+          <Stat label="Units alive" value={String(unitsAlive)} />
+          <Stat label="Available cap" value={String(availableCap)} />
+          <Stat label="Turns remaining" value={String(turnsRemaining)} />
+          <Stat
+            label="Max units this session"
+            value={String(maxUnits)}
+            hint={`(${maxCycles} cycles)`}
+          />
+          <Stat label="Food lands" value={String(foodTiles.length)} />
+          <Stat label="Magic lands" value={String(magicTiles.length)} />
+        </div>
+
+        {(player.productionSpellsActive ?? []).length > 0 && (
+          <div className="mb-6 text-xs text-neutral-500">
+            Active production spells contributing to your cap:{" "}
+            {(player.productionSpellsActive ?? [])
+              .map((p) => p.spellId)
+              .join(", ")}{" "}
+            (each lasts {PRODUCTION_SPELL_DURATION_TURNS} turns from cast).
+          </div>
+        )}
+
+        <div className="rounded-lg border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/50 dark:bg-emerald-900/10 p-4 mb-6">
+          <h2 className="font-semibold mb-3">Bulk recruit</h2>
+          {militaryTiles.length === 0 ? (
+            <p className="text-sm text-neutral-500">
+              You have no military tiles. Distribute some unassigned tiles to{" "}
+              <em>military</em> first — head to the dashboard&apos;s
+              bulk-assign panel or any tile&apos;s detail page.
+            </p>
+          ) : (
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="text-sm">
+                Unit type:{" "}
+                <select
+                  value={unitType}
+                  onChange={(e) => setUnitType(e.target.value as UnitType)}
+                  disabled={busy}
+                  className="ml-2 px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent capitalize"
+                >
+                  <option value="ground">ground</option>
+                  <option value="siege">siege</option>
+                  <option value="air">air</option>
+                </select>
+              </label>
+              <label className="text-sm">
+                Units (multiple of {UNITS_PER_CYCLE}):{" "}
+                <input
+                  type="number"
+                  step={UNITS_PER_CYCLE}
+                  min={UNITS_PER_CYCLE}
+                  max={Math.max(UNITS_PER_CYCLE, maxUnits)}
+                  value={requestedUnits}
+                  onChange={(e) => {
+                    const n = Number.parseInt(e.target.value, 10);
+                    if (Number.isFinite(n)) setRequestedUnits(n);
+                  }}
+                  disabled={busy}
+                  className="w-24 px-2 py-1 ml-2 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+                />
+              </label>
+              <button
+                onClick={handleRecruit}
+                disabled={busy || maxCycles === 0}
+                className="px-5 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+              >
+                {busy
+                  ? progress
+                    ? `Training ${progress.done} / ${progress.total} cycles…`
+                    : "Training…"
+                  : `Recruit ${Math.min(
+                      maxUnits,
+                      Math.max(
+                        UNITS_PER_CYCLE,
+                        Math.floor(requestedUnits / UNITS_PER_CYCLE) *
+                          UNITS_PER_CYCLE
+                      )
+                    )} ${unitType}`}
+              </button>
+              <span className="text-xs text-neutral-500">
+                ({TURNS_PER_CYCLE} turns / {UNITS_PER_CYCLE} units · across{" "}
+                {militaryTiles.length} tile
+                {militaryTiles.length === 1 ? "" : "s"})
+              </span>
+            </div>
+          )}
+
+          {progress && (
+            <div className="mt-4 space-y-1">
+              <div className="h-2 w-full bg-emerald-100 dark:bg-emerald-950/40 rounded overflow-hidden">
+                <div
+                  className="h-full bg-emerald-500 transition-all duration-200"
+                  style={{
+                    width: `${Math.round((progress.done / Math.max(1, progress.total)) * 100)}%`,
+                  }}
+                />
+              </div>
+              <div className="text-xs text-neutral-600 dark:text-neutral-400 flex justify-between">
+                <span>
+                  {progress.done} / {progress.total} cycles ·{" "}
+                  {progress.unitsBuilt} units trained
+                </span>
+                <span>
+                  {progress.artifactsFound} artifact
+                  {progress.artifactsFound === 1 ? "" : "s"} found
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <h2 className="text-lg font-semibold mb-3">Your military tiles</h2>
+        {militaryTiles.length === 0 ? (
+          <p className="text-sm text-neutral-500 italic">
+            None yet — distribute some unassigned tiles to military first.
+          </p>
+        ) : (
+          <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg divide-y divide-neutral-200 dark:divide-neutral-800">
+            {militaryTiles.map((t) => (
+              <Link
+                key={t.tileId}
+                href={`/game/tiles/${encodeURIComponent(t.tileId)}`}
+                className="flex items-center justify-between px-4 py-3 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-900"
+              >
+                <span className="font-mono">{t.tileId}</span>
+                <span className="text-xs text-neutral-500">
+                  G {t.units.ground} · S {t.units.siege} · A {t.units.air}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {recentReports.length > 0 && <ReportLog reports={recentReports} />}
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-3">
+      <div className="text-xs uppercase tracking-wide text-neutral-500 mb-1">
+        {label}
+      </div>
+      <div className="text-lg font-semibold">
+        {value}
+        {hint && (
+          <span className="text-xs text-neutral-500 ml-2 font-normal">
+            {hint}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const RARITY_TEXT: Record<string, string> = {
+  common: "text-neutral-500 dark:text-neutral-400",
+  rare: "text-blue-600 dark:text-blue-400",
+  epic: "text-purple-600 dark:text-purple-400",
+  legendary: "text-amber-600 dark:text-amber-400",
+};
+
+function ReportLog({ reports }: { reports: TurnReport[] }) {
+  return (
+    <div className="mt-8">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">
+        Field reports
+      </h3>
+      <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg max-h-96 overflow-y-auto divide-y divide-neutral-200 dark:divide-neutral-800">
+        {reports.map((r, idx) => (
+          <div
+            key={`${r.action}-${r.turnIndex}-${idx}`}
+            className="px-4 py-3 text-sm leading-relaxed"
+          >
+            <div className="flex items-baseline justify-between mb-1">
+              <span className="font-medium">{r.summary}</span>
+              <span className="text-xs text-neutral-500 capitalize ml-2 shrink-0">
+                {r.action} · {r.cost}t
+              </span>
+            </div>
+            {r.narrative.length > 0 && (
+              <div className="text-neutral-600 dark:text-neutral-400 italic space-y-1">
+                {r.narrative.map((line, lineIdx) => (
+                  <p key={lineIdx}>{line}</p>
+                ))}
+              </div>
+            )}
+            {r.artifactFound && (
+              <div
+                className={`mt-2 text-xs font-semibold uppercase tracking-wide ${
+                  RARITY_TEXT[r.artifactFound.rarity] ?? ""
+                }`}
+              >
+                {r.artifactFound.rarity} artifact found —{" "}
+                <span className="normal-case">{r.artifactFound.name}</span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -225,10 +225,15 @@ const COLLECTIONS = {
 
 const WORLD_META_DOC = "singleton";
 
+// Land types you can distribute a tile to. "unassigned" is allowed so the
+// player can revert a tile back (and pay 1 turn for the privilege); they
+// would then pay another turn to re-assign it. "unrevealed" stays
+// non-distributable — a tile becomes unassigned via explore.
 const VALID_DISTRIBUTABLE_TYPES = new Set<LandType>([
   "military",
   "food",
   "magic",
+  "unassigned",
 ]);
 const VALID_CASTES = new Set<Caste>(["black", "red", "white", "green", "blue"]);
 
@@ -1254,14 +1259,18 @@ export async function getRecentAttacksServer(
   limit = 50
 ): Promise<GameAttack[]> {
   const db = adminDbOrThrow();
+  // Single-field where + in-memory sort. Composite indexes are declared in
+  // firestore.indexes.json but may not be deployed in every environment;
+  // attack volume per player is small enough that sorting in JS is trivial.
+  // The wider 500-doc safety limit exists so a chatty player still loads.
+  const fetchLimit = Math.max(limit, 500);
   const queries: Promise<GameAttack[]>[] = [];
   if (side === "sent" || side === "all") {
     queries.push(
       db
         .collection(COLLECTIONS.ATTACKS)
         .where("attackerId", "==", userId)
-        .orderBy("createdAt", "desc")
-        .limit(limit)
+        .limit(fetchLimit)
         .get()
         .then((snap) => snap.docs.map((d) => d.data() as GameAttack))
     );
@@ -1271,8 +1280,7 @@ export async function getRecentAttacksServer(
       db
         .collection(COLLECTIONS.ATTACKS)
         .where("defenderId", "==", userId)
-        .orderBy("createdAt", "desc")
-        .limit(limit)
+        .limit(fetchLimit)
         .get()
         .then((snap) => snap.docs.map((d) => d.data() as GameAttack))
     );
@@ -1288,11 +1296,23 @@ export async function getRecentAttacksServer(
     out.push(a);
   }
   out.sort((a, b) => {
-    const ta = a.createdAt instanceof Date ? a.createdAt.getTime() : 0;
-    const tb = b.createdAt instanceof Date ? b.createdAt.getTime() : 0;
+    const ta = toDate(a.createdAt).getTime();
+    const tb = toDate(b.createdAt).getTime();
     return tb - ta;
   });
   return out.slice(0, limit);
+}
+
+// Coerce Firestore Timestamps / Dates / null into a Date. Avoids the previous
+// bug where `instanceof Date` failed against admin-SDK Timestamps and the
+// sort silently fell back to all-zeros (= unstable order).
+function toDate(value: Date | { toDate?: () => Date } | undefined | null): Date {
+  if (!value) return new Date(0);
+  if (value instanceof Date) return value;
+  if (typeof (value as { toDate?: () => Date }).toDate === "function") {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  return new Date(0);
 }
 
 // Admin testing helper. Places `count` units of `unitType` directly on `tileId`,


### PR DESCRIPTION
## Summary
Promotes #681 to main.

## Included PRs and authors
- #681 by @Ludwitt — feat(game): /game/recruit + bulk-unassign + attack-log 500 fix

## Test plan
- [ ] /game/attacks loads on prod (no more 500)
- [ ] /game/recruit shows military-tile stats + recruits in cycles with progress
- [ ] Dashboard bulk-revert lets you flip military/food/magic back to unassigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)