### PR TITLE
perf(game): PR B — bulkBuildUnitsServer collapses recruit batch into 1 txn

### DIFF
--- a/app/api/game/build/bulk/route.ts
+++ b/app/api/game/build/bulk/route.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import {
+  bulkBuildUnitsServer,
+  type BulkBuildPlanEntry,
+} from "@/lib/game/data-server";
+import type { UnitType } from "@/lib/game/types";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+const VALID_UNIT_TYPES: UnitType[] = ["ground", "siege", "air"];
+const MAX_TOTAL_CYCLES = 100;
+
+function parsePlan(raw: unknown): BulkBuildPlanEntry[] | string {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return "plan must be a non-empty array";
+  }
+  const out: BulkBuildPlanEntry[] = [];
+  let totalCycles = 0;
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") {
+      return "plan entries must be objects";
+    }
+    const e = entry as Record<string, unknown>;
+    const tileId = typeof e.tileId === "string" ? e.tileId : null;
+    const unitTypeRaw =
+      typeof e.unitType === "string" ? e.unitType : null;
+    const cyclesRaw = typeof e.cycles === "number" ? e.cycles : Number(e.cycles);
+    if (!tileId) return "plan entry missing tileId";
+    if (!unitTypeRaw || !VALID_UNIT_TYPES.includes(unitTypeRaw as UnitType)) {
+      return `plan entry has invalid unitType: ${String(unitTypeRaw)}`;
+    }
+    if (
+      !Number.isFinite(cyclesRaw) ||
+      cyclesRaw <= 0 ||
+      Math.floor(cyclesRaw) !== cyclesRaw
+    ) {
+      return "plan entry cycles must be a positive integer";
+    }
+    out.push({
+      tileId,
+      unitType: unitTypeRaw as UnitType,
+      cycles: cyclesRaw,
+    });
+    totalCycles += cyclesRaw;
+  }
+  if (totalCycles > MAX_TOTAL_CYCLES) {
+    return `plan total cycles ${totalCycles} exceeds max ${MAX_TOTAL_CYCLES}`;
+  }
+  return out;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody<{ plan?: unknown }>(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const parsed = parsePlan(bodyOrError.plan);
+    if (typeof parsed === "string") return apiError(parsed, 400);
+
+    const result = await bulkBuildUnitsServer(user.uid, parsed);
+    return apiSuccess({
+      player: result.player,
+      tiles: result.tiles,
+      produced: result.produced,
+      reports: result.reports,
+      stoppedEarly: result.stoppedEarly,
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/recruit/page.tsx
+++ b/app/game/recruit/page.tsx
@@ -129,42 +129,59 @@ export default function RecruitPage() {
       unitsBuilt: 0,
       artifactsFound: 0,
     });
-    let unitsBuilt = 0;
-    let artifactsFound = 0;
     try {
       const token = await user.getIdToken();
-      // Round-robin across military tiles so units distribute evenly.
+      // Build a round-robin plan across military tiles so units distribute
+      // evenly. Aggregate consecutive cycles to the same tile into one entry
+      // so the server's plan stays small.
+      const cyclesPerTile: Map<string, number> = new Map();
       for (let i = 0; i < totalCycles; i++) {
         const tileId = militaryTiles[i % militaryTiles.length].tileId;
-        const res = await fetch("/api/game/build", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ tileId, unitType }),
-        });
-        const data = await res.json();
-        if (!data.success) {
-          const msg =
-            typeof data.error === "string"
-              ? data.error
-              : data.error?.message ?? "Recruit failed";
-          setError(`Stopped at ${i} / ${totalCycles}: ${msg}`);
-          break;
-        }
-        unitsBuilt += UNITS_PER_CYCLE;
-        if (data.report) {
-          const report = data.report as TurnReport;
-          if (report.artifactFound) artifactsFound++;
-          setRecentReports((prev) => [report, ...prev].slice(0, 25));
-        }
-        setProgress({
-          done: i + 1,
-          total: totalCycles,
-          unitsBuilt,
-          artifactsFound,
-        });
+        cyclesPerTile.set(tileId, (cyclesPerTile.get(tileId) ?? 0) + 1);
+      }
+      const plan = Array.from(cyclesPerTile.entries()).map(
+        ([tileId, cycles]) => ({ tileId, unitType, cycles })
+      );
+      const res = await fetch("/api/game/build/bulk", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ plan }),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        const msg =
+          typeof data.error === "string"
+            ? data.error
+            : data.error?.message ?? "Recruit failed";
+        throw new Error(msg);
+      }
+      const reports: TurnReport[] = Array.isArray(data.reports)
+        ? data.reports
+        : [];
+      let artifactsFound = 0;
+      for (const r of reports) if (r.artifactFound) artifactsFound++;
+      const unitsBuilt =
+        typeof data.produced === "number"
+          ? data.produced
+          : reports.length * UNITS_PER_CYCLE;
+      if (reports.length > 0) {
+        setRecentReports((prev) =>
+          [...reports.slice().reverse(), ...prev].slice(0, 25)
+        );
+      }
+      setProgress({
+        done: reports.length,
+        total: totalCycles,
+        unitsBuilt,
+        artifactsFound,
+      });
+      if (data.stoppedEarly) {
+        setError(
+          `Stopped early after ${reports.length} / ${totalCycles}: ${data.stoppedEarly}`
+        );
       }
       await refresh();
     } catch (e) {
@@ -315,9 +332,7 @@ export default function RecruitPage() {
                 className="px-5 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
               >
                 {busy
-                  ? progress
-                    ? `Training ${progress.done} / ${progress.total} cycles…`
-                    : "Training…"
+                  ? "Training units…"
                   : `Recruit ${Math.min(
                       maxUnits,
                       Math.max(

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -929,6 +929,200 @@ export async function buildUnitsServer(
   });
 }
 
+export interface BulkBuildPlanEntry {
+  tileId: string;
+  unitType: UnitType;
+  cycles: number; // each cycle = BUILD_UNITS_TURN_COST turns + BUILD_UNITS_PER_TURN units
+}
+
+// Bulk build. Reads {player + 1 land-counts query + N military tile refs} once,
+// runs each plan entry's `cycles` build steps in memory (each step costs
+// BUILD_UNITS_TURN_COST turns and adds BUILD_UNITS_PER_TURN units), accumulates
+// artifact rolls + reports, and writes everything in one transaction.
+//
+// Stops cleanly with stoppedEarly if a step would exceed the unit cap or
+// the player runs out of turns mid-batch — earlier-succeeded steps still commit.
+//
+// Cap total cycles at 100 to stay under Firestore's 500-ops-per-txn limit
+// (worst case: 1 player + N tiles + 100 artifact creates ≈ 101+N writes).
+export async function bulkBuildUnitsServer(
+  userId: string,
+  plan: ReadonlyArray<BulkBuildPlanEntry>,
+  now: Date = new Date()
+): Promise<{
+  player: GamePlayer;
+  tiles: GameTile[];
+  produced: number;
+  reports: TurnReport[];
+  stoppedEarly?: string;
+}> {
+  if (plan.length === 0) {
+    throw new Error("bulkBuildUnitsServer: plan must not be empty");
+  }
+  const totalCycles = plan.reduce((sum, p) => sum + Math.max(0, p.cycles), 0);
+  if (totalCycles === 0) {
+    throw new Error("bulkBuildUnitsServer: total cycles must be > 0");
+  }
+  if (totalCycles > 100) {
+    throw new Error(
+      `bulkBuildUnitsServer: at most 100 cycles per call (got ${totalCycles})`
+    );
+  }
+  for (const p of plan) {
+    if (p.unitType !== "ground" && p.unitType !== "siege" && p.unitType !== "air") {
+      throw new Error(`bulkBuildUnitsServer: invalid unit type ${p.unitType}`);
+    }
+  }
+
+  const db = adminDbOrThrow();
+  // One owned-tiles query for the cap math, outside the txn.
+  const counts = await getOwnedLandCounts(userId);
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(userId);
+  // Dedupe tile refs in case the plan visits the same tile twice (round-robin
+  // over a small mil-tile pool will). We still issue one tx.update per tile
+  // at the end; the dedupe keeps the read set tight.
+  const uniqueTileIds = Array.from(new Set(plan.map((p) => p.tileId)));
+  const tileRefs = uniqueTileIds.map((id) =>
+    db.collection(COLLECTIONS.TILES).doc(id)
+  );
+
+  return db.runTransaction(async (tx) => {
+    const snaps = await tx.getAll(playerRef, ...tileRefs);
+    const playerSnap = snaps[0];
+    const tileSnaps = snaps.slice(1);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+
+    if (player.phase !== "play") {
+      throw new GameInvalidPhaseError("play", player.phase);
+    }
+
+    // In-memory tile state keyed by tileId. We mutate copies as we go and
+    // commit them once at the end.
+    const tilesById = new Map<string, GameTile>();
+    for (let i = 0; i < uniqueTileIds.length; i++) {
+      const id = uniqueTileIds[i];
+      const snap = tileSnaps[i];
+      if (!snap.exists) throw new GameTileNotFoundError();
+      const tile = snap.data() as GameTile;
+      if (tile.ownerId !== userId) throw new GameTileNotOwnedError();
+      if (tile.type !== "military") {
+        throw new GameTileTypeError("military", tile.type);
+      }
+      tilesById.set(id, tile);
+    }
+
+    const cap = effectiveUnitCap(player, counts.food, counts.magic);
+    let unitsAlive = player.stats.unitsAlive;
+    let turnsRemaining = player.turnsRemaining;
+    let turnsSpentTotal = player.turnsSpentTotal;
+    let stoppedEarly: string | undefined;
+
+    const reports: TurnReport[] = [];
+    let stepIndex = 0;
+    let producedTotal = 0;
+
+    outer: for (const entry of plan) {
+      for (let c = 0; c < entry.cycles; c++) {
+        const isFirst = stepIndex === 0;
+
+        if (turnsRemaining < BUILD_UNITS_TURN_COST) {
+          if (isFirst) {
+            throw new GameInsufficientTurnsError(
+              BUILD_UNITS_TURN_COST,
+              turnsRemaining
+            );
+          }
+          stoppedEarly = `out of turns at cycle ${stepIndex}`;
+          break outer;
+        }
+        if (unitsAlive + BUILD_UNITS_PER_TURN > cap) {
+          if (isFirst) {
+            throw new GameUnitCapExceededError(cap, unitsAlive);
+          }
+          stoppedEarly = `unit cap reached at cycle ${stepIndex} (${unitsAlive}/${cap})`;
+          break outer;
+        }
+
+        turnsRemaining -= BUILD_UNITS_TURN_COST;
+        turnsSpentTotal += BUILD_UNITS_TURN_COST;
+        unitsAlive += BUILD_UNITS_PER_TURN;
+        producedTotal += BUILD_UNITS_PER_TURN;
+
+        const artifact = rollAndStageArtifact(
+          tx,
+          db,
+          userId,
+          turnsSpentTotal,
+          "build",
+          now
+        );
+
+        const before = tilesById.get(entry.tileId)!;
+        const after: GameTile = {
+          ...before,
+          units: {
+            ...before.units,
+            [entry.unitType]:
+              before.units[entry.unitType] + BUILD_UNITS_PER_TURN,
+          },
+          updatedAt: now,
+        };
+        tilesById.set(entry.tileId, after);
+
+        reports.push(
+          buildBuildReport({
+            turnIndex: turnsSpentTotal,
+            cost: BUILD_UNITS_TURN_COST,
+            tileId: entry.tileId,
+            unitType: entry.unitType,
+            unitsBuilt: BUILD_UNITS_PER_TURN,
+            artifactFound: artifact,
+            rng: makeNarrativeRng(userId, turnsSpentTotal, "build"),
+          })
+        );
+
+        stepIndex++;
+      }
+    }
+
+    // Stage tile writes once each (not per cycle).
+    for (const id of uniqueTileIds) {
+      const after = tilesById.get(id)!;
+      const ref = db.collection(COLLECTIONS.TILES).doc(id);
+      tx.update(ref, { units: after.units, updatedAt: now });
+    }
+
+    if (stepIndex > 0) {
+      tx.update(playerRef, {
+        turnsRemaining,
+        turnsSpentTotal,
+        stats: { ...player.stats, unitsAlive },
+        updatedAt: now,
+      });
+    }
+
+    const updatedPlayer: GamePlayer = {
+      ...player,
+      turnsRemaining,
+      turnsSpentTotal,
+      stats: { ...player.stats, unitsAlive },
+      updatedAt: now,
+    };
+    const updatedTiles: GameTile[] = uniqueTileIds.map(
+      (id) => tilesById.get(id)!
+    );
+
+    return {
+      player: updatedPlayer,
+      tiles: updatedTiles,
+      produced: producedTotal,
+      reports,
+      stoppedEarly,
+    };
+  });
+}
+
 // Pre-arms a defense spell on one of the player's tiles. Triggered (and
 // consumed) when the tile is next attacked. Spell must match the player's caste.
 export async function armDefenseSpellServer(


### PR DESCRIPTION
## Summary

Second slice of the I/O optimization plan. Per-step build was particularly expensive because each cycle did its own \`getOwnedLandCounts\` query (an N-doc owned-tiles fetch) AND its own transaction. A 50-cycle recruit on a 200-tile player was ~10,000 reads.

- New \`bulkBuildUnitsServer(userId, plan)\` reads \`{ player + unique military tiles }\` in a single batched \`tx.getAll\` and runs all cycles in memory under one transaction. Cap math uses one outside-txn land-counts query (vs. one per cycle).
- New endpoint \`POST /api/game/build/bulk { plan: [{ tileId, unitType, cycles }] }\`.
- Recruit page builds the round-robin plan client-side (one entry per unique military tile with its cycle count) and fires a single POST.
- Per-step \"Training X / Y cycles…\" counter replaced with \"Training units…\" spinner per the plan.
- Stops cleanly with \`stoppedEarly\` on cap-exhaustion or out-of-turns mid-batch. Caps at 100 total cycles.

## I/O for a 50-cycle bulk recruit on a 5-mil-tile, 200-owned-tile player
- Reads: ~10,200 → ~106 (~99% drop)
- Writes: 150 → ~60 (per-tile updates collapse to one each)
- Transactions: **50 → 1**

## Test plan
- [x] tsc + eslint clean
- [x] 125 existing tests pass
- [ ] Manual smoke: /game/recruit → recruit 50 ground; observe single network request, units distribute round-robin, dashboard updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)