### PR TITLE
release: summer cohort admin contracts hotfix

### DIFF
--- a/app/api/summer-cohort/admin/access/route.ts
+++ b/app/api/summer-cohort/admin/access/route.ts
@@ -7,6 +7,10 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
+import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
+
+// Contract reference (no runtime inputs to validate on this probe).
+void summerCohortContract.adminAccess;
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";

--- a/app/api/summer-cohort/admin/applications/route.ts
+++ b/app/api/summer-cohort/admin/applications/route.ts
@@ -8,9 +8,9 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
+import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
   SUMMER_COHORT_COLLECTION,
-  isValidCohortId,
   type SummerCohortId,
   type SummerCohortStatus,
 } from "@/lib/summer-cohort";
@@ -71,15 +71,21 @@ export async function GET(request: NextRequest) {
   }
 
   const params = request.nextUrl.searchParams;
-  const cohortIdParam = params.get("cohortId");
-  const statusParam = params.get("status");
-
-  const cohortFilter =
-    cohortIdParam && isValidCohortId(cohortIdParam) ? cohortIdParam : null;
-  const statusFilter =
-    statusParam && VALID_STATUSES.has(statusParam as SummerCohortStatus)
-      ? (statusParam as SummerCohortStatus)
-      : null;
+  const parsedQuery = summerCohortContract.adminApplications.query.safeParse({
+    cohortId: params.get("cohortId") ?? undefined,
+    status: params.get("status") ?? undefined,
+  });
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      {
+        error:
+          parsedQuery.error.issues[0]?.message ?? "Invalid query parameters",
+      },
+      { status: 400 }
+    );
+  }
+  const cohortFilter = parsedQuery.data.cohortId ?? null;
+  const statusFilter = parsedQuery.data.status ?? null;
 
   let query: FirebaseFirestore.Query = db.collection(SUMMER_COHORT_COLLECTION);
   if (cohortFilter) {
@@ -93,7 +99,9 @@ export async function GET(request: NextRequest) {
   const rows: AdminApplicationRow[] = snap.docs.map((doc) => {
     const data = doc.data();
     const cohorts = Array.isArray(data.cohorts)
-      ? (data.cohorts as unknown[]).filter(isValidCohortId)
+      ? (data.cohorts as unknown[]).filter(
+          (c): c is SummerCohortId => c === "cohort-1" || c === "cohort-2"
+        )
       : [];
     const status =
       typeof data.status === "string" &&

--- a/app/api/summer-cohort/admin/intake-aggregates/route.ts
+++ b/app/api/summer-cohort/admin/intake-aggregates/route.ts
@@ -8,6 +8,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
+import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
   AI_TOOL_OPTIONS,
   CS_CREDENTIAL_OPTIONS,
@@ -130,7 +131,22 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Server not configured" }, { status: 500 });
   }
 
-  const cohort = request.nextUrl.searchParams.get("cohort");
+  const parsedQuery = summerCohortContract.adminIntakeAggregates.query.safeParse(
+    {
+      cohort:
+        request.nextUrl.searchParams.get("cohort") ?? undefined,
+    }
+  );
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      {
+        error:
+          parsedQuery.error.issues[0]?.message ?? "Invalid query parameters",
+      },
+      { status: 400 }
+    );
+  }
+  const cohort = parsedQuery.data.cohort ?? null;
 
   let query: FirebaseFirestore.Query = db.collection(
     SUMMER_COHORT_INTAKE_COLLECTION

--- a/lib/api-schemas/summer-cohort.ts
+++ b/lib/api-schemas/summer-cohort.ts
@@ -51,6 +51,15 @@ const VotesPostBody = z
   })
   .openapi("SummerCohortVoteBody");
 
+const AdminApplicationsQuery = z.object({
+  cohortId: z.enum(["cohort-1", "cohort-2"]).optional(),
+  status: z.enum(["pending", "admitted", "rejected", "waitlist"]).optional(),
+});
+
+const AdminIntakeAggregatesQuery = z.object({
+  cohort: z.string().min(1).max(64).optional(),
+});
+
 export const summerCohortContract = c.router(
   {
     applyGet: {
@@ -144,6 +153,45 @@ export const summerCohortContract = c.router(
       },
       metadata: {
         errorCodes: ["UNAUTHORIZED", "VALIDATION_ERROR", "SERVER_ERROR"] as const,
+      },
+    },
+    adminAccess: {
+      method: "GET",
+      path: "/api/summer-cohort/admin/access",
+      summary:
+        "Probe whether the current user is allowed in the Summer Cohort admin area",
+      responses: { 200: PassthroughOk, 401: ApiErrorSchema },
+      metadata: { errorCodes: ["UNAUTHORIZED"] as const },
+    },
+    adminApplications: {
+      method: "GET",
+      path: "/api/summer-cohort/admin/applications",
+      summary: "List applications (admin only) with optional cohort/status filter",
+      query: AdminApplicationsQuery,
+      responses: {
+        200: PassthroughOk,
+        401: ApiErrorSchema,
+        403: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "FORBIDDEN", "SERVER_ERROR"] as const,
+      },
+    },
+    adminIntakeAggregates: {
+      method: "GET",
+      path: "/api/summer-cohort/admin/intake-aggregates",
+      summary:
+        "Aggregate stats for intake-survey responses (admin only, no PII or free text)",
+      query: AdminIntakeAggregatesQuery,
+      responses: {
+        200: PassthroughOk,
+        401: ApiErrorSchema,
+        403: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "FORBIDDEN", "SERVER_ERROR"] as const,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Hotfix for the production build that failed on the previous release (PR #767): the three new `/api/summer-cohort/admin/*` routes weren't backed by ts-rest contracts, so `check:route-contracts` blocked the build.
- Adds `adminAccess` / `adminApplications` / `adminIntakeAggregates` entries to `summerCohortContract` and validates query params via `.safeParse()` on the two routes with inputs.

## Included PRs / commits
- `98768ec` fix(admin): wire ts-rest contracts for summer-cohort admin routes — @ludwitt

## Test plan
- [x] `node scripts/check-route-contracts.js` reports OK locally
- [x] `tsc --noEmit` clean
- [ ] Vercel production build succeeds after merge
- [ ] Set `SUMMER_COHORT_ADMIN_EMAILS=regorhunt02052@gmail.com` in Vercel before relying on /admin/summer-cohort

🤖 Generated with [Claude Code](https://claude.com/claude-code)