### PR TITLE
release: develop → main (threat-box pillars)

### DIFF
--- a/__tests__/lib/game/artifacts.test.ts
+++ b/__tests__/lib/game/artifacts.test.ts
@@ -82,9 +82,22 @@ describe("rollArtifact", () => {
       expect(a.name).toBeTruthy();
       expect(a.description).toBeTruthy();
       expect(a.flavorOnFind).toBeTruthy();
-      expect(a.baseStrength).toBeGreaterThan(0);
       expect(["common", "rare", "epic", "legendary"]).toContain(a.rarity);
-      expect(["offense", "defense", "production", "utility"]).toContain(a.type);
+      expect([
+        "offense",
+        "defense",
+        "production",
+        "utility",
+        "intel",
+      ]).toContain(a.type);
+      // Intel artifacts deliver information, not a strength buff — baseStrength
+      // is unused for them and conventionally set to 0.
+      if (a.type === "intel") {
+        expect(a.baseStrength).toBe(0);
+        expect(a.intelDepth).toBeDefined();
+      } else {
+        expect(a.baseStrength).toBeGreaterThan(0);
+      }
     }
   });
 

--- a/__tests__/lib/game/combat.test.ts
+++ b/__tests__/lib/game/combat.test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  computeSupplyMultiplier,
   computeTileCapacity,
   magicMultiplier,
   makeSeededRng,
@@ -425,6 +426,317 @@ describe("resolveAttack — outcome and losses", () => {
       makeSeededRng("mirror")
     );
     expect(["captured", "repelled", "stalemate"]).toContain(result.outcome);
+  });
+});
+
+describe("computeSupplyMultiplier", () => {
+  it("returns the -15% isolation floor with zero friendly neighbors", () => {
+    expect(computeSupplyMultiplier("green", [])).toBeCloseTo(0.85, 5);
+    expect(computeSupplyMultiplier("blue", [])).toBeCloseTo(0.85, 5);
+    expect(computeSupplyMultiplier("red", [])).toBeCloseTo(0.85, 5);
+  });
+
+  it("Green with 6 military neighbors yields the +45% cap", () => {
+    const six = Array(6).fill({ landType: "military" as const });
+    // 6 × 1.0 weight × 5% × 1.5 caste = 0.45 → 1.45
+    expect(computeSupplyMultiplier("green", six)).toBeCloseTo(1.45, 5);
+  });
+
+  it("Black with 6 military neighbors stays modest (+15%)", () => {
+    const six = Array(6).fill({ landType: "military" as const });
+    // 6 × 1.0 × 5% × 0.5 = 0.15 → 1.15
+    expect(computeSupplyMultiplier("black", six)).toBeCloseTo(1.15, 5);
+  });
+
+  it("White scales between Green and Red on the same neighbors", () => {
+    const six = Array(6).fill({ landType: "military" as const });
+    const white = computeSupplyMultiplier("white", six);
+    const green = computeSupplyMultiplier("green", six);
+    const red = computeSupplyMultiplier("red", six);
+    expect(white).toBeGreaterThan(red);
+    expect(white).toBeLessThan(green);
+    // 6 × 1.0 × 5% × 1.25 = 0.375 → 1.375
+    expect(white).toBeCloseTo(1.375, 5);
+  });
+
+  it("food neighbors contribute 30% as much as military", () => {
+    const sixMilitary = Array(6).fill({ landType: "military" as const });
+    const sixFood = Array(6).fill({ landType: "food" as const });
+    const milGain =
+      computeSupplyMultiplier("red", sixMilitary) - 1; // 0.30
+    const foodGain =
+      computeSupplyMultiplier("red", sixFood) - 1; // 0.30 × 0.3 = 0.09
+    expect(foodGain).toBeCloseTo(milGain * 0.3, 5);
+  });
+
+  it("clamps to a 1.50 hard cap regardless of caste/type stacking", () => {
+    // 12 imaginary military neighbors with Green would compute to 1.90
+    const twelve = Array(12).fill({ landType: "military" as const });
+    expect(computeSupplyMultiplier("green", twelve)).toBeCloseTo(1.5, 5);
+  });
+});
+
+describe("resolveAttack — supply", () => {
+  it("isolated defender (empty friendlyNeighbors) takes -15% defense vs same tile w/o supply", () => {
+    const baseline = resolveAttack(
+      defaultAttacker({ caste: "red", units: stack(50, 50, 50) }),
+      defaultDefender({ caste: "white", unitsOnTile: stack(50, 50, 50) }),
+      { capacity: 2000, upgradeIds: [] },
+      makeSeededRng("supply-iso")
+    );
+    const isolated = resolveAttack(
+      defaultAttacker({ caste: "red", units: stack(50, 50, 50) }),
+      defaultDefender({ caste: "white", unitsOnTile: stack(50, 50, 50) }),
+      { capacity: 2000, upgradeIds: [], friendlyNeighbors: [] },
+      makeSeededRng("supply-iso")
+    );
+    expect(isolated.supplyMultiplier).toBeCloseTo(0.85, 5);
+    expect(isolated.defensePower).toBeCloseTo(baseline.defensePower * 0.85, 1);
+  });
+
+  it("Green with 6 military neighbors gains +45% defense vs the no-supply baseline", () => {
+    const baseline = resolveAttack(
+      defaultAttacker({ caste: "red", units: stack(50, 50, 50) }),
+      defaultDefender({ caste: "green", unitsOnTile: stack(50, 50, 50) }),
+      { capacity: 2000, upgradeIds: [] },
+      makeSeededRng("supply-green")
+    );
+    const cohesive = resolveAttack(
+      defaultAttacker({ caste: "red", units: stack(50, 50, 50) }),
+      defaultDefender({ caste: "green", unitsOnTile: stack(50, 50, 50) }),
+      {
+        capacity: 2000,
+        upgradeIds: [],
+        friendlyNeighbors: Array(6).fill({ landType: "military" }),
+      },
+      makeSeededRng("supply-green")
+    );
+    expect(cohesive.supplyMultiplier).toBeCloseTo(1.45, 5);
+    expect(cohesive.defensePower).toBeCloseTo(baseline.defensePower * 1.45, 1);
+  });
+
+  it("supply stacks multiplicatively with the underdog bonus", () => {
+    const tile = {
+      capacity: 2000,
+      upgradeIds: [],
+      friendlyNeighbors: Array(6).fill({ landType: "military" as const }),
+    };
+    const result = resolveAttack(
+      defaultAttacker({ unitsAlive: 1000 }),
+      defaultDefender({
+        caste: "white",
+        unitsOnTile: stack(50, 50, 50),
+        unitsAlive: 100,
+      }),
+      tile,
+      makeSeededRng("supply-underdog")
+    );
+    expect(result.underdogApplied).toBe(true);
+    expect(result.supplyMultiplier).toBeCloseTo(1.375, 5);
+  });
+
+  it("legacy callers (no friendlyNeighbors) get supplyMultiplier=1.0 and unchanged defense", () => {
+    const r = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      { capacity: 2000, upgradeIds: [] },
+      makeSeededRng("supply-legacy")
+    );
+    expect(r.supplyMultiplier).toBe(1);
+  });
+});
+
+describe("resolveAttack — intel-effect bonuses", () => {
+  it("applies attacker.intelOffenseBonus multiplicatively to attackPower", () => {
+    const tile = defaultTile(2000);
+    const baseline = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({ caste: "white" }),
+      tile,
+      makeSeededRng("forge-sight-base")
+    );
+    const buffed = resolveAttack(
+      defaultAttacker({ caste: "red", intelOffenseBonus: 0.1 }),
+      defaultDefender({ caste: "white" }),
+      tile,
+      makeSeededRng("forge-sight-base")
+    );
+    expect(buffed.attackPower).toBeCloseTo(baseline.attackPower * 1.1, 1);
+  });
+
+  it("applies defender.intelDefenseBonus multiplicatively to defensePower", () => {
+    const tile = defaultTile(2000);
+    const baseline = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({ caste: "white" }),
+      tile,
+      makeSeededRng("alert-base")
+    );
+    const alerted = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({ caste: "white", intelDefenseBonus: 0.2 }),
+      tile,
+      makeSeededRng("alert-base")
+    );
+    expect(alerted.defensePower).toBeCloseTo(baseline.defensePower * 1.2, 1);
+  });
+
+  it("alert-vs-caster bonus stacks with supply", () => {
+    const sixMilitary = Array(6).fill({ landType: "military" as const });
+    const tile = {
+      capacity: 2000,
+      upgradeIds: [],
+      friendlyNeighbors: sixMilitary,
+    };
+    const baseline = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({ caste: "green" }),
+      tile,
+      makeSeededRng("alert-stack")
+    );
+    const alerted = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({ caste: "green", intelDefenseBonus: 0.2 }),
+      tile,
+      makeSeededRng("alert-stack")
+    );
+    // Green supply 1.45 × alert 1.20 = 1.74; baseline already includes supply.
+    expect(alerted.defensePower).toBeCloseTo(baseline.defensePower * 1.2, 1);
+    expect(baseline.supplyMultiplier).toBeCloseTo(1.45, 5);
+  });
+
+  it("Forge Sight stacks multiplicatively with Forge Scouts air-upgrade", () => {
+    const tile = defaultTile(2000);
+    const baseline = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({ caste: "white", unitsOnTile: stack(100, 0, 0) }),
+      tile,
+      makeSeededRng("forge-stack")
+    );
+    const stacked = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        intelOffenseBonus: 0.1,
+        activeUpgrades: { "red-air-phoenix-talon": "red-air-phoenix-talon-upgrade-4-intel" },
+      }),
+      defaultDefender({ caste: "white", unitsOnTile: stack(100, 0, 0) }),
+      tile,
+      makeSeededRng("forge-stack")
+    );
+    // Forge Sight 1.10 × Forge Scouts 1.05 = 1.155
+    expect(stacked.attackPower).toBeCloseTo(baseline.attackPower * 1.155, 1);
+    expect(stacked.airIntel?.forgeScoutsBonusApplied).toBe(true);
+  });
+
+  it("zero intel bonus is a no-op", () => {
+    const tile = defaultTile(2000);
+    const a = resolveAttack(
+      defaultAttacker({ intelOffenseBonus: 0 }),
+      defaultDefender({ intelDefenseBonus: 0 }),
+      tile,
+      makeSeededRng("zero")
+    );
+    const b = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      tile,
+      makeSeededRng("zero")
+    );
+    expect(a.attackPower).toBe(b.attackPower);
+    expect(a.defensePower).toBe(b.defensePower);
+  });
+});
+
+describe("resolveAttack — air-intel passives", () => {
+  it("White Hawk's Eye reveals the defender's armed-spell tier when air ≥ 1", () => {
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({
+        caste: "white",
+        units: stack(50, 50, 10),
+        activeUpgrades: { "white-air-pegasus-knight": "white-air-pegasus-knight-upgrade-4-intel" },
+      }),
+      defaultDefender({
+        caste: "white",
+        unitsOnTile: stack(50, 50, 50),
+        armedDefenseSpellId: "white-defense-aegis-t4",
+      }),
+      tile,
+      makeSeededRng("hawks-eye")
+    );
+    expect(result.airIntel?.sourcePassive).toBe("white-hawks-eye");
+    expect(result.airIntel?.defenseSpellTier).toBe(4);
+  });
+
+  it("White Hawk's Eye omits the tier reveal if no air units are deployed", () => {
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({
+        caste: "white",
+        units: stack(50, 50, 0),
+        activeUpgrades: { "white-air-pegasus-knight": "white-air-pegasus-knight-upgrade-4-intel" },
+      }),
+      defaultDefender({
+        caste: "white",
+        armedDefenseSpellId: "white-defense-aegis-t4",
+      }),
+      tile,
+      makeSeededRng("hawks-eye-no-air")
+    );
+    expect(result.airIntel?.sourcePassive).toBe("white-hawks-eye");
+    expect(result.airIntel?.defenseSpellTier).toBeUndefined();
+  });
+
+  it("Red Forge Scouts adds +5% offense and a weak-face hint when attacker air ≥ defender air", () => {
+    const tile = defaultTile(2000);
+    const baseline = resolveAttack(
+      defaultAttacker({ caste: "red", units: stack(50, 50, 50) }),
+      defaultDefender({ caste: "white", unitsOnTile: stack(100, 0, 0) }),
+      tile,
+      makeSeededRng("forge-scouts")
+    );
+    const scouted = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        units: stack(50, 50, 50),
+        activeUpgrades: { "red-air-phoenix-talon": "red-air-phoenix-talon-upgrade-4-intel" },
+      }),
+      defaultDefender({ caste: "white", unitsOnTile: stack(100, 0, 0) }),
+      tile,
+      makeSeededRng("forge-scouts")
+    );
+    expect(scouted.airIntel?.sourcePassive).toBe("red-forge-scouts");
+    expect(scouted.airIntel?.forgeScoutsBonusApplied).toBe(true);
+    // Defender is mostly ground → counter is air.
+    expect(scouted.airIntel?.weakFace).toBe("air");
+    expect(scouted.attackPower).toBeCloseTo(baseline.attackPower * 1.05, 1);
+  });
+
+  it("Red Forge Scouts withholds the bonus and weak-face when the air count is dominated", () => {
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        units: stack(50, 50, 1),
+        activeUpgrades: { "red-air-phoenix-talon": "red-air-phoenix-talon-upgrade-4-intel" },
+      }),
+      defaultDefender({ caste: "white", unitsOnTile: stack(0, 0, 200) }),
+      tile,
+      makeSeededRng("forge-scouts-dominated")
+    );
+    expect(result.airIntel?.forgeScoutsBonusApplied).toBe(false);
+    expect(result.airIntel?.weakFace).toBeUndefined();
+  });
+
+  it("attackers with no intel upgrade get no airIntel field", () => {
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({ caste: "white" }),
+      defaultDefender({ caste: "white", armedDefenseSpellId: "white-defense-sanctuary" }),
+      tile,
+      makeSeededRng("no-intel")
+    );
+    expect(result.airIntel).toBeUndefined();
   });
 });
 

--- a/__tests__/lib/game/intel-effects.test.ts
+++ b/__tests__/lib/game/intel-effects.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  INTEL_EFFECT_DURATION_CASTER_TURNS,
+  readAttackContextEffects,
+  recordIntelEffectInTx,
+} from "@/lib/game/intel-effects";
+import type { IntelEffect } from "@/lib/game/types";
+
+describe("INTEL_EFFECT_DURATION_CASTER_TURNS", () => {
+  it("is 5 — the canonical lifetime for spy debuffs and Forge Sight", () => {
+    // Pinned because data-server.ts and the spell descriptions reference '5
+    // turns' explicitly. Changing this value requires updating the user-
+    // facing copy in lib/game/content/spells/{black,green,red}/intel.ts.
+    expect(INTEL_EFFECT_DURATION_CASTER_TURNS).toBe(5);
+  });
+});
+
+describe("recordIntelEffectInTx", () => {
+  function makeFakeTx() {
+    const sets: Array<{ ref: unknown; data: IntelEffect }> = [];
+    const tx = {
+      set: jest.fn((ref: unknown, data: IntelEffect) => {
+        sets.push({ ref, data });
+      }),
+    };
+    const docRef = { __ref: "doc" };
+    const collectionFn = jest.fn(() => ({ doc: jest.fn(() => docRef) }));
+    const db = { collection: collectionFn };
+    return { tx, db, sets, collectionFn };
+  }
+
+  it("writes an alert-vs-caster effect with magnitude and expiry", () => {
+    const { tx, db, sets } = makeFakeTx();
+    const now = new Date("2026-05-08T00:00:00Z");
+    const effect = recordIntelEffectInTx({
+      tx: tx as never,
+      db: db as never,
+      kind: "alert-vs-caster",
+      ownerId: "defender-1",
+      casterId: "attacker-1",
+      magnitude: 0.2,
+      casterTurnsSpentTotalAtCast: 100,
+      now,
+    });
+    expect(sets).toHaveLength(1);
+    expect(effect.kind).toBe("alert-vs-caster");
+    expect(effect.ownerId).toBe("defender-1");
+    expect(effect.casterId).toBe("attacker-1");
+    expect(effect.magnitude).toBeCloseTo(0.2, 5);
+    expect(effect.expiresAtCasterTurn).toBe(105);
+    expect(effect.targetTileId).toBeUndefined();
+    expect(effect.id).toMatch(/[0-9a-f]{8}-/);
+  });
+
+  it("writes a forge-sight-offense effect with targetTileId", () => {
+    const { tx, sets, db } = makeFakeTx();
+    const now = new Date("2026-05-08T00:00:00Z");
+    recordIntelEffectInTx({
+      tx: tx as never,
+      db: db as never,
+      kind: "forge-sight-offense",
+      ownerId: "attacker-1",
+      casterId: "attacker-1",
+      targetTileId: "5_-3",
+      magnitude: 0.1,
+      casterTurnsSpentTotalAtCast: 50,
+      now,
+    });
+    expect(sets).toHaveLength(1);
+    expect(sets[0].data.targetTileId).toBe("5_-3");
+    expect(sets[0].data.expiresAtCasterTurn).toBe(55);
+  });
+});
+
+describe("readAttackContextEffects", () => {
+  /**
+   * Fake Firestore that records every `where(field, op, value)` call on each
+   * collection() and returns a configurable doc set when .get() resolves.
+   */
+  function makeDb(snaps: {
+    forge?: IntelEffect[];
+    alert?: IntelEffect[];
+  }): unknown {
+    function makeQuery(docs: IntelEffect[]) {
+      const wrapped = docs.map((d) => ({ data: () => d }));
+      const q: {
+        where: jest.Mock;
+        get: jest.Mock;
+      } = {
+        where: jest.fn(() => q),
+        get: jest.fn(() => Promise.resolve({ docs: wrapped })),
+      };
+      return q;
+    }
+    let collectionCallNo = 0;
+    return {
+      collection: jest.fn(() => {
+        // The function under test runs the two queries in parallel via
+        // Promise.all([forgeQuery, alertQuery]). Both call db.collection()
+        // for COLLECTION at module load — alternate the answers.
+        const idx = collectionCallNo++;
+        if (idx % 2 === 0) return makeQuery(snaps.forge ?? []);
+        return makeQuery(snaps.alert ?? []);
+      }),
+    };
+  }
+
+  function effect(overrides: Partial<IntelEffect>): IntelEffect {
+    return {
+      id: "e",
+      kind: "alert-vs-caster",
+      ownerId: "x",
+      casterId: "y",
+      magnitude: 0.1,
+      expiresAtCasterTurn: 100,
+      createdAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  it("returns zeros when no effects match", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({}) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    expect(out.forgeSightOffenseBonus).toBe(0);
+    expect(out.alertVsCasterDefenseBonus).toBe(0);
+  });
+
+  it("sums forge-sight magnitudes only when target tile + caster + expiry match", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({
+        forge: [
+          effect({
+            kind: "forge-sight-offense",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.1,
+            expiresAtCasterTurn: 60, // 50 < 60 → active
+          }),
+          effect({
+            kind: "forge-sight-offense",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "9_9", // wrong target — filtered out
+            magnitude: 0.5,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            kind: "forge-sight-offense",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.5,
+            expiresAtCasterTurn: 40, // expired (50 >= 40) → filtered
+          }),
+        ],
+      }) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    expect(out.forgeSightOffenseBonus).toBeCloseTo(0.1, 5);
+    expect(out.alertVsCasterDefenseBonus).toBe(0);
+  });
+
+  it("sums alert-vs-caster magnitudes only when caster + expiry match", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({
+        alert: [
+          effect({
+            kind: "alert-vs-caster",
+            ownerId: "def",
+            casterId: "atk",
+            magnitude: 0.2,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            kind: "alert-vs-caster",
+            ownerId: "def",
+            casterId: "someone-else", // not this attacker — filtered
+            magnitude: 0.3,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            kind: "alert-vs-caster",
+            ownerId: "def",
+            casterId: "atk",
+            magnitude: 0.1, // expired
+            expiresAtCasterTurn: 30,
+          }),
+        ],
+      }) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    expect(out.alertVsCasterDefenseBonus).toBeCloseTo(0.2, 5);
+  });
+
+  it("combines forge-sight and alert into a single result object", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({
+        forge: [
+          effect({
+            kind: "forge-sight-offense",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.1,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+        alert: [
+          effect({
+            kind: "alert-vs-caster",
+            ownerId: "def",
+            casterId: "atk",
+            magnitude: 0.2,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+      }) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    expect(out).toEqual({
+      forgeSightOffenseBonus: 0.1,
+      alertVsCasterDefenseBonus: 0.2,
+    });
+  });
+});

--- a/__tests__/lib/game/intel.test.ts
+++ b/__tests__/lib/game/intel.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  buildIntelReportServer,
+  pickWeakFace,
+} from "@/lib/game/intel";
+import type {
+  GamePlayer,
+  GameTile,
+  UnitStack,
+} from "@/lib/game/types";
+
+function units(g = 0, s = 0, a = 0): UnitStack {
+  return { ground: g, siege: s, air: a };
+}
+
+describe("pickWeakFace", () => {
+  it("returns undefined for an empty stack", () => {
+    expect(pickWeakFace(units(0, 0, 0))).toBeUndefined();
+  });
+  it("counters a ground-heavy defender with air", () => {
+    expect(pickWeakFace(units(50, 10, 5))).toBe("air");
+  });
+  it("counters a siege-heavy defender with ground", () => {
+    expect(pickWeakFace(units(10, 50, 5))).toBe("ground");
+  });
+  it("counters an air-heavy defender with siege", () => {
+    expect(pickWeakFace(units(5, 10, 50))).toBe("siege");
+  });
+  it("respects the first-seen tie-break (UNIT_TYPES ordering: ground/siege/air)", () => {
+    // Equal counts in all three slots → "ground" wins by being checked first
+    // and the strict > comparison keeps it as the dominant. Counter is "air".
+    expect(pickWeakFace(units(10, 10, 10))).toBe("air");
+  });
+});
+
+describe("buildIntelReportServer", () => {
+  function tile(overrides: Partial<GameTile>): GameTile {
+    const now = new Date("2026-05-08T00:00:00Z");
+    return {
+      tileId: "0_0",
+      q: 0,
+      r: 0,
+      ownerId: "defender-1",
+      type: "military",
+      level: 0,
+      units: units(50, 25, 0),
+      armedDefenseSpellId: null,
+      neighborTileIds: [],
+      upgradeIds: [],
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    };
+  }
+
+  function player(overrides: Partial<GamePlayer>): GamePlayer {
+    const now = new Date("2026-05-08T00:00:00Z");
+    return {
+      userId: "defender-1",
+      displayName: "Test",
+      caste: "white",
+      turnsRemaining: 100,
+      turnsSpentTotal: 0,
+      phase: "play",
+      tilesExplored: 0,
+      shieldUntil: now,
+      shieldDropAtTurn: 0,
+      productionSpellsActive: [],
+      stats: { attacksWon: 0, attacksLost: 0, tilesHeld: 10, unitsAlive: 100 },
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    };
+  }
+
+  /**
+   * Minimal Firestore fake: collection(name).doc(id).get() returns the
+   * configured data. db.getAll(...refs) batches a list of refs.
+   */
+  function makeDb(args: {
+    tiles?: Record<string, GameTile>;
+    players?: Record<string, GamePlayer>;
+    artifactsByOwner?: Record<string, number>;
+  }): unknown {
+    const tiles = args.tiles ?? {};
+    const players = args.players ?? {};
+    const artifactsByOwner = args.artifactsByOwner ?? {};
+
+    interface DocRef {
+      __collection: string;
+      __id: string;
+      get: () => Promise<{ exists: boolean; data: () => unknown }>;
+    }
+    function makeDocRef(collection: string, id: string): DocRef {
+      return {
+        __collection: collection,
+        __id: id,
+        get: () => {
+          if (collection === "game_tiles") {
+            const t = tiles[id];
+            return Promise.resolve({
+              exists: !!t,
+              data: () => t,
+            });
+          }
+          if (collection === "game_players") {
+            const p = players[id];
+            return Promise.resolve({
+              exists: !!p,
+              data: () => p,
+            });
+          }
+          return Promise.resolve({ exists: false, data: () => undefined });
+        },
+      };
+    }
+
+    function makeArtifactQuery(ownerId: string) {
+      const count = artifactsByOwner[ownerId] ?? 0;
+      const docs = Array.from({ length: count }, (_, i) => ({
+        data: () => ({ id: `art-${i}` }),
+      }));
+      const q: { where: jest.Mock; get: jest.Mock; size: number } = {
+        where: jest.fn(() => q),
+        get: jest.fn(() => Promise.resolve({ docs, size: docs.length })),
+        size: docs.length,
+      };
+      return q;
+    }
+
+    let lastArtifactOwnerId: string | null = null;
+    const collection = jest.fn((name: string) => {
+      if (name === "game_artifacts") {
+        return {
+          where: (field: string, _op: string, value: string) => {
+            if (field === "ownerId") lastArtifactOwnerId = value;
+            return makeArtifactQuery(lastArtifactOwnerId ?? "");
+          },
+        };
+      }
+      return {
+        doc: (id: string) => makeDocRef(name, id),
+      };
+    });
+
+    const getAll = jest.fn((...refs: DocRef[]) => {
+      return Promise.all(refs.map((r) => r.get()));
+    });
+
+    return { collection, getAll };
+  }
+
+  it("scope=tile returns target unit/landType/armed-spell with no neighbors", async () => {
+    const db = makeDb({
+      tiles: {
+        "0_0": tile({
+          tileId: "0_0",
+          armedDefenseSpellId: "white-defense-sanctuary",
+        }),
+      },
+    });
+    const r = await buildIntelReportServer({
+      db: db as never,
+      targetTileId: "0_0",
+      scope: "tile",
+      source: "spell",
+      sourceId: "white-intel-watchers-vigil-t2",
+      capturedAtTurn: 200,
+    });
+    expect(r.targetTileId).toBe("0_0");
+    expect(r.target.armedDefenseSpellId).toBe("white-defense-sanctuary");
+    expect(r.target.units.ground).toBe(50);
+    expect(r.target.isolatedSpawn).toBe(false);
+    expect(r.neighbors).toBeUndefined();
+    expect(r.kingdomDefender).toBeUndefined();
+    expect(r.weakFace).toBeUndefined();
+  });
+
+  it("scope=ring populates neighbors (skipping non-existent ones)", async () => {
+    const db = makeDb({
+      tiles: {
+        "0_0": tile({ tileId: "0_0" }),
+        // Only one neighbor exists in the cache; the other 5 are unrevealed.
+        "1_0": tile({
+          tileId: "1_0",
+          q: 1,
+          r: 0,
+          ownerId: "defender-1",
+          type: "food",
+          units: units(0, 0, 0),
+        }),
+      },
+    });
+    const r = await buildIntelReportServer({
+      db: db as never,
+      targetTileId: "0_0",
+      scope: "ring",
+      source: "spell",
+      sourceId: "blue-intel-tide-of-whispers-t2",
+      capturedAtTurn: 200,
+    });
+    expect(r.neighbors).toBeDefined();
+    expect(r.neighbors).toHaveLength(1);
+    expect(r.neighbors?.[0].tileId).toBe("1_0");
+    expect(r.neighbors?.[0].landType).toBe("food");
+  });
+
+  it("scope=kingdom adds defender stats + artifact count", async () => {
+    const db = makeDb({
+      tiles: {
+        "0_0": tile({ tileId: "0_0", ownerId: "defender-1" }),
+      },
+      players: {
+        "defender-1": player({
+          stats: {
+            attacksWon: 0,
+            attacksLost: 0,
+            tilesHeld: 200,
+            unitsAlive: 1500,
+          },
+          productionSpellsActive: [
+            { spellId: "blue-prod-1", expiresAtTurn: 999 },
+          ],
+        }),
+      },
+      artifactsByOwner: { "defender-1": 3 },
+    });
+    const r = await buildIntelReportServer({
+      db: db as never,
+      targetTileId: "0_0",
+      scope: "kingdom",
+      source: "spell",
+      sourceId: "black-intel-vein-of-truth-t2",
+      capturedAtTurn: 200,
+    });
+    expect(r.kingdomDefender).toBeDefined();
+    expect(r.kingdomDefender?.tilesHeld).toBe(200);
+    expect(r.kingdomDefender?.unitsAlive).toBe(1500);
+    expect(r.kingdomDefender?.activeProductionSpellIds).toEqual(["blue-prod-1"]);
+    expect(r.kingdomDefender?.artifactCount).toBe(3);
+  });
+
+  it("scope=weak-face fills weakFace from defender unit composition", async () => {
+    const db = makeDb({
+      tiles: {
+        // Mostly air → counter is siege.
+        "0_0": tile({ tileId: "0_0", units: units(5, 5, 80) }),
+      },
+    });
+    const r = await buildIntelReportServer({
+      db: db as never,
+      targetTileId: "0_0",
+      scope: "weak-face",
+      source: "spell",
+      sourceId: "red-intel-forge-sight-t2",
+      capturedAtTurn: 200,
+    });
+    expect(r.weakFace).toBe("siege");
+  });
+
+  it("scope=kingdom+supply adds the supply graph", async () => {
+    const db = makeDb({
+      tiles: {
+        "0_0": tile({ tileId: "0_0", ownerId: "defender-1", type: "military" }),
+        "1_0": tile({
+          tileId: "1_0",
+          q: 1,
+          r: 0,
+          ownerId: "defender-1",
+          type: "military",
+        }),
+        "0_1": tile({
+          tileId: "0_1",
+          q: 0,
+          r: 1,
+          ownerId: "defender-1",
+          type: "food",
+        }),
+      },
+      players: {
+        "defender-1": player({ caste: "green" }),
+      },
+    });
+    const r = await buildIntelReportServer({
+      db: db as never,
+      targetTileId: "0_0",
+      scope: "kingdom+supply",
+      source: "spell",
+      sourceId: "green-intel-root-whisper-t2",
+      capturedAtTurn: 200,
+    });
+    expect(r.supply).toBeDefined();
+    expect(r.supply?.friendlyNeighbors).toHaveLength(2);
+    // Green: 1.5 caste mult × (1.0 military + 0.3 food) × 5% = +9.75% → 1.0975.
+    expect(r.supply?.supplyMultiplier).toBeCloseTo(1.0975, 3);
+  });
+
+  it("throws when the target tile does not exist", async () => {
+    const db = makeDb({});
+    await expect(
+      buildIntelReportServer({
+        db: db as never,
+        targetTileId: "missing",
+        scope: "tile",
+        source: "artifact",
+        sourceId: "x",
+        capturedAtTurn: 0,
+      })
+    ).rejects.toThrow(/Intel target tile not found/);
+  });
+});

--- a/__tests__/lib/game/spells-tier.test.ts
+++ b/__tests__/lib/game/spells-tier.test.ts
@@ -18,8 +18,11 @@ import {
 import type { Caste, SpellType } from "@/lib/game/types";
 
 describe("spell content", () => {
-  it("registers 75 spells (5 castes × 3 types × 5 tiers)", () => {
-    expect(ALL_SPELLS.length).toBe(75);
+  it("registers 75 tiered spells (5 castes × 3 types × 5 tiers) plus 5 single-tier intel spells", () => {
+    // 75 from defense/offense/production tier ladders + 1 intel spell per
+    // caste = 80.
+    expect(ALL_SPELLS.length).toBe(80);
+    expect(ALL_SPELLS.filter((s) => s.type === "intel").length).toBe(5);
   });
 
   it("spell ids are unique", () => {
@@ -27,7 +30,7 @@ describe("spell content", () => {
     expect(ids.size).toBe(ALL_SPELLS.length);
   });
 
-  it("every (caste, type) has exactly five tiers", () => {
+  it("every (caste, type) has exactly five tiers for the offense/defense/production trio", () => {
     const castes: Caste[] = ["white", "blue", "black", "red", "green"];
     const types: SpellType[] = ["defense", "offense", "production"];
     for (const c of castes) {
@@ -36,6 +39,16 @@ describe("spell content", () => {
         expect(tiers.length).toBe(5);
         expect(tiers.map((s) => s.tier)).toEqual([1, 2, 3, 4, 5]);
       }
+    }
+  });
+
+  it("each caste has exactly one intel spell, gated at 1500 tiles, with an intelScope set", () => {
+    const castes: Caste[] = ["white", "blue", "black", "red", "green"];
+    for (const c of castes) {
+      const intel = getSpellsForCasteAndType(c, "intel");
+      expect(intel.length).toBe(1);
+      expect(intel[0].minTilesRequired).toBe(1500);
+      expect(intel[0].intelScope).toBeDefined();
     }
   });
 

--- a/__tests__/lib/game/turn-report.test.ts
+++ b/__tests__/lib/game/turn-report.test.ts
@@ -165,6 +165,7 @@ describe("buildAttackReport", () => {
       attackerLosses: { ground: 23, siege: 0, air: 0 },
       defenderLosses: { ground: 41, siege: 0, air: 0 },
       underdogApplied: false,
+      supplyMultiplier: 1,
       rng: { attackerRoll: 1, defenderRoll: 1 },
       appliedSpells: { offenseId: null, defenseId: null },
     };

--- a/__tests__/lib/game/upgrades.test.ts
+++ b/__tests__/lib/game/upgrades.test.ts
@@ -28,21 +28,24 @@ import { newPlayer } from "@/lib/game/turns";
 import type { GamePlayer } from "@/lib/game/types";
 
 describe("upgrade content", () => {
-  it("registers exactly 90 upgrades (45 unit + 45 building)", () => {
-    expect(ALL_UPGRADES.length).toBe(90);
-    expect(ALL_UPGRADES.filter((u) => u.targetKind === "unit").length).toBe(45);
+  it("registers exactly 95 upgrades (45 unit + 45 building + 5 air-intel)", () => {
+    // Each caste gets a 4th 'intel' option on its air unit; 5 castes → 5 extra.
+    expect(ALL_UPGRADES.length).toBe(95);
+    expect(ALL_UPGRADES.filter((u) => u.targetKind === "unit").length).toBe(50);
     expect(ALL_UPGRADES.filter((u) => u.targetKind === "building").length).toBe(
       45
     );
+    expect(ALL_UPGRADES.filter((u) => u.intelPassive).length).toBe(5);
   });
 
-  it("provides exactly three options per target", () => {
+  it("non-air targets have exactly three options; air units have four", () => {
     const byTarget = new Map<string, number>();
     for (const u of ALL_UPGRADES) {
       byTarget.set(u.targetId, (byTarget.get(u.targetId) ?? 0) + 1);
     }
-    for (const [, count] of byTarget) {
-      expect(count).toBe(3);
+    for (const [targetId, count] of byTarget) {
+      const expected = targetId.includes("-air-") ? 4 : 3;
+      expect(count).toBe(expected);
     }
   });
 

--- a/app/api/game/artifact/use/route.ts
+++ b/app/api/game/artifact/use/route.ts
@@ -29,7 +29,10 @@ export async function POST(request: NextRequest) {
       artifactId: parsed.data.artifactId,
       targetTileId: parsed.data.targetTileId ?? null,
     });
-    return apiSuccess({ artifact: result.artifact });
+    return apiSuccess({
+      artifact: result.artifact,
+      ...(result.intelReport ? { intelReport: result.intelReport } : {}),
+    });
   } catch (error) {
     return mapGameError(error);
   }

--- a/app/api/game/explore/far/route.ts
+++ b/app/api/game/explore/far/route.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { farExpeditionExploreServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { gameContract } from "@/lib/api-schemas/game";
+
+// Pin the contract reference at module scope so scripts/check-route-contracts.js
+// detects this route as contract-bound. The Far Expedition body is optional
+// and empty, so there's nothing to parse — we just check it's well-formed.
+const farExpeditionBodySchema = gameContract.farExpedition.body;
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    // Optional body: tolerate missing / empty / "{}" payloads.
+    if (request.headers.get("content-length")) {
+      try {
+        const text = await request.text();
+        if (text.trim().length > 0) {
+          const parsed = farExpeditionBodySchema?.safeParse(JSON.parse(text));
+          if (parsed && !parsed.success) {
+            return apiError(
+              parsed.error.issues[0]?.message ?? "Invalid body",
+              400
+            );
+          }
+        }
+      } catch {
+        // Non-JSON body — ignore; the action takes no parameters.
+      }
+    }
+
+    const result = await farExpeditionExploreServer(user.uid);
+    return apiSuccess({
+      player: result.player,
+      tile: result.tile,
+      report: result.report,
+      targetEnemyTileId: result.targetEnemyTileId,
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/spy/route.ts
+++ b/app/api/game/spy/route.ts
@@ -7,7 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
-import { attackTileServer } from "@/lib/game/data-server";
+import { castIntelSpellServer } from "@/lib/game/data-server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { gameContract } from "@/lib/api-schemas/game";
 
@@ -19,25 +19,21 @@ export async function POST(request: NextRequest) {
     const bodyOrError = await parseRequestBody(request);
     if (bodyOrError instanceof NextResponse) return bodyOrError;
 
-    const parsed = gameContract.attack.body.safeParse(bodyOrError);
+    const parsed = gameContract.spy.body.safeParse(bodyOrError);
     if (!parsed.success) {
       return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
     }
 
-    const result = await attackTileServer({
-      attackerId: user.uid,
-      sourceTileId: parsed.data.sourceTileId,
-      targetTileId: parsed.data.targetTileId,
-      units: parsed.data.units,
-      offenseSpellId: parsed.data.offenseSpellId ?? null,
-    });
+    const result = await castIntelSpellServer(
+      user.uid,
+      parsed.data.spellId,
+      parsed.data.targetTileId
+    );
     return apiSuccess({
-      attack: result.attack,
-      attackerPlayer: result.attackerPlayer,
-      sourceTile: result.sourceTile,
-      targetTile: result.targetTile,
+      player: result.player,
       report: result.report,
-      ...(result.intelReport ? { intelReport: result.intelReport } : {}),
+      intelReport: result.intelReport,
+      detected: result.detected,
     });
   } catch (error) {
     return mapGameError(error);

--- a/app/game/_components/dashboard/DashboardView.tsx
+++ b/app/game/_components/dashboard/DashboardView.tsx
@@ -24,6 +24,8 @@ import { ArmyCard } from "./ArmyCard";
 import { ThreatCard } from "./ThreatCard";
 import { ShieldCard } from "./ShieldCard";
 import { ExploreFrontier } from "./ExploreFrontier";
+import { FarExpedition } from "./FarExpedition";
+import { SpyAction } from "./SpyAction";
 import { BulkDistribute } from "./BulkDistribute";
 import { BulkUnassign } from "./BulkUnassign";
 import { MiniMap } from "./MiniMap";
@@ -168,6 +170,24 @@ export function DashboardView({ player, data }: DashboardViewProps) {
                 progress={exploreProgress}
                 maxCount={Math.min(50, player.turnsRemaining)}
                 onExplore={() => handleFrontierExplore(exploreCount)}
+              />
+            )}
+
+            {player.phase === "play" && (
+              <FarExpedition
+                turnsRemaining={player.turnsRemaining}
+                onSuccess={() => window.location.reload()}
+              />
+            )}
+
+            {player.phase === "play" && player.caste && (
+              <SpyAction
+                caste={player.caste}
+                tilesHeld={player.stats.tilesHeld}
+                turnsRemaining={player.turnsRemaining}
+                onSuccess={() => {
+                  /* spy doesn't change tile state, no reload needed */
+                }}
               />
             )}
 

--- a/app/game/_components/dashboard/FarExpedition.tsx
+++ b/app/game/_components/dashboard/FarExpedition.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+
+// Mirrors FAR_EXPEDITION_TURN_COST in lib/game/data-server.ts. Hardcoded
+// here because the dashboard runs on the client and data-server.ts pulls
+// in firebase-admin.
+const FAR_EXPEDITION_TURN_COST = 2;
+
+interface FarExpeditionProps {
+  turnsRemaining: number;
+  // Called after a successful far-expedition so the dashboard can refresh.
+  onSuccess: () => void;
+}
+
+interface SuccessResult {
+  tileId: string;
+  enemyTileId: string;
+}
+
+/**
+ * Spend 2 turns to plant a tile next to a random enemy. The tile lands
+ * isolated (no friendly neighbors) so it takes the supply system's −15%
+ * defense floor until you grow tiles around it.
+ */
+export function FarExpedition({ turnsRemaining, onSuccess }: FarExpeditionProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<SuccessResult | null>(null);
+
+  const canAfford = turnsRemaining >= FAR_EXPEDITION_TURN_COST;
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/game/explore/far", { method: "POST" });
+      const body = await res.json();
+      if (!res.ok || !body?.success) {
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      setResult({
+        tileId: body.tile?.tileId ?? "",
+        enemyTileId: body.targetEnemyTileId ?? "",
+      });
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      id="far-expedition"
+      className="rounded-lg border-2 border-amber-300 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-900/10 p-4 scroll-mt-24"
+    >
+      <div className="flex items-baseline justify-between mb-2">
+        <h2 className="font-semibold">Far Expedition</h2>
+        <span className="text-xs text-neutral-500">
+          {FAR_EXPEDITION_TURN_COST} turns / tile
+        </span>
+      </div>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3 leading-relaxed">
+        Plant a forward base adjacent to a random enemy tile. The new tile lands
+        isolated — defense runs at the −15% supply floor until you grow friendly
+        neighbors around it. Use sparingly, but it can crack a sealed kingdom.
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          onClick={run}
+          disabled={busy || !canAfford}
+          className="px-5 py-2 bg-amber-500 text-white rounded-lg hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+        >
+          {busy ? "Launching expedition…" : "Launch expedition"}
+        </button>
+        <span className="text-xs text-neutral-500">
+          (you have {turnsRemaining} turn{turnsRemaining === 1 ? "" : "s"} available)
+        </span>
+      </div>
+      {result && (
+        <p className="mt-3 text-sm text-amber-700 dark:text-amber-300">
+          Landed at {result.tileId} beside enemy tile {result.enemyTileId}.
+        </p>
+      )}
+      {error && (
+        <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/app/game/_components/dashboard/SpyAction.tsx
+++ b/app/game/_components/dashboard/SpyAction.tsx
@@ -1,0 +1,166 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import { getSpellsForCasteAndType } from "@/lib/game/content";
+import type { Caste, IntelReport } from "@/lib/game/types";
+
+interface SpyActionProps {
+  caste: Caste;
+  tilesHeld: number;
+  turnsRemaining: number;
+  onSuccess: () => void;
+}
+
+/**
+ * Cast the caste's intel ("spy") spell on a target enemy tile. The threat
+ * box doesn't currently include a tile-picker UI, so this card takes a
+ * tileId text input — players will typically paste from the map.
+ */
+export function SpyAction({
+  caste,
+  tilesHeld,
+  turnsRemaining,
+  onSuccess,
+}: SpyActionProps) {
+  const intelSpell = useMemo(() => {
+    const all = getSpellsForCasteAndType(caste, "intel");
+    return all[0] ?? null;
+  }, [caste]);
+
+  const [targetTileId, setTargetTileId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<IntelReport | null>(null);
+  const [detected, setDetected] = useState(false);
+
+  if (!intelSpell) return null;
+
+  const tilesGateMet = tilesHeld >= intelSpell.minTilesRequired;
+  const canAfford = turnsRemaining >= intelSpell.turnCost;
+
+  async function run() {
+    if (!intelSpell || !targetTileId.trim()) return;
+    setBusy(true);
+    setError(null);
+    setReport(null);
+    setDetected(false);
+    try {
+      const res = await fetch("/api/game/spy", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          spellId: intelSpell.id,
+          targetTileId: targetTileId.trim(),
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body?.success) {
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      setReport(body.intelReport ?? null);
+      setDetected(Boolean(body.detected));
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      id="spy-action"
+      className="rounded-lg border-2 border-violet-300 dark:border-violet-800 bg-violet-50/50 dark:bg-violet-900/10 p-4 scroll-mt-24"
+    >
+      <div className="flex items-baseline justify-between mb-2">
+        <h2 className="font-semibold">Spy: {intelSpell.name}</h2>
+        <span className="text-xs text-neutral-500">
+          {intelSpell.turnCost} turns
+        </span>
+      </div>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3 leading-relaxed">
+        {intelSpell.description}
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="text-sm">
+          Target tile:{" "}
+          <input
+            type="text"
+            value={targetTileId}
+            onChange={(e) => setTargetTileId(e.target.value)}
+            placeholder="e.g. 12_-3"
+            disabled={busy}
+            className="w-32 px-2 py-1 ml-2 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
+          />
+        </label>
+        <button
+          onClick={run}
+          disabled={
+            busy || !targetTileId.trim() || !tilesGateMet || !canAfford
+          }
+          className="px-5 py-2 bg-violet-500 text-white rounded-lg hover:bg-violet-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+        >
+          {busy ? "Casting…" : "Cast spy"}
+        </button>
+        {!tilesGateMet && (
+          <span className="text-xs text-neutral-500">
+            Needs {intelSpell.minTilesRequired} tiles held (you have {tilesHeld})
+          </span>
+        )}
+      </div>
+      {error && (
+        <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+      {report && (
+        <div className="mt-3 text-xs space-y-2 text-neutral-700 dark:text-neutral-300 bg-violet-100/40 dark:bg-violet-950/30 rounded p-3">
+          <p>
+            <strong>Target {report.targetTileId}</strong> ({report.target.landType}
+            ) — units G{report.target.units.ground} / S{report.target.units.siege}
+            {" "}/ A{report.target.units.air}
+            {report.target.armedDefenseSpellId
+              ? ` · armed: ${report.target.armedDefenseSpellId}`
+              : ""}
+          </p>
+          {report.weakFace && (
+            <p>Forge Sight: lead with <strong>{report.weakFace}</strong>.</p>
+          )}
+          {report.neighbors && (
+            <p>
+              {report.neighbors.length} neighbor tile
+              {report.neighbors.length === 1 ? "" : "s"} revealed.
+            </p>
+          )}
+          {report.kingdomDefender && (
+            <p>
+              Kingdom: {report.kingdomDefender.tilesHeld} tiles ·{" "}
+              {report.kingdomDefender.unitsAlive} units alive ·{" "}
+              {report.kingdomDefender.artifactCount} unused artifacts
+              {report.kingdomDefender.activeProductionSpellIds.length > 0
+                ? ` · ${report.kingdomDefender.activeProductionSpellIds.length} production spell(s) active`
+                : ""}
+              .
+            </p>
+          )}
+          {report.supply && (
+            <p>
+              Supply ×{report.supply.supplyMultiplier.toFixed(2)} — backed by{" "}
+              {report.supply.friendlyNeighbors.length} friendly tile
+              {report.supply.friendlyNeighbors.length === 1 ? "" : "s"}.
+            </p>
+          )}
+          {detected && (
+            <p className="text-amber-700 dark:text-amber-300">
+              The defender felt the spy. Expect retaliation.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/game/spells/_lib/constants.ts
+++ b/app/game/spells/_lib/constants.ts
@@ -19,13 +19,16 @@ export const TIERS: Array<{ tier: 1 | 2 | 3 | 4 | 5; minTiles: number }> = [
 
 // Column order in the tier × type table. Defense first because that's the
 // only column with bulk-arm UX, and reading "what should I cast right now"
-// usually starts with "what's keeping me alive".
+// usually starts with "what's keeping me alive". Intel is excluded from this
+// table — there's only one intel spell per caste, surfaced from the
+// threat-box "Spy" card instead.
 export const TYPE_COLUMNS: SpellType[] = ["defense", "offense", "production"];
 
 export const TYPE_LABEL: Record<SpellType, string> = {
   defense: "Defense",
   offense: "Offense",
   production: "Production",
+  intel: "Intel",
 };
 
 export const RARITY_TEXT: Record<string, string> = {

--- a/app/game/tiles/[tileId]/page.tsx
+++ b/app/game/tiles/[tileId]/page.tsx
@@ -7,16 +7,24 @@
 "use client";
 
 import Link from "next/link";
-import { use, useCallback, useEffect, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { ALL_SPELLS } from "@/lib/game/content";
+import { computeSupplyMultiplier } from "@/lib/game/combat";
+import { ALL_SPELLS, UPGRADES_BY_ID } from "@/lib/game/content";
 import type {
+  Caste,
   GamePlayer,
   GameTile,
+  IntelReport,
+  LandType,
   MapTile,
   TurnReport,
 } from "@/lib/game/types";
-import { mergeTiles as mergeTilesIntoCache } from "@/lib/game/local-map-cache";
+import {
+  loadCachedMap,
+  mergeTiles as mergeTilesIntoCache,
+} from "@/lib/game/local-map-cache";
+import { neighbors as axialNeighbors, tileIdFromAxial } from "@/lib/game/world-gen";
 import {
   EnemyTilePanel,
   OwnTilePanel,
@@ -64,6 +72,15 @@ export default function TileDetailPage({
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [recentReports, setRecentReports] = useState<TurnReport[]>([]);
+  const [intelReport, setIntelReport] = useState<IntelReport | null>(null);
+  // Snapshot of border tiles + owner records from the localStorage map cache.
+  // Used to compute enemy supply readouts on the tile detail page (the
+  // dashboard fetches /api/game/map/me; we read from its cache instead of
+  // refetching on every tile-detail load).
+  const [borderTiles, setBorderTiles] = useState<MapTile[]>([]);
+  const [ownersByUserId, setOwnersByUserId] = useState<
+    Map<string, { caste: Caste | null; displayName: string }>
+  >(() => new Map());
 
   const refresh = useCallback(async () => {
     if (!user) {
@@ -93,6 +110,21 @@ export default function TileDetailPage({
       setTile(tileData.tile ?? null);
       setPlayer(playerData.player);
       setOwnedTiles(playerData.tiles ?? []);
+      // Pull cached enemy-border and owner snapshots from the dashboard's
+      // localStorage cache. Best-effort: if the cache is missing the relevant
+      // tiles, the supply readout simply won't render.
+      const cached = loadCachedMap(user.uid);
+      if (cached) {
+        setBorderTiles(cached.borderTiles);
+        setOwnersByUserId(
+          new Map(
+            cached.owners.map((o) => [
+              o.userId,
+              { caste: o.caste, displayName: o.displayName },
+            ])
+          )
+        );
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -178,6 +210,12 @@ export default function TileDetailPage({
             [...newOnes.slice().reverse(), ...prev].slice(0, 25)
           );
         }
+        // Both /api/game/spy and a Blue/Black-passive attack response can
+        // return an intelReport. Surface the most recent one until the next
+        // action overwrites it.
+        if (data.intelReport) {
+          setIntelReport(data.intelReport as IntelReport);
+        }
         setMessage(data.stoppedEarly ? `Stopped: ${data.stoppedEarly}` : "Done.");
         return data;
       } catch (e) {
@@ -188,6 +226,95 @@ export default function TileDetailPage({
     },
     [user]
   );
+
+  // Hooks must run on every render, before any conditional returns.
+  const isOwn = tile?.ownerId === user?.uid;
+  const myCaste = player?.caste ?? null;
+
+  // Lookup table covering every map tile we know about — own tiles and the
+  // border ring around our kingdom. Used by both supply readouts (own + enemy)
+  // and the Crow Network panel.
+  const mapById = useMemo(() => {
+    const m = new Map<string, MapTile>();
+    for (const t of ownedTiles) m.set(t.tileId, t);
+    for (const t of borderTiles) m.set(t.tileId, t);
+    return m;
+  }, [ownedTiles, borderTiles]);
+
+  // Friendly neighbors of `tile` from a given owner's perspective. Filters
+  // out unrevealed/unassigned tiles (they don't supply). Returns null when
+  // we don't know enough — caller renders nothing.
+  function friendlyNeighborsForOwner(
+    targetTile: GameTile | MapTile,
+    ownerId: string
+  ): Array<{ tileId: string; landType: LandType }> {
+    const out: Array<{ tileId: string; landType: LandType }> = [];
+    for (const n of axialNeighbors(targetTile.q, targetTile.r)) {
+      const id = tileIdFromAxial(n.q, n.r);
+      const t = mapById.get(id);
+      if (!t || t.ownerId !== ownerId) continue;
+      if (t.type === "unrevealed" || t.type === "unassigned") continue;
+      out.push({ tileId: id, landType: t.type });
+    }
+    return out;
+  }
+
+  const supplyInfo = useMemo(() => {
+    if (!tile) return null;
+    if (isOwn && myCaste) {
+      const friendly = friendlyNeighborsForOwner(tile, user?.uid ?? "");
+      const mult = computeSupplyMultiplier(myCaste, friendly);
+      return {
+        mult,
+        friendlyCount: friendly.length,
+        scope: "own" as const,
+        friendly,
+      };
+    }
+    // Enemy tile path: needs the defender's caste from the cached owner
+    // record AND a non-empty cached map. Skip cleanly if either is missing.
+    if (!isOwn && tile.ownerId) {
+      const ownerCaste = ownersByUserId.get(tile.ownerId)?.caste ?? null;
+      if (!ownerCaste) return null;
+      // If we have ZERO map data for the enemy tile's neighborhood, skip —
+      // an "isolated" calc on no data would mislead the player.
+      let known = 0;
+      for (const n of axialNeighbors(tile.q, tile.r)) {
+        if (mapById.has(tileIdFromAxial(n.q, n.r))) known++;
+      }
+      if (known === 0) return null;
+      const friendly = friendlyNeighborsForOwner(tile, tile.ownerId);
+      const mult = computeSupplyMultiplier(ownerCaste, friendly);
+      return {
+        mult,
+        friendlyCount: friendly.length,
+        scope: "enemy" as const,
+        friendly,
+        knownNeighbors: known,
+      };
+    }
+    return null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- friendlyNeighborsForOwner is stable per render
+  }, [tile, isOwn, myCaste, mapById, ownersByUserId, user?.uid]);
+
+  // Green Crow Network: while the player has Green caste + the
+  // green-air-eagle-scout intel upgrade active, AND we're viewing one of
+  // their own tiles that has air units stationed, show the supply network
+  // breakdown. The base supply readout above is shown for all own tiles;
+  // this panel additionally surfaces the per-tile breakdown of contributors.
+  const crowNetwork = useMemo(() => {
+    if (!tile || !player || !isOwn) return null;
+    if (player.caste !== "green") return null;
+    if (tile.units.air <= 0) return null;
+    const upgrades = player.activeUpgrades ?? {};
+    const airUpgradeId = upgrades["green-air-eagle-scout"];
+    if (!airUpgradeId) return null;
+    const def = UPGRADES_BY_ID.get(airUpgradeId);
+    if (def?.intelPassive !== "green-crow-network") return null;
+    const friendly = friendlyNeighborsForOwner(tile, user?.uid ?? "");
+    return { friendly };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- friendlyNeighborsForOwner is stable per render
+  }, [tile, player, isOwn, mapById, user?.uid]);
 
   if (authLoading || loading) {
     return (
@@ -209,8 +336,6 @@ export default function TileDetailPage({
     );
   }
 
-  const isOwn = tile.ownerId === user.uid;
-  const myCaste = player.caste;
   const myDefenseSpells = myCaste
     ? ALL_SPELLS.filter((s) => s.caste === myCaste && s.type === "defense")
     : [];
@@ -247,6 +372,21 @@ export default function TileDetailPage({
             label="Armed defense"
             value={tile.armedDefenseSpellId ?? "—"}
           />
+          {supplyInfo && (
+            <Stat
+              label={
+                supplyInfo.scope === "enemy" ? "Supply (est.)" : "Supply"
+              }
+              value={`×${supplyInfo.mult.toFixed(2)} (${supplyInfo.friendlyCount} friendly${
+                supplyInfo.scope === "enemy"
+                  ? `, ${supplyInfo.knownNeighbors}/6 visible`
+                  : ""
+              })`}
+            />
+          )}
+          {tile.isolatedSpawn && (
+            <Stat label="Status" value="Isolated spawn" />
+          )}
         </div>
 
         {isOwn ? (
@@ -282,6 +422,26 @@ export default function TileDetailPage({
                 offenseSpellId,
               })
             }
+            onSpy={(spellId) =>
+              callApi("/api/game/spy", {
+                spellId,
+                targetTileId: tile.tileId,
+              })
+            }
+          />
+        )}
+
+        {crowNetwork && (
+          <CrowNetworkPanel
+            tile={tile}
+            friendly={crowNetwork.friendly}
+          />
+        )}
+
+        {intelReport && (
+          <IntelReportPanel
+            report={intelReport}
+            onDismiss={() => setIntelReport(null)}
           />
         )}
 
@@ -297,6 +457,115 @@ const RARITY_TEXT: Record<string, string> = {
   epic: "text-purple-600 dark:text-purple-400",
   legendary: "text-amber-600 dark:text-amber-400",
 };
+
+function IntelReportPanel({
+  report,
+  onDismiss,
+}: {
+  report: IntelReport;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="mt-6 rounded-lg border-2 border-violet-300 dark:border-violet-800 bg-violet-50/50 dark:bg-violet-950/30 p-4 space-y-3 text-sm">
+      <div className="flex items-baseline justify-between">
+        <h3 className="font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">
+          Intel report
+        </h3>
+        <button
+          onClick={onDismiss}
+          className="text-xs text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+        >
+          Dismiss
+        </button>
+      </div>
+      <p className="text-neutral-700 dark:text-neutral-300">
+        <strong>Target {report.targetTileId}</strong> ({report.target.landType}
+        ) — units G{report.target.units.ground} / S{report.target.units.siege}{" "}
+        / A{report.target.units.air}
+        {report.target.armedDefenseSpellId
+          ? ` · armed: ${report.target.armedDefenseSpellId}`
+          : ""}
+      </p>
+      {report.weakFace && (
+        <p className="text-neutral-700 dark:text-neutral-300">
+          Forge Sight: lead with <strong>{report.weakFace}</strong>.
+        </p>
+      )}
+      {report.neighbors && report.neighbors.length > 0 && (
+        <div>
+          <div className="text-xs uppercase tracking-wide text-neutral-500 mb-1">
+            Neighbors
+          </div>
+          <ul className="space-y-1 text-xs font-mono">
+            {report.neighbors.map((n) => (
+              <li key={n.tileId}>
+                {n.tileId} — {n.landType} ·{" "}
+                {n.ownerId ? `owner ${n.ownerId.slice(0, 6)}…` : "unclaimed"}{" "}
+                · G{n.units.ground} S{n.units.siege} A{n.units.air}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {report.kingdomDefender && (
+        <p className="text-neutral-700 dark:text-neutral-300">
+          Kingdom: {report.kingdomDefender.tilesHeld} tiles ·{" "}
+          {report.kingdomDefender.unitsAlive} units alive ·{" "}
+          {report.kingdomDefender.artifactCount} unused artifacts
+          {report.kingdomDefender.activeProductionSpellIds.length > 0
+            ? ` · ${report.kingdomDefender.activeProductionSpellIds.length} production spell(s) active`
+            : ""}
+          .
+        </p>
+      )}
+      {report.supply && (
+        <p className="text-neutral-700 dark:text-neutral-300">
+          Supply ×{report.supply.supplyMultiplier.toFixed(2)} — backed by{" "}
+          {report.supply.friendlyNeighbors.length} friendly tile
+          {report.supply.friendlyNeighbors.length === 1 ? "" : "s"}.
+        </p>
+      )}
+      <p className="text-xs text-neutral-500">
+        Source: {report.source} · {report.sourceId} · turn{" "}
+        {report.capturedAtTurn}
+      </p>
+    </div>
+  );
+}
+
+function CrowNetworkPanel({
+  tile,
+  friendly,
+}: {
+  tile: GameTile;
+  friendly: ReadonlyArray<{ tileId: string; landType: LandType }>;
+}) {
+  return (
+    <div className="mt-6 rounded-lg border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/50 dark:bg-emerald-950/30 p-4 space-y-2 text-sm">
+      <h3 className="font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+        Crow Network — supply graph
+      </h3>
+      <p className="text-xs text-neutral-600 dark:text-neutral-400">
+        While {tile.units.air} air unit{tile.units.air === 1 ? "" : "s"} roost
+        at {tile.tileId}, this tile&apos;s 1-ring supply network is laid bare.
+      </p>
+      {friendly.length === 0 ? (
+        <p className="text-xs text-neutral-500">
+          No friendly tiles in the 1-ring — this tile is isolated. Air units
+          here are scouting empty sky.
+        </p>
+      ) : (
+        <ul className="space-y-1 text-xs font-mono">
+          {friendly.map((n) => (
+            <li key={n.tileId}>
+              {n.tileId} — {n.landType}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 function ReportLog({ reports }: { reports: TurnReport[] }) {
   if (reports.length === 0) return null;

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -186,6 +186,7 @@ export function EnemyTilePanel({
   ownedTiles,
   busy,
   onAttack,
+  onSpy,
 }: {
   tile: MapTile;
   player: GamePlayer;
@@ -196,6 +197,9 @@ export function EnemyTilePanel({
     units: UnitStack,
     offenseSpellId: string | null
   ) => void;
+  // Optional: when present, renders a Spy section that casts the player's
+  // caste intel spell on this tile. Wires straight to /api/game/spy.
+  onSpy?: (spellId: string) => void;
 }) {
   const targetBorders = new Set(neighborTileIds(tile.q, tile.r));
   const myBorders = ownedTiles.filter((t) => targetBorders.has(t.tileId));
@@ -203,6 +207,17 @@ export function EnemyTilePanel({
   const offenseSpells = myCaste
     ? ALL_SPELLS.filter((s) => s.caste === myCaste && s.type === "offense")
     : [];
+  const intelSpell = myCaste
+    ? ALL_SPELLS.find((s) => s.caste === myCaste && s.type === "intel")
+    : null;
+  const intelTilesGateMet =
+    intelSpell !== undefined && intelSpell !== null
+      ? player.stats.tilesHeld >= intelSpell.minTilesRequired
+      : false;
+  const intelTurnsAffordable =
+    intelSpell !== undefined && intelSpell !== null
+      ? player.turnsRemaining >= intelSpell.turnCost
+      : false;
 
   const [sourceTileId, setSourceTileId] = useState(myBorders[0]?.tileId ?? "");
   const [ground, setGround] = useState(0);
@@ -226,88 +241,124 @@ export function EnemyTilePanel({
     player.phase === "play" &&
     player.turnsRemaining >= 1 + (offenseSpellId ? 5 : 0);
 
+  const spySection = onSpy && intelSpell ? (
+    <div className="rounded-lg border border-violet-200 dark:border-violet-900 bg-violet-50/50 dark:bg-violet-950/20 p-4 space-y-2">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">
+        Spy: {intelSpell.name}{" "}
+        <span className="text-neutral-400 normal-case font-normal">
+          — {intelSpell.turnCost} turns
+        </span>
+      </h2>
+      <p className="text-xs text-neutral-600 dark:text-neutral-400 leading-relaxed">
+        {intelSpell.description}
+      </p>
+      <button
+        onClick={() => onSpy(intelSpell.id)}
+        disabled={busy || !intelTilesGateMet || !intelTurnsAffordable}
+        className="px-4 py-2 bg-violet-600 text-white rounded-lg hover:bg-violet-500 transition-colors disabled:opacity-50 text-sm font-medium"
+      >
+        {busy ? "Casting…" : "Cast spy"}
+      </button>
+      {!intelTilesGateMet && (
+        <p className="text-xs text-neutral-500">
+          Needs {intelSpell.minTilesRequired} tiles held (you have{" "}
+          {player.stats.tilesHeld}).
+        </p>
+      )}
+    </div>
+  ) : null;
+
   if (myBorders.length === 0) {
     return (
-      <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-6 text-center text-sm text-neutral-500">
-        None of your tiles border this enemy tile, so you can&apos;t attack it.
+      <div className="space-y-4">
+        <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-6 text-center text-sm text-neutral-500">
+          None of your tiles border this enemy tile, so you can&apos;t attack
+          it.
+          {onSpy && intelSpell ? " You can still spy on it from anywhere." : ""}
+        </div>
+        {spySection}
       </div>
     );
   }
 
   return (
-    <div className="space-y-3">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-500">
-        Launch attack{" "}
-        <span className="text-neutral-400 normal-case font-normal">
-          — Air ▶ Ground ▶ Siege ▶ Air. 1 turn (+5 with spell).
-        </span>
-      </h2>
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+          Launch attack{" "}
+          <span className="text-neutral-400 normal-case font-normal">
+            — Air ▶ Ground ▶ Siege ▶ Air. 1 turn (+5 with spell).
+          </span>
+        </h2>
 
-      <label className="block text-sm font-medium">
-        Source tile
-        <select
-          value={sourceTileId}
-          onChange={(e) => setSourceTileId(e.target.value)}
-          className="mt-1 block w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+        <label className="block text-sm font-medium">
+          Source tile
+          <select
+            value={sourceTileId}
+            onChange={(e) => setSourceTileId(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+          >
+            {myBorders.map((t) => (
+              <option key={t.tileId} value={t.tileId}>
+                {t.tileId} — G{t.units.ground} S{t.units.siege} A{t.units.air}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="grid grid-cols-3 gap-3">
+          <UnitInput
+            label={`Ground / ${source?.units.ground ?? 0}`}
+            value={ground}
+            max={source?.units.ground ?? 0}
+            onChange={setGround}
+          />
+          <UnitInput
+            label={`Siege / ${source?.units.siege ?? 0}`}
+            value={siege}
+            max={source?.units.siege ?? 0}
+            onChange={setSiege}
+          />
+          <UnitInput
+            label={`Air / ${source?.units.air ?? 0}`}
+            value={air}
+            max={source?.units.air ?? 0}
+            onChange={setAir}
+          />
+        </div>
+
+        <label className="block text-sm font-medium">
+          Offense spell (optional, +5 turns)
+          <select
+            value={offenseSpellId}
+            onChange={(e) => setOffenseSpellId(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+          >
+            <option value="">— none —</option>
+            {offenseSpells.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <button
+          onClick={() =>
+            onAttack(
+              sourceTileId,
+              { ground, siege, air },
+              offenseSpellId || null
+            )
+          }
+          disabled={busy || !canAttack}
+          className="w-full px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors disabled:opacity-50"
         >
-          {myBorders.map((t) => (
-            <option key={t.tileId} value={t.tileId}>
-              {t.tileId} — G{t.units.ground} S{t.units.siege} A{t.units.air}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      <div className="grid grid-cols-3 gap-3">
-        <UnitInput
-          label={`Ground / ${source?.units.ground ?? 0}`}
-          value={ground}
-          max={source?.units.ground ?? 0}
-          onChange={setGround}
-        />
-        <UnitInput
-          label={`Siege / ${source?.units.siege ?? 0}`}
-          value={siege}
-          max={source?.units.siege ?? 0}
-          onChange={setSiege}
-        />
-        <UnitInput
-          label={`Air / ${source?.units.air ?? 0}`}
-          value={air}
-          max={source?.units.air ?? 0}
-          onChange={setAir}
-        />
+          {busy ? "Resolving…" : `Send ${sentTotal} units (cost ${1 + (offenseSpellId ? 5 : 0)} turns)`}
+        </button>
       </div>
 
-      <label className="block text-sm font-medium">
-        Offense spell (optional, +5 turns)
-        <select
-          value={offenseSpellId}
-          onChange={(e) => setOffenseSpellId(e.target.value)}
-          className="mt-1 block w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
-        >
-          <option value="">— none —</option>
-          {offenseSpells.map((s) => (
-            <option key={s.id} value={s.id}>
-              {s.name}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      <button
-        onClick={() =>
-          onAttack(
-            sourceTileId,
-            { ground, siege, air },
-            offenseSpellId || null
-          )
-        }
-        disabled={busy || !canAttack}
-        className="w-full px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-500 transition-colors disabled:opacity-50"
-      >
-        {busy ? "Resolving…" : `Send ${sentTotal} units (cost ${1 + (offenseSpellId ? 5 : 0)} turns)`}
-      </button>
+      {spySection}
     </div>
   );
 }

--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -594,6 +594,39 @@ export const gameContract = c.router(
       },
       metadata: { errorCodes: ["UNAUTHORIZED", "SERVER_ERROR"] as const },
     },
+    farExpedition: {
+      method: "POST",
+      path: "/api/game/explore/far",
+      summary:
+        "Spend 2 turns to plant a tile adjacent to a random enemy tile (Far Expedition).",
+      body: z.object({}).optional(),
+      responses: {
+        200: ActionOkResponse.extend({
+          targetEnemyTileId: z.string(),
+        }),
+        ...baseErrorResponses,
+      },
+      metadata: { errorCodes: ["UNAUTHORIZED", "SERVER_ERROR"] as const },
+    },
+    spy: {
+      method: "POST",
+      path: "/api/game/spy",
+      summary: "Cast an intel ('spy') spell on an enemy tile.",
+      body: z.object({
+        spellId: z.string().min(1),
+        targetTileId: z.string().min(1),
+      }),
+      responses: {
+        200: ActionOkResponse.extend({
+          intelReport: z.object({}).passthrough(),
+          detected: z.boolean(),
+        }),
+        ...actionErrorResponses,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "VALIDATION_ERROR", "SERVER_ERROR"] as const,
+      },
+    },
     exploreBulk: {
       method: "POST",
       path: "/api/game/explore/bulk",
@@ -662,6 +695,7 @@ export const gameContract = c.router(
           sourceTile: GameTileSchema,
           targetTile: GameTileSchema,
           report: TurnReportSchema,
+          intelReport: z.object({}).passthrough().optional(),
         }),
         ...actionErrorResponses,
       },
@@ -678,6 +712,7 @@ export const gameContract = c.router(
         200: z.object({
           success: z.literal(true),
           artifact: GameArtifactSchema,
+          intelReport: z.object({}).passthrough().optional(),
         }),
         ...actionErrorResponses,
       },

--- a/lib/game/api-error-map.ts
+++ b/lib/game/api-error-map.ts
@@ -21,6 +21,7 @@ import {
   GameInvalidPhaseError,
   GameInvalidSpellError,
   GameNameTakenError,
+  GameNoEnemyKingdomsError,
   GameNoUnrevealedTilesError,
   GameNotAdjacentError,
   GamePlayerAlreadyExistsError,
@@ -71,6 +72,7 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameUnitCapExceededError ||
     error instanceof GameTileTypeError ||
     error instanceof GameFrontierExhaustedError ||
+    error instanceof GameNoEnemyKingdomsError ||
     error instanceof GameArtifactAlreadyUsedError ||
     error instanceof GameNameTakenError ||
     error instanceof UpgradeAlreadyActiveError ||

--- a/lib/game/combat.ts
+++ b/lib/game/combat.ts
@@ -7,6 +7,7 @@
 import {
   BUILDINGS_BY_ID,
   SPELLS_BY_ID,
+  UPGRADES_BY_ID,
   getCasteProfile,
   getUnitForCasteAndType,
 } from "./content";
@@ -16,6 +17,7 @@ import {
   magicMultiplierBonusFromUpgrades,
 } from "./upgrades";
 import type {
+  AirIntelPassive,
   AttackOutcome,
   Caste,
   CombatAttackerInput,
@@ -23,6 +25,7 @@ import type {
   CombatResult,
   CombatTileInput,
   LandType,
+  SpellTier,
   UnitStack,
   UnitType,
 } from "./types";
@@ -56,6 +59,19 @@ const UNDERDOG_SIZE_RATIO = 0.5;
 const UNDERDOG_DEFENSE_BONUS = 0.25;
 const RNG_LOWER = 0.9;
 const RNG_RANGE = 0.2;
+
+// Supply: each friendly neighbor contributes 5% × type weight × caste mult,
+// then clamped between the isolation floor and the cap.
+const SUPPLY_PER_WEIGHT = 0.05;
+const SUPPLY_ISOLATION_FLOOR = 0.85;
+const SUPPLY_MAX = 1.5;
+const SUPPLY_TYPE_WEIGHTS: Record<LandType, number> = {
+  unrevealed: 0,
+  unassigned: 0,
+  military: 1.0,
+  magic: 0.6,
+  food: 0.3,
+};
 
 export function magicMultiplier(
   magicLandCount: number,
@@ -196,6 +212,61 @@ function compositionPower(
   return total;
 }
 
+// Forge Scouts (Red air-intel passive): +5% offense when attacker air ≥
+// defender air. Stacks multiplicatively with offense spell contribution.
+const FORGE_SCOUTS_BONUS = 0.05;
+
+// Defender's heaviest unit type → attacker's best counter under the
+// air→ground→siege→air rock-paper-scissors. Mirrors lib/game/intel.ts.
+const RPS_COUNTERS: Record<UnitType, UnitType> = {
+  ground: "air",
+  siege: "ground",
+  air: "siege",
+};
+
+function findActiveAirIntelPassive(
+  attackerCaste: Caste,
+  attackerUpgrades: Record<string, string>
+): AirIntelPassive | null {
+  const airTargetId = `${attackerCaste}-air-`;
+  for (const [targetId, upgradeId] of Object.entries(attackerUpgrades)) {
+    if (!targetId.startsWith(airTargetId)) continue;
+    const def = UPGRADES_BY_ID.get(upgradeId);
+    if (def?.intelPassive) return def.intelPassive;
+  }
+  return null;
+}
+
+function pickWeakFaceFromUnits(units: UnitStack): UnitType | undefined {
+  let max = 0;
+  let dominant: UnitType | undefined;
+  for (const t of UNIT_TYPES) {
+    if (units[t] > max) {
+      max = units[t];
+      dominant = t;
+    }
+  }
+  return dominant ? RPS_COUNTERS[dominant] : undefined;
+}
+
+// Defensive supply multiplier from friendly neighbors. Empty array → -15% floor.
+// Caste profile decides how aggressively neighbor weight stacks: Green 1.5×,
+// Blue 0.75×, etc.
+export function computeSupplyMultiplier(
+  caste: Caste,
+  friendlyNeighbors: ReadonlyArray<{ landType: LandType }>
+): number {
+  if (friendlyNeighbors.length === 0) return SUPPLY_ISOLATION_FLOOR;
+  let typeWeight = 0;
+  for (const n of friendlyNeighbors) {
+    typeWeight += SUPPLY_TYPE_WEIGHTS[n.landType] ?? 0;
+  }
+  const rawSupply = SUPPLY_PER_WEIGHT * typeWeight;
+  const casteBonus = getCasteProfile(caste).supplyMultiplier;
+  const supplyMult = 1.0 + rawSupply * casteBonus;
+  return Math.min(SUPPLY_MAX, Math.max(SUPPLY_ISOLATION_FLOOR, supplyMult));
+}
+
 function spellContribution(
   spellId: string | null,
   expectedType: "offense" | "defense",
@@ -243,6 +314,7 @@ export function resolveAttack(
       attackerLosses: emptyStack(),
       defenderLosses: emptyStack(),
       underdogApplied: false,
+      supplyMultiplier: 1,
       rng: { attackerRoll: 0, defenderRoll: 0 },
       appliedSpells,
     };
@@ -250,6 +322,11 @@ export function resolveAttack(
 
   const attackerUpgrades = attacker.activeUpgrades ?? {};
   const defenderUpgrades = defender.activeUpgrades ?? {};
+
+  const airIntelPassive = findActiveAirIntelPassive(
+    attacker.caste,
+    attackerUpgrades
+  );
 
   let attackPower = compositionPower(
     deployed,
@@ -273,6 +350,22 @@ export function resolveAttack(
     attacker.magicLandCount,
     attackerUpgrades
   );
+
+  // Red Forge Scouts: +5% offense when attacker air ≥ defender air.
+  let forgeScoutsBonusApplied = false;
+  if (
+    airIntelPassive === "red-forge-scouts" &&
+    deployed.air >= defender.unitsOnTile.air
+  ) {
+    attackPower *= 1 + FORGE_SCOUTS_BONUS;
+    forgeScoutsBonusApplied = true;
+  }
+
+  // Active intel effects (Red Forge Sight spell adds an offense bonus
+  // pre-resolved by the caller and passed in as a number).
+  if (attacker.intelOffenseBonus && attacker.intelOffenseBonus > 0) {
+    attackPower *= 1 + attacker.intelOffenseBonus;
+  }
   defensePower += spellContribution(
     defender.armedDefenseSpellId,
     "defense",
@@ -280,6 +373,19 @@ export function resolveAttack(
     defender.magicLandCount,
     defenderUpgrades
   );
+
+  // Supply: scale defense by how cohesive the defender's territory is around
+  // this tile. Skipped when callers don't supply neighbor info (legacy/tests).
+  let supplyMult = 1;
+  if (tile.friendlyNeighbors !== undefined) {
+    supplyMult = computeSupplyMultiplier(defender.caste, tile.friendlyNeighbors);
+    defensePower *= supplyMult;
+  }
+
+  // Alert-vs-caster intel effects (Black Vein of Truth, Green Root Whisper).
+  if (defender.intelDefenseBonus && defender.intelDefenseBonus > 0) {
+    defensePower *= 1 + defender.intelDefenseBonus;
+  }
 
   let underdogApplied = false;
   if (
@@ -316,6 +422,26 @@ export function resolveAttack(
       ? { ...defender.unitsOnTile }
       : applyLossFraction(defender.unitsOnTile, defenderLossFrac);
 
+  let airIntel: CombatResult["airIntel"];
+  if (airIntelPassive) {
+    airIntel = { sourcePassive: airIntelPassive };
+    if (airIntelPassive === "white-hawks-eye" && deployed.air >= 1) {
+      const tier = defenderSpellTier(defender.armedDefenseSpellId);
+      if (tier !== null) airIntel.defenseSpellTier = tier;
+    }
+    if (airIntelPassive === "red-forge-scouts") {
+      airIntel.forgeScoutsBonusApplied = forgeScoutsBonusApplied;
+      if (deployed.air >= defender.unitsOnTile.air) {
+        const wf = pickWeakFaceFromUnits(defender.unitsOnTile);
+        if (wf) airIntel.weakFace = wf;
+      }
+    }
+    // blue-sky-reader, black-crowfeast, green-crow-network: their reveals
+    // need state outside the combat function (neighbor tile data, recruit
+    // queue, kingdom-wide visibility) — surfaced by the attack server when
+    // it stitches the post-resolve report.
+  }
+
   return {
     outcome,
     unitsDeployed: deployed,
@@ -325,7 +451,15 @@ export function resolveAttack(
     attackerLosses,
     defenderLosses,
     underdogApplied,
+    supplyMultiplier: supplyMult,
     rng: { attackerRoll, defenderRoll },
     appliedSpells,
+    ...(airIntel ? { airIntel } : {}),
   };
+}
+
+function defenderSpellTier(spellId: string | null): SpellTier | null {
+  if (!spellId) return null;
+  const spell = SPELLS_BY_ID.get(spellId);
+  return spell ? spell.tier : null;
 }

--- a/lib/game/content/artifacts/common.ts
+++ b/lib/game/content/artifacts/common.ts
@@ -179,4 +179,16 @@ export const COMMON_ARTIFACTS: ArtifactDefinition[] = [
     flavorOnFind:
       "Hanging from a pole in an empty field. The crows give it a wide berth.",
   },
+  {
+    id: "common-whispered-map",
+    name: "Whispered Map",
+    rarity: "common",
+    type: "intel",
+    intelDepth: "tile",
+    baseStrength: 0,
+    description:
+      "A square of cured leather that re-draws itself when held over a place. Reveals the units, armed spell, and land type on a single enemy tile.",
+    flavorOnFind:
+      "It rolls open in your hand without prompting. The lines of ink seem damp; they dry into the shape of a place you have never been.",
+  },
 ];

--- a/lib/game/content/artifacts/epic.ts
+++ b/lib/game/content/artifacts/epic.ts
@@ -79,4 +79,16 @@ export const EPIC_ARTIFACTS: ArtifactDefinition[] = [
     flavorOnFind:
       "Wrapped in oiled cloth, hanging from a peg in a granary that no one has used for forty years. The grain inside is fresh.",
   },
+  {
+    id: "epic-black-mirror",
+    name: "Black Mirror",
+    rarity: "epic",
+    type: "intel",
+    intelDepth: "kingdom",
+    baseStrength: 0,
+    description:
+      "A polished disc of black volcanic glass. Reveals the target tile and a kingdom-wide audit of its owner — army, magic lands, active spells, artifact count.",
+    flavorOnFind:
+      "It rests face-down on a bare stone table in a room with no door. Turning it over, you see a face that is not yours, and a kingdom that is not yet yours.",
+  },
 ];

--- a/lib/game/content/artifacts/rare.ts
+++ b/lib/game/content/artifacts/rare.ts
@@ -131,4 +131,16 @@ export const RARE_ARTIFACTS: ArtifactDefinition[] = [
     flavorOnFind:
       "An old soldier ties it around the neck of your captain's horse and slips off into the trees.",
   },
+  {
+    id: "rare-crystal-lens",
+    name: "Crystal Lens",
+    rarity: "rare",
+    type: "intel",
+    intelDepth: "ring",
+    baseStrength: 0,
+    description:
+      "A faceted lens that draws nearby places into focus. Reveals an enemy tile and all six surrounding tiles — units, types, owners.",
+    flavorOnFind:
+      "It rests on a velvet cloth in an empty inn. Looking through it, you see the road outside, and also the road three valleys over.",
+  },
 ];

--- a/lib/game/content/castes.ts
+++ b/lib/game/content/castes.ts
@@ -9,36 +9,46 @@ import type { Caste, CasteProfile } from "../types";
 // MTG-inspired asymmetric balance. Sum of unitTypeBonuses ≈ 3.0 and sum of
 // spellTypeBonuses ≈ 3.15 across each row, so totals stay close while flavor
 // differs. Tile-capacity multiplier is the only non-combat lever.
+//
+// supplyMultiplier scales each caste's payoff for clustering tiles. Green/White
+// lean concentrated (held-line / long-defense lore); Blue/Black are happy
+// spread out (patient tide / cost-paid-forward). Isolated tiles always get
+// the -15% floor regardless of caste.
 export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
   white: {
     caste: "white",
     tileCapacityMultiplier: 1.0,
     unitTypeBonuses: { ground: 1.2, siege: 0.9, air: 1.0 },
-    spellTypeBonuses: { defense: 1.3, offense: 0.85, production: 1.0 },
+    spellTypeBonuses: { defense: 1.3, offense: 0.85, production: 1.0, intel: 1.0 },
+    supplyMultiplier: 1.25,
   },
   blue: {
     caste: "blue",
     tileCapacityMultiplier: 0.9,
     unitTypeBonuses: { ground: 0.95, siege: 0.95, air: 1.2 },
-    spellTypeBonuses: { defense: 0.95, offense: 0.95, production: 1.3 },
+    spellTypeBonuses: { defense: 0.95, offense: 0.95, production: 1.3, intel: 1.2 },
+    supplyMultiplier: 0.75,
   },
   black: {
     caste: "black",
     tileCapacityMultiplier: 1.0,
     unitTypeBonuses: { ground: 1.05, siege: 1.05, air: 1.05 },
-    spellTypeBonuses: { defense: 0.9, offense: 1.3, production: 0.9 },
+    spellTypeBonuses: { defense: 0.9, offense: 1.3, production: 0.9, intel: 1.0 },
+    supplyMultiplier: 0.5,
   },
   red: {
     caste: "red",
     tileCapacityMultiplier: 1.0,
     unitTypeBonuses: { ground: 1.0, siege: 1.2, air: 1.0 },
-    spellTypeBonuses: { defense: 0.85, offense: 1.3, production: 0.95 },
+    spellTypeBonuses: { defense: 0.85, offense: 1.3, production: 0.95, intel: 0.9 },
+    supplyMultiplier: 1.0,
   },
   green: {
     caste: "green",
     tileCapacityMultiplier: 1.2,
     unitTypeBonuses: { ground: 1.2, siege: 0.95, air: 0.95 },
-    spellTypeBonuses: { defense: 1.0, offense: 0.95, production: 1.1 },
+    spellTypeBonuses: { defense: 1.0, offense: 0.95, production: 1.1, intel: 1.3 },
+    supplyMultiplier: 1.5,
   },
 };
 

--- a/lib/game/content/index.ts
+++ b/lib/game/content/index.ts
@@ -36,18 +36,23 @@ import { WHITE_GROUND_UNIT } from "./units/white/ground";
 import { WHITE_SIEGE_UNIT } from "./units/white/siege";
 
 import { BLACK_DEFENSE_SPELLS } from "./spells/black/defense";
+import { BLACK_INTEL_SPELLS } from "./spells/black/intel";
 import { BLACK_OFFENSE_SPELLS } from "./spells/black/offense";
 import { BLACK_PRODUCTION_SPELLS } from "./spells/black/production";
 import { BLUE_DEFENSE_SPELLS } from "./spells/blue/defense";
+import { BLUE_INTEL_SPELLS } from "./spells/blue/intel";
 import { BLUE_OFFENSE_SPELLS } from "./spells/blue/offense";
 import { BLUE_PRODUCTION_SPELLS } from "./spells/blue/production";
 import { GREEN_DEFENSE_SPELLS } from "./spells/green/defense";
+import { GREEN_INTEL_SPELLS } from "./spells/green/intel";
 import { GREEN_OFFENSE_SPELLS } from "./spells/green/offense";
 import { GREEN_PRODUCTION_SPELLS } from "./spells/green/production";
 import { RED_DEFENSE_SPELLS } from "./spells/red/defense";
+import { RED_INTEL_SPELLS } from "./spells/red/intel";
 import { RED_OFFENSE_SPELLS } from "./spells/red/offense";
 import { RED_PRODUCTION_SPELLS } from "./spells/red/production";
 import { WHITE_DEFENSE_SPELLS } from "./spells/white/defense";
+import { WHITE_INTEL_SPELLS } from "./spells/white/intel";
 import { WHITE_OFFENSE_SPELLS } from "./spells/white/offense";
 import { WHITE_PRODUCTION_SPELLS } from "./spells/white/production";
 
@@ -66,10 +71,15 @@ export const ALL_UNITS: UnitDefinition[] = [
 
 export const ALL_SPELLS: SpellDefinition[] = [
   ...WHITE_DEFENSE_SPELLS, ...WHITE_OFFENSE_SPELLS, ...WHITE_PRODUCTION_SPELLS,
+  ...WHITE_INTEL_SPELLS,
   ...BLUE_DEFENSE_SPELLS, ...BLUE_OFFENSE_SPELLS, ...BLUE_PRODUCTION_SPELLS,
+  ...BLUE_INTEL_SPELLS,
   ...BLACK_DEFENSE_SPELLS, ...BLACK_OFFENSE_SPELLS, ...BLACK_PRODUCTION_SPELLS,
+  ...BLACK_INTEL_SPELLS,
   ...RED_DEFENSE_SPELLS, ...RED_OFFENSE_SPELLS, ...RED_PRODUCTION_SPELLS,
+  ...RED_INTEL_SPELLS,
   ...GREEN_DEFENSE_SPELLS, ...GREEN_OFFENSE_SPELLS, ...GREEN_PRODUCTION_SPELLS,
+  ...GREEN_INTEL_SPELLS,
 ];
 
 export const ALL_BUILDINGS: BuildingDefinition[] = BUILDINGS;

--- a/lib/game/content/spells/black/intel.ts
+++ b/lib/game/content/spells/black/intel.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Black pays in blood for the deepest read — a kingdom-wide audit, but the
+// caster sacrifices an air unit at cast time. The defender feels the spy
+// (alerted, +20% defense vs caster for 5 turns) — handled in the cast server.
+export const BLACK_INTEL_SPELLS: SpellDefinition[] = [
+  {
+    id: "black-intel-vein-of-truth-t2",
+    caste: "black",
+    type: "intel",
+    name: "Vein of Truth",
+    baseStrength: 0,
+    description:
+      "An offering opens a vein between two minds. Reveals the target tile and a kingdom-wide audit of its owner. Costs one air unit at cast time. The defender is alerted.",
+    tier: 2,
+    minTilesRequired: 1500,
+    turnCost: 8,
+    intelScope: "kingdom",
+  },
+];

--- a/lib/game/content/spells/blue/intel.ts
+++ b/lib/game/content/spells/blue/intel.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Blue's spy spreads through tide and rumor — it sees a wider ring but the
+// tide takes its time. Patient.
+export const BLUE_INTEL_SPELLS: SpellDefinition[] = [
+  {
+    id: "blue-intel-tide-of-whispers-t2",
+    caste: "blue",
+    type: "intel",
+    name: "Tide of Whispers",
+    baseStrength: 0,
+    description:
+      "Whispers carried on a slow tide. Reveals the target tile and all six neighbors — units, owners, land types. No defense-spell information.",
+    tier: 2,
+    minTilesRequired: 1500,
+    turnCost: 8,
+    intelScope: "ring",
+  },
+];

--- a/lib/game/content/spells/green/intel.ts
+++ b/lib/game/content/spells/green/intel.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Green sees the supply graph — uniquely Green, since Green's identity is
+// the held line. Defender alerted on cast.
+export const GREEN_INTEL_SPELLS: SpellDefinition[] = [
+  {
+    id: "green-intel-root-whisper-t2",
+    caste: "green",
+    type: "intel",
+    name: "Root Whisper",
+    baseStrength: 0,
+    description:
+      "Roots speak under stone. Reveals the target tile and its full supply network — every friendly neighbor that contributes, with land type — plus the defender's effective supply multiplier. The defender is alerted.",
+    tier: 2,
+    minTilesRequired: 1500,
+    turnCost: 8,
+    intelScope: "kingdom+supply",
+  },
+];

--- a/lib/game/content/spells/red/intel.ts
+++ b/lib/game/content/spells/red/intel.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Red's spy is a forge-scout: it reads a tile for its weakest face. The
+// reveal is narrow, but the caster gets a small offense bonus on follow-up.
+export const RED_INTEL_SPELLS: SpellDefinition[] = [
+  {
+    id: "red-intel-forge-sight-t2",
+    caste: "red",
+    type: "intel",
+    name: "Forge Sight",
+    baseStrength: 0,
+    description:
+      "A red lens reads the target's seam. Reveals the unit type the attacker should lead with, and tags the tile for +10% offense against it for 5 turns.",
+    tier: 2,
+    minTilesRequired: 1500,
+    turnCost: 8,
+    intelScope: "weak-face",
+  },
+];

--- a/lib/game/content/spells/white/intel.ts
+++ b/lib/game/content/spells/white/intel.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// White's spy is a single-target lens — pinpoint, never misses, never spreads.
+// "Long defense" lore: White watches its own walls, not its neighbors'.
+export const WHITE_INTEL_SPELLS: SpellDefinition[] = [
+  {
+    id: "white-intel-watchers-vigil-t2",
+    caste: "white",
+    type: "intel",
+    name: "Watcher's Vigil",
+    baseStrength: 0,
+    description:
+      "A single icon-lit watch is set on the target tile. Reveals exact unit count, land type, and the tier of any armed defense spell. No collateral information.",
+    tier: 2,
+    minTilesRequired: 1500,
+    turnCost: 8,
+    intelScope: "tile",
+  },
+];

--- a/lib/game/content/upgrades/units.ts
+++ b/lib/game/content/upgrades/units.ts
@@ -4,7 +4,13 @@
  * See LICENSE file for details.
  */
 
-import type { Caste, UnitDefinition, UnitType, UpgradeDefinition } from "../../types";
+import type {
+  AirIntelPassive,
+  Caste,
+  UnitDefinition,
+  UnitType,
+  UpgradeDefinition,
+} from "../../types";
 import { UNIT_LIST } from "../units/all";
 
 // Three flavour archetypes per unit. Numbers are deltas applied on top of
@@ -150,6 +156,86 @@ function makeUpgradesFor(unit: UnitDefinition): UpgradeDefinition[] {
   });
 }
 
-export const UNIT_UPGRADES: UpgradeDefinition[] = UNIT_LIST.flatMap(
-  makeUpgradesFor
-);
+// ─── Air-only "Intel" 4th upgrade option ───────────────────────────────
+// Each caste's air unit gets a passive scouting upgrade that fires during
+// the player's own attacks. The upgrade carries no stat delta — its value
+// is information. resolveAttack reads the intelPassive marker and emits
+// extra fields into the CombatResult when conditions are met.
+
+interface AirIntelEntry {
+  caste: Caste;
+  name: string;
+  description: string;
+  intelPassive: AirIntelPassive;
+}
+
+const AIR_INTEL_ENTRIES: readonly AirIntelEntry[] = [
+  {
+    caste: "white",
+    name: "Hawk's Eye",
+    description:
+      "Outrunner hawks circle ahead of any tile your air strikes. When you commit at least one air unit, you see the tier of the defender's armed defense spell before the dice roll.",
+    intelPassive: "white-hawks-eye",
+  },
+  {
+    caste: "blue",
+    name: "Sky Reader Network",
+    description:
+      "A web of patient eyes between stars. When your air outnumbers the defender's, the contents of the target tile's six neighbors are revealed before commit.",
+    intelPassive: "blue-sky-reader",
+  },
+  {
+    caste: "black",
+    name: "Crowfeast",
+    description:
+      "Failed attacks leave bodies; bodies talk. If an attack with five or more air units is repelled, the defender's recruit queue is revealed for the next five turns.",
+    intelPassive: "black-crowfeast",
+  },
+  {
+    caste: "red",
+    name: "Forge Scouts",
+    description:
+      "Founder-trained scouts read enemy lines for seams. When your air force matches or exceeds the defender's, you gain a +5% attack bonus and learn which unit type the defender is weakest against.",
+    intelPassive: "red-forge-scouts",
+  },
+  {
+    caste: "green",
+    name: "Crow Network",
+    description:
+      "Crows roost where your air sleeps. While air units are stationed on a friendly tile, that tile's full one-ring supply network is permanently visible to you.",
+    intelPassive: "green-crow-network",
+  },
+];
+
+function makeAirIntelUpgradeFor(
+  unit: UnitDefinition,
+  entry: AirIntelEntry
+): UpgradeDefinition {
+  return {
+    id: `${unit.id}-upgrade-4-intel`,
+    caste: unit.caste,
+    targetKind: "unit",
+    targetId: unit.id,
+    name: entry.name,
+    description: entry.description,
+    // Intel upgrades have no stat tweak — their value is information.
+    effects: {},
+    optionIndex: 4,
+    intelPassive: entry.intelPassive,
+  };
+}
+
+const AIR_INTEL_UPGRADES: UpgradeDefinition[] = UNIT_LIST.filter(
+  (u) => u.type === "air"
+).map((u) => {
+  const entry = AIR_INTEL_ENTRIES.find((e) => e.caste === u.caste);
+  if (!entry) {
+    throw new Error(`No air-intel entry registered for caste ${u.caste}`);
+  }
+  return makeAirIntelUpgradeFor(u, entry);
+});
+
+export const UNIT_UPGRADES: UpgradeDefinition[] = [
+  ...UNIT_LIST.flatMap(makeUpgradesFor),
+  ...AIR_INTEL_UPGRADES,
+];

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -12,8 +12,13 @@ import {
   makeSeededRng,
   resolveAttack,
 } from "./combat";
-import { SPELLS_BY_ID } from "./content";
+import { ARTIFACTS_BY_ID, SPELLS_BY_ID } from "./content";
 import { rollArtifact } from "./artifacts";
+import { buildIntelReportServer } from "./intel";
+import {
+  readAttackContextEffects,
+  recordIntelEffectInTx,
+} from "./intel-effects";
 import {
   buildArmDefenseReport,
   buildAttackReport,
@@ -55,6 +60,7 @@ import type {
   GameAttack,
   GamePlayer,
   GameTile,
+  IntelReport,
   LandType,
   MapTile,
   TurnAction,
@@ -84,6 +90,10 @@ export const ATTACK_TURN_COST = 1;
 export const SPELL_TURN_COST = 5;
 export const BUILD_UNITS_TURN_COST = 5;
 export const BUILD_UNITS_PER_TURN = 10;
+// Far expedition: 2× the normal explore cost. Lands a tile adjacent to a
+// random enemy tile, marked isolatedSpawn so the supply system applies the
+// -15% defense floor until the player grows neighbors around it.
+export const FAR_EXPEDITION_TURN_COST = 2;
 
 export class GamePlayerNotFoundError extends Error {
   constructor() {
@@ -239,6 +249,14 @@ export class GameNameTakenError extends Error {
   constructor() {
     super("That general name is already in use");
     this.name = "GameNameTakenError";
+  }
+}
+export class GameNoEnemyKingdomsError extends Error {
+  constructor() {
+    super(
+      "No enemy kingdoms exist on the map. Far Expedition needs an enemy to land beside."
+    );
+    this.name = "GameNoEnemyKingdomsError";
   }
 }
 
@@ -1537,6 +1555,212 @@ export async function armDefenseSpellServer(
   });
 }
 
+/**
+ * Casts an intel ("spy") spell. Spends the spell's turn cost and returns an
+ * IntelReport scoped per the spell's intelScope. Black's Vein of Truth also
+ * pays a blood cost: 1 air unit subtracted from the caster's unitsAlive.
+ *
+ * Detection side effects (Black/Green alerting the defender for a few turns)
+ * are NOT yet wired — the intel snapshot is returned and the report flags
+ * `detected: true`. Wiring the defender-side buff is a follow-up.
+ */
+export async function castIntelSpellServer(
+  userId: string,
+  spellId: string,
+  targetTileId: string,
+  now: Date = new Date()
+): Promise<{
+  player: GamePlayer;
+  report: TurnReport;
+  artifact: GameArtifact | null;
+  intelReport: IntelReport;
+  detected: boolean;
+}> {
+  const db = adminDbOrThrow();
+  const spell = SPELLS_BY_ID.get(spellId);
+  if (!spell) throw new GameInvalidSpellError(`unknown spellId: ${spellId}`);
+  if (spell.type !== "intel") {
+    throw new GameInvalidSpellError(`spell ${spellId} is not an intel spell`);
+  }
+  if (!spell.intelScope) {
+    throw new GameInvalidSpellError(
+      `intel spell ${spellId} has no scope configured`
+    );
+  }
+
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(userId);
+  const tileRef = db.collection(COLLECTIONS.TILES).doc(targetTileId);
+
+  const txResult = await db.runTransaction(async (tx) => {
+    const [playerSnap, tileSnap] = await Promise.all([
+      tx.get(playerRef),
+      tx.get(tileRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!tileSnap.exists) throw new GameTileNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+    const tile = tileSnap.data() as GameTile;
+
+    if (player.phase !== "play") {
+      throw new GameInvalidPhaseError("play", player.phase);
+    }
+    if (player.caste === null || spell.caste !== player.caste) {
+      throw new GameInvalidSpellError(
+        `spell ${spellId} requires caste ${spell.caste}`
+      );
+    }
+    if (player.stats.tilesHeld < spell.minTilesRequired) {
+      throw new GameInvalidSpellError(
+        `spell ${spellId} requires ${spell.minTilesRequired} tiles held; you have ${player.stats.tilesHeld}`
+      );
+    }
+    if (tile.ownerId === userId) {
+      throw new GameSelfAttackError();
+    }
+
+    const cost = spell.turnCost;
+    if (player.turnsRemaining < cost) {
+      throw new GameInsufficientTurnsError(cost, player.turnsRemaining);
+    }
+
+    // Black's Vein of Truth: 1 air unit blood cost. We deduct from
+    // stats.unitsAlive (kingdom-wide aggregate) since per-tile sourcing would
+    // require an extra parameter. If the player has 0 units, the spell still
+    // resolves — the cost just floors at 0 (lore: the blood is owed).
+    const bloodCost = spellId === "black-intel-vein-of-truth-t2" ? 1 : 0;
+
+    const turnsSpentTotal = player.turnsSpentTotal + cost;
+    const rolled = rollAndStageArtifact(
+      tx,
+      db,
+      userId,
+      turnsSpentTotal,
+      "spell-arm",
+      now
+    );
+    const artifact = rolled?.definition ?? null;
+
+    const updatedStats = {
+      ...player.stats,
+      unitsAlive: Math.max(0, player.stats.unitsAlive - bloodCost),
+    };
+    tx.update(playerRef, {
+      turnsRemaining: player.turnsRemaining - cost,
+      turnsSpentTotal,
+      stats: updatedStats,
+      updatedAt: now,
+    });
+
+    // Persist time-bounded intel effects produced by this cast. All three
+    // expire 5 caster turns after cast (see INTEL_EFFECT_DURATION_CASTER_TURNS).
+    if (spellId === "black-intel-vein-of-truth-t2" && tile.ownerId) {
+      recordIntelEffectInTx({
+        tx,
+        db,
+        kind: "alert-vs-caster",
+        ownerId: tile.ownerId,
+        casterId: userId,
+        magnitude: 0.2,
+        casterTurnsSpentTotalAtCast: turnsSpentTotal,
+        now,
+      });
+    } else if (spellId === "green-intel-root-whisper-t2" && tile.ownerId) {
+      recordIntelEffectInTx({
+        tx,
+        db,
+        kind: "alert-vs-caster",
+        ownerId: tile.ownerId,
+        casterId: userId,
+        magnitude: 0.1,
+        casterTurnsSpentTotalAtCast: turnsSpentTotal,
+        now,
+      });
+    } else if (spellId === "red-intel-forge-sight-t2") {
+      recordIntelEffectInTx({
+        tx,
+        db,
+        kind: "forge-sight-offense",
+        ownerId: userId,
+        casterId: userId,
+        targetTileId,
+        magnitude: 0.1,
+        casterTurnsSpentTotalAtCast: turnsSpentTotal,
+        now,
+      });
+    }
+
+    return {
+      player: {
+        ...player,
+        turnsRemaining: player.turnsRemaining - cost,
+        turnsSpentTotal,
+        stats: updatedStats,
+        updatedAt: now,
+      },
+      cost,
+      turnsSpentTotal,
+      artifactDef: artifact,
+      artifactDoc: rolled?.doc ?? null,
+    };
+  });
+
+  const intelReport = await buildIntelReportServer({
+    db,
+    targetTileId,
+    scope: spell.intelScope,
+    source: "spell",
+    sourceId: spell.id,
+    capturedAtTurn: txResult.turnsSpentTotal,
+    attackerCaste: spell.caste,
+  });
+
+  // Black & Green spies are detected by the defender; the alert is now
+  // persisted and applied at attack time (see recordIntelEffectInTx above).
+  const detected =
+    spellId === "black-intel-vein-of-truth-t2" ||
+    spellId === "green-intel-root-whisper-t2";
+
+  const baseReport: TurnReport = {
+    turnIndex: txResult.turnsSpentTotal,
+    action: "spell-arm",
+    cost: txResult.cost,
+    summary: `Cast ${spell.name} on ${targetTileId}`,
+    narrative: [
+      `${spell.name}: ${spell.description}`,
+      detected
+        ? "The defender felt the touch of the spy. They will be on edge."
+        : "The intel returns silently; nothing on the wind suggests you were noticed.",
+    ],
+    outcome: {
+      spellId: spell.id,
+      spellName: spell.name,
+      targetTileId,
+      detected,
+      intelScope: spell.intelScope,
+    },
+  };
+  const report = txResult.artifactDef
+    ? {
+        ...baseReport,
+        narrative: [...baseReport.narrative, txResult.artifactDef.flavorOnFind],
+        artifactFound: {
+          definitionId: txResult.artifactDef.id,
+          name: txResult.artifactDef.name,
+          rarity: txResult.artifactDef.rarity,
+          type: txResult.artifactDef.type,
+        },
+      }
+    : baseReport;
+
+  return {
+    player: txResult.player,
+    report,
+    artifact: txResult.artifactDoc,
+    intelReport,
+    detected,
+  };
+}
+
 // Casts a production spell. Lasts PRODUCTION_SPELL_DURATION_TURNS turns from
 // the moment of casting (measured by turnsSpentTotal).
 export async function castProductionSpellServer(
@@ -1659,6 +1883,10 @@ export async function attackTileServer(args: {
   targetTile: GameTile;
   report: TurnReport;
   artifact: GameArtifact | null;
+  // Set when the attacker's air-unit intel passive triggered a post-attack
+  // reveal. Currently produced for Blue Sky Reader (air > defender air → ring
+  // intel) and Black Crowfeast (failed attack with air ≥ 5 → kingdom intel).
+  intelReport?: IntelReport;
 }> {
   const now = args.now ?? new Date();
   if (!isValidUnitStack(args.units)) {
@@ -1698,6 +1926,20 @@ export async function attackTileServer(args: {
   const defenderRef = db.collection(COLLECTIONS.PLAYERS).doc(defenderId);
   const attackId = randomUUID();
   const attackRef = db.collection(COLLECTIONS.ATTACKS).doc(attackId);
+
+  // Read attacker's current turn count out of the txn so we can filter
+  // intel-effect expirations. Slightly stale by the time the txn runs but
+  // adequate — effect expirations are coarse (5 caster turns).
+  const attackerPreSnap = await attackerRef.get();
+  if (!attackerPreSnap.exists) throw new GamePlayerNotFoundError();
+  const attackerPre = attackerPreSnap.data() as GamePlayer;
+  const intelContext = await readAttackContextEffects({
+    db,
+    attackerId: args.attackerId,
+    attackerTurnsSpentTotal: attackerPre.turnsSpentTotal,
+    defenderId,
+    defenderTileId: args.targetTileId,
+  });
 
   if (offenseSpell) {
     // We can't validate caste-match yet without reading the player; deferred
@@ -1788,6 +2030,21 @@ export async function attackTileServer(args: {
       throw new GameTileFullError(availableSpace, sentTotal);
     }
 
+    // Read the 6 neighbor tiles to compute supply. Hex coords are immutable,
+    // so deriving IDs from (q, r) is canonical even if neighborTileIds drifts.
+    const neighborIds = neighborTileIds(target.q, target.r);
+    const neighborSnaps = await Promise.all(
+      neighborIds.map((id) => tx.get(db.collection(COLLECTIONS.TILES).doc(id)))
+    );
+    const friendlyNeighbors: Array<{ landType: LandType }> = [];
+    for (const snap of neighborSnaps) {
+      if (!snap.exists) continue;
+      const t = snap.data() as GameTile;
+      if (t.ownerId !== defenderId) continue;
+      if (t.type === "unrevealed" || t.type === "unassigned") continue;
+      friendlyNeighbors.push({ landType: t.type });
+    }
+
     // Compute defender food/magic land counts for spell scaling. We accept the
     // pre-txn `getOwnedLandCounts` cost only on the defender; the magic count
     // is what's needed by spellContribution inside resolveAttack. Use the
@@ -1805,6 +2062,7 @@ export async function attackTileServer(args: {
         magicLandCount: 0,
         unitsAlive: attacker.stats.unitsAlive,
         activeUpgrades: attackerActiveUpgrades,
+        intelOffenseBonus: intelContext.forgeSightOffenseBonus,
       },
       {
         caste: defender.caste,
@@ -1813,8 +2071,13 @@ export async function attackTileServer(args: {
         magicLandCount: 0,
         unitsAlive: defender.stats.unitsAlive,
         activeUpgrades: defenderActiveUpgrades,
+        intelDefenseBonus: intelContext.alertVsCasterDefenseBonus,
       },
-      { capacity: tileCapacity, upgradeIds: target.upgradeIds },
+      {
+        capacity: tileCapacity,
+        upgradeIds: target.upgradeIds,
+        friendlyNeighbors,
+      },
       makeSeededRng(`attack-${attackId}`)
     );
 
@@ -1942,8 +2205,45 @@ export async function attackTileServer(args: {
       },
       report,
       artifact: rolled?.doc ?? null,
+      // Snapshot for post-txn air-intel reveals.
+      _airIntelContext: {
+        airDeployed: result.unitsDeployed.air,
+        defenderAirAtAttack: target.units.air,
+        outcome: result.outcome,
+        sourcePassive: result.airIntel?.sourcePassive ?? null,
+        attackerTurnsSpentTotal,
+      },
     };
   });
+
+  // Build a post-attack intel report if a Blue/Black air-intel passive fired.
+  // We do this OUTSIDE the txn — buildIntelReportServer runs its own reads,
+  // and the data is informational so a tiny window of staleness is fine.
+  let intelReport: IntelReport | undefined;
+  const ctx = result._airIntelContext;
+  if (ctx.sourcePassive === "blue-sky-reader" && ctx.airDeployed > ctx.defenderAirAtAttack) {
+    intelReport = await buildIntelReportServer({
+      db,
+      targetTileId: args.targetTileId,
+      scope: "ring",
+      source: "passive",
+      sourceId: "blue-sky-reader",
+      capturedAtTurn: ctx.attackerTurnsSpentTotal,
+    });
+  } else if (
+    ctx.sourcePassive === "black-crowfeast" &&
+    ctx.outcome === "repelled" &&
+    ctx.airDeployed >= 5
+  ) {
+    intelReport = await buildIntelReportServer({
+      db,
+      targetTileId: args.targetTileId,
+      scope: "kingdom",
+      source: "passive",
+      sourceId: "black-crowfeast",
+      capturedAtTurn: ctx.attackerTurnsSpentTotal,
+    });
+  }
 
   // Fire-and-forget Discord notification on conquest. Wrapped in try/catch
   // inside notifyConquest itself; the caller never blocks on it.
@@ -1951,7 +2251,9 @@ export async function attackTileServer(args: {
     notifyConquest({ attack: result.attack });
   }
 
-  return result;
+  // Strip the internal-only context off the response.
+  const { _airIntelContext: _, ...publicResult } = result;
+  return { ...publicResult, ...(intelReport ? { intelReport } : {}) };
 }
 
 export async function getRecentAttacksServer(opts: {
@@ -2628,6 +2930,236 @@ export async function frontierExploreServer(
   });
 }
 
+// Maximum enemy tiles sampled when picking a Far Expedition target. Higher =
+// more variety but more reads; 250 is plenty for current game scale.
+const FAR_EXPEDITION_ENEMY_SAMPLE_CAP = 250;
+// We try up to this many enemy candidates before giving up. Each candidate has
+// 6 potential drop coords, so 8 candidates ≈ 48 unclaimed-checks worst case.
+const FAR_EXPEDITION_MAX_TRIES = 8;
+
+/**
+ * Far Expedition: spend 2 turns to plant a tile adjacent to a random enemy
+ * tile, weighted toward enemies closer to the caster's centroid. The new tile
+ * lands with `isolatedSpawn: true` and (because it has no friendly neighbors
+ * yet) takes the -15% supply floor until the player builds tiles around it.
+ *
+ * Always available as a strategic choice — not gated on the normal frontier
+ * being exhausted. Throws GameNoEnemyKingdomsError if no enemy tiles exist
+ * (e.g. early game with one player).
+ */
+export async function farExpeditionExploreServer(
+  userId: string,
+  now: Date = new Date()
+): Promise<{
+  player: GamePlayer;
+  tile: GameTile;
+  report: TurnReport;
+  artifact: GameArtifact | null;
+  targetEnemyTileId: string;
+}> {
+  const db = adminDbOrThrow();
+
+  const playerSnapPre = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .doc(userId)
+    .get();
+  if (!playerSnapPre.exists) throw new GamePlayerNotFoundError();
+  const playerPre = playerSnapPre.data() as GamePlayer;
+  if (playerPre.phase !== "play") {
+    throw new GameInvalidPhaseError("play", playerPre.phase);
+  }
+  if (playerPre.turnsRemaining < FAR_EXPEDITION_TURN_COST) {
+    throw new GameInsufficientTurnsError(
+      FAR_EXPEDITION_TURN_COST,
+      playerPre.turnsRemaining
+    );
+  }
+
+  const ownedSnap = await db
+    .collection(COLLECTIONS.TILES)
+    .where("ownerId", "==", userId)
+    .get();
+  const ownedTileIds = ownedSnap.docs.map((d) => d.id);
+  const center = hexCentroid([...ownedTileIds]);
+
+  // Sample enemy tiles. `!=` filters out null owners and the user themselves.
+  // Firestore's `!=` returns docs where the field exists and differs.
+  const enemySnap = await db
+    .collection(COLLECTIONS.TILES)
+    .where("ownerId", "!=", userId)
+    .limit(FAR_EXPEDITION_ENEMY_SAMPLE_CAP)
+    .get();
+  const enemies: Array<{ q: number; r: number; id: string }> = [];
+  for (const doc of enemySnap.docs) {
+    const t = doc.data() as GameTile;
+    if (!t.ownerId) continue;
+    enemies.push({ q: t.q, r: t.r, id: t.tileId });
+  }
+  if (enemies.length === 0) throw new GameNoEnemyKingdomsError();
+
+  const rng = makeSeededRng(
+    `far-expedition:${userId}:${playerPre.turnsSpentTotal}`
+  );
+
+  // Weight enemies by inverse hex distance from the caster's centroid (closer
+  // = more likely, but the long tail still admits distant raids). Build a
+  // cumulative weights array for O(log n) sampling, then walk it for retries
+  // by zeroing out the picked entry.
+  const weights = enemies.map((e) => 1 / (1 + Math.abs(e.q - center.q) + Math.abs(e.r - center.r)));
+  let unclaimedCoord: AxialCoord | null = null;
+  let pickedEnemyId: string | null = null;
+
+  for (let attempt = 0; attempt < FAR_EXPEDITION_MAX_TRIES; attempt++) {
+    const totalWeight = weights.reduce((s, w) => s + w, 0);
+    if (totalWeight <= 0) break;
+    let pick = rng() * totalWeight;
+    let idx = 0;
+    for (let i = 0; i < weights.length; i++) {
+      pick -= weights[i];
+      if (pick <= 0) {
+        idx = i;
+        break;
+      }
+    }
+    const enemy = enemies[idx];
+    weights[idx] = 0; // don't re-pick this enemy
+    if (!enemy) break;
+
+    const candidateCoords = axialNeighbors(enemy.q, enemy.r);
+    for (let i = candidateCoords.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [candidateCoords[i], candidateCoords[j]] = [
+        candidateCoords[j],
+        candidateCoords[i],
+      ];
+    }
+    const refs = candidateCoords.map((c) =>
+      db.collection(COLLECTIONS.TILES).doc(tileIdFromAxial(c.q, c.r))
+    );
+    const snaps = await db.getAll(...refs);
+    for (let i = 0; i < snaps.length; i++) {
+      if (snaps[i].exists) continue;
+      unclaimedCoord = candidateCoords[i];
+      pickedEnemyId = enemy.id;
+      break;
+    }
+    if (unclaimedCoord) break;
+  }
+
+  if (!unclaimedCoord || !pickedEnemyId) {
+    throw new GameFrontierExhaustedError();
+  }
+
+  const tileId = tileIdFromAxial(unclaimedCoord.q, unclaimedCoord.r);
+  const tileRef = db.collection(COLLECTIONS.TILES).doc(tileId);
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(userId);
+  const targetEnemyTileId = pickedEnemyId;
+  const dropCoord = unclaimedCoord;
+
+  return db.runTransaction(async (tx) => {
+    const [tileSnap, playerSnap] = await Promise.all([
+      tx.get(tileRef),
+      tx.get(playerRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+
+    const player = playerSnap.data() as GamePlayer;
+    if (player.phase !== "play") {
+      throw new GameInvalidPhaseError("play", player.phase);
+    }
+    if (player.turnsRemaining < FAR_EXPEDITION_TURN_COST) {
+      throw new GameInsufficientTurnsError(
+        FAR_EXPEDITION_TURN_COST,
+        player.turnsRemaining
+      );
+    }
+    // Race: another player may have claimed this coord since the pre-fetch.
+    if (tileSnap.exists) {
+      throw new GameFrontierExhaustedError();
+    }
+
+    const turnsSpentTotal = player.turnsSpentTotal + FAR_EXPEDITION_TURN_COST;
+    const tilesExplored = player.tilesExplored + 1;
+    const rolled = rollAndStageArtifact(
+      tx,
+      db,
+      userId,
+      turnsSpentTotal,
+      "explore",
+      now
+    );
+    const artifact = rolled?.definition ?? null;
+
+    const tile: GameTile = {
+      tileId,
+      q: dropCoord.q,
+      r: dropCoord.r,
+      ownerId: userId,
+      type: "unassigned",
+      level: 0,
+      units: { ground: 0, siege: 0, air: 0 },
+      armedDefenseSpellId: null,
+      neighborTileIds: neighborTileIds(dropCoord.q, dropCoord.r),
+      upgradeIds: [],
+      isolatedSpawn: true,
+      revealedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+    tx.set(tileRef, tile);
+
+    const updatedStats = {
+      ...player.stats,
+      tilesHeld: player.stats.tilesHeld + 1,
+    };
+    tx.update(playerRef, {
+      turnsRemaining: player.turnsRemaining - FAR_EXPEDITION_TURN_COST,
+      turnsSpentTotal,
+      tilesExplored,
+      stats: updatedStats,
+      updatedAt: now,
+    });
+
+    const baseReport = buildExploreReport(
+      turnsSpentTotal,
+      tile,
+      artifact,
+      makeSeededRng(`far-narr:${userId}:${turnsSpentTotal}`)
+    );
+    const report: TurnReport = {
+      ...baseReport,
+      action: "explore",
+      cost: FAR_EXPEDITION_TURN_COST,
+      summary: `Far Expedition — landed at ${tileId} beside enemy ${targetEnemyTileId}`,
+      narrative: [
+        ...baseReport.narrative,
+        `Forward base planted next to enemy tile ${targetEnemyTileId}. The tile is isolated — supply runs at the −15% floor until friendly neighbors arrive.`,
+      ],
+      outcome: {
+        ...baseReport.outcome,
+        farExpedition: true,
+        targetEnemyTileId,
+        isolated: true,
+      },
+    };
+
+    return {
+      player: {
+        ...player,
+        turnsRemaining: player.turnsRemaining - FAR_EXPEDITION_TURN_COST,
+        turnsSpentTotal,
+        tilesExplored,
+        stats: updatedStats,
+        updatedAt: now,
+      },
+      tile,
+      report,
+      artifact: rolled?.doc ?? null,
+      targetEnemyTileId,
+    };
+  });
+}
+
 // Walk hex rings outward from `center`, batched-getAll each ring, accumulate
 // unclaimed coords. Stops when we hit `target` unclaimed coords or `maxRing`.
 async function collectUnclaimedByRingWalk(
@@ -3035,12 +3567,16 @@ export async function spendArtifactServer(args: {
   artifactId: string;
   targetTileId?: string | null;
   now?: Date;
-}): Promise<{ artifact: GameArtifact }> {
+}): Promise<{ artifact: GameArtifact; intelReport?: IntelReport }> {
   const now = args.now ?? new Date();
   const db = adminDbOrThrow();
   const artifactRef = db.collection(COLLECTIONS.ARTIFACTS).doc(args.artifactId);
 
-  return db.runTransaction(async (tx) => {
+  // First mark the artifact used in a transaction so the inventory state is
+  // consistent. Intel artifacts then run a follow-up read pass to build the
+  // report; the report doesn't need transactional consistency with the
+  // artifact-used flag (it's a snapshot of public state at "now").
+  const result = await db.runTransaction(async (tx) => {
     const snap = await tx.get(artifactRef);
     if (!snap.exists) throw new GameArtifactNotFoundError();
     const artifact = snap.data() as GameArtifact;
@@ -3049,8 +3585,13 @@ export async function spendArtifactServer(args: {
     }
     if (artifact.used) throw new GameArtifactAlreadyUsedError();
 
-    // For now the only persisted effect is the used flag. PR 6d will branch
-    // on artifact.type and apply offense/defense/production effects.
+    const def = ARTIFACTS_BY_ID.get(artifact.definitionId) ?? null;
+    if (def?.type === "intel" && !args.targetTileId) {
+      throw new GameInvalidSpellError(
+        "Intel artifacts must be spent on a target tile"
+      );
+    }
+
     const updated: GameArtifact = {
       ...artifact,
       used: true,
@@ -3064,8 +3605,30 @@ export async function spendArtifactServer(args: {
       ...(args.targetTileId ? { usedOnTileId: args.targetTileId } : {}),
       updatedAt: now,
     });
-    return { artifact: updated };
+    return { artifact: updated, definition: def };
   });
+
+  if (result.definition?.type !== "intel" || !args.targetTileId) {
+    return { artifact: result.artifact };
+  }
+
+  // Read player to source capturedAtTurn from turnsSpentTotal.
+  const playerSnap = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .doc(args.userId)
+    .get();
+  const player = playerSnap.exists ? (playerSnap.data() as GamePlayer) : null;
+  const capturedAtTurn = player?.turnsSpentTotal ?? 0;
+
+  const intelReport = await buildIntelReportServer({
+    db,
+    targetTileId: args.targetTileId,
+    scope: result.definition.intelDepth ?? "tile",
+    source: "artifact",
+    sourceId: result.definition.id,
+    capturedAtTurn,
+  });
+  return { artifact: result.artifact, intelReport };
 }
 
 // ──── v2: Unit & building upgrades ────

--- a/lib/game/intel-effects.ts
+++ b/lib/game/intel-effects.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import type { IntelEffect, IntelEffectKind } from "./types";
+
+// Effects live in their own top-level collection so we can index by ownerId
+// + kind without bloating the player or tile docs. Lifetimes are bounded
+// (≤5 caster turns) so the collection stays small in practice; expired rows
+// can be GC'd by a follow-up sweep job.
+const COLLECTION = "game_intel_effects";
+
+// All currently-defined intel-spell debuffs/buffs persist for this many of
+// the caster's turns past cast time. Centralized so the spy spells stay in
+// step with combat reads.
+export const INTEL_EFFECT_DURATION_CASTER_TURNS = 5;
+
+interface RecordArgs {
+  tx: Transaction;
+  db: Firestore;
+  kind: IntelEffectKind;
+  ownerId: string;
+  casterId: string;
+  targetTileId?: string;
+  magnitude: number;
+  casterTurnsSpentTotalAtCast: number;
+  now: Date;
+}
+
+/**
+ * Persist a new intel effect inside an active transaction. Used by
+ * castIntelSpellServer at the moment of cast.
+ */
+export function recordIntelEffectInTx(args: RecordArgs): IntelEffect {
+  const id = randomUUID();
+  const expiresAtCasterTurn =
+    args.casterTurnsSpentTotalAtCast + INTEL_EFFECT_DURATION_CASTER_TURNS;
+  const effect: IntelEffect = {
+    id,
+    kind: args.kind,
+    ownerId: args.ownerId,
+    casterId: args.casterId,
+    ...(args.targetTileId ? { targetTileId: args.targetTileId } : {}),
+    magnitude: args.magnitude,
+    expiresAtCasterTurn,
+    createdAt: args.now,
+  };
+  args.tx.set(args.db.collection(COLLECTION).doc(id), effect);
+  return effect;
+}
+
+interface AttackContextEffects {
+  // Sum of `magnitude` values for currently-active "forge-sight-offense"
+  // effects owned by `attackerId`, targeting `defenderTileId`. Treat as an
+  // additive multiplier: 0.10 → +10% offense.
+  forgeSightOffenseBonus: number;
+  // Sum of magnitudes for currently-active "alert-vs-caster" effects owned
+  // by `defenderId` against `attackerId`. Additive: 0.30 → +30% defense.
+  alertVsCasterDefenseBonus: number;
+}
+
+/**
+ * Read intel effects relevant to a single attack. Run OUTSIDE the attack
+ * transaction — slight staleness is acceptable since alerts decay naturally
+ * and the caster's own turn count is the trigger for expiry.
+ *
+ * Two effect classes are aggregated:
+ *   - Forge Sight: caster armed against the target tile they're now attacking.
+ *   - Alert-vs-caster: defender was alerted by the attacker (Black/Green spy).
+ */
+export async function readAttackContextEffects(args: {
+  db: Firestore;
+  attackerId: string;
+  attackerTurnsSpentTotal: number;
+  defenderId: string;
+  defenderTileId: string;
+}): Promise<AttackContextEffects> {
+  const { db, attackerId, attackerTurnsSpentTotal, defenderId, defenderTileId } =
+    args;
+
+  // Two equality clauses each — within Firestore's single-field index defaults,
+  // no composite index needed. The remaining filters (targetTileId, casterId)
+  // are applied client-side; the result sets are tiny (≤5-turn lifetimes,
+  // small per-player effect counts).
+  const [forgeSnap, alertSnap] = await Promise.all([
+    db
+      .collection(COLLECTION)
+      .where("ownerId", "==", attackerId)
+      .where("kind", "==", "forge-sight-offense")
+      .get(),
+    db
+      .collection(COLLECTION)
+      .where("ownerId", "==", defenderId)
+      .where("kind", "==", "alert-vs-caster")
+      .get(),
+  ]);
+
+  let forgeSightOffenseBonus = 0;
+  for (const d of forgeSnap.docs) {
+    const e = d.data() as IntelEffect;
+    if (e.targetTileId !== defenderTileId) continue;
+    if (e.casterId !== attackerId) continue;
+    if (attackerTurnsSpentTotal < e.expiresAtCasterTurn) {
+      forgeSightOffenseBonus += e.magnitude;
+    }
+  }
+
+  let alertVsCasterDefenseBonus = 0;
+  for (const d of alertSnap.docs) {
+    const e = d.data() as IntelEffect;
+    if (e.casterId !== attackerId) continue;
+    if (attackerTurnsSpentTotal < e.expiresAtCasterTurn) {
+      alertVsCasterDefenseBonus += e.magnitude;
+    }
+  }
+
+  return { forgeSightOffenseBonus, alertVsCasterDefenseBonus };
+}

--- a/lib/game/intel.ts
+++ b/lib/game/intel.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Firestore } from "firebase-admin/firestore";
+import { computeSupplyMultiplier } from "./combat";
+import type {
+  Caste,
+  GamePlayer,
+  GameTile,
+  IntelDepth,
+  IntelReport,
+  LandType,
+  UnitStack,
+  UnitType,
+} from "./types";
+import { neighborTileIds } from "./world-gen";
+
+const TILES = "game_tiles";
+const PLAYERS = "game_players";
+const ARTIFACTS = "game_artifacts";
+
+const UNIT_TYPES: readonly UnitType[] = ["ground", "siege", "air"] as const;
+// Defender's heaviest unit type → attacker's best counter (the type that
+// beats it under air→ground→siege→air).
+const RPS_COUNTERS: Record<UnitType, UnitType> = {
+  ground: "air",
+  siege: "ground",
+  air: "siege",
+};
+
+export type IntelScope =
+  | IntelDepth
+  | "kingdom+supply"
+  | "weak-face";
+
+/**
+ * Read a snapshot of intel about a target tile. Reads run outside any
+ * transaction — the caller is expected to have already committed any
+ * source-of-intel side effects (artifact "used" flag, spell "cast" flag) so
+ * staleness here is acceptable. The intel is a point-in-time read of public
+ * server state.
+ */
+export async function buildIntelReportServer(args: {
+  db: Firestore;
+  targetTileId: string;
+  scope: IntelScope;
+  source: "artifact" | "spell" | "passive";
+  sourceId: string;
+  capturedAtTurn: number;
+  attackerCaste?: Caste;
+}): Promise<IntelReport> {
+  const { db, targetTileId, scope, source, sourceId, capturedAtTurn } = args;
+
+  const targetSnap = await db.collection(TILES).doc(targetTileId).get();
+  if (!targetSnap.exists) {
+    throw new Error(`Intel target tile not found: ${targetTileId}`);
+  }
+  const target = targetSnap.data() as GameTile;
+
+  const report: IntelReport = {
+    targetTileId,
+    targetOwnerId: target.ownerId,
+    capturedAtTurn,
+    source,
+    sourceId,
+    scope,
+    target: {
+      landType: target.type,
+      units: target.units,
+      armedDefenseSpellId: target.armedDefenseSpellId,
+      isolatedSpawn: target.isolatedSpawn ?? false,
+    },
+  };
+
+  const wantsRing =
+    scope === "ring" ||
+    scope === "kingdom" ||
+    scope === "kingdom+supply";
+
+  if (wantsRing) {
+    const nbrIds = neighborTileIds(target.q, target.r);
+    const refs = nbrIds.map((id) => db.collection(TILES).doc(id));
+    const snaps = await db.getAll(...refs);
+    const neighbors: NonNullable<IntelReport["neighbors"]> = [];
+    for (let i = 0; i < snaps.length; i++) {
+      const s = snaps[i];
+      if (!s.exists) continue;
+      const t = s.data() as GameTile;
+      neighbors.push({
+        tileId: nbrIds[i],
+        ownerId: t.ownerId,
+        landType: t.type,
+        units: t.units,
+      });
+    }
+    report.neighbors = neighbors;
+
+    if (scope === "kingdom+supply") {
+      const friendly: Array<{ landType: LandType }> = [];
+      const friendlyIds: Array<{ tileId: string; landType: LandType }> = [];
+      for (const n of neighbors) {
+        if (n.ownerId !== target.ownerId) continue;
+        if (n.landType === "unrevealed" || n.landType === "unassigned") continue;
+        friendly.push({ landType: n.landType });
+        friendlyIds.push({ tileId: n.tileId, landType: n.landType });
+      }
+      // Look up defender caste so the supply multiplier reflects who's playing
+      // the tile, not the spy. Falls back to a neutral 1.0 if owner missing.
+      let defenderCaste: Caste | null = null;
+      if (target.ownerId) {
+        const defSnap = await db.collection(PLAYERS).doc(target.ownerId).get();
+        if (defSnap.exists) {
+          defenderCaste = (defSnap.data() as GamePlayer).caste;
+        }
+      }
+      const supplyMult = defenderCaste
+        ? computeSupplyMultiplier(defenderCaste, friendly)
+        : 1;
+      report.supply = {
+        friendlyNeighbors: friendlyIds,
+        supplyMultiplier: supplyMult,
+      };
+    }
+  }
+
+  const wantsKingdom = scope === "kingdom" || scope === "kingdom+supply";
+  if (wantsKingdom && target.ownerId) {
+    const defSnap = await db.collection(PLAYERS).doc(target.ownerId).get();
+    if (defSnap.exists) {
+      const def = defSnap.data() as GamePlayer;
+      const artifactSnap = await db
+        .collection(ARTIFACTS)
+        .where("ownerId", "==", target.ownerId)
+        .where("used", "==", false)
+        .get();
+      report.kingdomDefender = {
+        tilesHeld: def.stats.tilesHeld,
+        unitsAlive: def.stats.unitsAlive,
+        activeProductionSpellIds: (def.productionSpellsActive ?? []).map(
+          (s) => s.spellId
+        ),
+        artifactCount: artifactSnap.size,
+      };
+    }
+  }
+
+  if (scope === "weak-face") {
+    report.weakFace = pickWeakFace(target.units);
+  }
+
+  return report;
+}
+
+// Exported for unit tests. The "weak face" of a defender stack is the
+// unit type their dominant slot is countered by under the standard
+// air→ground→siege→air RPS — i.e. what an attacker should lead with.
+export function pickWeakFace(units: UnitStack): UnitType | undefined {
+  let max = 0;
+  let dominant: UnitType | undefined;
+  for (const t of UNIT_TYPES) {
+    if (units[t] > max) {
+      max = units[t];
+      dominant = t;
+    }
+  }
+  if (!dominant) return undefined;
+  return RPS_COUNTERS[dominant];
+}

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -10,7 +10,18 @@ export type Caste = "black" | "red" | "white" | "green" | "blue";
 
 export type UnitType = "ground" | "siege" | "air";
 
-export type SpellType = "defense" | "offense" | "production";
+export type SpellType = "defense" | "offense" | "production" | "intel";
+
+// Reveal scope for intel-type artifacts and spells. Used by both
+// SpellDefinition.intelScope and ArtifactDefinition.intelDepth (the latter
+// is a strict subset). "kingdom+supply" is Green's Root Whisper exclusive
+// (returns the supply graph); "weak-face" is Red's Forge Sight exclusive.
+export type IntelSpellScope =
+  | "tile"
+  | "ring"
+  | "kingdom"
+  | "kingdom+supply"
+  | "weak-face";
 
 export type LandType = "unrevealed" | "unassigned" | "military" | "food" | "magic";
 
@@ -39,6 +50,7 @@ export interface SpellDefinition {
   // Flat power applied to attacker (offense) or defender (defense) combat totals,
   // or to the unit-cap / magic-multiplier for production. Multiplied at runtime by
   // (caster's magic-land soft-cap) × (caster's caste spellTypeBonus).
+  // Ignored for intel spells.
   baseStrength: number;
   description: string;
   // Tiered access: tier 1 is always castable; higher tiers gate by territory size.
@@ -47,6 +59,8 @@ export interface SpellDefinition {
   minTilesRequired: number;
   // Turn cost to cast or arm. Tier 1 spells cost 5; higher tiers cost more.
   turnCost: number;
+  // For type === "intel": which reveal scope the spy spell delivers.
+  intelScope?: IntelSpellScope;
 }
 
 export interface BuildingDefinition {
@@ -76,6 +90,16 @@ export interface UpgradeEffects {
   magicMultiplierDelta?: number;
 }
 
+// One of the named air-unit "intel" passives. Only meaningful when set on an
+// air-unit upgrade with optionIndex === 4. Each value names a specific
+// caste-flavored scouting behavior, surfaced during the player's own attacks.
+export type AirIntelPassive =
+  | "white-hawks-eye"
+  | "blue-sky-reader"
+  | "black-crowfeast"
+  | "red-forge-scouts"
+  | "green-crow-network";
+
 export interface UpgradeDefinition {
   id: string;
   caste: Caste;
@@ -87,7 +111,12 @@ export interface UpgradeDefinition {
   effects: UpgradeEffects;
   // 1..3 — purely informational; used by UI to label the three options as
   // Offensive / Defensive / Utility, but not enforced by content rules.
-  optionIndex: 1 | 2 | 3;
+  // Air units have a 4th "Intel" option that delivers a passive scouting
+  // benefit instead of a stat tweak.
+  optionIndex: 1 | 2 | 3 | 4;
+  // Set on the optionIndex-4 air-unit upgrades only; identifies which
+  // caste-flavored intel passive this upgrade provides.
+  intelPassive?: AirIntelPassive;
 }
 
 export interface CasteProfile {
@@ -95,6 +124,11 @@ export interface CasteProfile {
   tileCapacityMultiplier: number;
   unitTypeBonuses: Record<UnitType, number>;
   spellTypeBonuses: Record<SpellType, number>;
+  // How strongly this caste benefits from clustering. Multiplied against the
+  // raw supply contribution (sum of friendly-neighbor type weights × 5%) before
+  // it stacks on top of base defense. Green/White lean concentrated; Blue/Black
+  // are comfortable spread.
+  supplyMultiplier: number;
 }
 
 export interface UnitStack {
@@ -155,6 +189,12 @@ export interface GameTile {
   armedDefenseSpellId: string | null;
   neighborTileIds: string[];
   upgradeIds: string[];
+  // True when this tile was placed via Far Expedition adjacent to an enemy.
+  // Cleared the first time the tile gains a friendly neighbor (i.e. it's no
+  // longer truly isolated). Used by the UI to flag at-risk forward-operating
+  // tiles; combat math reads supply directly from neighbor state, not this
+  // flag.
+  isolatedSpawn?: boolean;
   lastAttackedAt?: Timestamp | Date;
   revealedAt?: Timestamp | Date;
   createdAt: Timestamp | Date;
@@ -203,6 +243,10 @@ export interface CombatAttackerInput {
   // Player's active upgrades (target id → upgrade id). Optional for legacy
   // call sites; resolveAttack coalesces to {} if absent.
   activeUpgrades?: Record<string, string>;
+  // Pre-resolved additive offense multiplier from active intel effects (e.g.
+  // Red Forge Sight = +0.10 against the targeted tile). Stacks
+  // multiplicatively on attackPower after spell contribution.
+  intelOffenseBonus?: number;
 }
 
 export interface CombatDefenderInput {
@@ -212,18 +256,38 @@ export interface CombatDefenderInput {
   magicLandCount: number;
   unitsAlive: number;
   activeUpgrades?: Record<string, string>;
+  // Pre-resolved additive defense multiplier from active alert-vs-caster
+  // intel effects (Black Vein of Truth = +0.20, Green Root Whisper = +0.10
+  // against the specific attacker). Stacks multiplicatively on defensePower
+  // after supply.
+  intelDefenseBonus?: number;
 }
 
 export interface CombatTileInput {
   capacity: number;
   upgradeIds: string[];
+  // Land types of defender-owned tiles adjacent to this tile (excludes
+  // unrevealed/unassigned — those are vacant lots, not supply nodes). When
+  // omitted (legacy/test callers), the supply system is skipped and defense
+  // is unmodified. When present and empty, the tile is treated as isolated
+  // and gets the -15% defense floor.
+  friendlyNeighbors?: ReadonlyArray<{ landType: LandType }>;
 }
 
 // ──── v2: Artifacts (single-use, caste-agnostic, found on turn-spend) ────
 
 export type ArtifactRarity = "common" | "rare" | "epic" | "legendary";
 
-export type ArtifactType = "offense" | "defense" | "production" | "utility";
+export type ArtifactType =
+  | "offense"
+  | "defense"
+  | "production"
+  | "utility"
+  | "intel";
+
+// Reveal scope for intel-type artifacts and spells. "tile" is the target only;
+// "ring" adds the 6 neighbor tiles; "kingdom" adds owner kingdom-wide stats.
+export type IntelDepth = "tile" | "ring" | "kingdom";
 
 export interface ArtifactDefinition {
   id: string;
@@ -231,12 +295,83 @@ export interface ArtifactDefinition {
   rarity: ArtifactRarity;
   type: ArtifactType;
   // Strength applied when the artifact is used. Larger than caste spell
-  // baseStrength on average — these are supposed to be lucky breaks.
+  // baseStrength on average — these are supposed to be lucky breaks. Ignored
+  // for intel-type artifacts.
   baseStrength: number;
   description: string;
   // One-line narrative when found and when used. Used by turn-report builders
   // to produce flavor text without needing a separate lookup.
   flavorOnFind: string;
+  // For type === "intel": how deep the reveal goes when the artifact is spent
+  // on a target tile. Ignored otherwise.
+  intelDepth?: IntelDepth;
+}
+
+// Persisted, time-bounded combat effects produced by intel spells. Read by
+// resolveAttack via the data-server attack handler.
+//
+// "alert-vs-caster" — the defender (ownerId) holds an alert against a
+//   specific caster: when that caster attacks the owner, the defender gets a
+//   `magnitude` defense bonus. Created by Black Vein of Truth (+0.20) and
+//   Green Root Whisper (+0.10).
+//
+// "forge-sight-offense" — the attacker (ownerId) gets a `magnitude` offense
+//   bonus when attacking a specific `targetTileId`. Created by Red Forge
+//   Sight (+0.10). Stacks with the Red Forge Scouts air-upgrade bonus.
+export type IntelEffectKind = "alert-vs-caster" | "forge-sight-offense";
+
+export interface IntelEffect {
+  id: string;
+  kind: IntelEffectKind;
+  // Player who holds the effect: defender for alerts, attacker for forge-sight.
+  ownerId: string;
+  // Player whose turn-clock the expiration is measured against. For alerts,
+  // this is also the player against whom the effect applies.
+  casterId: string;
+  // For forge-sight: the tile the bonus applies to. Unset for alerts.
+  targetTileId?: string;
+  magnitude: number;
+  // Effect expires when the casterId's turnsSpentTotal reaches this value.
+  expiresAtCasterTurn: number;
+  createdAt: Timestamp | Date;
+}
+
+// Snapshot returned to the player when an intel-type artifact or intel spell
+// resolves. Optional fields are populated according to the reveal scope.
+export interface IntelReport {
+  targetTileId: string;
+  targetOwnerId: string | null;
+  // Player turn at which the intel was captured. Stale data after a few turns
+  // is normal — the UI should label freshness off this.
+  capturedAtTurn: number;
+  source: "artifact" | "spell" | "passive";
+  sourceId: string;
+  scope: IntelSpellScope;
+  target: {
+    landType: LandType;
+    units: UnitStack;
+    armedDefenseSpellId: string | null;
+    isolatedSpawn: boolean;
+  };
+  neighbors?: Array<{
+    tileId: string;
+    ownerId: string | null;
+    landType: LandType;
+    units: UnitStack;
+  }>;
+  kingdomDefender?: {
+    tilesHeld: number;
+    unitsAlive: number;
+    activeProductionSpellIds: string[];
+    artifactCount: number;
+  };
+  // Green Root Whisper exclusive: friendlies that contribute to supply.
+  supply?: {
+    friendlyNeighbors: Array<{ tileId: string; landType: LandType }>;
+    supplyMultiplier: number;
+  };
+  // Red Forge Sight exclusive: which unit type the attacker should lead with.
+  weakFace?: UnitType;
 }
 
 export interface GameArtifact {
@@ -295,6 +430,19 @@ export interface CombatResult {
   attackerLosses: UnitStack;
   defenderLosses: UnitStack;
   underdogApplied: boolean;
+  // 1.0 if the supply system was not consulted (legacy callers); else the
+  // multiplier that scaled defense before underdog stacking. 0.85 = isolated.
+  supplyMultiplier: number;
   rng: { attackerRoll: number; defenderRoll: number };
   appliedSpells: { offenseId: string | null; defenseId: string | null };
+  // Pre-commit intel produced by the attacker's air-unit intel passive (if
+  // the upgrade is active and trigger conditions are met). Currently wired
+  // for white-hawks-eye (defenseSpellTier) and red-forge-scouts (weakFace +
+  // forgeScoutsBonusApplied). Other intel passives are content-only.
+  airIntel?: {
+    sourcePassive: AirIntelPassive;
+    defenseSpellTier?: SpellTier;
+    weakFace?: UnitType;
+    forgeScoutsBonusApplied?: boolean;
+  };
 }


### PR DESCRIPTION
## Summary
Ships the threat-box pillars: supply-based defense, Far Expedition, and the spy system (artifacts, caste intel spells, air-unit intel upgrades), plus the persistent intel-effects subsystem and supporting UI.

## Included PRs
- **#753** — feat(game): supply defense, far expedition, spy system

## Contributors
- Roger Hunt <ludwitt@ludwitt.com>

## Test plan
- [x] `npm run type-check` clean on develop
- [x] `npm test` — 1656 / 1656 passing on develop after merge
- [x] `npm run build` succeeded locally on develop tip (no errors, only existing warnings)
- [x] Route contracts OK (144 routes)
- [ ] Vercel preview spot-check on the release branch before promoting

🤖 Generated with [Claude Code](https://claude.com/claude-code)