### PR TITLE
fix(api): emit per-operation security in OpenAPI spec (#234 follow-up)

### DIFF
--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -85,6 +85,38 @@ openApiDoc.components = {
   securitySchemes: SECURITY_SCHEMES,
 };
 
+/**
+ * Per-operation security: ts-rest's generator doesn't propagate `security`
+ * from contract metadata into the spec. Heuristic: if an operation declares
+ * a 401 response, it requires authentication — emit `security: [bearerAuth,
+ * cookieAuth]` for it. Operations without 401 (public endpoints, cron
+ * routes that 403, webhooks with custom auth) are left as unauthenticated.
+ */
+const HTTP_METHODS = [
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "head",
+] as const;
+
+let authedOps = 0;
+for (const pathItem of Object.values(openApiDoc.paths ?? {})) {
+  if (!pathItem || typeof pathItem !== "object") continue;
+  for (const method of HTTP_METHODS) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const op = (pathItem as Record<string, any>)[method];
+    if (!op || typeof op !== "object") continue;
+    const responses = (op.responses ?? {}) as Record<string, unknown>;
+    if ("401" in responses) {
+      op.security = [{ bearerAuth: [] }, { cookieAuth: [] }];
+      authedOps += 1;
+    }
+  }
+}
+
 mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
 writeFileSync(OUTPUT_PATH, JSON.stringify(openApiDoc, null, 2) + "\n", "utf8");
 
@@ -95,5 +127,5 @@ const operationCount = Object.values(openApiDoc.paths ?? {}).reduce(
 console.log(
   `[openapi] Wrote ${OUTPUT_PATH} — ${
     Object.keys(openApiDoc.paths ?? {}).length
-  } paths, ${operationCount} operations.`
+  } paths, ${operationCount} operations (${authedOps} require auth).`
 );


### PR DESCRIPTION
Follow-up to #234. Caught while auditing the merged spec.

`@ts-rest/open-api` doesn't propagate `security` from contract metadata, so before this change the spec had `components.securitySchemes` defined but **0 of 174 operations referenced them** — Swagger UI couldn't show the auth lock icon and 'Try it out' had no way to authenticate.

Heuristic post-process in `scripts/generate-openapi.ts`: any operation that declares a 401 response gets `security: [{ bearerAuth: [] }, { cookieAuth: [] }]` injected. Public endpoints (analytics/summary, auth/resolve-email, badges/definitions, …), OAuth callbacks (discord, github, ludwitt), cron routes that 403 (game/rollover, account/purge), and signed webhooks are correctly left unauthenticated.

After: **136 of 174 operations require auth** in the spec; the 38 without are intentional.

Verified locally — `/api/docs` now shows the lock icon on every protected endpoint, and 'Try it out' picks up the Bearer token via the Authorize button.