### PR TITLE
Release: members empty-state fix + admin grant button + 2026-05-07 broadcast scripts

### DIFF
--- a/__tests__/components/members/MemberDirectory.test.tsx
+++ b/__tests__/components/members/MemberDirectory.test.tsx
@@ -151,12 +151,18 @@ describe("MemberDirectory", () => {
         members: [member],
         filteredAndSortedMembers: [],
         loading: false,
+        searchQuery: "not-a-real-user",
       });
       render(<MemberDirectory />);
-      expect(screen.getByText("No members match your search.")).toBeInTheDocument();
+      expect(
+        screen.getByText('No members found matching "not-a-real-user"')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Try different keywords or view all members.")
+      ).toBeInTheDocument();
     });
 
-    it("has a clear filters button in no-results state", async () => {
+    it("has a view-all-members action in no-results state", async () => {
       const member = buildMember();
       buildMockHook({
         members: [member],
@@ -165,7 +171,7 @@ describe("MemberDirectory", () => {
       });
       const user = userEvent.setup();
       render(<MemberDirectory />);
-      const clearBtn = screen.getByText("Clear filters");
+      const clearBtn = screen.getByText("View all members");
       await user.click(clearBtn);
       expect(mockHookReturn.clearFilters).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith("/members", { scroll: false });

--- a/__tests__/lib/game/exploration.test.ts
+++ b/__tests__/lib/game/exploration.test.ts
@@ -8,6 +8,7 @@ import {
   distanceToNearestOwned,
   hexCentroid,
   hostileSpawnProbability,
+  kingdomRadiusFromCentroid,
   riskScore,
   ringCoords,
   sampleFrontierTile,
@@ -36,6 +37,21 @@ describe("distanceToNearestOwned", () => {
   it("finds the closest owned tile", () => {
     const d = distanceToNearestOwned({ q: 5, r: 0 }, ["0_0", "3_0", "10_10"]);
     expect(d).toBe(2);
+  });
+});
+
+describe("kingdomRadiusFromCentroid", () => {
+  it("returns 0 for empty owned set", () => {
+    expect(kingdomRadiusFromCentroid({ q: 0, r: 0 }, [])).toBe(0);
+  });
+
+  it("returns 0 when only the centroid tile is owned", () => {
+    expect(kingdomRadiusFromCentroid({ q: 0, r: 0 }, ["0_0"])).toBe(0);
+  });
+
+  it("returns the max hex-distance from centroid to any owned tile", () => {
+    const owned = ["0_0", "3_0", "0_5", "-2_-2"];
+    expect(kingdomRadiusFromCentroid({ q: 0, r: 0 }, owned)).toBe(5);
   });
 });
 

--- a/__tests__/lib/game/world-gen.test.ts
+++ b/__tests__/lib/game/world-gen.test.ts
@@ -60,10 +60,56 @@ describe("spawnCenterForPlayerIndex", () => {
     expect(seen.size).toBe(50);
   });
 
-  it("places centers at the configured spacing", () => {
-    const a = spawnCenterForPlayerIndex(0, 50);
-    const b = spawnCenterForPlayerIndex(1, 50);
-    expect(b.q - a.q).toBe(50);
+  it("places index 0 at the origin", () => {
+    expect(spawnCenterForPlayerIndex(0)).toEqual({ q: 0, r: 0 });
+  });
+
+  it("places ring-1 indices (1..6) at hex-distance `spacing` from origin", () => {
+    const seen = new Set<string>();
+    for (let i = 1; i <= 6; i++) {
+      const c = spawnCenterForPlayerIndex(i, 50);
+      expect(hexDistance({ q: 0, r: 0 }, c)).toBe(50);
+      seen.add(tileIdFromAxial(c.q, c.r));
+    }
+    expect(seen.size).toBe(6);
+  });
+
+  it("places ring-2 indices (7..18) at hex-distance 2*spacing from origin", () => {
+    const seen = new Set<string>();
+    for (let i = 7; i <= 18; i++) {
+      const c = spawnCenterForPlayerIndex(i, 50);
+      expect(hexDistance({ q: 0, r: 0 }, c)).toBe(100);
+      seen.add(tileIdFromAxial(c.q, c.r));
+    }
+    expect(seen.size).toBe(12);
+  });
+
+  it("places adjacent kingdoms at least `spacing` hexes apart", () => {
+    const centers: ReturnType<typeof spawnCenterForPlayerIndex>[] = [];
+    for (let i = 0; i < 19; i++) {
+      centers.push(spawnCenterForPlayerIndex(i, 50));
+    }
+    for (let i = 0; i < centers.length; i++) {
+      for (let j = i + 1; j < centers.length; j++) {
+        expect(hexDistance(centers[i], centers[j])).toBeGreaterThanOrEqual(50);
+      }
+    }
+  });
+
+  it("does not march along a single axis (kingdoms span q AND r axes)", () => {
+    // The old grid layout planted everyone with r=0 for the first 100 indices.
+    // The hex spiral should populate both axes within the first ring.
+    const qs = new Set<number>();
+    const rs = new Set<number>();
+    for (let i = 0; i < 7; i++) {
+      const c = spawnCenterForPlayerIndex(i, 50);
+      qs.add(c.q);
+      rs.add(c.r);
+    }
+    // At least 2 distinct r values among the first 7 — proves we're not
+    // clamped to r=0 like the old grid was.
+    expect(rs.size).toBeGreaterThan(1);
+    expect(qs.size).toBeGreaterThan(1);
   });
 });
 

--- a/app/api/game/player/route.ts
+++ b/app/api/game/player/route.ts
@@ -20,12 +20,14 @@ export async function GET(request: NextRequest) {
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     const player = await getPlayerServer(user.uid);
-    if (!player) return apiSuccess({ player: null, tiles: [] });
-    // Lightweight projection — strips neighborTileIds, upgradeIds, level,
-    // and timestamps from the per-tile payload. Tile detail page fetches
-    // the full GameTile separately via /api/game/tile/[tileId].
+    // Surface server-evaluated admin status so the dashboard can gate the
+    // admin-only "Grant 100 turns" button. The client otherwise has no
+    // reliable way to read this — `users/{uid}.isAdmin` is never written;
+    // admin is decided by token claims + legacy email allowlist server-side.
+    const isAdmin = Boolean(user.isAdmin);
+    if (!player) return apiSuccess({ player: null, tiles: [], isAdmin });
     const tiles = await getOwnedMapTilesServer(user.uid);
-    return apiSuccess({ player, tiles });
+    return apiSuccess({ player, tiles, isAdmin });
   } catch (error) {
     return mapGameError(error);
   }

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -22,6 +22,7 @@ interface PlayerResponse {
   success: boolean;
   player: GamePlayer | null;
   tiles: MapTile[];
+  isAdmin?: boolean;
   error?: string;
 }
 
@@ -56,9 +57,13 @@ interface Eligibility {
 
 export default function GameDashboardPage() {
   const { user, userProfile, loading: authLoading } = useAuth();
-  const isAdmin = Boolean(
-    (userProfile as { isAdmin?: boolean } | null)?.isAdmin
-  );
+  // Server fills this in from the player API response (token claims +
+  // legacy email allowlist). The Firestore profile field is never written
+  // to in this codebase, so we can't rely on userProfile.isAdmin alone.
+  const [serverIsAdmin, setServerIsAdmin] = useState(false);
+  const isAdmin =
+    serverIsAdmin ||
+    Boolean((userProfile as { isAdmin?: boolean } | null)?.isAdmin);
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [tiles, setTiles] = useState<MapTile[]>([]);
   const [worldTiles, setWorldTiles] = useState<MapTile[]>([]);
@@ -113,6 +118,7 @@ export default function GameDashboardPage() {
       if (!data.success) throw new Error(data.error ?? "Failed to load player");
       setPlayer(data.player);
       setTiles(data.tiles ?? []);
+      setServerIsAdmin(Boolean(data.isAdmin));
       const elgData = (await elgRes.json()) as EligibilityResponse;
       if (elgData.success) {
         setEligibility({

--- a/components/members/MemberDirectory.tsx
+++ b/components/members/MemberDirectory.tsx
@@ -310,14 +310,19 @@ export function MemberDirectory({ initialSearch = "" }: MemberDirectoryProps) {
         ) : filteredAndSortedMembers.length === 0 ? (
           <div className="text-center py-12">
             <p className="text-neutral-600 dark:text-neutral-400 text-lg mb-4">
-              No members match your search.
+              {`No members found matching "${searchQuery.trim()}"`}
             </p>
-            <button
-              onClick={handleClearFilters}
-              className="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 underline"
-            >
-              Clear filters
-            </button>
+            <p className="text-neutral-500 dark:text-neutral-400 mb-3">
+              Try different keywords or view all members.
+            </p>
+            <div className="flex items-center justify-center gap-3">
+              <button
+                onClick={handleClearFilters}
+                className="text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 underline"
+              >
+                View all members
+              </button>
+            </div>
           </div>
         ) : (
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -70,6 +70,7 @@ import {
   type FrontierSample,
   distanceToNearestOwned,
   hexCentroid,
+  kingdomRadiusFromCentroid,
   ringCoords,
   riskScore,
 } from "./exploration";
@@ -463,8 +464,23 @@ export async function createPlayerWithSpawnServer(
     ]);
     if (playerSnap.exists) throw new GamePlayerAlreadyExistsError();
 
-    const playerCount = (metaSnap.data()?.playerCount as number) ?? 0;
-    const center = spawnCenterForPlayerIndex(playerCount);
+    const startingPlayerCount = (metaSnap.data()?.playerCount as number) ?? 0;
+    // The hex-spiral can land on a coord that an existing kingdom (planted
+    // under the old left-to-right grid) already occupies. Walk the spiral
+    // forward until the candidate center tile itself is unclaimed; the
+    // BFS in spawnPlayerLands handles small local conflicts beyond that.
+    const SPAWN_INDEX_MAX_RETRIES = 32;
+    let playerCount = startingPlayerCount;
+    let center = spawnCenterForPlayerIndex(playerCount);
+    for (let attempt = 0; attempt < SPAWN_INDEX_MAX_RETRIES; attempt++) {
+      const candidateId = tileIdFromAxial(center.q, center.r);
+      const candidateSnap = await tx.get(
+        db.collection(COLLECTIONS.TILES).doc(candidateId)
+      );
+      if (!candidateSnap.exists) break;
+      playerCount += 1;
+      center = spawnCenterForPlayerIndex(playerCount);
+    }
 
     const seed = `spawn-${userId}-${playerCount}`;
     const spawn = spawnPlayerLands({
@@ -2145,30 +2161,140 @@ export async function getPlayerEligibilityServer(
 // At our spacing this is roomy. If still nothing, refund the turn.
 const FRONTIER_MAX_RINGS = 12;
 
+// After this many tiles ever claimed via explore (v1 setup + v2 frontier
+// combined), the candidate picker switches from "ring-walk outward from the
+// owned-centroid" (which tightly globs new claims onto existing territory)
+// to a Monte Carlo sampler whose radius grows with each additional explore.
+// Pre-threshold keeps the random-then-glob feel of the early game; past it,
+// drops scatter further afield until they eventually reach other kingdoms.
+const EXPLORE_MONTE_CARLO_THRESHOLD = 150;
+// Random samples to try before falling back to a deterministic ring walk.
+const MONTE_CARLO_MAX_SAMPLES = 24;
+
+// Look up the owner of each of `coord`'s 6 neighbors and count those owned
+// by anyone other than `userId`. One batched getAll.
+async function countHostileNeighbors(
+  db: Firestore,
+  coord: AxialCoord,
+  userId: string
+): Promise<number> {
+  const ns = axialNeighbors(coord.q, coord.r);
+  const refs = ns.map((n) =>
+    db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(n.q, n.r))
+  );
+  const snaps = await db.getAll(...refs);
+  let hostileCount = 0;
+  for (const ns of snaps) {
+    if (!ns.exists) continue;
+    const data = ns.data();
+    if (data && data.ownerId && data.ownerId !== userId) hostileCount++;
+  }
+  return hostileCount;
+}
+
+async function buildFrontierSample(
+  db: Firestore,
+  userId: string,
+  coord: AxialCoord,
+  ownedTileIds: ReadonlyArray<string>
+): Promise<FrontierSample> {
+  const tileId = tileIdFromAxial(coord.q, coord.r);
+  const hostileCount = await countHostileNeighbors(db, coord, userId);
+  const distance = distanceToNearestOwned(coord, [...ownedTileIds]);
+  const distanceFinite = Number.isFinite(distance) ? distance : 0;
+  return {
+    tile: coord,
+    tileId,
+    distanceToCore: distanceFinite,
+    hostileNeighbors: hostileCount,
+    riskScore: riskScore({
+      hostileNeighbors: hostileCount,
+      distanceToCore: distanceFinite,
+    }),
+  };
+}
+
 /**
- * Pick an unclaimed tile coord adjacent to the player's territory and return
- * a FrontierSample describing it (distance, hostile-neighbor count, risk).
+ * Pick an unclaimed tile coord and return a FrontierSample describing it
+ * (distance, hostile-neighbor count, risk).
+ *
+ * Two-phase behavior:
+ *   - tilesExplored < EXPLORE_MONTE_CARLO_THRESHOLD: walk hex rings outward
+ *     from the owned-centroid (existing behavior). Drops cluster onto the
+ *     player's territory, naturally globbing into a contiguous kingdom.
+ *   - tilesExplored >= EXPLORE_MONTE_CARLO_THRESHOLD: Monte Carlo sample
+ *     within a radius that grows by +1 per explore past the threshold,
+ *     anchored on the centroid. Drops scatter outward and eventually reach
+ *     other kingdoms. Falls back to a ring walk over the same radius if too
+ *     many random picks collide with claimed tiles.
  *
  * The pre-fetch happens outside the transaction; the caller re-validates the
- * pick is still unclaimed inside the transaction. Returns null if no
- * unclaimed coord is found within FRONTIER_MAX_RINGS.
+ * pick is still unclaimed inside the transaction.
  */
 async function pickFrontierCandidate(
   db: Firestore,
   userId: string,
   ownedTileIds: ReadonlyArray<string>,
   tilesHeld: number,
+  tilesExplored: number,
   rng: () => number
 ): Promise<FrontierSample | null> {
   const center = hexCentroid([...ownedTileIds]);
-  const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
 
-  // Walk outward from minRing. For each ring, batch-getAll the coords and
-  // pick the first unclaimed one. Then a second getAll to count hostile
-  // neighbors at that coord.
-  for (let r = minRing; r <= FRONTIER_MAX_RINGS; r++) {
+  if (tilesExplored < EXPLORE_MONTE_CARLO_THRESHOLD) {
+    const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
+    return await pickByRingWalk(
+      db,
+      userId,
+      ownedTileIds,
+      center,
+      minRing,
+      FRONTIER_MAX_RINGS,
+      rng
+    );
+  }
+
+  const kingdomRadius = kingdomRadiusFromCentroid(center, ownedTileIds);
+  const extra = tilesExplored - EXPLORE_MONTE_CARLO_THRESHOLD;
+  // +1 keeps us at least one ring outside the current blob even at threshold.
+  const maxRadius = kingdomRadius + extra + 1;
+
+  for (let i = 0; i < MONTE_CARLO_MAX_SAMPLES; i++) {
+    const r = 1 + Math.floor(rng() * maxRadius);
+    const ring = ringCoords(center, r);
+    if (ring.length === 0) continue;
+    const c = ring[Math.floor(rng() * ring.length)];
+    const tileId = tileIdFromAxial(c.q, c.r);
+    const snap = await db.collection(COLLECTIONS.TILES).doc(tileId).get();
+    if (!snap.exists) {
+      return await buildFrontierSample(db, userId, c, ownedTileIds);
+    }
+  }
+
+  // Fallback: deterministic ring walk over the same radius range. Ensures we
+  // return *something* if random samples all happened to hit claimed tiles.
+  return await pickByRingWalk(
+    db,
+    userId,
+    ownedTileIds,
+    center,
+    1,
+    maxRadius,
+    rng
+  );
+}
+
+async function pickByRingWalk(
+  db: Firestore,
+  userId: string,
+  ownedTileIds: ReadonlyArray<string>,
+  center: AxialCoord,
+  minRing: number,
+  maxRing: number,
+  rng: () => number
+): Promise<FrontierSample | null> {
+  for (let r = minRing; r <= maxRing; r++) {
     const coords = ringCoords(center, r);
-    // In-place shuffle so direction varies. Fisher-Yates with our seeded rng.
     for (let i = coords.length - 1; i > 0; i--) {
       const j = Math.floor(rng() * (i + 1));
       [coords[i], coords[j]] = [coords[j], coords[i]];
@@ -2182,34 +2308,12 @@ async function pickFrontierCandidate(
 
     for (let i = 0; i < snaps.length; i++) {
       if (snaps[i].exists) continue;
-      const c = coords[i];
-      const tileId = tileIdFromAxial(c.q, c.r);
-
-      // Count hostile neighbors. getAll for the 6 neighbor refs.
-      const ns = axialNeighbors(c.q, c.r);
-      const neighborRefs = ns.map((n) =>
-        db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(n.q, n.r))
+      return await buildFrontierSample(
+        db,
+        userId,
+        coords[i],
+        ownedTileIds
       );
-      const neighborSnaps = await db.getAll(...neighborRefs);
-      let hostileCount = 0;
-      for (const ns of neighborSnaps) {
-        if (!ns.exists) continue;
-        const data = ns.data();
-        if (data && data.ownerId && data.ownerId !== userId) hostileCount++;
-      }
-
-      const distance = distanceToNearestOwned(c, [...ownedTileIds]);
-      const distanceFinite = Number.isFinite(distance) ? distance : 0;
-      return {
-        tile: c,
-        tileId,
-        distanceToCore: distanceFinite,
-        hostileNeighbors: hostileCount,
-        riskScore: riskScore({
-          hostileNeighbors: hostileCount,
-          distanceToCore: distanceFinite,
-        }),
-      };
     }
   }
   return null;
@@ -2255,6 +2359,7 @@ export async function frontierExploreServer(
     userId,
     ownedTileIds,
     playerPre.stats.tilesHeld,
+    playerPre.tilesExplored,
     candidateRng
   );
   if (sample === null) throw new GameFrontierExhaustedError();
@@ -2282,6 +2387,7 @@ export async function frontierExploreServer(
     }
 
     const turnsSpentTotal = player.turnsSpentTotal + 1;
+    const tilesExplored = player.tilesExplored + 1;
     const artifact = rollAndStageArtifact(
       tx,
       db,
@@ -2315,6 +2421,7 @@ export async function frontierExploreServer(
     tx.update(playerRef, {
       turnsRemaining: player.turnsRemaining - 1,
       turnsSpentTotal,
+      tilesExplored,
       stats: updatedStats,
       updatedAt: now,
     });
@@ -2342,6 +2449,7 @@ export async function frontierExploreServer(
         ...player,
         turnsRemaining: player.turnsRemaining - 1,
         turnsSpentTotal,
+        tilesExplored,
         stats: updatedStats,
         updatedAt: now,
       },
@@ -2352,16 +2460,89 @@ export async function frontierExploreServer(
   });
 }
 
+// Walk hex rings outward from `center`, batched-getAll each ring, accumulate
+// unclaimed coords. Stops when we hit `target` unclaimed coords or `maxRing`.
+async function collectUnclaimedByRingWalk(
+  db: Firestore,
+  center: AxialCoord,
+  minRing: number,
+  maxRing: number,
+  target: number,
+  rng: () => number
+): Promise<AxialCoord[]> {
+  const out: AxialCoord[] = [];
+  for (let r = minRing; r <= maxRing && out.length < target; r++) {
+    const coords = ringCoords(center, r);
+    for (let i = coords.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [coords[i], coords[j]] = [coords[j], coords[i]];
+    }
+    if (coords.length === 0) continue;
+    const refs = coords.map((c) =>
+      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+    );
+    const snaps = await db.getAll(...refs);
+    for (let i = 0; i < snaps.length; i++) {
+      if (!snaps[i].exists) out.push(coords[i]);
+      if (out.length >= target) break;
+    }
+  }
+  return out;
+}
+
+// Random sample distinct (ring, slot) coords within `maxRadius` of `center`,
+// batch-getAll each batch, accumulate unclaimed coords. Stops at `target`
+// unclaimed coords or `maxSamples` random tries (whichever first).
+async function collectUnclaimedByMonteCarlo(
+  db: Firestore,
+  center: AxialCoord,
+  maxRadius: number,
+  target: number,
+  maxSamples: number,
+  rng: () => number
+): Promise<AxialCoord[]> {
+  if (maxRadius <= 0) return [];
+  const out: AxialCoord[] = [];
+  const seen = new Set<string>();
+  // Sample in small batches so we can stop early without over-fetching.
+  const BATCH_SIZE = 8;
+  let samplesUsed = 0;
+  while (out.length < target && samplesUsed < maxSamples) {
+    const batch: AxialCoord[] = [];
+    while (batch.length < BATCH_SIZE && samplesUsed < maxSamples) {
+      samplesUsed++;
+      const r = 1 + Math.floor(rng() * maxRadius);
+      const ring = ringCoords(center, r);
+      if (ring.length === 0) continue;
+      const c = ring[Math.floor(rng() * ring.length)];
+      const id = tileIdFromAxial(c.q, c.r);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      batch.push(c);
+    }
+    if (batch.length === 0) break;
+    const refs = batch.map((c) =>
+      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+    );
+    const snaps = await db.getAll(...refs);
+    for (let i = 0; i < snaps.length; i++) {
+      if (!snaps[i].exists) out.push(batch[i]);
+      if (out.length >= target) break;
+    }
+  }
+  return out;
+}
+
 // Pre-fetches up to `count` unclaimed frontier coords + their hostile-neighbor
 // counts via batched getAlls, then claims all of them in ONE transaction.
 // Each step inside the txn rolls its own artifact (seeded by per-step turn
 // index) and emits a TurnReport.
 //
 // Algorithm:
-//   1. Outside txn: walk rings outward from the player's centroid, getAll the
-//      coords on each ring, accumulate unclaimed coords until we have ≥ count
-//      (with a small buffer so we can survive a few being claimed by the time
-//      we re-validate inside the txn).
+//   1. Outside txn: collect unclaimed coords. Pre-threshold uses a centroid
+//      ring walk (existing behavior); post-threshold uses Monte Carlo within
+//      a radius that grows with `tilesExplored`, falling back to a ring walk
+//      over the same radius if the random tries don't fill the batch.
 //   2. Outside txn: one batched getAll for the unique union of all picked
 //      coords' neighbors, to compute hostile-neighbor counts (presentation).
 //   3. Inside txn: re-read the picked candidates; for each that's still
@@ -2376,33 +2557,60 @@ async function pickFrontierCandidatesBulk(
   userId: string,
   ownedTileIds: ReadonlyArray<string>,
   tilesHeld: number,
+  tilesExplored: number,
   count: number,
   rng: () => number
 ): Promise<FrontierSample[]> {
   const center = hexCentroid([...ownedTileIds]);
-  const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
   const overscan = Math.max(5, Math.ceil(count * 1.5));
+  const useMonteCarlo = tilesExplored >= EXPLORE_MONTE_CARLO_THRESHOLD;
 
-  // Walk rings outward, collecting unclaimed coords until we have enough.
-  const unclaimed: AxialCoord[] = [];
-  for (
-    let r = minRing;
-    r <= FRONTIER_MAX_RINGS && unclaimed.length < overscan;
-    r++
-  ) {
-    const coords = ringCoords(center, r);
-    for (let i = coords.length - 1; i > 0; i--) {
-      const j = Math.floor(rng() * (i + 1));
-      [coords[i], coords[j]] = [coords[j], coords[i]];
-    }
-    if (coords.length === 0) continue;
-    const refs = coords.map((c) =>
-      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+  let unclaimed: AxialCoord[] = [];
+
+  if (!useMonteCarlo) {
+    const minRing = Math.max(1, 1 + Math.floor(tilesHeld / 40));
+    unclaimed = await collectUnclaimedByRingWalk(
+      db,
+      center,
+      minRing,
+      FRONTIER_MAX_RINGS,
+      overscan,
+      rng
     );
-    const snaps = await db.getAll(...refs);
-    for (let i = 0; i < snaps.length; i++) {
-      if (!snaps[i].exists) unclaimed.push(coords[i]);
-      if (unclaimed.length >= overscan) break;
+  } else {
+    const kingdomRadius = kingdomRadiusFromCentroid(center, ownedTileIds);
+    const extra = tilesExplored - EXPLORE_MONTE_CARLO_THRESHOLD;
+    const maxRadius = kingdomRadius + extra + 1;
+    unclaimed = await collectUnclaimedByMonteCarlo(
+      db,
+      center,
+      maxRadius,
+      overscan,
+      // Sample budget: enough to fill the batch with comfortable misses.
+      Math.max(MONTE_CARLO_MAX_SAMPLES, overscan * 4),
+      rng
+    );
+    if (unclaimed.length < count) {
+      // Fill any remaining slots from a deterministic ring walk over the
+      // same radius range so a sparse-RNG run still returns a usable batch.
+      const fallback = await collectUnclaimedByRingWalk(
+        db,
+        center,
+        1,
+        maxRadius,
+        overscan - unclaimed.length,
+        rng
+      );
+      const seen = new Set(
+        unclaimed.map((c) => tileIdFromAxial(c.q, c.r))
+      );
+      for (const c of fallback) {
+        const id = tileIdFromAxial(c.q, c.r);
+        if (!seen.has(id)) {
+          unclaimed.push(c);
+          seen.add(id);
+        }
+      }
     }
   }
 
@@ -2503,6 +2711,7 @@ export async function bulkFrontierExploreServer(
     userId,
     ownedTileIds,
     playerPre.stats.tilesHeld,
+    playerPre.tilesExplored,
     count,
     candidateRng
   );
@@ -2525,6 +2734,7 @@ export async function bulkFrontierExploreServer(
 
     let turnsRemaining = player.turnsRemaining;
     let turnsSpentTotal = player.turnsSpentTotal;
+    let tilesExplored = player.tilesExplored;
     let tilesHeld = player.stats.tilesHeld;
     const reports: TurnReport[] = [];
     const tilesCreated: GameTile[] = [];
@@ -2556,6 +2766,7 @@ export async function bulkFrontierExploreServer(
 
       turnsRemaining -= 1;
       turnsSpentTotal += 1;
+      tilesExplored += 1;
       tilesHeld += 1;
 
       const artifact = rollAndStageArtifact(
@@ -2617,6 +2828,7 @@ export async function bulkFrontierExploreServer(
     tx.update(playerRef, {
       turnsRemaining,
       turnsSpentTotal,
+      tilesExplored,
       stats: { ...player.stats, tilesHeld },
       updatedAt: now,
     });
@@ -2626,6 +2838,7 @@ export async function bulkFrontierExploreServer(
         ...player,
         turnsRemaining,
         turnsSpentTotal,
+        tilesExplored,
         stats: { ...player.stats, tilesHeld },
         updatedAt: now,
       },

--- a/lib/game/exploration.ts
+++ b/lib/game/exploration.ts
@@ -9,8 +9,12 @@ import {
   axialFromTileId,
   hexDistance,
   neighbors,
+  ringCoords,
   tileIdFromAxial,
 } from "./world-gen";
+
+// Re-exported for back-compat; canonical source is world-gen.
+export { ringCoords };
 
 // ───── Public types ─────
 
@@ -66,6 +70,25 @@ export function distanceToNearestOwned(
   return best;
 }
 
+/**
+ * Largest hex-distance from `center` to any tile in `ownedTileIds`. Returns 0
+ * if the player owns nothing or only the center itself. Used by the Monte
+ * Carlo phase of frontier exploration to anchor the outer-radius growth at
+ * the current edge of the player's blob.
+ */
+export function kingdomRadiusFromCentroid(
+  center: AxialCoord,
+  ownedTileIds: ReadonlyArray<string>
+): number {
+  let max = 0;
+  for (const id of ownedTileIds) {
+    const c = axialFromTileId(id);
+    const d = hexDistance(center, c);
+    if (d > max) max = d;
+  }
+  return max;
+}
+
 // ───── Frontier sampling ─────
 
 /**
@@ -91,27 +114,6 @@ export function riskScore(args: {
   // Distance contributes more slowly; 5 hexes from core ≈ +15, 20 hexes ≈ +30.
   const fromDistance = Math.min(30, args.distanceToCore * 1.5);
   return Math.round(Math.min(100, fromHostiles + fromDistance));
-}
-
-/**
- * Coords on the hex ring at exactly distance `r` from `center`. r=0 returns
- * just the center; r=1 returns 6 coords; r=2 returns 12; r=N returns 6N.
- *
- * Implemented as a brute-force scan of the bounding diamond — fine because
- * `r` is typically small (≤ 12).
- */
-export function ringCoords(center: AxialCoord, r: number): AxialCoord[] {
-  if (r <= 0) return [{ ...center }];
-  const out: AxialCoord[] = [];
-  for (let dq = -r; dq <= r; dq++) {
-    const drMin = Math.max(-r, -dq - r);
-    const drMax = Math.min(r, -dq + r);
-    for (let dr = drMin; dr <= drMax; dr++) {
-      const candidate = { q: center.q + dq, r: center.r + dr };
-      if (hexDistance(center, candidate) === r) out.push(candidate);
-    }
-  }
-  return out;
 }
 
 export interface SampleFrontierArgs {

--- a/lib/game/world-gen.ts
+++ b/lib/game/world-gen.ts
@@ -51,18 +51,34 @@ export function hexDistance(a: AxialCoord, b: AxialCoord): number {
   return (Math.abs(aq - bq) + Math.abs(ar - br) + Math.abs(as - bs)) / 2;
 }
 
-// Lay spawn centers on a square grid in axial space, scaled by `spacing`.
-// Player N (0-indexed) gets a unique center far from prior players. v1 — a
-// hex spiral would compress the frontier, but the grid is sufficient at our
-// scale and easier to reason about.
+// Coords on the hex ring at exactly distance `r` from `center`. r<=0 returns
+// just the center; r=1 returns 6 coords; r=N returns 6N. Order is stable
+// (clockwise starting from the north neighbor scaled out by r).
+export function ringCoords(center: AxialCoord, r: number): AxialCoord[] {
+  if (r <= 0) return [{ ...center }];
+  const out: AxialCoord[] = [];
+  for (const c of hexRingCoords(center, r)) out.push(c);
+  return out;
+}
+
+// Lay spawn centers on a hex spiral in axial space, scaled by `spacing`.
+// Index 0 lands on the origin, then the spiral fans out one hex-ring at a
+// time (6 slots on ring 1, 12 on ring 2, ...). This keeps new kingdoms
+// hex-symmetric around the origin instead of marching along a single axis,
+// which kept early players bunched on the q-axis under the old grid layout.
 export function spawnCenterForPlayerIndex(
   index: number,
   spacing = 50
 ): AxialCoord {
-  const COLS = 100;
-  const col = index % COLS;
-  const row = Math.floor(index / COLS);
-  return { q: col * spacing, r: row * spacing };
+  if (index <= 0) return { q: 0, r: 0 };
+  // Cumulative slots through ring k (k>=1) = 1 + 3k(k+1). Find the smallest
+  // k whose cumulative count covers `index`.
+  let k = 1;
+  while (1 + 3 * k * (k + 1) <= index) k++;
+  const slotInRing = index - (1 + 3 * (k - 1) * k);
+  const ring = ringCoords({ q: 0, r: 0 }, k);
+  const c = ring[slotInRing % ring.length];
+  return { q: c.q * spacing, r: c.r * spacing };
 }
 
 export interface SpawnPlayerLandsRequest {

--- a/scripts/send-broadcast-2026-05-07.ts
+++ b/scripts/send-broadcast-2026-05-07.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * General broadcast to all eventContacts (2026-05-07).
+ *
+ * Four sections:
+ *   1. Generals game — play + contribute PRs
+ *   2. PyData (Wed May 13) — MUST register on cursorboston.com with the
+ *      exact name on your driver's license (Moderna admit list)
+ *   3. Cohort 1 (starts Mon May 11) — apply at /summer-cohort
+ *   4. May 26 Boston Tech Week hack at Hult — register if you haven't
+ *
+ * Mirrors send-contact-list-email.ts mechanics: pulls from eventContacts,
+ * skips unsubscribed, syncs Mailgun suppressions first, HMAC unsubscribe link.
+ *
+ * Usage:
+ *   npx tsx scripts/send-broadcast-2026-05-07.ts --dry-run
+ *   npx tsx scripts/send-broadcast-2026-05-07.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const PYDATA_REGISTER_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026/register";
+const PYDATA_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026";
+const COHORT_URL = "https://www.cursorboston.com/summer-cohort";
+const MAY26_LUMA_URL = "https://luma.com/t5vseeed";
+const MAY26_SIGNUP_URL =
+  "https://www.cursorboston.com/hackathons/sports-hack-2026/signup";
+const MAY26_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
+const GENERALS_URL = "https://www.cursorboston.com/game";
+const GENERALS_DOCS_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/generals/README.md";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+}
+
+function buildEmail(contact: ContactData): { subject: string; html: string; text: string } {
+  const first = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
+  );
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  const subject =
+    "Cursor Boston — PyData (Wed), Cohort 1 (Mon), May 26 hack, and a game to play";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>A lot happening over the next three weeks. Four quick things — please act on the ones that apply to you.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">1. Generals — come play, and help us build it</h3>
+
+<p><strong>Generals</strong> is the turn-based strategy game we&apos;ve been growing inside the Cursor Boston site. Come <a href="${GENERALS_URL}">play a turn</a> — recruit units, claim tiles, raid for artifacts. It&apos;s designed to be picked up in 2 minutes a day.</p>
+
+<p>If you&apos;re into <strong>game design or game development</strong>, this is a real open contribution surface. Lore, units, spells, artifacts, castes, buildings, balance, UI — every piece is documented with exact file paths to edit and what testing we expect. Start at the <a href="${GENERALS_DOCS_URL}">contribution guide</a> and open a PR. Improvements ship fast.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">2. PyData × Moderna — Wednesday, May 13 — please re-register on the website</h3>
+
+<p>The Cursor Boston × PyData Data Science Hack at Moderna HQ is <strong>this Wednesday, May 13</strong>. Read more on the <a href="${PYDATA_DETAIL_URL}">event page</a>.</p>
+
+<p style="background:#fff8e1;border-left:4px solid #f59e0b;padding:12px 16px;margin:12px 0;"><strong>Critical:</strong> Even if you RSVP&apos;d on Luma, you <strong>must register on the website</strong> at <a href="${PYDATA_REGISTER_URL}">${PYDATA_REGISTER_URL}</a>. Moderna requires us to send them a final guest list ahead of time. <strong>If your name isn&apos;t on the list we send Moderna, you will not be admitted to the building.</strong></p>
+
+<p style="background:#fff8e1;border-left:4px solid #f59e0b;padding:12px 16px;margin:12px 0;"><strong>And the name you give us must match the name on your driver&apos;s license / government ID exactly.</strong> Moderna security checks IDs at the door. "Mike" on the list and "Michael" on your ID is a problem. Use your full legal first and last name.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">3. Summer Cohort 1 starts Monday — apply now</h3>
+
+<p>Our first cohort kicks off <strong>Monday, May 11</strong>. Six weeks of structured shipping, weekly check-ins, mentor pairing, and an immersion day at Hult on May 26. If you&apos;re looking for a reason to commit time to leveling up your AI-tooling skills with a group of people doing the same thing, this is it.</p>
+
+<p>Apply now at <a href="${COHORT_URL}">${COHORT_URL}</a>. Spots are capped — earlier applications get reviewed first.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">4. May 26 — Boston Tech Week hack at Hult — register if you haven&apos;t</h3>
+
+<p>Tuesday, May 26 we&apos;re running an in-person hack at Hult International (Cambridge) as part of <strong>Boston Tech Week</strong>. Open to anyone — cohort or not — but space is limited (80 seats).</p>
+
+<p>If you haven&apos;t already, RSVP via <a href="${MAY26_LUMA_URL}">Luma</a> and then complete the website signup at <a href="${MAY26_SIGNUP_URL}">${MAY26_SIGNUP_URL}</a>. Details on the <a href="${MAY26_DETAIL_URL}">event page</a>.</p>
+
+<hr style="margin:32px 0;border:none;border-top:1px solid #e5e5e5;"/>
+
+<p>Reply to this email if anything is unclear, you want to host or sponsor, or you&apos;re looking for a way to get more involved with the community than attending. We&apos;re actively recruiting people who want to <strong>maintain</strong>, <strong>organize</strong>, or <strong>contribute</strong>, not only attend.</p>
+
+<p>— Roger &amp; Cursor Boston<br/><small style="color:#666;">Repo: <a href="${REPO_URL}">${REPO_URL}</a></small></p>
+
+<p style="font-size:12px;color:#888;margin-top:24px;">You&apos;re receiving this because you registered for a Cursor Boston event. <a href="${unsubUrl}">Unsubscribe</a> at any time.</p>
+</body></html>`;
+
+  const text = `Hi ${first},
+
+A lot happening over the next three weeks. Four quick things — please act on the ones that apply to you.
+
+1. GENERALS — COME PLAY, AND HELP US BUILD IT
+
+Generals is the turn-based strategy game we've been growing inside the Cursor Boston site. Come play a turn — recruit units, claim tiles, raid for artifacts: ${GENERALS_URL}
+
+If you're into game design or game development, this is a real open contribution surface. Start at the contribution guide and open a PR: ${GENERALS_DOCS_URL}
+
+2. PYDATA × MODERNA — WEDNESDAY, MAY 13 — PLEASE RE-REGISTER ON THE WEBSITE
+
+The Cursor Boston × PyData Data Science Hack at Moderna HQ is Wednesday, May 13. Details: ${PYDATA_DETAIL_URL}
+
+CRITICAL: Even if you RSVP'd on Luma, you MUST register on the website: ${PYDATA_REGISTER_URL}
+If your name isn't on the list we send Moderna, you will NOT be admitted to the building.
+
+The name you give us must match the name on your driver's license / government ID EXACTLY. Moderna security checks IDs at the door. Use your full legal first and last name.
+
+3. SUMMER COHORT 1 STARTS MONDAY — APPLY NOW
+
+Our first cohort kicks off Monday, May 11. Six weeks of structured shipping, weekly check-ins, mentor pairing, and an immersion day at Hult on May 26. Apply now: ${COHORT_URL}
+Spots are capped — earlier applications get reviewed first.
+
+4. MAY 26 — BOSTON TECH WEEK HACK AT HULT — REGISTER IF YOU HAVEN'T
+
+Tuesday, May 26 we're running an in-person hack at Hult International (Cambridge) as part of Boston Tech Week. Open to anyone — cohort or not — but space is limited (80 seats).
+
+If you haven't already, RSVP via Luma: ${MAY26_LUMA_URL}
+Then complete the website signup: ${MAY26_SIGNUP_URL}
+Details: ${MAY26_DETAIL_URL}
+
+---
+
+Reply to this email if anything is unclear, you want to host or sponsor, or you're looking for a way to get more involved with the community than attending. We're actively recruiting people who want to maintain, organize, or contribute, not only attend.
+
+— Roger & Cursor Boston
+Repo: ${REPO_URL}
+
+You're receiving this because you registered for a Cursor Boston event.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  await syncMailgunSuppressions(db);
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    contacts.push({
+      email: data.email || doc.id,
+      name: data.name || "",
+      firstName: data.firstName || "",
+    });
+  }
+
+  console.log(`Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = contacts[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview (first 1500 chars) ---");
+      console.log(html.slice(0, 1500));
+      console.log("\n--- Text preview (first 800 chars) ---");
+      console.log(text.slice(0, 800));
+    }
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 50 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-may26-attendee-action-prompts.ts
+++ b/scripts/send-may26-attendee-action-prompts.ts
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Personalized "you're on the May 26 list — here are 3 things" email to every
+ * attendee on the Sports Hack 2026 (May 26) list. Three sections, each one
+ * flips between "do this" and "✓ already done" based on per-attendee state:
+ *
+ *   1. Claim your seat on the website  → flips ✓ if they have a
+ *      hackathonEventSignups doc for sports-hack-2026 (i.e. completed website
+ *      signup, not just Luma RSVP).
+ *   2. Apply to Cohort 1               → flips ✓ if they appear in
+ *      summerCohortApplications with cohorts including "cohort-1" and status
+ *      in {pending, admitted}.
+ *   3. Come play Generals              → flips between "come try it" and
+ *      "thanks for playing — back for another turn?" based on whether they
+ *      have a game_players/<userId> doc.
+ *
+ * Recipients = every dedup'd attendee in the unified May 26 list (mirrors
+ * scripts/rank-may26-attendees.ts logic): website signups + luma-only,
+ * skipping judges, declined, and eventContacts.unsubscribed.
+ *
+ * Usage:
+ *   npx tsx scripts/send-may26-attendee-action-prompts.ts --dry-run
+ *   npx tsx scripts/send-may26-attendee-action-prompts.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import {
+  SUMMER_COHORT_COLLECTION,
+  SUMMER_COHORT_IMMERSION,
+  isValidCohortId,
+} from "../lib/summer-cohort";
+import {
+  getDeclinedEmailsForEvent,
+  getJudgeEmailsForEvent,
+} from "../lib/hackathon-event-signup";
+
+const EVENT_ID = SUMMER_COHORT_IMMERSION.eventId;
+
+const COHORT_URL = "https://www.cursorboston.com/summer-cohort";
+const MAY26_SIGNUP_URL =
+  "https://www.cursorboston.com/hackathons/sports-hack-2026/signup";
+const MAY26_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
+const GENERALS_URL = "https://www.cursorboston.com/game";
+const GENERALS_LEADERBOARD_URL = "https://www.cursorboston.com/game/leaderboard";
+const GENERALS_DOCS_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/generals/README.md";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface Attendee {
+  email: string;
+  displayName: string | null;
+  confirmedOnSite: boolean;
+  cohort1: boolean;
+  playedGame: boolean;
+}
+
+function buildEmail(a: Attendee): { subject: string; html: string; text: string } {
+  const first = escapeHtml(
+    a.displayName?.split(" ")[0]?.trim() || "there"
+  );
+  const unsubUrl = buildUnsubscribeUrl(a.email);
+  const subject = "You're on the May 26 list — three quick things";
+
+  // Section 1 — claim seat on site
+  const seatHtml = a.confirmedOnSite
+    ? `<h3 style="margin-top:24px;margin-bottom:8px;">1. ✓ You&apos;re confirmed on the site for May 26</h3>
+<p>You&apos;ve completed the website signup as well as Luma — nothing to do here. <a href="${MAY26_DETAIL_URL}">Event details</a> if you want a refresher.</p>`
+    : `<h3 style="margin-top:24px;margin-bottom:8px;">1. Claim your seat on cursorboston.com</h3>
+<p>You&apos;re on Luma, but the seat isn&apos;t locked in until you also complete the <strong>website signup</strong>. The site is what we use for the unified leaderboard, your check-in QR, and your spot inside the 80-person cap.</p>
+<p><a href="${MAY26_SIGNUP_URL}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:10px 16px;border-radius:6px;font-weight:600;">Claim your seat →</a></p>`;
+
+  // Section 2 — cohort 1
+  const cohortHtml = a.cohort1
+    ? `<h3 style="margin-top:24px;margin-bottom:8px;">2. ✓ You&apos;re in for Cohort 1</h3>
+<p>You&apos;ve already applied to Cohort 1 — Cohort 1 has priority on the May 26 cap, so you&apos;re set there too. If you haven&apos;t finished the locality + presenting questions on your application, take 30 seconds at <a href="${COHORT_URL}">${COHORT_URL}</a>.</p>`
+    : `<h3 style="margin-top:24px;margin-bottom:8px;">2. Apply to Cohort 1 — starts Mon, May 11</h3>
+<p>Our first cohort is six weeks of structured shipping, weekly check-ins, mentor pairing, and the May 26 immersion day at Hult. If you want a reason to actually commit time to leveling up your AI-tooling skills with a group doing the same thing, this is it. Cohort 1 also gets priority on the 80-person cap for May 26.</p>
+<p><a href="${COHORT_URL}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:10px 16px;border-radius:6px;font-weight:600;">Apply to Cohort 1 →</a></p>`;
+
+  // Section 3 — generals
+  const generalsHtml = a.playedGame
+    ? `<h3 style="margin-top:24px;margin-bottom:8px;">3. Generals — thanks for playing. Come back for another turn.</h3>
+<p>You&apos;ve already taken at least one turn in <strong>Generals</strong>, our turn-based strategy game built into the site. Nice. <a href="${GENERALS_URL}">Take another turn</a>, climb the <a href="${GENERALS_LEADERBOARD_URL}">leaderboard</a>, and bring a friend on May 26 — leaderboard standing carries into the day.</p>
+<p>If you&apos;re into <strong>game development</strong> — especially Three.js / WebGL / graphical interfaces for gaming — Generals is wide open as a contribution surface. Lore, units, spells, artifacts, castes, buildings, balance, the map renderer, the 3D layer — every piece is documented with file paths and what testing we expect. <a href="${GENERALS_DOCS_URL}">Contribution guide</a>. If you ship a PR before May 26, you&apos;ll have something concrete to demo on the day.</p>`
+    : `<h3 style="margin-top:24px;margin-bottom:8px;">3. Come play Generals — and on May 26, bring some game-dev energy</h3>
+<p><strong>Generals</strong> is the turn-based strategy game we&apos;ve been growing inside the Cursor Boston site. Take a turn — recruit units, claim tiles, raid for artifacts. It&apos;s designed to be picked up in 2 minutes a day. <a href="${GENERALS_URL}">Play your first turn</a> · <a href="${GENERALS_LEADERBOARD_URL}">Leaderboard</a></p>
+<p>If you&apos;re into <strong>game development</strong> — especially <strong>Three.js, WebGL, or graphical interfaces for gaming</strong> — May 26 is an unusually good chance to get some real experience. Generals is wide open as a contribution surface: lore, units, spells, artifacts, castes, buildings, balance, the map renderer, and the whole 3D / canvas layer. Every piece is documented with exact file paths and what testing we expect. Start at the <a href="${GENERALS_DOCS_URL}">contribution guide</a>; ship a PR before the 26th and you&apos;ll have something concrete to demo on the day.</p>`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>You&apos;re on the list for our <strong>${escapeHtml(SUMMER_COHORT_IMMERSION.title)}</strong> — Tuesday, May 26 at Hult International (Cambridge), kicking off Boston Tech Week. Three quick things, only the ones that aren&apos;t already done apply to you.</p>
+
+${seatHtml}
+
+${cohortHtml}
+
+${generalsHtml}
+
+<hr style="margin:32px 0;border:none;border-top:1px solid #e5e5e5;"/>
+
+<p>Reply to this email if anything is unclear, you want to host or sponsor on the 26th, or you&apos;re looking for a way to get more involved with the community than attending — especially if you want to help build the game.</p>
+
+<p>— Roger &amp; Cursor Boston<br/><small style="color:#666;">Repo: <a href="${REPO_URL}">${REPO_URL}</a></small></p>
+
+<p style="font-size:12px;color:#888;margin-top:24px;">You&apos;re receiving this because you registered for the Cursor Boston May 26 immersion event. <a href="${escapeHtml(unsubUrl)}">Unsubscribe</a> at any time.</p>
+</body></html>`;
+
+  // Plain-text mirror
+  const seatText = a.confirmedOnSite
+    ? `1. CONFIRMED ON THE SITE
+You've completed the website signup as well as Luma — nothing to do here.
+Event details: ${MAY26_DETAIL_URL}`
+    : `1. CLAIM YOUR SEAT ON CURSORBOSTON.COM
+You're on Luma, but the seat isn't locked in until you also complete the website signup. The site is what we use for the unified leaderboard, your check-in QR, and your spot inside the 80-person cap.
+→ ${MAY26_SIGNUP_URL}`;
+
+  const cohortText = a.cohort1
+    ? `2. ALREADY APPLIED TO COHORT 1
+You've already applied to Cohort 1 — Cohort 1 has priority on the May 26 cap, so you're set there too. If you haven't finished the locality + presenting questions on your application, take 30 seconds: ${COHORT_URL}`
+    : `2. APPLY TO COHORT 1 — STARTS MON, MAY 11
+Six weeks of structured shipping, weekly check-ins, mentor pairing, and the May 26 immersion day at Hult. Cohort 1 also gets priority on the 80-person cap for May 26.
+→ ${COHORT_URL}`;
+
+  const generalsText = a.playedGame
+    ? `3. GENERALS — THANKS FOR PLAYING. COME BACK FOR ANOTHER TURN.
+You've already taken at least one turn in Generals. Nice. Take another turn: ${GENERALS_URL}
+Leaderboard: ${GENERALS_LEADERBOARD_URL}
+
+If you're into game development — especially Three.js / WebGL / graphical interfaces for gaming — Generals is wide open as a contribution surface. Lore, units, spells, artifacts, castes, buildings, balance, the map renderer, the 3D layer — every piece is documented with file paths and what testing we expect.
+Contribution guide: ${GENERALS_DOCS_URL}
+Ship a PR before May 26 and you'll have something concrete to demo on the day.`
+    : `3. COME PLAY GENERALS — AND ON MAY 26, BRING SOME GAME-DEV ENERGY
+Generals is the turn-based strategy game built into the Cursor Boston site. Take a turn — recruit units, claim tiles, raid for artifacts. Designed to be picked up in 2 minutes a day.
+Play: ${GENERALS_URL}
+Leaderboard: ${GENERALS_LEADERBOARD_URL}
+
+If you're into game development — especially Three.js, WebGL, or graphical interfaces for gaming — May 26 is an unusually good chance to get real experience. Generals is wide open as a contribution surface: lore, units, spells, artifacts, castes, buildings, balance, the map renderer, and the whole 3D / canvas layer. Every piece is documented with exact file paths and what testing we expect.
+Contribution guide: ${GENERALS_DOCS_URL}
+Ship a PR before the 26th and you'll have something concrete to demo on the day.`;
+
+  const text = `Hi ${a.displayName?.split(" ")[0]?.trim() || "there"},
+
+You're on the list for our ${SUMMER_COHORT_IMMERSION.title} — Tuesday, May 26 at Hult International (Cambridge), kicking off Boston Tech Week. Three quick things, only the ones that aren't already done apply to you.
+
+${seatText}
+
+${cohortText}
+
+${generalsText}
+
+---
+
+Reply to this email if anything is unclear, you want to host or sponsor on the 26th, or you're looking for a way to get more involved with the community than attending — especially if you want to help build the game.
+
+— Roger & Cursor Boston
+Repo: ${REPO_URL}
+
+You're receiving this because you registered for the Cursor Boston May 26 immersion event.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function parseArgs(argv: string[]) {
+  const dryRun = argv.includes("--dry-run");
+  const send = argv.includes("--send");
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  return { dryRun, send };
+}
+
+async function main() {
+  const { dryRun, send } = parseArgs(process.argv.slice(2));
+
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  if (send) await syncMailgunSuppressions(db);
+
+  // 1. Cohort-1 (pending+admitted) emails.
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const cohort1Emails = new Set<string>();
+  for (const doc of appsSnap.docs) {
+    const d = doc.data();
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts.filter(isValidCohortId) : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    const status = typeof d.status === "string" ? d.status : "pending";
+    if (status !== "pending" && status !== "admitted") continue;
+    const email = (d.email || "").toString().trim().toLowerCase();
+    if (email) cohort1Emails.add(email);
+  }
+  console.log(`Cohort-1 (pending+admitted): ${cohort1Emails.size}`);
+
+  // 2. Website signups for May 26 + their user docs.
+  const signupSnap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  const websiteUserIds = signupSnap.docs
+    .map((d) => d.data().userId as string | undefined)
+    .filter((u): u is string => Boolean(u));
+  const userMap = new Map<string, FirebaseFirestore.DocumentData>();
+  for (let i = 0; i < websiteUserIds.length; i += 10) {
+    const chunk = websiteUserIds.slice(i, i + 10);
+    const refs = chunk.map((id) => db.collection("users").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) if (s.exists) userMap.set(s.id, s.data() ?? {});
+  }
+  console.log(`Website signups (sports-hack-2026): ${signupSnap.size}`);
+
+  // 3. Luma registrants (already synced in Firestore).
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  console.log(`Luma registrants (sports-hack-2026): ${lumaSnap.size}`);
+
+  // 4. eventContacts → unsubscribed set.
+  const ecSnap = await db.collection("eventContacts").get();
+  const unsubscribedEmails = new Set<string>();
+  for (const doc of ecSnap.docs) {
+    if (doc.data().unsubscribed === true) {
+      const e = (doc.data().email || doc.id).toString().trim().toLowerCase();
+      if (e) unsubscribedEmails.add(e);
+    }
+  }
+  console.log(`Unsubscribed emails (global): ${unsubscribedEmails.size}`);
+
+  // 5. users by email — needed to map luma-only attendees to a userId for the
+  //    game_players check.
+  const usersByEmail = new Map<string, string>();
+  const usersSnap = await db.collection("users").get();
+  for (const doc of usersSnap.docs) {
+    const e = doc.data().email;
+    if (typeof e === "string") usersByEmail.set(e.trim().toLowerCase(), doc.id);
+  }
+
+  // 6. Per-event judge / declined filters.
+  const judgeEmails = getJudgeEmailsForEvent(EVENT_ID);
+  const declinedEmails = getDeclinedEmailsForEvent(EVENT_ID);
+
+  // 7. Build attendees: website first, then luma-only (skip dupes by email or
+  //    github login — same dedup as scripts/rank-may26-attendees.ts).
+  const attendees: Attendee[] = [];
+  const seenEmails = new Set<string>();
+  const websiteGithubLogins = new Set<string>();
+  const userIdsToCheckForGame = new Set<string>();
+
+  for (const doc of signupSnap.docs) {
+    const data = doc.data();
+    const userId = data.userId as string | undefined;
+    if (!userId) continue;
+    const profile = userMap.get(userId) ?? {};
+    const email =
+      typeof profile.email === "string"
+        ? profile.email.trim().toLowerCase()
+        : null;
+    if (!email) continue;
+    if (judgeEmails.has(email) || declinedEmails.has(email)) continue;
+    if (unsubscribedEmails.has(email)) continue;
+    seenEmails.add(email);
+    const ghLogin =
+      profile.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login ?? null
+        : null;
+    if (ghLogin) websiteGithubLogins.add(ghLogin.toLowerCase());
+    userIdsToCheckForGame.add(userId);
+    attendees.push({
+      email,
+      displayName:
+        typeof profile.displayName === "string" ? profile.displayName : null,
+      confirmedOnSite: true,
+      cohort1: cohort1Emails.has(email),
+      playedGame: false, // filled in below
+    });
+  }
+
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (d.email as string | undefined)?.trim().toLowerCase() ?? "";
+    if (!email) continue;
+    if (judgeEmails.has(email) || declinedEmails.has(email)) continue;
+    if (unsubscribedEmails.has(email)) continue;
+    if (seenEmails.has(email)) continue;
+    const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+    if (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase())) continue;
+    seenEmails.add(email);
+    const luminaUserId = usersByEmail.get(email);
+    if (luminaUserId) userIdsToCheckForGame.add(luminaUserId);
+    attendees.push({
+      email,
+      displayName: typeof d.name === "string" ? d.name : null,
+      confirmedOnSite: false,
+      cohort1: cohort1Emails.has(email),
+      playedGame: false,
+    });
+  }
+
+  // 8. Game-played check: batch-get game_players docs for all candidate uids.
+  const playedUserIds = new Set<string>();
+  const userIdsArr = [...userIdsToCheckForGame];
+  for (let i = 0; i < userIdsArr.length; i += 10) {
+    const chunk = userIdsArr.slice(i, i + 10);
+    const refs = chunk.map((id) => db.collection("game_players").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) if (s.exists) playedUserIds.add(s.id);
+  }
+  // Re-walk attendees to set playedGame.
+  // Build email→userId map from the two channels:
+  const emailToUserId = new Map<string, string>();
+  for (const doc of signupSnap.docs) {
+    const userId = doc.data().userId as string | undefined;
+    if (!userId) continue;
+    const profile = userMap.get(userId) ?? {};
+    const email =
+      typeof profile.email === "string"
+        ? profile.email.trim().toLowerCase()
+        : null;
+    if (email) emailToUserId.set(email, userId);
+  }
+  for (const a of attendees) {
+    const uid = emailToUserId.get(a.email) ?? usersByEmail.get(a.email);
+    if (uid && playedUserIds.has(uid)) a.playedGame = true;
+  }
+
+  // 9. Counts.
+  const totals = {
+    total: attendees.length,
+    confirmedOnSite: attendees.filter((a) => a.confirmedOnSite).length,
+    cohort1: attendees.filter((a) => a.cohort1).length,
+    played: attendees.filter((a) => a.playedGame).length,
+  };
+  console.log(
+    `\nRecipients: ${totals.total}\n  ✓ confirmed on site: ${totals.confirmedOnSite}  (${totals.total - totals.confirmedOnSite} need to claim)\n  ✓ cohort 1:           ${totals.cohort1}  (${totals.total - totals.cohort1} should apply)\n  ✓ played generals:    ${totals.played}  (${totals.total - totals.played} haven't played)`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+
+    // Print one sample of each variant we can find.
+    const variants: Array<[string, (a: Attendee) => boolean]> = [
+      ["confirmed=Y, cohort1=Y, played=Y", (a) => a.confirmedOnSite && a.cohort1 && a.playedGame],
+      ["confirmed=Y, cohort1=Y, played=N", (a) => a.confirmedOnSite && a.cohort1 && !a.playedGame],
+      ["confirmed=N, cohort1=Y, played=N", (a) => !a.confirmedOnSite && a.cohort1 && !a.playedGame],
+      ["confirmed=N, cohort1=N, played=N", (a) => !a.confirmedOnSite && !a.cohort1 && !a.playedGame],
+    ];
+    for (const [label, pred] of variants) {
+      const sample = attendees.find(pred);
+      console.log("============================================================");
+      console.log(`VARIANT — ${label}`);
+      console.log("============================================================");
+      if (!sample) {
+        console.log("  (no attendee matches this combination)\n");
+        continue;
+      }
+      const { subject, text } = buildEmail(sample);
+      console.log(`To:      ${sample.email} (${sample.displayName || "?"})`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n${text}\n`);
+    }
+
+    console.log(`Would send to ${attendees.length} recipients.`);
+    return;
+  }
+
+  // 10. Send.
+  let sent = 0;
+  let failed = 0;
+  for (const a of attendees) {
+    const { subject, html, text } = buildEmail(a);
+    try {
+      await sendEmail({ to: a.email, subject, html, text });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${attendees.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${a.email}`, e);
+    }
+    await sleep(450);
+  }
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-not-attending-may-events-prompt.ts
+++ b/scripts/send-not-attending-may-events-prompt.ts
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Broadcast to every eventContacts member who is NOT on either of the two
+ * upcoming May events:
+ *   - May 13 PyData × Cursor Boston (Moderna)
+ *   - May 26 Boston Tech Week Sports Hack at Hult
+ *
+ * Three sections:
+ *   1. Cohort 1 starts Mon, May 11 — apply if you haven't.
+ *   2. Come play Generals — and contribute if you're into game dev.
+ *   3. What should we build next? — solicit event ideas + organizers.
+ *
+ * Exclusion set (anyone we DON'T want this message to reach):
+ *   - eventContacts.eventNames includes any of:
+ *       "Cursor Boston-PyData Data Science Hack"
+ *       "Cursor Boston - AIC - Hult International - Boston Tech Week Speakers & Workshop"
+ *       "Cursor Boston - Boston Tech Week Sports Hack"
+ *   - email ∈ hackathonEventSignups (eventId=sports-hack-2026)
+ *   - email ∈ pydataHack2026Registrations (status != cancelled)
+ *   - eventContacts.unsubscribed === true
+ *
+ * Usage:
+ *   npx tsx scripts/send-not-attending-may-events-prompt.ts --dry-run
+ *   npx tsx scripts/send-not-attending-may-events-prompt.ts --send
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { PYDATA_2026_REGISTRATIONS_COLLECTION } from "../lib/pydata-2026";
+import { SUMMER_COHORT_IMMERSION } from "../lib/summer-cohort";
+
+const SPORTS_HACK_EVENT_ID = SUMMER_COHORT_IMMERSION.eventId;
+
+const COHORT_URL = "https://www.cursorboston.com/summer-cohort";
+const GENERALS_URL = "https://www.cursorboston.com/game";
+const GENERALS_LEADERBOARD_URL = "https://www.cursorboston.com/game/leaderboard";
+const GENERALS_DOCS_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/generals/README.md";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const EVENTS_URL = "https://www.cursorboston.com/events";
+
+const EXCLUDED_EVENT_NAMES = new Set<string>([
+  "Cursor Boston-PyData Data Science Hack",
+  "Cursor Boston - AIC - Hult International - Boston Tech Week Speakers & Workshop",
+  "Cursor Boston - Boston Tech Week Sports Hack",
+]);
+
+interface Recipient {
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): { subject: string; text: string; html: string } {
+  const greet = r.firstName ? `Hi ${r.firstName},` : "Hi there,";
+  const unsub = buildUnsubscribeUrl(r.email);
+  const subject =
+    "Cursor Boston — Cohort 1 starts Mon, come play Generals, and what should we build next?";
+
+  const text = `${greet}
+
+You're on the Cursor Boston list, but we don't have you down for either of the two big May events (PyData × Moderna May 13, or the Boston Tech Week hack at Hult on May 26 — both are at capacity / closing). That's fine — there's other stuff happening, and we'd love your input on what comes next.
+
+Three things, all optional, pick whichever apply:
+
+1. SUMMER COHORT 1 — STARTS MONDAY, MAY 11
+
+The first Cursor Boston cohort kicks off this Monday. Six weeks of structured shipping, weekly check-ins, mentor pairing, and an immersion day at Hult on May 26. Designed for people who want a real reason to commit time to leveling up their AI-tooling skills alongside others doing the same.
+
+Apply: ${COHORT_URL}
+(Cohort 2 is also open if Cohort 1 timing doesn't work.)
+
+2. PLAY GENERALS — AND HELP BUILD IT IF YOU'RE INTO GAME DEV
+
+Generals is the turn-based strategy game we've been growing inside the Cursor Boston site. Recruit units, claim tiles, raid for artifacts. Designed to be picked up in 2 minutes a day.
+
+Play: ${GENERALS_URL}
+Leaderboard: ${GENERALS_LEADERBOARD_URL}
+
+If you're into game development — Three.js, WebGL, graphical interfaces for gaming, or just gameplay design — this is a real open contribution surface. Lore, units, spells, artifacts, castes, buildings, balance, the map renderer, the 3D layer — every piece is documented with exact file paths and what testing we expect.
+
+Contribution guide: ${GENERALS_DOCS_URL}
+Repo: ${REPO_URL}
+
+Open a PR, get a review, see your work ship.
+
+3. WHAT SHOULD WE BUILD NEXT? — REPLY WITH IDEAS
+
+We want to hear from you. Two specific questions:
+
+  a. What kind of event would you actually show up for?
+     Hack night, talk series, hardware tinkering, robotics, voice agents, biotech × AI,
+     game dev night, design jam, weekend retreat, something else? Niche is fine — we
+     can host small things easily.
+
+  b. Want to organize one?
+     If you've got an idea AND want to help run it (find a venue, recruit a few people,
+     pick a date), reply and tell me. We have venue partners around Boston and a
+     mailing list that's easy to mobilize. The biggest constraint isn't space or
+     audience — it's people willing to organize.
+
+Reply to this email. I read everything.
+
+You can also browse what's already on the calendar: ${EVENTS_URL}
+
+— Roger
+Cursor Boston
+
+---
+You're getting this because you've been to a Cursor Boston event before but aren't on either of the two May events.
+Unsubscribe: ${unsub}
+`;
+
+  const html = `<!doctype html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111;max-width:640px;margin:0 auto;padding:24px;line-height:1.6;">
+  <p>${escapeHtml(greet)}</p>
+
+  <p>You&apos;re on the Cursor Boston list, but we don&apos;t have you down for either of the two big May events (PyData × Moderna May 13, or the Boston Tech Week hack at Hult on May 26 — both at capacity / closing). That&apos;s fine — there&apos;s other stuff happening, and we&apos;d love your input on what comes next.</p>
+
+  <p>Three things, all optional, pick whichever apply:</p>
+
+  <h3 style="margin-top:28px;margin-bottom:8px;">1. Summer Cohort 1 — starts Monday, May 11</h3>
+
+  <p>The first Cursor Boston cohort kicks off <strong>this Monday</strong>. Six weeks of structured shipping, weekly check-ins, mentor pairing, and an immersion day at Hult on May 26. Designed for people who want a real reason to commit time to leveling up their AI-tooling skills alongside others doing the same.</p>
+
+  <p><a href="${COHORT_URL}" style="display:inline-block;padding:10px 18px;background:#111;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Apply to Cohort 1 →</a></p>
+
+  <p style="color:#555;font-size:14px;">(Cohort 2 is also open if Cohort 1 timing doesn&apos;t work.)</p>
+
+  <h3 style="margin-top:28px;margin-bottom:8px;">2. Play Generals — and help build it if you&apos;re into game dev</h3>
+
+  <p><strong>Generals</strong> is the turn-based strategy game we&apos;ve been growing inside the Cursor Boston site. Recruit units, claim tiles, raid for artifacts. Designed to be picked up in 2 minutes a day. <a href="${GENERALS_URL}">Play</a> · <a href="${GENERALS_LEADERBOARD_URL}">Leaderboard</a></p>
+
+  <p>If you&apos;re into <strong>game development</strong> — Three.js, WebGL, graphical interfaces for gaming, or just gameplay design — this is a real open contribution surface. Lore, units, spells, artifacts, castes, buildings, balance, the map renderer, the 3D layer — every piece is documented with exact file paths and what testing we expect.</p>
+
+  <p><a href="${GENERALS_DOCS_URL}">Contribution guide</a> · <a href="${REPO_URL}">Repo</a> — open a PR, get a review, see your work ship.</p>
+
+  <h3 style="margin-top:28px;margin-bottom:8px;">3. What should we build next? — reply with ideas</h3>
+
+  <p>We want to hear from you. Two specific questions:</p>
+
+  <ol style="padding-left:20px;color:#222;">
+    <li style="margin-bottom:14px;">
+      <strong>What kind of event would you actually show up for?</strong><br>
+      <span style="color:#555;">Hack night, talk series, hardware tinkering, robotics, voice agents, biotech × AI, game dev night, design jam, weekend retreat, something else? Niche is fine — we can host small things easily.</span>
+    </li>
+    <li>
+      <strong>Want to organize one?</strong><br>
+      <span style="color:#555;">If you&apos;ve got an idea <em>and</em> want to help run it (find a venue, recruit a few people, pick a date), reply and tell me. We have venue partners around Boston and a mailing list that&apos;s easy to mobilize. The biggest constraint isn&apos;t space or audience — it&apos;s people willing to organize.</span>
+    </li>
+  </ol>
+
+  <p style="margin-top:20px;"><strong>Reply to this email.</strong> I read everything.</p>
+
+  <p style="color:#555;">You can also browse what&apos;s already on the calendar: <a href="${EVENTS_URL}">${EVENTS_URL}</a></p>
+
+  <p>— Roger<br>Cursor Boston</p>
+
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0 16px;">
+  <p style="font-size:12px;color:#999;">
+    You&apos;re getting this because you&apos;ve been to a Cursor Boston event before but aren&apos;t on either of the two May events.
+    <a href="${unsub}" style="color:#999;">Unsubscribe</a>
+  </p>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  if (send) await syncMailgunSuppressions(db);
+
+  // --- Build the exclusion set: anyone associated with either May event ---
+
+  // a. Sports-hack-2026 website signups → user emails.
+  const signupSnap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", SPORTS_HACK_EVENT_ID)
+    .get();
+  const sportsUserIds = signupSnap.docs
+    .map((d) => d.data().userId as string | undefined)
+    .filter((u): u is string => Boolean(u));
+  const sportsWebsiteEmails = new Set<string>();
+  for (let i = 0; i < sportsUserIds.length; i += 10) {
+    const chunk = sportsUserIds.slice(i, i + 10);
+    const refs = chunk.map((id) => db.collection("users").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) {
+      const e = s.data()?.email;
+      if (typeof e === "string") sportsWebsiteEmails.add(e.trim().toLowerCase());
+    }
+  }
+
+  // b. PyData site registrations.
+  const pydataSnap = await db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).get();
+  const pydataRegisteredEmails = new Set<string>();
+  for (const d of pydataSnap.docs) {
+    const data = d.data();
+    if (data.status === "cancelled") continue;
+    const e = (data.email || "").toString().trim().toLowerCase();
+    if (e) pydataRegisteredEmails.add(e);
+  }
+
+  // c. eventContacts: load once for both unsubscribe and event-name exclusion + recipient names.
+  const ecSnap = await db.collection("eventContacts").get();
+  console.log(`eventContacts: ${ecSnap.size}`);
+
+  const recipients: Recipient[] = [];
+  const seenEmails = new Set<string>();
+  let skippedEventOverlap = 0;
+  let skippedSportsSite = 0;
+  let skippedPydataSite = 0;
+  let skippedUnsub = 0;
+  let skippedNoEmail = 0;
+  let skippedDup = 0;
+
+  for (const doc of ecSnap.docs) {
+    const data = doc.data();
+    const email = (typeof data.email === "string" ? data.email : doc.id)
+      .toString()
+      .trim()
+      .toLowerCase();
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (seenEmails.has(email)) {
+      skippedDup++;
+      continue;
+    }
+    seenEmails.add(email);
+
+    if (data.unsubscribed === true) {
+      skippedUnsub++;
+      continue;
+    }
+
+    const eventNames = Array.isArray(data.eventNames) ? data.eventNames : [];
+    const overlapsExcludedEvent = eventNames.some(
+      (n: unknown) => typeof n === "string" && EXCLUDED_EVENT_NAMES.has(n)
+    );
+    if (overlapsExcludedEvent) {
+      skippedEventOverlap++;
+      continue;
+    }
+    if (sportsWebsiteEmails.has(email)) {
+      skippedSportsSite++;
+      continue;
+    }
+    if (pydataRegisteredEmails.has(email)) {
+      skippedPydataSite++;
+      continue;
+    }
+
+    const firstName =
+      (typeof data.firstName === "string" && data.firstName.trim()) ||
+      ((typeof data.name === "string" ? data.name : "").split(" ")[0] || "").trim();
+    recipients.push({ email, firstName });
+  }
+
+  console.log(
+    `\nExclusions:`
+  );
+  console.log(
+    `  eventName overlap (PyData / May 26):  ${skippedEventOverlap}`
+  );
+  console.log(
+    `  sports-hack-2026 site signup:          ${skippedSportsSite} (additional, not already counted)`
+  );
+  console.log(
+    `  pydata site registration:              ${skippedPydataSite} (additional, not already counted)`
+  );
+  console.log(
+    `  unsubscribed:                          ${skippedUnsub}`
+  );
+  console.log(
+    `  blank email / dup:                     ${skippedNoEmail + skippedDup}`
+  );
+  console.log(`\nRecipients: ${recipients.length}`);
+
+  if (dryRun) {
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample);
+      console.log(`\n--- sample to ${sample.email} (${sample.firstName || "(no first name)"}) ---`);
+      console.log(`Subject: ${subject}\n`);
+      console.log(text);
+    } else {
+      console.log("\n(no recipients — nothing to preview)");
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  console.log(`\nSending to ${recipients.length} recipients…`);
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, text, html } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, text, html });
+      sent++;
+      if (sent % 25 === 0 || sent === recipients.length) {
+        console.log(`  sent ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  FAILED ${r.email}: ${e instanceof Error ? e.message : e}`);
+    }
+    await new Promise((res) => setTimeout(res, 80));
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-pydata-badge-reminder.ts
+++ b/scripts/send-pydata-badge-reminder.ts
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Short reminder to every Luma RSVP for the May 13 PyData × Cursor Boston
+ * event at Moderna who has NOT yet registered on cursorboston.com for their
+ * badge. The full-context primer was already sent in
+ * send-pydata-moderna-access.ts; this is a tighter nudge focused on the
+ * Mon May 11 cutoff.
+ *
+ * Recipient set:
+ *   - Luma CSV (--csv) ∩ NOT in pydataHack2026Registrations ∩ NOT unsubscribed
+ *
+ * Usage:
+ *   npx tsx scripts/send-pydata-badge-reminder.ts --csv <path> --dry-run
+ *   npx tsx scripts/send-pydata-badge-reminder.ts --csv <path> --send
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { readFileSync } from "fs";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { PYDATA_2026_REGISTRATIONS_COLLECTION } from "../lib/pydata-2026";
+
+const REGISTER_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026/register";
+const EVENT_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-pydata-2026";
+const SUBMIT_DEADLINE_HUMAN = "Monday May 11, 11:59 PM ET";
+
+interface Recipient {
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function parseCsv(content: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      // ignore
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((c) => c.length > 0)) rows.push(row);
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  const out: Record<string, string>[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const obj: Record<string, string> = {};
+    for (let j = 0; j < header.length; j++)
+      obj[header[j]!] = (rows[r]![j] ?? "").trim();
+    out.push(obj);
+  }
+  return out;
+}
+
+function buildEmail(r: Recipient): { subject: string; text: string; html: string } {
+  const greet = r.firstName ? `Hi ${r.firstName},` : "Hi,";
+  const unsub = buildUnsubscribeUrl(r.email);
+  const subject =
+    "Reminder: register your badge for Wed May 13 PyData × Cursor Boston (deadline Mon)";
+
+  const text = `${greet}
+
+Quick reminder — you RSVP'd on Luma for the Cursor Boston × PyData Data Science Hack on Wednesday, May 13 at Moderna HQ in Cambridge, but you haven't yet registered on cursorboston.com to get your badge.
+
+DEADLINE: ${SUBMIT_DEADLINE_HUMAN}.
+
+That's the moment we hand the final guest list to Moderna. Names submitted after that point cannot be added — Moderna security will turn anyone away who isn't on the list, no exceptions.
+
+Register here (takes ~60 seconds):
+→ ${REGISTER_URL}
+
+What you'll need:
+  - Your full legal name as it appears on your government ID (driver's license or passport). "Mike" on the form vs. "Michael" on your ID will get you turned away.
+  - Email + (optional) phone + company.
+
+After the cutoff, Envoy emails you an NDA to sign and your unique entry QR code. Bring the QR + ID on the 13th.
+
+Event details: ${EVENT_DETAIL_URL}
+
+If you can't make it, just reply to this email so we can free up the slot for someone on the waitlist.
+
+— Roger
+Cursor Boston
+
+---
+You're getting this because you RSVP'd on Luma but haven't registered for your badge yet.
+Unsubscribe: ${unsub}
+`;
+
+  const html = `<!doctype html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111;max-width:640px;margin:0 auto;padding:24px;line-height:1.55;">
+  <p>${escapeHtml(greet)}</p>
+
+  <p>Quick reminder — you RSVP'd on Luma for the <strong>Cursor Boston × PyData Data Science Hack</strong> on <strong>Wednesday, May 13 at Moderna HQ in Cambridge</strong>, but you haven&apos;t yet registered on cursorboston.com to get your badge.</p>
+
+  <div style="margin:24px 0;padding:16px;border-left:4px solid #dc2626;background:#fef2f2;border-radius:6px;">
+    <p style="margin:0;color:#991b1b;font-size:16px;"><strong>Deadline: ${escapeHtml(SUBMIT_DEADLINE_HUMAN)}.</strong></p>
+    <p style="margin:8px 0 0 0;color:#991b1b;">That&apos;s the moment we hand the final guest list to Moderna. Names submitted after that point cannot be added — Moderna security will turn anyone away who isn&apos;t on the list, no exceptions.</p>
+    <p style="margin:16px 0 0 0;"><a href="${REGISTER_URL}" style="display:inline-block;padding:12px 24px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Register your badge now →</a></p>
+  </div>
+
+  <p><strong>What you&apos;ll need (~60 seconds):</strong></p>
+  <ul style="color:#444;">
+    <li>Your full legal name as it appears on your government ID (driver&apos;s license or passport). &quot;Mike&quot; on the form vs. &quot;Michael&quot; on your ID will get you turned away.</li>
+    <li>Email + (optional) phone + company.</li>
+  </ul>
+
+  <p>After the cutoff, Envoy emails you an NDA to sign and your unique entry QR code. Bring the QR + ID on the 13th.</p>
+
+  <p style="margin-top:24px;color:#555;">Event details: <a href="${EVENT_DETAIL_URL}" style="color:#10b981;">cursorboston.com</a></p>
+
+  <p>If you can&apos;t make it, just reply to this email so we can free up the slot for someone on the waitlist.</p>
+
+  <p>— Roger<br>Cursor Boston</p>
+
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0 16px;">
+  <p style="font-size:12px;color:#999;">
+    You&apos;re getting this because you RSVP&apos;d on Luma for the May 13 PyData × Cursor Boston event but haven&apos;t registered for your badge yet.
+    <a href="${unsub}" style="color:#999;">Unsubscribe</a>
+  </p>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  const csvIdx = args.indexOf("--csv");
+  if (csvIdx === -1 || !args[csvIdx + 1]) {
+    console.error("Pass --csv <path-to-luma-export.csv>");
+    process.exit(1);
+  }
+  const csvPath = args[csvIdx + 1]!;
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  if (send) await syncMailgunSuppressions(db);
+
+  // Load Luma CSV
+  let raw = readFileSync(csvPath, "utf8");
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  const lumaRows = parseCsv(raw);
+  console.log(`Luma CSV: ${lumaRows.length} rows`);
+
+  // eventContacts → unsubscribed + best-known firstName
+  const ec = await db.collection("eventContacts").get();
+  const unsubbed = new Set<string>();
+  const ecNameByEmail = new Map<string, string>();
+  for (const d of ec.docs) {
+    const data = d.data();
+    const email = (typeof data.email === "string" ? data.email : d.id).toLowerCase();
+    if (data.unsubscribed === true) unsubbed.add(email);
+    const fname = typeof data.firstName === "string" ? data.firstName : "";
+    if (fname) ecNameByEmail.set(email, fname);
+  }
+
+  // Site registrations (badge-issued set). Excluded statuses: cancelled.
+  const siteRegSnap = await db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).get();
+  const siteRegisteredEmails = new Set<string>();
+  let cancelledCount = 0;
+  for (const d of siteRegSnap.docs) {
+    const data = d.data();
+    const e = (data.email || "").toString().toLowerCase();
+    if (!e) continue;
+    if (data.status === "cancelled") {
+      cancelledCount++;
+      continue;
+    }
+    siteRegisteredEmails.add(e);
+  }
+
+  // Build recipient list — Luma rows ∩ NOT registered ∩ NOT unsubscribed
+  const seen = new Set<string>();
+  const recipients: Recipient[] = [];
+  let skippedRegistered = 0;
+  let skippedUnsub = 0;
+  let skippedDup = 0;
+  let skippedNoEmail = 0;
+  let skippedDeclined = 0;
+
+  for (const r of lumaRows) {
+    const email = (r.email || "").trim().toLowerCase();
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (seen.has(email)) {
+      skippedDup++;
+      continue;
+    }
+    seen.add(email);
+    if ((r.approval_status || "").toLowerCase() === "declined") {
+      skippedDeclined++;
+      continue;
+    }
+    if (unsubbed.has(email)) {
+      skippedUnsub++;
+      continue;
+    }
+    if (siteRegisteredEmails.has(email)) {
+      skippedRegistered++;
+      continue;
+    }
+    const firstName =
+      (r.first_name || "").trim() ||
+      ecNameByEmail.get(email) ||
+      ((r.name || "").split(" ")[0] || "").trim();
+    recipients.push({ email, firstName });
+  }
+
+  console.log(
+    `\nLuma list: ${lumaRows.length} rows`
+  );
+  console.log(
+    `Site registrations: ${siteRegSnap.size} (${cancelledCount} cancelled, ${siteRegisteredEmails.size} active)`
+  );
+  console.log(
+    `\nRecipients (Luma RSVP'd but no badge yet): ${recipients.length}`
+  );
+  console.log(
+    `Skipped: ${skippedRegistered} already-registered, ${skippedUnsub} unsubscribed, ${skippedDeclined} luma-declined, ${skippedDup} dupes, ${skippedNoEmail} blank-email`
+  );
+
+  if (dryRun) {
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample);
+      console.log(`\n--- sample to ${sample.email} (${sample.firstName || "(no first name)"}) ---`);
+      console.log(`Subject: ${subject}\n`);
+      console.log(text);
+    } else {
+      console.log("\n(no recipients — nothing to preview)");
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  console.log(`\nSending to ${recipients.length} recipients…`);
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, text, html } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, text, html });
+      sent++;
+      if (sent % 25 === 0 || sent === recipients.length) {
+        console.log(`  sent ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  FAILED ${r.email}: ${e instanceof Error ? e.message : e}`);
+    }
+    await new Promise((res) => setTimeout(res, 80));
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Develop → main release. Two PRs, each crediting the original contributor.

## Included PRs

- **#706 — fix(members): add clear empty state for unmatched search** — @SirinThamakaison
  Replaces the generic "No members match your search." with a query-aware "No members found matching \`{query}\`" plus helper text and a "View all members" recovery action. Tests updated in \`MemberDirectory.test.tsx\`.

- **#707 — fix(game): admin grant-100-turns button + 2026-05-07 broadcast scripts** — @rogerSuperBuilderAlpha (with Claude Opus 4.7)
  Restores the "Grant 100 turns (admin)" button on \`/game\` by surfacing server-evaluated \`isAdmin\` through \`/api/game/player\` (the previous gate read \`userProfile.isAdmin\`, a Firestore field never written in this repo). Also adds four 2026-05-07 ops broadcast scripts already used to email the May 26 attendee list, the PyData badge-reminder set, and the no-event eventContacts segment.

## Test plan

- [x] All component PRs already passed CI individually
- [x] Type check + game test suite clean on develop tip
- [ ] Smoke: \`/game\` admin button renders for token-claim or legacy-email admins
- [ ] Smoke: \`/members\` empty state renders the query-aware copy