### PR TITLE
fix(game): send Bearer token from FarExpedition + SpyAction

### DIFF
--- a/app/game/_components/dashboard/FarExpedition.tsx
+++ b/app/game/_components/dashboard/FarExpedition.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
 
 // Mirrors FAR_EXPEDITION_TURN_COST in lib/game/data-server.ts. Hardcoded
 // here because the dashboard runs on the client and data-server.ts pulls
@@ -30,6 +31,7 @@ interface SuccessResult {
  * defense floor until you grow tiles around it.
  */
 export function FarExpedition({ turnsRemaining, onSuccess }: FarExpeditionProps) {
+  const { user } = useAuth();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<SuccessResult | null>(null);
@@ -37,11 +39,19 @@ export function FarExpedition({ turnsRemaining, onSuccess }: FarExpeditionProps)
   const canAfford = turnsRemaining >= FAR_EXPEDITION_TURN_COST;
 
   async function run() {
+    if (!user) {
+      setError("Sign in to launch an expedition.");
+      return;
+    }
     setBusy(true);
     setError(null);
     setResult(null);
     try {
-      const res = await fetch("/api/game/explore/far", { method: "POST" });
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/explore/far", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
       const body = await res.json();
       if (!res.ok || !body?.success) {
         // apiError() shape is { success:false, error:{ message, code } }; some

--- a/app/game/_components/dashboard/SpyAction.tsx
+++ b/app/game/_components/dashboard/SpyAction.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
 import { getSpellsForCasteAndType } from "@/lib/game/content";
 import type { Caste, IntelReport } from "@/lib/game/types";
 
@@ -28,6 +29,7 @@ export function SpyAction({
   turnsRemaining,
   onSuccess,
 }: SpyActionProps) {
+  const { user } = useAuth();
   const intelSpell = useMemo(() => {
     const all = getSpellsForCasteAndType(caste, "intel");
     return all[0] ?? null;
@@ -46,14 +48,22 @@ export function SpyAction({
 
   async function run() {
     if (!intelSpell || !targetTileId.trim()) return;
+    if (!user) {
+      setError("Sign in to cast a spy spell.");
+      return;
+    }
     setBusy(true);
     setError(null);
     setReport(null);
     setDetected(false);
     try {
+      const token = await user.getIdToken();
       const res = await fetch("/api/game/spy", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           spellId: intelSpell.id,
           targetTileId: targetTileId.trim(),


### PR DESCRIPTION
Both clients hit a 401 because they were calling `/api/game/explore/far` and `/api/game/spy` without the `Authorization: Bearer <idToken>` header. Mirrors the dashboard fetch pattern.