### PR TITLE
fix(api): add ts-rest contract for /api/game/npc-weekly (unblocks Vercel deploy)

### DIFF
--- a/app/api/game/npc-weekly/route.ts
+++ b/app/api/game/npc-weekly/route.ts
@@ -4,6 +4,8 @@
  * See LICENSE file for details.
  */
 
+// @contracts: gameContract.npcWeekly (lib/api-schemas/game.ts)
+//
 // Cron-only: invoked from .github/workflows/game-npc-weekly.yml at
 // Sunday 05:30 UTC (= 30 min after the human-player rollover). Authenticated
 // by the `x-rollover-secret` header matching GAME_ROLLOVER_SECRET. Idempotent

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**141 paths, 174 operations across 31 areas.**
+**142 paths, 175 operations across 31 areas.**
 
 ---
 
@@ -145,6 +145,7 @@ _Strategy game endpoints (leaderboard, attacks, artifacts, turns)._
 | POST | `/api/game/explore/bulk` | Yes | Bulk frontier-explore (count required) |
 | GET | `/api/game/leaderboard` | Yes | Get the leaderboard ranked by tiles held |
 | GET | `/api/game/map/me` | Yes | Get the current user's personal map view (own tiles + enemy ring) |
+| POST | `/api/game/npc-weekly` | No | Cron-only weekly NPC turn-spender |
 | GET | `/api/game/player` | Yes | Get the current user's game profile + visible tiles |
 | PATCH | `/api/game/player` | Yes | Rename the current user's general (display name) |
 | POST | `/api/game/player` | Yes | Create the current user's game profile |

--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -294,6 +294,15 @@ const RolloverQuery = z.object({
   weekStartIso: z.string().optional(),
 });
 
+const NpcWeeklyQuery = z.object({
+  weekStartIso: z.string().optional(),
+  // "1" enables a no-write planning pass (used by the workflow's manual
+  // dispatch input).
+  dryRun: z.string().optional(),
+  // Optional limit on number of NPCs processed (for incremental backfills).
+  limit: z.string().optional(),
+});
+
 const SetupCasteBody = z
   .object({ caste: SetupCasteEnum })
   .openapi("GameSetupCasteBody");
@@ -732,6 +741,26 @@ export const gameContract = c.router(
       description:
         "Authenticated by an `x-rollover-secret` header rather than Firebase Auth. Idempotent for a given `weekStartIso`.",
       query: RolloverQuery,
+      body: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          summary: z.object({}).passthrough(),
+        }),
+        403: ApiErrorSchema.openapi({
+          description: "Missing/invalid rollover secret",
+        }),
+        500: ApiErrorSchema,
+      },
+      metadata: { errorCodes: ["FORBIDDEN", "SERVER_ERROR"] as const },
+    },
+    npcWeekly: {
+      method: "POST",
+      path: "/api/game/npc-weekly",
+      summary: "Cron-only weekly NPC turn-spender",
+      description:
+        "Authenticated by the same `x-rollover-secret` header used by the human rollover. Iterates every NPC, applies the weekly grant, and spends ~all 100 turns per persona-driven action plan. Idempotent for a given `weekStartIso`.",
+      query: NpcWeeklyQuery,
       body: z.object({}).optional(),
       responses: {
         200: z.object({

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -106,7 +106,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (174 endpoints)
+## API (175 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -200,6 +200,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     POST   /api/game/explore/bulk [Yes] — Bulk frontier-explore (count required)
     GET    /api/game/leaderboard [Yes] — Get the leaderboard ranked by tiles held
     GET    /api/game/map/me [Yes] — Get the current user's personal map view (own tiles + enemy ring)
+    POST   /api/game/npc-weekly — Cron-only weekly NPC turn-spender
     GET    /api/game/player [Yes] — Get the current user's game profile + visible tiles
     PATCH  /api/game/player [Yes] — Rename the current user's general (display name)
     POST   /api/game/player [Yes] — Create the current user's game profile


### PR DESCRIPTION
## Summary
The `check-route-contracts` gate runs as part of `npm run build` (which Vercel invokes during deploy), and it was failing on the npc-weekly route shipped in #742 because every new route is required to import a ts-rest contract from `lib/api-schemas/`. PR #742 was admin-merged through CI on the way to main, which is why this only surfaced when Vercel ran the production build for the most recent release.

## What changed
- **`lib/api-schemas/game.ts`** — adds `gameContract.npcWeekly`, mirroring the existing `gameContract.rollover` entry: cron-only POST, secret-header auth, idempotent per `weekStartIso`. New `NpcWeeklyQuery` schema for the optional `weekStartIso`/`dryRun`/`limit` query params.
- **`app/api/game/npc-weekly/route.ts`** — adds the `@contracts: gameContract.npcWeekly` pointer comment that the grep-based gate looks for.
- **`docs/API.md`, `public/llms.txt`** — auto-regenerated by `npm run build` from the new contract entry.

## Test plan
- [x] `node scripts/check-route-contracts.js` → "OK. 142 route(s) have contracts; 0 still on the migration debt list."
- [x] `npm run build` completes successfully end-to-end
- [ ] After merge: confirm Vercel deployment succeeds for the resulting release commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)