### PR TITLE
feat(game): single-surface Threats action hub at /game/threats

### DIFF
--- a/__tests__/app/game/_lib/dashboard-actions.test.ts
+++ b/__tests__/app/game/_lib/dashboard-actions.test.ts
@@ -1,0 +1,753 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  adminGrant,
+  armDefenseSpell,
+  attack,
+  bulkDistribute,
+  castIntelSpell,
+  createPlayer,
+  distributeTile,
+  farExpedition,
+  frontierExplore,
+  recruitUnits,
+  setPlayerName,
+  spendArtifact,
+  type DashboardMutators,
+} from "@/app/game/_lib/dashboard-actions";
+
+// Minimal mock of the firebase User shape — every action helper only ever
+// touches `.uid` and `.getIdToken()`.
+function makeUser(uid = "me") {
+  return {
+    uid,
+    getIdToken: jest.fn().mockResolvedValue(`token-${uid}`),
+  } as unknown as Parameters<typeof attack>[0];
+}
+
+function makeMutators(): DashboardMutators & {
+  // Surface the underlying jest mocks so individual tests can assert on calls.
+  __spies: {
+    setError: jest.Mock;
+    setPlayer: jest.Mock;
+    setRecentReports: jest.Mock;
+    mergeOwnedTiles: jest.Mock;
+    mergeBorderTiles: jest.Mock;
+    mergeArtifacts: jest.Mock;
+  };
+} {
+  const setError = jest.fn();
+  const setPlayer = jest.fn();
+  // Actually invoke the updater fn (rather than just capturing it as a stub)
+  // so the inline `(prev) => [...]` arrows in dashboard-actions are exercised
+  // — keeps function-coverage off the floor.
+  let reports: unknown[] = [];
+  const setRecentReports = jest.fn((updater: (prev: unknown[]) => unknown[]) => {
+    reports = updater(reports);
+  });
+  const mergeOwnedTiles = jest.fn();
+  const mergeBorderTiles = jest.fn();
+  const mergeArtifacts = jest.fn();
+  return {
+    setError,
+    setPlayer,
+    setRecentReports,
+    mergeOwnedTiles,
+    mergeBorderTiles,
+    mergeArtifacts,
+    __spies: {
+      setError,
+      setPlayer,
+      setRecentReports,
+      mergeOwnedTiles,
+      mergeBorderTiles,
+      mergeArtifacts,
+    },
+  };
+}
+
+function mockFetchOnce(json: unknown) {
+  const fetchMock = jest.fn().mockResolvedValue({
+    json: () => Promise.resolve(json),
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+const FAKE_TILE = {
+  tileId: "1_2",
+  q: 1,
+  r: 2,
+  type: "military",
+  ownerId: "me",
+  units: { ground: 10, siege: 0, air: 0 },
+  armedDefenseSpellId: null,
+};
+
+const FAKE_ENEMY_TILE = {
+  ...FAKE_TILE,
+  tileId: "3_4",
+  q: 3,
+  r: 4,
+  ownerId: "foe",
+};
+
+const FAKE_PLAYER = { id: "me", turnsRemaining: 100 };
+const FAKE_REPORT = { turnIndex: 1, summary: "did a thing" };
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("recruitUnits", () => {
+  it("posts the tileId + unitType, merges tile + player, returns produced", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      tile: FAKE_TILE,
+      player: FAKE_PLAYER,
+      report: FAKE_REPORT,
+      produced: 10,
+    });
+    const mut = makeMutators();
+    const out = await recruitUnits(makeUser(), "1_2", "ground", mut);
+    expect(out).toEqual({ produced: 10, reportSummary: "did a thing" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/build",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ tileId: "1_2", unitType: "ground" }),
+      })
+    );
+    expect(mut.__spies.setPlayer).toHaveBeenCalledWith(FAKE_PLAYER);
+    expect(mut.__spies.mergeOwnedTiles).toHaveBeenCalledWith([
+      expect.objectContaining({ tileId: FAKE_TILE.tileId }),
+    ]);
+    expect(mut.__spies.setError).toHaveBeenCalledWith(null);
+  });
+
+  it("surfaces server error message via setError", async () => {
+    mockFetchOnce({ success: false, error: { message: "Need 5 turns" } });
+    const mut = makeMutators();
+    const out = await recruitUnits(makeUser(), "1_2", "siege", mut);
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("Need 5 turns");
+  });
+
+  it("falls back to default error when error is missing", async () => {
+    mockFetchOnce({ success: false });
+    const mut = makeMutators();
+    await recruitUnits(makeUser(), "1_2", "air", mut);
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("Recruit failed");
+  });
+
+  it("accepts a string error too (legacy server shape)", async () => {
+    mockFetchOnce({ success: false, error: "raw string error" });
+    const mut = makeMutators();
+    await recruitUnits(makeUser(), "1_2", "ground", mut);
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("raw string error");
+  });
+});
+
+describe("armDefenseSpell", () => {
+  it("posts tileId + spellId and merges the tile", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      tile: FAKE_TILE,
+      player: FAKE_PLAYER,
+      report: FAKE_REPORT,
+    });
+    const mut = makeMutators();
+    const out = await armDefenseSpell(makeUser(), "1_2", "blue-shield-1", mut);
+    expect(out).toEqual({ reportSummary: "did a thing" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/spell/arm",
+      expect.objectContaining({
+        body: JSON.stringify({ tileId: "1_2", spellId: "blue-shield-1" }),
+      })
+    );
+    expect(mut.__spies.mergeOwnedTiles).toHaveBeenCalled();
+  });
+
+  it("surfaces error on failure", async () => {
+    mockFetchOnce({ success: false, error: "no caste" });
+    const mut = makeMutators();
+    const out = await armDefenseSpell(makeUser(), "1_2", "x", mut);
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("no caste");
+  });
+});
+
+describe("distributeTile", () => {
+  it("posts tileId + type + count=1", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      tile: FAKE_TILE,
+      player: FAKE_PLAYER,
+      report: FAKE_REPORT,
+    });
+    const mut = makeMutators();
+    await distributeTile(makeUser(), "1_2", "military", mut);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/setup/distribute",
+      expect.objectContaining({
+        body: JSON.stringify({ tileId: "1_2", type: "military", count: 1 }),
+      })
+    );
+  });
+
+  it("returns the report summary on success", async () => {
+    mockFetchOnce({
+      success: true,
+      tile: FAKE_TILE,
+      player: FAKE_PLAYER,
+      report: { summary: "Tile changed to military · 1 turn spent" },
+    });
+    const mut = makeMutators();
+    const out = await distributeTile(makeUser(), "1_2", "military", mut);
+    expect(out?.reportSummary).toMatch(/Tile changed to military/);
+  });
+
+  it("returns null + sets error on failure", async () => {
+    mockFetchOnce({ success: false, error: { message: "wrong phase" } });
+    const mut = makeMutators();
+    const out = await distributeTile(makeUser(), "1_2", "food", mut);
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("wrong phase");
+  });
+});
+
+describe("attack", () => {
+  it("aliases attackerPlayer→setPlayer, sourceTile→mergeOwnedTiles", async () => {
+    mockFetchOnce({
+      success: true,
+      attackerPlayer: FAKE_PLAYER,
+      sourceTile: FAKE_TILE,
+      targetTile: FAKE_ENEMY_TILE,
+      attack: { outcome: "victory" },
+      report: { summary: "Captured 3_4" },
+    });
+    const mut = makeMutators();
+    const out = await attack(
+      makeUser(),
+      {
+        sourceTileId: "1_2",
+        targetTileId: "3_4",
+        units: { ground: 5, siege: 0, air: 0 },
+        offenseSpellId: null,
+      },
+      mut
+    );
+    expect(out?.outcome).toBe("victory");
+    expect(out?.reportSummary).toBe("Captured 3_4");
+    expect(mut.__spies.setPlayer).toHaveBeenCalledWith(FAKE_PLAYER);
+    expect(mut.__spies.mergeOwnedTiles).toHaveBeenCalledWith([
+      expect.objectContaining({ tileId: FAKE_TILE.tileId }),
+    ]);
+    // Enemy tile (ownerId "foe", not "me") routes through mergeBorderTiles.
+    expect(mut.__spies.mergeBorderTiles).toHaveBeenCalledWith([
+      expect.objectContaining({ tileId: FAKE_ENEMY_TILE.tileId }),
+    ]);
+  });
+
+  it("routes captured target tile through mergeOwnedTiles when ownerId === user.uid", async () => {
+    const captured = { ...FAKE_ENEMY_TILE, ownerId: "me" };
+    mockFetchOnce({
+      success: true,
+      attackerPlayer: FAKE_PLAYER,
+      sourceTile: FAKE_TILE,
+      targetTile: captured,
+      attack: { outcome: "captured" },
+      report: { summary: "Captured" },
+    });
+    const mut = makeMutators();
+    await attack(
+      makeUser("me"),
+      {
+        sourceTileId: "1_2",
+        targetTileId: "3_4",
+        units: { ground: 5, siege: 0, air: 0 },
+        offenseSpellId: null,
+      },
+      mut
+    );
+    // Both source and the now-captured target tiles end up in mergeOwnedTiles.
+    expect(mut.__spies.mergeOwnedTiles).toHaveBeenCalledTimes(2);
+    expect(mut.__spies.mergeBorderTiles).not.toHaveBeenCalled();
+  });
+
+  it("returns intelReport when present in response", async () => {
+    const intel = { targetTileId: "3_4", target: { units: {} } };
+    mockFetchOnce({
+      success: true,
+      attackerPlayer: FAKE_PLAYER,
+      sourceTile: FAKE_TILE,
+      targetTile: FAKE_ENEMY_TILE,
+      attack: { outcome: "victory" },
+      report: { summary: "x" },
+      intelReport: intel,
+    });
+    const mut = makeMutators();
+    const out = await attack(
+      makeUser(),
+      {
+        sourceTileId: "1_2",
+        targetTileId: "3_4",
+        units: { ground: 5, siege: 0, air: 0 },
+        offenseSpellId: null,
+      },
+      mut
+    );
+    expect(out?.intelReport).toEqual(intel);
+  });
+
+  it("returns null on failure", async () => {
+    mockFetchOnce({ success: false, error: "no border" });
+    const mut = makeMutators();
+    const out = await attack(
+      makeUser(),
+      {
+        sourceTileId: "1_2",
+        targetTileId: "3_4",
+        units: { ground: 1, siege: 0, air: 0 },
+        offenseSpellId: null,
+      },
+      mut
+    );
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("no border");
+  });
+});
+
+describe("spendArtifact", () => {
+  const FAKE_ARTIFACT = {
+    id: "art-1",
+    ownerId: "me",
+    definitionId: "whispered-map",
+    rarity: "common",
+    type: "intel",
+    used: true,
+  };
+
+  it("includes targetTileId only when provided", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      artifact: FAKE_ARTIFACT,
+    });
+    const mut = makeMutators();
+    await spendArtifact(makeUser(), "art-1", "3_4", mut);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/artifact/use",
+      expect.objectContaining({
+        body: JSON.stringify({ artifactId: "art-1", targetTileId: "3_4" }),
+      })
+    );
+  });
+
+  it("omits targetTileId when null", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      artifact: FAKE_ARTIFACT,
+    });
+    const mut = makeMutators();
+    await spendArtifact(makeUser(), "art-1", null, mut);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/artifact/use",
+      expect.objectContaining({
+        body: JSON.stringify({ artifactId: "art-1" }),
+      })
+    );
+  });
+
+  it("calls mergeArtifacts with the returned artifact", async () => {
+    mockFetchOnce({ success: true, artifact: FAKE_ARTIFACT });
+    const mut = makeMutators();
+    await spendArtifact(makeUser(), "art-1", "3_4", mut);
+    expect(mut.__spies.mergeArtifacts).toHaveBeenCalledWith([FAKE_ARTIFACT]);
+  });
+
+  it("returns intelReport when present", async () => {
+    const intel = { targetTileId: "3_4", target: { units: {} } };
+    mockFetchOnce({
+      success: true,
+      artifact: FAKE_ARTIFACT,
+      intelReport: intel,
+    });
+    const mut = makeMutators();
+    const out = await spendArtifact(makeUser(), "art-1", "3_4", mut);
+    expect(out?.intelReport).toEqual(intel);
+  });
+
+  it("returns null + sets error on failure", async () => {
+    mockFetchOnce({ success: false, error: "already used" });
+    const mut = makeMutators();
+    const out = await spendArtifact(makeUser(), "art-1", null, mut);
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("already used");
+  });
+});
+
+describe("farExpedition", () => {
+  it("merges owned tile, then border tile, then pushes report", async () => {
+    const newOwn = { ...FAKE_TILE, tileId: "0_0" };
+    mockFetchOnce({
+      success: true,
+      tile: newOwn,
+      enemyTile: FAKE_ENEMY_TILE,
+      player: FAKE_PLAYER,
+      report: FAKE_REPORT,
+      targetEnemyTileId: "3_4",
+    });
+    const mut = makeMutators();
+    const out = await farExpedition(makeUser(), mut);
+    expect(out).toEqual({ tileId: "0_0", enemyTileId: "3_4" });
+    // Order matters: owned-tile merge must happen before border-tile merge
+    // so the cache's "is this tile a border tile?" check sees the new own tile.
+    const ownedOrder = mut.__spies.mergeOwnedTiles.mock.invocationCallOrder[0];
+    const borderOrder = mut.__spies.mergeBorderTiles.mock.invocationCallOrder[0];
+    expect(ownedOrder).toBeLessThan(borderOrder!);
+    expect(mut.__spies.setRecentReports).toHaveBeenCalled();
+  });
+
+  it("returns null + sets error on failure", async () => {
+    mockFetchOnce({ success: false, error: { message: "no enemies" } });
+    const mut = makeMutators();
+    const out = await farExpedition(makeUser(), mut);
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("no enemies");
+  });
+
+  it("handles network error (fetch throws)", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("offline")) as unknown as typeof fetch;
+    const mut = makeMutators();
+    const out = await farExpedition(makeUser(), mut);
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("offline");
+  });
+});
+
+describe("castIntelSpell", () => {
+  it("posts spellId + targetTileId, returns intelReport + detected flag", async () => {
+    const intel = { targetTileId: "3_4", target: { units: {} } };
+    const fetchMock = mockFetchOnce({
+      success: true,
+      player: FAKE_PLAYER,
+      report: FAKE_REPORT,
+      intelReport: intel,
+      detected: true,
+    });
+    const mut = makeMutators();
+    const out = await castIntelSpell(
+      makeUser(),
+      "blue-intel-1",
+      "3_4",
+      mut
+    );
+    expect(out).toEqual({ intelReport: intel, detected: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/spy",
+      expect.objectContaining({
+        body: JSON.stringify({ spellId: "blue-intel-1", targetTileId: "3_4" }),
+      })
+    );
+    expect(mut.__spies.setPlayer).toHaveBeenCalledWith(FAKE_PLAYER);
+    expect(mut.__spies.setRecentReports).toHaveBeenCalled();
+  });
+
+  it("defaults detected to false when missing", async () => {
+    mockFetchOnce({
+      success: true,
+      intelReport: { targetTileId: "3_4" },
+    });
+    const mut = makeMutators();
+    const out = await castIntelSpell(makeUser(), "x", "3_4", mut);
+    expect(out?.detected).toBe(false);
+  });
+
+  it("returns null on server failure", async () => {
+    mockFetchOnce({ success: false });
+    const mut = makeMutators();
+    const out = await castIntelSpell(makeUser(), "x", "3_4", mut);
+    expect(out).toBeNull();
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("Spy spell failed");
+  });
+});
+
+describe("frontierExplore", () => {
+  it("sets progress, consumes reports, merges tiles + player", async () => {
+    const reports = [
+      { turnIndex: 1, summary: "claimed 1", artifactFound: false },
+      { turnIndex: 2, summary: "claimed 2 (artifact!)", artifactFound: true },
+    ];
+    mockFetchOnce({
+      success: true,
+      reports,
+      tiles: [FAKE_TILE],
+      player: FAKE_PLAYER,
+    });
+    const mut = makeMutators();
+    const setProgress = jest.fn();
+    await frontierExplore(makeUser(), 5, mut, setProgress);
+    expect(setProgress).toHaveBeenCalledWith({
+      done: 0,
+      total: 5,
+      artifactsFound: 0,
+    });
+    expect(setProgress).toHaveBeenCalledWith({
+      done: 2,
+      total: 5,
+      artifactsFound: 1,
+    });
+    expect(setProgress).toHaveBeenLastCalledWith(null);
+    expect(mut.__spies.setRecentReports).toHaveBeenCalled();
+    expect(mut.__spies.setPlayer).toHaveBeenCalledWith(FAKE_PLAYER);
+    expect(mut.__spies.mergeOwnedTiles).toHaveBeenCalledWith([FAKE_TILE]);
+  });
+
+  it("clamps count between 1 and 50", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      reports: [],
+      tiles: [],
+      player: FAKE_PLAYER,
+    });
+    await frontierExplore(makeUser(), 9999, makeMutators(), jest.fn());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/explore/bulk",
+      expect.objectContaining({ body: JSON.stringify({ count: 50 }) })
+    );
+  });
+
+  it("surfaces stoppedEarly with a count prefix", async () => {
+    mockFetchOnce({
+      success: true,
+      reports: [{ turnIndex: 1, summary: "x", artifactFound: false }],
+      tiles: [],
+      player: FAKE_PLAYER,
+      stoppedEarly: "no more frontier",
+    });
+    const mut = makeMutators();
+    await frontierExplore(makeUser(), 10, mut, jest.fn());
+    expect(mut.__spies.setError).toHaveBeenCalledWith(
+      "Claimed 1 / 10: no more frontier"
+    );
+  });
+
+  it("returns early on server failure", async () => {
+    mockFetchOnce({ success: false, error: "no auth" });
+    const mut = makeMutators();
+    await frontierExplore(makeUser(), 5, mut, jest.fn());
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("no auth");
+  });
+
+  it("clamps count to 1 when given 0 or negative values", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      reports: [],
+      tiles: [],
+      player: FAKE_PLAYER,
+    });
+    await frontierExplore(makeUser(), 0, makeMutators(), jest.fn());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/explore/bulk",
+      expect.objectContaining({ body: JSON.stringify({ count: 1 }) })
+    );
+  });
+
+  it("handles network errors via the catch path", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("offline")) as unknown as typeof fetch;
+    const mut = makeMutators();
+    const setProgress = jest.fn();
+    await frontierExplore(makeUser(), 5, mut, setProgress);
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("offline");
+    expect(setProgress).toHaveBeenLastCalledWith(null);
+  });
+
+  it("handles non-Error rejections via the fallback message", async () => {
+    global.fetch = jest.fn().mockRejectedValue("just a string") as unknown as typeof fetch;
+    const mut = makeMutators();
+    await frontierExplore(makeUser(), 5, mut, jest.fn());
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("Explore failed");
+  });
+});
+
+describe("bulkDistribute", () => {
+  function tile(id: string, type: "military" | "unassigned" = "unassigned") {
+    return {
+      tileId: id,
+      q: 0,
+      r: 0,
+      type,
+      ownerId: "me",
+      units: { ground: 0, siege: 0, air: 0 },
+      armedDefenseSpellId: null,
+    };
+  }
+
+  it("returns immediately with an error when no source tiles match", async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const mut = makeMutators();
+    await bulkDistribute(
+      makeUser(),
+      {
+        targetType: "military",
+        count: 5,
+        sourceFilter: () => false,
+        sourceLabel: "unassigned",
+        tiles: [tile("a"), tile("b")],
+      },
+      mut,
+      jest.fn()
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mut.__spies.setError).toHaveBeenCalledWith(
+      "No unassigned tiles to distribute."
+    );
+  });
+
+  it("posts the filtered source tile ids and target type", async () => {
+    const fetchMock = mockFetchOnce({
+      success: true,
+      reports: [],
+      tiles: [],
+      player: FAKE_PLAYER,
+    });
+    await bulkDistribute(
+      makeUser(),
+      {
+        targetType: "food",
+        count: 2,
+        sourceFilter: (t) => t.type === "unassigned",
+        sourceLabel: "unassigned",
+        tiles: [tile("a"), tile("b"), tile("c", "military"), tile("d")],
+      },
+      makeMutators(),
+      jest.fn()
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/game/distribute/bulk",
+      expect.objectContaining({
+        body: JSON.stringify({ tileIds: ["a", "b"], type: "food" }),
+      })
+    );
+  });
+
+  it("handles fetch rejection gracefully", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("net down")) as unknown as typeof fetch;
+    const mut = makeMutators();
+    await bulkDistribute(
+      makeUser(),
+      {
+        targetType: "magic",
+        count: 1,
+        sourceFilter: () => true,
+        sourceLabel: "all",
+        tiles: [tile("a")],
+      },
+      mut,
+      jest.fn()
+    );
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("net down");
+  });
+
+  it("falls back to default error when rejection has no message", async () => {
+    global.fetch = jest.fn().mockRejectedValue("oops") as unknown as typeof fetch;
+    const mut = makeMutators();
+    await bulkDistribute(
+      makeUser(),
+      {
+        targetType: "magic",
+        count: 1,
+        sourceFilter: () => true,
+        sourceLabel: "all",
+        tiles: [tile("a")],
+      },
+      mut,
+      jest.fn()
+    );
+    expect(mut.__spies.setError).toHaveBeenLastCalledWith("Distribute failed");
+  });
+
+  it("surfaces stoppedEarly with the configured prefix", async () => {
+    mockFetchOnce({
+      success: true,
+      reports: [{ turnIndex: 1, summary: "ok", artifactFound: false }],
+      tiles: [],
+      player: FAKE_PLAYER,
+      stoppedEarly: "ran out of turns",
+    });
+    const mut = makeMutators();
+    await bulkDistribute(
+      makeUser(),
+      {
+        targetType: "magic",
+        count: 5,
+        sourceFilter: (t) => t.type === "unassigned",
+        sourceLabel: "unassigned",
+        tiles: [tile("a"), tile("b")],
+      },
+      mut,
+      jest.fn()
+    );
+    expect(mut.__spies.setError).toHaveBeenCalledWith(
+      "Stopped early after 1 / 2: ran out of turns"
+    );
+  });
+});
+
+describe("createPlayer / setPlayerName / adminGrant", () => {
+  it("createPlayer refetches on success", async () => {
+    mockFetchOnce({ success: true });
+    const refetch = jest.fn().mockResolvedValue(undefined);
+    const setError = jest.fn();
+    await createPlayer(makeUser(), "Roger", { setError }, refetch);
+    expect(setError).toHaveBeenCalledWith(null);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("createPlayer skips refetch + sets error on failure", async () => {
+    mockFetchOnce({ success: false, error: "name taken" });
+    const refetch = jest.fn();
+    const setError = jest.fn();
+    await createPlayer(makeUser(), "Roger", { setError }, refetch);
+    expect(refetch).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenLastCalledWith("name taken");
+  });
+
+  it("setPlayerName patches player on success", async () => {
+    mockFetchOnce({ success: true, player: FAKE_PLAYER });
+    const setError = jest.fn();
+    const setPlayer = jest.fn();
+    await setPlayerName(makeUser(), "New Name", { setError, setPlayer });
+    expect(setPlayer).toHaveBeenCalledWith(FAKE_PLAYER);
+  });
+
+  it("setPlayerName surfaces error on failure", async () => {
+    mockFetchOnce({ success: false, error: "name taken" });
+    const setError = jest.fn();
+    const setPlayer = jest.fn();
+    await setPlayerName(makeUser(), "X", { setError, setPlayer });
+    expect(setError).toHaveBeenLastCalledWith("name taken");
+    expect(setPlayer).not.toHaveBeenCalled();
+  });
+
+  it("adminGrant patches player on success", async () => {
+    mockFetchOnce({ success: true, player: FAKE_PLAYER });
+    const setError = jest.fn();
+    const setPlayer = jest.fn();
+    await adminGrant(makeUser(), { setError, setPlayer });
+    expect(setPlayer).toHaveBeenCalledWith(FAKE_PLAYER);
+  });
+
+  it("adminGrant surfaces error on failure", async () => {
+    mockFetchOnce({ success: false, error: { message: "not admin" } });
+    const setError = jest.fn();
+    const setPlayer = jest.fn();
+    await adminGrant(makeUser(), { setError, setPlayer });
+    expect(setError).toHaveBeenLastCalledWith("not admin");
+  });
+});

--- a/__tests__/app/game/_lib/dashboard-fetch.test.ts
+++ b/__tests__/app/game/_lib/dashboard-fetch.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { fetchInitialData } from "@/app/game/_lib/dashboard-fetch";
+
+// Mock the cache so we can control whether the cached-path or refetch-path
+// is exercised by each test.
+jest.mock("@/lib/game/local-map-cache", () => ({
+  loadCachedMap: jest.fn(),
+  saveCachedMap: jest.fn(),
+}));
+import {
+  loadCachedMap,
+  saveCachedMap,
+} from "@/lib/game/local-map-cache";
+
+const FAKE_PLAYER = { id: "me", turnsRemaining: 100 };
+const FAKE_TILE = {
+  tileId: "0_0",
+  q: 0,
+  r: 0,
+  type: "military",
+  ownerId: "me",
+  units: { ground: 0, siege: 0, air: 0 },
+  armedDefenseSpellId: null,
+};
+
+function makeUser(uid = "me") {
+  return {
+    uid,
+    getIdToken: jest.fn().mockResolvedValue(`token-${uid}`),
+  } as unknown as Parameters<typeof fetchInitialData>[0];
+}
+
+function makeSetters() {
+  return {
+    setPlayer: jest.fn(),
+    setTiles: jest.fn(),
+    setServerIsAdmin: jest.fn(),
+    setEligibility: jest.fn(),
+    setWorldTiles: jest.fn(),
+    setWorldOwners: jest.fn(),
+    setArtifacts: jest.fn(),
+    setError: jest.fn(),
+    setLoading: jest.fn(),
+  };
+}
+
+/** Mock fetch with one queued response per request, in order. */
+function mockFetchSequence(...responses: unknown[]) {
+  let i = 0;
+  const fetchMock = jest.fn().mockImplementation(() => {
+    const next = responses[i++];
+    return Promise.resolve({ json: () => Promise.resolve(next) });
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("fetchInitialData", () => {
+  it("populates player, eligibility, and artifacts in parallel", async () => {
+    (loadCachedMap as jest.Mock).mockReturnValue({
+      myTiles: [],
+      borderTiles: [FAKE_TILE],
+      owners: [
+        {
+          userId: "foe",
+          displayName: "Foe",
+          caste: null,
+          shielded: false,
+        },
+      ],
+      lastFetchedAt: Date.now(),
+    });
+    mockFetchSequence(
+      // /api/game/player
+      { success: true, player: FAKE_PLAYER, tiles: [FAKE_TILE], isAdmin: true },
+      // /api/game/eligibility
+      {
+        success: true,
+        githubLogin: "octocat",
+        mergedPrCountThisWeek: 3,
+        nextRolloverIso: "2026-05-15T00:00:00Z",
+        windowStartIso: "2026-05-08T00:00:00Z",
+      },
+      // /api/game/artifacts
+      {
+        success: true,
+        artifacts: [
+          { id: "a", used: false },
+          { id: "b", used: true },
+        ],
+      }
+    );
+    const setters = makeSetters();
+    await fetchInitialData(makeUser(), setters);
+
+    expect(setters.setPlayer).toHaveBeenCalledWith(FAKE_PLAYER);
+    expect(setters.setTiles).toHaveBeenCalledWith([FAKE_TILE]);
+    expect(setters.setServerIsAdmin).toHaveBeenCalledWith(true);
+    expect(setters.setEligibility).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubLogin: "octocat",
+        mergedPrCountThisWeek: 3,
+      })
+    );
+    // Used artifacts must be filtered out.
+    expect(setters.setArtifacts).toHaveBeenCalledWith([{ id: "a", used: false }]);
+    expect(setters.setWorldTiles).toHaveBeenCalledWith([FAKE_TILE]);
+    expect(setters.setLoading).toHaveBeenCalledWith(false);
+  });
+
+  it("falls back to /map/me + saveCachedMap when no cache exists", async () => {
+    (loadCachedMap as jest.Mock).mockReturnValue(null);
+    mockFetchSequence(
+      { success: true, player: FAKE_PLAYER, tiles: [], isAdmin: false },
+      {
+        success: true,
+        githubLogin: null,
+        mergedPrCountThisWeek: 0,
+        nextRolloverIso: "2026-05-15T00:00:00Z",
+        windowStartIso: "2026-05-08T00:00:00Z",
+      },
+      { success: true, artifacts: [] },
+      // /api/game/map/me
+      {
+        success: true,
+        myTiles: [],
+        borderTiles: [FAKE_TILE],
+        owners: [],
+      }
+    );
+    const setters = makeSetters();
+    await fetchInitialData(makeUser(), setters);
+    expect(saveCachedMap).toHaveBeenCalled();
+    expect(setters.setWorldTiles).toHaveBeenCalledWith([FAKE_TILE]);
+  });
+
+  it("surfaces an error when the player fetch fails", async () => {
+    (loadCachedMap as jest.Mock).mockReturnValue(null);
+    mockFetchSequence(
+      { success: false, error: "auth failed" },
+      { success: true, githubLogin: null, mergedPrCountThisWeek: 0, nextRolloverIso: "x", windowStartIso: "y" },
+      { success: true, artifacts: [] }
+    );
+    const setters = makeSetters();
+    await fetchInitialData(makeUser(), setters);
+    expect(setters.setError).toHaveBeenCalledWith("auth failed");
+    expect(setters.setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it("ignores artifact response when success=false", async () => {
+    (loadCachedMap as jest.Mock).mockReturnValue({
+      myTiles: [],
+      borderTiles: [],
+      owners: [],
+      lastFetchedAt: 0,
+    });
+    mockFetchSequence(
+      { success: true, player: FAKE_PLAYER, tiles: [], isAdmin: false },
+      { success: true, githubLogin: null, mergedPrCountThisWeek: 0, nextRolloverIso: "x", windowStartIso: "y" },
+      { success: false }
+    );
+    const setters = makeSetters();
+    await fetchInitialData(makeUser(), setters);
+    expect(setters.setArtifacts).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/game/threats/threats-derive.test.ts
+++ b/__tests__/app/game/threats/threats-derive.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { deriveThreatEntries } from "@/app/game/threats/_lib/threats-derive";
+import type { OwnerSummary } from "@/app/game/_lib/dashboard-types";
+import type { LandType, MapTile } from "@/lib/game/types";
+
+function tile(args: {
+  q: number;
+  r: number;
+  ownerId: string | null;
+  type?: LandType;
+  ground?: number;
+  siege?: number;
+  air?: number;
+}): MapTile {
+  return {
+    tileId: `${args.q}_${args.r}`,
+    q: args.q,
+    r: args.r,
+    type: args.type ?? "military",
+    ownerId: args.ownerId,
+    units: {
+      ground: args.ground ?? 0,
+      siege: args.siege ?? 0,
+      air: args.air ?? 0,
+    },
+    armedDefenseSpellId: null,
+  };
+}
+
+function owner(userId: string, displayName: string, shielded = false): OwnerSummary {
+  return { userId, displayName, caste: null, shielded };
+}
+
+describe("deriveThreatEntries", () => {
+  it("returns empty for empty inputs", () => {
+    expect(
+      deriveThreatEntries({
+        myUserId: "me",
+        myCaste: null,
+        myTiles: [],
+        worldTiles: [],
+        worldOwners: new Map(),
+      })
+    ).toEqual([]);
+  });
+
+  it("returns empty when no enemy tile borders any of mine", () => {
+    const mine = [tile({ q: 0, r: 0, ownerId: "me" })];
+    // Enemy is two tiles away (not a neighbor).
+    const enemy = [tile({ q: 5, r: 5, ownerId: "foe", ground: 5 })];
+    const owners = new Map<string, OwnerSummary>([["foe", owner("foe", "Foe")]]);
+    expect(
+      deriveThreatEntries({
+        myUserId: "me",
+        myCaste: null,
+        myTiles: mine,
+        worldTiles: enemy,
+        worldOwners: owners,
+      })
+    ).toEqual([]);
+  });
+
+  it("creates one entry per enemy tile bordering my territory", () => {
+    // me: (0,0)
+    // enemyA: (1,0) — adjacent to me
+    // enemyB: (-1,0) — adjacent to me, different owner
+    // enemyC: (5,5) — far away
+    const mine = [tile({ q: 0, r: 0, ownerId: "me", ground: 50 })];
+    const world = [
+      tile({ q: 1, r: 0, ownerId: "foeA", ground: 10 }),
+      tile({ q: -1, r: 0, ownerId: "foeB", ground: 20 }),
+      tile({ q: 5, r: 5, ownerId: "foeC", ground: 30 }),
+    ];
+    const owners = new Map<string, OwnerSummary>([
+      ["foeA", owner("foeA", "FoeA")],
+      ["foeB", owner("foeB", "FoeB")],
+      ["foeC", owner("foeC", "FoeC")],
+    ]);
+    const result = deriveThreatEntries({
+      myUserId: "me",
+      myCaste: null,
+      myTiles: mine,
+      worldTiles: world,
+      worldOwners: owners,
+    });
+    expect(result).toHaveLength(2);
+    const ids = result.map((e) => e.enemyTile.tileId).sort();
+    expect(ids).toEqual(["-1_0", "1_0"]);
+  });
+
+  it("picks the strongest source when multiple of mine border the same enemy", () => {
+    // mine A at (0,0) — 50 units; mine B at (2,-1) — 100 units
+    // enemy at (1,0) — borders both. B should win (larger total).
+    const weak = tile({ q: 0, r: 0, ownerId: "me", ground: 50 });
+    const strong = tile({ q: 2, r: -1, ownerId: "me", ground: 100 });
+    const enemy = tile({ q: 1, r: 0, ownerId: "foe", ground: 10 });
+    const result = deriveThreatEntries({
+      myUserId: "me",
+      myCaste: null,
+      myTiles: [weak, strong],
+      worldTiles: [enemy],
+      worldOwners: new Map([["foe", owner("foe", "Foe")]]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.bestSource.tileId).toBe(strong.tileId);
+    expect(result[0]!.candidateSources).toHaveLength(2);
+  });
+
+  it("sorts entries by myAdvantage descending (easiest first)", () => {
+    // Two enemies both bordering my one tile (50 units).
+    // weak enemy at (1,0): 5 units → advantage 10
+    // tough enemy at (-1,0): 50 units → advantage 1
+    const mine = tile({ q: 0, r: 0, ownerId: "me", ground: 50 });
+    const weakEnemy = tile({ q: 1, r: 0, ownerId: "weak", ground: 5 });
+    const toughEnemy = tile({ q: -1, r: 0, ownerId: "tough", ground: 50 });
+    const result = deriveThreatEntries({
+      myUserId: "me",
+      myCaste: null,
+      myTiles: [mine],
+      worldTiles: [weakEnemy, toughEnemy],
+      worldOwners: new Map([
+        ["weak", owner("weak", "Weak")],
+        ["tough", owner("tough", "Tough")],
+      ]),
+    });
+    expect(result.map((e) => e.enemyTile.tileId)).toEqual(["1_0", "-1_0"]);
+    expect(result[0]!.myAdvantage).toBeGreaterThan(result[1]!.myAdvantage);
+  });
+
+  it("uses supply multiplier when caste is set (boosting source strength)", () => {
+    // Two equal-unit candidate sources; one has a friendly military neighbor,
+    // the other is isolated. Caste is "green" (highest supplyMultiplier).
+    // Supply-boosted source must win.
+    const supplied = tile({ q: 0, r: 0, ownerId: "me", ground: 50 });
+    const friendlyNeighbor = tile({ q: 1, r: 0, ownerId: "me", type: "military" });
+    const isolated = tile({ q: 5, r: 5, ownerId: "me", ground: 50 });
+    // enemy at (2,0) borders only `friendlyNeighbor` (a military tile owned by me),
+    // so we need an enemy adjacent to BOTH supplied and isolated. Place enemy at
+    // (-1,0) (adjacent to supplied) and another enemy at (4,5) (adjacent to isolated).
+    // Then run them through derive separately to assert supply impact.
+    const enemyA = tile({ q: -1, r: 0, ownerId: "foe", ground: 5 });
+    const result = deriveThreatEntries({
+      myUserId: "me",
+      myCaste: "green",
+      myTiles: [supplied, friendlyNeighbor, isolated],
+      worldTiles: [enemyA],
+      worldOwners: new Map([["foe", owner("foe", "Foe")]]),
+    });
+    expect(result).toHaveLength(1);
+    // The supplied tile is the only one bordering enemyA.
+    expect(result[0]!.bestSource.tileId).toBe(supplied.tileId);
+    // Supply multiplier > 1 because of the friendly military neighbor.
+    expect(result[0]!.bestSourceSupply).toBeGreaterThan(1);
+  });
+
+  it("filters out unassigned/unrevealed tiles from friendly neighbor supply", () => {
+    // mine: (0,0) military, (1,0) unassigned. Enemy at (2,0) borders (1,0) only.
+    // Even with caste set, the friendly neighbor (0,0) is filtered out because
+    // (1,0) isn't supplying anything (it's the source itself), and there's no
+    // contributing neighbor — so supply == isolation floor.
+    const source = tile({ q: 1, r: 0, ownerId: "me", ground: 30 });
+    const unassigned = tile({ q: 0, r: 0, ownerId: "me", type: "unassigned" });
+    const enemy = tile({ q: 2, r: 0, ownerId: "foe", ground: 5 });
+    const result = deriveThreatEntries({
+      myUserId: "me",
+      myCaste: "red",
+      myTiles: [source, unassigned],
+      worldTiles: [enemy],
+      worldOwners: new Map([["foe", owner("foe", "Foe")]]),
+    });
+    expect(result).toHaveLength(1);
+    // Supply <= 1 because the unassigned neighbor doesn't contribute.
+    expect(result[0]!.bestSourceSupply).toBeLessThan(1);
+  });
+
+  it("ignores tiles owned by me even if they share a border with an enemy", () => {
+    // me has two tiles; one adjacent enemy. Should never include my own as enemy.
+    const mineA = tile({ q: 0, r: 0, ownerId: "me", ground: 30 });
+    const mineB = tile({ q: 1, r: 0, ownerId: "me", ground: 60 });
+    const enemy = tile({ q: 2, r: 0, ownerId: "foe", ground: 10 });
+    const result = deriveThreatEntries({
+      myUserId: "me",
+      myCaste: null,
+      myTiles: [mineA, mineB],
+      worldTiles: [enemy],
+      worldOwners: new Map([["foe", owner("foe", "Foe")]]),
+    });
+    expect(result).toHaveLength(1);
+    // Only mineB borders the enemy — must be the chosen source.
+    expect(result[0]!.bestSource.tileId).toBe(mineB.tileId);
+    expect(result[0]!.candidateSources).toHaveLength(1);
+  });
+});

--- a/app/game/_components/dashboard/NavGrid.tsx
+++ b/app/game/_components/dashboard/NavGrid.tsx
@@ -67,7 +67,8 @@ export function NavGrid({ phase }: NavGridProps) {
                 { href: "/game/tiles", label: "World map" },
               ]
             : [
-                { href: "/game/tiles", label: "World map", primary: true },
+                { href: "/game/threats", label: "Threats", primary: true },
+                { href: "/game/tiles", label: "World map" },
                 { href: "/game/recruit", label: "Recruit" },
                 { href: "/game/spells", label: "Spells" },
                 { href: "/game/upgrades", label: "Upgrades" },

--- a/app/game/_components/dashboard/ThreatCard.tsx
+++ b/app/game/_components/dashboard/ThreatCard.tsx
@@ -6,11 +6,28 @@
 
 "use client";
 
+import Link from "next/link";
 import type { ThreatSummary } from "../../_lib/dashboard-types";
 
 interface ThreatCardProps {
   threats: ThreatSummary;
   shielded: boolean;
+}
+
+/**
+ * Link the player from the threat callout into the consolidated Threats
+ * action hub at /game/threats. Rendered only when there's actually
+ * something on the border (skipped on the empty + shielded variants).
+ */
+function ViewAllThreatsLink() {
+  return (
+    <Link
+      href="/game/threats"
+      className="block text-xs text-emerald-600 dark:text-emerald-400 hover:underline mt-2"
+    >
+      View all threats →
+    </Link>
+  );
 }
 
 /**
@@ -87,6 +104,7 @@ export function ThreatCard({ threats, shielded }: ThreatCardProps) {
           shielded
         </div>
       )}
+      <ViewAllThreatsLink />
     </div>
   );
 }

--- a/app/game/_lib/dashboard-actions.ts
+++ b/app/game/_lib/dashboard-actions.ts
@@ -8,10 +8,15 @@
 
 import type { User } from "firebase/auth";
 import type {
+  GameArtifact,
   GamePlayer,
+  GameTile,
+  IntelReport,
   LandType,
   MapTile,
   TurnReport,
+  UnitStack,
+  UnitType,
 } from "@/lib/game/types";
 import type { ActionProgress } from "./dashboard-types";
 
@@ -31,6 +36,26 @@ export interface DashboardMutators {
    *  localStorage map cache. Used by Far Expedition and Attack to surface
    *  newly-adjacent enemy tiles in the threat box without a page reload. */
   mergeBorderTiles: (updates: MapTile[]) => void;
+  /** Patch the artifacts inventory after a use / find. Pass artifact docs
+   *  with `used` flipped or freshly-found artifacts. */
+  mergeArtifacts: (updates: GameArtifact[]) => void;
+}
+
+/**
+ * Convert the GameTile shape returned by single-tile action endpoints
+ * (build / arm / distribute / attack) into the lighter MapTile shape that
+ * lives in the dashboard's tiles + worldTiles state.
+ */
+function asMapTile(t: GameTile): MapTile {
+  return {
+    tileId: t.tileId,
+    q: t.q,
+    r: t.r,
+    type: t.type,
+    ownerId: t.ownerId ?? null,
+    units: t.units,
+    armedDefenseSpellId: t.armedDefenseSpellId ?? null,
+  };
 }
 
 /** Common error-message extraction for `data.error` (string | object). */
@@ -273,6 +298,235 @@ export async function castIntelSpell(
     };
   } catch (e) {
     mut.setError(e instanceof Error ? e.message : "Spy spell failed");
+    return null;
+  }
+}
+
+/**
+ * POST /api/game/attack — single-tile attack with optional offense spell.
+ * Patches both source (mine) and target (border) tiles + the attacker's
+ * player record from the response. Returns the IntelReport if a Blue/Black
+ * air-intel passive fired.
+ */
+export async function attack(
+  user: User,
+  args: {
+    sourceTileId: string;
+    targetTileId: string;
+    units: UnitStack;
+    offenseSpellId: string | null;
+  },
+  mut: DashboardMutators
+): Promise<{
+  outcome: string;
+  reportSummary: string;
+  intelReport: IntelReport | null;
+} | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/attack", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(args),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Attack failed"));
+    }
+    // Attack response uses `attackerPlayer` instead of the standard `player`.
+    if (data.attackerPlayer) mut.setPlayer(data.attackerPlayer as GamePlayer);
+    if (data.sourceTile) mut.mergeOwnedTiles([asMapTile(data.sourceTile as GameTile)]);
+    if (data.targetTile) {
+      const tt = data.targetTile as GameTile;
+      // If we captured the tile, it now belongs to us — funnel through
+      // mergeOwnedTiles. Otherwise it stays in the enemy ring.
+      if (tt.ownerId === user.uid) {
+        mut.mergeOwnedTiles([asMapTile(tt)]);
+      } else {
+        mut.mergeBorderTiles([asMapTile(tt)]);
+      }
+    }
+    if (data.report) {
+      mut.setRecentReports((prev) =>
+        [data.report as TurnReport, ...prev].slice(0, 50)
+      );
+    }
+    return {
+      outcome: (data.attack as { outcome?: string } | undefined)?.outcome ?? "",
+      reportSummary:
+        (data.report as { summary?: string } | undefined)?.summary ?? "",
+      intelReport: (data.intelReport as IntelReport | undefined) ?? null,
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Attack failed");
+    return null;
+  }
+}
+
+/** POST /api/game/build — recruit one batch (`+10` units of one type). */
+export async function recruitUnits(
+  user: User,
+  tileId: string,
+  unitType: UnitType,
+  mut: DashboardMutators
+): Promise<{ produced: number; reportSummary: string } | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/build", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ tileId, unitType }),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Recruit failed"));
+    }
+    if (data.player) mut.setPlayer(data.player as GamePlayer);
+    if (data.tile) mut.mergeOwnedTiles([asMapTile(data.tile as GameTile)]);
+    if (data.report) {
+      mut.setRecentReports((prev) =>
+        [data.report as TurnReport, ...prev].slice(0, 50)
+      );
+    }
+    return {
+      produced: typeof data.produced === "number" ? data.produced : 0,
+      reportSummary:
+        (data.report as { summary?: string } | undefined)?.summary ?? "",
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Recruit failed");
+    return null;
+  }
+}
+
+/** POST /api/game/spell/arm — pre-arm one defense spell on one tile. */
+export async function armDefenseSpell(
+  user: User,
+  tileId: string,
+  spellId: string,
+  mut: DashboardMutators
+): Promise<{ reportSummary: string } | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/spell/arm", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ tileId, spellId }),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Arm spell failed"));
+    }
+    if (data.player) mut.setPlayer(data.player as GamePlayer);
+    if (data.tile) mut.mergeOwnedTiles([asMapTile(data.tile as GameTile)]);
+    if (data.report) {
+      mut.setRecentReports((prev) =>
+        [data.report as TurnReport, ...prev].slice(0, 50)
+      );
+    }
+    return {
+      reportSummary:
+        (data.report as { summary?: string } | undefined)?.summary ?? "",
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Arm spell failed");
+    return null;
+  }
+}
+
+/**
+ * POST /api/game/setup/distribute — change one owned tile's land type
+ * (military / food / magic / unassigned). The "setup" route name is a v1
+ * artifact; the underlying server function permits the play phase too.
+ */
+export async function distributeTile(
+  user: User,
+  tileId: string,
+  type: LandType,
+  mut: DashboardMutators
+): Promise<{ reportSummary: string } | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/setup/distribute", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ tileId, type, count: 1 }),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Distribute failed"));
+    }
+    if (data.player) mut.setPlayer(data.player as GamePlayer);
+    if (data.tile) mut.mergeOwnedTiles([asMapTile(data.tile as GameTile)]);
+    if (data.report) {
+      mut.setRecentReports((prev) =>
+        [data.report as TurnReport, ...prev].slice(0, 50)
+      );
+    }
+    return {
+      reportSummary:
+        (data.report as { summary?: string } | undefined)?.summary ?? "",
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Distribute failed");
+    return null;
+  }
+}
+
+/**
+ * POST /api/game/artifact/use — spend a single artifact, optionally on a
+ * target tile. Intel artifacts return an IntelReport that the caller is
+ * expected to render (e.g. ThreatRow inline panel).
+ *
+ * Named `spendArtifact` (not `useArtifact`) to avoid React's
+ * `react-hooks/rules-of-hooks` lint flagging it inside `useCallback`.
+ */
+export async function spendArtifact(
+  user: User,
+  artifactId: string,
+  targetTileId: string | null,
+  mut: DashboardMutators
+): Promise<{ intelReport: IntelReport | null } | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/artifact/use", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        artifactId,
+        ...(targetTileId ? { targetTileId } : {}),
+      }),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Artifact use failed"));
+    }
+    if (data.artifact) mut.mergeArtifacts([data.artifact as GameArtifact]);
+    return {
+      intelReport: (data.intelReport as IntelReport | undefined) ?? null,
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Artifact use failed");
     return null;
   }
 }

--- a/app/game/_lib/dashboard-fetch.ts
+++ b/app/game/_lib/dashboard-fetch.ts
@@ -13,7 +13,7 @@ import {
   type CachedMapView,
   type CachedOwnerSummary,
 } from "@/lib/game/local-map-cache";
-import type { GamePlayer, MapTile } from "@/lib/game/types";
+import type { GameArtifact, GamePlayer, MapTile } from "@/lib/game/types";
 import type { Eligibility, OwnerSummary } from "./dashboard-types";
 
 /** State setters the initial-load fetcher reaches back into. */
@@ -24,6 +24,7 @@ export interface FetchSetters {
   setEligibility: (e: Eligibility | null) => void;
   setWorldTiles: (t: MapTile[]) => void;
   setWorldOwners: (m: Map<string, OwnerSummary>) => void;
+  setArtifacts: (a: GameArtifact[]) => void;
   setError: (msg: string | null) => void;
   setLoading: (v: boolean) => void;
 }
@@ -53,6 +54,12 @@ interface EligibilityResponse {
   error?: { message?: string } | string;
 }
 
+interface ArtifactsResponse {
+  success: boolean;
+  artifacts?: GameArtifact[];
+  error?: { message?: string } | string;
+}
+
 /**
  * Initial-load fetcher: pulls the player, eligibility, and (from cache
  * or fresh) the personal map view. Hand-runs once on mount and again
@@ -66,11 +73,14 @@ export async function fetchInitialData(
   set.setLoading(true);
   try {
     const token = await user.getIdToken();
-    const [playerRes, elgRes] = await Promise.all([
+    const [playerRes, elgRes, artifactsRes] = await Promise.all([
       fetch("/api/game/player", {
         headers: { Authorization: `Bearer ${token}` },
       }),
       fetch("/api/game/eligibility", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      fetch("/api/game/artifacts?limit=100", {
         headers: { Authorization: `Bearer ${token}` },
       }),
     ]);
@@ -87,6 +97,11 @@ export async function fetchInitialData(
         mergedPrCountThisWeek: elgData.mergedPrCountThisWeek,
         nextRolloverIso: elgData.nextRolloverIso,
       });
+    }
+
+    const artifactsData = (await artifactsRes.json()) as ArtifactsResponse;
+    if (artifactsData.success && Array.isArray(artifactsData.artifacts)) {
+      set.setArtifacts(artifactsData.artifacts.filter((a) => !a.used));
     }
 
     // Map data — cache is source of truth. If absent, fetch /map/me

--- a/app/game/_lib/use-dashboard-data.ts
+++ b/app/game/_lib/use-dashboard-data.ts
@@ -10,19 +10,27 @@ import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { mergeTiles as mergeTilesIntoCache } from "@/lib/game/local-map-cache";
 import type {
+  GameArtifact,
   GamePlayer,
   LandType,
   MapTile,
   TurnReport,
+  UnitStack,
+  UnitType,
 } from "@/lib/game/types";
 import {
   adminGrant,
+  armDefenseSpell,
+  attack,
   bulkDistribute,
   castIntelSpell,
   createPlayer,
+  distributeTile,
   farExpedition,
   frontierExplore,
+  recruitUnits,
   setPlayerName,
+  spendArtifact,
   type DashboardMutators,
 } from "./dashboard-actions";
 import { fetchInitialData } from "./dashboard-fetch";
@@ -77,6 +85,12 @@ export function useDashboardData() {
   const [renaming, setRenaming] = useState(false);
   const [renameInput, setRenameInput] = useState("");
 
+  // Inventory of unused artifacts. Loaded once on mount and patched in place
+  // whenever an artifact is found (frontier explore reports) or used (artifact
+  // use endpoint). Threats page + tile-detail page consume this directly so
+  // every action button knows what's available without a refetch.
+  const [artifacts, setArtifacts] = useState<GameArtifact[]>([]);
+
   /**
    * Patch the local owned-tile list AND the localStorage map cache so
    * downstream pages read the same data without an extra fetch.
@@ -115,12 +129,27 @@ export function useDashboardData() {
     [user]
   );
 
+  /**
+   * Patch the artifacts inventory after a use (artifact.used flips true) or
+   * a find (new artifact doc). Filters out used artifacts so callers always
+   * see only the still-spendable inventory.
+   */
+  const mergeArtifacts = useCallback((updates: GameArtifact[]) => {
+    if (updates.length === 0) return;
+    setArtifacts((prev) => {
+      const byId = new Map(prev.map((a) => [a.id, a] as const));
+      for (const u of updates) byId.set(u.id, u);
+      return Array.from(byId.values()).filter((a) => !a.used);
+    });
+  }, []);
+
   const mut: DashboardMutators = {
     setError,
     setPlayer,
     setRecentReports,
     mergeOwnedTiles,
     mergeBorderTiles,
+    mergeArtifacts,
   };
 
   const fetchPlayer = useCallback(async () => {
@@ -135,6 +164,7 @@ export function useDashboardData() {
       setEligibility,
       setWorldTiles,
       setWorldOwners,
+      setArtifacts,
       setError,
       setLoading,
     });
@@ -227,6 +257,56 @@ export function useDashboardData() {
     [user]
   );
 
+  const handleAttack = useCallback(
+    async (args: {
+      sourceTileId: string;
+      targetTileId: string;
+      units: UnitStack;
+      offenseSpellId: string | null;
+    }) => {
+      if (!user) return null;
+      return attack(user, args, mut);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
+  const handleRecruit = useCallback(
+    async (tileId: string, unitType: UnitType) => {
+      if (!user) return null;
+      return recruitUnits(user, tileId, unitType, mut);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
+  const handleArmDefenseSpell = useCallback(
+    async (tileId: string, spellId: string) => {
+      if (!user) return null;
+      return armDefenseSpell(user, tileId, spellId, mut);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
+  const handleDistributeTile = useCallback(
+    async (tileId: string, type: LandType) => {
+      if (!user) return null;
+      return distributeTile(user, tileId, type, mut);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
+  const handleUseArtifact = useCallback(
+    async (artifactId: string, targetTileId: string | null) => {
+      if (!user) return null;
+      return spendArtifact(user, artifactId, targetTileId, mut);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
   return {
     user,
     authLoading,
@@ -261,6 +341,12 @@ export function useDashboardData() {
     handleAdminGrant,
     handleFarExpedition,
     handleCastIntelSpell,
+    artifacts,
+    handleAttack,
+    handleRecruit,
+    handleArmDefenseSpell,
+    handleDistributeTile,
+    handleUseArtifact,
   };
 }
 

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -1,0 +1,622 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import { ARTIFACTS_BY_ID, getSpellsForCasteAndType } from "@/lib/game/content";
+import type {
+  GameArtifact,
+  GamePlayer,
+  IntelReport,
+  LandType,
+  SpellDefinition,
+  UnitType,
+} from "@/lib/game/types";
+import type { ThreatEntry } from "../_lib/threats-derive";
+
+const UNIT_TYPES: UnitType[] = ["ground", "siege", "air"];
+const LAND_TYPES: { type: LandType; label: string }[] = [
+  { type: "military", label: "Military" },
+  { type: "food", label: "Food" },
+  { type: "magic", label: "Magic" },
+  { type: "unassigned", label: "Unassigned" },
+];
+
+export interface ThreatRowProps {
+  entry: ThreatEntry;
+  player: GamePlayer;
+  artifacts: ReadonlyArray<GameArtifact>;
+  busy: boolean;
+  onAttack: (args: {
+    sourceTileId: string;
+    targetTileId: string;
+    units: { ground: number; siege: number; air: number };
+    offenseSpellId: string | null;
+  }) => Promise<{
+    outcome: string;
+    reportSummary: string;
+    intelReport: IntelReport | null;
+  } | null>;
+  onCastIntelSpell: (
+    spellId: string,
+    targetTileId: string
+  ) => Promise<{ intelReport: unknown; detected: boolean } | null>;
+  onUseArtifact: (
+    artifactId: string,
+    targetTileId: string | null
+  ) => Promise<{ intelReport: IntelReport | null } | null>;
+  onRecruit: (
+    tileId: string,
+    unitType: UnitType
+  ) => Promise<{ produced: number; reportSummary: string } | null>;
+  onArmDefenseSpell: (
+    tileId: string,
+    spellId: string
+  ) => Promise<{ reportSummary: string } | null>;
+  onDistributeTile: (
+    tileId: string,
+    type: LandType
+  ) => Promise<{ reportSummary: string } | null>;
+}
+
+/**
+ * One row in the Threats page: an enemy tile bordering my territory plus
+ * every action that can change the matchup. Collapsed by default — the
+ * Attack form is inline, everything else lives behind the expand chevron.
+ *
+ * Pre-checks: every action button computes its own `disabled + reason` from
+ * the live player + tile + artifact state. The user never fires a button
+ * that will 4xx out — the row tells them up-front why it's not allowed.
+ */
+export function ThreatRow(props: ThreatRowProps) {
+  const { entry, player, artifacts, busy } = props;
+  const [expanded, setExpanded] = useState(false);
+  const [sourceTileId, setSourceTileId] = useState(entry.bestSource.tileId);
+  const [ground, setGround] = useState(0);
+  const [siege, setSiege] = useState(0);
+  const [air, setAir] = useState(0);
+  const [offenseSpellId, setOffenseSpellId] = useState<string>("");
+  const [toast, setToast] = useState<string | null>(null);
+  const [intelReport, setIntelReport] = useState<IntelReport | null>(null);
+
+  const source =
+    entry.candidateSources.find((t) => t.tileId === sourceTileId) ??
+    entry.bestSource;
+
+  const myCaste = player.caste;
+  const offenseSpells = useMemo<SpellDefinition[]>(
+    () => (myCaste ? getSpellsForCasteAndType(myCaste, "offense") : []),
+    [myCaste]
+  );
+  const defenseSpells = useMemo<SpellDefinition[]>(
+    () => (myCaste ? getSpellsForCasteAndType(myCaste, "defense") : []),
+    [myCaste]
+  );
+  const intelSpell = useMemo<SpellDefinition | null>(
+    () =>
+      myCaste
+        ? getSpellsForCasteAndType(myCaste, "intel")[0] ?? null
+        : null,
+    [myCaste]
+  );
+
+  const offensiveArtifacts = artifacts.filter((a) => a.type === "offense");
+  const defensiveArtifacts = artifacts.filter((a) => a.type === "defense");
+  const intelArtifacts = artifacts.filter((a) => a.type === "intel");
+
+  const enemyShielded = entry.enemyOwner?.shielded ?? false;
+  const sentTotal = ground + siege + air;
+  const attackTurnCost = 1 + (offenseSpellId ? 5 : 0);
+  const attackDisabledReason = (() => {
+    if (enemyShielded) return "Enemy shielded";
+    if (sentTotal === 0) return "No units selected";
+    if (ground > source.units.ground) return `Source has only ${source.units.ground} ground`;
+    if (siege > source.units.siege) return `Source has only ${source.units.siege} siege`;
+    if (air > source.units.air) return `Source has only ${source.units.air} air`;
+    if (player.turnsRemaining < attackTurnCost)
+      return `Need ${attackTurnCost} turns (you have ${player.turnsRemaining})`;
+    if (player.phase !== "play") return "Not in play phase";
+    return null;
+  })();
+
+  async function handleAttack() {
+    setToast(null);
+    const res = await props.onAttack({
+      sourceTileId: source.tileId,
+      targetTileId: entry.enemyTile.tileId,
+      units: { ground, siege, air },
+      offenseSpellId: offenseSpellId || null,
+    });
+    if (res) {
+      setToast(res.reportSummary || `Attack ${res.outcome}`);
+      setGround(0);
+      setSiege(0);
+      setAir(0);
+      if (res.intelReport) setIntelReport(res.intelReport);
+    }
+  }
+
+  async function handleCastIntel() {
+    if (!intelSpell) return;
+    setToast(null);
+    const res = await props.onCastIntelSpell(
+      intelSpell.id,
+      entry.enemyTile.tileId
+    );
+    if (res?.intelReport) {
+      setIntelReport(res.intelReport as IntelReport);
+      setToast(`Intel captured · detected: ${res.detected ? "yes" : "no"}`);
+    }
+  }
+
+  async function handleUseArtifact(
+    artifact: GameArtifact,
+    targetTileId: string | null
+  ) {
+    setToast(null);
+    const res = await props.onUseArtifact(artifact.id, targetTileId);
+    if (res) {
+      const def = ARTIFACTS_BY_ID.get(artifact.definitionId);
+      setToast(`Used ${def?.name ?? "artifact"}`);
+      if (res.intelReport) setIntelReport(res.intelReport);
+    }
+  }
+
+  async function handleRecruit(unitType: UnitType) {
+    setToast(null);
+    const res = await props.onRecruit(source.tileId, unitType);
+    if (res) setToast(res.reportSummary || `+${res.produced} ${unitType}`);
+  }
+
+  async function handleArm(spellId: string) {
+    setToast(null);
+    const res = await props.onArmDefenseSpell(source.tileId, spellId);
+    if (res) setToast(res.reportSummary || "Armed");
+  }
+
+  async function handleAssign(type: LandType) {
+    setToast(null);
+    const res = await props.onDistributeTile(source.tileId, type);
+    if (res) setToast(res.reportSummary || `Tile set to ${type}`);
+  }
+
+  const enemyName = entry.enemyOwner?.displayName ?? entry.enemyTile.ownerId?.slice(0, 6) ?? "??";
+  const enemyCasteLabel = entry.enemyOwner?.caste
+    ? entry.enemyOwner.caste.charAt(0).toUpperCase() + entry.enemyOwner.caste.slice(1)
+    : "—";
+  const advantageLabel =
+    entry.myAdvantage >= 1
+      ? `${entry.myAdvantage.toFixed(1)}×`
+      : `1 / ${(1 / entry.myAdvantage).toFixed(1)}×`;
+  const advantageTone =
+    entry.myAdvantage >= 2
+      ? "text-emerald-600 dark:text-emerald-400"
+      : entry.myAdvantage >= 1
+        ? "text-amber-600 dark:text-amber-400"
+        : "text-red-600 dark:text-red-400";
+
+  return (
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 overflow-hidden">
+      {/* ─── Compact summary line ─────────────────────────────────────────── */}
+      <div className="px-4 py-3 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-sm">
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-200"
+          aria-expanded={expanded}
+          aria-label={expanded ? "Collapse" : "Expand"}
+        >
+          {expanded ? "▾" : "▸"}
+        </button>
+        <span className="font-mono font-semibold">{entry.enemyTile.tileId}</span>
+        <span className="text-neutral-600 dark:text-neutral-300">
+          {enemyName} · {enemyCasteLabel}
+        </span>
+        <span className="font-mono text-xs text-neutral-500">
+          G{entry.enemyTile.units.ground} S{entry.enemyTile.units.siege} A{entry.enemyTile.units.air}
+        </span>
+        {enemyShielded && (
+          <span className="px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 text-xs">
+            shielded
+          </span>
+        )}
+        <span className={`font-semibold ${advantageTone}`}>
+          adv {advantageLabel}
+        </span>
+      </div>
+
+      {/* ─── Inline attack form (visible always) ─────────────────────────── */}
+      <div className="px-4 pb-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto_minmax(0,1fr)] items-end">
+          <label className="text-xs">
+            <span className="text-neutral-500 block mb-0.5">Source</span>
+            <select
+              value={sourceTileId}
+              onChange={(e) => setSourceTileId(e.target.value)}
+              className="w-full px-2 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
+            >
+              {entry.candidateSources.map((t) => (
+                <option key={t.tileId} value={t.tileId}>
+                  {t.tileId} ({t.type}) — G{t.units.ground} S{t.units.siege} A{t.units.air}
+                </option>
+              ))}
+            </select>
+          </label>
+          <UnitInput
+            label={`G/${source.units.ground}`}
+            value={ground}
+            max={source.units.ground}
+            onChange={setGround}
+          />
+          <UnitInput
+            label={`S/${source.units.siege}`}
+            value={siege}
+            max={source.units.siege}
+            onChange={setSiege}
+          />
+          <UnitInput
+            label={`A/${source.units.air}`}
+            value={air}
+            max={source.units.air}
+            onChange={setAir}
+          />
+          <label className="text-xs">
+            <span className="text-neutral-500 block mb-0.5">Spell (+5t)</span>
+            <select
+              value={offenseSpellId}
+              onChange={(e) => setOffenseSpellId(e.target.value)}
+              className="w-full px-2 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
+            >
+              <option value="">— none —</option>
+              {offenseSpells.map((s) => (
+                <option key={s.id} value={s.id}>
+                  T{s.tier} {s.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <button
+          onClick={handleAttack}
+          disabled={busy || attackDisabledReason !== null}
+          title={attackDisabledReason ?? `Costs ${attackTurnCost} turns`}
+          className="px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-500 transition-colors disabled:opacity-50"
+        >
+          Attack ({attackTurnCost}t)
+        </button>
+      </div>
+      {attackDisabledReason && (
+        <div className="px-4 pb-2 text-xs text-neutral-500">
+          Attack disabled: {attackDisabledReason}.
+        </div>
+      )}
+
+      {/* ─── Toast (last action result) ──────────────────────────────────── */}
+      {toast && (
+        <div className="mx-4 mb-3 px-3 py-2 rounded bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900 text-xs text-emerald-800 dark:text-emerald-200 flex items-center justify-between gap-2">
+          <span>{toast}</span>
+          <button
+            onClick={() => setToast(null)}
+            className="text-emerald-600 dark:text-emerald-400 hover:text-emerald-900 dark:hover:text-emerald-200"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* ─── Intel report (rendered when populated by spy / intel artifact) ─ */}
+      {intelReport && (
+        <div className="mx-4 mb-3">
+          <ThreatIntelPanel
+            report={intelReport}
+            onDismiss={() => setIntelReport(null)}
+          />
+        </div>
+      )}
+
+      {/* ─── Expanded action panels ──────────────────────────────────────── */}
+      {expanded && (
+        <div className="border-t border-neutral-200 dark:border-neutral-800 px-4 py-3 space-y-4">
+          {/* Spy + intel artifacts */}
+          <section>
+            <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
+              Spy / intel
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {intelSpell && (
+                <SpyButton
+                  spell={intelSpell}
+                  player={player}
+                  busy={busy}
+                  onCast={handleCastIntel}
+                />
+              )}
+              {intelArtifacts.length === 0 && !intelSpell && (
+                <p className="text-xs text-neutral-500">
+                  No caste intel spell or intel artifacts available.
+                </p>
+              )}
+              {intelArtifacts.map((a) => {
+                const def = ARTIFACTS_BY_ID.get(a.definitionId);
+                return (
+                  <button
+                    key={a.id}
+                    onClick={() => handleUseArtifact(a, entry.enemyTile.tileId)}
+                    disabled={busy}
+                    title={def?.description ?? a.definitionId}
+                    className="px-3 py-1.5 text-xs rounded border border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30 disabled:opacity-50"
+                  >
+                    Use {def?.name ?? a.definitionId}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Offensive artifacts (used on enemy tile) */}
+          {offensiveArtifacts.length > 0 && (
+            <section>
+              <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
+                Offensive artifacts (on enemy)
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {offensiveArtifacts.map((a) => {
+                  const def = ARTIFACTS_BY_ID.get(a.definitionId);
+                  return (
+                    <button
+                      key={a.id}
+                      onClick={() =>
+                        handleUseArtifact(a, entry.enemyTile.tileId)
+                      }
+                      disabled={busy}
+                      title={def?.description ?? a.definitionId}
+                      className="px-3 py-1.5 text-xs rounded border border-red-300 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-50"
+                    >
+                      Use {def?.name ?? a.definitionId}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* Manage source tile */}
+          <section>
+            <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
+              Manage source · {source.tileId} ({source.type})
+            </h3>
+
+            <div className="space-y-3">
+              {/* Land type buttons */}
+              <div>
+                <p className="text-xs text-neutral-500 mb-1">Assign — 1 turn</p>
+                <div className="flex flex-wrap gap-2">
+                  {LAND_TYPES.map((a) => {
+                    const isCurrent = source.type === a.type;
+                    const cantSpend = player.turnsRemaining < 1;
+                    return (
+                      <button
+                        key={a.type}
+                        onClick={() => handleAssign(a.type)}
+                        disabled={busy || isCurrent || cantSpend}
+                        title={
+                          isCurrent
+                            ? "Current type"
+                            : cantSpend
+                              ? "Need 1 turn"
+                              : `Set tile to ${a.label.toLowerCase()}`
+                        }
+                        className={`px-3 py-1.5 text-xs rounded border ${
+                          isCurrent
+                            ? "border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 cursor-default"
+                            : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                        } disabled:opacity-50`}
+                      >
+                        {a.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Recruit */}
+              <div>
+                <p className="text-xs text-neutral-500 mb-1">
+                  Recruit — +10 / 5 turns (military tiles only)
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {UNIT_TYPES.map((u) => {
+                    const reason =
+                      source.type !== "military"
+                        ? "Tile is not military"
+                        : player.turnsRemaining < 5
+                          ? "Need 5 turns"
+                          : null;
+                    return (
+                      <button
+                        key={u}
+                        onClick={() => handleRecruit(u)}
+                        disabled={busy || reason !== null}
+                        title={reason ?? `Recruit +10 ${u}`}
+                        className="px-3 py-1.5 text-xs rounded border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 capitalize"
+                      >
+                        +10 {u}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Arm defense spell */}
+              {defenseSpells.length > 0 && (
+                <div>
+                  <p className="text-xs text-neutral-500 mb-1">
+                    Arm defense spell — 5 turns
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {defenseSpells.map((s) => {
+                      const reason =
+                        source.armedDefenseSpellId === s.id
+                          ? "Already armed"
+                          : player.turnsRemaining < 5
+                            ? "Need 5 turns"
+                            : player.stats.tilesHeld < s.minTilesRequired
+                              ? `Need ${s.minTilesRequired} tiles`
+                              : null;
+                      return (
+                        <button
+                          key={s.id}
+                          onClick={() => handleArm(s.id)}
+                          disabled={busy || reason !== null}
+                          title={reason ?? s.description}
+                          className="px-3 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
+                        >
+                          T{s.tier} {s.name}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Defense artifacts (on source tile) */}
+              {defensiveArtifacts.length > 0 && (
+                <div>
+                  <p className="text-xs text-neutral-500 mb-1">
+                    Defense artifacts (on source)
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {defensiveArtifacts.map((a) => {
+                      const def = ARTIFACTS_BY_ID.get(a.definitionId);
+                      return (
+                        <button
+                          key={a.id}
+                          onClick={() => handleUseArtifact(a, source.tileId)}
+                          disabled={busy}
+                          title={def?.description ?? a.definitionId}
+                          className="px-3 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
+                        >
+                          Use {def?.name ?? a.definitionId}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UnitInput({
+  label,
+  value,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  max: number;
+  onChange: (n: number) => void;
+}) {
+  return (
+    <label className="text-xs">
+      <span className="text-neutral-500 block mb-0.5">{label}</span>
+      <input
+        type="number"
+        min={0}
+        max={max}
+        value={value}
+        onChange={(e) => {
+          const n = Number.parseInt(e.target.value, 10);
+          onChange(Number.isFinite(n) ? Math.max(0, Math.min(max, n)) : 0);
+        }}
+        className="w-20 px-2 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
+      />
+    </label>
+  );
+}
+
+function SpyButton({
+  spell,
+  player,
+  busy,
+  onCast,
+}: {
+  spell: SpellDefinition;
+  player: GamePlayer;
+  busy: boolean;
+  onCast: () => void;
+}) {
+  const reason =
+    player.turnsRemaining < spell.turnCost
+      ? `Need ${spell.turnCost} turns`
+      : player.stats.tilesHeld < spell.minTilesRequired
+        ? `Need ${spell.minTilesRequired} tiles`
+        : null;
+  return (
+    <button
+      onClick={onCast}
+      disabled={busy || reason !== null}
+      title={reason ?? spell.description}
+      className="px-3 py-1.5 text-xs rounded border border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30 disabled:opacity-50"
+    >
+      Spy: {spell.name} ({spell.turnCost}t)
+    </button>
+  );
+}
+
+function ThreatIntelPanel({
+  report,
+  onDismiss,
+}: {
+  report: IntelReport;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="rounded-lg border-2 border-violet-300 dark:border-violet-800 bg-violet-50/50 dark:bg-violet-950/30 p-3 space-y-2 text-xs">
+      <div className="flex items-baseline justify-between">
+        <h4 className="font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">
+          Intel · {report.targetTileId}
+        </h4>
+        <button
+          onClick={onDismiss}
+          className="text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+        >
+          Dismiss
+        </button>
+      </div>
+      <p>
+        {report.target.landType} · G{report.target.units.ground} S
+        {report.target.units.siege} A{report.target.units.air}
+        {report.target.armedDefenseSpellId
+          ? ` · armed: ${report.target.armedDefenseSpellId}`
+          : ""}
+      </p>
+      {report.weakFace && (
+        <p>
+          Forge Sight: lead with <strong>{report.weakFace}</strong>.
+        </p>
+      )}
+      {report.kingdomDefender && (
+        <p>
+          Kingdom: {report.kingdomDefender.tilesHeld} tiles ·{" "}
+          {report.kingdomDefender.unitsAlive} units ·{" "}
+          {report.kingdomDefender.artifactCount} artifacts.
+        </p>
+      )}
+      {report.supply && (
+        <p>
+          Supply ×{report.supply.supplyMultiplier.toFixed(2)} (
+          {report.supply.friendlyNeighbors.length} friendly tiles).
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/game/threats/_lib/threats-derive.ts
+++ b/app/game/threats/_lib/threats-derive.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { computeSupplyMultiplier } from "@/lib/game/combat";
+import type { Caste, LandType, MapTile } from "@/lib/game/types";
+import type { OwnerSummary } from "@/app/game/_lib/dashboard-types";
+
+/**
+ * Six axial neighbor offsets for a pointy-top hex grid. Identical to the
+ * one in `dashboard-helpers.ts` — kept local so this lib is server/client-
+ * agnostic and pure.
+ */
+const HEX_NEIGHBORS = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+  [1, -1],
+  [-1, 1],
+] as const;
+
+export interface ThreatEntry {
+  /** The enemy tile that borders one or more of the player's tiles. */
+  enemyTile: MapTile;
+  /** Owner identity (caste, name, shielded). May be null if not in worldOwners. */
+  enemyOwner: OwnerSummary | null;
+  /** All player-owned tiles that border this enemy tile. */
+  candidateSources: MapTile[];
+  /** Strongest of the candidate sources, pre-picked for one-click attack. */
+  bestSource: MapTile;
+  /** Best source's effective strength (units × supply multiplier). */
+  bestSourceStrength: number;
+  /** Best source's supply multiplier (for display). */
+  bestSourceSupply: number;
+  /** (best source units) / max(1, enemy tile units). Sort key. */
+  myAdvantage: number;
+}
+
+function totalUnits(tile: MapTile): number {
+  return tile.units.ground + tile.units.siege + tile.units.air;
+}
+
+/**
+ * Walk every owned tile, find adjacent enemy tiles, and group by the enemy
+ * tile (each enemy tile becomes one ThreatEntry). For each group we compute
+ * the best source (highest units × supply mult), and a sortable advantage
+ * score so the page can show the easiest matchup first.
+ *
+ * Pure: no React, no fetches, no globals. Trivial to unit-test.
+ */
+export function deriveThreatEntries(args: {
+  myUserId: string;
+  myCaste: Caste | null;
+  myTiles: ReadonlyArray<MapTile>;
+  worldTiles: ReadonlyArray<MapTile>;
+  worldOwners: ReadonlyMap<string, OwnerSummary>;
+}): ThreatEntry[] {
+  const { myUserId, myCaste, myTiles, worldTiles, worldOwners } = args;
+  if (worldTiles.length === 0 || myTiles.length === 0) return [];
+
+  // Index my tiles + world tiles by axial coordinate so we can scan
+  // 6 neighbors per tile in O(1).
+  const myByCoord = new Map<string, MapTile>();
+  for (const t of myTiles) myByCoord.set(`${t.q},${t.r}`, t);
+  const worldByCoord = new Map<string, MapTile>();
+  for (const t of worldTiles) worldByCoord.set(`${t.q},${t.r}`, t);
+
+  // For each owned tile, build the set of friendly-neighbor land types
+  // once. We need this to compute supply multiplier per source candidate.
+  const friendlyNeighborsByTile = new Map<
+    string,
+    Array<{ tileId: string; landType: LandType }>
+  >();
+  for (const mine of myTiles) {
+    const neighbors: Array<{ tileId: string; landType: LandType }> = [];
+    for (const [dq, dr] of HEX_NEIGHBORS) {
+      const key = `${mine.q + dq},${mine.r + dr}`;
+      const f = myByCoord.get(key);
+      if (!f) continue;
+      // Only assigned tiles contribute to supply.
+      if (f.type === "unassigned" || f.type === "unrevealed") continue;
+      neighbors.push({ tileId: f.tileId, landType: f.type });
+    }
+    friendlyNeighborsByTile.set(mine.tileId, neighbors);
+  }
+
+  // Collect every enemy tile that borders at least one of my tiles, deduped
+  // by tileId. For each enemy tile, accumulate the list of my candidate
+  // sources (= my tiles that touch it).
+  type Bucket = {
+    enemyTile: MapTile;
+    sources: MapTile[];
+  };
+  const buckets = new Map<string, Bucket>();
+  for (const mine of myTiles) {
+    for (const [dq, dr] of HEX_NEIGHBORS) {
+      const key = `${mine.q + dq},${mine.r + dr}`;
+      const enemy = worldByCoord.get(key);
+      if (!enemy) continue;
+      if (!enemy.ownerId || enemy.ownerId === myUserId) continue;
+      let bucket = buckets.get(enemy.tileId);
+      if (!bucket) {
+        bucket = { enemyTile: enemy, sources: [] };
+        buckets.set(enemy.tileId, bucket);
+      }
+      bucket.sources.push(mine);
+    }
+  }
+
+  const entries: ThreatEntry[] = [];
+  for (const bucket of buckets.values()) {
+    if (bucket.sources.length === 0) continue;
+    let bestSource = bucket.sources[0]!;
+    let bestStrength = -1;
+    let bestSupply = 1;
+    for (const src of bucket.sources) {
+      const supply = myCaste
+        ? computeSupplyMultiplier(
+            myCaste,
+            friendlyNeighborsByTile.get(src.tileId) ?? []
+          )
+        : 1;
+      const strength = totalUnits(src) * supply;
+      if (
+        strength > bestStrength ||
+        (strength === bestStrength && src.tileId < bestSource.tileId)
+      ) {
+        bestStrength = strength;
+        bestSupply = supply;
+        bestSource = src;
+      }
+    }
+    const enemyUnits = Math.max(1, totalUnits(bucket.enemyTile));
+    const myAdvantage = bestStrength / enemyUnits;
+    entries.push({
+      enemyTile: bucket.enemyTile,
+      enemyOwner: worldOwners.get(bucket.enemyTile.ownerId ?? "") ?? null,
+      candidateSources: bucket.sources,
+      bestSource,
+      bestSourceStrength: bestStrength,
+      bestSourceSupply: bestSupply,
+      myAdvantage,
+    });
+  }
+
+  // Default sort: easiest matchup (highest myAdvantage) first.
+  entries.sort((a, b) => b.myAdvantage - a.myAdvantage);
+  return entries;
+}

--- a/app/game/threats/page.tsx
+++ b/app/game/threats/page.tsx
@@ -1,0 +1,187 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { SignedOutLanding } from "../_components/dashboard/SignedOutLanding";
+import { useDashboardData } from "../_lib/use-dashboard-data";
+import { ThreatRow } from "./_components/ThreatRow";
+import { deriveThreatEntries } from "./_lib/threats-derive";
+
+/**
+ * /game/threats — Single-surface action hub: every enemy tile bordering
+ * my territory becomes a ThreatRow with inline attack + expandable
+ * recruit / arm / artifact / spy actions.
+ *
+ * Reuses `useDashboardData` so all action handlers, soft-refresh state,
+ * and inventory are shared with the dashboard. No extra fetches at
+ * mount time beyond what the dashboard already does.
+ */
+export default function ThreatsPage() {
+  const data = useDashboardData();
+  const {
+    user,
+    authLoading,
+    loading,
+    error,
+    player,
+    tiles,
+    worldTiles,
+    worldOwners,
+    artifacts,
+    handleAttack,
+    handleCastIntelSpell,
+    handleUseArtifact,
+    handleRecruit,
+    handleArmDefenseSpell,
+    handleDistributeTile,
+  } = data;
+
+  const [hideShielded, setHideShielded] = useState(true);
+  const [hideOverwhelming, setHideOverwhelming] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const entries = useMemo(() => {
+    if (!user || !player) return [];
+    return deriveThreatEntries({
+      myUserId: user.uid,
+      myCaste: player.caste,
+      myTiles: tiles,
+      worldTiles,
+      worldOwners,
+    });
+  }, [user, player, tiles, worldTiles, worldOwners]);
+
+  const visibleEntries = useMemo(() => {
+    let out = entries;
+    if (hideShielded) {
+      out = out.filter((e) => !(e.enemyOwner?.shielded ?? false));
+    }
+    if (hideOverwhelming) {
+      out = out.filter((e) => e.myAdvantage >= 0.2); // ≥ 1 / 5×
+    }
+    return out;
+  }, [entries, hideShielded, hideOverwhelming]);
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-emerald-500" />
+      </div>
+    );
+  }
+
+  if (!user) return <SignedOutLanding />;
+
+  if (!player) {
+    return (
+      <main className="max-w-4xl mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">Threats</h1>
+        <p className="text-sm text-neutral-500">
+          You haven&apos;t enlisted yet.{" "}
+          <Link href="/game" className="text-emerald-600 hover:underline">
+            Go to the dashboard
+          </Link>{" "}
+          to spawn your general.
+        </p>
+      </main>
+    );
+  }
+
+  // Wrap action handlers so the page can show a single global "busy"
+  // indicator while any action is in flight. Each handler still patches
+  // local state via the mutator chain on completion.
+  function withBusy<TArgs extends unknown[], TResult>(
+    fn: ((...args: TArgs) => Promise<TResult>) | undefined
+  ): (...args: TArgs) => Promise<TResult> {
+    return async (...args: TArgs) => {
+      if (!fn) {
+        // Hooks are always present after the gates above; this branch
+        // is just a TS narrowing fallback.
+        return Promise.resolve() as TResult;
+      }
+      setBusy(true);
+      try {
+        return await fn(...args);
+      } finally {
+        setBusy(false);
+      }
+    };
+  }
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+      <header className="space-y-2">
+        <div className="flex items-baseline justify-between">
+          <h1 className="text-2xl font-bold">Threats</h1>
+          <Link
+            href="/game"
+            className="text-sm text-emerald-600 hover:underline"
+          >
+            ← Back to dashboard
+          </Link>
+        </div>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          {entries.length === 0
+            ? "No enemy tiles border your territory."
+            : `${entries.length} enemy tile${entries.length === 1 ? "" : "s"} bordering your territory · ${player.turnsRemaining} turns available.`}
+        </p>
+        <div className="flex flex-wrap gap-4 text-sm">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={hideShielded}
+              onChange={(e) => setHideShielded(e.target.checked)}
+            />
+            Hide shielded
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={hideOverwhelming}
+              onChange={(e) => setHideOverwhelming(e.target.checked)}
+            />
+            Hide overwhelming (5×+)
+          </label>
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded-lg border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {visibleEntries.length === 0 ? (
+        <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-6 text-center text-sm text-neutral-500">
+          {entries.length === 0
+            ? "Explore farther — no enemies on your border yet. Try Far Expedition from the dashboard."
+            : "All your bordering enemies are filtered out. Adjust the toggles above."}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {visibleEntries.map((entry) => (
+            <ThreatRow
+              key={entry.enemyTile.tileId}
+              entry={entry}
+              player={player}
+              artifacts={artifacts}
+              busy={busy}
+              onAttack={withBusy(handleAttack)}
+              onCastIntelSpell={withBusy(handleCastIntelSpell)}
+              onUseArtifact={withBusy(handleUseArtifact)}
+              onRecruit={withBusy(handleRecruit)}
+              onArmDefenseSpell={withBusy(handleArmDefenseSpell)}
+              onDistributeTile={withBusy(handleDistributeTile)}
+            />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/game/tiles/[tileId]/page.tsx
+++ b/app/game/tiles/[tileId]/page.tsx
@@ -13,6 +13,7 @@ import { computeSupplyMultiplier } from "@/lib/game/combat";
 import { ALL_SPELLS, UPGRADES_BY_ID } from "@/lib/game/content";
 import type {
   Caste,
+  GameArtifact,
   GamePlayer,
   GameTile,
   IntelReport,
@@ -81,6 +82,10 @@ export default function TileDetailPage({
   const [ownersByUserId, setOwnersByUserId] = useState<
     Map<string, { caste: Caste | null; displayName: string }>
   >(() => new Map());
+  // Lifted-up artifact inventory. Both panels need it so they can show
+  // "Use artifact" buttons inline. Refreshed on initial load and on each
+  // /api/game/artifact/use response (which returns the updated artifact).
+  const [artifacts, setArtifacts] = useState<GameArtifact[]>([]);
 
   const refresh = useCallback(async () => {
     if (!user) {
@@ -90,16 +95,23 @@ export default function TileDetailPage({
     setError(null);
     try {
       const token = await user.getIdToken();
-      const [tileRes, playerRes] = await Promise.all([
+      const [tileRes, playerRes, artifactsRes] = await Promise.all([
         fetch(`/api/game/tile/${encodeURIComponent(tileId)}`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
         fetch("/api/game/player", {
           headers: { Authorization: `Bearer ${token}` },
         }),
+        fetch("/api/game/artifacts?limit=100", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
       ]);
       const tileData = (await tileRes.json()) as TileResponse;
       const playerData = (await playerRes.json()) as PlayerResponse;
+      const artifactsData = (await artifactsRes.json()) as {
+        success: boolean;
+        artifacts?: GameArtifact[];
+      };
       if (!tileData.success) {
         const msg =
           typeof tileData.error === "string"
@@ -110,6 +122,9 @@ export default function TileDetailPage({
       setTile(tileData.tile ?? null);
       setPlayer(playerData.player);
       setOwnedTiles(playerData.tiles ?? []);
+      if (artifactsData.success && Array.isArray(artifactsData.artifacts)) {
+        setArtifacts(artifactsData.artifacts.filter((a) => !a.used));
+      }
       // Pull cached enemy-border and owner snapshots from the dashboard's
       // localStorage cache. Best-effort: if the cache is missing the relevant
       // tiles, the supply readout simply won't render.
@@ -216,7 +231,24 @@ export default function TileDetailPage({
         if (data.intelReport) {
           setIntelReport(data.intelReport as IntelReport);
         }
-        setMessage(data.stoppedEarly ? `Stopped: ${data.stoppedEarly}` : "Done.");
+        // /api/game/artifact/use returns the updated artifact (used=true).
+        // Drop it from the local inventory so the button disappears.
+        if (data.artifact) {
+          const a = data.artifact as GameArtifact;
+          setArtifacts((prev) =>
+            prev.filter((x) => x.id !== a.id).concat(a.used ? [] : [a])
+          );
+        }
+        // Prefer the report's summary line over a generic "Done." so the
+        // action banner explains what just happened ("Tile changed to military
+        // · 1 turn spent").
+        const summary =
+          (newOnes[0] as { summary?: string } | undefined)?.summary ?? null;
+        setMessage(
+          data.stoppedEarly
+            ? `Stopped: ${data.stoppedEarly}`
+            : summary ?? "Done."
+        );
         return data;
       } catch (e) {
         setError(e instanceof Error ? e.message : "Action failed");
@@ -394,6 +426,7 @@ export default function TileDetailPage({
             tile={tile}
             player={player}
             myDefenseSpells={myDefenseSpells}
+            artifacts={artifacts}
             busy={busy}
             onBuild={(unitType) =>
               callApi("/api/game/build", { tileId: tile.tileId, unitType })
@@ -407,12 +440,19 @@ export default function TileDetailPage({
                 type: targetType,
               })
             }
+            onUseArtifact={(artifactId) =>
+              callApi("/api/game/artifact/use", {
+                artifactId,
+                targetTileId: tile.tileId,
+              })
+            }
           />
         ) : (
           <EnemyTilePanel
             tile={tile}
             player={player}
             ownedTiles={ownedTiles}
+            artifacts={artifacts}
             busy={busy}
             onAttack={(sourceTileId, units, offenseSpellId) =>
               callApi("/api/game/attack", {
@@ -425,6 +465,12 @@ export default function TileDetailPage({
             onSpy={(spellId) =>
               callApi("/api/game/spy", {
                 spellId,
+                targetTileId: tile.tileId,
+              })
+            }
+            onUseArtifact={(artifactId) =>
+              callApi("/api/game/artifact/use", {
+                artifactId,
                 targetTileId: tile.tileId,
               })
             }

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -7,8 +7,9 @@
 "use client";
 
 import { useState } from "react";
-import { ALL_SPELLS } from "@/lib/game/content";
+import { ALL_SPELLS, ARTIFACTS_BY_ID } from "@/lib/game/content";
 import type {
+  GameArtifact,
   GamePlayer,
   LandType,
   MapTile,
@@ -37,19 +38,27 @@ export function OwnTilePanel({
   tile,
   player,
   myDefenseSpells,
+  artifacts = [],
   busy,
   onBuild,
   onArmSpell,
   onAssign,
+  onUseArtifact,
 }: {
   tile: MapTile;
   player: GamePlayer;
   myDefenseSpells: SpellDefinition[];
+  /** Unused artifacts only — pass [] to hide the artifacts section. */
+  artifacts?: ReadonlyArray<GameArtifact>;
   busy: boolean;
   onBuild: (unitType: UnitType) => void;
   onArmSpell: (spellId: string) => void;
   onAssign: (newType: LandType) => void;
+  /** Wires up to /api/game/artifact/use for defense artifacts. Optional —
+   *  panel hides the artifact section when not provided. */
+  onUseArtifact?: (artifactId: string) => void;
 }) {
+  const defensiveArtifacts = artifacts.filter((a) => a.type === "defense");
   const canBuild =
     player.phase === "play" &&
     tile.type === "military" &&
@@ -176,6 +185,39 @@ export function OwnTilePanel({
           </div>
         )}
       </section>
+
+      {onUseArtifact && (
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-2">
+            Defense artifacts{" "}
+            <span className="text-neutral-400 normal-case font-normal">
+              — apply to this tile
+            </span>
+          </h2>
+          {defensiveArtifacts.length === 0 ? (
+            <p className="text-sm text-neutral-500">
+              No unused defense artifacts in inventory.
+            </p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {defensiveArtifacts.map((a) => {
+                const def = ARTIFACTS_BY_ID.get(a.definitionId);
+                return (
+                  <button
+                    key={a.id}
+                    onClick={() => onUseArtifact(a.id)}
+                    disabled={busy || tile.type === "unrevealed"}
+                    title={def?.description ?? a.definitionId}
+                    className="px-3 py-1.5 text-sm border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50"
+                  >
+                    Use {def?.name ?? a.definitionId}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      )}
     </div>
   );
 }
@@ -184,13 +226,17 @@ export function EnemyTilePanel({
   tile,
   player,
   ownedTiles,
+  artifacts = [],
   busy,
   onAttack,
   onSpy,
+  onUseArtifact,
 }: {
   tile: MapTile;
   player: GamePlayer;
   ownedTiles: MapTile[];
+  /** Unused artifacts only — pass [] to hide artifact-use sections. */
+  artifacts?: ReadonlyArray<GameArtifact>;
   busy: boolean;
   onAttack: (
     sourceTileId: string,
@@ -200,7 +246,12 @@ export function EnemyTilePanel({
   // Optional: when present, renders a Spy section that casts the player's
   // caste intel spell on this tile. Wires straight to /api/game/spy.
   onSpy?: (spellId: string) => void;
+  /** Wires up to /api/game/artifact/use for offense + intel artifacts.
+   *  When present, panel renders sections for each artifact category. */
+  onUseArtifact?: (artifactId: string) => void;
 }) {
+  const offensiveArtifacts = artifacts.filter((a) => a.type === "offense");
+  const intelArtifacts = artifacts.filter((a) => a.type === "intel");
   const targetBorders = new Set(neighborTileIds(tile.q, tile.r));
   const myBorders = ownedTiles.filter((t) => targetBorders.has(t.tileId));
   const myCaste = player.caste;
@@ -241,6 +292,56 @@ export function EnemyTilePanel({
     player.phase === "play" &&
     player.turnsRemaining >= 1 + (offenseSpellId ? 5 : 0);
 
+  const offenseArtifactSection =
+    onUseArtifact && offensiveArtifacts.length > 0 ? (
+      <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/20 p-4 space-y-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-red-700 dark:text-red-300">
+          Offensive artifacts
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {offensiveArtifacts.map((a) => {
+            const def = ARTIFACTS_BY_ID.get(a.definitionId);
+            return (
+              <button
+                key={a.id}
+                onClick={() => onUseArtifact(a.id)}
+                disabled={busy}
+                title={def?.description ?? a.definitionId}
+                className="px-3 py-1.5 text-sm border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
+              >
+                Use {def?.name ?? a.definitionId}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    ) : null;
+
+  const intelArtifactSection =
+    onUseArtifact && intelArtifacts.length > 0 ? (
+      <div className="rounded-lg border border-violet-200 dark:border-violet-900 bg-violet-50/50 dark:bg-violet-950/20 p-4 space-y-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">
+          Intel artifacts
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {intelArtifacts.map((a) => {
+            const def = ARTIFACTS_BY_ID.get(a.definitionId);
+            return (
+              <button
+                key={a.id}
+                onClick={() => onUseArtifact(a.id)}
+                disabled={busy}
+                title={def?.description ?? a.definitionId}
+                className="px-3 py-1.5 text-sm border border-violet-300 dark:border-violet-700 rounded-lg hover:bg-violet-100 dark:hover:bg-violet-900/30 transition-colors disabled:opacity-50"
+              >
+                Use {def?.name ?? a.definitionId}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    ) : null;
+
   const spySection = onSpy && intelSpell ? (
     <div className="rounded-lg border border-violet-200 dark:border-violet-900 bg-violet-50/50 dark:bg-violet-950/20 p-4 space-y-2">
       <h2 className="text-sm font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">
@@ -277,6 +378,7 @@ export function EnemyTilePanel({
           {onSpy && intelSpell ? " You can still spy on it from anywhere." : ""}
         </div>
         {spySection}
+        {intelArtifactSection}
       </div>
     );
   }
@@ -358,7 +460,9 @@ export function EnemyTilePanel({
         </button>
       </div>
 
+      {offenseArtifactSection}
       {spySection}
+      {intelArtifactSection}
     </div>
   );
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**142 paths, 175 operations across 31 areas.**
+**144 paths, 177 operations across 31 areas.**
 
 ---
 
@@ -143,6 +143,7 @@ _Strategy game endpoints (leaderboard, attacks, artifacts, turns)._
 | GET | `/api/game/eligibility` | Yes | Get the current user's game eligibility state |
 | POST | `/api/game/explore` | Yes | Frontier-explore one or more new tiles |
 | POST | `/api/game/explore/bulk` | Yes | Bulk frontier-explore (count required) |
+| POST | `/api/game/explore/far` | Yes | Spend 2 turns to plant a tile adjacent to a random enemy tile (Far Expedition). |
 | GET | `/api/game/leaderboard` | Yes | Get the leaderboard ranked by tiles held |
 | GET | `/api/game/map/me` | Yes | Get the current user's personal map view (own tiles + enemy ring) |
 | POST | `/api/game/npc-weekly` | No | Cron-only weekly NPC turn-spender |
@@ -155,6 +156,7 @@ _Strategy game endpoints (leaderboard, attacks, artifacts, turns)._
 | POST | `/api/game/setup/explore` | Yes | Frontier-explore tiles during onboarding |
 | POST | `/api/game/spell/arm` | Yes | Arm a defense spell on one tile (single) or many (bulk) |
 | POST | `/api/game/spell/produce` | Yes | Cast a production spell (with optional batch count) |
+| POST | `/api/game/spy` | Yes | Cast an intel ('spy') spell on an enemy tile. |
 | GET | `/api/game/tile/{tileId}` | Yes | Get a single tile by id |
 | POST | `/api/game/upgrades/apply` | Yes | Apply an upgrade to a target |
 | POST | `/api/game/upgrades/remove` | Yes | Remove an upgrade from a target |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -106,7 +106,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (175 endpoints)
+## API (177 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -198,6 +198,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     GET    /api/game/eligibility [Yes] — Get the current user's game eligibility state
     POST   /api/game/explore [Yes] — Frontier-explore one or more new tiles
     POST   /api/game/explore/bulk [Yes] — Bulk frontier-explore (count required)
+    POST   /api/game/explore/far [Yes] — Spend 2 turns to plant a tile adjacent to a random enemy tile (Far Expedition).
     GET    /api/game/leaderboard [Yes] — Get the leaderboard ranked by tiles held
     GET    /api/game/map/me [Yes] — Get the current user's personal map view (own tiles + enemy ring)
     POST   /api/game/npc-weekly — Cron-only weekly NPC turn-spender
@@ -210,6 +211,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     POST   /api/game/setup/explore [Yes] — Frontier-explore tiles during onboarding
     POST   /api/game/spell/arm [Yes] — Arm a defense spell on one tile (single) or many (bulk)
     POST   /api/game/spell/produce [Yes] — Cast a production spell (with optional batch count)
+    POST   /api/game/spy [Yes] — Cast an intel ('spy') spell on an enemy tile.
     GET    /api/game/tile/{tileId} [Yes] — Get a single tile by id
     POST   /api/game/upgrades/apply [Yes] — Apply an upgrade to a target
     POST   /api/game/upgrades/remove [Yes] — Remove an upgrade from a target


### PR DESCRIPTION
## Summary

A new page that lists every enemy tile bordering the player's territory and exposes every relevant action inline — attack, recruit, arm defense, distribute, spy, intel/offense/defense artifact use — without the five-page click trail it took before.

- Compact ThreatRow per enemy with inline attack form + expandable manage-source / spy / artifact panels
- Pure derive picks strongest source (units × supply) and sorts by myAdvantage; defaults hide shielded enemies
- Tile-detail page brought to parity (artifact-use sections; success toast uses report summary)
- ThreatCard gains a "View all threats →" link; NavGrid promotes Threats to the primary action

## Implementation

- `app/game/threats/page.tsx`, `_components/ThreatRow.tsx`, `_lib/threats-derive.ts` (new)
- `useDashboardData` extended with artifacts inventory + mergeArtifacts + 5 single-tile handlers (attack / recruit / arm / distribute / use artifact). Soft-refresh chain fully reused — no reloads
- `OwnTilePanel` + `EnemyTilePanel` accept optional `artifacts` + `onUseArtifact` for inline artifact-use sections
- 54 new tests: threats-derive (8), dashboard-fetch with cache hit/miss (4), every dashboard-actions helper incl. rejection paths (42). 1710 tests pass total

## Test plan

- [ ] /game/threats lists one row per enemy bordering my territory; default-sorted by easiest matchup
- [ ] Compact-row Attack: pick source from dropdown, send units, tile units update inline (no reload), toast appears
- [ ] Expand row → change source type to food → Recruit disables with "Tile is not military" reason
- [ ] Arm defense spell from row → armedDefenseSpellId updates inline
- [ ] Use defense artifact on source → artifact disappears from inventory
- [ ] Cast spy on enemy → IntelReport renders inline below the row; auto-dismissable
- [ ] Use offense artifact on enemy → bonus surfaces in next attack's report
- [ ] /game/tiles/[tileId] for own tile → defense-artifact button appears + works
- [ ] Same for enemy tile → offense + intel artifact buttons appear + work
- [ ] Disabled buttons show inline reason on hover (turn-starved, wrong tile type, no caste, shielded enemy, no artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)