### PR TITLE
feat(game): names, world map pan/zoom, caste-pick lore, 300 starter turns

### DIFF
--- a/__tests__/lib/game/turns.test.ts
+++ b/__tests__/lib/game/turns.test.ts
@@ -8,6 +8,7 @@ import {
   PRODUCTION_SPELL_DURATION_TURNS,
   SHIELD_DURATION_WEEKS,
   SHIELD_TURN_THRESHOLD,
+  STARTING_TURN_GRANT,
   WEEKLY_TURN_GRANT,
   applyWeeklyGrant,
   canSpendTurns,
@@ -100,13 +101,13 @@ describe("newPlayer with v2 options", () => {
 });
 
 describe("newPlayer", () => {
-  it("starts at phase=explore with 100 turns and shield active", () => {
+  it("starts at phase=explore with the starting turn grant and shield active", () => {
     const created = new Date("2026-05-01T12:00:00.000Z");
     const p = newPlayer("user-1", created);
     expect(p.userId).toBe("user-1");
     expect(p.phase).toBe("explore");
     expect(p.caste).toBeNull();
-    expect(p.turnsRemaining).toBe(WEEKLY_TURN_GRANT);
+    expect(p.turnsRemaining).toBe(STARTING_TURN_GRANT);
     expect(p.turnsSpentTotal).toBe(0);
     expect(p.tilesExplored).toBe(0);
     expect(p.shieldDropAtTurn).toBe(SHIELD_TURN_THRESHOLD);
@@ -118,13 +119,13 @@ describe("spendTurns", () => {
   it("debits turnsRemaining and credits turnsSpentTotal", () => {
     const p = newPlayer("u", new Date("2026-05-01T00:00:00.000Z"));
     const after = spendTurns(p, 30);
-    expect(after.turnsRemaining).toBe(70);
+    expect(after.turnsRemaining).toBe(STARTING_TURN_GRANT - 30);
     expect(after.turnsSpentTotal).toBe(30);
   });
 
   it("throws when over-spending", () => {
     const p = newPlayer("u", new Date("2026-05-01T00:00:00.000Z"));
-    expect(() => spendTurns(p, 200)).toThrow();
+    expect(() => spendTurns(p, STARTING_TURN_GRANT + 1)).toThrow();
   });
 
   it("rejects negative spending", () => {
@@ -136,8 +137,8 @@ describe("spendTurns", () => {
 describe("canSpendTurns", () => {
   it("returns true when player has enough", () => {
     const p = newPlayer("u", new Date("2026-05-01T00:00:00.000Z"));
-    expect(canSpendTurns(p, 100)).toBe(true);
-    expect(canSpendTurns(p, 101)).toBe(false);
+    expect(canSpendTurns(p, STARTING_TURN_GRANT)).toBe(true);
+    expect(canSpendTurns(p, STARTING_TURN_GRANT + 1)).toBe(false);
   });
 });
 

--- a/app/api/game/leaderboard/route.ts
+++ b/app/api/game/leaderboard/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: NextRequest) {
     return apiSuccess({
       players: players.map((p) => ({
         userId: p.userId,
+        displayName: p.displayName ?? "",
         caste: p.caste,
         phase: p.phase,
         tilesHeld: p.stats.tilesHeld,

--- a/app/api/game/player/route.ts
+++ b/app/api/game/player/route.ts
@@ -11,6 +11,7 @@ import {
   createPlayerWithSpawnServer,
   getOwnedMapTilesServer,
   getPlayerServer,
+  setGeneralNameServer,
 } from "@/lib/game/data-server";
 import { getVerifiedUser } from "@/lib/server-auth";
 
@@ -34,11 +35,36 @@ export async function POST(request: NextRequest) {
   try {
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
-    const result = await createPlayerWithSpawnServer(user.uid);
+    const body = (await request.json().catch(() => ({}))) as {
+      displayName?: unknown;
+    };
+    if (typeof body.displayName !== "string") {
+      return apiError("displayName is required", 400);
+    }
+    const result = await createPlayerWithSpawnServer(user.uid, body.displayName);
     return apiSuccess(
       { player: result.player, tileIds: result.tileIds },
       201
     );
+  } catch (error) {
+    return mapGameError(error);
+  }
+}
+
+// Rename. Accepts { displayName: string }; same validation/uniqueness rules
+// as initial spawn.
+export async function PATCH(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const body = (await request.json().catch(() => ({}))) as {
+      displayName?: unknown;
+    };
+    if (typeof body.displayName !== "string") {
+      return apiError("displayName is required", 400);
+    }
+    const player = await setGeneralNameServer(user.uid, body.displayName);
+    return apiSuccess({ player });
   } catch (error) {
     return mapGameError(error);
   }

--- a/app/api/game/world/route.ts
+++ b/app/api/game/world/route.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import {
+  getAllMapTilesServer,
+  getAllOwnerSummariesServer,
+} from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+// Global map fetch: every tile in the world plus a per-owner summary
+// (displayName, caste, shielded). The client joins owner info onto tiles by
+// ownerId. Today this is ~500 tiles + 4 owners. If the population grows past
+// a few thousand tiles, switch to a viewport bounding-box query.
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const [tiles, owners] = await Promise.all([
+      getAllMapTilesServer(),
+      getAllOwnerSummariesServer(),
+    ]);
+    return apiSuccess({ tiles, owners });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/help/page.tsx
+++ b/app/game/help/page.tsx
@@ -1,0 +1,313 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "How to play — Generals",
+  description:
+    "Generals is a turn-based strategy game. Explore your lands, develop them, build units, attack neighbors. Read the progression guide and the lore.",
+};
+
+export default function GameHelpPage() {
+  return (
+    <div className="min-h-screen py-12 px-6">
+      <div className="max-w-3xl mx-auto">
+        <div className="flex items-baseline justify-between mb-8">
+          <h1 className="text-3xl font-bold">Generals — How to play</h1>
+          <Link
+            href="/game"
+            className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+          >
+            ← Dashboard
+          </Link>
+        </div>
+
+        <p className="text-neutral-600 dark:text-neutral-300 mb-10 leading-relaxed">
+          Generals is a slow, persistent, turn-based strategy game shared by the
+          whole cursor-boston community. You command one general on a hex map
+          shared with everyone else. Turns are scarce — they&apos;re the one
+          resource the game cares about. Spend them well.
+        </p>
+
+        <Section title="The shape of a game">
+          <p>
+            Every general moves through four phases. The early phases are guided
+            and short; the last one is the actual game and never ends.
+          </p>
+          <ol className="list-decimal ml-6 mt-3 space-y-2">
+            <li>
+              <strong>Explore.</strong> Reveal your starting lands one by one.
+              Skipped for new players in v2 — your 25-tile cluster lands already
+              revealed.
+            </li>
+            <li>
+              <strong>Distribute.</strong> Decide what each tile is for —{" "}
+              <em>military</em>, <em>food</em>, or <em>magic</em>. This sets
+              your economy for the rest of the game (you can change types later
+              at a turn cost).
+            </li>
+            <li>
+              <strong>Caste.</strong> Pick one of five factions. The choice is
+              permanent. See the <a href="#castes" className="underline">caste
+              guide</a> below.
+            </li>
+            <li>
+              <strong>Play.</strong> The open game. Recruit units on your
+              military tiles, cast spells from magic tiles, push the frontier,
+              attack neighbors, hunt artifacts.
+            </li>
+          </ol>
+        </Section>
+
+        <Section title="Step 1 — Explore your lands">
+          <p>
+            You spawn with <strong>25 tiles</strong>: about 20 contiguous and 3-5
+            scattered exclaves. In v2 they&apos;re already revealed, but the
+            metaphor still applies: every tile your general controls had to be
+            scouted, mapped, and claimed.
+          </p>
+          <p className="mt-3">
+            From your dashboard you can also <strong>explore the frontier</strong>
+             — push outward from any tile you own into the unrevealed wilderness.
+            Each frontier tile costs <strong>1 turn</strong> and has a 3% chance
+            to surface an <strong>artifact</strong>: a single-use trinket from
+            an older war. (More on artifacts below.)
+          </p>
+        </Section>
+
+        <Section title="Step 2 — Develop the lands">
+          <p>
+            Every tile you own starts as <em>unassigned</em>. You assign it one
+            of three types, each with a clear job:
+          </p>
+          <ul className="list-disc ml-6 mt-3 space-y-2">
+            <li>
+              <strong>Military.</strong> Where you recruit units. The number of
+              military tiles you hold caps how many soldiers you can field.
+            </li>
+            <li>
+              <strong>Food.</strong> Determines your <em>unit capacity</em> —
+              more food = more soldiers per military tile. An army that
+              outgrows its food collapses; the cap is hard.
+            </li>
+            <li>
+              <strong>Magic.</strong> Powers your spells. More magic = stronger
+              spell effects (a per-tile multiplier).
+            </li>
+          </ul>
+          <p className="mt-3">
+            Assigning a tile costs <strong>1 turn</strong>. The dashboard has a
+            bulk-distribute control so you don&apos;t have to click 25 times.
+            Bias toward food early — armies grow faster than tiles do.
+          </p>
+        </Section>
+
+        <Section title="Step 3 — Pick a caste" id="castes">
+          <p>
+            Castes are color-keyed factions inherited from a tabletop tradition.
+            They describe a strategic flavor, not anything else. Each is good at
+            two things and weak at one — pick the shape that fits how you like
+            to play.
+          </p>
+          <ul className="list-disc ml-6 mt-3 space-y-2">
+            <li>
+              <strong>White</strong> — light, hallowed, knightly. Defensive
+              specialist. Strong ground, very strong defense spells, weak
+              offense. Survives long enough to win the long game.
+            </li>
+            <li>
+              <strong>Blue</strong> — water, sky, moon. Magic specialist. Strong
+              air units, very strong production spells. Plays the economy.
+            </li>
+            <li>
+              <strong>Black</strong> — death, blood, bone. Generalist offense.
+              Slightly above average everywhere, devastating offensive spells.
+            </li>
+            <li>
+              <strong>Red</strong> — fire, fury, forge. Siege specialist. Strong
+              siege, brutal offense spells, fragile defense. Glass cannon.
+            </li>
+            <li>
+              <strong>Green</strong> — wood, growth, territory. The territory
+              caste. Highest tile capacity (more units per tile), strong ground.
+            </li>
+          </ul>
+          <p className="mt-3 text-sm text-neutral-500 dark:text-neutral-400">
+            The caste choice is permanent. You can&apos;t un-pick.
+          </p>
+        </Section>
+
+        <Section title="Step 4 — Build units">
+          <p>
+            Once you&apos;re in the play phase, head to <strong>Recruit</strong>
+             from any military tile. Each caste fields three unit types:
+          </p>
+          <ul className="list-disc ml-6 mt-3 space-y-1">
+            <li><strong>Ground.</strong> Bread-and-butter line infantry.</li>
+            <li><strong>Siege.</strong> Slow, expensive, breaks tile defenses.</li>
+            <li><strong>Air.</strong> Fast, fragile, ignores most ground terrain.</li>
+          </ul>
+          <p className="mt-3">
+            A recruit batch costs <strong>5 turns</strong> and produces a fixed
+            number of units, scaled by your caste&apos;s unit-type bonus. Your
+            army can&apos;t exceed the unit cap your food lands grant you.
+          </p>
+        </Section>
+
+        <Section title="Step 5 — Cast spells">
+          <p>
+            From the <strong>Spells</strong> page you can either <em>arm</em> a
+            tile with a defense spell (waiting to fire when attacked) or{" "}
+            <em>cast</em> an offense or production spell directly. Each spell
+            costs <strong>5 turns</strong>. Spell strength scales with your
+            magic-tile count and your caste&apos;s spell-type bonus.
+          </p>
+          <ul className="list-disc ml-6 mt-3 space-y-1">
+            <li><strong>Defense.</strong> Sits on a tile until attacked, then triggers.</li>
+            <li><strong>Offense.</strong> One-shot effect aimed at a target tile.</li>
+            <li><strong>Production.</strong> 100-turn buff to your unit cap.</li>
+          </ul>
+        </Section>
+
+        <Section title="Step 6 — Attack">
+          <p>
+            From <strong>Manage tiles</strong>, pick a tile bordering a neighbor
+            you want to take, choose how many units to send, and resolve the
+            attack. Attacks cost <strong>1 turn</strong>. Combat math is
+            deterministic and runs server-side — capacity, defense spells,
+            terrain, and the underdog rule all factor in.
+          </p>
+          <p className="mt-3">
+            New generals are <strong>shielded for 3 weeks</strong> (or until
+            they&apos;ve spent 300 turns, whichever is later). Shielded players
+            can&apos;t be attacked and can&apos;t initiate attacks — it&apos;s
+            time to build.
+          </p>
+        </Section>
+
+        <Section title="The turn economy">
+          <p>You start with <strong>300 turns</strong> when you enlist — enough
+            to assign every tile, recruit a real army, and push the frontier.
+          </p>
+          <p className="mt-3">After that, turns refill weekly:</p>
+          <ul className="list-disc ml-6 mt-3 space-y-1">
+            <li>
+              Merge at least one PR into <code className="text-xs px-1 rounded bg-neutral-100 dark:bg-neutral-800">cursor-boston</code>{" "}
+              during the week (Sunday-to-Sunday, EST).
+            </li>
+            <li>
+              The next Sunday at midnight EST, your bucket resets to{" "}
+              <strong>100 turns</strong>.
+            </li>
+            <li>No PR, no turns. The week skips you.</li>
+          </ul>
+          <p className="mt-3 text-sm text-neutral-500 dark:text-neutral-400">
+            Turn costs at a glance: explore 1, distribute 1, attack 1, recruit
+            5, spell 5.
+          </p>
+        </Section>
+
+        <Section title="Artifacts">
+          <p>
+            Every frontier-explore turn rolls a 3% chance to surface an
+            artifact: a single-use trinket pulled from the older war. Common,
+            rare, epic, legendary — strength scales with rarity. Artifacts live
+            in your inventory until you spend them.
+          </p>
+          <p className="mt-3 text-sm text-neutral-500 dark:text-neutral-400">
+            Some are useful, some are just strange. The Crown of the First
+            General sits on a stone bench in a sunlit grove. The grass beneath
+            the bench has not grown in centuries.
+          </p>
+        </Section>
+
+        <Section title="The world — a short lore note">
+          <p>
+            Generals lives in a vague pre-industrial world: banners and
+            quartermasters and frost on the morning grass. Five castes (white,
+            blue, black, red, green) wage long, slow campaigns across a hex
+            map that no one quite remembers settling.
+          </p>
+          <p className="mt-3">
+            The world&apos;s history is half-told and contradictory. There was
+            a <strong>First General</strong>, who wore a simple iron circlet
+            and never lost a battle. There is a <strong>Quiet King</strong>,
+            who never spoke and never lost either. There is{" "}
+            <strong>The Last Banner</strong>, planted in the center of an empty
+            battlefield whose battle the histories do not record. There is a{" "}
+            <strong>Stillborn Storm</strong> — a glass shard from a storm that
+            never finished forming. Your scouts find these things from time to
+            time, and your captains argue about them around the fire.
+          </p>
+          <p className="mt-3">
+            The tone the game tries to keep:
+          </p>
+          <ul className="list-disc ml-6 mt-3 space-y-1 text-sm text-neutral-600 dark:text-neutral-300">
+            <li>Sensory detail, not modern military jargon.</li>
+            <li>Magic happens. No one explains it.</li>
+            <li>Time slips — centuries-old grass, cold ash, dust still rising.</li>
+            <li>Death is present. It&apos;s not graphic.</li>
+            <li>No real-world places, religions, or historical figures.</li>
+          </ul>
+          <p className="mt-3">
+            If you find yourself reading the artifact descriptions out loud,
+            that&apos;s the right reaction.
+          </p>
+        </Section>
+
+        <Section title="A practical first-day plan">
+          <ol className="list-decimal ml-6 space-y-2">
+            <li>Bulk-assign your 25 starter tiles: ~10 food, ~10 military, ~5 magic. (~25 turns.)</li>
+            <li>Pick a caste that matches how you want to fight.</li>
+            <li>Recruit one or two batches of ground units. (~10 turns.)</li>
+            <li>Push the frontier 30-50 tiles outward — chase artifacts. (~30-50 turns.)</li>
+            <li>Sit back. Wait out the 3-week shield. Read the lore.</li>
+            <li>When the shield drops, find a neighbor and start something.</li>
+          </ol>
+          <p className="mt-3 text-sm text-neutral-500 dark:text-neutral-400">
+            That uses ~70-100 of your 300 starter turns. The rest is yours.
+          </p>
+        </Section>
+
+        <div className="mt-12 flex flex-wrap gap-3">
+          <Link
+            href="/game"
+            className="px-5 py-2.5 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+          >
+            ← Back to dashboard
+          </Link>
+          <Link
+            href="/game/leaderboard"
+            className="px-5 py-2.5 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+          >
+            Leaderboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  id,
+  children,
+}: {
+  title: string;
+  id?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10 scroll-mt-24">
+      <h2 className="text-xl font-semibold mb-3">{title}</h2>
+      <div className="text-neutral-700 dark:text-neutral-300 leading-relaxed">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/app/game/leaderboard/page.tsx
+++ b/app/game/leaderboard/page.tsx
@@ -13,6 +13,7 @@ import type { Caste, Phase } from "@/lib/game/types";
 
 interface LeaderRow {
   userId: string;
+  displayName: string;
   caste: Caste | null;
   phase: Phase;
   tilesHeld: number;
@@ -130,8 +131,10 @@ export default function LeaderboardPage() {
                   <td className="py-2 pr-2 font-mono text-neutral-500">
                     {i + 1}
                   </td>
-                  <td className="py-2 pr-2 font-mono text-xs">
-                    {r.userId === user.uid ? "You" : r.userId.slice(0, 10) + "…"}
+                  <td className="py-2 pr-2 text-sm">
+                    {r.userId === user.uid
+                      ? `${r.displayName || "You"} (you)`
+                      : r.displayName || "—"}
                   </td>
                   <td className="py-2 pr-2 capitalize">{r.caste ?? "—"}</td>
                   <td className="py-2 pr-2 text-right">{r.tilesHeld}</td>

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -62,6 +62,7 @@ export default function GameDashboardPage() {
     total: number;
     artifactsFound: number;
   } | null>(null);
+  const [nameInput, setNameInput] = useState("");
 
   const fetchPlayer = useCallback(async () => {
     setError(null);
@@ -105,28 +106,68 @@ export default function GameDashboardPage() {
     fetchPlayer();
   }, [authLoading, fetchPlayer]);
 
-  const handleCreatePlayer = useCallback(async () => {
-    if (!user) return;
-    setCreating(true);
-    setError(null);
-    try {
-      const token = await user.getIdToken();
-      const res = await fetch("/api/game/player", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-      });
-      const data = await res.json();
-      if (!data.success) throw new Error(data.error?.message ?? "Failed to create player");
-      await fetchPlayer();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to create player");
-    } finally {
-      setCreating(false);
-    }
-  }, [user, fetchPlayer]);
+  const handleCreatePlayer = useCallback(
+    async (displayName: string) => {
+      if (!user) return;
+      setCreating(true);
+      setError(null);
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/game/player", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ displayName }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          const msg =
+            typeof data.error === "string"
+              ? data.error
+              : data.error?.message ?? "Failed to create player";
+          throw new Error(msg);
+        }
+        await fetchPlayer();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to create player");
+      } finally {
+        setCreating(false);
+      }
+    },
+    [user, fetchPlayer]
+  );
+
+  const handleSetName = useCallback(
+    async (displayName: string) => {
+      if (!user) return;
+      setError(null);
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/game/player", {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ displayName }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          const msg =
+            typeof data.error === "string"
+              ? data.error
+              : data.error?.message ?? "Failed to save name";
+          throw new Error(msg);
+        }
+        await fetchPlayer();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to save name");
+      }
+    },
+    [user, fetchPlayer]
+  );
 
   const handleFrontierExplore = useCallback(
     async (count: number) => {
@@ -301,41 +342,131 @@ export default function GameDashboardPage() {
             into this repo any time during a week and you&apos;ll receive 100
             turns the following Sunday at midnight EST. No PR, no turns.
           </p>
-          <Link
-            href="/login"
-            className="inline-block px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
-          >
-            Sign In
-          </Link>
+          <div className="flex flex-wrap gap-3 justify-center">
+            <Link
+              href="/login"
+              className="inline-block px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors"
+            >
+              Sign In
+            </Link>
+            <Link
+              href="/game/help"
+              className="inline-block px-6 py-3 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            >
+              How to play
+            </Link>
+          </div>
         </div>
       </div>
     );
   }
 
   if (!player) {
+    const trimmed = nameInput.trim();
+    const canSubmit = trimmed.length >= 3 && trimmed.length <= 32 && !creating;
     return (
       <div className="min-h-screen flex items-center justify-center px-6">
         <div className="max-w-xl w-full text-center">
           <h1 className="text-3xl font-bold mb-4">Begin your campaign</h1>
           <p className="text-neutral-600 dark:text-neutral-300 mb-3">
-            You haven&apos;t enlisted yet. Pressing the button below will:
+            You haven&apos;t enlisted yet. Name your general and we&apos;ll:
           </p>
           <ul className="text-sm text-neutral-600 dark:text-neutral-400 mb-6 inline-block text-left list-disc ml-5">
             <li>Claim a 25-tile starting cluster, all already revealed.</li>
-            <li>Grant you 100 starter turns to assign land types and pick a caste.</li>
+            <li>Grant you 300 starter turns — enough to assign every tile, pick a caste, recruit a real army, and still push the frontier before next Sunday&apos;s rollover.</li>
             <li>Drop a 3-week shield over you so no one can attack until you&apos;ve had a chance to develop your forces.</li>
-            <li>From there: push the frontier, build armies, raid neighbors.</li>
+            <li>From there: explore outward, develop the lands you take, build units, raid neighbors.</li>
           </ul>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (canSubmit) handleCreatePlayer(trimmed);
+            }}
+            className="mb-3"
+          >
+            <label
+              htmlFor="general-name"
+              className="block text-left text-xs uppercase tracking-wide text-neutral-500 mb-1"
+            >
+              Name your general
+            </label>
+            <input
+              id="general-name"
+              type="text"
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+              placeholder="e.g. Captain Ash, The Quiet Hand"
+              maxLength={32}
+              className="w-full px-3 py-2 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-sm"
+              autoComplete="off"
+            />
+            <p className="mt-1 text-xs text-neutral-500 text-left">
+              3-32 characters. Letters, digits, spaces, apostrophes, hyphens.
+            </p>
+          </form>
           {error && (
             <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
           )}
-          <button
-            onClick={handleCreatePlayer}
-            disabled={creating}
-            className="px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors disabled:opacity-50"
+          <div className="flex flex-wrap gap-3 justify-center">
+            <button
+              onClick={() => handleCreatePlayer(trimmed)}
+              disabled={!canSubmit}
+              className="px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors disabled:opacity-50"
+            >
+              {creating ? "Spawning…" : "Enlist as a general"}
+            </button>
+            <Link
+              href="/game/help"
+              className="px-6 py-3 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            >
+              How to play
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Legacy gate: players who spawned before names were required get bounced
+  // through this picker on next visit.
+  if (!player.displayName) {
+    const trimmed = nameInput.trim();
+    const canSubmit = trimmed.length >= 3 && trimmed.length <= 32;
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md w-full text-center">
+          <h1 className="text-3xl font-bold mb-3">Name your general</h1>
+          <p className="text-neutral-600 dark:text-neutral-300 mb-6 text-sm leading-relaxed">
+            We retired anonymous IDs. Pick a name your fellow generals will see
+            on the map and the leaderboard. You can change it later.
+          </p>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (canSubmit) handleSetName(trimmed);
+            }}
           >
-            {creating ? "Spawning…" : "Enlist as a general"}
-          </button>
+            <input
+              type="text"
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+              placeholder="e.g. Captain Ash"
+              maxLength={32}
+              autoFocus
+              className="w-full px-3 py-2 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-sm mb-2"
+              autoComplete="off"
+            />
+            {error && (
+              <p className="mb-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+            )}
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors disabled:opacity-50"
+            >
+              Save name
+            </button>
+          </form>
         </div>
       </div>
     );
@@ -350,8 +481,22 @@ export default function GameDashboardPage() {
     <div className="min-h-screen py-12 px-6">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-baseline justify-between mb-8">
-          <h1 className="text-3xl font-bold">Generals — Dashboard</h1>
-          <span className="text-sm text-neutral-500">{user.email}</span>
+          <h1 className="text-3xl font-bold">{player.displayName}</h1>
+          <button
+            onClick={() => {
+              const next = window.prompt(
+                "Rename your general (3-32 chars)",
+                player.displayName
+              );
+              if (next && next.trim() && next.trim() !== player.displayName) {
+                handleSetName(next.trim());
+              }
+            }}
+            className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 underline"
+            title="Rename your general"
+          >
+            Rename
+          </button>
         </div>
 
         {error && (
@@ -518,6 +663,12 @@ export default function GameDashboardPage() {
             className="px-5 py-2.5 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
           >
             Leaderboard
+          </Link>
+          <Link
+            href="/game/help"
+            className="px-5 py-2.5 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+          >
+            Help &amp; Lore
           </Link>
           <button
             onClick={handleAdminGrant}

--- a/app/game/setup/page.tsx
+++ b/app/game/setup/page.tsx
@@ -9,9 +9,55 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
+import {
+  ALL_BUILDINGS,
+  CASTE_PROFILES,
+  getSpellForCasteAndType,
+  getUnitForCasteAndType,
+} from "@/lib/game/content";
 import type { Caste, GamePlayer, MapTile, LandType } from "@/lib/game/types";
 
 const CASTES: Caste[] = ["white", "blue", "black", "red", "green"];
+
+// Caste accent + lore text shown on the caste-pick card. Lore is intentionally
+// short (1 paragraph), matches the in-game restraint, and avoids real-world
+// references. Edit here when retuning caste identity; keep tone aligned with
+// docs/generals/LORE.md.
+const CASTE_PRESENTATION: Record<
+  Caste,
+  { swatch: string; tagline: string; lore: string }
+> = {
+  white: {
+    swatch: "#e5e7eb",
+    tagline: "Light · order · the long defense",
+    lore:
+      "White moves slowly and remembers everything. Their banners are old, their drills older, and their pikemen will hold a road for as many days as the road needs holding. Sanctuaries glow on the hilltops at dusk; the priests do not explain how.",
+  },
+  blue: {
+    swatch: "#60a5fa",
+    tagline: "Water · sky · the patient tide",
+    lore:
+      "Blue plays the long economy. Their captains are astronomers, their air corps moves on currents no scout can chart, and their production magic refills granaries through a winter no one can quite remember surviving. They win wars that began three seasons ago.",
+  },
+  black: {
+    swatch: "#a78bfa",
+    tagline: "Death · blood · the cost paid forward",
+    lore:
+      "Black armies are quiet at the edges and loud in the middle. Their reavers are bone-armored and tireless; their blood-tide spells fall on a battlefield like a price already settled. They take towns by walking through them. They keep no prisoners they can spare.",
+  },
+  red: {
+    swatch: "#f87171",
+    tagline: "Fire · forge · the short hot sentence",
+    lore:
+      "Red wars are decided in three days or three minutes. Their siege foundries turn out trebuchets that smell of pitch and bone-glue; their pyre-mortars throw heat that cracks stone. Their defenses are thin because their generals do not intend to need them.",
+  },
+  green: {
+    swatch: "#4ade80",
+    tagline: "Wood · growth · the held line",
+    lore:
+      "Green takes ground and keeps it. Their wardens build deeper than other castes, and their tiles hold more soldiers per acre because the soldiers eat from the land they stand on. Their air is weak; they don't intend to leave the ground.",
+  },
+};
 const DISTRIBUTABLE: LandType[] = ["military", "food", "magic"];
 
 interface PlayerResponse {
@@ -443,27 +489,17 @@ function DistributePanel({
       <div className="mb-6">
         <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed space-y-2">
           <p className="font-semibold">Step 3 of 3 — Pick a caste (permanent)</p>
-          <p>Each caste tilts your unit and spell strengths. You cannot change later.</p>
-          <ul className="list-disc ml-5">
-            <li><strong>White</strong> — defense / order. Strong ground units, strongest defense spells. Good for turtling.</li>
-            <li><strong>Blue</strong> — control / magic. Strong air units, strongest production spells (food cap boosts). Good for tempo.</li>
-            <li><strong>Black</strong> — sacrifice / swarm. Cheap balanced units, strong offense spells. Good for grinding wars.</li>
-            <li><strong>Red</strong> — aggression / fire. Strong siege, strongest offense spells. Good for blitzing.</li>
-            <li><strong>Green</strong> — growth. +20% tile capacity (so your tiles hold more units), strong ground swarms. Good for fortified expansion.</li>
-          </ul>
+          <p>Each card shows the lore, the three units you&apos;ll recruit, the three spells you&apos;ll cast, and the building upgrades available. The choice is locked the moment you pick.</p>
         </div>
 
-        <h2 className="font-semibold mb-3">Choose your caste to start playing</h2>
-        <div className="flex flex-wrap gap-2">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
           {CASTES.map((c) => (
-            <button
+            <CastePickCard
               key={c}
-              onClick={() => onChooseCaste(c)}
-              disabled={busy}
-              className="px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors capitalize disabled:opacity-50"
-            >
-              {c}
-            </button>
+              caste={c}
+              busy={busy}
+              onChoose={() => onChooseCaste(c)}
+            />
           ))}
         </div>
         <p className="text-xs text-neutral-500 mt-2">
@@ -514,4 +550,196 @@ function Counter({ label, value }: { label: string; value: number }) {
       <div className="text-lg font-semibold">{value}</div>
     </div>
   );
+}
+
+function CastePickCard({
+  caste,
+  busy,
+  onChoose,
+}: {
+  caste: Caste;
+  busy: boolean;
+  onChoose: () => void;
+}) {
+  const presentation = CASTE_PRESENTATION[caste];
+  const profile = CASTE_PROFILES[caste];
+  const ground = getUnitForCasteAndType(caste, "ground");
+  const siege = getUnitForCasteAndType(caste, "siege");
+  const air = getUnitForCasteAndType(caste, "air");
+  const defense = getSpellForCasteAndType(caste, "defense");
+  const offense = getSpellForCasteAndType(caste, "offense");
+  const production = getSpellForCasteAndType(caste, "production");
+  const buildings = ALL_BUILDINGS.filter(
+    (b) => b.caste === caste || b.caste === "neutral"
+  );
+
+  return (
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg p-4 bg-white dark:bg-neutral-950 flex flex-col">
+      <div className="flex items-center gap-3 mb-2">
+        <span
+          aria-hidden="true"
+          className="inline-block w-4 h-4 rounded-full border border-neutral-300 dark:border-neutral-700"
+          style={{ background: presentation.swatch }}
+        />
+        <h3 className="text-lg font-semibold capitalize">{caste}</h3>
+        <span className="text-xs text-neutral-500">{presentation.tagline}</span>
+      </div>
+
+      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed mb-3">
+        {presentation.lore}
+      </p>
+
+      <div className="grid grid-cols-3 gap-2 text-xs mb-3">
+        <Stat label="Tile cap" value={`×${profile.tileCapacityMultiplier.toFixed(2)}`} />
+        <Stat
+          label="Strongest unit"
+          value={topKey(profile.unitTypeBonuses)}
+        />
+        <Stat
+          label="Strongest spell"
+          value={topKey(profile.spellTypeBonuses)}
+        />
+      </div>
+
+      <details className="mb-2 text-sm" open>
+        <summary className="cursor-pointer font-medium text-xs uppercase tracking-wide text-neutral-500">
+          Units
+        </summary>
+        <div className="mt-2 space-y-2">
+          <UnitLine unit={ground} bonus={profile.unitTypeBonuses.ground} />
+          <UnitLine unit={siege} bonus={profile.unitTypeBonuses.siege} />
+          <UnitLine unit={air} bonus={profile.unitTypeBonuses.air} />
+        </div>
+      </details>
+
+      <details className="mb-2 text-sm">
+        <summary className="cursor-pointer font-medium text-xs uppercase tracking-wide text-neutral-500">
+          Spells
+        </summary>
+        <div className="mt-2 space-y-2">
+          <SpellLine
+            spell={defense}
+            slot="defense"
+            bonus={profile.spellTypeBonuses.defense}
+          />
+          <SpellLine
+            spell={offense}
+            slot="offense"
+            bonus={profile.spellTypeBonuses.offense}
+          />
+          <SpellLine
+            spell={production}
+            slot="production"
+            bonus={profile.spellTypeBonuses.production}
+          />
+        </div>
+      </details>
+
+      <details className="mb-3 text-sm">
+        <summary className="cursor-pointer font-medium text-xs uppercase tracking-wide text-neutral-500">
+          Buildings ({buildings.length})
+        </summary>
+        <div className="mt-2 text-sm">
+          {buildings.length === 0 ? (
+            <p className="text-neutral-500 italic text-xs">
+              No building upgrades yet — coming in v2. Tile improvements
+              currently come from the artifact pool and from production spells.
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {buildings.map((b) => (
+                <li key={b.id} className="text-xs">
+                  <span className="font-medium">{b.name}</span>
+                  <span className="text-neutral-500"> — {b.description}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </details>
+
+      <button
+        onClick={onChoose}
+        disabled={busy}
+        className="mt-auto w-full px-4 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 transition-colors capitalize disabled:opacity-50"
+      >
+        {busy ? "Locking…" : `Pick ${caste}`}
+      </button>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-neutral-200 dark:border-neutral-800 p-1.5 text-center">
+      <div className="text-[10px] uppercase tracking-wide text-neutral-500">
+        {label}
+      </div>
+      <div className="text-sm font-semibold capitalize">{value}</div>
+    </div>
+  );
+}
+
+function UnitLine({
+  unit,
+  bonus,
+}: {
+  unit: ReturnType<typeof getUnitForCasteAndType>;
+  bonus: number;
+}) {
+  return (
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded p-2">
+      <div className="flex items-baseline justify-between">
+        <span className="font-medium">{unit.name}</span>
+        <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+          {unit.type} · ×{bonus.toFixed(2)}
+        </span>
+      </div>
+      <div className="text-xs text-neutral-500 mt-0.5">
+        ATK {unit.attack} · DEF {unit.defense} · HP {unit.hp}
+      </div>
+      <div className="text-xs text-neutral-600 dark:text-neutral-400 italic mt-1">
+        {unit.description}
+      </div>
+    </div>
+  );
+}
+
+function SpellLine({
+  spell,
+  slot,
+  bonus,
+}: {
+  spell: ReturnType<typeof getSpellForCasteAndType>;
+  slot: "defense" | "offense" | "production";
+  bonus: number;
+}) {
+  return (
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded p-2">
+      <div className="flex items-baseline justify-between">
+        <span className="font-medium">{spell.name}</span>
+        <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+          {slot} · ×{bonus.toFixed(2)}
+        </span>
+      </div>
+      <div className="text-xs text-neutral-500 mt-0.5">
+        Base strength {spell.baseStrength}
+      </div>
+      <div className="text-xs text-neutral-600 dark:text-neutral-400 italic mt-1">
+        {spell.description}
+      </div>
+    </div>
+  );
+}
+
+function topKey(record: Record<string, number>): string {
+  let bestKey = "";
+  let bestVal = -Infinity;
+  for (const [k, v] of Object.entries(record)) {
+    if (v > bestVal) {
+      bestVal = v;
+      bestKey = k;
+    }
+  }
+  return bestKey;
 }

--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -8,14 +8,36 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import type { GamePlayer, MapTile, LandType } from "@/lib/game/types";
+import type { Caste, GamePlayer, MapTile, LandType } from "@/lib/game/types";
 
 interface PlayerResponse {
   success: boolean;
   player: GamePlayer | null;
   tiles: MapTile[];
+  error?: string;
+}
+
+interface OwnerSummary {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+}
+
+interface WorldResponse {
+  success: boolean;
+  tiles?: MapTile[];
+  owners?: OwnerSummary[];
   error?: string;
 }
 
@@ -28,13 +50,16 @@ const LAND_FILTERS: Array<LandType | "all"> = [
   "unrevealed",
 ];
 
-// Pixel size of a single hex (radius from center to corner).
+type ScopeFilter = "everyone" | "mine" | "foreign";
+
 const HEX_SIZE = 28;
 const SQRT3 = Math.sqrt(3);
-// Outer-edge padding around the bounding box, in pixels.
 const VIEWPORT_PADDING = HEX_SIZE * 1.5;
 
-// Pointy-top axial → pixel.
+const MIN_SCALE = 0.3;
+const MAX_SCALE = 4;
+const ZOOM_STEP = 1.15;
+
 function axialToPixel(q: number, r: number): { x: number; y: number } {
   return {
     x: HEX_SIZE * SQRT3 * (q + r / 2),
@@ -42,7 +67,6 @@ function axialToPixel(q: number, r: number): { x: number; y: number } {
   };
 }
 
-// Six vertices of a pointy-top hex centered at (cx, cy), as "x,y x,y …".
 function hexPoints(cx: number, cy: number): string {
   const dx = (HEX_SIZE * SQRT3) / 2;
   const dy = HEX_SIZE / 2;
@@ -58,8 +82,6 @@ function hexPoints(cx: number, cy: number): string {
     .join(" ");
 }
 
-// Tailwind-resolved colors for each land type. Keep the saturation low enough
-// that the field-report blue badge inside a tile still reads.
 const TYPE_FILL: Record<LandType, string> = {
   unrevealed: "#262626",
   unassigned: "#525252",
@@ -84,14 +106,40 @@ const TYPE_TEXT: Record<LandType, string> = {
   magic: "#fff",
 };
 
+// Caste-keyed border accent for foreign tiles. Picked to match the in-game
+// palette (white = stone, blue = sky, black = bone, red = ember, green = moss).
+const CASTE_BORDER: Record<Caste, string> = {
+  white: "#e5e7eb",
+  blue: "#60a5fa",
+  black: "#a78bfa",
+  red: "#f87171",
+  green: "#4ade80",
+};
+
 export default function TilesMapPage() {
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
   const [tiles, setTiles] = useState<MapTile[]>([]);
+  const [ownersById, setOwnersById] = useState<Map<string, OwnerSummary>>(
+    new Map()
+  );
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<LandType | "all">("all");
+  const [scope, setScope] = useState<ScopeFilter>("everyone");
   const [hovered, setHovered] = useState<MapTile | null>(null);
+
+  // Pan/zoom state — applied as an SVG transform on the rendered group.
+  // Initial values are recomputed from the world bounding box on first load.
+  const [scale, setScale] = useState(1);
+  const [tx, setTx] = useState(0);
+  const [ty, setTy] = useState(0);
+  const [didFit, setDidFit] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const dragRef = useRef<{ x: number; y: number; tx: number; ty: number } | null>(
+    null
+  );
 
   const refresh = useCallback(async () => {
     if (!user) {
@@ -100,13 +148,22 @@ export default function TilesMapPage() {
     }
     try {
       const token = await user.getIdToken();
-      const res = await fetch("/api/game/player", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = (await res.json()) as PlayerResponse;
-      if (data.success) {
-        setPlayer(data.player);
-        setTiles(data.tiles ?? []);
+      const [playerRes, worldRes] = await Promise.all([
+        fetch("/api/game/player", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch("/api/game/world", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+      const playerData = (await playerRes.json()) as PlayerResponse;
+      const worldData = (await worldRes.json()) as WorldResponse;
+      if (playerData.success) setPlayer(playerData.player);
+      if (worldData.success) {
+        setTiles(worldData.tiles ?? []);
+        const map = new Map<string, OwnerSummary>();
+        for (const o of worldData.owners ?? []) map.set(o.userId, o);
+        setOwnersById(map);
       }
     } finally {
       setLoading(false);
@@ -115,13 +172,13 @@ export default function TilesMapPage() {
 
   useEffect(() => {
     if (authLoading) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount
     refresh();
   }, [authLoading, refresh]);
 
-  // Compute the SVG viewBox once per tile-set change. Memoize so re-renders
-  // (filter, hover) don't re-run the math.
-  const viewBox = useMemo(() => {
+  // Bounding box of every tile we know about. Drives the initial fit-to-screen
+  // and the visible viewBox.
+  const bbox = useMemo(() => {
     if (tiles.length === 0) return null;
     let minX = Number.POSITIVE_INFINITY;
     let maxX = Number.NEGATIVE_INFINITY;
@@ -134,12 +191,123 @@ export default function TilesMapPage() {
       if (y < minY) minY = y;
       if (y > maxY) maxY = y;
     }
-    const x = minX - VIEWPORT_PADDING;
-    const y = minY - VIEWPORT_PADDING;
-    const width = maxX - minX + 2 * VIEWPORT_PADDING;
-    const height = maxY - minY + 2 * VIEWPORT_PADDING;
-    return { x, y, width, height };
+    return {
+      x: minX - VIEWPORT_PADDING,
+      y: minY - VIEWPORT_PADDING,
+      width: maxX - minX + 2 * VIEWPORT_PADDING,
+      height: maxY - minY + 2 * VIEWPORT_PADDING,
+    };
   }, [tiles]);
+
+  // First-time fit: center the viewport on the player's own tiles so they
+  // know where they are. Runs once when player + tiles are first available,
+  // or when the user clicks the recenter (⌖) button (which flips didFit back).
+  /* eslint-disable react-hooks/set-state-in-effect -- one-shot fit on data arrival */
+  useEffect(() => {
+    if (didFit || !player || tiles.length === 0) return;
+    const own = tiles.filter((t) => t.ownerId === player.userId);
+    if (own.length === 0) {
+      if (bbox) {
+        setTx(-(bbox.x + bbox.width / 2));
+        setTy(-(bbox.y + bbox.height / 2));
+        setScale(1);
+      }
+      setDidFit(true);
+      return;
+    }
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (const t of own) {
+      const { x, y } = axialToPixel(t.q, t.r);
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    setTx(-(minX + maxX) / 2);
+    setTy(-(minY + maxY) / 2);
+    setScale(1);
+    setDidFit(true);
+  }, [didFit, player, tiles, bbox]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Wheel zoom around the cursor.
+  const handleWheel = useCallback(
+    (e: ReactWheelEvent<SVGSVGElement>) => {
+      if (!svgRef.current) return;
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+      const next = Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale * factor));
+      if (next === scale) return;
+      // Convert cursor to SVG-local coordinates so the point under the cursor
+      // stays put across the zoom step.
+      const rect = svgRef.current.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      // World-space cursor position before the zoom.
+      const worldX = (cx - rect.width / 2) / scale - tx;
+      const worldY = (cy - rect.height / 2) / scale - ty;
+      // Solve for new tx, ty so that worldX/worldY map back to the same cx/cy.
+      const newTx = (cx - rect.width / 2) / next - worldX;
+      const newTy = (cy - rect.height / 2) / next - worldY;
+      setScale(next);
+      setTx(newTx);
+      setTy(newTy);
+    },
+    [scale, tx, ty]
+  );
+
+  const handlePointerDown = useCallback(
+    (e: ReactPointerEvent<SVGSVGElement>) => {
+      if (e.button !== 0 && e.pointerType === "mouse") return;
+      dragRef.current = { x: e.clientX, y: e.clientY, tx, ty };
+      setDragging(true);
+      (e.currentTarget as Element).setPointerCapture(e.pointerId);
+    },
+    [tx, ty]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: ReactPointerEvent<SVGSVGElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const dx = (e.clientX - drag.x) / scale;
+      const dy = (e.clientY - drag.y) / scale;
+      setTx(drag.tx + dx);
+      setTy(drag.ty + dy);
+    },
+    [scale]
+  );
+
+  const handlePointerUp = useCallback(
+    (e: ReactPointerEvent<SVGSVGElement>) => {
+      dragRef.current = null;
+      setDragging(false);
+      try {
+        (e.currentTarget as Element).releasePointerCapture(e.pointerId);
+      } catch {
+        /* already released */
+      }
+    },
+    []
+  );
+
+  const handleTileClick = useCallback(
+    (t: MapTile) => {
+      // Don't fire on the click that ended a drag — pointermove with no
+      // movement still sets dragRef briefly, but click only fires when the
+      // browser decides the pointer didn't move enough to be a drag.
+      if (!player) return;
+      if (t.ownerId === player.userId) {
+        router.push(`/game/tiles/${encodeURIComponent(t.tileId)}`);
+        return;
+      }
+      // Foreign tile — surface in hover card; no click-action wired yet.
+    },
+    [player, router]
+  );
 
   if (authLoading || loading) {
     return (
@@ -159,11 +327,22 @@ export default function TilesMapPage() {
     );
   }
 
+  const ownTiles = tiles.filter((t) => t.ownerId === player.userId);
+  const visibleTiles = tiles.filter((t) => {
+    if (scope === "mine" && t.ownerId !== player.userId) return false;
+    if (scope === "foreign" && t.ownerId === player.userId) return false;
+    return true;
+  });
+
+  const hoveredOwner = hovered && hovered.ownerId
+    ? ownersById.get(hovered.ownerId) ?? null
+    : null;
+
   return (
     <div className="min-h-screen py-12 px-6">
       <div className="max-w-6xl mx-auto">
         <div className="flex items-baseline justify-between mb-6">
-          <h1 className="text-3xl font-bold">Your territory</h1>
+          <h1 className="text-3xl font-bold">World map</h1>
           <Link
             href="/game"
             className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
@@ -174,10 +353,39 @@ export default function TilesMapPage() {
 
         <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed">
           <p>
-            Your lands rendered in hex space. Hover for details, click to
-            manage. The filter chips below dim non-matching tiles so you can
-            see your territory composition at a glance.
+            Drag to pan, scroll to zoom. Your tiles render in full color with
+            their land type; foreign tiles fade and pick up a caste-colored
+            ring. Generals still under the new-player shield show a lock —
+            they can&apos;t be attacked yet.
           </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 mb-3">
+          <span className="text-xs uppercase tracking-wide text-neutral-500 self-center mr-1">
+            Show
+          </span>
+          {(
+            [
+              { key: "everyone", label: `Everyone (${tiles.length})` },
+              { key: "mine", label: `Mine (${ownTiles.length})` },
+              {
+                key: "foreign",
+                label: `Foreign (${tiles.length - ownTiles.length})`,
+              },
+            ] as Array<{ key: ScopeFilter; label: string }>
+          ).map((opt) => (
+            <button
+              key={opt.key}
+              onClick={() => setScope(opt.key)}
+              className={`px-3 py-1.5 rounded-lg text-sm border ${
+                scope === opt.key
+                  ? "bg-emerald-500 text-white border-emerald-500"
+                  : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
         </div>
 
         <div className="flex flex-wrap gap-2 mb-4">
@@ -191,74 +399,105 @@ export default function TilesMapPage() {
                   : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               }`}
             >
-              {t} ({t === "all" ? tiles.length : tiles.filter((x) => x.type === t).length})
+              {t} (
+              {t === "all"
+                ? visibleTiles.length
+                : visibleTiles.filter((x) => x.type === t).length}
+              )
             </button>
           ))}
         </div>
 
         {tiles.length === 0 ? (
           <p className="text-center text-neutral-500 py-12">
-            You don&apos;t own any tiles yet.
+            The world is empty.
           </p>
         ) : (
           <div className="relative">
             <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg overflow-hidden bg-neutral-50 dark:bg-neutral-950">
-              {viewBox && (
-                <svg
-                  viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
-                  className="w-full h-auto"
-                  style={{
-                    maxHeight: "70vh",
-                    minHeight: "400px",
-                  }}
+              <svg
+                ref={svgRef}
+                onWheel={handleWheel}
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                onPointerCancel={handlePointerUp}
+                className="w-full h-auto block touch-none select-none"
+                style={{
+                  // viewBox stays anchored at -W/2..W/2 in SVG units; we apply
+                  // pan/zoom via the inner <g> transform so coordinate math
+                  // stays simple.
+                  height: "70vh",
+                  cursor: dragging ? "grabbing" : "grab",
+                }}
+                viewBox="-600 -400 1200 800"
+                preserveAspectRatio="xMidYMid meet"
+              >
+                <g
+                  transform={`scale(${scale}) translate(${tx} ${ty})`}
                 >
-                  {tiles.map((t) => {
+                  {visibleTiles.map((t) => {
                     const { x, y } = axialToPixel(t.q, t.r);
-                    const matched =
-                      filter === "all" || t.type === filter;
+                    const matched = filter === "all" || t.type === filter;
+                    const isOwn = t.ownerId === player.userId;
+                    const owner = t.ownerId
+                      ? ownersById.get(t.ownerId) ?? null
+                      : null;
                     const fill = TYPE_FILL[t.type];
-                    const stroke = TYPE_STROKE[t.type];
+                    const stroke = isOwn
+                      ? TYPE_STROKE[t.type]
+                      : owner?.caste
+                      ? CASTE_BORDER[owner.caste]
+                      : "#737373";
                     const text = TYPE_TEXT[t.type];
                     const armed = !!t.armedDefenseSpellId;
                     const totalUnits =
                       t.units.ground + t.units.siege + t.units.air;
+                    const opacity = !matched
+                      ? 0.12
+                      : isOwn
+                      ? 1
+                      : 0.6;
                     return (
                       <g
                         key={t.tileId}
-                        opacity={matched ? 1 : 0.18}
+                        opacity={opacity}
                         onMouseEnter={() => setHovered(t)}
                         onMouseLeave={() =>
                           setHovered((cur) =>
                             cur?.tileId === t.tileId ? null : cur
                           )
                         }
-                        onClick={() =>
-                          router.push(
-                            `/game/tiles/${encodeURIComponent(t.tileId)}`
-                          )
-                        }
-                        style={{ cursor: "pointer" }}
+                        onClick={(e) => {
+                          // Suppress click if a drag just ended this frame.
+                          if (Math.abs(e.movementX) + Math.abs(e.movementY) > 2)
+                            return;
+                          handleTileClick(t);
+                        }}
+                        style={{
+                          cursor: isOwn ? "pointer" : "default",
+                        }}
                       >
                         <polygon
                           points={hexPoints(x, y)}
                           fill={fill}
                           stroke={stroke}
-                          strokeWidth={1.5}
+                          strokeWidth={isOwn ? 1.5 : 2.25}
                         />
-                        {/* Tile id, small */}
-                        <text
-                          x={x}
-                          y={y - 6}
-                          textAnchor="middle"
-                          fontSize={9}
-                          fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
-                          fill={text}
-                          opacity={0.85}
-                          style={{ pointerEvents: "none" }}
-                        >
-                          {t.tileId}
-                        </text>
-                        {/* Unit count if any */}
+                        {isOwn && (
+                          <text
+                            x={x}
+                            y={y - 6}
+                            textAnchor="middle"
+                            fontSize={9}
+                            fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+                            fill={text}
+                            opacity={0.85}
+                            style={{ pointerEvents: "none" }}
+                          >
+                            {t.tileId}
+                          </text>
+                        )}
                         {totalUnits > 0 && (
                           <text
                             x={x}
@@ -272,7 +511,6 @@ export default function TilesMapPage() {
                             {totalUnits}
                           </text>
                         )}
-                        {/* Defense armed marker */}
                         {armed && (
                           <circle
                             cx={x + HEX_SIZE * 0.55}
@@ -284,14 +522,55 @@ export default function TilesMapPage() {
                             style={{ pointerEvents: "none" }}
                           />
                         )}
+                        {/* Shield indicator on foreign tiles */}
+                        {!isOwn && owner?.shielded && (
+                          <text
+                            x={x - HEX_SIZE * 0.55}
+                            y={y - HEX_SIZE * 0.4}
+                            fontSize={11}
+                            style={{ pointerEvents: "none" }}
+                          >
+                            🛡
+                          </text>
+                        )}
                       </g>
                     );
                   })}
-                </svg>
-              )}
+                </g>
+              </svg>
             </div>
 
-            {/* Hover info card, anchored bottom-right */}
+            {/* Zoom controls */}
+            <div className="absolute top-3 right-3 flex flex-col gap-1 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg shadow-sm">
+              <button
+                onClick={() =>
+                  setScale((s) => Math.min(MAX_SCALE, s * ZOOM_STEP))
+                }
+                className="px-2.5 py-1.5 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-t-lg"
+                title="Zoom in"
+              >
+                +
+              </button>
+              <button
+                onClick={() =>
+                  setScale((s) => Math.max(MIN_SCALE, s / ZOOM_STEP))
+                }
+                className="px-2.5 py-1.5 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800 border-t border-neutral-200 dark:border-neutral-800"
+                title="Zoom out"
+              >
+                −
+              </button>
+              <button
+                onClick={() => {
+                  setDidFit(false); // re-trigger the fit effect
+                }}
+                className="px-2.5 py-1.5 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-b-lg border-t border-neutral-200 dark:border-neutral-800"
+                title="Recenter on your territory"
+              >
+                ⌖
+              </button>
+            </div>
+
             {hovered && (
               <div className="absolute bottom-3 right-3 max-w-xs rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 p-3 text-xs shadow-lg pointer-events-none">
                 <div className="flex items-baseline justify-between mb-1">
@@ -311,9 +590,30 @@ export default function TilesMapPage() {
                     Armed: {hovered.armedDefenseSpellId}
                   </div>
                 )}
-                <div className="text-neutral-500 mt-1 italic">
-                  click to manage →
-                </div>
+                {hovered.ownerId && hovered.ownerId !== player.userId && (
+                  <div className="mt-2 pt-2 border-t border-neutral-200 dark:border-neutral-800">
+                    <div className="font-semibold">
+                      {hoveredOwner?.displayName || "Unnamed general"}
+                    </div>
+                    <div className="text-neutral-500 capitalize">
+                      {hoveredOwner?.caste ?? "no caste"}
+                    </div>
+                    {hoveredOwner?.shielded ? (
+                      <div className="text-amber-600 dark:text-amber-400 mt-1">
+                        🛡 Shielded — can&apos;t be attacked yet
+                      </div>
+                    ) : (
+                      <div className="text-red-600 dark:text-red-400 mt-1">
+                        Targetable
+                      </div>
+                    )}
+                  </div>
+                )}
+                {hovered.ownerId === player.userId && (
+                  <div className="text-neutral-500 mt-1 italic">
+                    click to manage →
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -331,6 +631,9 @@ export default function TilesMapPage() {
               style={{ background: "#60a5fa" }}
             />
             defense armed
+          </span>
+          <span className="inline-flex items-center gap-1.5 ml-2">
+            🛡 shielded
           </span>
         </div>
       </div>

--- a/lib/game/api-error-map.ts
+++ b/lib/game/api-error-map.ts
@@ -17,8 +17,10 @@ import {
   GameInsufficientUnitsError,
   GameInvalidCasteError,
   GameInvalidLandTypeError,
+  GameInvalidNameError,
   GameInvalidPhaseError,
   GameInvalidSpellError,
+  GameNameTakenError,
   GameNoUnrevealedTilesError,
   GameNotAdjacentError,
   GamePlayerAlreadyExistsError,
@@ -60,7 +62,8 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameUnitCapExceededError ||
     error instanceof GameTileTypeError ||
     error instanceof GameFrontierExhaustedError ||
-    error instanceof GameArtifactAlreadyUsedError
+    error instanceof GameArtifactAlreadyUsedError ||
+    error instanceof GameNameTakenError
   ) {
     return apiError(error.message, 409);
   }
@@ -69,7 +72,8 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameInvalidCasteError ||
     error instanceof GameInvalidSpellError ||
     error instanceof GameNotAdjacentError ||
-    error instanceof GameSelfAttackError
+    error instanceof GameSelfAttackError ||
+    error instanceof GameInvalidNameError
   ) {
     return apiError(error.message, 400);
   }

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -34,6 +34,7 @@ import {
   nextRolloverInstant,
   priorWeekRangeUtc,
   pruneExpiredProductionSpells,
+  validateGeneralName,
   weekStartIsoForRollover,
 } from "./turns";
 import type {
@@ -216,6 +217,18 @@ export class GameArtifactAlreadyUsedError extends Error {
     this.name = "GameArtifactAlreadyUsedError";
   }
 }
+export class GameInvalidNameError extends Error {
+  constructor(reason: string) {
+    super(`Invalid general name: ${reason}`);
+    this.name = "GameInvalidNameError";
+  }
+}
+export class GameNameTakenError extends Error {
+  constructor() {
+    super("That general name is already in use");
+    this.name = "GameNameTakenError";
+  }
+}
 
 const COLLECTIONS = {
   PLAYERS: "game_players",
@@ -335,6 +348,65 @@ export async function getOwnedMapTilesServer(
   });
 }
 
+// Global map view. Returns every tile in the world with the lightweight
+// MapTile projection. The whole world today is ~500 tiles (one batch); if it
+// grows beyond a few thousand, switch to a viewport bounding-box query
+// (where q ∈ [minQ, maxQ] and r ∈ [minR, maxR]).
+export async function getAllMapTilesServer(): Promise<MapTile[]> {
+  const db = adminDbOrThrow();
+  const snap = await db
+    .collection(COLLECTIONS.TILES)
+    .select("tileId", "q", "r", "type", "ownerId", "units", "armedDefenseSpellId")
+    .get();
+  return snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      tileId: data.tileId,
+      q: data.q,
+      r: data.r,
+      type: data.type,
+      ownerId: data.ownerId ?? null,
+      units: data.units,
+      armedDefenseSpellId: data.armedDefenseSpellId ?? null,
+    } as MapTile;
+  });
+}
+
+export interface OwnerSummary {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+}
+
+// Owner-side metadata for the global map: name, caste, shield status. One
+// record per player; the client joins it onto tiles by ownerId.
+export async function getAllOwnerSummariesServer(
+  now: Date = new Date()
+): Promise<OwnerSummary[]> {
+  const db = adminDbOrThrow();
+  const snap = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .select(
+      "userId",
+      "displayName",
+      "caste",
+      "shieldUntil",
+      "shieldDropAtTurn",
+      "turnsSpentTotal"
+    )
+    .get();
+  return snap.docs.map((d) => {
+    const data = d.data() as GamePlayer;
+    return {
+      userId: data.userId,
+      displayName: data.displayName ?? "",
+      caste: data.caste ?? null,
+      shielded: isShieldActive(data, now),
+    };
+  });
+}
+
 export async function getTileServer(tileId: string): Promise<GameTile | null> {
   const db = adminDbOrThrow();
   const snap = await db.collection(COLLECTIONS.TILES).doc(tileId).get();
@@ -352,9 +424,27 @@ const NEW_PLAYER_EXCLAVES_MAX = 5;
 // parallel spawns land on different centers.
 export async function createPlayerWithSpawnServer(
   userId: string,
+  rawDisplayName: string,
   now: Date = new Date()
 ): Promise<{ player: GamePlayer; tileIds: string[] }> {
   const db = adminDbOrThrow();
+  const cleanedName = (() => {
+    try {
+      return validateGeneralName(rawDisplayName);
+    } catch (e) {
+      throw new GameInvalidNameError(
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+  })();
+  // Pre-flight uniqueness check outside the txn (transactions can't run
+  // queries). The set inside the txn still guards against same-user double
+  // spawn via GamePlayerAlreadyExistsError; a same-name race between two
+  // brand-new users in the same instant is vanishingly rare given the
+  // 4-player population, so we accept the small TOCTOU window.
+  const taken = await isGeneralNameTakenServer(cleanedName, userId);
+  if (taken) throw new GameNameTakenError();
+
   const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(userId);
   const metaRef = db
     .collection(COLLECTIONS.WORLD_META)
@@ -387,8 +477,12 @@ export async function createPlayerWithSpawnServer(
       initialPhase: "distribute",
       tilesHeld: spawn.tileIds.length,
       tilesExplored: spawn.tileIds.length,
+      displayName: cleanedName,
     });
-    tx.set(playerRef, player);
+    tx.set(playerRef, {
+      ...player,
+      displayNameLower: cleanedName.toLowerCase(),
+    });
 
     for (const tileId of spawn.tileIds) {
       const tileRef = db.collection(COLLECTIONS.TILES).doc(tileId);
@@ -1853,6 +1947,61 @@ export async function runWeeklyRolloverServer(
     errorCount: summary.errors.length,
   });
   return summary;
+}
+
+// Case-insensitive uniqueness check. Excludes `excludeUserId` so a player
+// can re-save their own current name (no-op rename).
+export async function isGeneralNameTakenServer(
+  name: string,
+  excludeUserId?: string
+): Promise<boolean> {
+  const db = adminDbOrThrow();
+  const trimmed = name.trim();
+  if (!trimmed) return false;
+  const lower = trimmed.toLowerCase();
+  // Firestore can't do case-insensitive equality, so we store a derived field
+  // on write. Falls back to scanning — N is small (4 today, hundreds at peak).
+  // If the player count grows beyond a few thousand, denormalize to a
+  // game_player_names collection keyed by lowercased name.
+  const snap = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .where("displayNameLower", "==", lower)
+    .limit(1)
+    .get();
+  if (snap.empty) return false;
+  const doc = snap.docs[0];
+  if (excludeUserId && doc.id === excludeUserId) return false;
+  return true;
+}
+
+export async function setGeneralNameServer(
+  userId: string,
+  rawName: string,
+  now: Date = new Date()
+): Promise<GamePlayer> {
+  const db = adminDbOrThrow();
+  const cleaned = (() => {
+    try {
+      return validateGeneralName(rawName);
+    } catch (e) {
+      throw new GameInvalidNameError(
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+  })();
+  const taken = await isGeneralNameTakenServer(cleaned, userId);
+  if (taken) throw new GameNameTakenError();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(userId);
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(playerRef);
+    if (!snap.exists) throw new GamePlayerNotFoundError();
+    tx.update(playerRef, {
+      displayName: cleaned,
+      displayNameLower: cleaned.toLowerCase(),
+      updatedAt: now,
+    });
+    return { ...(snap.data() as GamePlayer), displayName: cleaned, updatedAt: now };
+  });
 }
 
 export async function getLeaderboardServer(

--- a/lib/game/turns.ts
+++ b/lib/game/turns.ts
@@ -9,6 +9,11 @@ import { SPELLS_BY_ID, getCasteProfile } from "./content";
 import type { ActiveProductionSpell, GamePlayer, Phase } from "./types";
 
 export const WEEKLY_TURN_GRANT = 100;
+// Initial bucket granted at spawn. Larger than the weekly grant so a fresh
+// general can clear setup (assign 25 lands, pick a caste) and still have a
+// substantial pool for early recruiting / first attacks before the next
+// Sunday rollover refills the bucket.
+export const STARTING_TURN_GRANT = 300;
 export const SHIELD_DURATION_WEEKS = 3;
 export const SHIELD_TURN_THRESHOLD = 300;
 export const UNDERDOG_SIZE_RATIO = 0.5;
@@ -83,6 +88,32 @@ export interface NewPlayerOptions {
   initialPhase?: Phase;
   tilesHeld?: number;
   tilesExplored?: number;
+  displayName?: string;
+}
+
+// 3-32 chars; letters, digits, spaces, apostrophes, hyphens. No leading/trailing
+// whitespace. Trimmed before storage. Returns the cleaned name on success.
+export const GENERAL_NAME_MIN = 3;
+export const GENERAL_NAME_MAX = 32;
+const GENERAL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 '\-]*[A-Za-z0-9]$/;
+
+export function validateGeneralName(raw: string): string {
+  if (typeof raw !== "string") {
+    throw new Error("Name must be a string");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length < GENERAL_NAME_MIN) {
+    throw new Error(`Name must be at least ${GENERAL_NAME_MIN} characters`);
+  }
+  if (trimmed.length > GENERAL_NAME_MAX) {
+    throw new Error(`Name must be at most ${GENERAL_NAME_MAX} characters`);
+  }
+  if (!GENERAL_NAME_PATTERN.test(trimmed)) {
+    throw new Error(
+      "Name may contain only letters, digits, spaces, apostrophes, and hyphens"
+    );
+  }
+  return trimmed;
 }
 
 export function newPlayer(
@@ -95,8 +126,9 @@ export function newPlayer(
   );
   return {
     userId,
+    displayName: options.displayName ?? "",
     caste: null,
-    turnsRemaining: WEEKLY_TURN_GRANT,
+    turnsRemaining: STARTING_TURN_GRANT,
     turnsSpentTotal: 0,
     phase: options.initialPhase ?? "explore",
     tilesExplored: options.tilesExplored ?? 0,

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -77,6 +77,10 @@ export interface PlayerStats {
 
 export interface GamePlayer {
   userId: string;
+  // The name the player picked for their general. Empty string for legacy
+  // players who spawned before names were required — the dashboard forces
+  // them through the picker on next visit.
+  displayName: string;
   caste: Caste | null;
   casteLockedAt?: Timestamp | Date;
   turnsRemaining: number;


### PR DESCRIPTION
## Summary

Five UX upgrades to /game, requested by the user this session:

- **Starter turns 100 → 300.** Decoupled `STARTING_TURN_GRANT` from the weekly Sunday rollover (still 100). New generals can clear setup, pick a caste, recruit a real army, and push the frontier before the first refill.
- **Help & Lore page** at `/game/help`. Phase-by-phase progression, turn economy, caste tour, short in-world lore note. Linked from the dashboard, sign-in landing, and enlistment screen.
- **General names.** `displayName` on `GamePlayer` (3-32 chars, case-insensitive unique). `POST /api/game/player` requires a name; `PATCH` renames. Legacy players hit a forced picker on next visit. Leaderboard shows names instead of UID prefixes.
- **World map.** `/game/tiles` is now a global pan/zoom view. New `GET /api/game/world` returns every tile + per-owner `{ displayName, caste, shielded }`. Drag pans, wheel zooms around the cursor, `⌖` recenters. Foreign tiles render at 60% opacity with a caste-colored ring; shielded owners get a 🛡 + "can't be attacked yet" hover card. Server still owns the shield rule (`GameShieldedError`).
- **Caste-pick lore preview** on `/game/setup`. Five rich cards: lore paragraph, tile-cap multiplier, strongest slots, collapsible unit/spell/building sections.

Plus a one-off Firestore op (not in this diff) granting +300 turns to the four existing players to bring them in line.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm test -- __tests__/lib/game` — 126/126 pass
- [x] ESLint clean on touched files
- [x] Local dev server: `/game`, `/game/help`, `/game/tiles`, `/game/setup` all 200; `/api/game/world` 401 without auth
- [ ] Manual: enlist a new test general → name input flow works end to end
- [ ] Manual: pan/zoom feels right on the existing 4-player world; shielded marker visible
- [ ] Manual: caste-pick cards render unit/spell content for all five castes

🤖 Generated with [Claude Code](https://claude.com/claude-code)