### PR TITLE
docs(generals): contribution guide — lore, units, spells, artifacts, castes, buildings, UI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ Read docs in this order depending on your goal:
 | 7 | [VERCEL.md](VERCEL.md) | Why PRs do not deploy to Vercel; production-only settings |
 | 8 | [Architecture Decision Records](adr/README.md) | Why the project is built the way it is |
 
+**Generals (the strategy game at `/game`):** open contribution surface for lore, units, spells, artifacts, castes, buildings, and UI. Start at [generals/README.md](generals/README.md).
+
 **Operations / events** (not required for typical code contributions):
 
 - [HACK_A_SPRINT_2026_OPS.md](HACK_A_SPRINT_2026_OPS.md)

--- a/docs/generals/ARTIFACTS.md
+++ b/docs/generals/ARTIFACTS.md
@@ -1,0 +1,153 @@
+# Artifacts
+
+Artifacts are single-use, caste-agnostic items found on a turn-spend. Unlike units and spells (which are bound to castes and have fixed slots), artifacts are an open-ended content surface — **you can add as many as you want**, as long as they fit the rarity bands. Today's repo has roughly: 17 common, 11 rare, 7 epic, 4 legendary.
+
+This is the easiest place to contribute lore + mechanics together.
+
+---
+
+## Where artifact content lives
+
+```
+lib/game/content/artifacts/
+├── common.ts        → exports COMMON_ARTIFACTS    (array)
+├── rare.ts          → exports RARE_ARTIFACTS      (array)
+├── epic.ts          → exports EPIC_ARTIFACTS      (array)
+├── legendary.ts     → exports LEGENDARY_ARTIFACTS (array)
+└── index.ts         → concatenates into ALL_ARTIFACTS + ARTIFACTS_BY_RARITY
+```
+
+To add an artifact, append a new object to the relevant rarity array. No registry edits needed — `index.ts` picks it up automatically.
+
+---
+
+## Schema
+
+```ts
+export const COMMON_ARTIFACTS: ArtifactDefinition[] = [
+  // ... existing artifacts ...
+  {
+    id: "common-windworn-helm",       // unique, kebab-case, format: ${rarity}-${slug}
+    name: "Windworn Helm",
+    rarity: "common",
+    type: "defense",                   // "offense" | "defense" | "production" | "utility"
+    baseStrength: 32,                  // see bands
+    description: "A dented half-helm that sings when struck.",
+    flavorOnFind:
+      "A goatherd had been using it as a milk pail. He hands it over for a fair trade and seems pleased to be rid of it.",
+  },
+];
+```
+
+Pulled from `lib/game/types.ts`:
+
+```ts
+export interface ArtifactDefinition {
+  id: string;
+  name: string;
+  rarity: ArtifactRarity;       // "common" | "rare" | "epic" | "legendary"
+  type: ArtifactType;            // "offense" | "defense" | "production" | "utility"
+  baseStrength: number;
+  description: string;
+  flavorOnFind: string;          // narrative line shown when the artifact is found
+}
+```
+
+---
+
+## What each artifact type does
+
+| Type | Effect at use-time |
+|---|---|
+| `offense` | Flat add to attacker's combat total |
+| `defense` | Flat add to defender's combat total when used on a tile |
+| `production` | Flat add to unit cap **or** magic multiplier (interpretation varies by artifact) |
+| `utility` | Contextual — extra exploration, free turn refunds, etc.; described in flavor text |
+
+Artifacts are **not** scaled by caste bonuses or magic multipliers. The number you write is the number that lands. That's why the bands are tight.
+
+---
+
+## Rarity bands and drop economy
+
+| Rarity | `baseStrength` band | Drop weight | Approx. drops per 100 turns |
+|---|---|---|---|
+| `common` | 25 – 40 | 70 | 2.1 |
+| `rare` | 60 – 82 | 22 | 0.66 |
+| `epic` | 115 – 142 | 7 | 0.21 |
+| `legendary` | 200 – 240 | 1 | 0.03 |
+
+The base drop rate is `ARTIFACT_DROP_RATE = 0.03` (3% per turn-spend) — see `lib/game/artifacts.ts`. Multiply by the rarity's share of the 100-weight pool to get the per-rarity rate. A legendary lands once every ~3,300 turn-spends in the wild — that's the design intent. They're supposed to feel like genuine events.
+
+If you propose a 500-baseStrength legendary "to make it special," the answer is no. Legendaries are already special by being rare. The cap exists so a single lucky drop doesn't decide a multiplayer match.
+
+---
+
+## Flavor text — `flavorOnFind` is the heart of the artifact
+
+`description` shows in the inventory ("a small, dented shield"). `flavorOnFind` shows the moment you discover it ("It was being used as a roof tile by a goatherd…"). The `flavorOnFind` line is what makes the artifact feel like a story.
+
+Tone guide:
+- **Common.** Mundane discovery, slight surreal edge. A goatherd, a child, a dented thing in the mud. 1–2 sentences.
+- **Rare.** Mid-stakes. Someone gives it to you, or you find it where it shouldn't be. 1–2 sentences.
+- **Epic.** Eerie, half-explained. Witnesses disagree. The object behaves slightly impossibly. 2–3 sentences.
+- **Legendary.** Quiet, almost mythic. The story refuses to fully explain itself. The artifact has agency. 2–4 sentences.
+
+Read the existing artifacts in `legendary.ts` for the tone target. The "Crown of the First General" entry is a good example: spare, suggestive, slightly haunted.
+
+---
+
+## Adding a new artifact — example
+
+Here's a complete diff for adding a new common defense artifact:
+
+```ts
+// lib/game/content/artifacts/common.ts
+export const COMMON_ARTIFACTS: ArtifactDefinition[] = [
+  // ... existing ones ...
+  {
+    id: "common-twice-buried-shield",
+    name: "Twice-Buried Shield",
+    rarity: "common",
+    type: "defense",
+    baseStrength: 36,
+    description: "A round shield that has clearly been pulled out of the earth more than once.",
+    flavorOnFind:
+      "Your scouts dig it up by accident while pitching a tent. The previous owner had buried it carefully; whoever buried it before that did the same.",
+  },
+];
+```
+
+Then run:
+
+```bash
+npm test -- __tests__/lib/game/artifacts.test.ts
+```
+
+The test suite verifies:
+- All artifact IDs are unique
+- Every artifact has the required fields populated
+- Rarity is one of the four valid values
+- Type is one of the four valid values
+- Drop rate over 5,000 rolls is within ±1.5% of nominal
+- Rarity distribution roughly matches `RARITY_WEIGHTS`
+
+If your PR breaks any of those, the test fails. Fix the data; don't loosen the test.
+
+---
+
+## Things that don't ship
+
+- **Cursed / negative artifacts.** Artifacts are always good. The mechanic isn't there to roll a bad thing on a turn-spend.
+- **Caste-specific artifacts.** Artifacts are caste-agnostic by design. If your idea reads "the Blue-only Kelp Crown," redesign it as a generic-defense artifact whose flavor leans aquatic.
+- **Permanent artifacts.** All artifacts are single-use. The runtime tracks `used` and `usedAtTurn`. Don't propose a passive item.
+- **Artifacts that change other players' state.** Combat already does that. Artifact effects apply to the using player only.
+
+---
+
+## Testing your artifact
+
+1. Add it.
+2. `npm test -- __tests__/lib/game/artifacts.test.ts`
+3. Local smoke: log in, run frontier explore on `/game` repeatedly. At 3% drop with heavy common weighting, you'll hit a common artifact within 30–50 turns. Check `/game/artifacts` for the inventory; click your new artifact to confirm flavor text renders.
+4. To test rare/epic/legendary, temporarily bump `ARTIFACT_DROP_RATE` to 1.0 in `lib/game/artifacts.ts` **locally only** — never commit that change.

--- a/docs/generals/BALANCE.md
+++ b/docs/generals/BALANCE.md
@@ -1,0 +1,151 @@
+# Balance — guardrails for Generals content
+
+This is the load-bearing doc. Every other content guide links back to the bands defined here. Read this first if you intend to add or tune numbers anywhere.
+
+---
+
+## Why bands matter
+
+Generals is asymmetric — castes have different strengths and one is supposed to dominate certain matchups — but the **floor and ceiling** of every stat is fixed so no one strategy makes the game unplayable. The published bands give contributors freedom to flavor units and spells without accidentally landing a 4× outlier.
+
+If your design needs to break a band, that's fine — but call it out in the PR description with the rationale, and expect a longer review.
+
+---
+
+## Combat math you should know before tuning
+
+The combat resolver lives in `lib/game/combat.ts`. The simplified shape:
+
+```
+attackerPower = Σ(units[type].count × unit.attack × casteUnitBonus[type] × rpsMultiplier)
+              + offenseSpell.baseStrength × magicMultiplier × casteSpellBonus.offense
+              + offenseArtifact.baseStrength       (if used)
+
+defenderPower = Σ(units[type].count × unit.defense × casteUnitBonus[type])
+              + defenseSpell.baseStrength × magicMultiplier × casteSpellBonus.defense
+              + defenseArtifact.baseStrength       (if armed)
+              + tileCapacity * tileDefenseFactor   (military tiles only)
+
+attackerRoll  = uniform(0.9, 1.1)   // seeded RNG, deterministic per (userId, turn)
+defenderRoll  = uniform(0.9, 1.1)
+
+if defender.unitsAlive < 0.5 × attacker.unitsAlive:
+    defensePower *= 1.25            // underdog bonus
+
+outcome = compare(attackerPower × attackerRoll, defensePower × defenderRoll)
+```
+
+**Knobs and where they live:**
+
+| Constant | Value | File |
+|---|---|---|
+| `BASE_TILE_CAPACITY` | 500 | `lib/game/combat.ts` |
+| `LAND_TYPE_CAPACITY_DELTA` | military +200, food 0, magic −100 | `lib/game/combat.ts` |
+| `UNDERDOG_SIZE_RATIO` | 0.5 | `lib/game/combat.ts` |
+| `UNDERDOG_DEFENSE_BONUS` | 0.25 | `lib/game/combat.ts` |
+| `RNG_LOWER` / `RNG_RANGE` | 0.9 / 0.2 | `lib/game/combat.ts` |
+| `magicMultiplier(n)` | 1 + 0.05·min(n,50) + 0.025·max(n−50,0) | `lib/game/combat.ts` |
+| `unitCapFromFoodLands(n)` | 5·min(n,50) + 2.5·max(n−50,0) | `lib/game/combat.ts` |
+| `ATTACK_TURN_COST` | 1 | `lib/game/data-server.ts` |
+| `SPELL_TURN_COST` | 5 | `lib/game/data-server.ts` |
+| `BUILD_UNITS_TURN_COST` | 5 | `lib/game/data-server.ts` |
+| `BUILD_UNITS_PER_TURN` | 10 | `lib/game/data-server.ts` |
+| `ARTIFACT_DROP_RATE` | 0.03 | `lib/game/artifacts.ts` |
+| `RARITY_WEIGHTS` | common 70 / rare 22 / epic 7 / legendary 1 | `lib/game/artifacts.ts` |
+
+These are not content. **Tuning them is a separate review** — open an issue before touching them.
+
+---
+
+## Rock-paper-scissors among unit types
+
+```
+air > ground > siege > air
+```
+
+Same-type matchups are neutral (1.0×). Beating-type pairs apply a multiplier inside `combat.ts`. If you add a unit, you do **not** add a new type — every unit must be `ground | siege | air`. The RPS structure is baked into the combat math.
+
+---
+
+## Stat bands by content type
+
+These are the ranges you should stay inside. Each pointer doc (`UNITS.md`, `SPELLS.md`, `ARTIFACTS.md`, `CASTES.md`) repeats these for convenience, but this is the source of truth.
+
+### Units
+
+| Stat | Recommended | Hard floor / ceiling in code | Notes |
+|---|---|---|---|
+| `attack` | 10 – 18 | 9 – 22 | Siege rises toward the top; air is mid; ground is low–mid. The Inferno Engine (red siege, attack 22) is the explicit ceiling — most units stay ≤ 18. |
+| `defense` | 5 – 13 | 5 – 14 | Ground is highest; siege is lowest. The Pikeman (white ground, defense 14) is the ceiling. |
+| `hp` | 7 – 12 | 7 – 12 | Ground is highest; siege/air are lower. |
+| Sum (att+def+hp) | 30 – 35 | 29 – 35 | Roughly constant per unit; flavor differences come from how the budget is split, not the total. |
+
+A unit must specialize. Don't ship one that's at the top of all three bands — pick a strength, accept a weakness. If your design needs to bend a recommended band (like the Inferno Engine bends `attack`), that's fine, but call it out in your PR.
+
+### Spells
+
+| Type | Caste's hard primary | Caste's soft primary | Caste's off-suit | Rationale |
+|---|---|---|---|---|
+| Offense | 65–80 | (n/a) | 25–40 | The "main weapon" of red/black; weak utility for the others. |
+| Defense | 55–65 | 35–45 | 25–35 | White's specialty; green's softer defense; weak for offense-focused castes. |
+| Production | 60–75 | 45–55 | 25–40 | Blue's specialty; green's softer production; modest for everyone else. |
+
+Rule of thumb: **each caste gets exactly one strong spell type** (their flavor) and two weaker ones. White/blue/black/red run their primary at the hard band (60–75); green runs its primary softer (50) and its off-suits higher (35–40) — green trades a sharp ceiling for being playable in every slot. The runtime multiplies `baseStrength` by `magicMultiplier(magicLandCount) × spellTypeBonus[caste][type]`, so a 70 baseStrength offense spell on a 30-magic-land black caste lands at roughly `70 × 2.5 × 1.3 ≈ 228` effective power. That's why the bands are tight — small base changes amplify a lot.
+
+### Artifacts (single-use, caste-agnostic)
+
+| Rarity | `baseStrength` band | Drop weight |
+|---|---|---|
+| Common | 25–40 | 70 |
+| Rare | 60–82 | 22 |
+| Epic | 115–142 | 7 |
+| Legendary | 200–240 | 1 |
+
+`baseStrength` is added flat to the relevant combat side at use-time (offense → attacker, defense → defender, production → unit cap or magic multiplier, utility → contextual). No caste or magic-land scaling applies to artifacts. Since legendaries land at ~1 in 3,300 turn-spends (3% drop × 1% rarity), they can be game-changing — but a contributor proposing a 500-baseStrength legendary will get pushback. The cap is 240 for a reason.
+
+### Castes
+
+| Field | Band |
+|---|---|
+| `tileCapacityMultiplier` | 0.85 – 1.20 |
+| `unitTypeBonuses[t]` | 0.85 – 1.30 |
+| `spellTypeBonuses[t]` | 0.85 – 1.30 |
+| Sum of `unitTypeBonuses` across types | ≈ 3.00 |
+| Sum of `spellTypeBonuses` across types | ≈ 3.15 |
+
+The sum constraint matters more than the individual numbers. A caste that sums to 3.6 across unit bonuses is meaningfully stronger than one at 3.0 even if no individual number breaks the band. See [CASTES.md](CASTES.md) for the full design pattern.
+
+### Buildings
+
+Currently empty — `lib/game/content/buildings/index.ts` exports `[]`. The v2 contract is:
+
+| Field | Band | Notes |
+|---|---|---|
+| `capacityBonus` | 50 – 200 | Adds flat to a tile's effective unit capacity. |
+| `unitTypeAffinity.multiplier` | 1.05 – 1.20 | Multiplies that unit type's combat stats on the tile. |
+
+A building should grant **one** of those, not both. Stacking is not designed for.
+
+---
+
+## RNG and reproducibility
+
+The artifact roll, attack roll, narrative pick, and frontier-candidate sample all use a seeded mulberry32 PRNG (`makeSeededRng` in `lib/game/combat.ts`). The seed format is:
+
+```
+artifact:${userId}:${turnsSpentTotal}     // bulk + per-step both use this
+attack:${userId}:${turnsSpentTotal}       // combat resolution
+explore:${userId}:${turnsSpentTotal}      // narrative pick
+```
+
+If you add new content that needs RNG, **reuse this scheme**. Don't introduce new seed shapes. The bulk-vs-per-step parity test in `__tests__/lib/game/artifacts.test.ts` pins the artifact contract — the same pattern applies elsewhere.
+
+---
+
+## When in doubt, model it
+
+If you're not sure your numbers are balanced, sketch a worst-case scenario:
+
+> "If I'm a caste-X player with 50 magic lands, full unit cap from food, and I cast my new offense spell with a legendary offense artifact equipped, what's the total power?"
+
+If that number is above ~3,000, you're outside the design space. Most fights resolve in the 500–1,500 range; the underdog bonus and the 0.9–1.1 RNG band are calibrated for that.

--- a/docs/generals/BUILDINGS.md
+++ b/docs/generals/BUILDINGS.md
@@ -1,0 +1,130 @@
+# Buildings (tile upgrades)
+
+Buildings are an empty content surface today. The v1 game ships without any buildings; `lib/game/content/buildings/index.ts` exports `[]`. That empty array **is the contract** — adding a building means appending to it.
+
+This doc tells you what shape buildings should take, where they hook into combat, and what bands they live in.
+
+---
+
+## Where building content lives
+
+```
+lib/game/content/buildings/
+└── index.ts        → exports BUILDINGS array (currently empty)
+```
+
+For a small number of buildings, just add objects directly to the array in `index.ts`. Once we have 5+, split into per-caste files following the `units/` and `spells/` pattern (`buildings/black/forge.ts`, `buildings/index.ts` re-exports).
+
+---
+
+## Schema
+
+```ts
+export const BUILDINGS: BuildingDefinition[] = [
+  {
+    id: "neutral-watchtower",        // unique, kebab-case, format: ${caste-or-neutral}-${slug}
+    caste: "neutral",                 // "neutral" or one of the five castes
+    name: "Watchtower",
+    description: "A timber tower that lets defenders see attackers coming.",
+    capacityBonus: 80,                // optional — flat add to tile's effective unit capacity
+    unitTypeAffinity: undefined,      // optional — multiplier for one unit type's combat stats
+  },
+];
+```
+
+Pulled from `lib/game/types.ts`:
+
+```ts
+export interface BuildingDefinition {
+  id: string;
+  caste: Caste | "neutral";
+  name: string;
+  description: string;
+  capacityBonus?: number;
+  unitTypeAffinity?: { type: UnitType; multiplier: number };
+}
+```
+
+A building should grant **exactly one** of `capacityBonus` or `unitTypeAffinity`. Stacking is not designed for and will get pushback.
+
+---
+
+## What buildings do at runtime
+
+In `lib/game/combat.ts`:
+
+- `computeTileCapacity(landType, caste, upgradeIds)` walks `upgradeIds` and adds each building's `capacityBonus` to the tile's capacity. This raises the unit cap on that specific tile.
+- The combat resolver multiplies a unit's stats by `unitTypeAffinity.multiplier` if the building grants it for that unit's type. So a "Forge" with `{ type: "siege", multiplier: 1.15 }` makes siege units on that tile hit 15% harder.
+
+`upgradeIds` lives on `GameTile.upgradeIds: string[]`. A tile can hold multiple upgrades, but the runtime sums `capacityBonus` linearly — there's no diminishing returns. **Keep individual bonuses tight** so stacking doesn't go wild.
+
+---
+
+## Stat bands
+
+| Field | Band | Notes |
+|---|---|---|
+| `capacityBonus` | 50 – 200 | Tile cap is `BASE_TILE_CAPACITY + landTypeDelta + capacityBonus`. A military tile is 700 base; +200 brings it to 900, which is meaningful but not game-ending. |
+| `unitTypeAffinity.multiplier` | 1.05 – 1.20 | A 1.20 multiplier on top of caste bonuses (up to 1.30) and RPS multipliers can swing combat heavily. Keep most affinities in 1.05–1.10. |
+
+If you propose a building that grants both `capacityBonus: 200` AND `unitTypeAffinity.multiplier: 1.20`, the answer is no. Pick one.
+
+---
+
+## Caste vs. neutral
+
+- **`"neutral"`** buildings can be built on any tile by any player. Use this for generic infrastructure (watchtowers, forts).
+- **Caste-locked** buildings only work for that caste. Use this for thematic buildings tied to a faction's lore (a "Black Mausoleum" for the black caste, etc.).
+
+The runtime does **not** today enforce caste-locking on buildings — that's a v2 mechanic. If your contribution depends on the lock being enforced, open an issue first.
+
+---
+
+## Adding a building — example
+
+```ts
+// lib/game/content/buildings/index.ts
+export const BUILDINGS: BuildingDefinition[] = [
+  {
+    id: "neutral-watchtower",
+    caste: "neutral",
+    name: "Watchtower",
+    description: "Timber tower granting defenders an early warning of incoming columns.",
+    capacityBonus: 80,
+  },
+  {
+    id: "red-forge",
+    caste: "red",
+    name: "Forge",
+    description: "A red-caste smithy that hardens siege engines beyond their normal tolerances.",
+    unitTypeAffinity: { type: "siege", multiplier: 1.10 },
+  },
+];
+```
+
+Then run:
+
+```bash
+npm run type-check
+npm test -- __tests__/lib/game
+```
+
+`combat.test.ts` covers `computeTileCapacity` and the unit-type-affinity multiplier path. If your new building breaks the tile-capacity math (e.g., negative result, NaN), it'll fail there.
+
+---
+
+## What's NOT in scope yet
+
+These are runtime-side gaps. If your contribution wants any of them, file an issue first — they're more than a content PR.
+
+- **A "build a building" UI flow.** The current `app/game/recruit/page.tsx` only handles unit recruitment. There's no page for placing a building on a tile yet.
+- **A turn cost / resource cost for building.** The runtime doesn't model materials. Buildings would currently need a flat turn-cost similar to spells.
+- **Demolition.** No way to remove an upgrade from a tile yet.
+
+A reasonable v2 addition path: stub a `POST /api/game/build-upgrade` that costs N turns and adds the upgrade ID to `GameTile.upgradeIds`. Until that ships, building definitions are dormant.
+
+---
+
+## Lore tone for buildings
+
+Same register as units and spells: 1-sentence description, evocative but functional. Look at the existing unit descriptions for tone — "Bone-armored shock infantry that swarms past the corpses of its own" is the style. Don't write a paragraph.

--- a/docs/generals/CASTES.md
+++ b/docs/generals/CASTES.md
@@ -1,0 +1,193 @@
+# Castes
+
+A caste is a faction with its own asymmetric strengths. Generals ships with **5 castes**: white, blue, black, red, green. The names are inherited from a tabletop tradition (Magic-style color identity); they describe a strategic flavor, not a real-world group.
+
+This is the deepest contribution surface. Renaming a caste, redesigning its profile, or adding a sixth caste touches lore, units, spells, the setup page, and the combat math. **Read this whole doc before opening a caste PR.**
+
+---
+
+## Where caste content lives
+
+| File | What's there |
+|---|---|
+| `lib/game/types.ts` | `Caste` type alias |
+| `lib/game/content/castes.ts` | `CASTE_PROFILES` registry |
+| `lib/game/content/units/{caste}/{type}.ts` | One unit definition per caste×type |
+| `lib/game/content/spells/{caste}/{type}.ts` | One spell definition per caste×type |
+| `lib/game/content/index.ts` | Imports + exposes `ALL_UNITS`, `ALL_SPELLS` |
+| `app/game/setup/page.tsx` | The caste-pick UI |
+
+Adding a caste means writing in **all six** of those places. Renaming a caste means updating the first one (the type) and renaming everything that references it.
+
+---
+
+## Schema
+
+```ts
+// lib/game/types.ts
+export type Caste = "black" | "red" | "white" | "green" | "blue";
+
+// lib/game/content/castes.ts
+export interface CasteProfile {
+  caste: Caste;
+  tileCapacityMultiplier: number;
+  unitTypeBonuses: Record<UnitType, number>;     // ground, siege, air
+  spellTypeBonuses: Record<SpellType, number>;   // defense, offense, production
+}
+```
+
+Existing profiles for reference:
+
+```ts
+white:  cap 1.00, units {g 1.20, s 0.90, a 1.00}, spells {def 1.30, off 0.85, prod 1.00}
+blue:   cap 0.90, units {g 0.95, s 0.95, a 1.20}, spells {def 0.95, off 0.95, prod 1.30}
+black:  cap 1.00, units {g 1.05, s 1.05, a 1.05}, spells {def 0.90, off 1.30, prod 0.90}
+red:    cap 1.00, units {g 1.00, s 1.20, a 1.00}, spells {def 0.85, off 1.30, prod 0.95}
+green:  cap 1.20, units {g 1.20, s 0.95, a 0.95}, spells {def 1.00, off 0.95, prod 1.10}
+```
+
+Read horizontally:
+- **white** is a defensive specialist. Strong ground, very strong defense spells, weak offense spells.
+- **blue** is a magic specialist. Strong air, very strong production spells (long-game economy).
+- **black** is a generalist offensive caste. Slightly above average everywhere, very strong offense spells.
+- **red** is a siege/burn specialist. Strong siege, very strong offense spells, fragile defense.
+- **green** is the territory caste. Highest tile capacity (more units per tile), strong ground, balanced spells.
+
+---
+
+## The design constraints (read this carefully)
+
+```
+Sum of unitTypeBonuses across types  ≈ 3.00
+Sum of spellTypeBonuses across types ≈ 3.15
+tileCapacityMultiplier               ∈ [0.85, 1.20]
+Each individual bonus                ∈ [0.85, 1.30]
+```
+
+The **sum constraint** matters more than the individual numbers. A caste with `{1.30, 1.30, 1.30}` for unit bonuses sums to 3.90 and dominates every type — that's not asymmetric balance, it's just power. Hold the sum near 3.00 and trade strengths for weaknesses.
+
+A good rule of thumb: each caste gets **one strong slot per row** (1.20–1.30), one neutral (0.95–1.05), one weak (0.85–0.95). That sums to ~3.00 and makes the matchups feel different.
+
+---
+
+## Renaming an existing caste
+
+If you want to rename "black" to "obsidian":
+
+1. Update `Caste` in `lib/game/types.ts` (rename the literal).
+2. Update the key in `CASTE_PROFILES` (`lib/game/content/castes.ts`).
+3. Update `caste:` in all 3 unit files (`lib/game/content/units/obsidian/*.ts`) — and rename the folder.
+4. Update `caste:` in all 3 spell files (`lib/game/content/spells/obsidian/*.ts`) — and rename the folder.
+5. Update `id:` in those 6 content files (`black-ground-reaver` → `obsidian-ground-reaver`). **This breaks every existing player roster** — see "ID stability" below.
+6. Update import paths in `lib/game/content/index.ts`.
+7. Update the caste-pick UI in `app/game/setup/page.tsx` (label, swatch color).
+8. Search for the string `"black"` across `app/game/**` and `lib/game/**` and update any UI labels, color tokens, or class names.
+9. Rename narratives if any reference the caste by name (most don't — narratives are intentionally caste-neutral).
+
+Run `npm run type-check && npm run lint && npm test -- __tests__/lib/game` after.
+
+### ID stability — the load-bearing caveat
+
+Player documents in Firestore store `caste: "black"` as a string. Tile and unit IDs include the caste prefix. **A rename breaks live game state** for players who already chose that caste. Acceptable migration paths:
+
+- **Soft rename (recommended).** Keep the internal `Caste` literal as `"black"`, only change the display name + color in the UI. Then `caste: "obsidian"` shown to the player but stored as `"black"`.
+- **Hard rename with backfill.** Write a migration script under `scripts/` that updates existing player documents. This is much more work and needs explicit reviewer signoff.
+
+If you are doing a soft rename, you do **not** need to touch the IDs in the unit/spell files. Just update the display strings.
+
+---
+
+## Redesigning a caste's profile
+
+If you want to retune black from "generalist offense" to "anti-air specialist":
+
+```ts
+// Original
+black: {
+  caste: "black",
+  tileCapacityMultiplier: 1.0,
+  unitTypeBonuses: { ground: 1.05, siege: 1.05, air: 1.05 },     // sum 3.15 — slightly hot
+  spellTypeBonuses: { defense: 0.90, offense: 1.30, production: 0.90 },   // sum 3.10
+},
+
+// Retuned — anti-air emphasis, sum stays near 3.00
+black: {
+  caste: "black",
+  tileCapacityMultiplier: 1.0,
+  unitTypeBonuses: { ground: 0.90, siege: 0.85, air: 1.30 },     // sum 3.05
+  spellTypeBonuses: { defense: 0.90, offense: 1.20, production: 1.05 },   // sum 3.15
+},
+```
+
+Once you've changed the profile, **rebalance the unit + spell stats** for that caste so they fit the new identity. An anti-air black caste should probably also have a higher-attack air unit; the current Vampire Bat (`atk 14`) is fine for a generalist, low for a specialist. See [UNITS.md](UNITS.md) and [SPELLS.md](SPELLS.md) for the bands.
+
+---
+
+## Adding a sixth caste
+
+This is a substantial PR. Expected scope:
+
+1. **Pick a name and color.** Keep the lore non-political. Avoid: real ethnic groups, religions, geopolitical alignments. Acceptable: nature/element themes, abstract concepts (memory, silence), invented words.
+
+2. **Add the literal** to `Caste` in `lib/game/types.ts`:
+   ```ts
+   export type Caste = "black" | "red" | "white" | "green" | "blue" | "amber";
+   ```
+   TypeScript will then flag every `switch` and `Record<Caste, T>` that's missing a branch. Walk those errors — there are several.
+
+3. **Write the profile** in `lib/game/content/castes.ts`:
+   ```ts
+   amber: {
+     caste: "amber",
+     tileCapacityMultiplier: 1.0,
+     unitTypeBonuses: { ground: 1.10, siege: 0.95, air: 0.95 },
+     spellTypeBonuses: { defense: 1.10, offense: 1.10, production: 0.95 },
+   },
+   ```
+   Sums to ≈ 3.00 and ≈ 3.15. Pick a flavor — what's amber's identity? "Memory caste, siege via ancient war machines"? Pick one and let it shape your unit/spell choices.
+
+4. **Write 3 units** in `lib/game/content/units/amber/{ground,siege,air}.ts`. Stat bands in [UNITS.md](UNITS.md).
+
+5. **Write 3 spells** in `lib/game/content/spells/amber/{defense,offense,production}.ts`. Stat bands in [SPELLS.md](SPELLS.md).
+
+6. **Wire imports** in `lib/game/content/index.ts`. Both `ALL_UNITS` and `ALL_SPELLS` arrays need amber entries.
+
+7. **Update the setup page** in `app/game/setup/page.tsx` to show the new caste in the picker.
+
+8. **Pick a color/swatch.** This is in the setup-page UI and possibly in `app/game/tiles/page.tsx` (hex map color). Use a Tailwind color that doesn't clash with the existing five — amber, teal, purple, etc.
+
+9. **Run the full test suite:**
+   ```bash
+   npm run type-check
+   npm run lint
+   npm test -- __tests__/lib/game
+   ```
+   All five existing castes' tests must still pass.
+
+10. **Manual smoke.** On `/game/setup` pick the new caste, recruit one of each unit type, cast each spell type, attack a neutral tile.
+
+Lore is welcome but optional in the PR — you can ship the mechanics first and a follow-up PR can expand the lore in unit/spell descriptions.
+
+---
+
+## Lore tone — what reads well, what doesn't
+
+The five existing castes are intentionally elemental + abstract:
+
+- **white** — light, hallowed, knightly. Sanctuary, Knights, Pegasus.
+- **blue** — water, sky, moon. Tide-Guard, Storm Caller, Lunar Bloom.
+- **black** — death, blood, bone. Reaver, Bone Hurler, Blood Tide.
+- **red** — fire, fury, forge. Marauder, Pyre Mortar, Pyre Strike.
+- **green** — wood, growth, territory. Warden, Catapult, Greenwood Bloom.
+
+A new caste should fit the same shape. Things that work: amber/memory, slate/stone, sea/depths, void/silence, ash/aftermath. Things that don't: anything that maps to a real ethnic, religious, or political group.
+
+---
+
+## Things to ask before submitting
+
+- Does the profile sum near 3.00 / 3.15?
+- Does the caste have a clear identity in 1 sentence?
+- Are the units and spells for the caste consistent with that identity?
+- Have I run all three checks (type-check, lint, tests)?
+- Have I tested it locally end-to-end (setup, recruit, spell, attack)?

--- a/docs/generals/LORE.md
+++ b/docs/generals/LORE.md
@@ -1,0 +1,144 @@
+# Lore — descriptions, narratives, flavor text
+
+Lore is the contribution surface most likely to land cleanly: every unit, spell, artifact, and turn action carries a short prose payload that you can write or rewrite. No mechanics change, no balance review, no test failures unless you accidentally break a string literal.
+
+---
+
+## Three places lore lives
+
+### 1. Content descriptions
+
+Every `UnitDefinition`, `SpellDefinition`, `ArtifactDefinition`, and `BuildingDefinition` has a `description` field. This is the one-line blurb shown next to the item in the inventory and recruit/spell pages.
+
+| Type | File | Field |
+|---|---|---|
+| Unit | `lib/game/content/units/{caste}/{type}.ts` | `description` |
+| Spell | `lib/game/content/spells/{caste}/{type}.ts` | `description` |
+| Artifact | `lib/game/content/artifacts/{rarity}.ts` | `description` |
+| Building | `lib/game/content/buildings/index.ts` | `description` |
+
+Tone target: **one sentence, evocative, functional.** Look at the existing descriptions for style:
+
+> "Bone-armored shock infantry that swarms past the corpses of its own."
+> "A trebuchet wound from femurs and sinew. Still warm."
+> "A river-smoothed stone with three runes scratched into it."
+
+Don't write a paragraph. Don't explain mechanics in the description ("This unit has +20% attack vs. siege" goes in code, not in lore).
+
+### 2. Artifact `flavorOnFind`
+
+Artifacts have a second prose field, `flavorOnFind`, shown the moment you discover one. This is where the **story** of the artifact lives. Tone scales with rarity:
+
+- **Common.** Mundane, slight surreal edge. 1-2 sentences.
+- **Rare.** Mid-stakes. 1-2 sentences.
+- **Epic.** Eerie, half-explained. Witnesses disagree. 2-3 sentences.
+- **Legendary.** Quiet, almost mythic. The story refuses to fully explain itself. 2-4 sentences.
+
+Read `legendary.ts` for the high-end target tone. The "Crown of the First General" entry is the model: spare, suggestive, slightly haunted.
+
+### 3. Turn-report narratives
+
+Every turn-action (explore, build, distribute, spell-arm, spell-produce, attack) generates a one-line narrative for the player's report log. These live in:
+
+```
+lib/game/content/narratives/
+├── explore.ts            → EXPLORE_NARRATIVES
+├── build.ts              → BUILD_NARRATIVES
+├── distribute.ts         → DISTRIBUTE_NARRATIVES
+├── spell-arm.ts          → SPELL_ARM_NARRATIVES
+├── spell-produce.ts      → SPELL_PRODUCE_NARRATIVES
+└── attack-fragments.ts   → ATTACK_OPENINGS, ATTACK_MIDS, ATTACK_OUTCOMES
+```
+
+Each non-attack file follows the same pattern:
+
+```ts
+const HUMAN_X_NARRATIVES: string[] = [
+  // Hand-curated lines. Add new lines here.
+];
+
+const AI_X_NARRATIVES: string[] = [
+  // AI-generated stock lines. Replace with HUMAN lines as we go.
+];
+
+export const X_NARRATIVES = [...HUMAN_X_NARRATIVES, ...AI_X_NARRATIVES];
+```
+
+The runtime picks one line at random (seeded) per turn. **Add new lines to the `HUMAN_*` block.** Don't edit the `AI_*` block — those are placeholders we want to retire over time, but rewriting them line-by-line is churn without value. If you want to retire an AI line, copy it into the human block, rewrite it there, and delete it from the AI block in the same PR.
+
+### Attack narratives are templated
+
+`attack-fragments.ts` is structured differently because attack reports need to reference real numbers (units sent, casualties, outcome). The runtime picks one fragment from each of `ATTACK_OPENINGS`, `ATTACK_MIDS`, `ATTACK_OUTCOMES`, in order, and stitches them together with the structured details.
+
+Example final report:
+> "Your forces marched out before dawn. After a brutal skirmish across the border line, the tile fell to your colors. You lost 23 ground; they lost 41."
+
+When adding fragments:
+- **Openings** are about the launch ("Your forces marched out before dawn.")
+- **Mids** are about the engagement ("After a brutal skirmish across the border line,")
+- **Outcomes** are about the result; provide variants for each `AttackOutcome`: `captured | repelled | stalemate`
+
+Each fragment must read naturally when joined to any other fragment in its sibling pools. Don't write a mid that contradicts a possible opening or outcome.
+
+---
+
+## Tone guide for the whole game
+
+Generals' lore lives in a vague pre-industrial world: banners, columns, captains, scouts, smiths, sergeants, priests, kings. Read 5 existing units and 5 existing artifacts before writing anything new — you'll absorb the register.
+
+What works:
+- Sensory detail (smell of wood smoke, frost on the morning grass)
+- Specific small actions (a quartermaster signs a ledger, a child presses something into a hand)
+- Restraint about magic (it happens, it's described matter-of-factly, no one explains it)
+- Time slipping (centuries-old grass, cold ash, dust still rising)
+
+What doesn't:
+- Modern military terminology ("regiment-strength force conducted a frontal assault")
+- Direct mechanical descriptions ("granting +30 attack")
+- Gore for gore's sake (death is present, but not graphic)
+- Real-world politics, religions, or ethnic groups
+
+---
+
+## Adding a HUMAN narrative line — example
+
+```ts
+// lib/game/content/narratives/explore.ts
+const HUMAN_EXPLORE_NARRATIVES: string[] = [
+  // ... existing lines ...
+  "Your scouts find a stone bridge over a stream that vanishes underground a hundred yards downstream. The bridge is in better repair than the road that leads to it.",
+];
+```
+
+That's the entire change. Run:
+
+```bash
+npm run lint
+npm test -- __tests__/lib/game
+```
+
+The narrative-pick logic is tested via `turn-report.test.ts`. As long as your line is a non-empty string, it'll pass.
+
+---
+
+## Style rules
+
+- **One sentence per line for explore/build/distribute narratives.** Two sentences max. The report log is read fast.
+- **No second-person plural.** "Your scouts" not "your scouts and you." The player is the general; scouts are agents.
+- **Past or simple-present tense.** Mix is fine. Avoid future ("will arrive") — those read like a forecast, not a report.
+- **Avoid pronouns that could be misread.** "He" / "she" / "they" without a clear antecedent get confusing across narrative lines. Prefer named roles (scout, captain, smith).
+- **No emojis. No exclamation marks.** The tone is restrained.
+- **No real proper nouns.** No place names, no historical figures, no IP references. Castes are color-keyed; no faction has a real-world name.
+
+---
+
+## Big lore additions
+
+If your contribution is more than a handful of new lines — say, a full mythology document for the white caste, or a worldbuilding writeup for what the artifacts collectively imply — open a discussion in your PR before merging. Mythology that contradicts existing artifact flavor will get pushback. The existing legendaries (especially "The Last Banner" and "Stillborn Storm") implicitly suggest a world; new lore should fit that world rather than overwriting it.
+
+A reasonable structure for big lore work:
+1. PR 1: a `docs/generals/lore/` markdown collection that proposes the worldbuilding without changing any code.
+2. Discussion thread on the PR — get reviewer alignment.
+3. PR 2: rewrite descriptions / narratives in the code to match.
+
+Lore that lives only in markdown is fine; not all lore needs to ship in-game.

--- a/docs/generals/README.md
+++ b/docs/generals/README.md
@@ -1,0 +1,64 @@
+# Contributing to Generals
+
+Generals is the turn-based strategy game shipped at `/game`. The game world, castes, units, spells, artifacts, lore, and UI are all open to outside contribution. This is a guide for landing those contributions safely — without breaking balance, the multiplayer integrity model, or each other's PRs.
+
+If you have not yet sent a PR to this repo, read [docs/FIRST_CONTRIBUTION.md](../FIRST_CONTRIBUTION.md) first. All Generals PRs target the `develop` branch.
+
+---
+
+## Where you can contribute
+
+| Area | Doc | What you change |
+|---|---|---|
+| Lore (descriptions, narratives, flavor text) | [LORE.md](LORE.md) | `lib/game/content/{units,spells,artifacts}/**`, `lib/game/content/narratives/*.ts` |
+| Units (per-caste ground/siege/air) | [UNITS.md](UNITS.md) | `lib/game/content/units/{caste}/{type}.ts` |
+| Spells (per-caste offense/defense/production) | [SPELLS.md](SPELLS.md) | `lib/game/content/spells/{caste}/{type}.ts` |
+| Artifacts (single-use, found on turn-spend) | [ARTIFACTS.md](ARTIFACTS.md) | `lib/game/content/artifacts/{common,rare,epic,legendary}.ts` |
+| Buildings / tile upgrades | [BUILDINGS.md](BUILDINGS.md) | `lib/game/content/buildings/index.ts` (currently empty — v2 surface) |
+| Castes (rename, redesign, add new) | [CASTES.md](CASTES.md) | `lib/game/content/castes.ts` + cascade edits |
+| UI pages, components, icons, color palette | [UI_AND_GRAPHICS.md](UI_AND_GRAPHICS.md) | `app/game/**`, `components/**`, `public/**` |
+| Cross-cutting balance principles | [BALANCE.md](BALANCE.md) | Read before touching numbers anywhere |
+
+---
+
+## How to test your changes locally
+
+1. `npm install`
+2. `npm run dev` — the dashboard is at `http://localhost:3000/game`
+3. Sign in with a test Google account, click **Start playing** to spawn a starting territory.
+4. Exercise whatever you changed:
+   - New unit → recruit it on `/game/recruit` and attack with it
+   - New spell → arm/cast it on `/game/spells`, then attack or wait for production tick
+   - New artifact → run frontier explore (`/game` → "Explore frontier") repeatedly; artifacts roll at a 3% rate per turn
+   - New caste → reset your player on `/game/setup` and pick the new caste
+
+5. Run the static checks before pushing:
+   ```bash
+   npm run type-check
+   npm run lint
+   npm test -- __tests__/lib/game
+   ```
+
+The game tests are pure — they cover content schema, combat math, RNG determinism, exploration, and turn reports. If your PR breaks a content invariant, those tests will catch it.
+
+---
+
+## Things that will get a PR rejected
+
+- **Numbers outside the documented bands** in [BALANCE.md](BALANCE.md). A new "Black Dragon" with attack 9999 isn't going to ship. If you genuinely need to push outside a band, open the discussion in your PR description and link to the band you're breaking.
+- **Caste-specific names that read as racially or politically loaded.** Castes are color-coded (white/blue/black/red/green) inheriting from a tabletop tradition. Lore and renames must stay clear of real-world ethnic, religious, or political mappings.
+- **Editing other people's lore for flavor reasons alone.** Add new narrative lines to the `HUMAN_*` blocks; don't rewrite existing curated ones unless you spot a typo or factual error.
+- **Touching the data layer for content changes.** `lib/game/data-server.ts`, the API routes, and Firestore rules are not content surface. If your idea seems to need them, open an issue first to discuss.
+- **Unsigned commits.** This repo enforces DCO. Use `git commit -s`.
+
+---
+
+## Multiplayer integrity (read this once)
+
+Generals is multiplayer; the **server is the source of truth**. Combat resolution, artifact RNG, turn-cost validation, and capacity caps all run inside Firestore transactions on the server. The client is a thin presenter — anything visible in the UI can be inspected by an attacker, anything sent in a request body can be forged.
+
+This means:
+- Content (units, spells, artifacts, castes) ships **as code** in `lib/game/content/`. The server imports the same module the client does, so your numbers are authoritative.
+- You cannot add a unit/spell/artifact/caste via "data only" — it's a TypeScript const. That's intentional.
+- If your contribution is a UI affordance only (a new page, a new component), the server doesn't change. You just consume the existing API.
+- If your contribution would need a new server endpoint or a Firestore rule change, open an issue first — that crosses the trust boundary and needs review beyond a content PR.

--- a/docs/generals/SPELLS.md
+++ b/docs/generals/SPELLS.md
@@ -1,0 +1,176 @@
+# Spells
+
+A spell is a one-shot effect bound to a caste and a type. Generals ships with **15 spells** — 5 castes × 3 types (`offense | defense | production`). Each caste has exactly one of each type; this is enforced by `getSpellForCasteAndType` in `lib/game/content/index.ts`.
+
+---
+
+## Where spell content lives
+
+```
+lib/game/content/spells/
+├── black/
+│   ├── defense.ts      → exports BLACK_DEFENSE_SPELL
+│   ├── offense.ts      → exports BLACK_OFFENSE_SPELL
+│   └── production.ts   → exports BLACK_PRODUCTION_SPELL
+├── blue/    (defense, offense, production)
+├── green/   (defense, offense, production)
+├── red/     (defense, offense, production)
+└── white/   (defense, offense, production)
+```
+
+---
+
+## Schema
+
+```ts
+export const BLACK_OFFENSE_SPELL: SpellDefinition = {
+  id: "black-offense-blood-tide",      // unique, kebab-case, format: ${caste}-${type}-${slug}
+  caste: "black",                      // must match folder
+  type: "offense",                     // must match filename
+  name: "Blood Tide",                  // display name
+  baseStrength: 70,                    // see bands
+  description: "A rolling crimson surge that breaks lines and resolve.",
+};
+```
+
+Pulled from `lib/game/types.ts`:
+
+```ts
+export interface SpellDefinition {
+  id: string;
+  caste: Caste;
+  type: SpellType;          // "defense" | "offense" | "production"
+  name: string;
+  baseStrength: number;
+  description: string;
+}
+```
+
+---
+
+## What spell types do
+
+| Type | Effect | Where applied | Turn cost |
+|---|---|---|---|
+| `offense` | Adds flat power to attacker total at attack-time | `lib/game/combat.ts` | 5 (paid when attacking with the spell) |
+| `defense` | Adds flat power to defender total when armed on a tile | `lib/game/combat.ts` | 5 (paid at arm-time) |
+| `production` | Boosts unit cap or magic multiplier for `PRODUCTION_SPELL_DURATION_TURNS` (see `lib/game/turns.ts`) | Player-wide buff | 5 (paid at cast-time) |
+
+The runtime computes effective spell power as:
+
+```
+effectivePower = baseStrength × magicMultiplier(magicLandCount) × spellTypeBonus[caste][type]
+```
+
+So a spell with `baseStrength: 70` cast by a black caste (offense bonus 1.30) with 30 magic lands (multiplier ≈ 2.5) lands at roughly `70 × 2.5 × 1.30 ≈ 228` effective power. **Small base changes amplify a lot** — that's why the bands are tight.
+
+---
+
+## Stat bands by caste-type pairing
+
+Each caste has exactly **one strong spell type** (their flavor) and two weaker ones.
+
+| Caste | Strong type | Off-suit |
+|---|---|---|
+| white | defense | offense, production |
+| blue | production | defense, offense |
+| black | offense | defense, production |
+| red | offense | defense, production |
+| green | production | defense, offense |
+
+| Slot | `baseStrength` band |
+|---|---|
+| Caste's strong type (hard primary) | 60 – 80 |
+| Caste's strong type (soft primary, e.g. green) | 40 – 55 |
+| Caste's off-suit type | 25 – 40 |
+
+**Hard vs. soft primaries:** white/blue/black/red run their flavor type at 60–75 and their off-suits at 25. Green is intentionally softer — its primary (production, Bloom = 50) is below the hard band, and its off-suits (defense Thornwall = 40, offense Stampede = 35) are higher. Green trades a clear ceiling for being playable in every spell slot. If you tune green spells, keep that shape; if you tune a non-green caste's primary, target 60–75.
+
+For reference, here are the existing spells:
+
+| Caste | Type | Name | baseStrength |
+|---|---|---|---|
+| white | defense (★) | Sanctuary | 60 |
+| white | offense | Smite | 25 |
+| white | production | Harvest Festival | 25 |
+| blue | defense | Mirror Veil | 30 |
+| blue | offense | Tempest | 30 |
+| blue | production (★) | Arcane Surge | 70 |
+| black | defense | Shadow Pact | 25 |
+| black | offense (★) | Blood Tide | 70 |
+| black | production | Necromancy | 30 |
+| red | defense | Fire Wall | 25 |
+| red | offense (★) | Inferno | 75 |
+| red | production | Forge Boon | 30 |
+| green | defense | Thornwall | 40 |
+| green | offense | Stampede | 35 |
+| green | production (★) | Bloom | 50 |
+
+(★ = the caste's primary strength.)
+
+Note: the existing whites/blacks/reds run their primary at the upper end and their off-suit at the lower end. Greens and blues are softer-edged. If you tune a spell, **stay consistent with the caste's archetype** — don't, e.g., push white's offense to 60. White is a defensive caste; that's the whole shape of the design.
+
+---
+
+## Adding or editing a spell
+
+There are exactly 15 spell slots — one per (caste, type) pair — so you cannot **add** a spell unless you also add a new caste (see [CASTES.md](CASTES.md)). What you **can** do:
+
+- **Tweak baseStrength** within the band for that slot.
+- **Rename** a spell and rewrite its description. Keep the `id` stable.
+- **Add a new caste**, which adds 3 spell slots.
+
+### Renaming and re-flavoring an existing spell
+
+Look up the existing `id` in the spell file before editing — never invent one.
+
+```ts
+// Before — value comes from lib/game/content/spells/red/offense.ts
+export const RED_OFFENSE_SPELL: SpellDefinition = {
+  id: "red-offense-inferno",
+  ...
+  name: "Inferno",
+  description: "...",
+};
+
+// After — same id, new name + flavor
+export const RED_OFFENSE_SPELL: SpellDefinition = {
+  id: "red-offense-inferno",            // do NOT change
+  ...
+  name: "Cinder March",
+  description: "Embers fall ahead of your column. Where they land, banners burn before riders arrive.",
+};
+```
+
+### Tuning baseStrength
+
+```ts
+// Original — black offense (primary) at 70
+baseStrength: 70,
+
+// Acceptable retune
+baseStrength: 75,  // top of the strong-type band
+
+// NOT acceptable
+baseStrength: 90,  // out of band; would dominate matchups
+```
+
+---
+
+## Production spells specifically
+
+Production spells don't add power to combat — they buff the player for a fixed duration. Read `lib/game/turns.ts` for the exact mechanics. The `baseStrength` of a production spell maps to a unit-cap boost and/or a magic-multiplier boost; the bigger the number, the bigger the buff.
+
+The duration is fixed (`PRODUCTION_SPELL_DURATION_TURNS`) — don't try to design a "longer-lasting weaker buff." That's a runtime change, not a content change.
+
+---
+
+## Testing
+
+Same as units — run:
+
+```bash
+npm test -- __tests__/lib/game
+```
+
+To verify in-game, log in, pick the caste whose spell you tuned, and on `/game/spells` either **arm** a defense spell on one of your tiles or **cast** a production spell. Offense spells are tested by attacking with one selected (`/game/tiles/[tileId]` enemy panel).

--- a/docs/generals/UI_AND_GRAPHICS.md
+++ b/docs/generals/UI_AND_GRAPHICS.md
@@ -1,0 +1,176 @@
+# UI and graphics
+
+The Generals UI is six client pages plus shared layout. Everything is React 18 / Next.js 16 App Router / Tailwind. There's no Generals-specific design system yet — we use the project's overall palette and component conventions.
+
+This doc tells you where each page lives, what the visual conventions are, and how to add an icon or a color without breaking the existing pages.
+
+---
+
+## Page map
+
+```
+app/game/
+├── page.tsx                      → /game (dashboard, frontier explore, bulk distribute/unassign)
+├── setup/page.tsx                → /game/setup (caste pick, starting territory)
+├── tiles/page.tsx                → /game/tiles (hex map, all owned tiles)
+├── tiles/[tileId]/page.tsx       → /game/tiles/[tileId] (tile detail; assign on own, attack on enemy)
+├── recruit/page.tsx              → /game/recruit (bulk recruit units)
+├── spells/page.tsx               → /game/spells (cast production spells, arm defense spells)
+├── attacks/page.tsx              → /game/attacks (attack log)
+├── artifacts/page.tsx            → /game/artifacts (inventory of found artifacts)
+└── leaderboard/page.tsx          → /game/leaderboard (player rankings)
+```
+
+Each page is a server-rendered shell with `"use client"` data-fetching components inside. They all follow the same shape:
+
+1. Top: page header, back link, error/loading state
+2. Middle: data section (cards, lists, hex map)
+3. Bottom: action panel (forms, buttons that call `/api/game/*`)
+
+If you're adding a page, copy `app/game/recruit/page.tsx` as a starting template — it's simple, modern, and exercises every common pattern (auth, callApi, busy state, a report log).
+
+---
+
+## Calling the server
+
+Every page uses the same `callApi(path, body)` pattern:
+
+```ts
+const callApi = async (path: string, body: object) => {
+  const token = await user.getIdToken();
+  const res = await fetch(path, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+};
+```
+
+Don't re-invent this. Don't add error-handling library wrappers. Trust the shape: every game API route returns `{ success: true, ...data }` or `{ success: false, error: string | { message: string } }`.
+
+---
+
+## Styling conventions
+
+### Tailwind, not CSS-in-JS
+
+The whole project uses Tailwind utility classes. Don't import `styled-components` or write CSS modules — they'll be removed in review. The only inline styling allowed is for SVG fill/stroke values (the hex map uses raw hex codes for performance).
+
+### Dark mode is mandatory
+
+Every component must work in light AND dark mode. This means:
+
+```tsx
+// Every text color and background needs both variants
+<div className="text-neutral-900 dark:text-neutral-100">
+<div className="bg-white dark:bg-neutral-900">
+<div className="border-neutral-200 dark:border-neutral-800">
+```
+
+Don't ship a component that's only legible in light mode. There is no "default" mode — the user's system preference decides.
+
+### Color tokens for game state
+
+| Concept | Class pattern | Hex (for SVG) |
+|---|---|---|
+| Unassigned tile | `bg-neutral-500` | `#525252` |
+| Military tile | `bg-red-600 text-white` | `#dc2626` |
+| Food tile | `bg-green-600 text-white` | `#16a34a` |
+| Magic tile | `bg-blue-600 text-white` | `#2563eb` |
+| Unrevealed tile | `bg-neutral-800` | `#262626` |
+| Action button | `bg-emerald-500 hover:bg-emerald-400 text-white` | — |
+| Destructive button | `bg-rose-500 hover:bg-rose-400 text-white` | — |
+| Info banner | `bg-blue-50 dark:bg-blue-900/10 border-blue-200 dark:border-blue-900/50` | — |
+
+The hex codes for tile types are pinned in `app/game/tiles/page.tsx` as `TYPE_FILL` / `TYPE_STROKE` / `TYPE_TEXT`. **If you change them, update everywhere they're referenced** — the tile-type swatch in the hex-map filter bar uses the same constants.
+
+### Caste colors (current convention)
+
+The setup page (`app/game/setup/page.tsx`) currently uses Tailwind's `capitalize` plus emerald-on-select for the caste picker — caste-specific colors aren't fully wired yet. If you implement them, the convention should be:
+
+| Caste | Tailwind class | Why |
+|---|---|---|
+| white | `bg-stone-100 text-stone-900 border-stone-300` | Light, clean, functional |
+| blue | `bg-blue-600 text-white` | Matches magic tile |
+| black | `bg-stone-900 text-stone-100 border-stone-700` | Dark, restrained |
+| red | `bg-red-700 text-white` | Slightly darker than military tile to differentiate |
+| green | `bg-emerald-700 text-white` | Slightly darker than food tile |
+
+(These are recommendations, not committed code yet. If you write a caste-color helper, put it in a new file at `lib/game/ui-colors.ts` and export a `casteColorClasses(caste): string` function so all pages can pick it up consistently.)
+
+---
+
+## Icons
+
+The project uses [`lucide-react`](https://lucide.dev) (already installed in `package.json`). To add an icon:
+
+```tsx
+import { Sword, Shield, Sparkles } from "lucide-react";
+
+<Sword className="w-4 h-4" />
+```
+
+Common icons used elsewhere in the codebase: `Award`, `Calendar`, `Trophy`, `Users`, `Video`, `ExternalLink`, `GitMerge`, `Sun`, `CheckCircle`. Reuse those before reaching for new ones — visual consistency across pages matters.
+
+For Generals specifically, reasonable picks:
+- Attack: `Sword`
+- Defense: `Shield`
+- Spells: `Sparkles` or `Wand2`
+- Units: `Users` (already used elsewhere) or `Sword` for combat units
+- Artifacts: `Gem` or `Star`
+- Buildings: `Building2` or `Home`
+- Explore: `Compass`
+- Map: `Map` or `Hexagon`
+
+If you need an icon that isn't in `lucide-react`, prefer adding it to `lucide-react` upstream rather than introducing a second icon library. We don't want a mix.
+
+---
+
+## Hex map specifically
+
+`app/game/tiles/page.tsx` renders the territory as an inline SVG. Tiles are pointy-top hexagons. The math (axial → cartesian, hex point list) is in the same file.
+
+If you want to enhance the hex map:
+- **Tile labels:** Currently shows total unit count and an "armed" indicator if a defense spell is up. Don't add more visual complexity — the map is meant to be skimmable at a glance.
+- **Hover tooltip:** Already wired via local `hovered` state. To add a new field to the tooltip, edit the `<div>` rendered conditionally near the bottom of the file.
+- **Click navigation:** Each `<g>` element navigates to `/game/tiles/[tileId]` on click. Keep that behavior — it's how attack initiation works.
+
+For background on attacks specifically, see [the contributing README's "How to test" section](README.md#how-to-test-your-changes-locally).
+
+---
+
+## Graphics assets
+
+The `public/` directory currently has no Generals-specific imagery. The hex map renders pure SVG; unit/spell/artifact items are text-only with a description.
+
+If you want to **add illustrations** (unit portraits, spell glyphs, artifact iconography):
+
+1. Create `public/game/` and put assets there.
+2. Use these conventions:
+   - **PNG or SVG.** Avoid JPEG (banding on dark backgrounds). SVG preferred where possible.
+   - **128×128 px** for unit/spell/artifact item icons. Larger illustrations: 512×512.
+   - **Transparent background.** Don't bake in a card frame; the UI handles framing.
+   - **Filename: `${id}.png` or `${id}.svg`.** A unit's id is its kebab-case `id` field, e.g., `public/game/units/black-ground-reaver.png`.
+
+3. To wire an asset, extend the relevant page's render to look up `/game/units/${unit.id}.png` and render an `<Image>` next to the description. Fall back to no image if the file is missing.
+
+4. **Keep file sizes small.** Under 30 KB per icon, under 200 KB per illustration. The `public/` directory is shipped to every page-load on Next.js — bloat there hurts every visitor.
+
+5. Style: there is no committed style guide for Generals art. If you contribute illustrations, propose a style in your PR (e.g., "ink-and-watercolor in the manner of medieval marginalia") and the project can adopt it as a convention going forward.
+
+---
+
+## Things to ask before submitting a UI PR
+
+- Does it work in dark mode?
+- Does it work on mobile (320–480px wide)?
+- Are all colors using Tailwind tokens or the existing TYPE_FILL constants?
+- Is there a back-link to `/game` at the top of any new page?
+- Does it call `/api/game/*` via the existing pattern, with `Authorization: Bearer ${idToken}`?
+- Did you run `npm run lint` and `npm run type-check` before pushing?
+
+If your PR is a substantial UI redesign (not just a new page), open an issue first. The current visual language is restrained and consistent across pages — a flashy redesign of one page will create dissonance with the others.

--- a/docs/generals/UNITS.md
+++ b/docs/generals/UNITS.md
@@ -1,0 +1,159 @@
+# Units
+
+A unit is a stack archetype that can be recruited on military tiles and sent into combat. Generals ships with **15 units** — 5 castes × 3 types (`ground | siege | air`). Each caste has exactly one of each type; this is enforced by `getUnitForCasteAndType` in `lib/game/content/index.ts`.
+
+---
+
+## Where unit content lives
+
+```
+lib/game/content/units/
+├── black/
+│   ├── air.ts      → exports BLACK_AIR_UNIT
+│   ├── ground.ts   → exports BLACK_GROUND_UNIT
+│   └── siege.ts    → exports BLACK_SIEGE_UNIT
+├── blue/    (air, ground, siege)
+├── green/   (air, ground, siege)
+├── red/     (air, ground, siege)
+└── white/   (air, ground, siege)
+```
+
+Each file exports a single `UnitDefinition` constant. The registry (`lib/game/content/index.ts`) imports all 15 and exposes them via `ALL_UNITS`, `UNITS_BY_ID`, and `getUnitForCasteAndType`.
+
+---
+
+## Schema
+
+```ts
+export const BLACK_GROUND_UNIT: UnitDefinition = {
+  id: "black-ground-reaver",         // unique, kebab-case, format: ${caste}-${type}-${slug}
+  caste: "black",                    // must match folder
+  type: "ground",                    // must match filename
+  name: "Reaver",                    // display name
+  attack: 12,                        // see bands
+  defense: 10,                       // see bands
+  hp: 9,                             // see bands
+  description: "Bone-armored shock infantry that swarms past the corpses of its own.",
+};
+```
+
+Pulled from `lib/game/types.ts`:
+
+```ts
+export interface UnitDefinition {
+  id: string;
+  caste: Caste;
+  type: UnitType;
+  name: string;
+  attack: number;
+  defense: number;
+  hp: number;
+  description: string;
+}
+```
+
+---
+
+## Stat bands
+
+| Stat | Range in code | Typical specialization |
+|---|---|---|
+| `attack` | 9 – 22 | Siege 16–22, air 13–16, ground 9–12 |
+| `defense` | 5 – 14 | Ground 10–14, air 7–9, siege 5–7 |
+| `hp` | 7 – 12 | Ground 9–12, air 7–8, siege 7–9 |
+| Sum | 29 – 35 | Hold the budget constant; redistribute for flavor |
+
+A unit must specialize. Don't ship one that's max in all three — pick a strength, accept a weakness. See [BALANCE.md](BALANCE.md) for the underlying combat math.
+
+For reference, here are the existing units (read-only — don't edit other people's lore for flavor):
+
+| Caste | Type | Name | atk / def / hp |
+|---|---|---|---|
+| white | ground | Pikeman | 9 / 14 / 11 |
+| white | siege | Bombardier | 16 / 7 / 9 |
+| white | air | Pegasus Knight | 13 / 9 / 8 |
+| blue | ground | Stormcaller | 11 / 10 / 9 |
+| blue | siege | Skyglass Catapult | 17 / 5 / 8 |
+| blue | air | Sky Reader | 16 / 7 / 7 |
+| black | ground | Reaver | 12 / 10 / 9 |
+| black | siege | Bone Hurler | 18 / 6 / 7 |
+| black | air | Vampire Bat | 14 / 8 / 7 |
+| red | ground | Marauder | 12 / 10 / 10 |
+| red | siege | Inferno Engine | 22 / 5 / 8 |
+| red | air | Phoenix Talon | 15 / 8 / 7 |
+| green | ground | Warden | 10 / 13 / 12 |
+| green | siege | Wood-Spitter | 16 / 7 / 9 |
+| green | air | Eagle Scout | 13 / 9 / 8 |
+
+**Outliers worth knowing:** the Pikeman sits at the floor of `attack` (9) and the ceiling of `defense` (14) — it's the most pure-defensive unit in the game. The Inferno Engine sits at the ceiling of `attack` (22) with the floor of `defense` (5) — it's the most fragile-but-deadly siege unit. Both bend the bands to make their identity legible. New units should generally stay inside 10–18 attack and 5–13 defense; if you need to push to the edge, justify it in your PR.
+
+---
+
+## Adding or editing a unit
+
+There are exactly 15 unit slots — one per (caste, type) pair — so you cannot **add** a unit unless you also add a new caste (see [CASTES.md](CASTES.md)). What you **can** do:
+
+- **Tweak stats** within the bands. Open a PR explaining the design intent.
+- **Rename** a unit and rewrite its description. Keep the `id` stable so existing player rosters don't break.
+- **Add a new caste**, which adds 3 unit slots. See [CASTES.md](CASTES.md).
+
+### Renaming an existing unit
+
+```ts
+// Before
+export const BLACK_GROUND_UNIT: UnitDefinition = {
+  id: "black-ground-reaver",
+  ...
+  name: "Reaver",
+  description: "Bone-armored shock infantry that swarms past the corpses of its own.",
+};
+
+// After — rename + new flavor, id stays the same
+export const BLACK_GROUND_UNIT: UnitDefinition = {
+  id: "black-ground-reaver",         // do NOT change
+  ...
+  name: "Bone Reaver",
+  description: "Black-iron infantry that fights with the calm of the already-dead.",
+};
+```
+
+### Tuning stats
+
+```ts
+// Original
+attack: 12, defense: 10, hp: 9,    // sum 31, ground specialist
+
+// Acceptable retune — same sum, redistributed
+attack: 11, defense: 11, hp: 9,    // softer attack, harder defense
+
+// NOT acceptable — out of band
+attack: 22, defense: 10, hp: 9,    // attack > 18
+```
+
+---
+
+## Combat-side context (what your numbers do)
+
+When the server resolves an attack:
+
+1. Sum unit-side power: `Σ count[type] × unit.attack × casteUnitBonus[type] × rpsMultiplier`. Same for defense.
+2. Add spell power, artifact power, tile capacity adjustments.
+3. Multiply each side by a seeded RNG roll in [0.9, 1.1].
+4. Apply the underdog bonus (×1.25 to defense) if `defender.unitsAlive < 0.5 × attacker.unitsAlive`.
+5. Compare totals and decide outcome.
+
+So a unit's `attack` is multiplied by **caste's unit-type bonus** (0.85–1.30) and **RPS multiplier** when it's the beating type. A black ground unit with attack 12 attacking a green siege defender gets `12 × 1.05 (black ground bonus) × ground-beats-siege multiplier`. Don't try to invert this off-line — trust the bands and read `lib/game/combat.ts` if you need the exact constants.
+
+---
+
+## Testing
+
+Run the content tests after editing:
+
+```bash
+npm test -- __tests__/lib/game
+```
+
+There's no per-unit test (units are just data), but `combat.test.ts` exercises the resolver with realistic stacks and will fail if you accidentally land a stat that breaks unit caps or the RNG bounds.
+
+If you want to manually verify your unit pulls its weight, log in locally, switch caste on `/game/setup`, recruit your unit on `/game/recruit`, and attack a neutral tile.


### PR DESCRIPTION
## Summary

Adds \`docs/generals/\` — a 9-doc contribution guide so people can pick a surface (lore, units, spells, artifacts, castes, buildings, UI) and ship a PR without having to reverse-engineer the game code. Total ~1,340 lines across 9 markdown files.

\`\`\`
docs/generals/
├── README.md           # entry point + how to test locally
├── BALANCE.md          # cross-cutting bands, RNG, turn costs (load-bearing)
├── LORE.md             # descriptions, narratives, flavorOnFind tone
├── UNITS.md            # add/edit/rename units; current roster table
├── SPELLS.md           # add/edit/rename spells; baseStrength bands
├── ARTIFACTS.md        # rarity bands; flavor tone scaling
├── BUILDINGS.md        # v2 surface (currently empty array)
├── CASTES.md           # rename, redesign, add a sixth caste
└── UI_AND_GRAPHICS.md  # page map, color tokens, dark-mode reqs, asset conventions
\`\`\`

Wires the new subdir into \`docs/README.md\`.

## Why

The game is shipped end-to-end and we want outside contributors to expand the content surface (more artifacts, new caste profiles, retuned stats, illustrations). Without docs, a contributor can't know what bands their numbers should land in, what gets rejected for balance reasons, or which parts of the codebase are off-limits as content surface.

Every doc cites real file paths, real exported constants from \`lib/game/combat.ts\` and \`lib/game/artifacts.ts\`, and the actual stat ranges of shipped content (e.g., the Inferno Engine at attack 22 is called out as the explicit ceiling so a contributor doesn't hit \"recommended max 18\" and assume it's hard).

## Test plan

- [x] Every internal markdown link resolves
- [x] Every constant cited (\`BASE_TILE_CAPACITY\`, \`UNDERDOG_SIZE_RATIO\`, \`ARTIFACT_DROP_RATE\`, etc.) verified against current source
- [x] Every unit and spell name in the roster tables matches the actual content files
- [ ] Reviewer eyeball pass on tone — am I describing this game accurately for someone who has never played?

🤖 Generated with [Claude Code](https://claude.com/claude-code)