### PR TITLE
feat(game): two-phase explore + hex-spiral kingdom seeding

### DIFF
--- a/__tests__/lib/game/exploration.test.ts
+++ b/__tests__/lib/game/exploration.test.ts
@@ -8,6 +8,7 @@ import {
   distanceToNearestOwned,
   hexCentroid,
   hostileSpawnProbability,
+  kingdomRadiusFromCentroid,
   riskScore,
   ringCoords,
   sampleFrontierTile,
@@ -36,6 +37,21 @@ describe("distanceToNearestOwned", () => {
   it("finds the closest owned tile", () => {
     const d = distanceToNearestOwned({ q: 5, r: 0 }, ["0_0", "3_0", "10_10"]);
     expect(d).toBe(2);
+  });
+});
+
+describe("kingdomRadiusFromCentroid", () => {
+  it("returns 0 for empty owned set", () => {
+    expect(kingdomRadiusFromCentroid({ q: 0, r: 0 }, [])).toBe(0);
+  });
+
+  it("returns 0 when only the centroid tile is owned", () => {
+    expect(kingdomRadiusFromCentroid({ q: 0, r: 0 }, ["0_0"])).toBe(0);
+  });
+
+  it("returns the max hex-distance from centroid to any owned tile", () => {
+    const owned = ["0_0", "3_0", "0_5", "-2_-2"];
+    expect(kingdomRadiusFromCentroid({ q: 0, r: 0 }, owned)).toBe(5);
   });
 });
 

--- a/__tests__/lib/game/world-gen.test.ts
+++ b/__tests__/lib/game/world-gen.test.ts
@@ -60,10 +60,56 @@ describe("spawnCenterForPlayerIndex", () => {
     expect(seen.size).toBe(50);
   });
 
-  it("places centers at the configured spacing", () => {
-    const a = spawnCenterForPlayerIndex(0, 50);
-    const b = spawnCenterForPlayerIndex(1, 50);
-    expect(b.q - a.q).toBe(50);
+  it("places index 0 at the origin", () => {
+    expect(spawnCenterForPlayerIndex(0)).toEqual({ q: 0, r: 0 });
+  });
+
+  it("places ring-1 indices (1..6) at hex-distance `spacing` from origin", () => {
+    const seen = new Set<string>();
+    for (let i = 1; i <= 6; i++) {
+      const c = spawnCenterForPlayerIndex(i, 50);
+      expect(hexDistance({ q: 0, r: 0 }, c)).toBe(50);
+      seen.add(tileIdFromAxial(c.q, c.r));
+    }
+    expect(seen.size).toBe(6);
+  });
+
+  it("places ring-2 indices (7..18) at hex-distance 2*spacing from origin", () => {
+    const seen = new Set<string>();
+    for (let i = 7; i <= 18; i++) {
+      const c = spawnCenterForPlayerIndex(i, 50);
+      expect(hexDistance({ q: 0, r: 0 }, c)).toBe(100);
+      seen.add(tileIdFromAxial(c.q, c.r));
+    }
+    expect(seen.size).toBe(12);
+  });
+
+  it("places adjacent kingdoms at least `spacing` hexes apart", () => {
+    const centers: ReturnType<typeof spawnCenterForPlayerIndex>[] = [];
+    for (let i = 0; i < 19; i++) {
+      centers.push(spawnCenterForPlayerIndex(i, 50));
+    }
+    for (let i = 0; i < centers.length; i++) {
+      for (let j = i + 1; j < centers.length; j++) {
+        expect(hexDistance(centers[i], centers[j])).toBeGreaterThanOrEqual(50);
+      }
+    }
+  });
+
+  it("does not march along a single axis (kingdoms span q AND r axes)", () => {
+    // The old grid layout planted everyone with r=0 for the first 100 indices.
+    // The hex spiral should populate both axes within the first ring.
+    const qs = new Set<number>();
+    const rs = new Set<number>();
+    for (let i = 0; i < 7; i++) {
+      const c = spawnCenterForPlayerIndex(i, 50);
+      qs.add(c.q);
+      rs.add(c.r);
+    }
+    // At least 2 distinct r values among the first 7 — proves we're not
+    // clamped to r=0 like the old grid was.
+    expect(rs.size).toBeGreaterThan(1);
+    expect(qs.size).toBeGreaterThan(1);
   });
 });
 

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -70,6 +70,7 @@ import {
   type FrontierSample,
   distanceToNearestOwned,
   hexCentroid,
+  kingdomRadiusFromCentroid,
   ringCoords,
   riskScore,
 } from "./exploration";
@@ -463,8 +464,23 @@ export async function createPlayerWithSpawnServer(
     ]);
     if (playerSnap.exists) throw new GamePlayerAlreadyExistsError();
 
-    const playerCount = (metaSnap.data()?.playerCount as number) ?? 0;
-    const center = spawnCenterForPlayerIndex(playerCount);
+    const startingPlayerCount = (metaSnap.data()?.playerCount as number) ?? 0;
+    // The hex-spiral can land on a coord that an existing kingdom (planted
+    // under the old left-to-right grid) already occupies. Walk the spiral
+    // forward until the candidate center tile itself is unclaimed; the
+    // BFS in spawnPlayerLands handles small local conflicts beyond that.
+    const SPAWN_INDEX_MAX_RETRIES = 32;
+    let playerCount = startingPlayerCount;
+    let center = spawnCenterForPlayerIndex(playerCount);
+    for (let attempt = 0; attempt < SPAWN_INDEX_MAX_RETRIES; attempt++) {
+      const candidateId = tileIdFromAxial(center.q, center.r);
+      const candidateSnap = await tx.get(
+        db.collection(COLLECTIONS.TILES).doc(candidateId)
+      );
+      if (!candidateSnap.exists) break;
+      playerCount += 1;
+      center = spawnCenterForPlayerIndex(playerCount);
+    }
 
     const seed = `spawn-${userId}-${playerCount}`;
     const spawn = spawnPlayerLands({
@@ -2145,30 +2161,140 @@ export async function getPlayerEligibilityServer(
 // At our spacing this is roomy. If still nothing, refund the turn.
 const FRONTIER_MAX_RINGS = 12;
 
+// After this many tiles ever claimed via explore (v1 setup + v2 frontier
+// combined), the candidate picker switches from "ring-walk outward from the
+// owned-centroid" (which tightly globs new claims onto existing territory)
+// to a Monte Carlo sampler whose radius grows with each additional explore.
+// Pre-threshold keeps the random-then-glob feel of the early game; past it,
+// drops scatter further afield until they eventually reach other kingdoms.
+const EXPLORE_MONTE_CARLO_THRESHOLD = 150;
+// Random samples to try before falling back to a deterministic ring walk.
+const MONTE_CARLO_MAX_SAMPLES = 24;
+
+// Look up the owner of each of `coord`'s 6 neighbors and count those owned
+// by anyone other than `userId`. One batched getAll.
+async function countHostileNeighbors(
+  db: Firestore,
+  coord: AxialCoord,
+  userId: string
+): Promise<number> {
+  const ns = axialNeighbors(coord.q, coord.r);
+  const refs = ns.map((n) =>
+    db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(n.q, n.r))
+  );
+  const snaps = await db.getAll(...refs);
+  let hostileCount = 0;
+  for (const ns of snaps) {
+    if (!ns.exists) continue;
+    const data = ns.data();
+    if (data && data.ownerId && data.ownerId !== userId) hostileCount++;
+  }
+  return hostileCount;
+}
+
+async function buildFrontierSample(
+  db: Firestore,
+  userId: string,
+  coord: AxialCoord,
+  ownedTileIds: ReadonlyArray<string>
+): Promise<FrontierSample> {
+  const tileId = tileIdFromAxial(coord.q, coord.r);
+  const hostileCount = await countHostileNeighbors(db, coord, userId);
+  const distance = distanceToNearestOwned(coord, [...ownedTileIds]);
+  const distanceFinite = Number.isFinite(distance) ? distance : 0;
+  return {
+    tile: coord,
+    tileId,
+    distanceToCore: distanceFinite,
+    hostileNeighbors: hostileCount,
+    riskScore: riskScore({
+      hostileNeighbors: hostileCount,
+      distanceToCore: distanceFinite,
+    }),
+  };
+}
+
 /**
- * Pick an unclaimed tile coord adjacent to the player's territory and return
- * a FrontierSample describing it (distance, hostile-neighbor count, risk).
+ * Pick an unclaimed tile coord and return a FrontierSample describing it
+ * (distance, hostile-neighbor count, risk).
+ *
+ * Two-phase behavior:
+ *   - tilesExplored < EXPLORE_MONTE_CARLO_THRESHOLD: walk hex rings outward
+ *     from the owned-centroid (existing behavior). Drops cluster onto the
+ *     player's territory, naturally globbing into a contiguous kingdom.
+ *   - tilesExplored >= EXPLORE_MONTE_CARLO_THRESHOLD: Monte Carlo sample
+ *     within a radius that grows by +1 per explore past the threshold,
+ *     anchored on the centroid. Drops scatter outward and eventually reach
+ *     other kingdoms. Falls back to a ring walk over the same radius if too
+ *     many random picks collide with claimed tiles.
  *
  * The pre-fetch happens outside the transaction; the caller re-validates the
- * pick is still unclaimed inside the transaction. Returns null if no
- * unclaimed coord is found within FRONTIER_MAX_RINGS.
+ * pick is still unclaimed inside the transaction.
  */
 async function pickFrontierCandidate(
   db: Firestore,
   userId: string,
   ownedTileIds: ReadonlyArray<string>,
   tilesHeld: number,
+  tilesExplored: number,
   rng: () => number
 ): Promise<FrontierSample | null> {
   const center = hexCentroid([...ownedTileIds]);
-  const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
 
-  // Walk outward from minRing. For each ring, batch-getAll the coords and
-  // pick the first unclaimed one. Then a second getAll to count hostile
-  // neighbors at that coord.
-  for (let r = minRing; r <= FRONTIER_MAX_RINGS; r++) {
+  if (tilesExplored < EXPLORE_MONTE_CARLO_THRESHOLD) {
+    const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
+    return await pickByRingWalk(
+      db,
+      userId,
+      ownedTileIds,
+      center,
+      minRing,
+      FRONTIER_MAX_RINGS,
+      rng
+    );
+  }
+
+  const kingdomRadius = kingdomRadiusFromCentroid(center, ownedTileIds);
+  const extra = tilesExplored - EXPLORE_MONTE_CARLO_THRESHOLD;
+  // +1 keeps us at least one ring outside the current blob even at threshold.
+  const maxRadius = kingdomRadius + extra + 1;
+
+  for (let i = 0; i < MONTE_CARLO_MAX_SAMPLES; i++) {
+    const r = 1 + Math.floor(rng() * maxRadius);
+    const ring = ringCoords(center, r);
+    if (ring.length === 0) continue;
+    const c = ring[Math.floor(rng() * ring.length)];
+    const tileId = tileIdFromAxial(c.q, c.r);
+    const snap = await db.collection(COLLECTIONS.TILES).doc(tileId).get();
+    if (!snap.exists) {
+      return await buildFrontierSample(db, userId, c, ownedTileIds);
+    }
+  }
+
+  // Fallback: deterministic ring walk over the same radius range. Ensures we
+  // return *something* if random samples all happened to hit claimed tiles.
+  return await pickByRingWalk(
+    db,
+    userId,
+    ownedTileIds,
+    center,
+    1,
+    maxRadius,
+    rng
+  );
+}
+
+async function pickByRingWalk(
+  db: Firestore,
+  userId: string,
+  ownedTileIds: ReadonlyArray<string>,
+  center: AxialCoord,
+  minRing: number,
+  maxRing: number,
+  rng: () => number
+): Promise<FrontierSample | null> {
+  for (let r = minRing; r <= maxRing; r++) {
     const coords = ringCoords(center, r);
-    // In-place shuffle so direction varies. Fisher-Yates with our seeded rng.
     for (let i = coords.length - 1; i > 0; i--) {
       const j = Math.floor(rng() * (i + 1));
       [coords[i], coords[j]] = [coords[j], coords[i]];
@@ -2182,34 +2308,12 @@ async function pickFrontierCandidate(
 
     for (let i = 0; i < snaps.length; i++) {
       if (snaps[i].exists) continue;
-      const c = coords[i];
-      const tileId = tileIdFromAxial(c.q, c.r);
-
-      // Count hostile neighbors. getAll for the 6 neighbor refs.
-      const ns = axialNeighbors(c.q, c.r);
-      const neighborRefs = ns.map((n) =>
-        db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(n.q, n.r))
+      return await buildFrontierSample(
+        db,
+        userId,
+        coords[i],
+        ownedTileIds
       );
-      const neighborSnaps = await db.getAll(...neighborRefs);
-      let hostileCount = 0;
-      for (const ns of neighborSnaps) {
-        if (!ns.exists) continue;
-        const data = ns.data();
-        if (data && data.ownerId && data.ownerId !== userId) hostileCount++;
-      }
-
-      const distance = distanceToNearestOwned(c, [...ownedTileIds]);
-      const distanceFinite = Number.isFinite(distance) ? distance : 0;
-      return {
-        tile: c,
-        tileId,
-        distanceToCore: distanceFinite,
-        hostileNeighbors: hostileCount,
-        riskScore: riskScore({
-          hostileNeighbors: hostileCount,
-          distanceToCore: distanceFinite,
-        }),
-      };
     }
   }
   return null;
@@ -2255,6 +2359,7 @@ export async function frontierExploreServer(
     userId,
     ownedTileIds,
     playerPre.stats.tilesHeld,
+    playerPre.tilesExplored,
     candidateRng
   );
   if (sample === null) throw new GameFrontierExhaustedError();
@@ -2282,6 +2387,7 @@ export async function frontierExploreServer(
     }
 
     const turnsSpentTotal = player.turnsSpentTotal + 1;
+    const tilesExplored = player.tilesExplored + 1;
     const artifact = rollAndStageArtifact(
       tx,
       db,
@@ -2315,6 +2421,7 @@ export async function frontierExploreServer(
     tx.update(playerRef, {
       turnsRemaining: player.turnsRemaining - 1,
       turnsSpentTotal,
+      tilesExplored,
       stats: updatedStats,
       updatedAt: now,
     });
@@ -2342,6 +2449,7 @@ export async function frontierExploreServer(
         ...player,
         turnsRemaining: player.turnsRemaining - 1,
         turnsSpentTotal,
+        tilesExplored,
         stats: updatedStats,
         updatedAt: now,
       },
@@ -2352,16 +2460,89 @@ export async function frontierExploreServer(
   });
 }
 
+// Walk hex rings outward from `center`, batched-getAll each ring, accumulate
+// unclaimed coords. Stops when we hit `target` unclaimed coords or `maxRing`.
+async function collectUnclaimedByRingWalk(
+  db: Firestore,
+  center: AxialCoord,
+  minRing: number,
+  maxRing: number,
+  target: number,
+  rng: () => number
+): Promise<AxialCoord[]> {
+  const out: AxialCoord[] = [];
+  for (let r = minRing; r <= maxRing && out.length < target; r++) {
+    const coords = ringCoords(center, r);
+    for (let i = coords.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [coords[i], coords[j]] = [coords[j], coords[i]];
+    }
+    if (coords.length === 0) continue;
+    const refs = coords.map((c) =>
+      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+    );
+    const snaps = await db.getAll(...refs);
+    for (let i = 0; i < snaps.length; i++) {
+      if (!snaps[i].exists) out.push(coords[i]);
+      if (out.length >= target) break;
+    }
+  }
+  return out;
+}
+
+// Random sample distinct (ring, slot) coords within `maxRadius` of `center`,
+// batch-getAll each batch, accumulate unclaimed coords. Stops at `target`
+// unclaimed coords or `maxSamples` random tries (whichever first).
+async function collectUnclaimedByMonteCarlo(
+  db: Firestore,
+  center: AxialCoord,
+  maxRadius: number,
+  target: number,
+  maxSamples: number,
+  rng: () => number
+): Promise<AxialCoord[]> {
+  if (maxRadius <= 0) return [];
+  const out: AxialCoord[] = [];
+  const seen = new Set<string>();
+  // Sample in small batches so we can stop early without over-fetching.
+  const BATCH_SIZE = 8;
+  let samplesUsed = 0;
+  while (out.length < target && samplesUsed < maxSamples) {
+    const batch: AxialCoord[] = [];
+    while (batch.length < BATCH_SIZE && samplesUsed < maxSamples) {
+      samplesUsed++;
+      const r = 1 + Math.floor(rng() * maxRadius);
+      const ring = ringCoords(center, r);
+      if (ring.length === 0) continue;
+      const c = ring[Math.floor(rng() * ring.length)];
+      const id = tileIdFromAxial(c.q, c.r);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      batch.push(c);
+    }
+    if (batch.length === 0) break;
+    const refs = batch.map((c) =>
+      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+    );
+    const snaps = await db.getAll(...refs);
+    for (let i = 0; i < snaps.length; i++) {
+      if (!snaps[i].exists) out.push(batch[i]);
+      if (out.length >= target) break;
+    }
+  }
+  return out;
+}
+
 // Pre-fetches up to `count` unclaimed frontier coords + their hostile-neighbor
 // counts via batched getAlls, then claims all of them in ONE transaction.
 // Each step inside the txn rolls its own artifact (seeded by per-step turn
 // index) and emits a TurnReport.
 //
 // Algorithm:
-//   1. Outside txn: walk rings outward from the player's centroid, getAll the
-//      coords on each ring, accumulate unclaimed coords until we have ≥ count
-//      (with a small buffer so we can survive a few being claimed by the time
-//      we re-validate inside the txn).
+//   1. Outside txn: collect unclaimed coords. Pre-threshold uses a centroid
+//      ring walk (existing behavior); post-threshold uses Monte Carlo within
+//      a radius that grows with `tilesExplored`, falling back to a ring walk
+//      over the same radius if the random tries don't fill the batch.
 //   2. Outside txn: one batched getAll for the unique union of all picked
 //      coords' neighbors, to compute hostile-neighbor counts (presentation).
 //   3. Inside txn: re-read the picked candidates; for each that's still
@@ -2376,33 +2557,60 @@ async function pickFrontierCandidatesBulk(
   userId: string,
   ownedTileIds: ReadonlyArray<string>,
   tilesHeld: number,
+  tilesExplored: number,
   count: number,
   rng: () => number
 ): Promise<FrontierSample[]> {
   const center = hexCentroid([...ownedTileIds]);
-  const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
   const overscan = Math.max(5, Math.ceil(count * 1.5));
+  const useMonteCarlo = tilesExplored >= EXPLORE_MONTE_CARLO_THRESHOLD;
 
-  // Walk rings outward, collecting unclaimed coords until we have enough.
-  const unclaimed: AxialCoord[] = [];
-  for (
-    let r = minRing;
-    r <= FRONTIER_MAX_RINGS && unclaimed.length < overscan;
-    r++
-  ) {
-    const coords = ringCoords(center, r);
-    for (let i = coords.length - 1; i > 0; i--) {
-      const j = Math.floor(rng() * (i + 1));
-      [coords[i], coords[j]] = [coords[j], coords[i]];
-    }
-    if (coords.length === 0) continue;
-    const refs = coords.map((c) =>
-      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+  let unclaimed: AxialCoord[] = [];
+
+  if (!useMonteCarlo) {
+    const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
+    unclaimed = await collectUnclaimedByRingWalk(
+      db,
+      center,
+      minRing,
+      FRONTIER_MAX_RINGS,
+      overscan,
+      rng
     );
-    const snaps = await db.getAll(...refs);
-    for (let i = 0; i < snaps.length; i++) {
-      if (!snaps[i].exists) unclaimed.push(coords[i]);
-      if (unclaimed.length >= overscan) break;
+  } else {
+    const kingdomRadius = kingdomRadiusFromCentroid(center, ownedTileIds);
+    const extra = tilesExplored - EXPLORE_MONTE_CARLO_THRESHOLD;
+    const maxRadius = kingdomRadius + extra + 1;
+    unclaimed = await collectUnclaimedByMonteCarlo(
+      db,
+      center,
+      maxRadius,
+      overscan,
+      // Sample budget: enough to fill the batch with comfortable misses.
+      Math.max(MONTE_CARLO_MAX_SAMPLES, overscan * 4),
+      rng
+    );
+    if (unclaimed.length < count) {
+      // Fill any remaining slots from a deterministic ring walk over the
+      // same radius range so a sparse-RNG run still returns a usable batch.
+      const fallback = await collectUnclaimedByRingWalk(
+        db,
+        center,
+        1,
+        maxRadius,
+        overscan - unclaimed.length,
+        rng
+      );
+      const seen = new Set(
+        unclaimed.map((c) => tileIdFromAxial(c.q, c.r))
+      );
+      for (const c of fallback) {
+        const id = tileIdFromAxial(c.q, c.r);
+        if (!seen.has(id)) {
+          unclaimed.push(c);
+          seen.add(id);
+        }
+      }
     }
   }
 
@@ -2503,6 +2711,7 @@ export async function bulkFrontierExploreServer(
     userId,
     ownedTileIds,
     playerPre.stats.tilesHeld,
+    playerPre.tilesExplored,
     count,
     candidateRng
   );
@@ -2525,6 +2734,7 @@ export async function bulkFrontierExploreServer(
 
     let turnsRemaining = player.turnsRemaining;
     let turnsSpentTotal = player.turnsSpentTotal;
+    let tilesExplored = player.tilesExplored;
     let tilesHeld = player.stats.tilesHeld;
     const reports: TurnReport[] = [];
     const tilesCreated: GameTile[] = [];
@@ -2556,6 +2766,7 @@ export async function bulkFrontierExploreServer(
 
       turnsRemaining -= 1;
       turnsSpentTotal += 1;
+      tilesExplored += 1;
       tilesHeld += 1;
 
       const artifact = rollAndStageArtifact(
@@ -2617,6 +2828,7 @@ export async function bulkFrontierExploreServer(
     tx.update(playerRef, {
       turnsRemaining,
       turnsSpentTotal,
+      tilesExplored,
       stats: { ...player.stats, tilesHeld },
       updatedAt: now,
     });
@@ -2626,6 +2838,7 @@ export async function bulkFrontierExploreServer(
         ...player,
         turnsRemaining,
         turnsSpentTotal,
+        tilesExplored,
         stats: { ...player.stats, tilesHeld },
         updatedAt: now,
       },

--- a/lib/game/exploration.ts
+++ b/lib/game/exploration.ts
@@ -9,8 +9,12 @@ import {
   axialFromTileId,
   hexDistance,
   neighbors,
+  ringCoords,
   tileIdFromAxial,
 } from "./world-gen";
+
+// Re-exported for back-compat; canonical source is world-gen.
+export { ringCoords };
 
 // ───── Public types ─────
 
@@ -66,6 +70,25 @@ export function distanceToNearestOwned(
   return best;
 }
 
+/**
+ * Largest hex-distance from `center` to any tile in `ownedTileIds`. Returns 0
+ * if the player owns nothing or only the center itself. Used by the Monte
+ * Carlo phase of frontier exploration to anchor the outer-radius growth at
+ * the current edge of the player's blob.
+ */
+export function kingdomRadiusFromCentroid(
+  center: AxialCoord,
+  ownedTileIds: ReadonlyArray<string>
+): number {
+  let max = 0;
+  for (const id of ownedTileIds) {
+    const c = axialFromTileId(id);
+    const d = hexDistance(center, c);
+    if (d > max) max = d;
+  }
+  return max;
+}
+
 // ───── Frontier sampling ─────
 
 /**
@@ -91,27 +114,6 @@ export function riskScore(args: {
   // Distance contributes more slowly; 5 hexes from core ≈ +15, 20 hexes ≈ +30.
   const fromDistance = Math.min(30, args.distanceToCore * 1.5);
   return Math.round(Math.min(100, fromHostiles + fromDistance));
-}
-
-/**
- * Coords on the hex ring at exactly distance `r` from `center`. r=0 returns
- * just the center; r=1 returns 6 coords; r=2 returns 12; r=N returns 6N.
- *
- * Implemented as a brute-force scan of the bounding diamond — fine because
- * `r` is typically small (≤ 12).
- */
-export function ringCoords(center: AxialCoord, r: number): AxialCoord[] {
-  if (r <= 0) return [{ ...center }];
-  const out: AxialCoord[] = [];
-  for (let dq = -r; dq <= r; dq++) {
-    const drMin = Math.max(-r, -dq - r);
-    const drMax = Math.min(r, -dq + r);
-    for (let dr = drMin; dr <= drMax; dr++) {
-      const candidate = { q: center.q + dq, r: center.r + dr };
-      if (hexDistance(center, candidate) === r) out.push(candidate);
-    }
-  }
-  return out;
 }
 
 export interface SampleFrontierArgs {

--- a/lib/game/world-gen.ts
+++ b/lib/game/world-gen.ts
@@ -51,18 +51,34 @@ export function hexDistance(a: AxialCoord, b: AxialCoord): number {
   return (Math.abs(aq - bq) + Math.abs(ar - br) + Math.abs(as - bs)) / 2;
 }
 
-// Lay spawn centers on a square grid in axial space, scaled by `spacing`.
-// Player N (0-indexed) gets a unique center far from prior players. v1 — a
-// hex spiral would compress the frontier, but the grid is sufficient at our
-// scale and easier to reason about.
+// Coords on the hex ring at exactly distance `r` from `center`. r<=0 returns
+// just the center; r=1 returns 6 coords; r=N returns 6N. Order is stable
+// (clockwise starting from the north neighbor scaled out by r).
+export function ringCoords(center: AxialCoord, r: number): AxialCoord[] {
+  if (r <= 0) return [{ ...center }];
+  const out: AxialCoord[] = [];
+  for (const c of hexRingCoords(center, r)) out.push(c);
+  return out;
+}
+
+// Lay spawn centers on a hex spiral in axial space, scaled by `spacing`.
+// Index 0 lands on the origin, then the spiral fans out one hex-ring at a
+// time (6 slots on ring 1, 12 on ring 2, ...). This keeps new kingdoms
+// hex-symmetric around the origin instead of marching along a single axis,
+// which kept early players bunched on the q-axis under the old grid layout.
 export function spawnCenterForPlayerIndex(
   index: number,
   spacing = 50
 ): AxialCoord {
-  const COLS = 100;
-  const col = index % COLS;
-  const row = Math.floor(index / COLS);
-  return { q: col * spacing, r: row * spacing };
+  if (index <= 0) return { q: 0, r: 0 };
+  // Cumulative slots through ring k (k>=1) = 1 + 3k(k+1). Find the smallest
+  // k whose cumulative count covers `index`.
+  let k = 1;
+  while (1 + 3 * k * (k + 1) <= index) k++;
+  const slotInRing = index - (1 + 3 * (k - 1) * k);
+  const ring = ringCoords({ q: 0, r: 0 }, k);
+  const c = ring[slotInRing % ring.length];
+  return { q: c.q * spacing, r: c.r * spacing };
 }
 
 export interface SpawnPlayerLandsRequest {


### PR DESCRIPTION
Frontier explore now glops onto the player's territory only for the
first 150 explores; past that it switches to a Monte Carlo sampler
whose radius grows by +1 per explore, anchored on the owned-centroid.
Drops eventually scatter far enough to reach neighboring kingdoms
instead of forever expanding the player's own blob.

New kingdoms also spawn on a hex spiral around the origin (6 slots on
ring 1, 12 on ring 2, ...) instead of marching left-to-right along the
q-axis. The collision loop in createPlayerWithSpawnServer skips spiral
slots already occupied by an existing left-to-right kingdom so the
old grid stays put.

Threshold counts cumulative tilesExplored across v1 setup-phase and v2
frontier explores; frontierExploreServer / bulkFrontierExploreServer
now both bump that counter.