### PR TITLE
fix(members): add clear empty state for unmatched search

### DIFF
--- a/__tests__/components/members/MemberDirectory.test.tsx
+++ b/__tests__/components/members/MemberDirectory.test.tsx
@@ -151,12 +151,18 @@ describe("MemberDirectory", () => {
         members: [member],
         filteredAndSortedMembers: [],
         loading: false,
+        searchQuery: "not-a-real-user",
       });
       render(<MemberDirectory />);
-      expect(screen.getByText("No members match your search.")).toBeInTheDocument();
+      expect(
+        screen.getByText('No members found matching "not-a-real-user"')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Try different keywords or view all members.")
+      ).toBeInTheDocument();
     });
 
-    it("has a clear filters button in no-results state", async () => {
+    it("has a view-all-members action in no-results state", async () => {
       const member = buildMember();
       buildMockHook({
         members: [member],
@@ -165,7 +171,7 @@ describe("MemberDirectory", () => {
       });
       const user = userEvent.setup();
       render(<MemberDirectory />);
-      const clearBtn = screen.getByText("Clear filters");
+      const clearBtn = screen.getByText("View all members");
       await user.click(clearBtn);
       expect(mockHookReturn.clearFilters).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith("/members", { scroll: false });

--- a/components/members/MemberDirectory.tsx
+++ b/components/members/MemberDirectory.tsx
@@ -310,14 +310,19 @@ export function MemberDirectory({ initialSearch = "" }: MemberDirectoryProps) {
         ) : filteredAndSortedMembers.length === 0 ? (
           <div className="text-center py-12">
             <p className="text-neutral-600 dark:text-neutral-400 text-lg mb-4">
-              No members match your search.
+              {`No members found matching "${searchQuery.trim()}"`}
             </p>
-            <button
-              onClick={handleClearFilters}
-              className="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 underline"
-            >
-              Clear filters
-            </button>
+            <p className="text-neutral-500 dark:text-neutral-400 mb-3">
+              Try different keywords or view all members.
+            </p>
+            <div className="flex items-center justify-center gap-3">
+              <button
+                onClick={handleClearFilters}
+                className="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 underline"
+              >
+                View all members
+              </button>
+            </div>
           </div>
         ) : (
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
Clarify member search results by showing query-specific no-match feedback with a clear recovery action, reducing confusion when filters return zero entries.

## Description
This PR improves the Members page empty state when search/filters return no results.

### Summary of changes
- Updated `MemberDirectory` no-results state to show the user’s query:
  - `No members found matching "{query}"`
- Added actionable helper text:
  - `Try different keywords or view all members.`
- Updated the recovery action label from `Clear filters` to `View all members` (same behavior: clear filters/search and return full list)
- Added/updated tests in `MemberDirectory.test.tsx` to validate:
  - query-specific no-match message
  - helper guidance text
  - reset action behavior

### Motivation / context
Previously, users could interpret the state as a blank page/bug when no members matched their filters. This makes the outcome explicit and provides a clear next step.

**Base branch:** `develop`  
Fixes #578

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Accessibility improvement

## How Has This Been Tested?
- [x] Tested locally
- [ ] Tested on mobile devices
- [ ] Tested accessibility (keyboard navigation, screen readers)
- [ ] Tested authentication flows
- [ ] Tested form submissions

### Test details
- Ran targeted tests:
- `npm run test -- MemberDirectory.test.tsx`
- Verified no-results UX expectations in test coverage:
- empty state appears for non-existent query
- helper text appears
- “View all members” action clears filters and routes back to `/members`

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A (small text/UI empty-state update)

## Additional Notes
- PR targets `develop` as required.
- Change scope is intentionally small (S-sized issue) and limited to:
- `components/members/MemberDirectory.tsx`
- `__tests__/components/members/MemberDirectory.test.tsx`