### PR TITLE
Release: game UX pass (map nav, enemy contrast, spells tier table, threat-priority recruit)

### DIFF
--- a/__tests__/lib/game/threat.test.ts
+++ b/__tests__/lib/game/threat.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  computeTileThreat,
+  rankTileIdsByThreat,
+} from "@/lib/game/threat";
+import type { ThreatOwnerInfo } from "@/lib/game/threat";
+import type { MapTile, LandType } from "@/lib/game/types";
+import { neighbors, tileIdFromAxial } from "@/lib/game/world-gen";
+
+function tile(q: number, r: number, ownerId: string | null, type: LandType = "military"): MapTile {
+  return {
+    tileId: tileIdFromAxial(q, r),
+    q,
+    r,
+    type,
+    ownerId,
+    units: { ground: 0, siege: 0, air: 0 },
+    armedDefenseSpellId: null,
+  };
+}
+
+const ME = "me";
+const ENEMY_A = "enemyA";
+const ENEMY_B = "enemyB";
+
+const UNSHIELDED: ThreatOwnerInfo = { shielded: false };
+const SHIELDED: ThreatOwnerInfo = { shielded: true };
+
+describe("computeTileThreat", () => {
+  it("returns an empty map when the player has no tiles", () => {
+    const out = computeTileThreat({
+      myTiles: [],
+      worldTiles: [tile(5, 0, ENEMY_A)],
+      owners: new Map([[ENEMY_A, UNSHIELDED]]),
+      myUserId: ME,
+    });
+    expect(out.size).toBe(0);
+  });
+
+  it("scores 0 when the world has no enemies", () => {
+    const me = tile(0, 0, ME);
+    const out = computeTileThreat({
+      myTiles: [me],
+      worldTiles: [me],
+      owners: new Map(),
+      myUserId: ME,
+    });
+    expect(out.get(me.tileId)).toEqual({
+      hostileNeighbors: 0,
+      distanceToEnemy: Number.POSITIVE_INFINITY,
+      score: 0,
+    });
+  });
+
+  it("counts each unshielded enemy that sits in a hex neighbor slot", () => {
+    const me = tile(0, 0, ME);
+    // Two of the six neighbors are unshielded enemies.
+    const ns = neighbors(0, 0);
+    const enemy1 = tile(ns[0].q, ns[0].r, ENEMY_A);
+    const enemy2 = tile(ns[1].q, ns[1].r, ENEMY_A);
+    const out = computeTileThreat({
+      myTiles: [me],
+      worldTiles: [me, enemy1, enemy2],
+      owners: new Map([[ENEMY_A, UNSHIELDED]]),
+      myUserId: ME,
+    });
+    const t = out.get(me.tileId)!;
+    expect(t.hostileNeighbors).toBe(2);
+    expect(t.distanceToEnemy).toBe(1);
+    // 2 * 1000 + 1 / (1 + 1) = 2000.5
+    expect(t.score).toBeCloseTo(2000.5, 5);
+  });
+
+  it("ignores shielded enemies — they cannot attack", () => {
+    const me = tile(0, 0, ME);
+    const ns = neighbors(0, 0);
+    const shieldedEnemy = tile(ns[0].q, ns[0].r, ENEMY_A);
+    const out = computeTileThreat({
+      myTiles: [me],
+      worldTiles: [me, shieldedEnemy],
+      owners: new Map([[ENEMY_A, SHIELDED]]),
+      myUserId: ME,
+    });
+    const t = out.get(me.tileId)!;
+    expect(t.hostileNeighbors).toBe(0);
+    // No unshielded enemy at all → distance is infinity, term is 0.
+    expect(t.distanceToEnemy).toBe(Number.POSITIVE_INFINITY);
+    expect(t.score).toBe(0);
+  });
+
+  it("counts a tile bordering two enemies (different owners) correctly", () => {
+    const me = tile(0, 0, ME);
+    const ns = neighbors(0, 0);
+    const enemyA = tile(ns[0].q, ns[0].r, ENEMY_A);
+    const enemyB = tile(ns[2].q, ns[2].r, ENEMY_B);
+    const out = computeTileThreat({
+      myTiles: [me],
+      worldTiles: [me, enemyA, enemyB],
+      owners: new Map([
+        [ENEMY_A, UNSHIELDED],
+        [ENEMY_B, UNSHIELDED],
+      ]),
+      myUserId: ME,
+    });
+    expect(out.get(me.tileId)!.hostileNeighbors).toBe(2);
+  });
+
+  it("a bordering tile always outranks a non-bordering one that is merely close", () => {
+    // Border tile: adjacent to enemyA at hex distance 1.
+    const ns = neighbors(0, 0);
+    const border = tile(0, 0, ME);
+    const enemy = tile(ns[0].q, ns[0].r, ENEMY_A);
+    // Non-border tile: 2 hexes from enemy (closer than infinity, but not adjacent).
+    const offBy2 = tile(ns[1].q + ns[1].q, ns[1].r + ns[1].r, ME);
+    // Sanity: offBy2 is not adjacent to enemy.
+    const myTiles = [border, offBy2];
+    const out = computeTileThreat({
+      myTiles,
+      worldTiles: [...myTiles, enemy],
+      owners: new Map([[ENEMY_A, UNSHIELDED]]),
+      myUserId: ME,
+    });
+    const borderScore = out.get(border.tileId)!.score;
+    const offScore = out.get(offBy2.tileId)!.score;
+    expect(borderScore).toBeGreaterThan(offScore);
+    // And specifically: border's score is at least 1000 (one hostile neighbor),
+    // off-tile's score is < 1 (no hostile neighbor).
+    expect(borderScore).toBeGreaterThanOrEqual(1000);
+    expect(offScore).toBeLessThan(1);
+  });
+
+  it("skips own-owned tiles when scanning the world for enemies", () => {
+    // A tile owned by `me` should never count as an enemy neighbor.
+    const me1 = tile(0, 0, ME);
+    const ns = neighbors(0, 0);
+    const me2 = tile(ns[0].q, ns[0].r, ME);
+    const out = computeTileThreat({
+      myTiles: [me1],
+      worldTiles: [me1, me2],
+      owners: new Map(),
+      myUserId: ME,
+    });
+    expect(out.get(me1.tileId)!.hostileNeighbors).toBe(0);
+  });
+
+  it("treats unknown owners as unshielded (safer to over-count)", () => {
+    const me = tile(0, 0, ME);
+    const ns = neighbors(0, 0);
+    const ghost = tile(ns[0].q, ns[0].r, "ghost-with-no-owner-record");
+    const out = computeTileThreat({
+      myTiles: [me],
+      worldTiles: [me, ghost],
+      // owners map omits "ghost-with-no-owner-record"
+      owners: new Map(),
+      myUserId: ME,
+    });
+    expect(out.get(me.tileId)!.hostileNeighbors).toBe(1);
+  });
+});
+
+describe("rankTileIdsByThreat", () => {
+  it("orders by descending score, with axial coord as a stable tiebreaker", () => {
+    const ranked = rankTileIdsByThreat(
+      ["1_0", "0_0", "2_-1"],
+      new Map([
+        ["1_0", { hostileNeighbors: 1, distanceToEnemy: 1, score: 1000.5 }],
+        ["0_0", { hostileNeighbors: 0, distanceToEnemy: 5, score: 0.16 }],
+        ["2_-1", { hostileNeighbors: 1, distanceToEnemy: 2, score: 1000.33 }],
+      ])
+    );
+    expect(ranked).toEqual(["1_0", "2_-1", "0_0"]);
+  });
+
+  it("appends tiles with no threat record at the end (treated as score 0)", () => {
+    const ranked = rankTileIdsByThreat(
+      ["unknown_tile", "1_0"],
+      new Map([
+        ["1_0", { hostileNeighbors: 1, distanceToEnemy: 1, score: 1000.5 }],
+      ])
+    );
+    expect(ranked).toEqual(["1_0", "unknown_tile"]);
+  });
+
+  it("uses axial coord (q then r) as the tiebreaker on equal scores", () => {
+    const equalScore = { hostileNeighbors: 0, distanceToEnemy: 5, score: 0 };
+    const ranked = rankTileIdsByThreat(
+      ["3_2", "1_5", "1_4"],
+      new Map([
+        ["3_2", equalScore],
+        ["1_5", equalScore],
+        ["1_4", equalScore],
+      ])
+    );
+    // q ascending: 1_4 (q=1, r=4) < 1_5 (q=1, r=5) < 3_2 (q=3, r=2)
+    expect(ranked).toEqual(["1_4", "1_5", "3_2"]);
+  });
+});

--- a/app/api/game/spell/arm/route.ts
+++ b/app/api/game/spell/arm/route.ts
@@ -10,6 +10,9 @@ import { mapGameError } from "@/lib/game/api-error-map";
 import { parseBatchCount, runBatch } from "@/lib/game/api-batch";
 import { armDefenseSpellServer } from "@/lib/game/data-server";
 import { getVerifiedUser } from "@/lib/server-auth";
+import type { TurnReport } from "@/lib/game/types";
+
+const MAX_BULK_TILES = 200;
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,19 +21,74 @@ export async function POST(request: NextRequest) {
 
     const bodyOrError = await parseRequestBody<{
       tileId?: unknown;
+      tileIds?: unknown;
       spellId?: unknown;
       count?: unknown;
     }>(request);
     if (bodyOrError instanceof NextResponse) return bodyOrError;
 
-    const tileId =
-      typeof bodyOrError.tileId === "string" ? bodyOrError.tileId : null;
     const spellId =
       typeof bodyOrError.spellId === "string" ? bodyOrError.spellId : null;
-    if (!tileId) return apiError("tileId is required", 400);
     if (!spellId) return apiError("spellId is required", 400);
-    const count = parseBatchCount(bodyOrError.count);
 
+    // Bulk form: { spellId, tileIds: string[] } — arms one tile per id, in
+    // order, attempting every tile even if earlier ones fail. Returns a
+    // partial-success summary so the UI can show "armed 7 of 10; 3 failed".
+    if (Array.isArray(bodyOrError.tileIds)) {
+      const tileIds = bodyOrError.tileIds.filter(
+        (x): x is string => typeof x === "string" && x.length > 0
+      );
+      if (tileIds.length === 0) {
+        return apiError("tileIds must be a non-empty array of strings", 400);
+      }
+      if (tileIds.length > MAX_BULK_TILES) {
+        return apiError(
+          `Too many tileIds (${tileIds.length}); cap is ${MAX_BULK_TILES}`,
+          400
+        );
+      }
+
+      const armed: Array<{ tileId: string; report: TurnReport }> = [];
+      const failed: Array<{ tileId: string; reason: string }> = [];
+      let lastResult: Awaited<ReturnType<typeof armDefenseSpellServer>> | null = null;
+      for (const tileId of tileIds) {
+        try {
+          const out = await armDefenseSpellServer(user.uid, tileId, spellId);
+          armed.push({ tileId, report: out.report });
+          lastResult = out;
+        } catch (err) {
+          failed.push({
+            tileId,
+            reason: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // If every single attempt failed, fall through to mapGameError so the
+      // user gets a clean error response rather than a "0 armed" success.
+      if (armed.length === 0 && failed.length > 0) {
+        // Re-run the first attempt to surface its original GameError shape
+        // (preserves error code + HTTP status). Only the first failure is
+        // worth re-throwing; subsequent ones likely share the same root cause.
+        return mapGameError(new Error(failed[0]!.reason));
+      }
+
+      return apiSuccess({
+        player: lastResult?.player ?? null,
+        armed: armed.length,
+        failed,
+        reports: armed.map((a) => a.report),
+      });
+    }
+
+    // Single-tile form: { spellId, tileId, count? } — preserves existing
+    // batch-arming behavior (same tile + spell, repeated `count` times).
+    const tileId =
+      typeof bodyOrError.tileId === "string" ? bodyOrError.tileId : null;
+    if (!tileId) {
+      return apiError("tileId or tileIds is required", 400);
+    }
+    const count = parseBatchCount(bodyOrError.count);
     const { reports, lastResult, stoppedEarly } = await runBatch(count, () =>
       armDefenseSpellServer(user.uid, tileId, spellId)
     );

--- a/app/game/recruit/page.tsx
+++ b/app/game/recruit/page.tsx
@@ -7,14 +7,20 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { getCasteProfile } from "@/lib/game/content";
 import {
   effectiveUnitCap,
   PRODUCTION_SPELL_DURATION_TURNS,
 } from "@/lib/game/turns";
+import {
+  computeTileThreat,
+  rankTileIdsByThreat,
+  type ThreatOwnerInfo,
+} from "@/lib/game/threat";
 import type {
+  Caste,
   GamePlayer,
   MapTile,
   TurnReport,
@@ -33,18 +39,71 @@ interface PlayerResponse {
   error?: PlayerResponseError | string;
 }
 
+interface OwnerSummary {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+}
+
+interface WorldResponse {
+  success: boolean;
+  tiles?: MapTile[];
+  owners?: OwnerSummary[];
+  error?: PlayerResponseError | string;
+}
+
 const UNITS_PER_CYCLE = 10;
 const TURNS_PER_CYCLE = 5;
+
+/**
+ * Distribute `totalCycles` build-cycles across `tileIds` (in threat-ranked
+ * order, top-threat first), favoring earlier entries. Linear weights:
+ * rank 0 gets weight N, rank N-1 gets weight 1, total = N(N+1)/2. The top
+ * tile receives roughly N times the bottom tile's share, with remainder
+ * cycles falling to the most-threatened tiles first.
+ *
+ * Returns plan entries with `cycles > 0` only.
+ */
+function buildThreatPriorityPlan(
+  threatRankedTileIds: ReadonlyArray<string>,
+  totalCycles: number
+): Array<{ tileId: string; cycles: number }> {
+  const N = threatRankedTileIds.length;
+  if (N === 0 || totalCycles <= 0) return [];
+  const weights = threatRankedTileIds.map((_, i) => N - i);
+  const totalWeight = weights.reduce((a, b) => a + b, 0);
+  const cycles = threatRankedTileIds.map((_, i) =>
+    Math.floor((totalCycles * weights[i]) / totalWeight)
+  );
+  let assigned = cycles.reduce((a, b) => a + b, 0);
+  // Top-down remainder allocation so the most-threatened tile picks up the
+  // leftover when totalCycles doesn't divide evenly.
+  let cursor = 0;
+  while (assigned < totalCycles) {
+    cycles[cursor % N]++;
+    assigned++;
+    cursor++;
+  }
+  return threatRankedTileIds
+    .map((tileId, idx) => ({ tileId, cycles: cycles[idx] }))
+    .filter((p) => p.cycles > 0);
+}
 
 export default function RecruitPage() {
   const { user, loading: authLoading } = useAuth();
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [tiles, setTiles] = useState<MapTile[]>([]);
+  const [worldTiles, setWorldTiles] = useState<MapTile[]>([]);
+  const [owners, setOwners] = useState<Map<string, OwnerSummary>>(new Map());
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [unitType, setUnitType] = useState<UnitType>("ground");
   const [requestedUnits, setRequestedUnits] = useState(50);
+  // "" → auto-route by threat across all military tiles. Otherwise the
+  // user has explicitly picked one tile and 100% of the recruit goes there.
+  const [selectedTileId, setSelectedTileId] = useState<string>("");
   const [progress, setProgress] = useState<{
     done: number;
     total: number;
@@ -61,10 +120,15 @@ export default function RecruitPage() {
     setError(null);
     try {
       const token = await user.getIdToken();
-      const res = await fetch("/api/game/player", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = (await res.json()) as PlayerResponse;
+      const [playerRes, worldRes] = await Promise.all([
+        fetch("/api/game/player", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch("/api/game/world", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+      const data = (await playerRes.json()) as PlayerResponse;
       if (!data.success) {
         const msg =
           typeof data.error === "string"
@@ -74,6 +138,13 @@ export default function RecruitPage() {
       }
       setPlayer(data.player);
       setTiles(data.tiles ?? []);
+      const worldData = (await worldRes.json()) as WorldResponse;
+      if (worldData.success) {
+        setWorldTiles(worldData.tiles ?? []);
+        const map = new Map<string, OwnerSummary>();
+        for (const o of worldData.owners ?? []) map.set(o.userId, o);
+        setOwners(map);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -87,9 +158,31 @@ export default function RecruitPage() {
     refresh();
   }, [authLoading, refresh]);
 
-  const militaryTiles = tiles.filter((t) => t.type === "military");
+  const militaryTiles = useMemo(
+    () => tiles.filter((t) => t.type === "military"),
+    [tiles]
+  );
   const foodTiles = tiles.filter((t) => t.type === "food");
   const magicTiles = tiles.filter((t) => t.type === "magic");
+
+  // Threat-ranked military-tile ids. Drives the auto-route distribution and
+  // the order tiles appear in the manual-override picker (most exposed at
+  // top is what a player wants to see).
+  const threatRankedMilitaryIds = useMemo(() => {
+    if (!player) return [] as string[];
+    const ownerInfo = new Map<string, ThreatOwnerInfo>();
+    for (const [uid, o] of owners) ownerInfo.set(uid, { shielded: o.shielded });
+    const threat = computeTileThreat({
+      myTiles: militaryTiles,
+      worldTiles,
+      owners: ownerInfo,
+      myUserId: player.userId,
+    });
+    return rankTileIdsByThreat(
+      militaryTiles.map((t) => t.tileId),
+      threat
+    );
+  }, [militaryTiles, worldTiles, owners, player]);
 
   // Compute the player's current effective unit cap. This mirrors what the
   // server uses inside buildUnitsServer so the displayed numbers match what
@@ -106,17 +199,38 @@ export default function RecruitPage() {
   const maxCycles = Math.min(maxCyclesByCap, maxCyclesByTurns);
   const maxUnits = maxCycles * UNITS_PER_CYCLE;
 
+  // Final units rounded to a multiple of UNITS_PER_CYCLE and bounded by cap.
+  const effectiveUnits = useMemo(
+    () =>
+      Math.max(
+        UNITS_PER_CYCLE,
+        Math.min(
+          maxUnits,
+          Math.floor(requestedUnits / UNITS_PER_CYCLE) * UNITS_PER_CYCLE
+        )
+      ),
+    [maxUnits, requestedUnits]
+  );
+  const effectiveCycles = Math.max(0, Math.floor(effectiveUnits / UNITS_PER_CYCLE));
+
+  // Distribution preview, used to render a transparent "this is where the
+  // units are going" line above the recruit button. Auto-routes by threat
+  // unless the user explicitly picked a tile.
+  const planPreview = useMemo(() => {
+    if (effectiveCycles === 0) return [];
+    if (selectedTileId) {
+      return [{ tileId: selectedTileId, cycles: effectiveCycles }];
+    }
+    return buildThreatPriorityPlan(threatRankedMilitaryIds, effectiveCycles);
+  }, [effectiveCycles, selectedTileId, threatRankedMilitaryIds]);
+
   const handleRecruit = useCallback(async () => {
     if (!user || !player) return;
     if (militaryTiles.length === 0) {
       setError("You have no military tiles to recruit from.");
       return;
     }
-    const units = Math.max(
-      UNITS_PER_CYCLE,
-      Math.min(maxUnits, Math.floor(requestedUnits / UNITS_PER_CYCLE) * UNITS_PER_CYCLE)
-    );
-    const totalCycles = Math.floor(units / UNITS_PER_CYCLE);
+    const totalCycles = effectiveCycles;
     if (totalCycles === 0) {
       setError("Not enough turns or capacity to recruit any units.");
       return;
@@ -131,17 +245,14 @@ export default function RecruitPage() {
     });
     try {
       const token = await user.getIdToken();
-      // Build a round-robin plan across military tiles so units distribute
-      // evenly. Aggregate consecutive cycles to the same tile into one entry
-      // so the server's plan stays small.
-      const cyclesPerTile: Map<string, number> = new Map();
-      for (let i = 0; i < totalCycles; i++) {
-        const tileId = militaryTiles[i % militaryTiles.length].tileId;
-        cyclesPerTile.set(tileId, (cyclesPerTile.get(tileId) ?? 0) + 1);
-      }
-      const plan = Array.from(cyclesPerTile.entries()).map(
-        ([tileId, cycles]) => ({ tileId, unitType, cycles })
-      );
+      const planEntries = selectedTileId
+        ? [{ tileId: selectedTileId, cycles: totalCycles }]
+        : buildThreatPriorityPlan(threatRankedMilitaryIds, totalCycles);
+      const plan = planEntries.map(({ tileId, cycles }) => ({
+        tileId,
+        unitType,
+        cycles,
+      }));
       const res = await fetch("/api/game/build/bulk", {
         method: "POST",
         headers: {
@@ -190,7 +301,16 @@ export default function RecruitPage() {
       setBusy(false);
       setProgress(null);
     }
-  }, [user, player, militaryTiles, maxUnits, requestedUnits, unitType, refresh]);
+  }, [
+    user,
+    player,
+    militaryTiles,
+    effectiveCycles,
+    selectedTileId,
+    threatRankedMilitaryIds,
+    unitType,
+    refresh,
+  ]);
 
   if (authLoading || loading) {
     return (
@@ -296,57 +416,88 @@ export default function RecruitPage() {
               bulk-assign panel or any tile&apos;s detail page.
             </p>
           ) : (
-            <div className="flex flex-wrap items-center gap-3">
-              <label className="text-sm">
-                Unit type:{" "}
-                <select
-                  value={unitType}
-                  onChange={(e) => setUnitType(e.target.value as UnitType)}
-                  disabled={busy}
-                  className="ml-2 px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent capitalize"
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <label className="text-sm">
+                  Unit type:{" "}
+                  <select
+                    value={unitType}
+                    onChange={(e) => setUnitType(e.target.value as UnitType)}
+                    disabled={busy}
+                    className="ml-2 px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent capitalize"
+                  >
+                    <option value="ground">ground</option>
+                    <option value="siege">siege</option>
+                    <option value="air">air</option>
+                  </select>
+                </label>
+                <label className="text-sm">
+                  Units (multiple of {UNITS_PER_CYCLE}):{" "}
+                  <input
+                    type="number"
+                    step={UNITS_PER_CYCLE}
+                    min={UNITS_PER_CYCLE}
+                    max={Math.max(UNITS_PER_CYCLE, maxUnits)}
+                    value={requestedUnits}
+                    onChange={(e) => {
+                      const n = Number.parseInt(e.target.value, 10);
+                      if (Number.isFinite(n)) setRequestedUnits(n);
+                    }}
+                    disabled={busy}
+                    className="w-24 px-2 py-1 ml-2 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+                  />
+                </label>
+                <label className="text-sm">
+                  Distribute to:{" "}
+                  <select
+                    value={selectedTileId}
+                    onChange={(e) => setSelectedTileId(e.target.value)}
+                    disabled={busy || militaryTiles.length === 0}
+                    className="ml-2 px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+                  >
+                    <option value="">
+                      Auto — most-threatened tiles first
+                    </option>
+                    {threatRankedMilitaryIds.map((tileId, idx) => (
+                      <option key={tileId} value={tileId}>
+                        {tileId}
+                        {idx === 0 ? " (top threat)" : ""}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button
+                  onClick={handleRecruit}
+                  disabled={busy || maxCycles === 0}
+                  className="px-5 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
                 >
-                  <option value="ground">ground</option>
-                  <option value="siege">siege</option>
-                  <option value="air">air</option>
-                </select>
-              </label>
-              <label className="text-sm">
-                Units (multiple of {UNITS_PER_CYCLE}):{" "}
-                <input
-                  type="number"
-                  step={UNITS_PER_CYCLE}
-                  min={UNITS_PER_CYCLE}
-                  max={Math.max(UNITS_PER_CYCLE, maxUnits)}
-                  value={requestedUnits}
-                  onChange={(e) => {
-                    const n = Number.parseInt(e.target.value, 10);
-                    if (Number.isFinite(n)) setRequestedUnits(n);
-                  }}
-                  disabled={busy}
-                  className="w-24 px-2 py-1 ml-2 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
-                />
-              </label>
-              <button
-                onClick={handleRecruit}
-                disabled={busy || maxCycles === 0}
-                className="px-5 py-2 bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
-              >
-                {busy
-                  ? "Training units…"
-                  : `Recruit ${Math.min(
-                      maxUnits,
-                      Math.max(
-                        UNITS_PER_CYCLE,
-                        Math.floor(requestedUnits / UNITS_PER_CYCLE) *
-                          UNITS_PER_CYCLE
-                      )
-                    )} ${unitType}`}
-              </button>
-              <span className="text-xs text-neutral-500">
-                ({TURNS_PER_CYCLE} turns / {UNITS_PER_CYCLE} units · across{" "}
-                {militaryTiles.length} tile
-                {militaryTiles.length === 1 ? "" : "s"})
-              </span>
+                  {busy
+                    ? "Training units…"
+                    : `Recruit ${effectiveUnits} ${unitType}`}
+                </button>
+              </div>
+              <p className="text-xs text-neutral-500">
+                {TURNS_PER_CYCLE} turns / {UNITS_PER_CYCLE} units · across{" "}
+                {militaryTiles.length} military tile
+                {militaryTiles.length === 1 ? "" : "s"}.
+              </p>
+              {planPreview.length > 0 && (
+                <div className="rounded-md border border-emerald-200 dark:border-emerald-900/50 bg-white dark:bg-neutral-950 px-3 py-2 text-xs">
+                  <div className="font-medium mb-1">
+                    {selectedTileId ? "Routing to" : "Auto-routing units"}
+                  </div>
+                  <ul className="font-mono text-[11px] space-y-0.5 text-neutral-700 dark:text-neutral-300">
+                    {planPreview.map(({ tileId, cycles }, idx) => (
+                      <li key={tileId}>
+                        {tileId} +{cycles * UNITS_PER_CYCLE}
+                        {!selectedTileId && idx === 0 && planPreview.length > 1
+                          ? "  (most-threatened)"
+                          : ""}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
           )}
 

--- a/app/game/spells/page.tsx
+++ b/app/game/spells/page.tsx
@@ -7,13 +7,20 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ALL_SPELLS, SPELLS_BY_ID } from "@/lib/game/content";
+import {
+  computeTileThreat,
+  rankTileIdsByThreat,
+  type ThreatOwnerInfo,
+} from "@/lib/game/threat";
 import type {
+  Caste,
   GamePlayer,
   MapTile,
   SpellDefinition,
+  SpellType,
   TurnReport,
 } from "@/lib/game/types";
 
@@ -29,17 +36,58 @@ interface PlayerResponse {
   error?: PlayerResponseError | string;
 }
 
-// Per-spell turn cost is now read from spell.turnCost (varies by tier 1..5).
+interface OwnerSummary {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+}
+
+interface WorldResponse {
+  success: boolean;
+  tiles?: MapTile[];
+  owners?: OwnerSummary[];
+  error?: PlayerResponseError | string;
+}
+
+// 5 tiers, in display order. Min-tiles & turn-cost come from each spell's own
+// fields — this list is only used to render the row scaffolding so locked
+// tiers still appear with their requirement.
+const TIERS: Array<{ tier: 1 | 2 | 3 | 4 | 5; minTiles: number }> = [
+  { tier: 1, minTiles: 0 },
+  { tier: 2, minTiles: 500 },
+  { tier: 3, minTiles: 1500 },
+  { tier: 4, minTiles: 5000 },
+  { tier: 5, minTiles: 20000 },
+];
+
+// Column order in the tier × type table. Defense first because that's the
+// only column with bulk-arm UX, and reading "what should I cast right now"
+// usually starts with "what's keeping me alive".
+const TYPE_COLUMNS: SpellType[] = ["defense", "offense", "production"];
+
+const TYPE_LABEL: Record<SpellType, string> = {
+  defense: "Defense",
+  offense: "Offense",
+  production: "Production",
+};
 
 export default function SpellsPage() {
   const { user, loading: authLoading } = useAuth();
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [tiles, setTiles] = useState<MapTile[]>([]);
+  const [worldTiles, setWorldTiles] = useState<MapTile[]>([]);
+  const [owners, setOwners] = useState<Map<string, OwnerSummary>>(new Map());
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [recentReports, setRecentReports] = useState<TurnReport[]>([]);
+  // Defense-spell single-arm picker (legacy flow, preserved as the "arm one"
+  // shortcut alongside the new bulk panel).
   const [armTargetTileId, setArmTargetTileId] = useState<string>("");
+  // Which defense spell, if any, has its bulk-arm panel open.
+  const [bulkSpellId, setBulkSpellId] = useState<string | null>(null);
+  const [bulkN, setBulkN] = useState<number>(0);
 
   const refresh = useCallback(async () => {
     if (!user) {
@@ -49,10 +97,15 @@ export default function SpellsPage() {
     setError(null);
     try {
       const token = await user.getIdToken();
-      const res = await fetch("/api/game/player", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = (await res.json()) as PlayerResponse;
+      const [playerRes, worldRes] = await Promise.all([
+        fetch("/api/game/player", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch("/api/game/world", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+      const data = (await playerRes.json()) as PlayerResponse;
       if (!data.success) {
         const msg =
           typeof data.error === "string"
@@ -62,6 +115,13 @@ export default function SpellsPage() {
       }
       setPlayer(data.player);
       setTiles(data.tiles ?? []);
+      const worldData = (await worldRes.json()) as WorldResponse;
+      if (worldData.success) {
+        setWorldTiles(worldData.tiles ?? []);
+        const map = new Map<string, OwnerSummary>();
+        for (const o of worldData.owners ?? []) map.set(o.userId, o);
+        setOwners(map);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -102,6 +162,11 @@ export default function SpellsPage() {
             [data.report as TurnReport, ...prev].slice(0, 25)
           );
         }
+        if (Array.isArray(data.reports)) {
+          setRecentReports((prev) =>
+            [...(data.reports as TurnReport[]), ...prev].slice(0, 25)
+          );
+        }
         await refresh();
         return data;
       } catch (e) {
@@ -124,7 +189,7 @@ export default function SpellsPage() {
     [callApi]
   );
 
-  const armDefense = useCallback(
+  const armDefenseSingle = useCallback(
     async (spellId: string) => {
       if (!armTargetTileId) {
         setError("Pick a tile to arm the spell on first.");
@@ -143,15 +208,87 @@ export default function SpellsPage() {
     [callApi, armTargetTileId]
   );
 
-  const casteSpells: SpellDefinition[] = player?.caste
-    ? ALL_SPELLS.filter((s) => s.caste === player.caste)
-    : [];
+  const armDefenseBulk = useCallback(
+    async (spellId: string, tileIds: string[]) => {
+      if (tileIds.length === 0) return;
+      setBusyId(spellId);
+      try {
+        const data = await callApi("/api/game/spell/arm", {
+          spellId,
+          tileIds,
+        });
+        if (data && Array.isArray(data.failed) && data.failed.length > 0) {
+          // Surface partial failure prominently — the user just spent turns
+          // and only some landed.
+          const sample = data.failed
+            .slice(0, 3)
+            .map((f: { tileId: string; reason: string }) => `${f.tileId}: ${f.reason}`)
+            .join("; ");
+          setError(
+            `Armed ${data.armed ?? 0} of ${tileIds.length}; ${data.failed.length} failed (${sample}${data.failed.length > 3 ? "…" : ""})`
+          );
+        }
+        setBulkSpellId(null);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [callApi]
+  );
 
-  const armableTiles = tiles.filter(
-    (t) => t.type !== "unrevealed" && t.ownerId === player?.userId
+  // Build a (tier, type) → spell lookup so the table cells can pull their
+  // spell in O(1). React Compiler memoizes this for us.
+  const spellByTierAndType = (() => {
+    const map = new Map<string, SpellDefinition>();
+    if (!player?.caste) return map;
+    for (const s of ALL_SPELLS) {
+      if (s.caste !== player.caste) continue;
+      map.set(`${s.tier}|${s.type}`, s);
+    }
+    return map;
+  })();
+
+  // Tiles eligible to receive a defense spell: owned, revealed, not already
+  // armed. Sorted by per-tile threat for the bulk panel.
+  const armableUnarmedTiles = useMemo(
+    () =>
+      tiles.filter(
+        (t) =>
+          t.type !== "unrevealed" &&
+          t.ownerId === player?.userId &&
+          !t.armedDefenseSpellId
+      ),
+    [tiles, player?.userId]
+  );
+
+  // Including armed tiles too — used by the legacy single-arm picker so
+  // re-arming is still possible if the user wants to swap spells on a tile.
+  const armableTiles = useMemo(
+    () =>
+      tiles.filter(
+        (t) => t.type !== "unrevealed" && t.ownerId === player?.userId
+      ),
+    [tiles, player?.userId]
   );
 
   const armedTiles = tiles.filter((t) => t.armedDefenseSpellId);
+
+  // Per-tile threat score, used to sort the bulk-arm preview.
+  const threatRanked = useMemo(() => {
+    if (!player) return [] as string[];
+    const ownerInfo = new Map<string, ThreatOwnerInfo>();
+    for (const [uid, o] of owners) ownerInfo.set(uid, { shielded: o.shielded });
+    const threat = computeTileThreat({
+      myTiles: armableUnarmedTiles,
+      worldTiles,
+      owners: ownerInfo,
+      myUserId: player.userId,
+    });
+    return rankTileIdsByThreat(
+      armableUnarmedTiles.map((t) => t.tileId),
+      threat
+    );
+  }, [armableUnarmedTiles, worldTiles, owners, player]);
 
   if (authLoading || loading) {
     return (
@@ -201,7 +338,7 @@ export default function SpellsPage() {
 
   return (
     <div className="min-h-screen py-12 px-6">
-      <div className="max-w-5xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         <div className="flex items-baseline justify-between mb-6">
           <h1 className="text-3xl font-bold capitalize">
             {player.caste} spell book
@@ -215,22 +352,11 @@ export default function SpellsPage() {
         </div>
 
         <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-6 text-sm leading-relaxed">
-          <p className="mb-2">
-            Each caste has three spell lines (defense / offense / production)
-            and <strong>five tiers</strong> per line. Higher tiers unlock as
-            your territory grows:
-          </p>
-          <ul className="list-disc ml-5 space-y-0.5 text-xs">
-            <li>Tier 1 — always available, 5 turns.</li>
-            <li>Tier 2 — 500 tiles held, 8 turns.</li>
-            <li>Tier 3 — 1,500 tiles held, 12 turns.</li>
-            <li>Tier 4 — 5,000 tiles held, 18 turns.</li>
-            <li>Tier 5 — 20,000 tiles held, 25 turns.</li>
-          </ul>
-          <p className="mt-2 text-xs text-neutral-600 dark:text-neutral-400">
-            You currently hold{" "}
-            <strong className="font-mono">{tilesHeld}</strong> tiles. Locked
-            tiers are listed but not castable.
+          <p className="mb-1">
+            Five tiers × three spell types. Higher tiers unlock as your
+            territory grows. You currently hold{" "}
+            <strong className="font-mono">{tilesHeld}</strong> tiles · turns
+            remaining: <strong>{player.turnsRemaining}</strong>.
           </p>
         </div>
 
@@ -238,29 +364,60 @@ export default function SpellsPage() {
           <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
 
-        <div className="text-sm text-neutral-500 mb-6">
-          Turns remaining: <strong>{player.turnsRemaining}</strong>
-        </div>
-
-        <h2 className="text-lg font-semibold mb-3">Your spells</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-          {casteSpells.map((s) => {
-            const unlocked = tilesHeld >= s.minTilesRequired;
-            const affordable = player.turnsRemaining >= s.turnCost;
+        {/* Tier × type spell book table */}
+        <div className="space-y-6 mb-10">
+          {TIERS.map(({ tier, minTiles }) => {
+            const tierUnlocked = tilesHeld >= minTiles;
             return (
-              <SpellCard
-                key={s.id}
-                spell={s}
-                busy={busyId !== null}
-                busyForThis={busyId === s.id}
-                unlocked={unlocked}
-                affordable={affordable}
-                armTargetTileId={armTargetTileId}
-                setArmTargetTileId={setArmTargetTileId}
-                armableTiles={armableTiles}
-                onCastProduction={() => castProduction(s.id)}
-                onArmDefense={() => armDefense(s.id)}
-              />
+              <section
+                key={tier}
+                className={`border rounded-xl overflow-hidden ${
+                  tierUnlocked
+                    ? "border-neutral-200 dark:border-neutral-800"
+                    : "border-neutral-200 dark:border-neutral-800 opacity-60"
+                }`}
+              >
+                <header className="flex items-baseline justify-between px-4 py-2 bg-neutral-50 dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-800">
+                  <h2 className="text-sm font-semibold uppercase tracking-wide">
+                    Tier {tier}
+                  </h2>
+                  <span className="text-xs text-neutral-500">
+                    {tierUnlocked
+                      ? `unlocked at ${minTiles.toLocaleString()} tiles`
+                      : `locked — needs ${minTiles.toLocaleString()} tiles`}
+                  </span>
+                </header>
+                <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-neutral-200 dark:divide-neutral-800">
+                  {TYPE_COLUMNS.map((col) => {
+                    const spell = spellByTierAndType.get(`${tier}|${col}`);
+                    return (
+                      <SpellCell
+                        key={col}
+                        column={col}
+                        spell={spell}
+                        player={player}
+                        tilesHeld={tilesHeld}
+                        busy={busyId !== null}
+                        busyForThis={
+                          spell ? busyId === spell.id : false
+                        }
+                        armTargetTileId={armTargetTileId}
+                        setArmTargetTileId={setArmTargetTileId}
+                        armableTiles={armableTiles}
+                        bulkSpellId={bulkSpellId}
+                        setBulkSpellId={setBulkSpellId}
+                        bulkN={bulkN}
+                        setBulkN={setBulkN}
+                        threatRanked={threatRanked}
+                        armableUnarmedTiles={armableUnarmedTiles}
+                        onCastProduction={castProduction}
+                        onArmDefenseSingle={armDefenseSingle}
+                        onArmDefenseBulk={armDefenseBulk}
+                      />
+                    );
+                  })}
+                </div>
+              </section>
             );
           })}
         </div>
@@ -295,8 +452,8 @@ export default function SpellsPage() {
         <h2 className="text-lg font-semibold mb-3">Tiles with defense armed</h2>
         {armedTiles.length === 0 ? (
           <p className="text-sm text-neutral-500 italic mb-8">
-            No tiles armed yet. Pick one from your tiles list and arm a defense
-            spell on it.
+            No tiles armed yet. Use the bulk-arm panel on a defense spell — it
+            sorts your tiles by threat (bordering enemies first).
           </p>
         ) : (
           <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg mb-8 divide-y divide-neutral-200 dark:divide-neutral-800">
@@ -320,121 +477,212 @@ export default function SpellsPage() {
           </div>
         )}
 
-        {recentReports.length > 0 && (
-          <ReportLog reports={recentReports} />
-        )}
+        {recentReports.length > 0 && <ReportLog reports={recentReports} />}
       </div>
     </div>
   );
 }
 
-function SpellCard({
+function SpellCell({
+  column,
   spell,
+  player,
+  tilesHeld,
   busy,
   busyForThis,
-  unlocked,
-  affordable,
   armTargetTileId,
   setArmTargetTileId,
   armableTiles,
+  bulkSpellId,
+  setBulkSpellId,
+  bulkN,
+  setBulkN,
+  threatRanked,
+  armableUnarmedTiles,
   onCastProduction,
-  onArmDefense,
+  onArmDefenseSingle,
+  onArmDefenseBulk,
 }: {
-  spell: SpellDefinition;
+  column: SpellType;
+  spell: SpellDefinition | undefined;
+  player: GamePlayer;
+  tilesHeld: number;
   busy: boolean;
   busyForThis: boolean;
-  unlocked: boolean;
-  affordable: boolean;
   armTargetTileId: string;
   setArmTargetTileId: (id: string) => void;
   armableTiles: MapTile[];
-  onCastProduction: () => void;
-  onArmDefense: () => void;
+  bulkSpellId: string | null;
+  setBulkSpellId: (id: string | null) => void;
+  bulkN: number;
+  setBulkN: (n: number) => void;
+  threatRanked: string[];
+  armableUnarmedTiles: MapTile[];
+  onCastProduction: (spellId: string) => void;
+  onArmDefenseSingle: (spellId: string) => void;
+  onArmDefenseBulk: (spellId: string, tileIds: string[]) => void;
 }) {
+  if (!spell) {
+    return (
+      <div className="p-4 text-xs text-neutral-400 italic">
+        {TYPE_LABEL[column]} — no spell at this tier for your caste.
+      </div>
+    );
+  }
+
+  const unlocked = tilesHeld >= spell.minTilesRequired;
+  const affordable = player.turnsRemaining >= spell.turnCost;
   const canAct = unlocked && affordable;
   const buttonLabel = !unlocked
-    ? `Unlocks at ${spell.minTilesRequired.toLocaleString()} tiles`
+    ? `Locked`
     : !affordable
-      ? "Not enough turns"
+      ? "Out of turns"
       : "";
+
+  // Bulk-arm bookkeeping for the defense column.
+  const bulkOpen = bulkSpellId === spell.id;
+  const maxByTurns = Math.floor(player.turnsRemaining / Math.max(1, spell.turnCost));
+  const maxByTiles = armableUnarmedTiles.length;
+  const cap = Math.max(0, Math.min(maxByTurns, maxByTiles));
+  const effectiveN = Math.max(0, Math.min(bulkN, cap));
+  const previewTileIds = threatRanked.slice(0, effectiveN);
+
   return (
-    <div
-      className={`border rounded-lg p-4 flex flex-col ${
-        unlocked
-          ? "border-neutral-200 dark:border-neutral-800"
-          : "border-neutral-200 dark:border-neutral-800 opacity-60"
-      }`}
-    >
-      <div className="flex items-baseline justify-between mb-1 gap-2">
-        <h3 className="font-semibold">{spell.name}</h3>
-        <span className="text-xs uppercase tracking-wide text-neutral-500 shrink-0">
-          T{spell.tier} · {spell.type}
+    <div className="p-4 flex flex-col gap-3 min-h-[8rem]">
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="font-semibold text-sm">{spell.name}</h3>
+        <span className="text-[10px] uppercase tracking-wide text-neutral-500 shrink-0">
+          {TYPE_LABEL[column]}
         </span>
       </div>
-      <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3">
+      <p className="text-xs text-neutral-600 dark:text-neutral-400 leading-relaxed flex-1">
         {spell.description}
       </p>
-      <div className="text-xs text-neutral-500 mb-3">
+      <div className="text-[11px] text-neutral-500">
         Strength <strong>{spell.baseStrength}</strong> · cost{" "}
         <strong>{spell.turnCost}t</strong>
-        {!unlocked && (
-          <span className="ml-2 text-amber-600 dark:text-amber-400">
-            🔒 {spell.minTilesRequired.toLocaleString()} tiles
-          </span>
-        )}
       </div>
 
-      {spell.type === "production" && (
+      {column === "production" && (
         <button
-          onClick={onCastProduction}
+          onClick={() => onCastProduction(spell.id)}
           disabled={busy || !canAct}
-          className="mt-auto w-full px-4 py-2 text-sm bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="w-full px-3 py-1.5 text-xs bg-emerald-500 text-white rounded hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {busyForThis
             ? "Casting…"
             : canAct
-              ? `Cast (${spell.turnCost} turns)`
-              : buttonLabel}
+              ? `Cast (${spell.turnCost}t)`
+              : buttonLabel || "Cast"}
         </button>
       )}
 
-      {spell.type === "defense" && (
-        <div className="mt-auto space-y-2">
-          <select
-            value={armTargetTileId}
-            onChange={(e) => setArmTargetTileId(e.target.value)}
-            disabled={busy || !unlocked}
-            className="w-full px-2 py-1.5 text-sm border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
-          >
-            <option value="">Pick a tile to arm…</option>
-            {armableTiles.map((t) => (
-              <option key={t.tileId} value={t.tileId}>
-                {t.tileId} ({t.type})
-              </option>
-            ))}
-          </select>
+      {column === "defense" && !bulkOpen && (
+        <div className="space-y-2">
           <button
-            onClick={onArmDefense}
-            disabled={busy || !canAct || !armTargetTileId}
-            className="w-full px-4 py-2 text-sm bg-emerald-500 text-white rounded-lg hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            onClick={() => {
+              // Default N: as many as the player can afford and has unarmed
+              // tiles to receive — typical "arm everything I can" intent.
+              setBulkSpellId(spell.id);
+              setBulkN(cap);
+            }}
+            disabled={busy || !canAct || cap === 0}
+            className="w-full px-3 py-1.5 text-xs bg-emerald-500 text-white rounded hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            {busyForThis
-              ? "Arming…"
-              : canAct
-                ? `Arm (${spell.turnCost} turns)`
-                : buttonLabel}
+            {!canAct
+              ? buttonLabel || "Bulk-arm"
+              : cap === 0
+                ? "All tiles already armed"
+                : `Bulk-arm top tiles (max ${cap})`}
           </button>
+          <details className="text-[11px]">
+            <summary className="cursor-pointer text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300">
+              Or arm one tile manually…
+            </summary>
+            <div className="mt-2 space-y-2">
+              <select
+                value={armTargetTileId}
+                onChange={(e) => setArmTargetTileId(e.target.value)}
+                disabled={busy || !unlocked}
+                className="w-full px-2 py-1 text-xs border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+              >
+                <option value="">Pick a tile…</option>
+                {armableTiles.map((t) => (
+                  <option key={t.tileId} value={t.tileId}>
+                    {t.tileId} ({t.type})
+                    {t.armedDefenseSpellId ? " · armed" : ""}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={() => onArmDefenseSingle(spell.id)}
+                disabled={busy || !canAct || !armTargetTileId}
+                className="w-full px-3 py-1 text-xs border border-emerald-500 text-emerald-700 dark:text-emerald-300 rounded hover:bg-emerald-50 dark:hover:bg-emerald-900/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Arm one
+              </button>
+            </div>
+          </details>
         </div>
       )}
 
-      {spell.type === "offense" && (
-        <p className="mt-auto text-xs text-neutral-500 italic leading-relaxed">
-          Attached at attack time from a tile&apos;s attack form. Open an enemy
-          tile from{" "}
-          <Link
-            href="/game/tiles"
-            className="underline hover:no-underline"
-          >
+      {column === "defense" && bulkOpen && (
+        <div className="rounded-md border border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-900/10 p-3 space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <label
+              htmlFor={`bulk-n-${spell.id}`}
+              className="text-[11px] font-medium uppercase tracking-wide text-neutral-600 dark:text-neutral-300"
+            >
+              Arm on top
+            </label>
+            <input
+              id={`bulk-n-${spell.id}`}
+              type="number"
+              min={1}
+              max={cap}
+              value={effectiveN}
+              onChange={(e) => setBulkN(Number(e.target.value) || 0)}
+              className="w-16 px-2 py-1 text-xs border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+            />
+            <span className="text-[11px] text-neutral-500">/ {cap} tiles</span>
+          </div>
+          <p className="text-[11px] text-neutral-500 leading-snug">
+            Sorted by threat: tiles bordering an unshielded enemy first, then
+            by hex distance to the nearest enemy. Cost:{" "}
+            <strong>{effectiveN * spell.turnCost}t</strong>.
+          </p>
+          <div className="text-[11px] max-h-28 overflow-y-auto border border-neutral-200 dark:border-neutral-800 rounded bg-white dark:bg-neutral-950 px-2 py-1 font-mono">
+            {previewTileIds.length === 0 ? (
+              <p className="italic text-neutral-400">
+                No tiles in range — adjust N or close.
+              </p>
+            ) : (
+              previewTileIds.map((id) => <div key={id}>{id}</div>)
+            )}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => onArmDefenseBulk(spell.id, previewTileIds)}
+              disabled={busy || effectiveN === 0}
+              className="flex-1 px-3 py-1.5 text-xs bg-emerald-500 text-white rounded hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {busyForThis ? "Arming…" : `Arm ${effectiveN}`}
+            </button>
+            <button
+              onClick={() => setBulkSpellId(null)}
+              disabled={busy}
+              className="px-3 py-1.5 text-xs border border-neutral-300 dark:border-neutral-700 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {column === "offense" && (
+        <p className="text-[11px] text-neutral-500 italic leading-relaxed">
+          Attached at attack time. Open an enemy tile from{" "}
+          <Link href="/game/tiles" className="underline hover:no-underline">
             Manage tiles
           </Link>{" "}
           and pick this spell in the attack panel.

--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -11,11 +11,9 @@ import { useRouter } from "next/navigation";
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
-  type WheelEvent as ReactWheelEvent,
 } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import type { Caste, GamePlayer, MapTile, LandType } from "@/lib/game/types";
@@ -57,7 +55,14 @@ const SQRT3 = Math.sqrt(3);
 const VIEWPORT_PADDING = HEX_SIZE * 1.5;
 
 const MIN_SCALE = 0.3;
-const MAX_SCALE = 4;
+const MAX_SCALE = 6;
+// SVG viewBox is fixed; pan/zoom is applied via inner <g> transform. These
+// constants drive the "fit to content" math when the user clicks recenter.
+const VIEWBOX_W = 1200;
+const VIEWBOX_H = 800;
+// Leave a small breathing room around the fit so the outermost tiles aren't
+// clipped at the edge.
+const FIT_MARGIN = 0.95;
 const ZOOM_STEP = 1.15;
 
 function axialToPixel(q: number, r: number): { x: number; y: number } {
@@ -80,6 +85,42 @@ function hexPoints(cx: number, cy: number): string {
   ]
     .map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`)
     .join(" ");
+}
+
+/**
+ * Compute pan/zoom values that fit `tiles` inside the SVG viewBox with a
+ * small margin. Returns `null` if `tiles` is empty.
+ *
+ * The viewBox is centered at (0, 0) with extent VIEWBOX_W × VIEWBOX_H. After
+ * applying `scale * translate(tx, ty)` to the inner <g>, an axial-pixel
+ * point `(x, y)` maps to SVG `(scale * (x + tx), scale * (y + ty))`. We
+ * pick `tx, ty` to center the bbox at the origin and `scale` so the bbox
+ * fits.
+ */
+function fitTilesToViewport(
+  tiles: ReadonlyArray<MapTile>
+): { scale: number; tx: number; ty: number } | null {
+  if (tiles.length === 0) return null;
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (const t of tiles) {
+    const { x, y } = axialToPixel(t.q, t.r);
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  const w = maxX - minX + 2 * VIEWPORT_PADDING;
+  const h = maxY - minY + 2 * VIEWPORT_PADDING;
+  const fit = Math.min(VIEWBOX_W / w, VIEWBOX_H / h) * FIT_MARGIN;
+  const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, fit));
+  return {
+    scale,
+    tx: -(minX + maxX) / 2,
+    ty: -(minY + maxY) / 2,
+  };
 }
 
 const TYPE_FILL: Record<LandType, string> = {
@@ -105,6 +146,12 @@ const TYPE_TEXT: Record<LandType, string> = {
   food: "#fff",
   magic: "#fff",
 };
+
+// Foreign-tile fill — high luminance so it pops against own tiles' saturated
+// type fills and against the dark map background. The caste-colored border
+// at width 3.5 carries the faction info; an inner colored dot retains type
+// info ("that white-bordered tile is a military land").
+const FOREIGN_FILL = "#f8fafc";
 
 // Caste-keyed border accent for foreign tiles. Picked to match the in-game
 // palette (white = stone, blue = sky, black = bone, red = ember, green = moss).
@@ -176,88 +223,61 @@ export default function TilesMapPage() {
     refresh();
   }, [authLoading, refresh]);
 
-  // Bounding box of every tile we know about. Drives the initial fit-to-screen
-  // and the visible viewBox.
-  const bbox = useMemo(() => {
-    if (tiles.length === 0) return null;
-    let minX = Number.POSITIVE_INFINITY;
-    let maxX = Number.NEGATIVE_INFINITY;
-    let minY = Number.POSITIVE_INFINITY;
-    let maxY = Number.NEGATIVE_INFINITY;
-    for (const t of tiles) {
-      const { x, y } = axialToPixel(t.q, t.r);
-      if (x < minX) minX = x;
-      if (x > maxX) maxX = x;
-      if (y < minY) minY = y;
-      if (y > maxY) maxY = y;
-    }
-    return {
-      x: minX - VIEWPORT_PADDING,
-      y: minY - VIEWPORT_PADDING,
-      width: maxX - minX + 2 * VIEWPORT_PADDING,
-      height: maxY - minY + 2 * VIEWPORT_PADDING,
-    };
-  }, [tiles]);
-
   // First-time fit: center the viewport on the player's own tiles so they
-  // know where they are. Runs once when player + tiles are first available,
-  // or when the user clicks the recenter (⌖) button (which flips didFit back).
+  // know where they are, and zoom so the *entire* kingdom fits. Runs once
+  // when player + tiles are first available, or when the user clicks the
+  // recenter (⌖) button (which flips didFit back).
   /* eslint-disable react-hooks/set-state-in-effect -- one-shot fit on data arrival */
   useEffect(() => {
     if (didFit || !player || tiles.length === 0) return;
     const own = tiles.filter((t) => t.ownerId === player.userId);
-    if (own.length === 0) {
-      if (bbox) {
-        setTx(-(bbox.x + bbox.width / 2));
-        setTy(-(bbox.y + bbox.height / 2));
-        setScale(1);
-      }
-      setDidFit(true);
-      return;
+    const fit = own.length > 0 ? fitTilesToViewport(own) : fitTilesToViewport(tiles);
+    if (fit) {
+      setTx(fit.tx);
+      setTy(fit.ty);
+      setScale(fit.scale);
     }
-    let minX = Number.POSITIVE_INFINITY;
-    let maxX = Number.NEGATIVE_INFINITY;
-    let minY = Number.POSITIVE_INFINITY;
-    let maxY = Number.NEGATIVE_INFINITY;
-    for (const t of own) {
-      const { x, y } = axialToPixel(t.q, t.r);
-      if (x < minX) minX = x;
-      if (x > maxX) maxX = x;
-      if (y < minY) minY = y;
-      if (y > maxY) maxY = y;
-    }
-    setTx(-(minX + maxX) / 2);
-    setTy(-(minY + maxY) / 2);
-    setScale(1);
     setDidFit(true);
-  }, [didFit, player, tiles, bbox]);
+  }, [didFit, player, tiles]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   // Wheel zoom around the cursor.
-  const handleWheel = useCallback(
-    (e: ReactWheelEvent<SVGSVGElement>) => {
-      if (!svgRef.current) return;
+  //
+  // Attached via `addEventListener({ passive: false })` in an effect below
+  // — React's synthetic `onWheel` listener is passive by default, so
+  // `e.preventDefault()` is silently dropped and the page scrolls behind
+  // the map when the user tries to zoom. Stored in a ref so the effect's
+  // attach/detach doesn't depend on the latest closure.
+  const wheelStateRef = useRef({ scale, tx, ty });
+  useEffect(() => {
+    wheelStateRef.current = { scale, tx, ty };
+  }, [scale, tx, ty]);
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const onWheelNative = (e: WheelEvent) => {
       e.preventDefault();
+      const { scale: s, tx: ttx, ty: tty } = wheelStateRef.current;
+      // macOS pinch-to-zoom on trackpads also fires wheel events with
+      // ctrlKey=true; same handler covers both.
       const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
-      const next = Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale * factor));
-      if (next === scale) return;
-      // Convert cursor to SVG-local coordinates so the point under the cursor
-      // stays put across the zoom step.
-      const rect = svgRef.current.getBoundingClientRect();
+      const next = Math.max(MIN_SCALE, Math.min(MAX_SCALE, s * factor));
+      if (next === s) return;
+      const rect = svg.getBoundingClientRect();
       const cx = e.clientX - rect.left;
       const cy = e.clientY - rect.top;
-      // World-space cursor position before the zoom.
-      const worldX = (cx - rect.width / 2) / scale - tx;
-      const worldY = (cy - rect.height / 2) / scale - ty;
-      // Solve for new tx, ty so that worldX/worldY map back to the same cx/cy.
+      const worldX = (cx - rect.width / 2) / s - ttx;
+      const worldY = (cy - rect.height / 2) / s - tty;
       const newTx = (cx - rect.width / 2) / next - worldX;
       const newTy = (cy - rect.height / 2) / next - worldY;
       setScale(next);
       setTx(newTx);
       setTy(newTy);
-    },
-    [scale, tx, ty]
-  );
+    };
+    svg.addEventListener("wheel", onWheelNative, { passive: false });
+    return () => svg.removeEventListener("wheel", onWheelNative);
+  }, []);
 
   const handlePointerDown = useCallback(
     (e: ReactPointerEvent<SVGSVGElement>) => {
@@ -417,7 +437,6 @@ export default function TilesMapPage() {
             <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg overflow-hidden bg-neutral-50 dark:bg-neutral-950">
               <svg
                 ref={svgRef}
-                onWheel={handleWheel}
                 onPointerDown={handlePointerDown}
                 onPointerMove={handlePointerMove}
                 onPointerUp={handlePointerUp}
@@ -440,24 +459,29 @@ export default function TilesMapPage() {
                     const { x, y } = axialToPixel(t.q, t.r);
                     const matched = filter === "all" || t.type === filter;
                     const isOwn = t.ownerId === player.userId;
+                    const isForeign = !!t.ownerId && !isOwn;
                     const owner = t.ownerId
                       ? ownersById.get(t.ownerId) ?? null
                       : null;
-                    const fill = TYPE_FILL[t.type];
+                    // Foreign tiles use a near-white fill + thick caste-colored
+                    // border so they read as "not yours" in one glance, even on
+                    // a busy map. Type info is preserved via an inner colored
+                    // dot rendered below the polygon.
+                    const fill = isForeign ? FOREIGN_FILL : TYPE_FILL[t.type];
                     const stroke = isOwn
                       ? TYPE_STROKE[t.type]
                       : owner?.caste
                       ? CASTE_BORDER[owner.caste]
                       : "#737373";
+                    const strokeWidth = isOwn ? 1.5 : isForeign ? 3.5 : 2.25;
                     const text = TYPE_TEXT[t.type];
                     const armed = !!t.armedDefenseSpellId;
                     const totalUnits =
                       t.units.ground + t.units.siege + t.units.air;
-                    const opacity = !matched
-                      ? 0.12
-                      : isOwn
-                      ? 1
-                      : 0.6;
+                    // Filter dimming still applies, but the muddy 0.6 wash on
+                    // foreign tiles is gone — the bright fill carries the
+                    // visual weight on its own.
+                    const opacity = matched ? 1 : 0.12;
                     return (
                       <g
                         key={t.tileId}
@@ -482,8 +506,20 @@ export default function TilesMapPage() {
                           points={hexPoints(x, y)}
                           fill={fill}
                           stroke={stroke}
-                          strokeWidth={isOwn ? 1.5 : 2.25}
+                          strokeWidth={strokeWidth}
                         />
+                        {/* Inner type-dot on foreign tiles preserves the
+                            tactical info (military / food / magic) that the
+                            white fill would otherwise hide. */}
+                        {isForeign && (t.type === "military" || t.type === "food" || t.type === "magic") && (
+                          <circle
+                            cx={x}
+                            cy={y}
+                            r={5}
+                            fill={TYPE_FILL[t.type]}
+                            style={{ pointerEvents: "none" }}
+                          />
+                        )}
                         {isOwn && (
                           <text
                             x={x}

--- a/lib/game/threat.ts
+++ b/lib/game/threat.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Per-tile threat assessment for friendly tiles. Two consumers today:
+ *
+ *   1. `/game/spells` bulk-arm-defense — sort target tiles so the most-exposed
+ *      ones get armed first.
+ *   2. `/game/recruit` auto-routing — distribute new units onto the tiles most
+ *      likely to be attacked.
+ *
+ * A tile's `score` is constructed so that any tile bordering an unshielded
+ * enemy outranks every non-bordering tile, regardless of distance — that
+ * matches the attack model (`lib/game/data-server.ts`: attacks must come from
+ * an adjacent enemy tile).
+ */
+
+import type { MapTile } from "./types";
+import { axialFromTileId, hexDistance, neighborTileIds } from "./world-gen";
+
+/**
+ * Narrow shape of the owner record consumed here — only `shielded` matters
+ * for the threat calculation. Both server (`OwnerSummary` in
+ * `data-server.ts`) and client (`OwnerSummary` mirror in `app/game/page.tsx`,
+ * `app/game/tiles/page.tsx`) types satisfy this shape, so callers can pass
+ * whichever they have without a conversion step.
+ */
+export interface ThreatOwnerInfo {
+  shielded: boolean;
+}
+
+/**
+ * Per-tile threat record for one friendly tile.
+ *
+ * - `hostileNeighbors`: how many of the 6 adjacent tiles are owned by
+ *   *unshielded* enemies. Shielded enemies cannot attack, so they don't
+ *   contribute to attack likelihood.
+ * - `distanceToEnemy`: hex-distance to the nearest unshielded enemy tile in
+ *   the world. `Number.POSITIVE_INFINITY` if no unshielded enemy exists.
+ * - `score`: composite ranking value. Higher = more likely to be attacked.
+ */
+export interface TileThreat {
+  hostileNeighbors: number;
+  distanceToEnemy: number;
+  score: number;
+}
+
+export interface ComputeTileThreatArgs {
+  /** Tiles the requesting user owns (the ones we score). */
+  myTiles: ReadonlyArray<MapTile>;
+  /** Every tile in the visible world (used to find enemy positions). */
+  worldTiles: ReadonlyArray<MapTile>;
+  /** Owner metadata keyed by `userId`. Provides shielded status. */
+  owners: ReadonlyMap<string, ThreatOwnerInfo>;
+  /** The viewer's own user id; tiles with this owner are skipped as "enemy". */
+  myUserId: string;
+}
+
+/**
+ * Build a `tileId → TileThreat` map for every owned tile in `myTiles`.
+ *
+ * Score formula:
+ *
+ *   score = hostileNeighbors * 1000 + 1 / (distanceToEnemy + 1)
+ *
+ * The `* 1000` ensures a single-bordering tile (`hostileNeighbors = 1`,
+ * `score ≈ 1000.x`) always sorts above a non-bordering tile, even one that
+ * is only 2 hexes away from an enemy (`score = 0 + 1/3 = 0.33`). Within the
+ * bordering set, more hostile neighbors wins; within the non-bordering set,
+ * closer wins.
+ */
+export function computeTileThreat(args: ComputeTileThreatArgs): Map<string, TileThreat> {
+  const { myTiles, worldTiles, owners, myUserId } = args;
+
+  // 1. Identify enemy tiles owned by an unshielded foreign player.
+  const enemyTiles: MapTile[] = [];
+  const enemyTileIds = new Set<string>();
+  for (const t of worldTiles) {
+    if (!t.ownerId || t.ownerId === myUserId) continue;
+    const owner = owners.get(t.ownerId);
+    // Treat unknown owners as unshielded — safer to over-count threat than
+    // under-count when the owner record didn't make it into the response.
+    if (owner && owner.shielded) continue;
+    enemyTiles.push(t);
+    enemyTileIds.add(t.tileId);
+  }
+
+  const out = new Map<string, TileThreat>();
+
+  // 2. For each of my tiles, count hostile neighbors and find min distance
+  //    to any enemy tile.
+  for (const t of myTiles) {
+    const adj = neighborTileIds(t.q, t.r);
+    let hostileNeighbors = 0;
+    for (const id of adj) {
+      if (enemyTileIds.has(id)) hostileNeighbors++;
+    }
+
+    let distanceToEnemy = Number.POSITIVE_INFINITY;
+    if (enemyTiles.length > 0) {
+      const me = { q: t.q, r: t.r };
+      for (const e of enemyTiles) {
+        const d = hexDistance(me, { q: e.q, r: e.r });
+        if (d < distanceToEnemy) distanceToEnemy = d;
+      }
+    }
+
+    const distanceTerm = Number.isFinite(distanceToEnemy)
+      ? 1 / (distanceToEnemy + 1)
+      : 0;
+    const score = hostileNeighbors * 1000 + distanceTerm;
+
+    out.set(t.tileId, { hostileNeighbors, distanceToEnemy, score });
+  }
+
+  return out;
+}
+
+/**
+ * Convenience: return tile ids ranked by descending threat score, with stable
+ * ordering as a tiebreaker (axial coord). Tiles not present in `threat` are
+ * appended at the end with score 0 — useful when callers want a complete
+ * ordering of every owned tile.
+ */
+export function rankTileIdsByThreat(
+  tileIds: ReadonlyArray<string>,
+  threat: ReadonlyMap<string, TileThreat>
+): string[] {
+  return [...tileIds].sort((a, b) => {
+    const sa = threat.get(a)?.score ?? 0;
+    const sb = threat.get(b)?.score ?? 0;
+    if (sa !== sb) return sb - sa;
+    // Stable tiebreaker: axial coord (lex).
+    const ca = axialFromTileId(a);
+    const cb = axialFromTileId(b);
+    if (ca.q !== cb.q) return ca.q - cb.q;
+    return ca.r - cb.r;
+  });
+}


### PR DESCRIPTION
Develop → main release.

## Included PR

- **#709 — feat(game): map fit-zoom + enemy contrast, spells tier×type + bulk-arm, recruit threat-priority** — @rogerSuperBuilderAlpha (with Claude Opus 4.7)
  Four UX gaps in \`/game\`, one pass:
  1. World-map recenter now fit-zooms the entire owned kingdom; wheel-zoom rebound to a non-passive native listener so the page no longer scrolls behind the map.
  2. Foreign tiles render with bright \`#f8fafc\` fill + 3.5-px caste-colored border + inner type dot — friend/foe parses at a glance.
  3. Spells page: flat caste-filtered grid → tier-major / type-minor 5 × 3 table. Defense cells get a bulk-arm panel with threat-sorted preview and partial-success feedback.
  4. Recruit: round-robin → linear-weighted threat-priority distribution with a manual tile-override picker and an inline routing preview.

  New shared \`lib/game/threat.ts\` (\`computeTileThreat\` / \`rankTileIdsByThreat\`) drives both bulk-arm and recruit auto-route. \`/api/game/spell/arm\` extended to accept \`{ tileIds: string[] }\` with explicit \`{ armed, failed: [{tileId, reason}] }\` partial-success semantics; single-tile form preserved.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Game test suite: **174 / 174** passing (10 suites; 11 new tests for \`computeTileThreat\`)
- [x] ESLint clean on all touched files