### PR TITLE
release: develop → main (NPC tooling scripts)

### DIFF
--- a/scripts/reset-game-player.ts
+++ b/scripts/reset-game-player.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * One-off: wipe a player's game state so the account starts over.
+ *
+ * Deletes:
+ *   - game_players/{uid}
+ *   - all game_tiles where ownerId == uid (frees those hexes back to unrevealed)
+ *   - all game_artifacts where ownerId == uid
+ *   - all game_attacks where attackerId == uid OR defenderId == uid
+ *
+ * Idempotent — re-running on a missing uid is a no-op.
+ *
+ * Usage:
+ *   npx tsx scripts/reset-game-player.ts <email>
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import type { Firestore, WriteBatch } from "firebase-admin/firestore";
+import { getAdminAuth, getAdminDb } from "../lib/firebase-admin";
+
+const COLLECTIONS = {
+  PLAYERS: "game_players",
+  TILES: "game_tiles",
+  ATTACKS: "game_attacks",
+  ARTIFACTS: "game_artifacts",
+} as const;
+
+async function resolveUidForEmail(
+  db: Firestore,
+  email: string
+): Promise<string | null> {
+  const auth = getAdminAuth();
+  if (auth) {
+    try {
+      const u = await auth.getUserByEmail(email);
+      return u.uid;
+    } catch {
+      /* fall through */
+    }
+  }
+  const lookup = await db.collection("emailLookup").doc(email).get();
+  if (lookup.exists) {
+    const uid = lookup.data()?.uid as string | undefined;
+    if (uid) return uid;
+  }
+  const byEmail = await db
+    .collection("users")
+    .where("email", "==", email)
+    .limit(2)
+    .get();
+  if (!byEmail.empty) {
+    if (byEmail.docs.length > 1) {
+      console.warn(
+        `[warn] Multiple users for ${email}; using first doc ${byEmail.docs[0]!.id}`
+      );
+    }
+    return byEmail.docs[0]!.id;
+  }
+  return null;
+}
+
+async function deleteWhere(
+  db: Firestore,
+  collection: string,
+  field: string,
+  value: string
+): Promise<number> {
+  const snap = await db.collection(collection).where(field, "==", value).get();
+  if (snap.empty) return 0;
+  // Firestore batches cap at 500 ops.
+  const BATCH_LIMIT = 400;
+  let written = 0;
+  let batch: WriteBatch = db.batch();
+  let inBatch = 0;
+  for (const doc of snap.docs) {
+    batch.delete(doc.ref);
+    inBatch += 1;
+    if (inBatch >= BATCH_LIMIT) {
+      await batch.commit();
+      written += inBatch;
+      batch = db.batch();
+      inBatch = 0;
+    }
+  }
+  if (inBatch > 0) {
+    await batch.commit();
+    written += inBatch;
+  }
+  return written;
+}
+
+async function main() {
+  const email = process.argv[2];
+  if (!email) {
+    console.error("Usage: npx tsx scripts/reset-game-player.ts <email>");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const uid = await resolveUidForEmail(db, email.toLowerCase());
+  if (!uid) {
+    console.error(`No user found for ${email}.`);
+    process.exit(1);
+  }
+  console.log(`Resolved ${email} → ${uid}`);
+
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(uid);
+  const playerSnap = await playerRef.get();
+  if (playerSnap.exists) {
+    await playerRef.delete();
+    console.log(`Deleted ${COLLECTIONS.PLAYERS}/${uid}`);
+  } else {
+    console.log(`${COLLECTIONS.PLAYERS}/${uid}: not found, skipping.`);
+  }
+
+  const tiles = await deleteWhere(db, COLLECTIONS.TILES, "ownerId", uid);
+  console.log(`Deleted ${tiles} ${COLLECTIONS.TILES} doc(s).`);
+
+  const artifacts = await deleteWhere(
+    db,
+    COLLECTIONS.ARTIFACTS,
+    "ownerId",
+    uid
+  );
+  console.log(`Deleted ${artifacts} ${COLLECTIONS.ARTIFACTS} doc(s).`);
+
+  const attacksSent = await deleteWhere(
+    db,
+    COLLECTIONS.ATTACKS,
+    "attackerId",
+    uid
+  );
+  const attacksReceived = await deleteWhere(
+    db,
+    COLLECTIONS.ATTACKS,
+    "defenderId",
+    uid
+  );
+  console.log(
+    `Deleted ${attacksSent} sent + ${attacksReceived} received ${COLLECTIONS.ATTACKS} doc(s).`
+  );
+
+  console.log(`Done. ${email} can now run setup again.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/run-npc-weekly.ts
+++ b/scripts/run-npc-weekly.ts
@@ -1,0 +1,710 @@
+#!/usr/bin/env node
+/**
+ * Weekly NPC turn-spender. Designed to run once per week, ideally after the
+ * GitHub Actions `game-weekly-rollover` cron (which only grants turns to
+ * players with merged PRs — NPCs don't qualify).
+ *
+ * Per NPC (any player doc with `isNpc == true`):
+ *   1. Apply weekly grant (turnsRemaining = 100), idempotent per week-start.
+ *   2. Pick a persona deterministically from the uid → drives action mix.
+ *   3. Spend ~all 100 turns across:
+ *        - tier-1 production spell casts (5 turns)
+ *        - bulk unit builds up to food cap        (5 turns / 10 units)
+ *        - up to 15 attacks vs. adjacent OTHER NPC tiles  (1 turn each;
+ *          humans are never targeted)
+ *
+ * Re-running the same week is a no-op for NPCs already granted that week.
+ *
+ * Usage:
+ *   npx tsx scripts/run-npc-weekly.ts [--week=YYYY-MM-DD] [--dry-run] [--limit=N]
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import type { Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import {
+  attackTileServer,
+  bulkBuildUnitsServer,
+  castProductionSpellServer,
+} from "../lib/game/data-server";
+import {
+  applyWeeklyGrant,
+  isShieldActive,
+  weekStartIsoForRollover,
+} from "../lib/game/turns";
+import {
+  computeTileCapacity,
+  makeSeededRng,
+} from "../lib/game/combat";
+import { effectiveUnitCap } from "../lib/game/turns";
+import { getSpellForCasteAndType } from "../lib/game/content";
+import type {
+  GamePlayer,
+  GameTile,
+  UnitStack,
+  UnitType,
+} from "../lib/game/types";
+
+const COLLECTIONS = {
+  PLAYERS: "game_players",
+  TILES: "game_tiles",
+} as const;
+
+const ATTACK_HARD_CAP = 15;
+
+type PersonaName =
+  | "builder"
+  | "raider"
+  | "magus"
+  | "diplomat"
+  | "warmonger"
+  | "tactician";
+
+interface Persona {
+  name: PersonaName;
+  // Target attack count this week (clamped to 0..ATTACK_HARD_CAP).
+  attacks: number;
+  // Number of production-spell casts this week (each costs 5 turns).
+  spells: number;
+  // If non-null, attacker prefers this unit type when picking a source tile.
+  preferredUnit: UnitType | null;
+  // Fraction of source-tile units to deploy in an attack (clamped 0.3–0.95).
+  deployFraction: number;
+}
+
+const PERSONAS: Record<PersonaName, Persona> = {
+  builder:    { name: "builder",    attacks: 2,  spells: 3, preferredUnit: null,    deployFraction: 0.5 },
+  diplomat:   { name: "diplomat",   attacks: 1,  spells: 4, preferredUnit: null,    deployFraction: 0.4 },
+  tactician:  { name: "tactician",  attacks: 8,  spells: 2, preferredUnit: null,    deployFraction: 0.65 },
+  magus:      { name: "magus",      attacks: 5,  spells: 6, preferredUnit: "air",   deployFraction: 0.6 },
+  raider:     { name: "raider",     attacks: 14, spells: 1, preferredUnit: "ground", deployFraction: 0.7 },
+  warmonger:  { name: "warmonger",  attacks: 15, spells: 0, preferredUnit: "siege", deployFraction: 0.8 },
+};
+
+const PERSONA_NAMES: PersonaName[] = Object.keys(PERSONAS) as PersonaName[];
+
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 33) ^ s.charCodeAt(i);
+  }
+  return h >>> 0;
+}
+
+function personaForUid(uid: string): Persona {
+  const idx = djb2(uid) % PERSONA_NAMES.length;
+  return PERSONAS[PERSONA_NAMES[idx]!];
+}
+
+function sumStack(s: UnitStack): number {
+  return s.ground + s.siege + s.air;
+}
+
+interface AttackCandidate {
+  sourceTileId: string;
+  targetTileId: string;
+  defenderId: string;
+  // Total attacker units available on the source tile at planning time.
+  sourceUnits: UnitStack;
+  // Open capacity on the target tile at planning time.
+  targetCapacity: number;
+}
+
+// Scores attack candidates by a "weakness * affordability" heuristic. Targets
+// with low defenders + high open capacity rise; sources with lots of units
+// rise. Persona's preferredUnit nudges sources that have that unit type.
+function scoreCandidate(c: AttackCandidate, persona: Persona): number {
+  const srcTotal = sumStack(c.sourceUnits);
+  if (srcTotal <= 0) return -1;
+  const preferredBoost = persona.preferredUnit
+    ? c.sourceUnits[persona.preferredUnit] / Math.max(1, srcTotal)
+    : 0.5;
+  return srcTotal * 1.0 + preferredBoost * 50 + c.targetCapacity * 0.1;
+}
+
+function pickUnitsToSend(
+  src: UnitStack,
+  fraction: number,
+  capRoom: number,
+  preferred: UnitType | null
+): UnitStack {
+  const total = sumStack(src);
+  if (total <= 0 || capRoom <= 0) return { ground: 0, siege: 0, air: 0 };
+  // Target send size as fraction of source units, but cap to target's open
+  // space. We never send fewer than 1 unit if we can.
+  let target = Math.min(Math.floor(total * fraction), capRoom);
+  if (target <= 0) target = Math.min(1, total, capRoom);
+
+  const result: UnitStack = { ground: 0, siege: 0, air: 0 };
+  let remaining = target;
+
+  // First fill from preferred type if specified.
+  const order: UnitType[] = preferred
+    ? [preferred, ...(["ground", "siege", "air"] as UnitType[]).filter((t) => t !== preferred)]
+    : ["ground", "siege", "air"];
+
+  for (const t of order) {
+    if (remaining <= 0) break;
+    const take = Math.min(src[t], remaining);
+    result[t] = take;
+    remaining -= take;
+  }
+  return result;
+}
+
+interface NpcContext {
+  player: GamePlayer;
+  // All tiles owned by this NPC.
+  myTiles: GameTile[];
+  myMilitary: GameTile[];
+  myFoodCount: number;
+  myMagicCount: number;
+}
+
+interface WorldSnapshot {
+  // All NPC players keyed by uid. Used to filter "attack only NPCs".
+  npcs: Map<string, GamePlayer>;
+  // tileId → owner (for adjacency lookups). Includes both NPC and human tiles.
+  ownerByTile: Map<string, string>;
+  // tileId → tile data (only NPC-owned tiles, since those are our only valid targets).
+  npcTilesById: Map<string, GameTile>;
+  // Owner uid → list of their tiles (NPC owners only).
+  tilesByOwner: Map<string, GameTile[]>;
+}
+
+async function loadWorldSnapshot(db: Firestore): Promise<WorldSnapshot> {
+  const playersSnap = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .where("isNpc", "==", true)
+    .get();
+  const npcs = new Map<string, GamePlayer>();
+  for (const d of playersSnap.docs) {
+    npcs.set(d.id, d.data() as GamePlayer);
+  }
+
+  const tilesSnap = await db.collection(COLLECTIONS.TILES).get();
+  const ownerByTile = new Map<string, string>();
+  const npcTilesById = new Map<string, GameTile>();
+  const tilesByOwner = new Map<string, GameTile[]>();
+  for (const d of tilesSnap.docs) {
+    const t = d.data() as GameTile;
+    if (t.ownerId) ownerByTile.set(t.tileId, t.ownerId);
+    if (t.ownerId && npcs.has(t.ownerId)) {
+      npcTilesById.set(t.tileId, t);
+      const arr = tilesByOwner.get(t.ownerId) ?? [];
+      arr.push(t);
+      tilesByOwner.set(t.ownerId, arr);
+    }
+  }
+
+  return { npcs, ownerByTile, npcTilesById, tilesByOwner };
+}
+
+function buildContext(
+  uid: string,
+  world: WorldSnapshot
+): NpcContext | null {
+  const player = world.npcs.get(uid);
+  if (!player) return null;
+  const myTiles = world.tilesByOwner.get(uid) ?? [];
+  const myMilitary = myTiles.filter((t) => t.type === "military");
+  let foodCount = 0;
+  let magicCount = 0;
+  for (const t of myTiles) {
+    if (t.type === "food") foodCount += 1;
+    else if (t.type === "magic") magicCount += 1;
+  }
+  return {
+    player,
+    myTiles,
+    myMilitary,
+    myFoodCount: foodCount,
+    myMagicCount: magicCount,
+  };
+}
+
+function findAttackCandidates(
+  ctx: NpcContext,
+  world: WorldSnapshot,
+  persona: Persona,
+  now: Date,
+  rng: () => number
+): AttackCandidate[] {
+  const candidates: AttackCandidate[] = [];
+  // Each pair (source mil tile of mine, adjacent target NPC tile NOT mine).
+  // Filter targets owned by shielded NPCs (would throw GameShieldedError).
+  for (const src of ctx.myMilitary) {
+    if (sumStack(src.units) < 5) continue;
+    for (const neighborId of src.neighborTileIds) {
+      const target = world.npcTilesById.get(neighborId);
+      if (!target) continue; // neighbor is unrevealed, human-owned, or unowned
+      if (target.ownerId === ctx.player.userId) continue;
+      const defender = world.npcs.get(target.ownerId!);
+      if (!defender) continue;
+      if (isShieldActive(defender, now)) continue;
+      const targetCap = computeTileCapacity(
+        target.type,
+        defender.caste,
+        target.upgradeIds,
+        defender.activeUpgrades ?? {}
+      );
+      const open = Math.max(0, targetCap - sumStack(target.units));
+      if (open < 1) continue;
+      candidates.push({
+        sourceTileId: src.tileId,
+        targetTileId: target.tileId,
+        defenderId: target.ownerId!,
+        sourceUnits: { ...src.units },
+        targetCapacity: open,
+      });
+    }
+  }
+
+  // Score and sort, then add a small random jitter so equally-scored ties
+  // don't all collapse onto the same source.
+  return candidates
+    .map((c) => ({ c, s: scoreCandidate(c, persona) + rng() * 5 }))
+    .sort((a, b) => b.s - a.s)
+    .map((x) => x.c);
+}
+
+interface ActionLog {
+  builds: number;
+  attacks: number;
+  spellsCast: number;
+  attackOutcomes: { captured: number; repelled: number; stalemate: number };
+  errors: string[];
+}
+
+async function spendNpcTurns(args: {
+  db: Firestore;
+  ctx: NpcContext;
+  persona: Persona;
+  world: WorldSnapshot;
+  now: Date;
+  dryRun: boolean;
+}): Promise<ActionLog> {
+  const { ctx, persona, world, now, dryRun } = args;
+  const log: ActionLog = {
+    builds: 0,
+    attacks: 0,
+    spellsCast: 0,
+    attackOutcomes: { captured: 0, repelled: 0, stalemate: 0 },
+    errors: [],
+  };
+  if (!ctx.player.caste) return log; // can't act without a caste
+  const caste = ctx.player.caste;
+
+  let player = ctx.player;
+  const rng = makeSeededRng(`npc-week:${player.userId}:${now.toISOString().slice(0, 10)}`);
+
+  // ── Phase 1: production spells (cheap & low risk) ──
+  if (persona.spells > 0) {
+    const spell = getSpellForCasteAndType(caste, "production");
+    const targetCasts = persona.spells;
+    for (let i = 0; i < targetCasts; i++) {
+      if (player.turnsRemaining < spell.turnCost) break;
+      if (dryRun) {
+        player = {
+          ...player,
+          turnsRemaining: player.turnsRemaining - spell.turnCost,
+          turnsSpentTotal: player.turnsSpentTotal + spell.turnCost,
+        };
+        log.spellsCast += 1;
+        continue;
+      }
+      try {
+        const r = await castProductionSpellServer(player.userId, spell.id, now);
+        player = r.player;
+        log.spellsCast += 1;
+      } catch (e) {
+        log.errors.push(`spell: ${(e as Error).message}`);
+        break;
+      }
+    }
+  }
+
+  // ── Phase 2: bulk unit builds up to cap ──
+  // Compute current cap from latest land counts. We rely on the in-memory
+  // land counts (stable across this script run; food/magic don't shift).
+  const currentCap = effectiveUnitCap(
+    player,
+    ctx.myFoodCount,
+    ctx.myMagicCount
+  );
+  const room = Math.max(0, currentCap - player.stats.unitsAlive);
+  // Each cycle = 5 turns → 10 units. Cap each call to 100 cycles per
+  // bulkBuildUnitsServer's hard limit.
+  const wantedCycles = Math.floor(room / 10);
+  // Reserve attack budget: keep enough turns for max-attack count. Each attack
+  // costs 1 turn (no offense spells in v1).
+  const attacksReserved = Math.min(persona.attacks, ATTACK_HARD_CAP);
+  const buildBudgetTurns = Math.max(0, player.turnsRemaining - attacksReserved);
+  const cyclesAffordable = Math.floor(buildBudgetTurns / 5);
+  let cyclesLeft = Math.min(wantedCycles, cyclesAffordable);
+
+  if (cyclesLeft > 0 && ctx.myMilitary.length > 0) {
+    while (cyclesLeft > 0) {
+      const chunk = Math.min(cyclesLeft, 100);
+      // Round-robin distribute chunk across military tiles. Each tile in the
+      // plan can have many cycles; bulkBuildUnitsServer will dedupe writes.
+      const plan = makeBuildPlan(
+        ctx.myMilitary,
+        chunk,
+        persona.preferredUnit ?? "ground",
+        rng
+      );
+      if (plan.length === 0) break;
+      if (dryRun) {
+        player = {
+          ...player,
+          turnsRemaining: player.turnsRemaining - chunk * 5,
+          turnsSpentTotal: player.turnsSpentTotal + chunk * 5,
+          stats: {
+            ...player.stats,
+            unitsAlive: player.stats.unitsAlive + chunk * 10,
+          },
+        };
+        log.builds += chunk;
+        cyclesLeft -= chunk;
+        continue;
+      }
+      try {
+        const r = await bulkBuildUnitsServer(player.userId, plan, now);
+        player = r.player;
+        log.builds += chunk;
+        cyclesLeft -= chunk;
+        if (r.stoppedEarly) {
+          break;
+        }
+      } catch (e) {
+        log.errors.push(`bulkBuild: ${(e as Error).message}`);
+        break;
+      }
+    }
+  }
+
+  // ── Phase 3: attacks (live re-read of source tile units required) ──
+  // Re-fetch the source tiles from the DB for the latest unit counts (the
+  // builds above changed them). Cheaper than re-reading the world snapshot.
+  if (persona.attacks > 0 && !dryRun) {
+    await refreshContextFromDb(args.db, ctx);
+  }
+
+  let attacksRemaining = Math.min(persona.attacks, ATTACK_HARD_CAP);
+  while (attacksRemaining > 0 && player.turnsRemaining >= 1) {
+    const candidates = findAttackCandidates(ctx, world, persona, now, rng);
+    const picked = candidates.shift();
+    if (!picked) break;
+    const send = pickUnitsToSend(
+      picked.sourceUnits,
+      persona.deployFraction,
+      picked.targetCapacity,
+      persona.preferredUnit
+    );
+    if (sumStack(send) === 0) {
+      // Mark this source as drained so we don't re-pick it.
+      const src = ctx.myMilitary.find((t) => t.tileId === picked.sourceTileId);
+      if (src) src.units = { ground: 0, siege: 0, air: 0 };
+      continue;
+    }
+    if (dryRun) {
+      player = {
+        ...player,
+        turnsRemaining: player.turnsRemaining - 1,
+        turnsSpentTotal: player.turnsSpentTotal + 1,
+      };
+      const src = ctx.myMilitary.find((t) => t.tileId === picked.sourceTileId);
+      if (src) {
+        src.units = {
+          ground: src.units.ground - send.ground,
+          siege: src.units.siege - send.siege,
+          air: src.units.air - send.air,
+        };
+      }
+      log.attacks += 1;
+      attacksRemaining -= 1;
+      continue;
+    }
+    try {
+      const r = await attackTileServer({
+        attackerId: player.userId,
+        sourceTileId: picked.sourceTileId,
+        targetTileId: picked.targetTileId,
+        units: send,
+        offenseSpellId: null,
+        now,
+      });
+      player = r.attackerPlayer;
+      log.attacks += 1;
+      log.attackOutcomes[r.attack.outcome] += 1;
+
+      // Update local state so subsequent candidate scoring is fresh:
+      //   - source tile unit counts decreased (and possibly target captured).
+      const src = ctx.myMilitary.find((t) => t.tileId === picked.sourceTileId);
+      if (src) src.units = r.sourceTile.units;
+      if (r.attack.outcome === "captured") {
+        // Add captured tile to my list (now mine, type unchanged for now).
+        ctx.myTiles.push(r.targetTile);
+        if (r.targetTile.type === "military") ctx.myMilitary.push(r.targetTile);
+        if (r.targetTile.type === "food") ctx.myFoodCount += 1;
+        if (r.targetTile.type === "magic") ctx.myMagicCount += 1;
+        // Remove from defender's tile list in world snapshot (so we don't
+        // accidentally re-target it).
+        world.npcTilesById.delete(r.targetTile.tileId);
+        const defenderArr = world.tilesByOwner.get(picked.defenderId);
+        if (defenderArr) {
+          world.tilesByOwner.set(
+            picked.defenderId,
+            defenderArr.filter((t) => t.tileId !== r.targetTile.tileId)
+          );
+        }
+        // Add to my own list in world snapshot.
+        world.npcTilesById.set(r.targetTile.tileId, r.targetTile);
+        const mine = world.tilesByOwner.get(player.userId) ?? [];
+        mine.push(r.targetTile);
+        world.tilesByOwner.set(player.userId, mine);
+      } else {
+        // Update defender's tile in snapshot with post-combat unit counts.
+        world.npcTilesById.set(r.targetTile.tileId, r.targetTile);
+      }
+    } catch (e) {
+      log.errors.push(`attack: ${(e as Error).message}`);
+      // Don't break — try the next candidate; the failure may be specific
+      // (e.g. tile filled up between scan and attack).
+    }
+    attacksRemaining -= 1;
+  }
+
+  // ── Phase 4: dump leftover budget on more builds, if any cap room ──
+  if (!dryRun && player.turnsRemaining >= 5) {
+    await refreshContextFromDb(args.db, ctx);
+    const cap = effectiveUnitCap(
+      player,
+      ctx.myFoodCount,
+      ctx.myMagicCount
+    );
+    const dumpRoom = Math.max(0, cap - player.stats.unitsAlive);
+    let dumpCycles = Math.min(
+      Math.floor(dumpRoom / 10),
+      Math.floor(player.turnsRemaining / 5)
+    );
+    while (dumpCycles > 0 && ctx.myMilitary.length > 0) {
+      const chunk = Math.min(dumpCycles, 100);
+      const plan = makeBuildPlan(
+        ctx.myMilitary,
+        chunk,
+        persona.preferredUnit ?? "ground",
+        rng
+      );
+      if (plan.length === 0) break;
+      try {
+        const r = await bulkBuildUnitsServer(player.userId, plan, now);
+        player = r.player;
+        log.builds += chunk;
+        dumpCycles -= chunk;
+        if (r.stoppedEarly) break;
+      } catch (e) {
+        log.errors.push(`bulkBuild(dump): ${(e as Error).message}`);
+        break;
+      }
+    }
+  }
+
+  return log;
+}
+
+async function refreshContextFromDb(db: Firestore, ctx: NpcContext) {
+  const fresh = await db
+    .collection(COLLECTIONS.TILES)
+    .where("ownerId", "==", ctx.player.userId)
+    .get();
+  const myTiles: GameTile[] = fresh.docs.map((d) => d.data() as GameTile);
+  ctx.myTiles = myTiles;
+  ctx.myMilitary = myTiles.filter((t) => t.type === "military");
+  ctx.myFoodCount = myTiles.filter((t) => t.type === "food").length;
+  ctx.myMagicCount = myTiles.filter((t) => t.type === "magic").length;
+}
+
+function makeBuildPlan(
+  miltiles: GameTile[],
+  totalCycles: number,
+  preferred: UnitType,
+  rng: () => number
+): { tileId: string; unitType: UnitType; cycles: number }[] {
+  if (miltiles.length === 0 || totalCycles <= 0) return [];
+  // Split cycles round-robin across tiles, with the preferred unit as the
+  // type. 80% preferred, 20% rotating among the others, so personas read
+  // visibly different on the leaderboard while still keeping some breadth.
+  const plan: { tileId: string; unitType: UnitType; cycles: number }[] = [];
+  let cyclesLeft = totalCycles;
+  const tileOrder = [...miltiles].sort(() => rng() - 0.5);
+  let tileIdx = 0;
+  while (cyclesLeft > 0) {
+    const tile = tileOrder[tileIdx % tileOrder.length]!;
+    const isPreferred = rng() < 0.8;
+    const unitType: UnitType = isPreferred
+      ? preferred
+      : (["ground", "siege", "air"] as UnitType[]).filter((t) => t !== preferred)[
+          Math.floor(rng() * 2)
+        ]!;
+    plan.push({ tileId: tile.tileId, unitType, cycles: 1 });
+    cyclesLeft -= 1;
+    tileIdx += 1;
+  }
+  // Coalesce contiguous (tileId, unitType) entries to keep the plan compact.
+  const coalesced: { tileId: string; unitType: UnitType; cycles: number }[] = [];
+  for (const e of plan) {
+    const prev = coalesced[coalesced.length - 1];
+    if (prev && prev.tileId === e.tileId && prev.unitType === e.unitType) {
+      prev.cycles += e.cycles;
+    } else {
+      coalesced.push({ ...e });
+    }
+  }
+  return coalesced;
+}
+
+async function applyGrantIfDue(args: {
+  db: Firestore;
+  player: GamePlayer;
+  weekStartIso: string;
+  now: Date;
+  dryRun: boolean;
+}): Promise<{ granted: boolean; player: GamePlayer }> {
+  const { db, player, weekStartIso, now, dryRun } = args;
+  if (player.lastWeeklyGrantWeekStart === weekStartIso) {
+    return { granted: false, player };
+  }
+  const next = applyWeeklyGrant(player, weekStartIso, now);
+  if (dryRun) {
+    return { granted: true, player: next };
+  }
+  await db
+    .collection(COLLECTIONS.PLAYERS)
+    .doc(player.userId)
+    .update({
+      turnsRemaining: next.turnsRemaining,
+      lastWeeklyGrantAt: next.lastWeeklyGrantAt,
+      lastWeeklyGrantWeekStart: next.lastWeeklyGrantWeekStart,
+      updatedAt: next.updatedAt,
+    });
+  return { granted: true, player: next };
+}
+
+function parseArgs(argv: string[]): {
+  weekStartIso: string | null;
+  dryRun: boolean;
+  limit: number | null;
+} {
+  let weekStartIso: string | null = null;
+  let dryRun = false;
+  let limit: number | null = null;
+  for (const a of argv) {
+    if (a.startsWith("--week=")) weekStartIso = a.slice("--week=".length);
+    else if (a === "--dry-run") dryRun = true;
+    else if (a.startsWith("--limit=")) limit = Number.parseInt(a.slice("--limit=".length), 10);
+  }
+  return { weekStartIso, dryRun, limit };
+}
+
+async function main() {
+  const { weekStartIso: weekArg, dryRun, limit } = parseArgs(process.argv.slice(2));
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+  const now = new Date();
+  const weekStartIso = weekArg ?? weekStartIsoForRollover(now);
+  console.log(
+    `[npc-weekly] week=${weekStartIso} dryRun=${dryRun} limit=${limit ?? "all"}`
+  );
+
+  const world = await loadWorldSnapshot(db);
+  console.log(`[npc-weekly] loaded ${world.npcs.size} NPC players`);
+
+  let processed = 0;
+  let granted = 0;
+  let skipped = 0;
+  const totals = {
+    builds: 0,
+    attacks: 0,
+    spellsCast: 0,
+    captured: 0,
+    repelled: 0,
+    stalemate: 0,
+    errors: 0,
+  };
+
+  // Shuffle order so weekly conflicts don't always favor early-uid NPCs.
+  const orderRng = makeSeededRng(`npc-weekly-order:${weekStartIso}`);
+  const uids = [...world.npcs.keys()].sort(() => orderRng() - 0.5);
+
+  for (const uid of uids) {
+    if (limit !== null && processed >= limit) break;
+    processed += 1;
+
+    let player = world.npcs.get(uid)!;
+
+    const grantRes = await applyGrantIfDue({
+      db,
+      player,
+      weekStartIso,
+      now,
+      dryRun,
+    });
+    if (!grantRes.granted) {
+      skipped += 1;
+      continue;
+    }
+    granted += 1;
+    player = grantRes.player;
+    world.npcs.set(uid, player);
+
+    if (isShieldActive(player, now)) {
+      // Shielded NPCs can't attack; they can still build and cast spells.
+      // Carry on but the persona's attacks will all fail; no-op the attack
+      // count to keep the run quiet.
+    }
+
+    const ctx = buildContext(uid, world);
+    if (!ctx) continue;
+    ctx.player = player;
+    const persona = personaForUid(uid);
+
+    const log = await spendNpcTurns({ db, ctx, persona, world, now, dryRun });
+
+    totals.builds += log.builds;
+    totals.attacks += log.attacks;
+    totals.spellsCast += log.spellsCast;
+    totals.captured += log.attackOutcomes.captured;
+    totals.repelled += log.attackOutcomes.repelled;
+    totals.stalemate += log.attackOutcomes.stalemate;
+    totals.errors += log.errors.length;
+
+    console.log(
+      `[npc-weekly] ${player.displayName} (${persona.name}, ${player.caste}): ` +
+        `builds=${log.builds} attacks=${log.attacks} (cap=${log.attackOutcomes.captured}/rep=${log.attackOutcomes.repelled}/sta=${log.attackOutcomes.stalemate}) ` +
+        `spells=${log.spellsCast} errors=${log.errors.length}`
+    );
+    if (log.errors.length > 0) {
+      for (const err of log.errors.slice(0, 3)) console.log(`    ! ${err}`);
+    }
+  }
+
+  console.log(
+    `\n[npc-weekly] Done. processed=${processed} granted=${granted} skipped=${skipped}`
+  );
+  console.log(
+    `  builds=${totals.builds} attacks=${totals.attacks} ` +
+      `(captured=${totals.captured}, repelled=${totals.repelled}, stalemate=${totals.stalemate}) ` +
+      `spells=${totals.spellsCast} errors=${totals.errors}`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/seed-game-npcs.ts
+++ b/scripts/seed-game-npcs.ts
@@ -1,0 +1,516 @@
+#!/usr/bin/env node
+/**
+ * Seeds N synthetic "NPC" players with end-state values that look like they've
+ * played ~300 turns each:
+ *   - random caste, distribution mix, troop composition
+ *   - 25–80 owned tiles spawned via the same hex-spiral helper used by setup
+ *   - units stocked on military tiles, clamped to per-tile capacity and the
+ *     player-wide food-derived unit cap
+ *   - 1–2 active caste upgrades for variety
+ *   - phase: "play", caste set, casteLockedAt now, shield expired (turnsSpent
+ *     >= SHIELD_TURN_THRESHOLD)
+ *
+ * NOT a faithful turn-by-turn simulation — it writes terminal state directly.
+ * Runs against whatever Firestore the env points at; idempotent insofar as it
+ * uses fresh uuids per NPC, so reruns just add more NPCs.
+ *
+ * Usage:
+ *   npx tsx scripts/seed-game-npcs.ts [count]    # default 50
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { randomUUID } from "node:crypto";
+import type { Firestore, WriteBatch } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { ALL_UPGRADES } from "../lib/game/content";
+import {
+  computeTileCapacity,
+  makeSeededRng,
+  unitCapFromFoodLands,
+} from "../lib/game/combat";
+import {
+  SHIELD_DURATION_WEEKS,
+  SHIELD_TURN_THRESHOLD,
+} from "../lib/game/turns";
+import {
+  axialFromTileId,
+  neighborTileIds,
+  spawnCenterForPlayerIndex,
+  spawnPlayerLands,
+  tileIdFromAxial,
+} from "../lib/game/world-gen";
+import type {
+  Caste,
+  GamePlayer,
+  GameTile,
+  LandType,
+  UnitStack,
+  UnitType,
+} from "../lib/game/types";
+
+const COLLECTIONS = {
+  PLAYERS: "game_players",
+  TILES: "game_tiles",
+  WORLD_META: "game_world_meta",
+} as const;
+const WORLD_META_DOC = "singleton";
+
+const CASTES: Caste[] = ["black", "red", "white", "green", "blue"];
+
+// 60 fantasy general names; we slice a unique one per NPC and append " ##"
+// for any past index 60 to stay under the 32-char general-name limit while
+// guaranteeing displayNameLower uniqueness.
+const NAME_POOL = [
+  "Aurelius the Bold", "Magna Carthos", "Lord Veil", "Vexa Stormcaller",
+  "Ironclaw Drun", "Sable Maro", "Captain Idriel", "General Tovak",
+  "Nyx Brightblade", "Halric the Patient", "Dame Orla", "Kestrel Vale",
+  "Mordan Greycloak", "Pyra Ashwright", "Yorick Stoneheart", "Lirien Dawnstrike",
+  "Khorvath", "Thessia Zenrunner", "Bram Hollowwind", "Selene Ironvein",
+  "Drogath the Iron", "Mara Vellis", "Caspian Starwatch", "Edda Brightspear",
+  "Faolan Brae", "Garven Thrune", "Hessa Quickflame", "Ivar the Quiet",
+  "Joren Sablebrook", "Kael Vornn", "Lysa Marchwarden", "Mira Tindalewright",
+  "Nereus Coldforge", "Othric Vael", "Petra Mossguard", "Quill Aldecroft",
+  "Roen Skywatcher", "Sirin Vox", "Talia Nethermoor", "Ulric Stormhand",
+  "Vesper Glade", "Wystan Ferndale", "Xanthe Brightthorn", "Yael Ashenroot",
+  "Zara Hexblade", "Eos Ravenshade", "Bellweather Tor", "Cyran the Silent",
+  "Dunric Bramble", "Eira Loomwhisper", "Faldric Vex", "Gisla Thornveil",
+  "Halen Pyrewright", "Indra Cloudglen", "Joss the Veiled", "Kira Ravenwood",
+  "Lothan Mossbright", "Mern Stormhollow", "Nilani Tide", "Orin the Frost",
+];
+
+interface Strategy {
+  name: string;
+  // Target distribution of revealed tiles between military / food / magic.
+  // Must sum to 1; small remainder goes to "unassigned".
+  mil: number;
+  food: number;
+  magic: number;
+  // Target unit composition (sums to 1).
+  ground: number;
+  siege: number;
+  air: number;
+}
+
+const STRATEGIES: Strategy[] = [
+  { name: "war machine", mil: 0.55, food: 0.25, magic: 0.20, ground: 0.5, siege: 0.3, air: 0.2 },
+  { name: "balanced", mil: 0.35, food: 0.40, magic: 0.25, ground: 0.34, siege: 0.33, air: 0.33 },
+  { name: "magic-focused", mil: 0.25, food: 0.35, magic: 0.40, ground: 0.3, siege: 0.2, air: 0.5 },
+  { name: "food-rich", mil: 0.30, food: 0.55, magic: 0.15, ground: 0.5, siege: 0.25, air: 0.25 },
+  { name: "ground-rusher", mil: 0.50, food: 0.35, magic: 0.15, ground: 0.8, siege: 0.1, air: 0.1 },
+  { name: "siege-master", mil: 0.45, food: 0.35, magic: 0.20, ground: 0.15, siege: 0.7, air: 0.15 },
+  { name: "air-superior", mil: 0.45, food: 0.30, magic: 0.25, ground: 0.15, siege: 0.15, air: 0.7 },
+  { name: "fortress", mil: 0.35, food: 0.30, magic: 0.35, ground: 0.4, siege: 0.4, air: 0.2 },
+];
+
+function pick<T>(rng: () => number, arr: readonly T[]): T {
+  return arr[Math.floor(rng() * arr.length)] as T;
+}
+
+// Distribute `total` items across `count` buckets according to weights, using
+// largest-remainder rounding so the totals are exact. Each bucket is at least 0.
+function distributeByWeights(total: number, weights: number[]): number[] {
+  const sum = weights.reduce((a, b) => a + b, 0);
+  if (sum <= 0 || total <= 0) return weights.map(() => 0);
+  const raw = weights.map((w) => (total * w) / sum);
+  const floored = raw.map((x) => Math.floor(x));
+  let allocated = floored.reduce((a, b) => a + b, 0);
+  const remainders = raw.map((x, i) => ({ i, frac: x - Math.floor(x) }));
+  remainders.sort((a, b) => b.frac - a.frac);
+  let k = 0;
+  while (allocated < total) {
+    floored[remainders[k % remainders.length]!.i]! += 1;
+    allocated += 1;
+    k += 1;
+  }
+  return floored;
+}
+
+function npcDisplayName(index: number): string {
+  if (index < NAME_POOL.length) return NAME_POOL[index]!;
+  // Wrap around with a numeric suffix; max known length 24 + " 99" = 27 ≤ 32.
+  const base = NAME_POOL[index % NAME_POOL.length]!;
+  return `${base} ${Math.floor(index / NAME_POOL.length) + 1}`;
+}
+
+function chooseUpgradesForCaste(
+  caste: Caste,
+  rng: () => number,
+  count: number
+): Record<string, string> {
+  const candidates = ALL_UPGRADES.filter((u) => u.caste === caste);
+  const out: Record<string, string> = {};
+  // Shuffle candidates and take up to `count` non-conflicting ones (one per
+  // targetId). Effectively random subset.
+  const shuffled = [...candidates].sort(() => rng() - 0.5);
+  for (const u of shuffled) {
+    if (out[u.targetId]) continue;
+    out[u.targetId] = u.id;
+    if (Object.keys(out).length >= count) break;
+  }
+  return out;
+}
+
+interface SpawnedPlayer {
+  uid: string;
+  player: GamePlayer;
+  tiles: GameTile[];
+}
+
+function buildNpc(args: {
+  index: number;
+  spawnIndex: number;
+  claimedTileIds: Set<string>;
+  now: Date;
+  rng: () => number;
+}): SpawnedPlayer {
+  const { index, spawnIndex, claimedTileIds, now, rng } = args;
+  const caste = pick(rng, CASTES);
+  const strategy = pick(rng, STRATEGIES);
+  // Tile size variety: 25 (fresh-spawn) to 80 (assumed to have captured tiles).
+  const tilesTotal = 25 + Math.floor(rng() * 56);
+
+  const center = spawnCenterForPlayerIndex(spawnIndex);
+  const spawn = spawnPlayerLands({
+    center,
+    claimedTileIds,
+    rng,
+    totalTiles: tilesTotal,
+    contiguousTarget: Math.max(20, Math.floor(tilesTotal * 0.8)),
+    exclavesMin: 3,
+    exclavesMax: 5,
+  });
+
+  // Distribute land types.
+  const mil = Math.round(tilesTotal * strategy.mil);
+  const food = Math.round(tilesTotal * strategy.food);
+  const magic = Math.round(tilesTotal * strategy.magic);
+  // Any remainder lands in "unassigned" (the player chose not to commit yet).
+  const used = mil + food + magic;
+  const unassigned = Math.max(0, tilesTotal - used);
+  // If used > tilesTotal due to rounding, trim from the smallest bucket.
+  let m = mil, f = food, g = magic;
+  if (used > tilesTotal) {
+    const overflow = used - tilesTotal;
+    const buckets: { key: "m" | "f" | "g"; n: number }[] = [
+      { key: "m", n: m }, { key: "f", n: f }, { key: "g", n: g },
+    ];
+    buckets.sort((a, b) => a.n - b.n);
+    let left = overflow;
+    for (const b of buckets) {
+      const take = Math.min(b.n, left);
+      if (b.key === "m") m -= take;
+      if (b.key === "f") f -= take;
+      if (b.key === "g") g -= take;
+      left -= take;
+      if (left === 0) break;
+    }
+  }
+
+  // Shuffle tile order so type assignment is not spatially uniform.
+  const shuffledTiles = [...spawn.tileIds].sort(() => rng() - 0.5);
+  const types: LandType[] = [];
+  for (let i = 0; i < m; i++) types.push("military");
+  for (let i = 0; i < f; i++) types.push("food");
+  for (let i = 0; i < g; i++) types.push("magic");
+  for (let i = 0; i < unassigned; i++) types.push("unassigned");
+  while (types.length < shuffledTiles.length) types.push("unassigned");
+
+  const activeUpgrades = chooseUpgradesForCaste(
+    caste,
+    rng,
+    1 + Math.floor(rng() * 2)
+  );
+
+  // Compute unit cap and per-tile capacity.
+  const foodCount = f;
+  const unitCap = unitCapFromFoodLands(foodCount);
+  // Apply caste bonuses to a target unit count: NPCs aim for 70–100% of cap so
+  // not every general is fully maxed.
+  const fillFactor = 0.7 + rng() * 0.3;
+  const targetUnits = Math.floor(unitCap * fillFactor);
+  // Compose unit type counts.
+  const composition = distributeByWeights(targetUnits, [
+    strategy.ground, strategy.siege, strategy.air,
+  ]);
+  let groundLeft = composition[0]!;
+  let siegeLeft = composition[1]!;
+  let airLeft = composition[2]!;
+  // Caste's tile capacity for military land.
+  const milCapPerTile = computeTileCapacity(
+    "military",
+    caste,
+    [],
+    activeUpgrades
+  );
+
+  const uid = `npc-${String(index).padStart(3, "0")}-${randomUUID().slice(0, 8)}`;
+
+  const tiles: GameTile[] = shuffledTiles.map((tileId, i) => {
+    const { q, r } = axialFromTileId(tileId);
+    const type = types[i]!;
+    const units: UnitStack = { ground: 0, siege: 0, air: 0 };
+    if (type === "military") {
+      let space = milCapPerTile;
+      // Allocate units onto this tile, preferring the bigger remaining buckets.
+      const order: { kind: UnitType; remaining: () => number }[] = (
+        [
+          { kind: "ground" as UnitType, remaining: () => groundLeft },
+          { kind: "siege" as UnitType, remaining: () => siegeLeft },
+          { kind: "air" as UnitType, remaining: () => airLeft },
+        ]
+      ).sort((a, b) => b.remaining() - a.remaining());
+      for (const slot of order) {
+        if (space <= 0) break;
+        const take = Math.min(space, slot.remaining());
+        if (take <= 0) continue;
+        units[slot.kind] = take;
+        if (slot.kind === "ground") groundLeft -= take;
+        if (slot.kind === "siege") siegeLeft -= take;
+        if (slot.kind === "air") airLeft -= take;
+        space -= take;
+      }
+    }
+    return {
+      tileId,
+      q,
+      r,
+      ownerId: uid,
+      type,
+      level: 0,
+      units,
+      armedDefenseSpellId: null,
+      neighborTileIds: neighborTileIds(q, r),
+      upgradeIds: [],
+      revealedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+  });
+
+  // Mark every spawned tile as claimed so subsequent NPC spawns avoid them.
+  for (const t of tiles) claimedTileIds.add(t.tileId);
+
+  // Compute final unitsAlive after fitting.
+  const unitsAlive = tiles.reduce(
+    (sum, t) => sum + t.units.ground + t.units.siege + t.units.air,
+    0
+  );
+
+  // Shield: turnsSpentTotal >= SHIELD_TURN_THRESHOLD drops the shield via
+  // isShieldActive(), regardless of shieldUntil. We still set shieldUntil to
+  // the past so any UI showing the date is consistent.
+  const shieldUntil = new Date(
+    now.getTime() - SHIELD_DURATION_WEEKS * 7 * 24 * 60 * 60 * 1000
+  );
+
+  // Vary win/loss counts a bit (purely cosmetic on the leaderboard).
+  const attacksWon = Math.floor(rng() * 12);
+  const attacksLost = Math.floor(rng() * 8);
+
+  const player: GamePlayer & {
+    displayNameLower: string;
+    isNpc: boolean;
+  } = {
+    userId: uid,
+    displayName: npcDisplayName(index),
+    caste,
+    casteLockedAt: now,
+    turnsRemaining: Math.floor(rng() * 80), // 0–79 leftover from the bucket
+    turnsSpentTotal: 300,
+    phase: "play",
+    tilesExplored: tilesTotal,
+    shieldUntil,
+    shieldDropAtTurn: SHIELD_TURN_THRESHOLD,
+    productionSpellsActive: [],
+    activeUpgrades,
+    stats: {
+      attacksWon,
+      attacksLost,
+      tilesHeld: tilesTotal,
+      unitsAlive,
+    },
+    createdAt: now,
+    updatedAt: now,
+    // Extra fields stored alongside but not on the GamePlayer type.
+    displayNameLower: npcDisplayName(index).toLowerCase(),
+    isNpc: true,
+  };
+
+  return { uid, player, tiles };
+}
+
+async function commitPlayer(
+  db: Firestore,
+  player: SpawnedPlayer
+): Promise<void> {
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(player.uid);
+  // Use sub-batches; tiles can run 80+ which is well under the 500 op limit
+  // but we batch separately from the player doc for clarity.
+  await playerRef.set(player.player as GamePlayer);
+  const BATCH_LIMIT = 400;
+  let batch: WriteBatch = db.batch();
+  let inBatch = 0;
+  for (const tile of player.tiles) {
+    const ref = db.collection(COLLECTIONS.TILES).doc(tile.tileId);
+    batch.set(ref, tile);
+    inBatch += 1;
+    if (inBatch >= BATCH_LIMIT) {
+      await batch.commit();
+      batch = db.batch();
+      inBatch = 0;
+    }
+  }
+  if (inBatch > 0) await batch.commit();
+}
+
+async function loadClaimedTiles(db: Firestore): Promise<Set<string>> {
+  const snap = await db.collection(COLLECTIONS.TILES).get();
+  const set = new Set<string>();
+  for (const d of snap.docs) set.add(d.id);
+  return set;
+}
+
+async function loadExistingNames(db: Firestore): Promise<Set<string>> {
+  const snap = await db.collection(COLLECTIONS.PLAYERS).get();
+  const set = new Set<string>();
+  for (const d of snap.docs) {
+    const p = d.data();
+    if (typeof p.displayNameLower === "string") set.add(p.displayNameLower);
+    else if (typeof p.displayName === "string" && p.displayName)
+      set.add(p.displayName.toLowerCase());
+  }
+  return set;
+}
+
+async function main() {
+  const count = Number.parseInt(process.argv[2] ?? "50", 10);
+  if (!Number.isFinite(count) || count <= 0) {
+    console.error("Usage: npx tsx scripts/seed-game-npcs.ts [count]");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const metaRef = db.collection(COLLECTIONS.WORLD_META).doc(WORLD_META_DOC);
+  const metaSnap = await metaRef.get();
+  const startingPlayerCount =
+    (metaSnap.data()?.playerCount as number | undefined) ?? 0;
+
+  console.log(
+    `[seed-npcs] starting; world playerCount=${startingPlayerCount}, target ${count} NPCs`
+  );
+
+  const claimedTileIds = await loadClaimedTiles(db);
+  const existingNames = await loadExistingNames(db);
+  console.log(
+    `[seed-npcs] loaded ${claimedTileIds.size} existing tiles, ${existingNames.size} existing names`
+  );
+
+  const now = new Date();
+  const masterRng = makeSeededRng(`npc-seed-${now.getTime()}`);
+
+  let spawnIndex = startingPlayerCount;
+  const summary: Array<{
+    uid: string;
+    name: string;
+    caste: Caste;
+    tiles: number;
+    units: number;
+  }> = [];
+
+  for (let i = 0; i < count; i++) {
+    // Skip names already in use (rare; pool has 60 unique).
+    let nameIndex = i;
+    let candidateName = npcDisplayName(nameIndex);
+    let safety = 0;
+    while (existingNames.has(candidateName.toLowerCase()) && safety < 200) {
+      nameIndex += 1;
+      candidateName = npcDisplayName(nameIndex);
+      safety += 1;
+    }
+    existingNames.add(candidateName.toLowerCase());
+
+    // Walk forward until we land on a non-collision spawn center, like the
+    // setup-new-player retry loop. Up to 32 tries per NPC.
+    let spawned: SpawnedPlayer | null = null;
+    let tries = 0;
+    while (!spawned && tries < 32) {
+      const center = spawnCenterForPlayerIndex(spawnIndex);
+      const candidateCenterId = tileIdFromAxial(center.q, center.r);
+      if (claimedTileIds.has(candidateCenterId)) {
+        spawnIndex += 1;
+        tries += 1;
+        continue;
+      }
+      try {
+        spawned = buildNpc({
+          index: nameIndex,
+          spawnIndex,
+          claimedTileIds,
+          now,
+          rng: masterRng,
+        });
+      } catch (e) {
+        console.warn(
+          `[seed-npcs] spawn at index ${spawnIndex} failed: ${(e as Error).message}; retrying`
+        );
+        spawnIndex += 1;
+        tries += 1;
+      }
+    }
+    if (!spawned) {
+      console.error(`[seed-npcs] failed to place NPC ${i + 1}; aborting`);
+      process.exit(1);
+    }
+
+    // Override the NPC's name with the resolved candidate (in case we
+    // bumped past pool collisions above).
+    spawned.player.displayName = candidateName;
+    (spawned.player as unknown as { displayNameLower: string }).displayNameLower =
+      candidateName.toLowerCase();
+
+    await commitPlayer(db, spawned);
+    summary.push({
+      uid: spawned.uid,
+      name: spawned.player.displayName,
+      caste: spawned.player.caste!,
+      tiles: spawned.player.stats.tilesHeld,
+      units: spawned.player.stats.unitsAlive,
+    });
+    console.log(
+      `[seed-npcs] (${i + 1}/${count}) ${candidateName} [${spawned.player.caste}] tiles=${spawned.player.stats.tilesHeld} units=${spawned.player.stats.unitsAlive} spawnIdx=${spawnIndex}`
+    );
+    spawnIndex += 1;
+  }
+
+  // Bump world_meta.playerCount so future setups skip past the slots we used.
+  await metaRef.set(
+    {
+      playerCount: spawnIndex,
+      lastSpawnAt: now,
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+
+  // Summary stats.
+  const byCaste: Record<string, number> = {};
+  for (const s of summary) byCaste[s.caste] = (byCaste[s.caste] ?? 0) + 1;
+  const totalUnits = summary.reduce((a, b) => a + b.units, 0);
+  const totalTiles = summary.reduce((a, b) => a + b.tiles, 0);
+  console.log(
+    `\n[seed-npcs] Done. Created ${summary.length} NPCs.`
+  );
+  console.log(`  Caste counts: ${JSON.stringify(byCaste)}`);
+  console.log(`  Total tiles: ${totalTiles}, total units: ${totalUnits}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Release of develop into main. Single PR included since the previous main release:

- **#740** by @Ludwitt — NPC seeding (`scripts/seed-game-npcs.ts`), weekly turn-spender (`scripts/run-npc-weekly.ts`), and per-player reset (`scripts/reset-game-player.ts`).

## Test plan
- [x] PR #740 already validated end-to-end against Firestore (50 NPCs seeded, weekly run granted+spent turns for all 50, idempotent re-run produced 0 writes)
- [x] Scripts only — no app code, schemas, or routes change