### PR TITLE
feat(game): inline tile prep + structured battle readout on threats page

### DIFF
--- a/__tests__/app/game/_lib/dashboard-actions.test.ts
+++ b/__tests__/app/game/_lib/dashboard-actions.test.ts
@@ -304,6 +304,70 @@ describe("attack", () => {
     expect(out?.intelReport).toEqual(intel);
   });
 
+  it("returns combat + report + targetTile so the row can render BattleReport", async () => {
+    const combat = {
+      outcome: "captured",
+      unitsDeployed: { ground: 5, siege: 0, air: 0 },
+      unitsClampedFromCapacity: 0,
+      attackPower: 100,
+      defensePower: 50,
+      attackerLosses: { ground: 1, siege: 0, air: 0 },
+      defenderLosses: { ground: 4, siege: 2, air: 1 },
+      underdogApplied: false,
+      supplyMultiplier: 1,
+      rng: { attackerRoll: 1.0, defenderRoll: 1.0 },
+      appliedSpells: { offenseId: null, defenseId: null },
+    };
+    const report = { summary: "Captured 3_4", narrative: ["a", "b"] };
+    mockFetchOnce({
+      success: true,
+      attackerPlayer: FAKE_PLAYER,
+      sourceTile: FAKE_TILE,
+      targetTile: FAKE_ENEMY_TILE,
+      attack: { outcome: "victory" },
+      report,
+      combat,
+    });
+    const mut = makeMutators();
+    const out = await attack(
+      makeUser(),
+      {
+        sourceTileId: "1_2",
+        targetTileId: "3_4",
+        units: { ground: 5, siege: 0, air: 0 },
+        offenseSpellId: null,
+      },
+      mut
+    );
+    expect(out?.combat).toEqual(combat);
+    expect(out?.report).toEqual(report);
+    expect(out?.targetTile).toEqual(FAKE_ENEMY_TILE);
+  });
+
+  it("returns combat=null when older server response omits the field", async () => {
+    mockFetchOnce({
+      success: true,
+      attackerPlayer: FAKE_PLAYER,
+      sourceTile: FAKE_TILE,
+      targetTile: FAKE_ENEMY_TILE,
+      attack: { outcome: "victory" },
+      report: { summary: "x" },
+      // intentionally no `combat` field
+    });
+    const mut = makeMutators();
+    const out = await attack(
+      makeUser(),
+      {
+        sourceTileId: "1_2",
+        targetTileId: "3_4",
+        units: { ground: 5, siege: 0, air: 0 },
+        offenseSpellId: null,
+      },
+      mut
+    );
+    expect(out?.combat).toBeNull();
+  });
+
   it("returns null on failure", async () => {
     mockFetchOnce({ success: false, error: "no border" });
     const mut = makeMutators();

--- a/__tests__/app/game/threats/battle-report.test.tsx
+++ b/__tests__/app/game/threats/battle-report.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BattleReport } from "@/app/game/threats/_components/BattleReport";
+import type {
+  CombatResult,
+  GameTile,
+  TurnReport,
+  UnitStack,
+} from "@/lib/game/types";
+
+// jsdom helpers ------------------------------------------------------------
+
+function stack(g: number, s: number, a: number): UnitStack {
+  return { ground: g, siege: s, air: a };
+}
+
+function makeCombat(over: Partial<CombatResult> = {}): CombatResult {
+  return {
+    outcome: "captured",
+    unitsDeployed: stack(10, 5, 0),
+    unitsClampedFromCapacity: 0,
+    attackPower: 320,
+    defensePower: 180,
+    attackerLosses: stack(3, 1, 0),
+    defenderLosses: stack(40, 15, 15),
+    underdogApplied: false,
+    supplyMultiplier: 1,
+    rng: { attackerRoll: 1.05, defenderRoll: 0.94 },
+    appliedSpells: { offenseId: null, defenseId: null },
+    ...over,
+  };
+}
+
+function makeReport(over: Partial<TurnReport> = {}): TurnReport {
+  return {
+    turnIndex: 12,
+    action: "attack",
+    cost: 1,
+    summary: "Captured -149_47",
+    narrative: [
+      "The captains rallied at dusk.",
+      "Sent G10 S5 A0 (15 total). Lost G3 S1 A0; defenders lost G40 S15 A15.",
+    ],
+    outcome: { targetTileId: "-149_47" },
+    ...over,
+  };
+}
+
+function makeTargetTile(units: UnitStack = stack(10, 5, 5)): GameTile {
+  return {
+    tileId: "-149_47",
+    q: -149,
+    r: 47,
+    type: "military",
+    ownerId: "foe",
+    units,
+    armedDefenseSpellId: null,
+    capacity: 200,
+    level: 1,
+    upgradeIds: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as GameTile;
+}
+
+// tests --------------------------------------------------------------------
+
+describe("BattleReport", () => {
+  it("renders the Captured banner with target tile id and turn cost", () => {
+    render(
+      <BattleReport
+        combat={makeCombat()}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Captured -149_47/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 turn spent/i)).toBeInTheDocument();
+  });
+
+  it("renders the Repelled banner for repelled outcomes", () => {
+    render(
+      <BattleReport
+        combat={makeCombat({ outcome: "repelled" })}
+        report={makeReport({ summary: "Repelled at -149_47" })}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Repelled at -149_47/i)).toBeInTheDocument();
+  });
+
+  it("renders the Stalemate banner for stalemate outcomes", () => {
+    render(
+      <BattleReport
+        combat={makeCombat({ outcome: "stalemate" })}
+        report={makeReport({ summary: "Stalemate at -149_47", cost: 6 })}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Stalemate at -149_47/i)).toBeInTheDocument();
+    expect(screen.getByText(/6 turns spent/i)).toBeInTheDocument();
+  });
+
+  it("derives Defender-had as targetTile.units + defenderLosses", () => {
+    // post-attack target tile has 10/5/5; defender lost 40/15/15.
+    // → defender had 50/20/20 (90 total).
+    render(
+      <BattleReport
+        combat={makeCombat()}
+        report={makeReport()}
+        targetTile={makeTargetTile(stack(10, 5, 5))}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/G50 · S20 · A20/)).toBeInTheDocument();
+    expect(screen.getByText(/\(90 total\)/)).toBeInTheDocument();
+  });
+
+  it("renders You-sent stack from combat.unitsDeployed", () => {
+    render(
+      <BattleReport
+        combat={makeCombat({ unitsDeployed: stack(7, 0, 8) })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/G7 · S0 · A8/)).toBeInTheDocument();
+    // The narrative line in makeReport() also contains "(15 total)" — both
+    // the Forces section and the prose hit the matcher, so just assert at
+    // least one occurrence.
+    expect(screen.getAllByText(/\(15 total\)/).length).toBeGreaterThanOrEqual(
+      1
+    );
+  });
+
+  it("renders losses for both sides per unit type", () => {
+    render(
+      <BattleReport
+        combat={makeCombat({
+          attackerLosses: stack(3, 1, 0),
+          defenderLosses: stack(40, 15, 15),
+        })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/G3 · S1 · A0/)).toBeInTheDocument();
+    expect(screen.getByText(/G40 · S15 · A15/)).toBeInTheDocument();
+    // Totals: attacker 4, defender 70
+    expect(screen.getByText("(4)")).toBeInTheDocument();
+    expect(screen.getByText("(70)")).toBeInTheDocument();
+  });
+
+  it("emits the underdog modifier line only when applied", () => {
+    const { rerender } = render(
+      <BattleReport
+        combat={makeCombat({ underdogApplied: false })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.queryByText(/Underdog bonus active/i)).not.toBeInTheDocument();
+
+    rerender(
+      <BattleReport
+        combat={makeCombat({ underdogApplied: true })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Underdog bonus active/i)).toBeInTheDocument();
+  });
+
+  it("emits supply mult line only when supplyMultiplier !== 1", () => {
+    const { rerender } = render(
+      <BattleReport
+        combat={makeCombat({ supplyMultiplier: 1 })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.queryByText(/Defender supply/i)).not.toBeInTheDocument();
+
+    rerender(
+      <BattleReport
+        combat={makeCombat({ supplyMultiplier: 1.15 })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Defender supply · ×1\.15/)).toBeInTheDocument();
+  });
+
+  it("renders applied offense + defense spell names when available", () => {
+    render(
+      <BattleReport
+        combat={makeCombat({
+          appliedSpells: {
+            offenseId: "red-fire-1",
+            defenseId: "blue-shield-1",
+          },
+        })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    // We don't know exact spell names without looking them up; just assert
+    // that BOTH offense + defense lines render with their tier markers.
+    expect(screen.getByText(/Offense spell ·/)).toBeInTheDocument();
+    expect(screen.getByText(/Defense spell triggered ·/)).toBeInTheDocument();
+  });
+
+  it("renders airIntel weakFace + defenseSpellTier modifier lines", () => {
+    render(
+      <BattleReport
+        combat={makeCombat({
+          airIntel: {
+            sourcePassive: "red-forge-scouts",
+            weakFace: "siege",
+            defenseSpellTier: 3,
+          },
+        })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Forge Sight · led with siege/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Hawks Eye · revealed defense-spell tier 3/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders capacity-clamped line only when units were dropped", () => {
+    const { rerender } = render(
+      <BattleReport
+        combat={makeCombat({ unitsClampedFromCapacity: 0 })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.queryByText(/Capacity dropped/)).not.toBeInTheDocument();
+    rerender(
+      <BattleReport
+        combat={makeCombat({ unitsClampedFromCapacity: 7 })}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Capacity dropped 7 pre-combat/)).toBeInTheDocument();
+  });
+
+  it("always renders RNG and power lines", () => {
+    render(
+      <BattleReport
+        combat={makeCombat()}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(
+      screen.getByText(/RNG · attacker 1\.05× \/ defender 0\.94×/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Power · attack 320 vs defense 180/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the joined narrative text", () => {
+    render(
+      <BattleReport
+        combat={makeCombat()}
+        report={makeReport({
+          narrative: ["Line A", "Line B"],
+        })}
+        targetTile={makeTargetTile()}
+        onDismiss={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/Line A Line B/)).toBeInTheDocument();
+  });
+
+  it("dismisses via the close button", () => {
+    const onDismiss = jest.fn();
+    render(
+      <BattleReport
+        combat={makeCombat()}
+        report={makeReport()}
+        targetTile={makeTargetTile()}
+        onDismiss={onDismiss}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/game/attack/route.ts
+++ b/app/api/game/attack/route.ts
@@ -37,6 +37,7 @@ export async function POST(request: NextRequest) {
       sourceTile: result.sourceTile,
       targetTile: result.targetTile,
       report: result.report,
+      combat: result.combat,
       ...(result.intelReport ? { intelReport: result.intelReport } : {}),
     });
   } catch (error) {

--- a/app/game/_lib/dashboard-actions.ts
+++ b/app/game/_lib/dashboard-actions.ts
@@ -8,6 +8,7 @@
 
 import type { User } from "firebase/auth";
 import type {
+  CombatResult,
   GameArtifact,
   GamePlayer,
   GameTile,
@@ -321,6 +322,11 @@ export async function attack(
   outcome: string;
   reportSummary: string;
   intelReport: IntelReport | null;
+  combat: CombatResult | null;
+  report: TurnReport | null;
+  /** Post-combat enemy tile state — used by BattleReport to derive
+   *  defender pre-attack units = `targetTile.units + combat.defenderLosses`. */
+  targetTile: GameTile | null;
 } | null> {
   mut.setError(null);
   try {
@@ -360,6 +366,9 @@ export async function attack(
       reportSummary:
         (data.report as { summary?: string } | undefined)?.summary ?? "",
       intelReport: (data.intelReport as IntelReport | undefined) ?? null,
+      combat: (data.combat as CombatResult | undefined) ?? null,
+      report: (data.report as TurnReport | undefined) ?? null,
+      targetTile: (data.targetTile as GameTile | undefined) ?? null,
     };
   } catch (e) {
     mut.setError(e instanceof Error ? e.message : "Attack failed");

--- a/app/game/threats/_components/BattleReport.tsx
+++ b/app/game/threats/_components/BattleReport.tsx
@@ -1,0 +1,238 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { SPELLS_BY_ID } from "@/lib/game/content";
+import type {
+  CombatResult,
+  GameTile,
+  TurnReport,
+  UnitStack,
+} from "@/lib/game/types";
+
+export interface BattleReportProps {
+  /** The full combat resolution (RNG, modifiers, applied spells, intel). */
+  combat: CombatResult;
+  /** The TurnReport produced by the same attack — used for the prose
+   *  narrative and the cost-in-turns banner. */
+  report: TurnReport;
+  /** Post-combat enemy tile state. We derive defender pre-attack units as
+   *  `targetTile.units + combat.defenderLosses`. */
+  targetTile: GameTile;
+  /** Click-to-dismiss handler. The card persists until cleared (or the
+   *  next attack on the same row overwrites it). */
+  onDismiss: () => void;
+}
+
+const UNDERDOG_DEFENSE_BONUS = 0.25; // mirrors lib/game/combat.ts:59
+
+function totalUnits(stack: UnitStack): number {
+  return stack.ground + stack.siege + stack.air;
+}
+
+function addStacks(a: UnitStack, b: UnitStack): UnitStack {
+  return {
+    ground: a.ground + b.ground,
+    siege: a.siege + b.siege,
+    air: a.air + b.air,
+  };
+}
+
+function fmtRoll(n: number): string {
+  return `${n.toFixed(2)}×`;
+}
+
+/**
+ * Inline structured battle readout shown on a Threat row after an attack.
+ * Replaces the legacy one-line toast. Persists until dismissed; the next
+ * attack on the same row overwrites it via the parent's local state.
+ *
+ * Sections rendered:
+ *   - Outcome banner (Captured / Repelled / Stalemate, color-coded)
+ *   - Forces (you sent / defender had — derived for the latter)
+ *   - Losses (per unit type for both sides)
+ *   - Modifiers (only the lines that actually applied + the always-on RNG)
+ *   - Narrative (the existing 2-line prose from buildAttackReport)
+ */
+export function BattleReport({
+  combat,
+  report,
+  targetTile,
+  onDismiss,
+}: BattleReportProps) {
+  const defenderPreAttack = addStacks(targetTile.units, combat.defenderLosses);
+  const sent = combat.unitsDeployed;
+  const sentTotal = totalUnits(sent);
+  const defenderHadTotal = totalUnits(defenderPreAttack);
+  const attackerLost = combat.attackerLosses;
+  const defenderLost = combat.defenderLosses;
+
+  const banner = (() => {
+    if (combat.outcome === "captured") {
+      return {
+        label: `Captured ${report.outcome?.targetTileId ?? targetTile.tileId}`,
+        tone: "emerald",
+        classes:
+          "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-300 dark:border-emerald-700 text-emerald-800 dark:text-emerald-200",
+      };
+    }
+    if (combat.outcome === "repelled") {
+      return {
+        label: `Repelled at ${report.outcome?.targetTileId ?? targetTile.tileId}`,
+        tone: "red",
+        classes:
+          "bg-red-50 dark:bg-red-950/30 border-red-300 dark:border-red-700 text-red-800 dark:text-red-200",
+      };
+    }
+    return {
+      label: `Stalemate at ${report.outcome?.targetTileId ?? targetTile.tileId}`,
+      tone: "amber",
+      classes:
+        "bg-amber-50 dark:bg-amber-950/30 border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200",
+    };
+  })();
+
+  // Modifier lines — only emit the ones that actually applied. RNG always
+  // shows because there's always a roll.
+  const modifiers: string[] = [];
+  if (combat.underdogApplied) {
+    modifiers.push(
+      `Underdog bonus active · ×${(1 + UNDERDOG_DEFENSE_BONUS).toFixed(2)} on defense`
+    );
+  }
+  if (combat.supplyMultiplier !== 1) {
+    modifiers.push(
+      `Defender supply · ×${combat.supplyMultiplier.toFixed(2)}`
+    );
+  }
+  if (combat.appliedSpells.offenseId) {
+    const s = SPELLS_BY_ID.get(combat.appliedSpells.offenseId);
+    modifiers.push(
+      s
+        ? `Offense spell · ${s.name} · T${s.tier}`
+        : `Offense spell · ${combat.appliedSpells.offenseId}`
+    );
+  }
+  if (combat.appliedSpells.defenseId) {
+    const s = SPELLS_BY_ID.get(combat.appliedSpells.defenseId);
+    modifiers.push(
+      s
+        ? `Defense spell triggered · ${s.name} · T${s.tier}`
+        : `Defense spell triggered · ${combat.appliedSpells.defenseId}`
+    );
+  }
+  if (combat.airIntel?.weakFace) {
+    modifiers.push(`Forge Sight · led with ${combat.airIntel.weakFace}`);
+  }
+  if (combat.airIntel?.defenseSpellTier !== undefined) {
+    modifiers.push(
+      `Hawks Eye · revealed defense-spell tier ${combat.airIntel.defenseSpellTier}`
+    );
+  }
+  if (combat.unitsClampedFromCapacity > 0) {
+    modifiers.push(
+      `Capacity dropped ${combat.unitsClampedFromCapacity} pre-combat`
+    );
+  }
+  modifiers.push(
+    `RNG · attacker ${fmtRoll(combat.rng.attackerRoll)} / defender ${fmtRoll(combat.rng.defenderRoll)}`
+  );
+  modifiers.push(
+    `Power · attack ${combat.attackPower.toFixed(0)} vs defense ${combat.defensePower.toFixed(0)}`
+  );
+
+  return (
+    <div className={`rounded-lg border-2 ${banner.classes}`}>
+      <div className="flex items-baseline justify-between px-3 py-2">
+        <h3 className="font-semibold uppercase tracking-wide text-xs">
+          {banner.label}
+          <span className="text-neutral-500 normal-case font-normal ml-2">
+            · {report.cost} turn{report.cost === 1 ? "" : "s"} spent
+          </span>
+        </h3>
+        <button
+          onClick={onDismiss}
+          aria-label="Dismiss battle report"
+          className="text-xs text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-300"
+        >
+          ✕ dismiss
+        </button>
+      </div>
+
+      <div className="px-3 pb-3 space-y-3 text-xs text-neutral-700 dark:text-neutral-200">
+        {/* ─── Forces ─────────────────────────────────────────────── */}
+        <section>
+          <h4 className="font-semibold uppercase tracking-wide text-[11px] text-neutral-500 mb-1">
+            Forces
+          </h4>
+          <div className="grid grid-cols-[max-content_1fr_max-content] gap-x-3 font-mono">
+            <span className="text-neutral-500">You sent</span>
+            <span>
+              G{sent.ground} · S{sent.siege} · A{sent.air}
+            </span>
+            <span className="text-neutral-500">({sentTotal} total)</span>
+            <span className="text-neutral-500">Defender had</span>
+            <span>
+              G{defenderPreAttack.ground} · S{defenderPreAttack.siege} · A
+              {defenderPreAttack.air}
+            </span>
+            <span className="text-neutral-500">({defenderHadTotal} total)</span>
+          </div>
+        </section>
+
+        {/* ─── Losses ─────────────────────────────────────────────── */}
+        <section>
+          <h4 className="font-semibold uppercase tracking-wide text-[11px] text-neutral-500 mb-1">
+            Losses
+          </h4>
+          <div className="grid grid-cols-[max-content_1fr_max-content] gap-x-3 font-mono">
+            <span className="text-neutral-500">You lost</span>
+            <span>
+              G{attackerLost.ground} · S{attackerLost.siege} · A
+              {attackerLost.air}
+            </span>
+            <span className="text-neutral-500">
+              ({totalUnits(attackerLost)})
+            </span>
+            <span className="text-neutral-500">Defender lost</span>
+            <span>
+              G{defenderLost.ground} · S{defenderLost.siege} · A
+              {defenderLost.air}
+            </span>
+            <span className="text-neutral-500">
+              ({totalUnits(defenderLost)})
+            </span>
+          </div>
+        </section>
+
+        {/* ─── Modifiers ─────────────────────────────────────────── */}
+        <section>
+          <h4 className="font-semibold uppercase tracking-wide text-[11px] text-neutral-500 mb-1">
+            Modifiers
+          </h4>
+          <ul className="list-disc list-inside space-y-0.5">
+            {modifiers.map((m, i) => (
+              <li key={i}>{m}</li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ─── Narrative ─────────────────────────────────────────── */}
+        {report.narrative.length > 0 && (
+          <section>
+            <h4 className="font-semibold uppercase tracking-wide text-[11px] text-neutral-500 mb-1">
+              Narrative
+            </h4>
+            <p className="italic leading-relaxed text-neutral-600 dark:text-neutral-300">
+              {report.narrative.join(" ")}
+            </p>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -9,14 +9,18 @@
 import { useMemo, useState } from "react";
 import { ARTIFACTS_BY_ID, getSpellsForCasteAndType } from "@/lib/game/content";
 import type {
+  CombatResult,
   GameArtifact,
   GamePlayer,
+  GameTile,
   IntelReport,
   LandType,
   SpellDefinition,
+  TurnReport,
   UnitType,
 } from "@/lib/game/types";
 import type { ThreatEntry } from "../_lib/threats-derive";
+import { BattleReport } from "./BattleReport";
 
 const UNIT_TYPES: UnitType[] = ["ground", "siege", "air"];
 const LAND_TYPES: { type: LandType; label: string }[] = [
@@ -40,6 +44,9 @@ export interface ThreatRowProps {
     outcome: string;
     reportSummary: string;
     intelReport: IntelReport | null;
+    combat: CombatResult | null;
+    report: TurnReport | null;
+    targetTile: GameTile | null;
   } | null>;
   onCastIntelSpell: (
     spellId: string,
@@ -82,6 +89,14 @@ export function ThreatRow(props: ThreatRowProps) {
   const [offenseSpellId, setOffenseSpellId] = useState<string>("");
   const [toast, setToast] = useState<string | null>(null);
   const [intelReport, setIntelReport] = useState<IntelReport | null>(null);
+  // Structured battle readout shown after an attack lands. Replaces the
+  // plain toast for attack actions; non-attack actions (recruit, arm, etc.)
+  // still use the toast.
+  const [battle, setBattle] = useState<{
+    combat: CombatResult;
+    report: TurnReport;
+    targetTile: GameTile;
+  } | null>(null);
 
   const source =
     entry.candidateSources.find((t) => t.tileId === sourceTileId) ??
@@ -125,6 +140,7 @@ export function ThreatRow(props: ThreatRowProps) {
 
   async function handleAttack() {
     setToast(null);
+    setBattle(null);
     const res = await props.onAttack({
       sourceTileId: source.tileId,
       targetTileId: entry.enemyTile.tileId,
@@ -132,7 +148,18 @@ export function ThreatRow(props: ThreatRowProps) {
       offenseSpellId: offenseSpellId || null,
     });
     if (res) {
-      setToast(res.reportSummary || `Attack ${res.outcome}`);
+      // If we have full combat detail + report + post-combat tile, render
+      // the structured battle card. Otherwise (older server response) fall
+      // back to a one-line toast.
+      if (res.combat && res.report && res.targetTile) {
+        setBattle({
+          combat: res.combat,
+          report: res.report,
+          targetTile: res.targetTile,
+        });
+      } else {
+        setToast(res.reportSummary || `Attack ${res.outcome}`);
+      }
       setGround(0);
       setSiege(0);
       setAir(0);
@@ -228,6 +255,61 @@ export function ThreatRow(props: ThreatRowProps) {
         </span>
       </div>
 
+      {/* ─── Source prep strip — always visible (assign + recruit) ──────── */}
+      <div className="px-4 pb-2 space-y-1.5">
+        {/* Assign land type */}
+        <div className="flex flex-wrap items-center gap-1.5 text-xs">
+          <span className="text-neutral-500 mr-1">Assign source · 1t:</span>
+          {LAND_TYPES.map((a) => {
+            const isCurrent = source.type === a.type;
+            const cantSpend = player.turnsRemaining < 1;
+            const reason = isCurrent
+              ? `Already ${a.label.toLowerCase()}`
+              : cantSpend
+                ? "Need 1 turn"
+                : null;
+            return (
+              <button
+                key={a.type}
+                onClick={() => handleAssign(a.type)}
+                disabled={busy || reason !== null}
+                title={reason ?? `Set source to ${a.label.toLowerCase()}`}
+                className={`px-2 py-1 rounded border ${
+                  isCurrent
+                    ? "border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300"
+                    : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                } disabled:opacity-50`}
+              >
+                {a.label}
+              </button>
+            );
+          })}
+        </div>
+        {/* Recruit */}
+        <div className="flex flex-wrap items-center gap-1.5 text-xs">
+          <span className="text-neutral-500 mr-1">Recruit · 5t:</span>
+          {UNIT_TYPES.map((u) => {
+            const reason =
+              source.type !== "military"
+                ? "Tile is not military — assign first"
+                : player.turnsRemaining < 5
+                  ? "Need 5 turns"
+                  : null;
+            return (
+              <button
+                key={u}
+                onClick={() => handleRecruit(u)}
+                disabled={busy || reason !== null}
+                title={reason ?? `Recruit +10 ${u} on source`}
+                className="px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 capitalize"
+              >
+                +10 {u}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
       {/* ─── Inline attack form (visible always) ─────────────────────────── */}
       <div className="px-4 pb-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
         <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto_minmax(0,1fr)] items-end">
@@ -294,7 +376,19 @@ export function ThreatRow(props: ThreatRowProps) {
         </div>
       )}
 
-      {/* ─── Toast (last action result) ──────────────────────────────────── */}
+      {/* ─── Battle report (full structured readout after an attack) ─────── */}
+      {battle && (
+        <div className="mx-4 mb-3">
+          <BattleReport
+            combat={battle.combat}
+            report={battle.report}
+            targetTile={battle.targetTile}
+            onDismiss={() => setBattle(null)}
+          />
+        </div>
+      )}
+
+      {/* ─── Toast (one-line result for non-attack actions) ──────────────── */}
       {toast && (
         <div className="mx-4 mb-3 px-3 py-2 rounded bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900 text-xs text-emerald-800 dark:text-emerald-200 flex items-center justify-between gap-2">
           <span>{toast}</span>
@@ -383,73 +477,14 @@ export function ThreatRow(props: ThreatRowProps) {
             </section>
           )}
 
-          {/* Manage source tile */}
+          {/* Manage source tile — defense-side only.
+              Assign + recruit live in the always-visible strip up top. */}
           <section>
             <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
-              Manage source · {source.tileId} ({source.type})
+              Defend source · {source.tileId} ({source.type})
             </h3>
 
             <div className="space-y-3">
-              {/* Land type buttons */}
-              <div>
-                <p className="text-xs text-neutral-500 mb-1">Assign — 1 turn</p>
-                <div className="flex flex-wrap gap-2">
-                  {LAND_TYPES.map((a) => {
-                    const isCurrent = source.type === a.type;
-                    const cantSpend = player.turnsRemaining < 1;
-                    return (
-                      <button
-                        key={a.type}
-                        onClick={() => handleAssign(a.type)}
-                        disabled={busy || isCurrent || cantSpend}
-                        title={
-                          isCurrent
-                            ? "Current type"
-                            : cantSpend
-                              ? "Need 1 turn"
-                              : `Set tile to ${a.label.toLowerCase()}`
-                        }
-                        className={`px-3 py-1.5 text-xs rounded border ${
-                          isCurrent
-                            ? "border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 cursor-default"
-                            : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-                        } disabled:opacity-50`}
-                      >
-                        {a.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Recruit */}
-              <div>
-                <p className="text-xs text-neutral-500 mb-1">
-                  Recruit — +10 / 5 turns (military tiles only)
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {UNIT_TYPES.map((u) => {
-                    const reason =
-                      source.type !== "military"
-                        ? "Tile is not military"
-                        : player.turnsRemaining < 5
-                          ? "Need 5 turns"
-                          : null;
-                    return (
-                      <button
-                        key={u}
-                        onClick={() => handleRecruit(u)}
-                        disabled={busy || reason !== null}
-                        title={reason ?? `Recruit +10 ${u}`}
-                        className="px-3 py-1.5 text-xs rounded border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 capitalize"
-                      >
-                        +10 {u}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
               {/* Arm defense spell */}
               {defenseSpells.length > 0 && (
                 <div>

--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -130,6 +130,43 @@ const TurnReportSchema = z
       "Per-action turn report. Shape varies by action type — see `lib/game/turn-report.ts` for the discriminated union.",
   });
 
+// Mirrors `CombatResult` from `lib/game/types.ts`. Returned alongside the
+// TurnReport on attack responses so the client can render a structured
+// battle readout (RNG rolls, supply ×, applied spells, intel-passive flags,
+// per-unit-type loss breakdowns). Optional on the response so older clients
+// that ignore it remain compatible.
+const CombatResultSchema = z
+  .object({
+    outcome: z.string(),
+    unitsDeployed: UnitStackSchema,
+    unitsClampedFromCapacity: z.number().int().nonnegative(),
+    attackPower: z.number(),
+    defensePower: z.number(),
+    attackerLosses: UnitStackSchema,
+    defenderLosses: UnitStackSchema,
+    underdogApplied: z.boolean(),
+    supplyMultiplier: z.number(),
+    rng: z.object({
+      attackerRoll: z.number(),
+      defenderRoll: z.number(),
+    }),
+    appliedSpells: z.object({
+      offenseId: z.string().nullable(),
+      defenseId: z.string().nullable(),
+    }),
+    airIntel: z
+      .object({
+        sourcePassive: z.string(),
+        defenseSpellTier: z.number().int().optional(),
+        weakFace: UnitTypeEnum.optional(),
+        forgeScoutsBonusApplied: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
+  .openapi("GameCombatResult");
+
 // ──────────────────── Common response wrappers ────────────────────
 
 const PlayerOkResponse = z.object({
@@ -700,6 +737,7 @@ export const gameContract = c.router(
           sourceTile: GameTileSchema,
           targetTile: GameTileSchema,
           report: TurnReportSchema,
+          combat: CombatResultSchema.optional(),
           intelReport: z.object({}).passthrough().optional(),
         }),
         ...actionErrorResponses,

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -56,6 +56,7 @@ import {
 import type {
   ArtifactDefinition,
   Caste,
+  CombatResult,
   GameArtifact,
   GameAttack,
   GamePlayer,
@@ -1882,6 +1883,10 @@ export async function attackTileServer(args: {
   sourceTile: GameTile;
   targetTile: GameTile;
   report: TurnReport;
+  // Full combat resolution result. Already feeds buildAttackReport; we surface
+  // it on the response too so the client can render Forces / Losses /
+  // Modifiers / Narrative without re-deriving from outcome alone.
+  combat: CombatResult;
   artifact: GameArtifact | null;
   // Set when the attacker's air-unit intel passive triggered a post-attack
   // reveal. Currently produced for Blue Sky Reader (air > defender air → ring
@@ -2204,6 +2209,11 @@ export async function attackTileServer(args: {
         updatedAt: now,
       },
       report,
+      // Full CombatResult so the client can render a structured battle
+      // readout (RNG rolls, supply ×, applied spells, intel passive flags,
+      // per-unit-type loss breakdowns). Already feeds buildAttackReport;
+      // we just expose it on the response too.
+      combat: result,
       artifact: rolled?.doc ?? null,
       // Snapshot for post-txn air-intel reveals.
       _airIntelContext: {


### PR DESCRIPTION
## Summary

Two issues surfaced after the Threats page hub shipped in #763:

1. The auto-picked source tile is often **unassigned with 0 units** — the row says "Attack disabled: No units selected" with no obvious next step. Users had to expand → assign → recruit → collapse → set inputs → attack.
2. The post-attack readout was a one-line toast. The combat resolver already produced a rich `CombatResult` (RNG, supply ×, applied spells, intel-passive flags, per-unit-type loss breakdowns) — none of it surfaced.

## Changes

- **ThreatRow** gains an always-visible source-prep strip above the attack form: `[Mil][Food][Magic][Unassign]` + `+10 [Ground/Siege/Air]`, each with disabled-with-reason tooltips. Removes the duplicate "Manage source" sub-section from the expand chevron.
- **Server**: `attackTileServer` + the `/api/game/attack` route + the ts-rest contract pass the full `CombatResult` through alongside the `TurnReport`. Optional on the response so older clients stay compatible.
- **`<BattleReport>` component** renders inline on the row in place of the toast: outcome banner (emerald/red/amber), Forces (you-sent + derived defender-had), per-unit-type Losses, Modifiers (only the lines that applied + always-on RNG + power), and the prose narrative.
- **16 new tests**: BattleReport (14, RTL — banners, derivation, per-modifier conditional rendering, dismiss); dashboard-actions (2 — combat threads through; backward-compatible).

## Test plan

- [ ] /game/threats: rows now show `Assign source · 1t: [Mil][Food][Magic][Unassign]` + `Recruit · 5t: +10 [Gnd][Siege][Air]` strips above the attack form, regardless of source state
- [ ] Click `Mil` on an unassigned source → tile flips to military inline (no expand, no reload)
- [ ] Click `+10 Ground` after assigning → ground count appears in the source dropdown
- [ ] Set 5 ground in attack inputs, click Attack → battle card replaces the toast with Forces / Losses / Modifiers / Narrative
- [ ] Lose an attack → red Repelled banner; Modifiers section reflects underdog / supply × / spell tier as applicable
- [ ] Defender-had derivation visible: e.g. defender pre-attack G50 S20 A20 (90 total) when targetTile post-attack G10 S5 A5 + losses G40 S15 A15
- [ ] Dismiss button clears the card; next attack on the same row overwrites it

🤖 Generated with [Claude Code](https://claude.com/claude-code)