### PR TITLE
feat(game): personal map view + local cache (fix 'only 1 tile loaded')

### DIFF
--- a/__tests__/lib/game/local-map-cache.test.ts
+++ b/__tests__/lib/game/local-map-cache.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  REFRESH_INTERVAL_MS,
+  clearCachedMap,
+  loadCachedMap,
+  mayRefresh,
+  mergeOwners,
+  mergeTiles,
+  msUntilRefresh,
+  saveCachedMap,
+  type CachedMapView,
+  type CachedOwnerSummary,
+} from "@/lib/game/local-map-cache";
+import type { LandType, MapTile } from "@/lib/game/types";
+import { tileIdFromAxial } from "@/lib/game/world-gen";
+
+function tile(
+  q: number,
+  r: number,
+  ownerId: string | null,
+  type: LandType = "military"
+): MapTile {
+  return {
+    tileId: tileIdFromAxial(q, r),
+    q,
+    r,
+    type,
+    ownerId,
+    units: { ground: 0, siege: 0, air: 0 },
+    armedDefenseSpellId: null,
+  };
+}
+
+const USER = "user-1";
+const OTHER = "user-2";
+const ENEMY_A = "enemyA";
+
+class MemStorage implements Storage {
+  private data = new Map<string, string>();
+  get length(): number {
+    return this.data.size;
+  }
+  clear(): void {
+    this.data.clear();
+  }
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+  key(idx: number): string | null {
+    return Array.from(this.data.keys())[idx] ?? null;
+  }
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+}
+
+describe("local-map-cache", () => {
+  let originalLocalStorage: Storage | undefined;
+  let mem: MemStorage;
+
+  beforeEach(() => {
+    mem = new MemStorage();
+    // jsdom provides window.localStorage; replace it with our in-memory impl.
+    originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      value: mem,
+      configurable: true,
+      writable: true,
+    });
+    // Also set on window if defined (jsdom).
+    if (typeof window !== "undefined") {
+      Object.defineProperty(window, "localStorage", {
+        value: mem,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, "localStorage", {
+        value: originalLocalStorage,
+        configurable: true,
+        writable: true,
+      });
+      if (typeof window !== "undefined") {
+        Object.defineProperty(window, "localStorage", {
+          value: originalLocalStorage,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  describe("save/load round-trip", () => {
+    it("persists and reads back a view", () => {
+      const view: CachedMapView = {
+        myTiles: [tile(0, 0, USER), tile(1, 0, USER)],
+        borderTiles: [tile(2, 0, ENEMY_A)],
+        owners: [
+          {
+            userId: ENEMY_A,
+            displayName: "Enemy A",
+            caste: "iron",
+            shielded: false,
+          },
+        ],
+        lastFetchedAt: 1_000_000,
+      };
+      saveCachedMap(USER, view);
+      const loaded = loadCachedMap(USER);
+      expect(loaded).not.toBeNull();
+      expect(loaded?.myTiles).toHaveLength(2);
+      expect(loaded?.borderTiles).toHaveLength(1);
+      expect(loaded?.owners[0]?.userId).toBe(ENEMY_A);
+      expect(loaded?.lastFetchedAt).toBe(1_000_000);
+    });
+
+    it("returns null for a missing entry", () => {
+      expect(loadCachedMap(USER)).toBeNull();
+    });
+
+    it("does not return another user's cache", () => {
+      saveCachedMap(USER, {
+        myTiles: [tile(0, 0, USER)],
+        borderTiles: [],
+        owners: [],
+        lastFetchedAt: 1_000_000,
+      });
+      expect(loadCachedMap(OTHER)).toBeNull();
+    });
+
+    it("rejects an entry with a corrupt JSON payload", () => {
+      mem.setItem("cb-game-map-v1:" + USER, "not-json");
+      expect(loadCachedMap(USER)).toBeNull();
+    });
+
+    it("rejects an entry with a mismatched embedded userId", () => {
+      saveCachedMap(USER, {
+        myTiles: [],
+        borderTiles: [],
+        owners: [],
+        lastFetchedAt: 1_000_000,
+      });
+      // Tamper: load, swap, write back under USER's key.
+      const raw = mem.getItem("cb-game-map-v1:" + USER)!;
+      const parsed = JSON.parse(raw);
+      parsed.userId = OTHER;
+      mem.setItem("cb-game-map-v1:" + USER, JSON.stringify(parsed));
+      expect(loadCachedMap(USER)).toBeNull();
+    });
+  });
+
+  describe("clearCachedMap", () => {
+    it("removes the entry for a user", () => {
+      saveCachedMap(USER, {
+        myTiles: [tile(0, 0, USER)],
+        borderTiles: [],
+        owners: [],
+        lastFetchedAt: 1_000_000,
+      });
+      clearCachedMap(USER);
+      expect(loadCachedMap(USER)).toBeNull();
+    });
+  });
+
+  describe("mergeTiles", () => {
+    function seed(): void {
+      saveCachedMap(USER, {
+        myTiles: [tile(0, 0, USER), tile(1, 0, USER)],
+        borderTiles: [tile(2, 0, ENEMY_A)],
+        owners: [],
+        lastFetchedAt: 1_000_000,
+      });
+    }
+
+    it("returns null when there is no cache to merge into", () => {
+      expect(mergeTiles(USER, [tile(0, 0, USER)])).toBeNull();
+    });
+
+    it("updates an existing owned tile in place", () => {
+      seed();
+      const updated: MapTile = {
+        ...tile(0, 0, USER),
+        units: { ground: 5, siege: 0, air: 0 },
+      };
+      const next = mergeTiles(USER, [updated]);
+      expect(next?.myTiles).toHaveLength(2);
+      const t = next?.myTiles.find((m) => m.tileId === tileIdFromAxial(0, 0));
+      expect(t?.units.ground).toBe(5);
+    });
+
+    it("moves a conquered border tile from border → my tiles", () => {
+      seed();
+      const conquered = tile(2, 0, USER); // was ENEMY_A's
+      const next = mergeTiles(USER, [conquered]);
+      expect(
+        next?.myTiles.some((t) => t.tileId === tileIdFromAxial(2, 0))
+      ).toBe(true);
+      expect(
+        next?.borderTiles.some((t) => t.tileId === tileIdFromAxial(2, 0))
+      ).toBe(false);
+    });
+
+    it("moves a lost own tile from my tiles → border (if it touches another own tile)", () => {
+      seed();
+      const lost = tile(1, 0, ENEMY_A); // was USER's, still touches (0,0)
+      const next = mergeTiles(USER, [lost]);
+      expect(
+        next?.myTiles.some((t) => t.tileId === tileIdFromAxial(1, 0))
+      ).toBe(false);
+      expect(
+        next?.borderTiles.some((t) => t.tileId === tileIdFromAxial(1, 0))
+      ).toBe(true);
+    });
+
+    it("drops an enemy update that does not border any of my tiles", () => {
+      seed();
+      const remote = tile(10, 10, ENEMY_A);
+      const next = mergeTiles(USER, [remote]);
+      expect(
+        next?.borderTiles.some((t) => t.tileId === tileIdFromAxial(10, 10))
+      ).toBe(false);
+    });
+
+    it("drops a tile that becomes unowned (null ownerId) from both buckets", () => {
+      seed();
+      const cleared = tile(2, 0, null);
+      const next = mergeTiles(USER, [cleared]);
+      expect(
+        next?.borderTiles.some((t) => t.tileId === tileIdFromAxial(2, 0))
+      ).toBe(false);
+      expect(
+        next?.myTiles.some((t) => t.tileId === tileIdFromAxial(2, 0))
+      ).toBe(false);
+    });
+
+    it("does not bump lastFetchedAt", () => {
+      seed();
+      const before = loadCachedMap(USER)?.lastFetchedAt;
+      mergeTiles(USER, [tile(0, 0, USER)]);
+      const after = loadCachedMap(USER)?.lastFetchedAt;
+      expect(after).toBe(before);
+    });
+  });
+
+  describe("mergeOwners", () => {
+    it("adds new owner summaries and replaces existing ones", () => {
+      saveCachedMap(USER, {
+        myTiles: [],
+        borderTiles: [],
+        owners: [
+          {
+            userId: ENEMY_A,
+            displayName: "Old Name",
+            caste: "iron",
+            shielded: false,
+          },
+        ],
+        lastFetchedAt: 1_000_000,
+      });
+      const updates: CachedOwnerSummary[] = [
+        {
+          userId: ENEMY_A,
+          displayName: "New Name",
+          caste: "iron",
+          shielded: true,
+        },
+        {
+          userId: "enemyB",
+          displayName: "Enemy B",
+          caste: "stone",
+          shielded: false,
+        },
+      ];
+      const next = mergeOwners(USER, updates);
+      expect(next?.owners).toHaveLength(2);
+      expect(
+        next?.owners.find((o) => o.userId === ENEMY_A)?.displayName
+      ).toBe("New Name");
+      expect(
+        next?.owners.find((o) => o.userId === ENEMY_A)?.shielded
+      ).toBe(true);
+    });
+
+    it("returns null when no cache exists", () => {
+      expect(mergeOwners(USER, [])).toBeNull();
+    });
+  });
+
+  describe("mayRefresh / msUntilRefresh", () => {
+    const view: CachedMapView = {
+      myTiles: [],
+      borderTiles: [],
+      owners: [],
+      lastFetchedAt: 1_000_000,
+    };
+
+    it("permits refresh when no view is cached", () => {
+      expect(mayRefresh(null)).toBe(true);
+      expect(msUntilRefresh(null)).toBe(0);
+    });
+
+    it("blocks refresh inside the rate-limit window", () => {
+      const now = view.lastFetchedAt + REFRESH_INTERVAL_MS - 1;
+      expect(mayRefresh(view, now)).toBe(false);
+      expect(msUntilRefresh(view, now)).toBe(1);
+    });
+
+    it("permits refresh once the window has elapsed", () => {
+      const now = view.lastFetchedAt + REFRESH_INTERVAL_MS;
+      expect(mayRefresh(view, now)).toBe(true);
+      expect(msUntilRefresh(view, now)).toBe(0);
+    });
+  });
+});

--- a/app/api/game/map/me/route.ts
+++ b/app/api/game/map/me/route.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { getMyMapServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+// Personal map view: only own tiles + the enemy ring touching them, plus
+// owner summaries for those enemies. Replaces the unbounded /api/game/world
+// fetch on the busy game pages — read cost scales with kingdom perimeter,
+// not world size.
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const { myTiles, borderTiles, owners } = await getMyMapServer(user.uid);
+    return apiSuccess({ myTiles, borderTiles, owners });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -9,6 +9,13 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
+import {
+  loadCachedMap,
+  saveCachedMap,
+  mergeTiles as mergeTilesIntoCache,
+  type CachedMapView,
+  type CachedOwnerSummary,
+} from "@/lib/game/local-map-cache";
 import { effectiveUnitCap } from "@/lib/game/turns";
 import type {
   Caste,
@@ -33,10 +40,11 @@ interface OwnerSummary {
   shielded: boolean;
 }
 
-interface WorldResponse {
+interface MapMeResponse {
   success: boolean;
-  tiles?: MapTile[];
-  owners?: OwnerSummary[];
+  myTiles?: MapTile[];
+  borderTiles?: MapTile[];
+  owners?: CachedOwnerSummary[];
   error?: string;
 }
 
@@ -94,16 +102,22 @@ export default function GameDashboardPage() {
   const [renaming, setRenaming] = useState(false);
   const [renameInput, setRenameInput] = useState("");
 
-  // Merge updated tiles into the local owned-tile list by tileId. Used to
-  // patch state from action responses instead of triggering a full refetch.
-  const mergeOwnedTiles = useCallback((updates: MapTile[]) => {
-    if (updates.length === 0) return;
-    setTiles((prev) => {
-      const byId = new Map(prev.map((t) => [t.tileId, t] as const));
-      for (const u of updates) byId.set(u.tileId, u);
-      return Array.from(byId.values());
-    });
-  }, []);
+  // Merge updated tiles into the local owned-tile list by tileId AND into
+  // the localStorage map cache so the change persists across page nav.
+  // Used to patch state from action responses instead of triggering a full
+  // refetch.
+  const mergeOwnedTiles = useCallback(
+    (updates: MapTile[]) => {
+      if (updates.length === 0) return;
+      setTiles((prev) => {
+        const byId = new Map(prev.map((t) => [t.tileId, t] as const));
+        for (const u of updates) byId.set(u.tileId, u);
+        return Array.from(byId.values());
+      });
+      if (user) mergeTilesIntoCache(user.uid, updates);
+    },
+    [user]
+  );
 
   const fetchPlayer = useCallback(async () => {
     setError(null);
@@ -114,14 +128,11 @@ export default function GameDashboardPage() {
     setLoading(true);
     try {
       const token = await user.getIdToken();
-      const [playerRes, elgRes, worldRes] = await Promise.all([
+      const [playerRes, elgRes] = await Promise.all([
         fetch("/api/game/player", {
           headers: { Authorization: `Bearer ${token}` },
         }),
         fetch("/api/game/eligibility", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-        fetch("/api/game/world", {
           headers: { Authorization: `Bearer ${token}` },
         }),
       ]);
@@ -138,12 +149,30 @@ export default function GameDashboardPage() {
           nextRolloverIso: elgData.nextRolloverIso,
         });
       }
-      const worldData = (await worldRes.json()) as WorldResponse;
-      if (worldData.success) {
-        setWorldTiles(worldData.tiles ?? []);
-        const map = new Map<string, OwnerSummary>();
-        for (const o of worldData.owners ?? []) map.set(o.userId, o);
-        setWorldOwners(map);
+      // Map data — use the cache as source of truth. If absent, fetch from
+      // /api/game/map/me once. The dashboard only needs the border ring +
+      // owner summaries to compute the threat card; my tiles come from
+      // /api/game/player above.
+      const cached = loadCachedMap(user.uid);
+      if (cached) {
+        setWorldTiles(cached.borderTiles);
+        setWorldOwners(new Map(cached.owners.map((o) => [o.userId, o])));
+      } else {
+        const mapRes = await fetch("/api/game/map/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const mapData = (await mapRes.json()) as MapMeResponse;
+        if (mapData.success) {
+          const view: CachedMapView = {
+            myTiles: mapData.myTiles ?? [],
+            borderTiles: mapData.borderTiles ?? [],
+            owners: mapData.owners ?? [],
+            lastFetchedAt: Date.now(),
+          };
+          saveCachedMap(user.uid, view);
+          setWorldTiles(view.borderTiles);
+          setWorldOwners(new Map(view.owners.map((o) => [o.userId, o])));
+        }
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load player");

--- a/app/game/recruit/page.tsx
+++ b/app/game/recruit/page.tsx
@@ -15,6 +15,13 @@ import {
   PRODUCTION_SPELL_DURATION_TURNS,
 } from "@/lib/game/turns";
 import {
+  loadCachedMap,
+  saveCachedMap,
+  mergeTiles as mergeTilesIntoCache,
+  type CachedMapView,
+  type CachedOwnerSummary,
+} from "@/lib/game/local-map-cache";
+import {
   computeTileThreat,
   rankTileIdsByThreat,
   type ThreatOwnerInfo,
@@ -46,10 +53,11 @@ interface OwnerSummary {
   shielded: boolean;
 }
 
-interface WorldResponse {
+interface MapMeResponse {
   success: boolean;
-  tiles?: MapTile[];
-  owners?: OwnerSummary[];
+  myTiles?: MapTile[];
+  borderTiles?: MapTile[];
+  owners?: CachedOwnerSummary[];
   error?: PlayerResponseError | string;
 }
 
@@ -94,7 +102,10 @@ export default function RecruitPage() {
   const { user, loading: authLoading } = useAuth();
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [tiles, setTiles] = useState<MapTile[]>([]);
-  const [worldTiles, setWorldTiles] = useState<MapTile[]>([]);
+  // Border-only enemy ring (sufficient for threat sort — all that matters
+  // for "most-threatened tile first" is adjacency). Hydrated from cache;
+  // kept fresh by action handlers across pages.
+  const [borderTiles, setBorderTiles] = useState<MapTile[]>([]);
   const [owners, setOwners] = useState<Map<string, OwnerSummary>>(new Map());
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
@@ -112,7 +123,7 @@ export default function RecruitPage() {
   } | null>(null);
   const [recentReports, setRecentReports] = useState<TurnReport[]>([]);
 
-  const refresh = useCallback(async () => {
+  const refreshPlayer = useCallback(async () => {
     if (!user) {
       setLoading(false);
       return;
@@ -120,15 +131,10 @@ export default function RecruitPage() {
     setError(null);
     try {
       const token = await user.getIdToken();
-      const [playerRes, worldRes] = await Promise.all([
-        fetch("/api/game/player", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-        fetch("/api/game/world", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-      ]);
-      const data = (await playerRes.json()) as PlayerResponse;
+      const res = await fetch("/api/game/player", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as PlayerResponse;
       if (!data.success) {
         const msg =
           typeof data.error === "string"
@@ -138,13 +144,6 @@ export default function RecruitPage() {
       }
       setPlayer(data.player);
       setTiles(data.tiles ?? []);
-      const worldData = (await worldRes.json()) as WorldResponse;
-      if (worldData.success) {
-        setWorldTiles(worldData.tiles ?? []);
-        const map = new Map<string, OwnerSummary>();
-        for (const o of worldData.owners ?? []) map.set(o.userId, o);
-        setOwners(map);
-      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -152,11 +151,45 @@ export default function RecruitPage() {
     }
   }, [user]);
 
+  // Cold-load: hydrate map from localStorage cache; only hit the server if
+  // there's no cache yet. Subsequent page visits skip the network round-
+  // trip entirely; action responses keep the cache fresh.
   useEffect(() => {
-    if (authLoading) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
-    refresh();
-  }, [authLoading, refresh]);
+    if (authLoading || !user) return;
+    let cancelled = false;
+    (async () => {
+      const cached = loadCachedMap(user.uid);
+      if (cached && !cancelled) {
+        setBorderTiles(cached.borderTiles);
+        setOwners(new Map(cached.owners.map((o) => [o.userId, o])));
+      } else {
+        try {
+          const token = await user.getIdToken();
+          const res = await fetch("/api/game/map/me", {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          const data = (await res.json()) as MapMeResponse;
+          if (!cancelled && data.success) {
+            const view: CachedMapView = {
+              myTiles: data.myTiles ?? [],
+              borderTiles: data.borderTiles ?? [],
+              owners: data.owners ?? [],
+              lastFetchedAt: Date.now(),
+            };
+            saveCachedMap(user.uid, view);
+            setBorderTiles(view.borderTiles);
+            setOwners(new Map(view.owners.map((o) => [o.userId, o])));
+          }
+        } catch {
+          /* surfaced via the player fetch error path if both fail */
+        }
+      }
+      if (!cancelled) await refreshPlayer();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user, refreshPlayer]);
 
   const militaryTiles = useMemo(
     () => tiles.filter((t) => t.type === "military"),
@@ -167,14 +200,15 @@ export default function RecruitPage() {
 
   // Threat-ranked military-tile ids. Drives the auto-route distribution and
   // the order tiles appear in the manual-override picker (most exposed at
-  // top is what a player wants to see).
+  // top is what a player wants to see). The threat model only cares about
+  // adjacency, so the border-tile slice is sufficient.
   const threatRankedMilitaryIds = useMemo(() => {
     if (!player) return [] as string[];
     const ownerInfo = new Map<string, ThreatOwnerInfo>();
     for (const [uid, o] of owners) ownerInfo.set(uid, { shielded: o.shielded });
     const threat = computeTileThreat({
       myTiles: militaryTiles,
-      worldTiles,
+      worldTiles: borderTiles,
       owners: ownerInfo,
       myUserId: player.userId,
     });
@@ -182,7 +216,7 @@ export default function RecruitPage() {
       militaryTiles.map((t) => t.tileId),
       threat
     );
-  }, [militaryTiles, worldTiles, owners, player]);
+  }, [militaryTiles, borderTiles, owners, player]);
 
   // Compute the player's current effective unit cap. This mirrors what the
   // server uses inside buildUnitsServer so the displayed numbers match what
@@ -294,9 +328,9 @@ export default function RecruitPage() {
           `Stopped early after ${reports.length} / ${totalCycles}: ${data.stoppedEarly}`
         );
       }
-      // Merge action response into local state instead of refetching
-      // /api/game/player + /api/game/world. Recruit only changes the player's
-      // own military tiles + player stats; world tiles + owners never move.
+      // Merge the action response into local state + the localStorage map
+      // cache. Recruit only mutates the player's own military tiles + player
+      // stats; world tiles + owners never move.
       if (data.player) setPlayer(data.player as GamePlayer);
       if (Array.isArray(data.tiles)) {
         const updates = data.tiles as MapTile[];
@@ -305,6 +339,7 @@ export default function RecruitPage() {
           for (const u of updates) byId.set(u.tileId, u);
           return Array.from(byId.values());
         });
+        if (user) mergeTilesIntoCache(user.uid, updates);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Recruit failed");

--- a/app/game/spells/page.tsx
+++ b/app/game/spells/page.tsx
@@ -11,6 +11,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ALL_SPELLS, SPELLS_BY_ID } from "@/lib/game/content";
 import {
+  loadCachedMap,
+  saveCachedMap,
+  mergeTiles as mergeTilesIntoCache,
+  type CachedMapView,
+  type CachedOwnerSummary,
+} from "@/lib/game/local-map-cache";
+import {
   computeTileThreat,
   rankTileIdsByThreat,
   type ThreatOwnerInfo,
@@ -43,13 +50,6 @@ interface OwnerSummary {
   shielded: boolean;
 }
 
-interface WorldResponse {
-  success: boolean;
-  tiles?: MapTile[];
-  owners?: OwnerSummary[];
-  error?: PlayerResponseError | string;
-}
-
 // 5 tiers, in display order. Min-tiles & turn-cost come from each spell's own
 // fields — this list is only used to render the row scaffolding so locked
 // tiers still appear with their requirement.
@@ -72,11 +72,22 @@ const TYPE_LABEL: Record<SpellType, string> = {
   production: "Production",
 };
 
+interface MapMeResponse {
+  success: boolean;
+  myTiles?: MapTile[];
+  borderTiles?: MapTile[];
+  owners?: CachedOwnerSummary[];
+  error?: PlayerResponseError | string;
+}
+
 export default function SpellsPage() {
   const { user, loading: authLoading } = useAuth();
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [tiles, setTiles] = useState<MapTile[]>([]);
-  const [worldTiles, setWorldTiles] = useState<MapTile[]>([]);
+  // Border-only enemy tiles (sufficient for the threat calc — adjacency is
+  // all that matters). Hydrated from cache on mount, kept fresh by action
+  // handlers across the game pages.
+  const [borderTiles, setBorderTiles] = useState<MapTile[]>([]);
   const [owners, setOwners] = useState<Map<string, OwnerSummary>>(new Map());
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -89,7 +100,10 @@ export default function SpellsPage() {
   const [bulkSpellId, setBulkSpellId] = useState<string | null>(null);
   const [bulkN, setBulkN] = useState<number>(0);
 
-  const refresh = useCallback(async () => {
+  // Fetch only the player object; tile + owner data lives in the local-map
+  // cache (mutated in-place by action handlers, refreshed manually on the
+  // map page).
+  const refreshPlayer = useCallback(async () => {
     if (!user) {
       setLoading(false);
       return;
@@ -97,15 +111,10 @@ export default function SpellsPage() {
     setError(null);
     try {
       const token = await user.getIdToken();
-      const [playerRes, worldRes] = await Promise.all([
-        fetch("/api/game/player", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-        fetch("/api/game/world", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-      ]);
-      const data = (await playerRes.json()) as PlayerResponse;
+      const res = await fetch("/api/game/player", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as PlayerResponse;
       if (!data.success) {
         const msg =
           typeof data.error === "string"
@@ -115,13 +124,6 @@ export default function SpellsPage() {
       }
       setPlayer(data.player);
       setTiles(data.tiles ?? []);
-      const worldData = (await worldRes.json()) as WorldResponse;
-      if (worldData.success) {
-        setWorldTiles(worldData.tiles ?? []);
-        const map = new Map<string, OwnerSummary>();
-        for (const o of worldData.owners ?? []) map.set(o.userId, o);
-        setOwners(map);
-      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -129,11 +131,45 @@ export default function SpellsPage() {
     }
   }, [user]);
 
+  // Cold-load: hydrate map data from the localStorage cache; if absent,
+  // fetch /api/game/map/me once. After that, action responses keep the
+  // cache (and this page's state) up to date — no automatic refetches.
   useEffect(() => {
-    if (authLoading) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
-    refresh();
-  }, [authLoading, refresh]);
+    if (authLoading || !user) return;
+    let cancelled = false;
+    (async () => {
+      const cached = loadCachedMap(user.uid);
+      if (cached && !cancelled) {
+        setBorderTiles(cached.borderTiles);
+        setOwners(new Map(cached.owners.map((o) => [o.userId, o])));
+      } else {
+        try {
+          const token = await user.getIdToken();
+          const res = await fetch("/api/game/map/me", {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          const data = (await res.json()) as MapMeResponse;
+          if (!cancelled && data.success) {
+            const view: CachedMapView = {
+              myTiles: data.myTiles ?? [],
+              borderTiles: data.borderTiles ?? [],
+              owners: data.owners ?? [],
+              lastFetchedAt: Date.now(),
+            };
+            saveCachedMap(user.uid, view);
+            setBorderTiles(view.borderTiles);
+            setOwners(new Map(view.owners.map((o) => [o.userId, o])));
+          }
+        } catch {
+          /* surfaced via the player fetch error path if both fail */
+        }
+      }
+      if (!cancelled) await refreshPlayer();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user, refreshPlayer]);
 
   const callApi = useCallback(
     async (path: string, body: unknown) => {
@@ -167,28 +203,22 @@ export default function SpellsPage() {
             [...(data.reports as TurnReport[]), ...prev].slice(0, 25)
           );
         }
-        // Merge action response into local state instead of refetching
-        // /api/game/player + /api/game/world. Spell actions never change
-        // world tiles or owner summaries — only the casting player's state
-        // and (for arm) the targeted tile.
+        // Merge action response into local state + the localStorage cache.
+        // Spell actions never change world tiles or owner summaries — only
+        // the casting player's state and (for arm) the targeted tile(s).
         if (data.player) setPlayer(data.player as GamePlayer);
-        if (data.tile) {
-          const updated = data.tile as MapTile;
-          setTiles((prev) => {
-            const idx = prev.findIndex((t) => t.tileId === updated.tileId);
-            if (idx === -1) return [...prev, updated];
-            const next = prev.slice();
-            next[idx] = updated;
-            return next;
-          });
-        }
+        const tileUpdates: MapTile[] = [];
+        if (data.tile) tileUpdates.push(data.tile as MapTile);
         if (Array.isArray(data.tiles)) {
-          const updates = data.tiles as MapTile[];
+          tileUpdates.push(...(data.tiles as MapTile[]));
+        }
+        if (tileUpdates.length > 0) {
           setTiles((prev) => {
             const byId = new Map(prev.map((t) => [t.tileId, t] as const));
-            for (const u of updates) byId.set(u.tileId, u);
+            for (const u of tileUpdates) byId.set(u.tileId, u);
             return Array.from(byId.values());
           });
+          if (user) mergeTilesIntoCache(user.uid, tileUpdates);
         }
         return data;
       } catch (e) {
@@ -295,14 +325,16 @@ export default function SpellsPage() {
 
   const armedTiles = tiles.filter((t) => t.armedDefenseSpellId);
 
-  // Per-tile threat score, used to sort the bulk-arm preview.
+  // Per-tile threat score, used to sort the bulk-arm preview. The threat
+  // model only cares about adjacency, so the border-tile slice from the
+  // cache is sufficient (and dramatically cheaper than the whole world).
   const threatRanked = useMemo(() => {
     if (!player) return [] as string[];
     const ownerInfo = new Map<string, ThreatOwnerInfo>();
     for (const [uid, o] of owners) ownerInfo.set(uid, { shielded: o.shielded });
     const threat = computeTileThreat({
       myTiles: armableUnarmedTiles,
-      worldTiles,
+      worldTiles: borderTiles,
       owners: ownerInfo,
       myUserId: player.userId,
     });
@@ -310,7 +342,7 @@ export default function SpellsPage() {
       armableUnarmedTiles.map((t) => t.tileId),
       threat
     );
-  }, [armableUnarmedTiles, worldTiles, owners, player]);
+  }, [armableUnarmedTiles, borderTiles, owners, player]);
 
   if (authLoading || loading) {
     return (

--- a/app/game/tiles/[tileId]/page.tsx
+++ b/app/game/tiles/[tileId]/page.tsx
@@ -24,11 +24,24 @@ import type {
   UnitType,
 } from "@/lib/game/types";
 import { neighborTileIds } from "@/lib/game/world-gen";
+import { mergeTiles as mergeTilesIntoCache } from "@/lib/game/local-map-cache";
 
 interface TileResponse {
   success: boolean;
   tile?: GameTile;
   error?: { message: string } | string;
+}
+
+function asMapTile(t: GameTile): MapTile {
+  return {
+    tileId: t.tileId,
+    q: t.q,
+    r: t.r,
+    type: t.type,
+    ownerId: t.ownerId ?? null,
+    units: t.units,
+    armedDefenseSpellId: t.armedDefenseSpellId ?? null,
+  };
 }
 
 interface PlayerResponse {
@@ -126,6 +139,7 @@ export default function TileDetailPage({
         // Attack returns attackerPlayer/defenderPlayer instead of player.
         if (data.attackerPlayer)
           setPlayer(data.attackerPlayer as GamePlayer);
+        const tilesToCache: MapTile[] = [];
         if (data.tile) {
           const t = data.tile as GameTile;
           setTile(t);
@@ -143,8 +157,19 @@ export default function TileDetailPage({
             };
             return next;
           });
+          tilesToCache.push(asMapTile(t));
         }
-        if (data.targetTile) setTile(data.targetTile as GameTile);
+        if (data.targetTile) {
+          const t = data.targetTile as GameTile;
+          setTile(t);
+          tilesToCache.push(asMapTile(t));
+        }
+        // Push tile updates into the localStorage map cache so the world
+        // map + threat displays on other pages reflect this action without
+        // a manual refresh.
+        if (tilesToCache.length > 0 && user) {
+          mergeTilesIntoCache(user.uid, tilesToCache);
+        }
         // Pull TurnReport(s) off the response and push them on top of the
         // recent-reports stack. Both single-report (`report`) and batch
         // (`reports`) shapes are accepted.

--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -11,11 +11,20 @@ import { useRouter } from "next/navigation";
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { useAuth } from "@/contexts/AuthContext";
+import {
+  loadCachedMap,
+  saveCachedMap,
+  mayRefresh,
+  msUntilRefresh,
+  type CachedMapView,
+  type CachedOwnerSummary,
+} from "@/lib/game/local-map-cache";
 import type { Caste, GamePlayer, MapTile, LandType } from "@/lib/game/types";
 
 interface PlayerResponse {
@@ -30,6 +39,14 @@ interface OwnerSummary {
   displayName: string;
   caste: Caste | null;
   shielded: boolean;
+}
+
+interface MapMeResponse {
+  success: boolean;
+  myTiles?: MapTile[];
+  borderTiles?: MapTile[];
+  owners?: CachedOwnerSummary[];
+  error?: string;
 }
 
 interface WorldResponse {
@@ -172,18 +189,31 @@ const CASTE_BORDER: Record<Caste, string> = {
   green: "#4ade80",
 };
 
+type ViewMode = "personal" | "world";
+
 export default function TilesMapPage() {
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
-  const [tiles, setTiles] = useState<MapTile[]>([]);
-  const [ownersById, setOwnersById] = useState<Map<string, OwnerSummary>>(
-    new Map()
-  );
+  // Cached personal view: { myTiles, borderTiles, owners, lastFetchedAt }.
+  // Source of truth in `personal` mode; persisted to localStorage and
+  // mutated by action responses across the game pages.
+  const [cachedView, setCachedView] = useState<CachedMapView | null>(null);
+  // One-shot whole-world snapshot for the 🌐 button. Not persisted — every
+  // click re-fetches.
+  const [worldView, setWorldView] = useState<{
+    tiles: MapTile[];
+    owners: OwnerSummary[];
+  } | null>(null);
+  const [mode, setMode] = useState<ViewMode>("personal");
   const [player, setPlayer] = useState<GamePlayer | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [filter, setFilter] = useState<LandType | "all">("all");
   const [scope, setScope] = useState<ScopeFilter>("everyone");
   const [hovered, setHovered] = useState<MapTile | null>(null);
+  // Re-renders the refresh button's countdown text every 30s while it's
+  // gated. Cheap — only state-bumps when the cache has a recent fetch.
+  const [, forceTick] = useState(0);
 
   // Pan/zoom state — applied as an SVG transform on the rendered group.
   // Initial values are recomputed from the world bounding box on first load.
@@ -197,58 +227,155 @@ export default function TilesMapPage() {
     null
   );
 
-  const refresh = useCallback(async () => {
-    if (!user) {
-      setLoading(false);
-      return;
-    }
+  // Always grab the current player object; cheap and we want fresh
+  // turnsRemaining etc.
+  const fetchPlayer = useCallback(async () => {
+    if (!user) return;
     try {
       const token = await user.getIdToken();
-      const [playerRes, worldRes] = await Promise.all([
-        fetch("/api/game/player", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-        fetch("/api/game/world", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-      ]);
-      const playerData = (await playerRes.json()) as PlayerResponse;
-      const worldData = (await worldRes.json()) as WorldResponse;
-      if (playerData.success) setPlayer(playerData.player);
-      if (worldData.success) {
-        setTiles(worldData.tiles ?? []);
-        const map = new Map<string, OwnerSummary>();
-        for (const o of worldData.owners ?? []) map.set(o.userId, o);
-        setOwnersById(map);
-      }
-    } finally {
-      setLoading(false);
+      const res = await fetch("/api/game/player", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as PlayerResponse;
+      if (data.success) setPlayer(data.player);
+    } catch {
+      /* ignore */
     }
   }, [user]);
 
+  // Full personal-map fetch. Resets the rate-limit clock. Called on first
+  // visit (no cache) and when the user clicks the refresh button.
+  const refreshPersonalMap = useCallback(async () => {
+    if (!user) return;
+    setRefreshing(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/map/me", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as MapMeResponse;
+      if (data.success) {
+        const view: CachedMapView = {
+          myTiles: data.myTiles ?? [],
+          borderTiles: data.borderTiles ?? [],
+          owners: data.owners ?? [],
+          lastFetchedAt: Date.now(),
+        };
+        saveCachedMap(user.uid, view);
+        setCachedView(view);
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  }, [user]);
+
+  // Cold load: hydrate from localStorage if present, otherwise fetch
+  // fresh. The cache stays valid until the user clicks refresh — no auto-
+  // expiry. Action handlers across the game pages keep it incrementally
+  // up-to-date.
   useEffect(() => {
-    if (authLoading) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount
-    refresh();
-  }, [authLoading, refresh]);
+    if (authLoading || !user) return;
+    let cancelled = false;
+    (async () => {
+      const cached = loadCachedMap(user.uid);
+      if (cached) {
+        setCachedView(cached);
+      }
+      await fetchPlayer();
+      if (cancelled) return;
+      if (!cached) {
+        await refreshPersonalMap();
+      }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user, fetchPlayer, refreshPersonalMap]);
+
+  // Tick the refresh-countdown UI once a minute so the disabled button's
+  // remaining-time text doesn't go stale.
+  useEffect(() => {
+    if (!cachedView) return;
+    const id = setInterval(() => forceTick((n) => n + 1), 30 * 1000);
+    return () => clearInterval(id);
+  }, [cachedView]);
+
+  // Whole-world snapshot for the 🌐 button. Lazy: only runs when the user
+  // explicitly switches modes.
+  const fetchWorldOnce = useCallback(async () => {
+    if (!user) return;
+    setRefreshing(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/world", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as WorldResponse;
+      if (data.success) {
+        setWorldView({
+          tiles: data.tiles ?? [],
+          owners: data.owners ?? [],
+        });
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  }, [user]);
+
+  // Derive the tiles + owners we render from the active mode. In `personal`
+  // mode we union myTiles + borderTiles from the cache; in `world` mode we
+  // render the one-shot world snapshot. Owners comes from whichever bucket
+  // is active.
+  const tiles: MapTile[] = useMemo(
+    () =>
+      mode === "world" && worldView
+        ? worldView.tiles
+        : cachedView
+          ? [...cachedView.myTiles, ...cachedView.borderTiles]
+          : [],
+    [mode, worldView, cachedView]
+  );
+
+  const ownersById: Map<string, OwnerSummary> = useMemo(() => {
+    const ownersList =
+      mode === "world" && worldView
+        ? worldView.owners
+        : cachedView?.owners ?? [];
+    const m = new Map<string, OwnerSummary>();
+    for (const o of ownersList) m.set(o.userId, o as OwnerSummary);
+    return m;
+  }, [mode, worldView, cachedView]);
 
   // First-time fit: center the viewport on the player's own tiles so they
   // know where they are, and zoom so the *entire* kingdom fits. Runs once
   // when player + tiles are first available, or when the user clicks the
-  // recenter (⌖) button (which flips didFit back).
+  // recenter (⌖) button (which flips didFit back). In world mode we fit
+  // the whole world instead.
   /* eslint-disable react-hooks/set-state-in-effect -- one-shot fit on data arrival */
   useEffect(() => {
     if (didFit || !player || tiles.length === 0) return;
-    const own = tiles.filter((t) => t.ownerId === player.userId);
-    const fit = own.length > 0 ? fitTilesToViewport(own) : fitTilesToViewport(tiles);
+    const fitTarget =
+      mode === "world"
+        ? tiles
+        : tiles.filter((t) => t.ownerId === player.userId);
+    const source = fitTarget.length > 0 ? fitTarget : tiles;
+    const fit = fitTilesToViewport(source);
     if (fit) {
       setTx(fit.tx);
       setTy(fit.ty);
       setScale(fit.scale);
     }
     setDidFit(true);
-  }, [didFit, player, tiles]);
+  }, [didFit, player, tiles, mode]);
   /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Re-fit on mode change so toggling Personal/World snaps to the right
+  // viewport.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mode is a derived view-state trigger; one-shot reset of the fit-once latch
+    setDidFit(false);
+  }, [mode]);
 
   // Wheel zoom around the cursor.
   //
@@ -382,12 +509,28 @@ export default function TilesMapPage() {
 
         <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-4 text-sm leading-relaxed">
           <p>
-            Drag to pan, scroll to zoom. Your tiles render in full color with
-            their land type; foreign tiles fade and pick up a caste-colored
-            ring. Generals still under the new-player shield show a lock —
-            they can&apos;t be attacked yet.
+            Drag to pan, scroll to zoom. <strong>Personal mode</strong> shows
+            your tiles + the enemy ring touching your borders, cached locally
+            so it loads instantly. <strong>World mode</strong> (🌐) fetches
+            every tile in the world for context.
           </p>
         </div>
+
+        <PersonalMapToolbar
+          mode={mode}
+          onModeChange={(next) => {
+            setMode(next);
+            if (next === "world" && !worldView) {
+              void fetchWorldOnce();
+            }
+          }}
+          cachedView={cachedView}
+          refreshing={refreshing}
+          onRefresh={() => {
+            if (cachedView && !mayRefresh(cachedView)) return;
+            void refreshPersonalMap();
+          }}
+        />
 
         <div className="flex flex-wrap gap-2 mb-3">
           <span className="text-xs uppercase tracking-wide text-neutral-500 self-center mr-1">
@@ -607,29 +750,12 @@ export default function TilesMapPage() {
               </button>
               <button
                 onClick={() => {
-                  setDidFit(false); // re-trigger the fit effect (your kingdom)
+                  setDidFit(false); // re-trigger the fit effect for current mode
                 }}
-                className="px-2.5 py-1.5 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800 border-t border-neutral-200 dark:border-neutral-800"
+                className="px-2.5 py-1.5 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-b-lg border-t border-neutral-200 dark:border-neutral-800"
                 title="Recenter on your territory"
               >
                 ⌖
-              </button>
-              <button
-                onClick={() => {
-                  // Snap to a fit-zoom of the entire world. Useful when the
-                  // recenter ⌖ left you zoomed in on a small kingdom and the
-                  // surrounding map looks empty.
-                  const fit = fitTilesToViewport(tiles);
-                  if (fit) {
-                    setTx(fit.tx);
-                    setTy(fit.ty);
-                    setScale(fit.scale);
-                  }
-                }}
-                className="px-2.5 py-1.5 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-b-lg border-t border-neutral-200 dark:border-neutral-800"
-                title="Show the whole world"
-              >
-                🌐
               </button>
             </div>
 
@@ -699,6 +825,85 @@ export default function TilesMapPage() {
           </span>
         </div>
       </div>
+    </div>
+  );
+}
+
+function PersonalMapToolbar({
+  mode,
+  onModeChange,
+  cachedView,
+  refreshing,
+  onRefresh,
+}: {
+  mode: "personal" | "world";
+  onModeChange: (next: "personal" | "world") => void;
+  cachedView: CachedMapView | null;
+  refreshing: boolean;
+  onRefresh: () => void;
+}) {
+  const ms = msUntilRefresh(cachedView);
+  const allowed = ms === 0;
+  // "5 min" rate-limit countdown. Round up to whole minutes for the button
+  // copy so the user sees a stable 5/4/3/2/1 progression.
+  const minutesLeft = Math.ceil(ms / 60_000);
+  const lastFetched = cachedView
+    ? new Date(cachedView.lastFetchedAt).toLocaleTimeString([], {
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : null;
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4">
+      <span className="text-xs uppercase tracking-wide text-neutral-500 mr-1">
+        View
+      </span>
+      <button
+        onClick={() => onModeChange("personal")}
+        className={`px-3 py-1.5 rounded-lg text-sm border ${
+          mode === "personal"
+            ? "bg-emerald-500 text-white border-emerald-500"
+            : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+        }`}
+      >
+        Personal
+      </button>
+      <button
+        onClick={() => onModeChange("world")}
+        className={`px-3 py-1.5 rounded-lg text-sm border ${
+          mode === "world"
+            ? "bg-emerald-500 text-white border-emerald-500"
+            : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+        }`}
+        title="Fetch the whole world (no rate limit; rarely needed)"
+      >
+        🌐 Whole world
+      </button>
+      {mode === "personal" && (
+        <>
+          <button
+            onClick={onRefresh}
+            disabled={refreshing || !allowed}
+            className="px-3 py-1.5 rounded-lg text-sm border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            title={
+              !allowed
+                ? `Cooldown — refresh available in ~${minutesLeft} min`
+                : "Refetch your map from the server"
+            }
+          >
+            {refreshing
+              ? "Refreshing…"
+              : allowed
+                ? "↻ Refresh map"
+                : `↻ Refresh in ~${minutesLeft}m`}
+          </button>
+          {lastFetched && (
+            <span className="text-xs text-neutral-500">
+              Last fetched at {lastFetched}
+            </span>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -96,6 +96,13 @@ function hexPoints(cx: number, cy: number): string {
  * point `(x, y)` maps to SVG `(scale * (x + tx), scale * (y + ty))`. We
  * pick `tx, ty` to center the bbox at the origin and `scale` so the bbox
  * fits.
+ *
+ * Important: we only zoom *out* to fit — never zoom *in* past 1:1 on
+ * recenter. For small kingdoms (e.g. a 5-tile cluster) the natural fit
+ * scale is ~6×, which pegs to MAX_SCALE and pushes the surrounding world
+ * off-screen — leaving the user staring at one hex. Capping the fit at 1
+ * keeps neighboring tiles visible for context; the user can still wheel-
+ * zoom in afterward.
  */
 function fitTilesToViewport(
   tiles: ReadonlyArray<MapTile>
@@ -115,7 +122,9 @@ function fitTilesToViewport(
   const w = maxX - minX + 2 * VIEWPORT_PADDING;
   const h = maxY - minY + 2 * VIEWPORT_PADDING;
   const fit = Math.min(VIEWBOX_W / w, VIEWBOX_H / h) * FIT_MARGIN;
-  const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, fit));
+  // Clamp to [MIN_SCALE, 1] — never zoom in past 1:1 on recenter, only
+  // zoom out enough to make the kingdom fit.
+  const scale = Math.max(MIN_SCALE, Math.min(1, fit));
   return {
     scale,
     tx: -(minX + maxX) / 2,
@@ -598,12 +607,29 @@ export default function TilesMapPage() {
               </button>
               <button
                 onClick={() => {
-                  setDidFit(false); // re-trigger the fit effect
+                  setDidFit(false); // re-trigger the fit effect (your kingdom)
                 }}
-                className="px-2.5 py-1.5 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-b-lg border-t border-neutral-200 dark:border-neutral-800"
+                className="px-2.5 py-1.5 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800 border-t border-neutral-200 dark:border-neutral-800"
                 title="Recenter on your territory"
               >
                 ⌖
+              </button>
+              <button
+                onClick={() => {
+                  // Snap to a fit-zoom of the entire world. Useful when the
+                  // recenter ⌖ left you zoomed in on a small kingdom and the
+                  // surrounding map looks empty.
+                  const fit = fitTilesToViewport(tiles);
+                  if (fit) {
+                    setTx(fit.tx);
+                    setTy(fit.ty);
+                    setScale(fit.scale);
+                  }
+                }}
+                className="px-2.5 py-1.5 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-b-lg border-t border-neutral-200 dark:border-neutral-800"
+                title="Show the whole world"
+              >
+                🌐
               </button>
             </div>
 

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -442,6 +442,92 @@ export interface OwnerSummary {
   shielded: boolean;
 }
 
+// Personal map view: my tiles + the *enemy* tiles that share an edge with
+// any of my tiles + owner summaries for those enemies. Designed to be the
+// default fetch for /game/tiles, /game/spells, /game/recruit — the rest of
+// the world isn't relevant to those pages.
+//
+// Read cost: 1 query (own tiles) + 1 batched docRef.getAll() for the
+// border ring + 1 batched docRef.getAll() for owner summaries. For a
+// 25-tile spawn cluster: ~25 + ~30 + ~5 = ~60 reads (vs ~500 for the
+// full-world fetch). Scales with kingdom perimeter, not world size.
+export interface MyMapView {
+  myTiles: MapTile[];
+  borderTiles: MapTile[];
+  owners: OwnerSummary[];
+}
+
+export async function getMyMapServer(
+  userId: string,
+  now: Date = new Date()
+): Promise<MyMapView> {
+  const db = adminDbOrThrow();
+  const myTiles = await getOwnedMapTilesServer(userId);
+  if (myTiles.length === 0) {
+    return { myTiles: [], borderTiles: [], owners: [] };
+  }
+
+  // Build the set of neighbor tile ids that are NOT mine.
+  const myIds = new Set(myTiles.map((t) => t.tileId));
+  const neighborIds = new Set<string>();
+  for (const t of myTiles) {
+    for (const id of neighborTileIds(t.q, t.r)) {
+      if (!myIds.has(id)) neighborIds.add(id);
+    }
+  }
+
+  // Batch-fetch the border ring. We could pre-filter to only-existent docs,
+  // but db.getAll handles missing docs cheaply (returns non-existent
+  // snapshots) so a single round-trip is fine.
+  const borderTiles: MapTile[] = [];
+  const enemyOwnerIds = new Set<string>();
+  if (neighborIds.size > 0) {
+    const refs = [...neighborIds].map((id) =>
+      db.collection(COLLECTIONS.TILES).doc(id)
+    );
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) {
+      if (!s.exists) continue;
+      const data = s.data()!;
+      // Per spec: only enemy tiles. Skip unowned and self-owned border
+      // tiles entirely. Unowned-but-revealed neighbors don't load —
+      // there's no enemy presence there to display.
+      if (!data.ownerId || data.ownerId === userId) continue;
+      borderTiles.push({
+        tileId: data.tileId,
+        q: data.q,
+        r: data.r,
+        type: data.type,
+        ownerId: data.ownerId,
+        units: data.units,
+        armedDefenseSpellId: data.armedDefenseSpellId ?? null,
+      });
+      enemyOwnerIds.add(data.ownerId);
+    }
+  }
+
+  // Owner summaries for the enemies on our border.
+  const owners: OwnerSummary[] = [];
+  if (enemyOwnerIds.size > 0) {
+    const ownerRefs = [...enemyOwnerIds].map((uid) =>
+      db.collection(COLLECTIONS.PLAYERS).doc(uid)
+    );
+    const ownerSnaps = await db.getAll(...ownerRefs);
+    for (const s of ownerSnaps) {
+      if (!s.exists) continue;
+      const p = s.data() as GamePlayer;
+      owners.push({
+        userId: p.userId,
+        displayName: p.displayName ?? "",
+        caste: p.caste ?? null,
+        shielded: isShieldActive(p, now),
+      });
+    }
+  }
+
+  return { myTiles, borderTiles, owners };
+}
+
 // Owner-side metadata for the global map: name, caste, shield status. One
 // record per player; the client joins it onto tiles by ownerId.
 export async function getAllOwnerSummariesServer(

--- a/lib/game/local-map-cache.ts
+++ b/lib/game/local-map-cache.ts
@@ -1,0 +1,242 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Per-user localStorage cache for the personal map view (own tiles +
+ * enemy-adjacent ring + owner summaries). Drives /game/tiles, /game/spells,
+ * /game/recruit so they don't refetch the whole world on every page load.
+ *
+ * Design:
+ *   - One entry per `userId` so signing into a different account doesn't
+ *     leak the previous account's view.
+ *   - Schema-versioned. A bumped `CACHE_VERSION` invalidates old entries
+ *     transparently — no migration code, just a fresh fetch on next load.
+ *   - Action handlers call `mergeTiles` / `mergeOwners` after every action
+ *     response, so the cache stays current across page navigations
+ *     without an extra read.
+ *   - Manual refresh is rate-limited to once every 5 minutes. The gate is
+ *     client-side (localStorage timestamp); the server still enforces
+ *     normal API auth + rate limits, so this is a UX nicety, not a
+ *     security boundary.
+ */
+
+import type { Caste, MapTile } from "./types";
+
+const CACHE_VERSION = 1;
+const KEY_PREFIX = "cb-game-map-v" + CACHE_VERSION + ":";
+export const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface CachedOwnerSummary {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+}
+
+export interface CachedMapView {
+  myTiles: MapTile[];
+  borderTiles: MapTile[];
+  owners: CachedOwnerSummary[];
+  lastFetchedAt: number; // ms epoch
+}
+
+interface StoredEntry extends CachedMapView {
+  v: number; // schema version, must equal CACHE_VERSION
+  userId: string;
+}
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    // Private mode, locked-down browser, etc.
+    return null;
+  }
+}
+
+function keyFor(userId: string): string {
+  return KEY_PREFIX + userId;
+}
+
+/** Load a cached view for `userId`. Returns null on missing / corrupt /
+ *  version-mismatch / userId-mismatch (defensive against multi-account). */
+export function loadCachedMap(userId: string): CachedMapView | null {
+  const s = storage();
+  if (!s) return null;
+  const raw = s.getItem(keyFor(userId));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as StoredEntry;
+    if (parsed.v !== CACHE_VERSION) return null;
+    if (parsed.userId !== userId) return null;
+    if (!Array.isArray(parsed.myTiles)) return null;
+    if (!Array.isArray(parsed.borderTiles)) return null;
+    if (!Array.isArray(parsed.owners)) return null;
+    if (typeof parsed.lastFetchedAt !== "number") return null;
+    return {
+      myTiles: parsed.myTiles,
+      borderTiles: parsed.borderTiles,
+      owners: parsed.owners,
+      lastFetchedAt: parsed.lastFetchedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Persist a fresh view to the cache. Call after a full /api/game/map/me
+ *  fetch (manual refresh or first load). */
+export function saveCachedMap(
+  userId: string,
+  view: Omit<CachedMapView, "lastFetchedAt"> & { lastFetchedAt?: number }
+): void {
+  const s = storage();
+  if (!s) return;
+  const entry: StoredEntry = {
+    v: CACHE_VERSION,
+    userId,
+    myTiles: view.myTiles,
+    borderTiles: view.borderTiles,
+    owners: view.owners,
+    lastFetchedAt: view.lastFetchedAt ?? Date.now(),
+  };
+  try {
+    s.setItem(keyFor(userId), JSON.stringify(entry));
+  } catch {
+    // Storage full / quota exceeded — drop silently. The next manual
+    // refresh will succeed once the user clears something or the storage
+    // clears itself.
+  }
+}
+
+/** Clear the cache for `userId`. Call on sign-out or on schema changes. */
+export function clearCachedMap(userId: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.removeItem(keyFor(userId));
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Merge a partial set of tile updates into the cached view. Tiles whose
+ * `tileId` is already present are replaced; new tile ids are appended into
+ * the appropriate bucket based on `ownerId`:
+ *   - tile owned by `userId` → `myTiles`, removed from `borderTiles` if it
+ *     used to live there (e.g. you just conquered a border tile).
+ *   - tile owned by someone else → `borderTiles` (only if it touches one
+ *     of your tiles), removed from `myTiles` if it used to be yours.
+ *   - tile with null owner → removed from both buckets (re-fog edge case).
+ *
+ * No-ops if the cache doesn't exist; the caller's next refresh will
+ * fetch the whole view fresh.
+ */
+export function mergeTiles(
+  userId: string,
+  updates: ReadonlyArray<MapTile>
+): CachedMapView | null {
+  const cached = loadCachedMap(userId);
+  if (!cached) return null;
+
+  const myById = new Map(cached.myTiles.map((t) => [t.tileId, t] as const));
+  const borderById = new Map(
+    cached.borderTiles.map((t) => [t.tileId, t] as const)
+  );
+
+  // Build a fast adjacency check: a tile is on my border iff at least one
+  // neighbor is in `myById`. We snapshot myIds *before* applying updates so
+  // a single batch of updates produces consistent border membership.
+  const myIdsBefore = new Set(myById.keys());
+
+  for (const u of updates) {
+    if (u.ownerId === userId) {
+      myById.set(u.tileId, u);
+      borderById.delete(u.tileId);
+    } else if (u.ownerId) {
+      myById.delete(u.tileId);
+      // Only keep if it touches something I already owned.
+      if (tileTouchesAny(u, myIdsBefore)) {
+        borderById.set(u.tileId, u);
+      } else {
+        borderById.delete(u.tileId);
+      }
+    } else {
+      myById.delete(u.tileId);
+      borderById.delete(u.tileId);
+    }
+  }
+
+  const next: CachedMapView = {
+    myTiles: Array.from(myById.values()),
+    borderTiles: Array.from(borderById.values()),
+    owners: cached.owners,
+    // Action-driven merges do not reset lastFetchedAt — only a full fetch
+    // resets the rate-limit clock.
+    lastFetchedAt: cached.lastFetchedAt,
+  };
+  saveCachedMap(userId, next);
+  return next;
+}
+
+/** Add or replace owner summaries (e.g. you conquered a border tile and
+ *  need its previous owner's record kept around for history, or you saw a
+ *  new enemy show up on your border via attack). */
+export function mergeOwners(
+  userId: string,
+  updates: ReadonlyArray<CachedOwnerSummary>
+): CachedMapView | null {
+  const cached = loadCachedMap(userId);
+  if (!cached) return null;
+  const byId = new Map(cached.owners.map((o) => [o.userId, o] as const));
+  for (const u of updates) byId.set(u.userId, u);
+  const next: CachedMapView = {
+    ...cached,
+    owners: Array.from(byId.values()),
+  };
+  saveCachedMap(userId, next);
+  return next;
+}
+
+/** True iff at least 5 minutes have elapsed since the last full refresh. */
+export function mayRefresh(view: CachedMapView | null, now: number = Date.now()): boolean {
+  if (!view) return true;
+  return now - view.lastFetchedAt >= REFRESH_INTERVAL_MS;
+}
+
+/** Milliseconds remaining until refresh is allowed again. 0 if already
+ *  allowed. Useful for rendering a countdown next to the disabled button. */
+export function msUntilRefresh(
+  view: CachedMapView | null,
+  now: number = Date.now()
+): number {
+  if (!view) return 0;
+  return Math.max(0, REFRESH_INTERVAL_MS - (now - view.lastFetchedAt));
+}
+
+// --- helpers ---
+
+// Six axial neighbor offsets for a pointy-top hex grid. Mirrors the same
+// constant on the world map page; kept inline so this module is dependency-
+// free of the world-gen lib (which would pull in unused exports).
+const HEX_NEIGHBORS: ReadonlyArray<readonly [number, number]> = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [1, -1],
+  [-1, 1],
+];
+
+function tileTouchesAny(t: MapTile, ids: ReadonlySet<string>): boolean {
+  for (const [dq, dr] of HEX_NEIGHBORS) {
+    const id = `${t.q + dq}_${t.r + dr}`;
+    if (ids.has(id)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- Replaces full-world fetch on /game/tiles with a personal view: own tiles + enemy-bordering ring + relevant owner summaries (`/api/game/map/me`).
- Adds a per-user, schema-versioned `localStorage` cache (`lib/game/local-map-cache.ts`). Action handlers across game pages merge their response into the cache, so the world map + threat displays stay current without refetching.
- Manual refresh button rate-limited to once per 5 minutes (UX nicety; server still enforces auth).
- /game/spells, /game/recruit, dashboard mini-map all migrated to read border tiles from the cache instead of `/api/game/world`.
- World snapshot still available behind a 🌐 toggle on the map page for the rare case a player wants global context.

## Why
User reported "only 1 tile loaded" on /game/tiles. The world fetch was returning so much data the page failed to render. This change scopes the default fetch to what each player actually needs (their kingdom + immediate frontier), and caches it so navigating between game pages doesn't re-pay the round trip.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] 192 game tests pass (`npx jest --config config/jest.config.js __tests__/lib/game/`)
- [x] 18 new tests for `local-map-cache` (save/load isolation, multi-account, border-membership invariants under merge, refresh window)
- [x] ESLint clean across all touched files (max-warnings 0)
- [ ] Manual: load /game/tiles with a >50-tile kingdom — verify all own tiles render, enemy-bordering tiles render, refresh button shows countdown for 5 min after a successful refresh
- [ ] Manual: take an action (recruit / arm spell / attack), navigate away and back — local view reflects the change without a refresh
- [ ] Manual: 🌐 toggle still works and pulls a one-shot world snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)