### PR TITLE
feat(cohort): readiness modal, setup + game tabs, status email

### DIFF
--- a/app/summer-cohort/_components/CohortTabs.tsx
+++ b/app/summer-cohort/_components/CohortTabs.tsx
@@ -9,6 +9,8 @@
 export type CohortTabId =
   | "info"
   | "intake-survey"
+  | "setup"
+  | "game"
   | "week-1"
   | "week-2"
   | "week-3"
@@ -27,6 +29,8 @@ const ALL_TABS: readonly TabSpec[] = [
   { id: "info", label: "Cohort Info", shortLabel: "Cohort" },
   { id: "intake-survey", label: "Intake Survey", shortLabel: "Survey" },
   { id: "my-info", label: "My Info", shortLabel: "Me" },
+  { id: "setup", label: "Setup Instructions", shortLabel: "Setup" },
+  { id: "game", label: "Game", shortLabel: "Game" },
   { id: "week-1", label: "Week 1: PM", shortLabel: "W1" },
   { id: "week-2", label: "Week 2: Comms", shortLabel: "W2" },
   { id: "week-3", label: "Week 3: Vibe Marketing", shortLabel: "W3" },

--- a/app/summer-cohort/_components/GamePromoPanel.tsx
+++ b/app/summer-cohort/_components/GamePromoPanel.tsx
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowRight,
+  ExternalLink,
+  GitPullRequest,
+  Lightbulb,
+  Swords,
+} from "lucide-react";
+
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+export function GamePromoPanel() {
+  return (
+    <section
+      role="tabpanel"
+      id="tabpanel-game"
+      aria-labelledby="tab-game"
+      className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-purple-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+          For fun (and PRs)
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-purple-500/10 px-2 py-0.5 text-xs font-semibold text-purple-700 dark:text-purple-400">
+          <Swords className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
+          /game
+        </span>
+      </div>
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        The Cursor Boston game
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        A persistent web game we built into this same repo. Recruit, run
+        threats, cast spells, climb the leaderboard. It&apos;s small and
+        opinionated on purpose — and it&apos;s the easiest place in the
+        codebase to ship something visible.
+      </p>
+
+      <Link
+        href="/game"
+        className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-purple-500 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-purple-400 sm:w-auto"
+      >
+        Open /game
+        <ArrowRight className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+      </Link>
+
+      <div className="mt-6 rounded-lg border-2 border-purple-300 bg-purple-50/50 p-5 dark:border-purple-800 dark:bg-purple-950/20">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-purple-700 dark:text-purple-400">
+          <Lightbulb className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          Help shape it
+        </div>
+        <h3 className="mt-2 text-base font-semibold text-neutral-900 dark:text-neutral-100">
+          Have an idea? Open a PR.
+        </h3>
+        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+          New spells, new threat types, balance tweaks, cleaner UI, a whole new
+          game mode — anything goes. The PR fast-lane that got most of you
+          admitted is still active, and contributions to <code>/game</code> are
+          exactly the kind of work we want to see.
+        </p>
+        <ul className="mt-3 space-y-2 text-sm text-neutral-700 dark:text-neutral-300">
+          <li className="flex gap-2">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              Game logic lives under <code>lib/game/</code>; UI is under{" "}
+              <code>app/game/</code>.
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              Pick something small for your first PR — a new spell or a tile
+              tweak ships in an afternoon.
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              Wild ideas welcome. Open an issue first if you want a sanity
+              check before you build.
+            </span>
+          </li>
+        </ul>
+
+        <a
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 inline-flex items-center gap-2 rounded-lg border border-purple-400 bg-white px-4 py-2.5 text-sm font-semibold text-purple-700 transition-colors hover:bg-purple-50 dark:border-purple-700 dark:bg-neutral-900 dark:text-purple-300 dark:hover:bg-purple-950/40"
+        >
+          <GitPullRequest className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+          Open the repo on GitHub
+          <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/app/summer-cohort/_components/SetupInstructionsPanel.tsx
+++ b/app/summer-cohort/_components/SetupInstructionsPanel.tsx
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { CheckCircle2, ExternalLink, Laptop, MessageCircle } from "lucide-react";
+
+const ALC_URL = "https://ludwitt.com/alc";
+
+export function SetupInstructionsPanel() {
+  return (
+    <section
+      role="tabpanel"
+      id="tabpanel-setup"
+      aria-labelledby="tab-setup"
+      className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+          Before kickoff
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+          <Laptop className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
+          Local machine
+        </span>
+      </div>
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        Get your machine ready
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        You&apos;ll be writing and shipping code from your laptop starting Mon
+        May 11. Three things have to be installed and working:
+      </p>
+
+      <ul className="mt-5 space-y-3 text-sm text-neutral-800 dark:text-neutral-200">
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <CheckCircle2
+            className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-semibold">Node.js (LTS)</p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              The runtime everything else builds on. Install the LTS version.
+            </p>
+          </div>
+        </li>
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <CheckCircle2
+            className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-semibold">Git</p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              Install it and sign in with the GitHub account you connected on
+              the My Info tab — your PRs need to come from the same identity.
+            </p>
+          </div>
+        </li>
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <CheckCircle2
+            className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-semibold">Cursor (or Claude Code)</p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              Pick one. Cursor is recommended for cohort live work since the
+              walkthroughs assume it, but Claude Code is fully fine if you
+              already have a flow.
+            </p>
+          </div>
+        </li>
+      </ul>
+
+      <a
+        href={ALC_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-500 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 sm:w-auto"
+      >
+        Open the full setup walkthrough
+        <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+      </a>
+
+      <p className="mt-5 flex items-start gap-2 border-t border-neutral-200 pt-4 text-xs text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
+        <MessageCircle
+          className="mt-0.5 h-3.5 w-3.5 shrink-0"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        <span>
+          Hit a snag during install? Drop a question in the cohort Discord —
+          someone is almost certainly already past it.
+        </span>
+      </p>
+    </section>
+  );
+}

--- a/app/summer-cohort/_components/SetupReadinessModal.tsx
+++ b/app/summer-cohort/_components/SetupReadinessModal.tsx
@@ -1,0 +1,240 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  CircleAlert,
+  ExternalLink,
+  Laptop,
+  X,
+} from "lucide-react";
+
+const ALC_URL = "https://ludwitt.com/alc";
+
+interface SetupReadinessModalProps {
+  /** Discord is not connected — triggers the modal to pop. */
+  needsDiscord: boolean;
+  /** GitHub is not connected — triggers the modal to pop. */
+  needsGithub: boolean;
+  /** Intake survey not yet submitted — displayed only, never triggers pop. */
+  needsSurvey: boolean;
+  onConnectDiscord: () => void;
+  onConnectGithub: () => void;
+  /** Closes the modal and switches the page to the intake-survey tab. */
+  onGoToSurvey: () => void;
+}
+
+/**
+ * Sticky readiness modal for admitted Cohort 1 admits.
+ * Pops on every page load while Discord OR GitHub is missing.
+ * Closing only suppresses for the current page-load — no localStorage flag
+ * — so users keep being nudged until they connect both.
+ */
+export function SetupReadinessModal({
+  needsDiscord,
+  needsGithub,
+  needsSurvey,
+  onConnectDiscord,
+  onConnectGithub,
+  onGoToSurvey,
+}: SetupReadinessModalProps) {
+  const shouldOpen = needsDiscord || needsGithub;
+  const [isOpen, setIsOpen] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Open whenever the trigger condition becomes true. We only auto-open on
+  // the rising edge so that closing the modal doesn't immediately re-open it
+  // within the same page-load.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (shouldOpen && !wasOpenRef.current) {
+       
+      setIsOpen(true);
+      wasOpenRef.current = true;
+    }
+    if (!shouldOpen) {
+      wasOpenRef.current = false;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- hide modal once user has completed both connections
+      setIsOpen(false);
+    }
+  }, [shouldOpen]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      closeButtonRef.current?.focus();
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) handleClose();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, handleClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="setup-readiness-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full max-w-lg rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl md:p-8">
+        <button
+          ref={closeButtonRef}
+          onClick={handleClose}
+          className="absolute right-4 top-4 rounded-lg p-1 text-neutral-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          aria-label="Close readiness check"
+        >
+          <X className="h-5 w-5" strokeWidth={2.25} aria-hidden="true" />
+        </button>
+
+        <h2
+          id="setup-readiness-title"
+          className="pr-8 text-xl font-bold text-white md:text-2xl"
+        >
+          Cohort 1 kicks off Mon, May 11 — let&apos;s get you ready
+        </h2>
+        <p className="mt-2 text-sm text-neutral-400">
+          A few quick checks before kickoff. Knock these out now and you can
+          show up Monday focused on the work, not the setup.
+        </p>
+
+        <ul className="mt-5 space-y-2">
+          <StatusRow
+            label="Connect Discord"
+            done={!needsDiscord}
+            doneCopy="Connected — we'll add you to the cohort channel."
+            actionLabel="Connect Discord"
+            onAction={onConnectDiscord}
+          />
+          <StatusRow
+            label="Connect GitHub"
+            done={!needsGithub}
+            doneCopy="Connected — your PRs will count toward the cohort."
+            actionLabel="Connect GitHub"
+            onAction={onConnectGithub}
+          />
+          <StatusRow
+            label="Intake survey (~5 min)"
+            done={!needsSurvey}
+            doneCopy="Submitted. Thanks!"
+            actionLabel="Take the survey"
+            onAction={() => {
+              onGoToSurvey();
+              handleClose();
+            }}
+          />
+        </ul>
+
+        <div className="mt-5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-300">
+            <Laptop className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+            On your laptop
+          </div>
+          <p className="mt-1.5 text-sm text-neutral-200">
+            Install <strong>Node</strong>, <strong>Git</strong>, and{" "}
+            <strong>Cursor</strong> (or Claude Code) before Monday. The full
+            walkthrough is at <span className="font-mono">ludwitt.com/alc</span>.
+          </p>
+          <a
+            href={ALC_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+          >
+            Open the setup walkthrough
+            <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          </a>
+        </div>
+
+        <button
+          onClick={handleClose}
+          className="mt-5 w-full text-center text-sm text-neutral-500 transition-colors hover:text-neutral-300 focus-visible:text-white focus-visible:underline focus-visible:outline-none"
+        >
+          I&apos;ll come back to this
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface StatusRowProps {
+  label: string;
+  done: boolean;
+  doneCopy: string;
+  actionLabel: string;
+  onAction: () => void;
+}
+
+function StatusRow({
+  label,
+  done,
+  doneCopy,
+  actionLabel,
+  onAction,
+}: StatusRowProps) {
+  return (
+    <li
+      className={`flex items-center gap-3 rounded-lg border px-4 py-3 ${
+        done
+          ? "border-emerald-700/40 bg-emerald-500/5"
+          : "border-amber-700/60 bg-amber-500/10"
+      }`}
+    >
+      {done ? (
+        <CheckCircle2
+          className="h-5 w-5 shrink-0 text-emerald-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+      ) : (
+        <CircleAlert
+          className="h-5 w-5 shrink-0 text-amber-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-white">{label}</p>
+        <p className="mt-0.5 text-xs text-neutral-400">
+          {done ? doneCopy : "Not done yet."}
+        </p>
+      </div>
+      {!done ? (
+        <button
+          type="button"
+          onClick={onAction}
+          className="shrink-0 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-amber-950 transition-colors hover:bg-amber-400"
+        >
+          {actionLabel}
+        </button>
+      ) : null}
+    </li>
+  );
+}

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -34,8 +34,11 @@ import {
 import { ClaimSpotByPRCard } from "./_components/ClaimSpotByPRCard";
 import { CohortProgramBreakdown } from "./_components/CohortProgramBreakdown";
 import { CohortTabs, type CohortTabId } from "./_components/CohortTabs";
+import { GamePromoPanel } from "./_components/GamePromoPanel";
 import { InfoTabPanel } from "./_components/InfoTabPanel";
 import { IntakeSurveyForm } from "./_components/IntakeSurveyForm";
+import { SetupInstructionsPanel } from "./_components/SetupInstructionsPanel";
+import { SetupReadinessModal } from "./_components/SetupReadinessModal";
 import { Week4LudwittPanel } from "./_components/Week4LudwittPanel";
 import { Week5StartupPanel } from "./_components/Week5StartupPanel";
 import { Week6OssPanel } from "./_components/Week6OssPanel";
@@ -789,6 +792,16 @@ function SummerCohortPageInner() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      {showTabs ? (
+        <SetupReadinessModal
+          needsDiscord={!discord.discordInfo}
+          needsGithub={!github.githubInfo?.login}
+          needsSurvey={intakeStatus === "incomplete"}
+          onConnectDiscord={discord.connect}
+          onConnectGithub={github.connect}
+          onGoToSurvey={() => setActiveTab("intake-survey")}
+        />
+      ) : null}
       <header className="mb-8">
         <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
           <Sun className="h-3.5 w-3.5" strokeWidth={2.25} />
@@ -957,6 +970,10 @@ function SummerCohortPageInner() {
                     <Week5StartupPanel />
                   ) : activeTab === "week-6" ? (
                     <Week6OssPanel />
+                  ) : activeTab === "setup" ? (
+                    <SetupInstructionsPanel />
+                  ) : activeTab === "game" ? (
+                    <GamePromoPanel />
                   ) : null}
                 </div>
                 <CohortCodeOfConductFooter />

--- a/scripts/send-cohort1-status-and-game.ts
+++ b/scripts/send-cohort1-status-and-game.ts
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+/**
+ * Cohort 1 — pre-kickoff personalized checklist + /game promo.
+ *
+ * For each admitted cohort-1 applicant, send an email that lays out
+ * (per-recipient) what they still owe before Mon May 11:
+ *   - Discord connected?       (users/{uid}.discord.id)
+ *   - GitHub connected?        (users/{uid}.github.login)
+ *   - Intake survey submitted? (summerCohortIntakeSurveys collection by email)
+ *   - Local setup walkthrough  (always shown — there's no completion field)
+ * And promote /game with a "PR your ideas" CTA.
+ *
+ * Idempotent via `cohort1StatusCheckEmailedAt` on the application doc —
+ * re-runs skip anyone already stamped. Use --force to re-send.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-status-and-game.ts --dry-run
+ *   npx tsx scripts/send-cohort1-status-and-game.ts --send
+ *   npx tsx scripts/send-cohort1-status-and-game.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION, isValidCohortId } from "../lib/summer-cohort";
+import { SUMMER_COHORT_INTAKE_COLLECTION } from "../lib/summer-cohort-intake";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const GAME_URL = "https://cursorboston.com/game";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const ALC_URL = "https://ludwitt.com/alc";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  name: string;
+  discordUsername: string | null;
+  githubLogin: string | null;
+  surveyDone: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function row({
+  done,
+  label,
+  doneCopy,
+  todoCopy,
+  ctaUrl,
+  ctaLabel,
+}: {
+  done: boolean;
+  label: string;
+  doneCopy: string;
+  todoCopy: string;
+  ctaUrl: string;
+  ctaLabel: string;
+}): string {
+  if (done) {
+    return `<li style="margin:6px 0;padding:10px 14px;border-left:4px solid #10b981;background:#ecfdf5;border-radius:6px;">
+  <strong>✅ ${escapeHtml(label)}</strong> — ${escapeHtml(doneCopy)}
+</li>`;
+  }
+  return `<li style="margin:6px 0;padding:10px 14px;border-left:4px solid #f59e0b;background:#fffbeb;border-radius:6px;">
+  <strong>⚠️ ${escapeHtml(label)}</strong> — ${escapeHtml(todoCopy)}
+  &nbsp;<a href="${ctaUrl}" style="color:#92400e;font-weight:600;">${escapeHtml(ctaLabel)} →</a>
+</li>`;
+}
+
+function rowText({
+  done,
+  label,
+  doneCopy,
+  todoCopy,
+  ctaUrl,
+  ctaLabel,
+}: {
+  done: boolean;
+  label: string;
+  doneCopy: string;
+  todoCopy: string;
+  ctaUrl: string;
+  ctaLabel: string;
+}): string {
+  if (done) return `  [✓] ${label} — ${doneCopy}`;
+  return `  [ ] ${label} — ${todoCopy}\n      ${ctaLabel}: ${ctaUrl}`;
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(r.name?.split(" ")[0]?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const discordDone = r.discordUsername !== null;
+  const githubDone = r.githubLogin !== null;
+  const allReady = discordDone && githubDone && r.surveyDone;
+
+  const subject = "Cohort 1 — Monday checklist + try /game";
+
+  const checklistHtml = [
+    row({
+      done: discordDone,
+      label: "Discord",
+      doneCopy: `connected as @${r.discordUsername ?? ""}`,
+      todoCopy: "not connected — we can't add you to the cohort channel without this",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect Discord",
+    }),
+    row({
+      done: githubDone,
+      label: "GitHub",
+      doneCopy: `connected as @${r.githubLogin ?? ""}`,
+      todoCopy: "not connected — your PRs need this to count",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect GitHub",
+    }),
+    row({
+      done: r.surveyDone,
+      label: "Intake survey",
+      doneCopy: "submitted — thank you",
+      todoCopy: "~5 min, helps us tailor the program to who's in the room",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Take the survey",
+    }),
+  ].join("");
+
+  const checklistText = [
+    rowText({
+      done: discordDone,
+      label: "Discord",
+      doneCopy: `connected as @${r.discordUsername ?? ""}`,
+      todoCopy: "not connected — we can't add you to the cohort channel without this",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect Discord",
+    }),
+    rowText({
+      done: githubDone,
+      label: "GitHub",
+      doneCopy: `connected as @${r.githubLogin ?? ""}`,
+      todoCopy: "not connected — your PRs need this to count",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect GitHub",
+    }),
+    rowText({
+      done: r.surveyDone,
+      label: "Intake survey",
+      doneCopy: "submitted — thank you",
+      todoCopy: "~5 min, helps us tailor the program to who's in the room",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Take the survey",
+    }),
+  ].join("\n");
+
+  const lead = allReady
+    ? `<p>Hi ${first},</p>
+<p><strong>You're all set for Monday.</strong> Cohort 1 kicks off <strong>Mon, May 11</strong> — see below for one last laptop check, plus something fun to play with this weekend.</p>`
+    : `<p>Hi ${first},</p>
+<p>Cohort 1 kicks off <strong>Mon, May 11</strong>. Quick personalized check on what you still owe so you can show up Monday focused on the work, not the setup:</p>`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+${lead}
+
+<ul style="list-style:none;padding:0;margin:16px 0;">${checklistHtml}</ul>
+
+<p style="margin:18px 0 6px 0;"><strong>💻 On your laptop, before Monday:</strong></p>
+<p style="margin:0 0 10px 0;">Install <strong>Node</strong> (LTS), <strong>Git</strong>, and <strong>Cursor</strong> (or Claude Code if you already have a flow). Full walkthrough — every step, every gotcha — is here:</p>
+<p style="margin:0 0 18px 0;">
+  <a href="${ALC_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;">Open the setup walkthrough →</a>
+</p>
+
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:24px 0;"/>
+
+<p style="margin:0 0 8px 0;"><strong>🎮 While you wait — try /game</strong></p>
+<p style="margin:0 0 12px 0;">We built a small persistent web game right inside this same repo: recruit, run threats, cast spells, climb the leaderboard. Play it for 10 minutes — and if you have ideas for new spells, threat types, balance tweaks, or UI improvements, <strong>open a PR</strong>. The PR fast-lane that admitted most of you is still active, and contributions to <code>/game</code> are exactly the kind of work we want to see this summer.</p>
+<p style="margin:0 0 6px 0;">
+  <a href="${GAME_URL}" style="display:inline-block;background:#7c3aed;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;margin-right:6px;">Open /game →</a>
+  <a href="${REPO_URL}" style="display:inline-block;background:#fff;color:#7c3aed;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;border:1px solid #7c3aed;">Open the repo →</a>
+</p>
+<p style="margin:8px 0 0 0;font-size:13px;color:#555;">Game logic lives under <code>lib/game/</code>; UI under <code>app/game/</code>. Pick something small for your first PR — a new spell ships in an afternoon.</p>
+
+<p style="margin-top:24px;">Reply with anything — questions, install snags, ideas you want to sanity-check before building.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you're an admitted Cohort 1 participant.<br/>
+Don't want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const leadText = allReady
+    ? `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+YOU'RE ALL SET FOR MONDAY. Cohort 1 kicks off Mon, May 11 — see below for one last laptop check, plus something fun to play with this weekend.`
+    : `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+Cohort 1 kicks off Mon, May 11. Quick personalized check on what you still owe so you can show up Monday focused on the work, not the setup:`;
+
+  const text = `${leadText}
+
+YOUR CHECKLIST
+${checklistText}
+
+ON YOUR LAPTOP, BEFORE MONDAY
+Install Node (LTS), Git, and Cursor (or Claude Code if you already have a flow). Full walkthrough — every step, every gotcha:
+  ${ALC_URL}
+
+----
+
+WHILE YOU WAIT — TRY /game
+We built a small persistent web game right inside this same repo: recruit, run threats, cast spells, climb the leaderboard. Play it for 10 minutes — and if you have ideas for new spells, threat types, balance tweaks, or UI improvements, OPEN A PR. The PR fast-lane that admitted most of you is still active, and contributions to /game are exactly the kind of work we want to see this summer.
+
+  Play: ${GAME_URL}
+  Repo: ${REPO_URL}
+
+Game logic lives under lib/game/; UI under app/game/. Pick something small for your first PR — a new spell ships in an afternoon.
+
+Reply with anything — questions, install snags, ideas you want to sanity-check before building.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you're an admitted Cohort 1 participant.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  const force = args.includes("--force");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Loading existing intake submissions from ${SUMMER_COHORT_INTAKE_COLLECTION}…`);
+  const intakeSnap = await db.collection(SUMMER_COHORT_INTAKE_COLLECTION).get();
+  const intakeEmails = new Set<string>();
+  for (const doc of intakeSnap.docs) {
+    const email = (doc.data().email || "").toString().trim().toLowerCase();
+    if (email) intakeEmails.add(email);
+  }
+  console.log(`Existing intake submissions: ${intakeEmails.size}`);
+
+  console.log(`Loading cohort-1 admits from ${SUMMER_COHORT_COLLECTION}…`);
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .where("cohorts", "array-contains", "cohort-1")
+    .where("status", "==", "admitted")
+    .get();
+
+  const recipients: Recipient[] = [];
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let withDiscord = 0;
+  let withGithub = 0;
+  let withSurvey = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    const cohorts = Array.isArray(data.cohorts)
+      ? data.cohorts.filter(isValidCohortId)
+      : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    if (!force && data.cohort1StatusCheckEmailedAt) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+
+    const uid = (data.userId || doc.id).toString();
+    let discordUsername: string | null = null;
+    let githubLogin: string | null = null;
+    if (uid) {
+      const userSnap = await db.collection("users").doc(uid).get();
+      const ud = userSnap.data();
+      const d = ud?.discord;
+      const g = ud?.github;
+      if (d?.id && typeof d.username === "string") discordUsername = d.username;
+      if (g?.login && typeof g.login === "string") githubLogin = g.login;
+    }
+    const surveyDone = intakeEmails.has(email.toLowerCase());
+
+    if (discordUsername) withDiscord++;
+    if (githubLogin) withGithub++;
+    if (surveyDone) withSurvey++;
+
+    recipients.push({
+      applicationId: doc.id,
+      email,
+      name: typeof data.name === "string" ? data.name : "",
+      discordUsername,
+      githubLogin,
+      surveyDone,
+    });
+  }
+
+  console.log(
+    `Eligible to email: ${recipients.length} | already emailed: ${skippedAlreadyEmailed} | no email: ${skippedNoEmail}`
+  );
+  console.log(
+    `  state breakdown — Discord: ${withDiscord}/${recipients.length}, GitHub: ${withGithub}/${recipients.length}, Survey: ${withSurvey}/${recipients.length}`
+  );
+
+  if (recipients.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const allMissing = recipients.find(
+      (r) => !r.discordUsername && !r.githubLogin && !r.surveyDone
+    );
+    const allDone = recipients.find(
+      (r) => r.discordUsername && r.githubLogin && r.surveyDone
+    );
+    const samples = [
+      { label: "ALL MISSING", recipient: allMissing },
+      { label: "ALL DONE", recipient: allDone },
+      { label: "FIRST", recipient: recipients[0] },
+    ].filter((s, i, arr) => {
+      if (!s.recipient) return false;
+      // dedupe by recipient identity
+      return arr.findIndex((x) => x.recipient?.applicationId === s.recipient!.applicationId) === i;
+    });
+
+    for (const s of samples) {
+      const r = s.recipient!;
+      const { subject, html } = buildEmail(r);
+      console.log("============================================================");
+      console.log(`SAMPLE — ${s.label}`);
+      console.log("============================================================");
+      console.log(`To:      ${r.email} (${r.name || "(no name)"})`);
+      console.log(`Discord: ${r.discordUsername ?? "(not connected)"}`);
+      console.log(`GitHub:  ${r.githubLogin ?? "(not connected)"}`);
+      console.log(`Survey:  ${r.surveyDone ? "submitted" : "not submitted"}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- HTML preview (first 2400 chars) ----\n${html.slice(0, 2400)}\n…\n`);
+    }
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(r.applicationId).set(
+        { cohort1StatusCheckEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      sent++;
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Pre-kickoff push for Cohort 1 (kicks off **Mon May 11**). Three coupled changes:

- **`SetupReadinessModal`** pops on `/summer-cohort` for admitted cohort-1 users until both Discord and GitHub are connected. Sticky per page-load (no localStorage suppression — closes for the visit, returns next visit). Surfaces survey status as a third row and pushes `ludwitt.com/alc` for local-machine setup.
- **Two new tabs** on the cohort page:
  - *Setup Instructions* — Node/Git/Cursor checklist + CTA to `ludwitt.com/alc`
  - *Game* — promotes `/game` and invites cohort members to PR additions/expansions (new spells, threats, balance tweaks, UI ideas)
- **`scripts/send-cohort1-status-and-game.ts`** — per-recipient personalized status email. Each admit gets ✅/⚠️ for Discord (`users/{uid}.discord.username`), GitHub (`users/{uid}.github.login`), and intake survey (lookup in `summerCohortIntakeSurveys` by lowercased email) plus the setup walkthrough and `/game` promo. Idempotent via `cohort1StatusCheckEmailedAt`. **Already sent to all 103 admits** during the session that produced this PR (sent 103, failed 0).

State at send time: Discord 38/103 connected • GitHub 63/103 connected • Survey 21/103 done — so the modal + email are doing real work.

## Test plan
- [ ] Sign in as an admitted cohort-1 user with Discord/GitHub *not* connected → modal pops on load. X-close → close. Reload → pops again. ✓ sticky.
- [ ] Connect both Discord and GitHub → reload → modal does **not** pop. ✓ trigger condition.
- [ ] In modal, click survey "Take the survey" → modal closes, page switches to intake-survey tab.
- [ ] Click "Setup Instructions" tab → Node/Git/Cursor checklist + ludwitt.com/alc CTA renders.
- [ ] Click "Game" tab → /game CTA + repo-PR CTA render. Click /game → working game dashboard loads.
- [ ] Sign in as a non-admitted user → modal does not render at all.
- [ ] Re-run `npx tsx scripts/send-cohort1-status-and-game.ts --dry-run` → eligible count is 0 (already-emailed via `cohort1StatusCheckEmailedAt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)