### PR TITLE
release: develop → main (map cache headers)

### DIFF
--- a/app/api/game/map/me/route.ts
+++ b/app/api/game/map/me/route.ts
@@ -21,7 +21,16 @@ export async function GET(request: NextRequest) {
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     const { myTiles, borderTiles, owners } = await getMyMapServer(user.uid);
-    return apiSuccess({ myTiles, borderTiles, owners });
+    const res = apiSuccess({ myTiles, borderTiles, owners });
+    // Per-user response — browser-only cache. Action handlers update local
+    // state from their own responses, so rapid refresh-button mashing is the
+    // only thing that benefits here. 30s caps reads at ≤2/min/user even
+    // under aggressive refresh, while keeping post-attack staleness short.
+    res.headers.set(
+      "Cache-Control",
+      "private, max-age=30, must-revalidate"
+    );
+    return res;
   } catch (error) {
     return mapGameError(error);
   }

--- a/app/api/game/world/route.ts
+++ b/app/api/game/world/route.ts
@@ -71,14 +71,31 @@ export async function GET(request: NextRequest) {
     const bbox = parseBbox(url);
     if (bbox) {
       const tiles = await getMapTilesInBoundsServer(bbox);
-      return apiSuccess({ tiles });
+      const res = apiSuccess({ tiles });
+      // Bbox-keyed responses are identical for all users → CDN-cacheable.
+      // 60s shared cache + 120s stale-while-revalidate keeps refresh storms
+      // off Firestore while bounding staleness to 1 minute.
+      res.headers.set(
+        "Cache-Control",
+        "public, max-age=30, s-maxage=60, stale-while-revalidate=120"
+      );
+      return res;
     }
 
     const [tiles, owners] = await Promise.all([
       getAllMapTilesServer(),
       getAllOwnerSummariesServer(),
     ]);
-    return apiSuccess({ tiles, owners });
+    const res = apiSuccess({ tiles, owners });
+    // Bare GET returns the same global snapshot for every caller. Cache
+    // aggressively at the edge — at 3K+ tiles this is by far the most
+    // expensive read path. Once the 🌐 world view migrates to bbox + a
+    // separate owners endpoint, this branch can be capped to bbox-only.
+    res.headers.set(
+      "Cache-Control",
+      "public, max-age=30, s-maxage=60, stale-while-revalidate=120"
+    );
+    return res;
   } catch (error) {
     return mapGameError(error);
   }

--- a/app/game/tiles/_lib/use-tiles-data.ts
+++ b/app/game/tiles/_lib/use-tiles-data.ts
@@ -135,9 +135,11 @@ export function useTilesData() {
     setWorldError(null);
     try {
       const token = await user.getIdToken();
+      // Honor the route's Cache-Control (public, s-maxage=60). The world
+      // snapshot is identical for every caller, so a CDN/browser hit is
+      // exactly the same data — no reason to bypass cache here.
       const res = await fetch("/api/game/world", {
         headers: { Authorization: `Bearer ${token}` },
-        cache: "no-store",
       });
       if (!res.ok) {
         throw new Error(`World fetch failed: HTTP ${res.status}`);


### PR DESCRIPTION
## Summary
Release of develop into main. Single PR included since the previous main release:

- **#744** by @Ludwitt — adds `Cache-Control` headers to `/api/game/map/me` (private, 30s) and `/api/game/world` (public, 60s s-maxage). Drops `cache: "no-store"` on the 🌐 world fetch. Cuts projected weekly map reads ~10× at 1k humans by absorbing refresh storms at the browser/CDN edge instead of Firestore.

## Test plan
- [x] PR #744 already validated: tsc clean
- [ ] After deploy: confirm `Cache-Control` headers present in DevTools on both endpoints
- [ ] Verify rapid refresh on the tiles page only hits the network once per 30s