### PR TITLE
feat(game): /game/tiles renders territory as a hex map

### DIFF
--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -7,7 +7,8 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import type { GamePlayer, GameTile, LandType } from "@/lib/game/types";
 
@@ -27,12 +28,70 @@ const LAND_FILTERS: Array<LandType | "all"> = [
   "unrevealed",
 ];
 
-export default function TilesListPage() {
+// Pixel size of a single hex (radius from center to corner).
+const HEX_SIZE = 28;
+const SQRT3 = Math.sqrt(3);
+// Outer-edge padding around the bounding box, in pixels.
+const VIEWPORT_PADDING = HEX_SIZE * 1.5;
+
+// Pointy-top axial → pixel.
+function axialToPixel(q: number, r: number): { x: number; y: number } {
+  return {
+    x: HEX_SIZE * SQRT3 * (q + r / 2),
+    y: HEX_SIZE * (3 / 2) * r,
+  };
+}
+
+// Six vertices of a pointy-top hex centered at (cx, cy), as "x,y x,y …".
+function hexPoints(cx: number, cy: number): string {
+  const dx = (HEX_SIZE * SQRT3) / 2;
+  const dy = HEX_SIZE / 2;
+  return [
+    [cx, cy - HEX_SIZE],
+    [cx + dx, cy - dy],
+    [cx + dx, cy + dy],
+    [cx, cy + HEX_SIZE],
+    [cx - dx, cy + dy],
+    [cx - dx, cy - dy],
+  ]
+    .map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`)
+    .join(" ");
+}
+
+// Tailwind-resolved colors for each land type. Keep the saturation low enough
+// that the field-report blue badge inside a tile still reads.
+const TYPE_FILL: Record<LandType, string> = {
+  unrevealed: "#262626",
+  unassigned: "#525252",
+  military: "#dc2626",
+  food: "#16a34a",
+  magic: "#2563eb",
+};
+
+const TYPE_STROKE: Record<LandType, string> = {
+  unrevealed: "#404040",
+  unassigned: "#737373",
+  military: "#fca5a5",
+  food: "#86efac",
+  magic: "#93c5fd",
+};
+
+const TYPE_TEXT: Record<LandType, string> = {
+  unrevealed: "#a3a3a3",
+  unassigned: "#fafafa",
+  military: "#fff",
+  food: "#fff",
+  magic: "#fff",
+};
+
+export default function TilesMapPage() {
+  const router = useRouter();
   const { user, loading: authLoading } = useAuth();
   const [tiles, setTiles] = useState<GameTile[]>([]);
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<LandType | "all">("all");
+  const [hovered, setHovered] = useState<GameTile | null>(null);
 
   const refresh = useCallback(async () => {
     if (!user) {
@@ -60,6 +119,28 @@ export default function TilesListPage() {
     refresh();
   }, [authLoading, refresh]);
 
+  // Compute the SVG viewBox once per tile-set change. Memoize so re-renders
+  // (filter, hover) don't re-run the math.
+  const viewBox = useMemo(() => {
+    if (tiles.length === 0) return null;
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (const t of tiles) {
+      const { x, y } = axialToPixel(t.q, t.r);
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    const x = minX - VIEWPORT_PADDING;
+    const y = minY - VIEWPORT_PADDING;
+    const width = maxX - minX + 2 * VIEWPORT_PADDING;
+    const height = maxY - minY + 2 * VIEWPORT_PADDING;
+    return { x, y, width, height };
+  }, [tiles]);
+
   if (authLoading || loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -78,14 +159,11 @@ export default function TilesListPage() {
     );
   }
 
-  const filtered =
-    filter === "all" ? tiles : tiles.filter((t) => t.type === filter);
-
   return (
     <div className="min-h-screen py-12 px-6">
-      <div className="max-w-5xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="flex items-baseline justify-between mb-6">
-          <h1 className="text-3xl font-bold">Your tiles</h1>
+          <h1 className="text-3xl font-bold">Your territory</h1>
           <Link
             href="/game"
             className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
@@ -96,13 +174,13 @@ export default function TilesListPage() {
 
         <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed">
           <p>
-            Every tile you own. Click any tile to manage it: build units (military
-            tiles only), arm a defense spell, or scout neighbors. The filter
-            chips below show how your tiles are distributed.
+            Your lands rendered in hex space. Hover for details, click to
+            manage. The filter chips below dim non-matching tiles so you can
+            see your territory composition at a glance.
           </p>
         </div>
 
-        <div className="flex flex-wrap gap-2 mb-6">
+        <div className="flex flex-wrap gap-2 mb-4">
           {LAND_FILTERS.map((t) => (
             <button
               key={t}
@@ -118,37 +196,159 @@ export default function TilesListPage() {
           ))}
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {filtered.map((t) => (
-            <Link
-              key={t.tileId}
-              href={`/game/tiles/${encodeURIComponent(t.tileId)}`}
-              className="block border border-neutral-200 dark:border-neutral-800 rounded-lg p-4 hover:bg-neutral-50 dark:hover:bg-neutral-900 transition-colors"
-            >
-              <div className="flex items-center justify-between mb-2">
-                <span className="font-mono text-sm">{t.tileId}</span>
-                <span className="text-xs uppercase tracking-wide text-neutral-500 capitalize">
-                  {t.type}
-                </span>
-              </div>
-              <div className="text-xs text-neutral-500">
-                Units: G {t.units.ground} · S {t.units.siege} · A {t.units.air}
-              </div>
-              {t.armedDefenseSpellId && (
-                <div className="text-xs text-blue-600 dark:text-blue-400 mt-1">
-                  Armed: {t.armedDefenseSpellId}
-                </div>
-              )}
-            </Link>
-          ))}
-        </div>
-
-        {filtered.length === 0 && (
+        {tiles.length === 0 ? (
           <p className="text-center text-neutral-500 py-12">
-            No tiles match this filter.
+            You don&apos;t own any tiles yet.
           </p>
+        ) : (
+          <div className="relative">
+            <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg overflow-hidden bg-neutral-50 dark:bg-neutral-950">
+              {viewBox && (
+                <svg
+                  viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
+                  className="w-full h-auto"
+                  style={{
+                    maxHeight: "70vh",
+                    minHeight: "400px",
+                  }}
+                >
+                  {tiles.map((t) => {
+                    const { x, y } = axialToPixel(t.q, t.r);
+                    const matched =
+                      filter === "all" || t.type === filter;
+                    const fill = TYPE_FILL[t.type];
+                    const stroke = TYPE_STROKE[t.type];
+                    const text = TYPE_TEXT[t.type];
+                    const armed = !!t.armedDefenseSpellId;
+                    const totalUnits =
+                      t.units.ground + t.units.siege + t.units.air;
+                    return (
+                      <g
+                        key={t.tileId}
+                        opacity={matched ? 1 : 0.18}
+                        onMouseEnter={() => setHovered(t)}
+                        onMouseLeave={() =>
+                          setHovered((cur) =>
+                            cur?.tileId === t.tileId ? null : cur
+                          )
+                        }
+                        onClick={() =>
+                          router.push(
+                            `/game/tiles/${encodeURIComponent(t.tileId)}`
+                          )
+                        }
+                        style={{ cursor: "pointer" }}
+                      >
+                        <polygon
+                          points={hexPoints(x, y)}
+                          fill={fill}
+                          stroke={stroke}
+                          strokeWidth={1.5}
+                        />
+                        {/* Tile id, small */}
+                        <text
+                          x={x}
+                          y={y - 6}
+                          textAnchor="middle"
+                          fontSize={9}
+                          fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+                          fill={text}
+                          opacity={0.85}
+                          style={{ pointerEvents: "none" }}
+                        >
+                          {t.tileId}
+                        </text>
+                        {/* Unit count if any */}
+                        {totalUnits > 0 && (
+                          <text
+                            x={x}
+                            y={y + 8}
+                            textAnchor="middle"
+                            fontSize={11}
+                            fontWeight={600}
+                            fill={text}
+                            style={{ pointerEvents: "none" }}
+                          >
+                            {totalUnits}
+                          </text>
+                        )}
+                        {/* Defense armed marker */}
+                        {armed && (
+                          <circle
+                            cx={x + HEX_SIZE * 0.55}
+                            cy={y - HEX_SIZE * 0.55}
+                            r={4}
+                            fill="#60a5fa"
+                            stroke="#fff"
+                            strokeWidth={1}
+                            style={{ pointerEvents: "none" }}
+                          />
+                        )}
+                      </g>
+                    );
+                  })}
+                </svg>
+              )}
+            </div>
+
+            {/* Hover info card, anchored bottom-right */}
+            {hovered && (
+              <div className="absolute bottom-3 right-3 max-w-xs rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 p-3 text-xs shadow-lg pointer-events-none">
+                <div className="flex items-baseline justify-between mb-1">
+                  <span className="font-mono font-semibold">
+                    {hovered.tileId}
+                  </span>
+                  <span className="capitalize text-neutral-500">
+                    {hovered.type}
+                  </span>
+                </div>
+                <div className="text-neutral-600 dark:text-neutral-400">
+                  G {hovered.units.ground} · S {hovered.units.siege} · A{" "}
+                  {hovered.units.air}
+                </div>
+                {hovered.armedDefenseSpellId && (
+                  <div className="text-blue-600 dark:text-blue-400 mt-1">
+                    Armed: {hovered.armedDefenseSpellId}
+                  </div>
+                )}
+                <div className="text-neutral-500 mt-1 italic">
+                  click to manage →
+                </div>
+              </div>
+            )}
+          </div>
         )}
+
+        <div className="mt-4 flex flex-wrap gap-3 text-xs text-neutral-500">
+          <Legend type="military" />
+          <Legend type="food" />
+          <Legend type="magic" />
+          <Legend type="unassigned" />
+          <Legend type="unrevealed" />
+          <span className="inline-flex items-center gap-1.5 ml-2">
+            <span
+              className="inline-block w-2 h-2 rounded-full"
+              style={{ background: "#60a5fa" }}
+            />
+            defense armed
+          </span>
+        </div>
       </div>
     </div>
+  );
+}
+
+function Legend({ type }: { type: LandType }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 capitalize">
+      <span
+        className="inline-block w-3 h-3 rounded-sm"
+        style={{
+          background: TYPE_FILL[type],
+          border: `1px solid ${TYPE_STROKE[type]}`,
+        }}
+      />
+      {type}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the list-of-cards view at \`/game/tiles\` with an SVG hex-map renderer that draws tiles in their actual axial coords:

- Pointy-top hexes, auto-fitted viewBox, click → tile detail
- Unit totals rendered inline on each hex; small blue dot marks armed-defense tiles
- Land-type filter chips now dim non-matching tiles instead of hiding them, so you can see territory composition spatially
- Hover card with tile details (units, armed spell)
- Color legend at the bottom

Owned tiles only for now — enemy-border rendering is a follow-on PR. The frontier-explore risk score already surfaces hostile proximity numerically.

## Test plan
- [x] tsc + eslint clean
- [ ] After deploy: load /game/tiles, verify hex map renders, hover/click work, filter chips dim correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)