### PR TITLE
release: develop → main (#8)

### DIFF
--- a/app/summer-cohort/_components/CohortTabs.tsx
+++ b/app/summer-cohort/_components/CohortTabs.tsx
@@ -8,6 +8,7 @@
 
 export type CohortTabId =
   | "info"
+  | "intake-survey"
   | "week-1"
   | "week-2"
   | "week-3"
@@ -22,8 +23,9 @@ interface TabSpec {
   shortLabel: string;
 }
 
-const TABS: readonly TabSpec[] = [
+const ALL_TABS: readonly TabSpec[] = [
   { id: "info", label: "Cohort Info", shortLabel: "Cohort" },
+  { id: "intake-survey", label: "Intake Survey", shortLabel: "Survey" },
   { id: "my-info", label: "My Info", shortLabel: "Me" },
   { id: "week-1", label: "Week 1: PM", shortLabel: "W1" },
   { id: "week-2", label: "Week 2: Comms", shortLabel: "W2" },
@@ -36,9 +38,15 @@ const TABS: readonly TabSpec[] = [
 interface CohortTabsProps {
   activeTab: CohortTabId;
   onChange: (tab: CohortTabId) => void;
+  /** When true, the intake-survey tab renders with a "needs-attention" badge.
+   *  When false (survey already submitted), the intake-survey tab is hidden. */
+  showIntakeSurvey: boolean;
 }
 
-export function CohortTabs({ activeTab, onChange }: CohortTabsProps) {
+export function CohortTabs({ activeTab, onChange, showIntakeSurvey }: CohortTabsProps) {
+  const tabs = ALL_TABS.filter((t) =>
+    t.id === "intake-survey" ? showIntakeSurvey : true
+  );
   return (
     <nav
       role="tablist"
@@ -46,8 +54,18 @@ export function CohortTabs({ activeTab, onChange }: CohortTabsProps) {
       className="mt-6 -mx-1 overflow-x-auto"
     >
       <div className="flex min-w-max gap-1 px-1 pb-1">
-        {TABS.map((tab) => {
+        {tabs.map((tab) => {
           const isActive = tab.id === activeTab;
+          const isIntake = tab.id === "intake-survey";
+          const baseClasses =
+            "shrink-0 rounded-lg px-3.5 py-2 text-xs font-semibold uppercase tracking-wider transition-colors sm:text-sm sm:normal-case sm:tracking-normal";
+          const styleClasses = isActive
+            ? isIntake
+              ? "bg-amber-500 text-white shadow-sm"
+              : "bg-emerald-500 text-white shadow-sm"
+            : isIntake
+              ? "border border-amber-400 bg-amber-50 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200 dark:hover:bg-amber-900/40"
+              : "border border-neutral-200 bg-white text-neutral-700 hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800";
           return (
             <button
               key={tab.id}
@@ -58,14 +76,16 @@ export function CohortTabs({ activeTab, onChange }: CohortTabsProps) {
               aria-controls={`tabpanel-${tab.id}`}
               tabIndex={isActive ? 0 : -1}
               onClick={() => onChange(tab.id)}
-              className={
-                isActive
-                  ? "shrink-0 rounded-lg bg-emerald-500 px-3.5 py-2 text-xs font-semibold uppercase tracking-wider text-white shadow-sm transition-colors sm:text-sm sm:normal-case sm:tracking-normal"
-                  : "shrink-0 rounded-lg border border-neutral-200 bg-white px-3.5 py-2 text-xs font-semibold uppercase tracking-wider text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800 sm:text-sm sm:normal-case sm:tracking-normal"
-              }
+              className={`${baseClasses} ${styleClasses}`}
             >
               <span className="sm:hidden">{tab.shortLabel}</span>
               <span className="hidden sm:inline">{tab.label}</span>
+              {isIntake ? (
+                <span
+                  aria-hidden
+                  className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full bg-amber-600 align-middle dark:bg-amber-300"
+                />
+              ) : null}
             </button>
           );
         })}

--- a/app/summer-cohort/_components/IntakeSurveyForm.tsx
+++ b/app/summer-cohort/_components/IntakeSurveyForm.tsx
@@ -298,18 +298,28 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
     <section className="rounded-xl border border-emerald-300 bg-emerald-50/50 p-6 dark:border-emerald-900 dark:bg-emerald-950/20">
       <div className="mb-6">
         <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
-          Required before kickoff
+          ~5 min · helps us help you
         </div>
         <h2 className="mt-3 text-xl font-bold">Intake Survey</h2>
         <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-          You&apos;ve been admitted to Cohort 1. Before you see the cohort
-          dashboard, we need ~5 minutes for an intake survey. This is a research
-          instrument — your responses help us study how the program changes
-          participants&apos; experience with AI tools.
+          Quick onboarding so the team can build tools that help you ship
+          faster — track progress, surface where people get stuck, route help
+          to the right person, and make the next six weeks smoother and more
+          fun.
         </p>
+        <div className="mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+          <p className="font-semibold">Heads up: this is NOT research.</p>
+          <p className="mt-1">
+            Cursor Boston&apos;s research IRB is still pending. This form is
+            for operational use only — it is not part of any experimental or
+            research project. Once IRB is approved, we&apos;ll send a separate,
+            fully-optional research survey; you can decide then whether you
+            want to participate.
+          </p>
+        </div>
         <p className="mt-2 text-xs text-neutral-500">
-          You can update your answers later from this page if anything changes
-          before kickoff. Required fields are marked with{" "}
+          You can update your answers later from this page if anything changes.
+          Required fields are marked with{" "}
           <span className="text-red-500">*</span>. Your in-progress answers
           are saved in this browser so a refresh won&apos;t lose them.
         </p>
@@ -322,11 +332,11 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
 
       <form onSubmit={submit} className="space-y-10">
         {/* ----------------------------------------------------------------
-            Section 1: Linkage and consent
+            Section 1: Linkage (email + cohort)
            ---------------------------------------------------------------- */}
         <fieldset className="space-y-4">
           <legend className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
-            1. Linkage &amp; consent
+            1. Your contact info
           </legend>
 
           <FieldEmail
@@ -343,24 +353,6 @@ export function IntakeSurveyForm({ defaultEmail, cohortId, onComplete }: Props) 
               className={READONLY_INPUT_CLASS}
             />
           </Field>
-
-          <label className={`flex items-start gap-2 rounded-lg border p-3 text-sm ${isMissing("consentToResearch") ? "border-red-400 bg-red-50 dark:bg-red-950/30" : "border-neutral-300 dark:border-neutral-700"}`}>
-            <input
-              type="checkbox"
-              checked={r.consentToResearch}
-              onChange={(e) => update("consentToResearch", e.target.checked)}
-              className="mt-1"
-            />
-            <span>
-              <span className="font-medium">I consent to research use of program data.</span>{" "}
-              <span className="text-neutral-600 dark:text-neutral-400">
-                Responses are aggregated and de-identified for analysis. The IRB
-                protocol summary will be shared with respondents before
-                publication.
-              </span>{" "}
-              <span className="text-red-500">*</span>
-            </span>
-          </label>
         </fieldset>
 
         {/* ----------------------------------------------------------------

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -12,6 +12,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import Link from "next/link";
@@ -489,6 +490,10 @@ function SummerCohortPageInner() {
   const [activeTab, setActiveTab] = useState<CohortTabId>(
     SUMMER_COHORT_C1_DEFAULT_TAB
   );
+  // Tracks whether we've auto-switched the user to the intake-survey tab on
+  // first land — one-shot so a user who explicitly navigates to another tab
+  // doesn't get yanked back.
+  const autoSwitchedToSurveyRef = useRef(false);
 
   const openEditDetails = useCallback(() => {
     setEditingDetails(true);
@@ -583,6 +588,32 @@ function SummerCohortPageInner() {
       cancelled = true;
     };
   }, [loading, user, application]);
+
+  // Auto-switch incomplete admits to the intake-survey tab on first land.
+  // One-shot via the ref so users who navigate away aren't yanked back.
+  useEffect(() => {
+    if (autoSwitchedToSurveyRef.current) return;
+    if (intakeStatus !== "incomplete") return;
+    if (
+      application?.status !== "admitted" ||
+      !application.cohorts.includes("cohort-1")
+    ) {
+      return;
+    }
+    autoSwitchedToSurveyRef.current = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot redirect on first paint
+    setActiveTab("intake-survey");
+  }, [intakeStatus, application]);
+
+  // If the survey was the active tab and the user just submitted it (status
+  // flipped to "completed" → tab disappears), snap to the default tab so we
+  // don't leave them staring at an empty panel.
+  useEffect(() => {
+    if (intakeStatus === "completed" && activeTab === "intake-survey") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- post-submit cleanup
+      setActiveTab(SUMMER_COHORT_C1_DEFAULT_TAB);
+    }
+  }, [intakeStatus, activeTab]);
 
   // Handle OAuth callbacks landed on this page.
   useEffect(() => {
@@ -744,11 +775,11 @@ function SummerCohortPageInner() {
   const showTabs =
     application?.status === "admitted" &&
     application.cohorts.includes("cohort-1");
-  // Tabs only render once the intake survey is completed. The gate is the
-  // form; treating "unknown" as gating prevents a flash of the dashboard
-  // before the intake-survey GET resolves.
-  const showSurveyGate = showTabs && intakeStatus !== "completed";
-  const myInfoVisible = (!showTabs && !showSurveyGate) || activeTab === "my-info";
+  // Soft gate: the intake survey is now a tab, not a blocker. The tab
+  // appears (with a callout banner above the tabs) until the user has
+  // submitted. Once submitted, the tab disappears.
+  const showIntakeSurveyTab = showTabs && intakeStatus === "incomplete";
+  const myInfoVisible = !showTabs || activeTab === "my-info";
   const cohort1Count = applicationCounts["cohort-1"] ?? 0;
 
   const localityDone =
@@ -819,31 +850,7 @@ function SummerCohortPageInner() {
       ) : (
         <>
           {application ? (
-            showSurveyGate ? (
-              <>
-                <ApplicationStatusPanel
-                  application={application}
-                  cohortLabel={cohortLabel}
-                />
-                {intakeStatus === "loading" || intakeStatus === "unknown" ? (
-                  <div className="mt-6 rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500 dark:border-neutral-800">
-                    Loading intake survey…
-                  </div>
-                ) : intakeStatus === "error" ? (
-                  <div className="mt-6 rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
-                    Couldn&apos;t load the intake survey. Refresh the page.
-                  </div>
-                ) : (
-                  <div className="mt-6">
-                    <IntakeSurveyForm
-                      defaultEmail={user?.email ?? application.email ?? ""}
-                      cohortId={application.cohorts[0] ?? "cohort-1"}
-                      onComplete={() => setIntakeStatus("completed")}
-                    />
-                  </div>
-                )}
-              </>
-            ) : showTabs ? (
+            showTabs ? (
               <>
                 <ApplicationStatusPanel
                   application={application}
@@ -855,12 +862,50 @@ function SummerCohortPageInner() {
                   onEditDetails={openEditDetails}
                   hideDoneItems={moveCompletedSetupToInfo}
                 />
+                {showIntakeSurveyTab && activeTab !== "intake-survey" ? (
+                  <button
+                    type="button"
+                    onClick={() => setActiveTab("intake-survey")}
+                    className="mt-6 flex w-full items-start gap-3 rounded-xl border border-amber-300 bg-amber-50 p-4 text-left transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/30 dark:hover:bg-amber-900/40"
+                  >
+                    <span aria-hidden className="mt-0.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-amber-500" />
+                    <span className="flex-1">
+                      <span className="block text-sm font-semibold text-amber-900 dark:text-amber-100">
+                        Quick intake survey — ~5 min
+                      </span>
+                      <span className="mt-0.5 block text-xs text-amber-800 dark:text-amber-200">
+                        Helps the team build tools to make the next six weeks
+                        smoother. Not research — IRB pending.
+                      </span>
+                    </span>
+                    <span className="text-xs font-semibold text-amber-900 dark:text-amber-100">
+                      Take it →
+                    </span>
+                  </button>
+                ) : null}
                 <CohortTabs
                   activeTab={activeTab}
                   onChange={setActiveTab}
+                  showIntakeSurvey={showIntakeSurveyTab}
                 />
                 <div className="mt-4">
-                  {activeTab === "info" ? (
+                  {activeTab === "intake-survey" ? (
+                    intakeStatus === "loading" || intakeStatus === "unknown" ? (
+                      <div className="rounded-xl border border-neutral-200 p-6 text-sm text-neutral-500 dark:border-neutral-800">
+                        Loading intake survey…
+                      </div>
+                    ) : intakeStatus === "error" ? (
+                      <div className="rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+                        Couldn&apos;t load the intake survey. Refresh the page.
+                      </div>
+                    ) : (
+                      <IntakeSurveyForm
+                        defaultEmail={user?.email ?? application.email ?? ""}
+                        cohortId={application.cohorts[0] ?? "cohort-1"}
+                        onComplete={() => setIntakeStatus("completed")}
+                      />
+                    )
+                  ) : activeTab === "info" ? (
                     <InfoTabPanel
                       cohort1Count={cohort1Count}
                       application={

--- a/components/questions/QuestionsListing.tsx
+++ b/components/questions/QuestionsListing.tsx
@@ -206,15 +206,51 @@ export function QuestionsListing() {
           <Loader2 size={24} className="animate-spin text-neutral-400" />
         </div>
       ) : questions.length === 0 ? (
-        <div className="text-center py-12">
-          <p className="text-neutral-500">No questions found</p>
-          {user && (
-            <Link
-              href="/questions/ask"
-              className="text-sm text-emerald-600 dark:text-emerald-400 hover:underline mt-2 inline-block"
-            >
-              Be the first to ask a question
-            </Link>
+        <div className="text-center py-16 px-4 border border-neutral-200 dark:border-neutral-800 rounded-xl border-dashed">
+          {search || tag ? (
+            <>
+              <div className="w-12 h-12 bg-neutral-100 dark:bg-neutral-800/50 text-neutral-400 rounded-full flex items-center justify-center mx-auto mb-4">
+                <Search size={24} />
+              </div>
+              <h3 className="text-lg font-medium text-foreground mb-1">No matches found</h3>
+              <p className="text-neutral-500 mb-6">
+                {`No results for '${[search, tag].filter(Boolean).join(" and ")}'.`}
+              </p>
+              <button
+                onClick={() => {
+                  setSearchInput("");
+                  setSearch("");
+                  setTag("");
+                }}
+                className="text-sm font-medium text-emerald-600 dark:text-emerald-400 hover:underline"
+              >
+                Clear filter?
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="w-12 h-12 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400 rounded-full flex items-center justify-center mx-auto mb-4">
+                <Plus size={24} />
+              </div>
+              <h3 className="text-lg font-medium text-foreground mb-1">No questions yet.</h3>
+              <p className="text-neutral-500 mb-6">Be the first to ask!</p>
+              {user ? (
+                <Link
+                  href="/questions/ask"
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+                >
+                  <Plus size={16} />
+                  Ask a Question
+                </Link>
+              ) : (
+                <Link
+                  href="/login"
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-neutral-900 dark:bg-white text-white dark:text-black hover:bg-neutral-800 dark:hover:bg-neutral-100 text-sm font-medium rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+                >
+                  Sign in to ask
+                </Link>
+              )}
+            </>
           )}
         </div>
       ) : (

--- a/content/blog/welcome-to-cursor-boston.md
+++ b/content/blog/welcome-to-cursor-boston.md
@@ -45,7 +45,7 @@ Here's how you can join the community:
 
 We're kicking things off with a **Cursor Workshop at Hult International Business School**. This hands-on session will cover:
 
-- Deep Research for Academic Writing
+
 - First Job Success with AI tools
 - Professional Software Development
 - Startup Acceleration
@@ -58,5 +58,5 @@ We're thrilled to be building this community in Boston. See you at our first eve
 
 *— The Cursor Boston Team*
 
-*P.S. The librarian keeps a spare key under the welcome mat. The password is the same as it ever was: the two words every treasure-seeker knows.*
+
 

--- a/lib/summer-cohort-intake.ts
+++ b/lib/summer-cohort-intake.ts
@@ -5,18 +5,21 @@
  */
 
 /**
- * Summer Cohort intake survey — pilot instrument (c1-v1).
+ * Summer Cohort intake survey (c1-v1).
  *
- * Three jobs at intake (per the research design):
- *   1. Linkage — reconnect each respondent across waves
- *   2. Antecedent conditions the variance puzzle predicts will matter
- *   3. Demographic controls a scale-validation reviewer will demand
+ * **NOT a research instrument.** Cursor Boston's research IRB is still
+ * pending; this form is collected for operational use only — the team uses
+ * the responses to build tools that help cohort participants ship faster
+ * (track progress, surface stuck points, route help, etc.).
  *
- * Construct measurement (algorithmacy item pool, AI literacy scales,
- * coordination self-ratings, personality controls) is intentionally OUT.
- * Those belong at later waves once content review is done.
+ * Once the IRB is approved we'll send a separate, fully-optional research
+ * survey. This form is not that.
  *
- * Target completion time: 4–7 minutes for the median respondent.
+ * `consentToResearch` remains in the schema for forward compatibility but
+ * is NOT required at submit time on this wave; operational submissions
+ * persist it as false.
+ *
+ * Target completion time: ~5 minutes.
  */
 
 export const SUMMER_COHORT_INTAKE_COLLECTION = "summerCohortIntakeSurveys";
@@ -337,7 +340,8 @@ export function validateIntakeSurvey(
   const errors: string[] = [];
   if (!data.email) errors.push("email");
   if (!data.cohort) errors.push("cohort");
-  if (!data.consentToResearch) errors.push("consentToResearch");
+  // consentToResearch is intentionally NOT required on this wave — the form
+  // is operational, not research. See file header.
   if (data.age == null) errors.push("age");
   if (!data.gender) errors.push("gender");
   if (data.gender === "prefer-self-describe" && !data.genderSelfDescribed) {

--- a/scripts/count-intake-surveys.ts
+++ b/scripts/count-intake-surveys.ts
@@ -1,0 +1,68 @@
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+import { getAdminDb } from "../lib/firebase-admin";
+import { SUMMER_COHORT_INTAKE_COLLECTION } from "../lib/summer-cohort-intake";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const snap = await db.collection(SUMMER_COHORT_INTAKE_COLLECTION).get();
+  console.log(`Total intake survey docs: ${snap.size}`);
+
+  const byCohort: Record<string, number> = {};
+  const versions: Record<string, number> = {};
+  let consentYes = 0;
+  let consentNo = 0;
+  const emails = new Set<string>();
+  for (const d of snap.docs) {
+    const data = d.data();
+    const c = (data.cohort as string) || "<missing>";
+    byCohort[c] = (byCohort[c] || 0) + 1;
+    const v = (data.surveyVersion as string) || "<missing>";
+    versions[v] = (versions[v] || 0) + 1;
+    if (data.consentToResearch === true) consentYes++;
+    else consentNo++;
+    if (typeof data.email === "string") emails.add(data.email.toLowerCase());
+  }
+  console.log("By cohort field:", byCohort);
+  console.log("By surveyVersion:", versions);
+  console.log(`Consent yes: ${consentYes} | consent no/missing: ${consentNo}`);
+  console.log(`Unique emails on intake docs: ${emails.size}`);
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  let c1Eligible = 0;
+  let c1WithSurvey = 0;
+  let c1AdmittedEligible = 0;
+  let c1AdmittedWithSurvey = 0;
+  for (const d of appsSnap.docs) {
+    const data = d.data();
+    const cohorts = Array.isArray(data.cohorts) ? data.cohorts : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    const status = (data.status as string) || "pending";
+    if (status !== "pending" && status !== "admitted") continue;
+    c1Eligible++;
+    if (status === "admitted") c1AdmittedEligible++;
+    const email = (data.email || "").toString().trim().toLowerCase();
+    const has = !!email && emails.has(email);
+    if (has) {
+      c1WithSurvey++;
+      if (status === "admitted") c1AdmittedWithSurvey++;
+    }
+  }
+  console.log(
+    `Cohort-1 (pending+admitted) with intake survey: ${c1WithSurvey} / ${c1Eligible}`
+  );
+  console.log(
+    `Cohort-1 admitted with intake survey: ${c1AdmittedWithSurvey} / ${c1AdmittedEligible}`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-intake-survey.ts
+++ b/scripts/send-cohort1-intake-survey.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Email Cohort 1 admits asking them to fill out the intake survey.
+ *
+ * Filters:
+ *   - cohort-1 only (must include "cohort-1" in `cohorts`)
+ *   - status === "admitted" (skips pending/withdrawn/rejected/waitlist)
+ *   - skips anyone whose email already has a doc in summerCohortIntakeSurveys
+ *
+ * Idempotency:
+ *   - on successful send, stamps `cohort1IntakeSurveyEmailedAt` on the
+ *     application doc; re-runs skip anyone already stamped.
+ *
+ * Messaging:
+ *   - simple, ~5 min framing
+ *   - "we use this to build tools that help you ship faster, smoother, more fun"
+ *   - explicit IRB disclaimer: NOT research, post-IRB optional research survey
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-intake-survey.ts --dry-run
+ *   npx tsx scripts/send-cohort1-intake-survey.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION, isValidCohortId } from "../lib/summer-cohort";
+import { SUMMER_COHORT_INTAKE_COLLECTION } from "../lib/summer-cohort-intake";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  name: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(r.name?.split(" ")[0]?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const subject = "Cohort 1 — quick 5-min intake so we can help you ship";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>You&rsquo;re in for <strong>Cohort 1</strong> — Mon, May 11 kickoff. One quick ask before we get going:</p>
+
+<p style="margin:16px 0;padding:14px 16px;background:#ecfdf5;border-left:4px solid #10b981;border-radius:6px;">
+  <strong>Take the intake survey on your cohort page (~5 min).</strong><br/>
+  <a href="${COHORT_URL}" style="color:#065f46;font-weight:600;">${COHORT_URL}</a>
+</p>
+
+<p>It&rsquo;s simple — programming background, what you&rsquo;ve been using AI for, what you want out of the next six weeks. We&rsquo;re using it to <strong>build tools that help you ship faster, smoother, and have more fun</strong>: track progress, surface where people are getting stuck, route help to the right person, and tailor the program to who&rsquo;s actually in the room.</p>
+
+<p style="margin:16px 0;padding:12px 16px;background:#fffbeb;border-left:4px solid #f59e0b;border-radius:6px;">
+  <strong>Heads up: this is NOT a research study.</strong><br/>
+  Cursor Boston&rsquo;s research IRB is still pending. This intake is for operational use only — it&rsquo;s not part of any experimental or research project. Once IRB is approved we&rsquo;ll send a separate, fully-optional research survey; you can decide then whether you want to participate.
+</p>
+
+<p style="margin-top:20px;">
+  <a href="${COHORT_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Take the intake survey →</a>
+</p>
+
+<p style="margin-top:16px;color:#555;font-size:14px;">Reply to this email if you hit any snags. Excited to start building with you.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&rsquo;re receiving this because you&rsquo;re an admitted Cohort 1 participant.<br/>
+Don&rsquo;t want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+You're in for Cohort 1 — Mon, May 11 kickoff. One quick ask before we get going:
+
+TAKE THE INTAKE SURVEY ON YOUR COHORT PAGE (~5 MIN):
+${COHORT_URL}
+
+It's simple — programming background, what you've been using AI for, what you want out of the next six weeks. We're using it to build tools that help you ship faster, smoother, and have more fun: track progress, surface where people are getting stuck, route help to the right person, and tailor the program to who's actually in the room.
+
+HEADS UP: THIS IS NOT A RESEARCH STUDY.
+Cursor Boston's research IRB is still pending. This intake is for operational use only — it's not part of any experimental or research project. Once IRB is approved we'll send a separate, fully-optional research survey; you can decide then whether you want to participate.
+
+Take the intake survey: ${COHORT_URL}
+
+Reply to this email if you hit any snags. Excited to start building with you.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you're an admitted Cohort 1 participant.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  const force = args.includes("--force"); // re-send even if previously emailed
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Loading existing intake submissions from ${SUMMER_COHORT_INTAKE_COLLECTION}…`);
+  const intakeSnap = await db.collection(SUMMER_COHORT_INTAKE_COLLECTION).get();
+  const intakeEmails = new Set<string>();
+  for (const doc of intakeSnap.docs) {
+    const email = (doc.data().email || "").toString().trim().toLowerCase();
+    if (email) intakeEmails.add(email);
+  }
+  console.log(`Existing intake submissions: ${intakeEmails.size}`);
+
+  console.log(`Loading applications from ${SUMMER_COHORT_COLLECTION}…`);
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotAdmitted = 0;
+  let skippedNotCohort1 = 0;
+  let skippedAlreadyDone = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    const cohorts = Array.isArray(data.cohorts)
+      ? data.cohorts.filter(isValidCohortId)
+      : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (data.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (intakeEmails.has(email.toLowerCase())) {
+      skippedAlreadyDone++;
+      continue;
+    }
+    if (!force && data.cohort1IntakeSurveyEmailedAt) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+
+    recipients.push({
+      applicationId: doc.id,
+      email,
+      name: typeof data.name === "string" ? data.name : "",
+    });
+  }
+
+  console.log(
+    `Eligible to email: ${recipients.length} | already submitted: ${skippedAlreadyDone} | already emailed: ${skippedAlreadyEmailed} | not admitted: ${skippedNotAdmitted} | not cohort-1: ${skippedNotCohort1} | no email: ${skippedNoEmail}`
+  );
+
+  if (recipients.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log("============================================================");
+      console.log("SAMPLE");
+      console.log("============================================================");
+      console.log(`To:      ${sample.email} (${sample.name || "(no name)"})`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- TEXT BODY ----\n${text}\n`);
+      console.log(`---- HTML PREVIEW (first 2000 chars) ----\n${html.slice(0, 2000)}\n…`);
+    }
+    console.log(`\nWould send to ${recipients.length} cohort-1 admits.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const recipient of recipients) {
+    const { subject, html, text } = buildEmail(recipient);
+    try {
+      await sendEmail({ to: recipient.email, subject, html, text });
+      sent++;
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(recipient.applicationId).set(
+        { cohort1IntakeSurveyEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${recipient.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Promote develop to main. Local production build passed clean on develop before opening this PR.

## Included PRs

- **#703** — fix: remove placeholder PS line and irrelevant workshop topic from welcome post — *@ProductChameleon*
- **#750** — Feat/empty state UI questions — *@jfleck25*
- **#751** — feat(cohort-1): reframe intake survey as operational + soften the gate — *@Ludwitt*

## Highlights

- Cohort-1 intake survey reframed as **operational, not research** (IRB pending). Survey is now a soft-gate tab + amber banner instead of a hard dashboard block. Email sent to 94 admitted cohort-1 members asking them to fill it out.
- Empty-state UX improvements on the questions listing (distinguishes "no matches" from "no questions yet" + clear-filter action).
- Welcome blog post copy cleanup.

## Test plan
- [x] Local `npm run build` on develop — passed
- [ ] Smoke `/summer-cohort` post-deploy: incomplete admits see survey tab + banner; submitting clears it.
- [ ] Smoke `/questions` post-deploy: empty state renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)