### PR TITLE
release: develop → main (game world snapshot)

### DIFF
--- a/app/api/game/map/me/route.ts
+++ b/app/api/game/map/me/route.ts
@@ -8,28 +8,52 @@ import { NextRequest } from "next/server";
 import { apiError, apiSuccess } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
 import { getMyMapServer } from "@/lib/game/data-server";
+import {
+  deriveMyMapFromSnapshot,
+  readWorldSnapshotServer,
+} from "@/lib/game/world-snapshot";
 import { getVerifiedUser } from "@/lib/server-auth";
 
 // @contracts: gameContract.getMyMap (lib/api-schemas/game.ts)
 //
 // Personal map view: only own tiles + the enemy ring touching them, plus
-// owner summaries for those enemies. Replaces the unbounded /api/game/world
-// fetch on the busy game pages — read cost scales with kingdom perimeter,
-// not world size.
+// owner summaries for those enemies. Reads `game_world_snapshots/latest`
+// and filters in-memory — that's 1 Firestore read per call instead of
+// ~50. Falls back to the live-query implementation only if no snapshot
+// exists yet (first deploy / wiped snapshots).
+//
+// Staleness contract: the snapshot is rebuilt every ~5 min by the cron
+// at /api/internal/snapshots/rebuild?only=game-world (and at the end of
+// the weekly NPC cron). The player's own actions update local client
+// state from each action's response, so a player's own builds/attacks
+// are reflected immediately on the client. Only OTHER players' changes
+// (incoming attacks, captures) ride the snapshot delay.
 export async function GET(request: NextRequest) {
   try {
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
+
+    const cached = await readWorldSnapshotServer();
+    if (cached) {
+      const view = deriveMyMapFromSnapshot(cached.snapshot, user.uid);
+      const res = apiSuccess(view);
+      // Per-user response — browser-only cache. Action handlers update
+      // local state from their own response, so this 60s window only
+      // affects rapid refresh-button mashing and route transitions.
+      res.headers.set("Cache-Control", "private, max-age=60, must-revalidate");
+      if (cached.isStale) res.headers.set("X-World-Snapshot-Stale", "true");
+      res.headers.set(
+        "X-World-Snapshot-GeneratedAt",
+        cached.snapshot.generatedAt
+      );
+      return res;
+    }
+
+    // Snapshot missing — fall back to the live implementation. Logged via
+    // the snapshot logger, but expected only on first deploy.
     const { myTiles, borderTiles, owners } = await getMyMapServer(user.uid);
     const res = apiSuccess({ myTiles, borderTiles, owners });
-    // Per-user response — browser-only cache. Action handlers update local
-    // state from their own responses, so rapid refresh-button mashing is the
-    // only thing that benefits here. 30s caps reads at ≤2/min/user even
-    // under aggressive refresh, while keeping post-attack staleness short.
-    res.headers.set(
-      "Cache-Control",
-      "private, max-age=30, must-revalidate"
-    );
+    res.headers.set("Cache-Control", "private, max-age=30, must-revalidate");
     return res;
   } catch (error) {
     return mapGameError(error);

--- a/app/api/game/world/route.ts
+++ b/app/api/game/world/route.ts
@@ -12,6 +12,10 @@ import {
   getAllOwnerSummariesServer,
   getMapTilesInBoundsServer,
 } from "@/lib/game/data-server";
+import {
+  filterSnapshotToBbox,
+  readWorldSnapshotServer,
+} from "@/lib/game/world-snapshot";
 import { getVerifiedUser } from "@/lib/server-auth";
 
 // @contracts: gameContract.getWorld (lib/api-schemas/game.ts)
@@ -19,21 +23,21 @@ import { getVerifiedUser } from "@/lib/server-auth";
 // Global map fetch.
 //
 // Two modes (additive — back-compat preserved):
-//   • Bare GET → returns { tiles, owners } for the entire world. Legacy mode.
-//     Kept so existing callers don't break, but new clients should pass bbox.
+//   • Bare GET → returns { tiles, owners } for the entire world.
 //   • GET ?qMin=&qMax=&rMin=&rMax= → returns { tiles } for the bbox only.
-//     No owners — fetch /api/game/owners separately (snapshot-cached on the
-//     client). Slashes per-action read cost from O(world) to O(viewport).
+//
+// Both modes prefer the periodic `game_world_snapshots/latest` doc — a
+// single read instead of scanning ~3K tiles + every player. The route
+// falls back to live queries only if no snapshot exists yet (e.g. first
+// deploy before the cron has run). Snapshot rebuild lives at
+// `/api/internal/snapshots/rebuild?only=game-world` and is also kicked
+// off at the end of the weekly NPC cron.
 function parseBbox(url: URL): {
   qMin: number;
   qMax: number;
   rMin: number;
   rMax: number;
 } | null {
-  // All four params must be explicitly present. Without this guard,
-  // Number(null) === 0 collapses a bare GET into a degenerate bbox of
-  // (0,0)..(0,0) — which matches exactly one tile (0_0) and silently
-  // breaks the "fetch whole world" code path.
   const rawQMin = url.searchParams.get("qMin");
   const rawQMax = url.searchParams.get("qMax");
   const rawRMin = url.searchParams.get("rMin");
@@ -62,6 +66,10 @@ function parseBbox(url: URL): {
   return { qMin, qMax, rMin, rMax };
 }
 
+const SNAPSHOT_CACHE = "public, max-age=60, s-maxage=300, stale-while-revalidate=600";
+const LIVE_FALLBACK_CACHE =
+  "public, max-age=30, s-maxage=60, stale-while-revalidate=120";
+
 export async function GET(request: NextRequest) {
   try {
     const user = await getVerifiedUser(request);
@@ -69,32 +77,34 @@ export async function GET(request: NextRequest) {
 
     const url = new URL(request.url);
     const bbox = parseBbox(url);
-    if (bbox) {
-      const tiles = await getMapTilesInBoundsServer(bbox);
-      const res = apiSuccess({ tiles });
-      // Bbox-keyed responses are identical for all users → CDN-cacheable.
-      // 60s shared cache + 120s stale-while-revalidate keeps refresh storms
-      // off Firestore while bounding staleness to 1 minute.
-      res.headers.set(
-        "Cache-Control",
-        "public, max-age=30, s-maxage=60, stale-while-revalidate=120"
-      );
+
+    const cached = await readWorldSnapshotServer();
+    if (cached) {
+      const tiles = bbox
+        ? filterSnapshotToBbox(cached.snapshot, bbox)
+        : cached.snapshot.tiles;
+      const body = bbox ? { tiles } : { tiles, owners: cached.snapshot.owners };
+      const res = apiSuccess(body);
+      res.headers.set("Cache-Control", SNAPSHOT_CACHE);
+      if (cached.isStale) res.headers.set("X-World-Snapshot-Stale", "true");
+      res.headers.set("X-World-Snapshot-GeneratedAt", cached.snapshot.generatedAt);
       return res;
     }
 
+    // Fallback path — only on first request after a fresh deploy or if the
+    // snapshot collection was wiped. Cron will repopulate it within minutes.
+    if (bbox) {
+      const tiles = await getMapTilesInBoundsServer(bbox);
+      const res = apiSuccess({ tiles });
+      res.headers.set("Cache-Control", LIVE_FALLBACK_CACHE);
+      return res;
+    }
     const [tiles, owners] = await Promise.all([
       getAllMapTilesServer(),
       getAllOwnerSummariesServer(),
     ]);
     const res = apiSuccess({ tiles, owners });
-    // Bare GET returns the same global snapshot for every caller. Cache
-    // aggressively at the edge — at 3K+ tiles this is by far the most
-    // expensive read path. Once the 🌐 world view migrates to bbox + a
-    // separate owners endpoint, this branch can be capped to bbox-only.
-    res.headers.set(
-      "Cache-Control",
-      "public, max-age=30, s-maxage=60, stale-while-revalidate=120"
-    );
+    res.headers.set("Cache-Control", LIVE_FALLBACK_CACHE);
     return res;
   } catch (error) {
     return mapGameError(error);

--- a/app/api/internal/snapshots/rebuild/route.ts
+++ b/app/api/internal/snapshots/rebuild/route.ts
@@ -18,6 +18,7 @@ import {
   computePublicMembersSnapshot,
   MEMBERS_SNAPSHOT_CACHE_TTL_MS,
 } from "@/lib/members-public-snapshot";
+import { rebuildWorldSnapshotServer } from "@/lib/game/world-snapshot";
 
 // @contracts: internalContract.snapshotsRebuildGet, internalContract.snapshotsRebuildPost (lib/api-schemas/internal.ts)
 
@@ -73,11 +74,22 @@ async function handleRebuild(request: NextRequest): Promise<NextResponse> {
   const only = request.nextUrl.searchParams.get("only");
   let runAnalytics = !only || only === "analytics" || only === "all";
   let runMembers = !only || only === "members" || only === "all";
+  // Game world snapshot — opt-in via `only=game-world` (or the umbrella
+  // `all`). Kept off the default unscoped run because it has a tighter
+  // freshness budget than the other snapshots; its dedicated cron entry
+  // in vercel.json fires every 5 minutes vs analytics/members at 6h.
+  let runGameWorld = only === "game-world" || only === "all";
 
   try {
     const result: {
       analytics?: { ok: boolean; error?: string };
       members?: { ok: boolean; count?: number; error?: string };
+      gameWorld?: {
+        ok: boolean;
+        tileCount?: number;
+        ownerCount?: number;
+        error?: string;
+      };
     } = {};
 
     // Skip rebuild if the existing snapshot is still fresh (avoids redundant
@@ -139,8 +151,50 @@ async function handleRebuild(request: NextRequest): Promise<NextResponse> {
       }
     }
 
+    if (runGameWorld) {
+      try {
+        // Tighter freshness budget than analytics/members: this powers the
+        // live map view, so we want it ≤5 min stale. Skip if the existing
+        // snapshot was just rebuilt to deflect rapid cron retries.
+        const GAME_WORLD_FRESHNESS_MS = 60 * 1000; // 1 minute
+        if (!force) {
+          const existing = await db
+            .collection("game_world_snapshots")
+            .doc("latest")
+            .get();
+          const updatedAt = existing.data()?.generatedAt;
+          if (
+            updatedAt &&
+            Date.now() -
+              new Date(updatedAt.toDate?.() ?? updatedAt).getTime() <
+              GAME_WORLD_FRESHNESS_MS
+          ) {
+            result.gameWorld = { ok: true, error: "skipped: snapshot still fresh" };
+            runGameWorld = false;
+          }
+        }
+        if (runGameWorld) {
+          const out = await rebuildWorldSnapshotServer();
+          result.gameWorld = {
+            ok: true,
+            tileCount: out.tileCount,
+            ownerCount: out.ownerCount,
+          };
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.logError(e, {
+          endpoint: "/api/internal/snapshots/rebuild",
+          phase: "game-world",
+        });
+        result.gameWorld = { ok: false, error: msg };
+      }
+    }
+
     const ok =
-      (!runAnalytics || result.analytics?.ok) && (!runMembers || result.members?.ok);
+      (!runAnalytics || result.analytics?.ok) &&
+      (!runMembers || result.members?.ok) &&
+      (!runGameWorld || result.gameWorld?.ok);
     return NextResponse.json({ ok, invocationId, ...result }, { status: ok ? 200 : 500 });
   } catch (error) {
     logger.logError(error, { endpoint: "/api/internal/snapshots/rebuild", invocationId });

--- a/lib/game/npc-weekly.ts
+++ b/lib/game/npc-weekly.ts
@@ -32,6 +32,7 @@ import {
 } from "./turns";
 import { computeTileCapacity, makeSeededRng } from "./combat";
 import { getSpellForCasteAndType } from "./content";
+import { rebuildWorldSnapshotServer } from "./world-snapshot";
 import type {
   GamePlayer,
   GameTile,
@@ -624,6 +625,19 @@ export async function runNpcWeeklyServer(
     skippedAlreadyGranted: summary.skippedAlreadyGranted,
     totals: summary.totals,
   });
+
+  // The cron has touched many tiles + player docs; rebuild the world
+  // snapshot now so the next read by any human serves fresh data without
+  // waiting up to 5 min for the periodic snapshot cron.
+  if (!dryRun && summary.granted > 0) {
+    try {
+      await rebuildWorldSnapshotServer();
+    } catch (e) {
+      logger.warn("World snapshot rebuild after NPC weekly failed", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
 
   return summary;
 }

--- a/lib/game/world-snapshot.ts
+++ b/lib/game/world-snapshot.ts
@@ -1,0 +1,271 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// Periodic denormalized snapshot of the entire game world. The map read
+// path (`/api/game/world` and `/api/game/map/me`) reads this single doc
+// instead of scanning `game_tiles` + `game_players` on every request.
+//
+// Doc cost (per Firestore pricing): 1 read per fetch instead of ~3K reads
+// at today's tile count. At 1K humans this is the difference between
+// $50/yr and $500+/yr in just-the-map costs.
+//
+// Doc shape lives at `game_world_snapshots/latest`.
+//
+// Staleness budget: 5 minutes (TTL_MS). Game is weekly-paced; player
+// actions update local client state from their own response so a player's
+// own changes are reflected immediately. Staleness only affects how soon
+// other players' changes (incoming attacks, captures) become visible.
+
+import type { Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logger } from "@/lib/logger";
+import { isShieldActive } from "./turns";
+import type { Caste, GamePlayer, MapTile } from "./types";
+import { neighborTileIds } from "./world-gen";
+
+export const WORLD_SNAPSHOT_COLLECTION = "game_world_snapshots";
+export const WORLD_SNAPSHOT_DOC = "latest";
+// Soft TTL — readers tolerate serving stale snapshots a bit past this
+// window (CDN cache will revalidate eventually). The cron / weekly-NPC
+// hooks rebuild well within this budget so the staleness flag is rare.
+export const WORLD_SNAPSHOT_TTL_MS = 5 * 60 * 1000;
+
+export interface WorldSnapshotOwner {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+}
+
+export interface WorldSnapshot {
+  tiles: MapTile[];
+  owners: WorldSnapshotOwner[];
+  // Wall-clock time the snapshot was assembled. Used for the
+  // `X-World-Snapshot-Stale` response header.
+  generatedAt: string; // ISO
+  tileCount: number;
+  ownerCount: number;
+}
+
+interface StoredWorldSnapshot {
+  tiles: MapTile[];
+  owners: WorldSnapshotOwner[];
+  generatedAt: FirebaseFirestore.Timestamp | Date;
+  expiresAt: FirebaseFirestore.Timestamp | Date;
+  tileCount: number;
+  ownerCount: number;
+}
+
+// Reads every tile and every player to build a snapshot. Mirrors the
+// projections used by `getAllMapTilesServer` and `getAllOwnerSummariesServer`,
+// so the snapshot's payload is identical to what those functions returned
+// pre-snapshot — just delivered in one doc.
+export async function computeWorldSnapshot(
+  db: Firestore,
+  now: Date = new Date()
+): Promise<WorldSnapshot> {
+  const [tilesSnap, playersSnap] = await Promise.all([
+    db
+      .collection("game_tiles")
+      .select("tileId", "q", "r", "type", "ownerId", "units", "armedDefenseSpellId")
+      .get(),
+    db
+      .collection("game_players")
+      .select(
+        "userId",
+        "displayName",
+        "caste",
+        "shieldUntil",
+        "shieldDropAtTurn",
+        "turnsSpentTotal"
+      )
+      .get(),
+  ]);
+
+  const tiles: MapTile[] = tilesSnap.docs.map((d) => {
+    const data = d.data();
+    return {
+      tileId: data.tileId,
+      q: data.q,
+      r: data.r,
+      type: data.type,
+      ownerId: data.ownerId ?? null,
+      units: data.units,
+      armedDefenseSpellId: data.armedDefenseSpellId ?? null,
+    };
+  });
+
+  const owners: WorldSnapshotOwner[] = playersSnap.docs.map((d) => {
+    const p = d.data() as GamePlayer;
+    return {
+      userId: p.userId,
+      displayName: p.displayName ?? "",
+      caste: p.caste ?? null,
+      shielded: isShieldActive(p, now),
+    };
+  });
+
+  return {
+    tiles,
+    owners,
+    generatedAt: now.toISOString(),
+    tileCount: tiles.length,
+    ownerCount: owners.length,
+  };
+}
+
+// Reads + writes the snapshot doc. Idempotent. Logs the size so we can
+// monitor when we approach the 1MB Firestore doc limit (will need
+// sharding around ~12K tiles — see comment at end of file).
+export async function rebuildWorldSnapshotServer(
+  now: Date = new Date()
+): Promise<{ tileCount: number; ownerCount: number; bytes: number }> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not initialized");
+
+  const snapshot = await computeWorldSnapshot(db, now);
+  const stored: StoredWorldSnapshot = {
+    tiles: snapshot.tiles,
+    owners: snapshot.owners,
+    generatedAt: now,
+    expiresAt: new Date(now.getTime() + WORLD_SNAPSHOT_TTL_MS),
+    tileCount: snapshot.tileCount,
+    ownerCount: snapshot.ownerCount,
+  };
+
+  const ref = db.collection(WORLD_SNAPSHOT_COLLECTION).doc(WORLD_SNAPSHOT_DOC);
+  await ref.set(stored);
+
+  // Approximate size as JSON; close enough for capacity monitoring without
+  // pulling in a Firestore-byte-counter library. Firestore's 1MB limit is
+  // on the binary-encoded doc, which is typically ~70-90% of JSON length.
+  const bytes = JSON.stringify(stored).length;
+
+  logger.info("Game world snapshot rebuilt", {
+    tileCount: snapshot.tileCount,
+    ownerCount: snapshot.ownerCount,
+    approxBytes: bytes,
+    capacityPctOf1MB: Math.round((bytes / (1024 * 1024)) * 100),
+  });
+
+  return {
+    tileCount: snapshot.tileCount,
+    ownerCount: snapshot.ownerCount,
+    bytes,
+  };
+}
+
+// Reads the snapshot doc. Returns null if no snapshot exists yet (e.g.
+// before the first cron run). Caller falls back to live queries.
+export async function readWorldSnapshotServer(): Promise<{
+  snapshot: WorldSnapshot;
+  isStale: boolean;
+} | null> {
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const ref = db.collection(WORLD_SNAPSHOT_COLLECTION).doc(WORLD_SNAPSHOT_DOC);
+  const doc = await ref.get();
+  if (!doc.exists) return null;
+
+  const data = doc.data() as StoredWorldSnapshot | undefined;
+  if (!data || !Array.isArray(data.tiles) || !Array.isArray(data.owners)) {
+    return null;
+  }
+
+  const generatedAt =
+    data.generatedAt instanceof Date
+      ? data.generatedAt
+      : data.generatedAt?.toDate?.() ?? new Date(0);
+  const expiresAt =
+    data.expiresAt instanceof Date
+      ? data.expiresAt
+      : data.expiresAt?.toDate?.() ?? new Date(0);
+
+  return {
+    snapshot: {
+      tiles: data.tiles,
+      owners: data.owners,
+      generatedAt: generatedAt.toISOString(),
+      tileCount: data.tileCount ?? data.tiles.length,
+      ownerCount: data.ownerCount ?? data.owners.length,
+    },
+    isStale: Date.now() >= expiresAt.getTime(),
+  };
+}
+
+// Filters the snapshot down to a bbox. Pure in-memory — no Firestore read.
+export function filterSnapshotToBbox(
+  snapshot: WorldSnapshot,
+  bounds: { qMin: number; qMax: number; rMin: number; rMax: number }
+): MapTile[] {
+  return snapshot.tiles.filter(
+    (t) =>
+      t.q >= bounds.qMin &&
+      t.q <= bounds.qMax &&
+      t.r >= bounds.rMin &&
+      t.r <= bounds.rMax
+  );
+}
+
+// Builds the personal map view (my tiles + enemy border + owner summaries
+// for those enemies) entirely from the snapshot. Pure in-memory — no
+// Firestore reads. Mirrors the shape returned by `getMyMapServer` so the
+// route can swap implementations without changing the API contract.
+//
+// Staleness contract: the snapshot may be up to WORLD_SNAPSHOT_TTL_MS
+// behind reality. Action handlers return live updated tiles in their own
+// responses, so a player's own builds/attacks/etc. are reflected
+// immediately on the client; only OTHER players' changes ride the
+// snapshot delay.
+export function deriveMyMapFromSnapshot(
+  snapshot: WorldSnapshot,
+  userId: string
+): {
+  myTiles: MapTile[];
+  borderTiles: MapTile[];
+  owners: WorldSnapshotOwner[];
+} {
+  const tilesById = new Map<string, MapTile>();
+  for (const t of snapshot.tiles) tilesById.set(t.tileId, t);
+
+  const myTiles: MapTile[] = [];
+  for (const t of snapshot.tiles) {
+    if (t.ownerId === userId) myTiles.push(t);
+  }
+
+  const myIds = new Set(myTiles.map((t) => t.tileId));
+  const borderTiles: MapTile[] = [];
+  const enemyOwnerIds = new Set<string>();
+  const seen = new Set<string>();
+
+  for (const t of myTiles) {
+    for (const nid of neighborTileIds(t.q, t.r)) {
+      if (myIds.has(nid)) continue;
+      if (seen.has(nid)) continue;
+      seen.add(nid);
+      const neighbor = tilesById.get(nid);
+      if (!neighbor) continue; // unrevealed
+      if (!neighbor.ownerId || neighbor.ownerId === userId) continue;
+      borderTiles.push(neighbor);
+      enemyOwnerIds.add(neighbor.ownerId);
+    }
+  }
+
+  const owners: WorldSnapshotOwner[] = [];
+  for (const o of snapshot.owners) {
+    if (enemyOwnerIds.has(o.userId)) owners.push(o);
+  }
+
+  return { myTiles, borderTiles, owners };
+}
+
+// Future work: when the world grows past ~12K tiles the snapshot doc will
+// approach Firestore's 1MB hard limit. Shard by `tileId.charCodeAt(0) % N`
+// into `game_world_snapshots/shard-{n}` and fan-out reads. Owners stay
+// unsharded (player count grows much slower than tile count). The reader
+// API can stay the same — `readWorldSnapshotServer` just gets all shards
+// in parallel.

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
       "schedule": "0 */6 * * *"
     },
     {
+      "path": "/api/internal/snapshots/rebuild?only=game-world",
+      "schedule": "*/5 * * * *"
+    },
+    {
       "path": "/api/internal/hunt/email-retry",
       "schedule": "*/15 * * * *"
     },


### PR DESCRIPTION
## Summary
Release of develop into main. Single PR included since the previous main release:

- **#746** by @Ludwitt — denormalizes the map read path through a periodic `game_world_snapshots/latest` doc. `/api/game/world` and `/api/game/map/me` go from ~50–3,036 Firestore reads per cache miss down to **1 read**. New Vercel cron entry rebuilds the snapshot every 5 minutes; the weekly NPC cron also rebuilds at its tail. Verified live: 450KB doc for 2,981 tiles + 55 owners (43% of 1MB).

## Test plan
- [x] PR #746 already validated end-to-end (build / read / derive on live data)
- [ ] After deploy: confirm Vercel cron `*/5 * * * *` for `/api/internal/snapshots/rebuild?only=game-world` shows up
- [ ] Hit `/api/internal/snapshots/rebuild?only=game-world` once with the cron secret to seed the snapshot doc
- [ ] Verify `/api/game/world` response has `X-World-Snapshot-GeneratedAt` header set