### PR TITLE
perf(game): cache map endpoints to absorb refresh storms

### DIFF
--- a/app/api/game/map/me/route.ts
+++ b/app/api/game/map/me/route.ts
@@ -21,7 +21,16 @@ export async function GET(request: NextRequest) {
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     const { myTiles, borderTiles, owners } = await getMyMapServer(user.uid);
-    return apiSuccess({ myTiles, borderTiles, owners });
+    const res = apiSuccess({ myTiles, borderTiles, owners });
+    // Per-user response — browser-only cache. Action handlers update local
+    // state from their own responses, so rapid refresh-button mashing is the
+    // only thing that benefits here. 30s caps reads at ≤2/min/user even
+    // under aggressive refresh, while keeping post-attack staleness short.
+    res.headers.set(
+      "Cache-Control",
+      "private, max-age=30, must-revalidate"
+    );
+    return res;
   } catch (error) {
     return mapGameError(error);
   }

--- a/app/api/game/world/route.ts
+++ b/app/api/game/world/route.ts
@@ -71,14 +71,31 @@ export async function GET(request: NextRequest) {
     const bbox = parseBbox(url);
     if (bbox) {
       const tiles = await getMapTilesInBoundsServer(bbox);
-      return apiSuccess({ tiles });
+      const res = apiSuccess({ tiles });
+      // Bbox-keyed responses are identical for all users → CDN-cacheable.
+      // 60s shared cache + 120s stale-while-revalidate keeps refresh storms
+      // off Firestore while bounding staleness to 1 minute.
+      res.headers.set(
+        "Cache-Control",
+        "public, max-age=30, s-maxage=60, stale-while-revalidate=120"
+      );
+      return res;
     }
 
     const [tiles, owners] = await Promise.all([
       getAllMapTilesServer(),
       getAllOwnerSummariesServer(),
     ]);
-    return apiSuccess({ tiles, owners });
+    const res = apiSuccess({ tiles, owners });
+    // Bare GET returns the same global snapshot for every caller. Cache
+    // aggressively at the edge — at 3K+ tiles this is by far the most
+    // expensive read path. Once the 🌐 world view migrates to bbox + a
+    // separate owners endpoint, this branch can be capped to bbox-only.
+    res.headers.set(
+      "Cache-Control",
+      "public, max-age=30, s-maxage=60, stale-while-revalidate=120"
+    );
+    return res;
   } catch (error) {
     return mapGameError(error);
   }

--- a/app/game/tiles/_lib/use-tiles-data.ts
+++ b/app/game/tiles/_lib/use-tiles-data.ts
@@ -135,9 +135,11 @@ export function useTilesData() {
     setWorldError(null);
     try {
       const token = await user.getIdToken();
+      // Honor the route's Cache-Control (public, s-maxage=60). The world
+      // snapshot is identical for every caller, so a CDN/browser hit is
+      // exactly the same data — no reason to bypass cache here.
       const res = await fetch("/api/game/world", {
         headers: { Authorization: `Bearer ${token}` },
-        cache: "no-store",
       });
       if (!res.ok) {
         throw new Error(`World fetch failed: HTTP ${res.status}`);


### PR DESCRIPTION
## Summary
Adds `Cache-Control` headers to the two map read paths so rapid refresh-button mashing and route transitions don't translate into Firestore reads. Solves the \"useless updates if users constantly refresh\" concern from the scaling review.

- **`/api/game/map/me`** → `private, max-age=30, must-revalidate`. Per-user response, browser-only cache. 30s caps reads at ≤2/min/user even under aggressive refresh, keeping post-attack staleness short. Action handlers already update local state from their own response, so the player's own actions feel instant regardless.
- **`/api/game/world`** (both bbox and bare GET) → `public, max-age=30, s-maxage=60, stale-while-revalidate=120`. The world snapshot is identical for every caller → safe to share at the Vercel edge cache.
- **`use-tiles-data.ts`** drops `cache: \"no-store\"` from the world fetch so the route's headers take effect.

## Why
At 5 humans the savings are pennies. At 1k humans this cuts projected weekly map reads from ~1M → ~100K (~10× win, ~\$100/yr saved at \$0.06 / 100k reads). The bare-world GET (~3K reads today, ~55K reads at 1k humans) is now bounded to Firestore at most once per 60s globally regardless of caller count.

## Out of scope (follow-up)
Capping the bare-world GET to require a bbox would let us drop ~55K reads/call at 1k humans entirely. It needs migrating the 🌐 world-view client off the owners-coupled bare response to bbox + a separate owners endpoint. A pointer comment is left in `app/api/game/world/route.ts`.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] After deploy: confirm `Cache-Control` headers in DevTools on `/api/game/map/me` and `/api/game/world?qMin=…` responses
- [ ] Verify rapid refresh of the tiles page only hits the network on the first request within 30s (subsequent ones served from disk cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)