### PR TITLE
chore(firestore): rules + index for game_intel_effects

### DIFF
--- a/config/firebase/firestore.indexes.json
+++ b/config/firebase/firestore.indexes.json
@@ -317,6 +317,14 @@
       ]
     },
     {
+      "collectionGroup": "game_intel_effects",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerId", "order": "ASCENDING" },
+        { "fieldPath": "kind", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "communityReports",
       "queryScope": "COLLECTION",
       "fields": [

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -430,6 +430,18 @@ service cloud.firestore {
       allow create, update, delete: if false;
     }
 
+    // Game — Intel effects (v2): time-bounded combat modifiers produced by
+    // intel spells (alert-vs-caster from Black/Green spies; forge-sight-
+    // offense from Red Forge Sight). A player can only read effects they
+    // own (i.e. effects targeting them as defender, or their own attacker-
+    // side buffs). All writes go through the Admin SDK via /api/game/spy
+    // and /api/game/attack.
+    match /game_intel_effects/{effectId} {
+      allow read: if request.auth != null
+        && resource.data.ownerId == request.auth.uid;
+      allow create, update, delete: if false;
+    }
+
     // Trust & safety: in-product abuse-report records on community
     // user-generated content. Reporters can only create their own
     // reports; only admins can list/triage. Server-side mutations via


### PR DESCRIPTION
## Summary
Source-tracks the Firestore rules + index changes I just deployed to the live project, so develop/main match prod.

- New rule: authenticated owners can read their own \`game_intel_effects\` docs; writes via Admin SDK (mirrors \`game_artifacts\`).
- New composite index on \`(ownerId, kind)\` for the queries in \`lib/game/intel-effects.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)