### PR TITLE
release: game battle sim + cohort readiness (May 9 2026)

### DIFF
--- a/__tests__/lib/game/combat.test.ts
+++ b/__tests__/lib/game/combat.test.ts
@@ -5,16 +5,24 @@
  */
 
 import {
+  applyFlyoverModifiers,
   computeSupplyMultiplier,
   computeTileCapacity,
+  distributeUnitKills,
   magicMultiplier,
   makeSeededRng,
+  realizedSpellMagnitude,
   resolveAttack,
+  rollSpellEffectiveness,
+  SPELL_RNG_LOWER,
+  SPELL_RNG_MIDPOINT,
+  SPELL_RNG_RANGE,
   unitCapFromFoodLands,
 } from "@/lib/game/combat";
 import type {
   CombatAttackerInput,
   CombatDefenderInput,
+  CombatResult,
   CombatTileInput,
   UnitStack,
 } from "@/lib/game/types";
@@ -772,5 +780,652 @@ describe("resolveAttack — determinism", () => {
       expect(r.rng.defenderRoll).toBeGreaterThanOrEqual(0.9);
       expect(r.rng.defenderRoll).toBeLessThan(1.1);
     }
+  });
+});
+
+describe("resolveAttack — tile-type modifiers (May 2026 rework)", () => {
+  // Each test pairs a baseline (no landType / sourceLandType — neutral
+  // ×1.00) against a configured-tile run, using the same seed so the RNG
+  // rolls are identical. We assert ratios on attackPower / defensePower.
+
+  it("legacy callers (no landType / sourceLandType) get neutral multipliers and 0 standing defense", () => {
+    const r = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("legacy-tile-types")
+    );
+    expect(r.sourceLandTypeMultiplier).toBe(1);
+    expect(r.targetLandTypeMultiplier).toBe(1);
+    expect(r.standingDefenseAdded).toBe(0);
+    expect(r.magicTileOffenseSpellBonusApplied).toBe(false);
+    expect(r.magicTileDefenseSpellBonusApplied).toBe(false);
+  });
+
+  it("military source tile multiplies attack power by 1.20", () => {
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("source-mil")
+    );
+    const fromMilitary = resolveAttack(
+      defaultAttacker({ sourceLandType: "military" }),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("source-mil")
+    );
+    expect(fromMilitary.sourceLandTypeMultiplier).toBe(1.2);
+    expect(fromMilitary.attackPower).toBeCloseTo(baseline.attackPower * 1.2, 1);
+  });
+
+  it("food source tile penalizes attack by 0.75", () => {
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("source-food")
+    );
+    const fromFood = resolveAttack(
+      defaultAttacker({ sourceLandType: "food" }),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("source-food")
+    );
+    expect(fromFood.sourceLandTypeMultiplier).toBe(0.75);
+    expect(fromFood.attackPower).toBeCloseTo(baseline.attackPower * 0.75, 1);
+  });
+
+  it("magic source tile is neutral on attack power", () => {
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("source-magic")
+    );
+    const fromMagic = resolveAttack(
+      defaultAttacker({ sourceLandType: "magic" }),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("source-magic")
+    );
+    expect(fromMagic.sourceLandTypeMultiplier).toBe(1);
+    expect(fromMagic.attackPower).toBeCloseTo(baseline.attackPower, 1);
+  });
+
+  it("military target tile multiplies defense by 1.25", () => {
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("target-mil")
+    );
+    const onMilitary = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      { capacity: 2000, upgradeIds: [], landType: "military" },
+      makeSeededRng("target-mil")
+    );
+    expect(onMilitary.targetLandTypeMultiplier).toBe(1.25);
+    // Defense = unit_def × 1.25 + standing(military 30% of attack).
+    const expected =
+      baseline.defensePower * 1.25 + onMilitary.attackPower * 0.3;
+    expect(onMilitary.defensePower).toBeCloseTo(expected, 1);
+  });
+
+  it("magic target tile multiplies defense by 1.25 + adds 15% standing floor", () => {
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("target-magic")
+    );
+    const onMagic = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      { capacity: 2000, upgradeIds: [], landType: "magic" },
+      makeSeededRng("target-magic")
+    );
+    expect(onMagic.targetLandTypeMultiplier).toBe(1.25);
+    const expected =
+      baseline.defensePower * 1.25 + onMagic.attackPower * 0.15;
+    expect(onMagic.defensePower).toBeCloseTo(expected, 1);
+    expect(onMagic.standingDefenseAdded).toBeCloseTo(
+      onMagic.attackPower * 0.15,
+      1
+    );
+  });
+
+  it("food target tile gets no defense multiplier and no standing floor", () => {
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("target-food")
+    );
+    const onFood = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      { capacity: 2000, upgradeIds: [], landType: "food" },
+      makeSeededRng("target-food")
+    );
+    expect(onFood.targetLandTypeMultiplier).toBe(1);
+    expect(onFood.standingDefenseAdded).toBe(0);
+    expect(onFood.defensePower).toBeCloseTo(baseline.defensePower, 1);
+  });
+
+  it("empty military tile still resists at ~30% of attack power (standing defense)", () => {
+    const onEmptyMilitary = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({ unitsOnTile: stack(0, 0, 0) }),
+      { capacity: 2000, upgradeIds: [], landType: "military" },
+      makeSeededRng("empty-mil")
+    );
+    // No units → unit_def = 0, ×1.25 = 0; only standing applies.
+    expect(onEmptyMilitary.standingDefenseAdded).toBeCloseTo(
+      onEmptyMilitary.attackPower * 0.3,
+      1
+    );
+    expect(onEmptyMilitary.defensePower).toBeCloseTo(
+      onEmptyMilitary.standingDefenseAdded,
+      1
+    );
+    expect(onEmptyMilitary.defensePower).toBeGreaterThan(0);
+  });
+
+  it("empty food tile has zero defense (no garrison)", () => {
+    const onEmptyFood = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({ unitsOnTile: stack(0, 0, 0) }),
+      { capacity: 2000, upgradeIds: [], landType: "food" },
+      makeSeededRng("empty-food")
+    );
+    expect(onEmptyFood.defensePower).toBe(0);
+    expect(onEmptyFood.standingDefenseAdded).toBe(0);
+  });
+
+  it("offense spell from a magic source tile is amplified by 1.25", () => {
+    const tile = defaultTile(2000);
+    const noMagicSource = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        offenseSpellId: "red-offense-inferno",
+        magicLandCount: 50,
+      }),
+      defaultDefender(),
+      tile,
+      makeSeededRng("magic-spell-source")
+    );
+    const fromMagicSource = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        offenseSpellId: "red-offense-inferno",
+        magicLandCount: 50,
+        sourceLandType: "magic",
+      }),
+      defaultDefender(),
+      tile,
+      makeSeededRng("magic-spell-source")
+    );
+    expect(fromMagicSource.magicTileOffenseSpellBonusApplied).toBe(true);
+    expect(noMagicSource.magicTileOffenseSpellBonusApplied).toBe(false);
+    // The amplified contribution increases attackPower vs the non-amplified
+    // baseline (magnitude depends on spell+caste; we only check direction).
+    expect(fromMagicSource.attackPower).toBeGreaterThan(
+      noMagicSource.attackPower
+    );
+  });
+
+  it("defense spell armed on a magic target tile is amplified by 1.25", () => {
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({
+        caste: "white",
+        armedDefenseSpellId: "white-defense-sanctuary",
+        magicLandCount: 50,
+      }),
+      defaultTile(2000),
+      makeSeededRng("magic-spell-target")
+    );
+    const armedOnMagic = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({
+        caste: "white",
+        armedDefenseSpellId: "white-defense-sanctuary",
+        magicLandCount: 50,
+      }),
+      { capacity: 2000, upgradeIds: [], landType: "magic" },
+      makeSeededRng("magic-spell-target")
+    );
+    expect(armedOnMagic.magicTileDefenseSpellBonusApplied).toBe(true);
+    expect(baseline.magicTileDefenseSpellBonusApplied).toBe(false);
+    expect(armedOnMagic.defensePower).toBeGreaterThan(baseline.defensePower);
+  });
+});
+
+describe("resolveAttack — pre-attack mods (siege / disarm / pre-cast)", () => {
+  // Same pattern as the tile-type modifier suite: pair a neutral baseline
+  // with a configured run, identical seed, then assert ratios.
+
+  it("legacy callers (no siege / disarm / pre-cast fields) get 0 on all three CombatResult fields", () => {
+    const r = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      defaultTile(2000),
+      makeSeededRng("legacy-pre-attack")
+    );
+    expect(r.siegeDebuffApplied).toBe(0);
+    expect(r.defenseDisarmApplied).toBe(0);
+    expect(r.preCastOffenseApplied).toBe(0);
+  });
+
+  it("siege debuff drops the standing-defense floor proportionally", () => {
+    const tile = {
+      capacity: 2000,
+      upgradeIds: [],
+      landType: "military" as const,
+    };
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({ unitsOnTile: stack(0, 0, 0) }),
+      tile,
+      makeSeededRng("siege-floor")
+    );
+    const oneSiege = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({ unitsOnTile: stack(0, 0, 0) }),
+      { ...tile, siegeDebuffMagnitude: 0.10 },
+      makeSeededRng("siege-floor")
+    );
+    expect(baseline.siegeDebuffApplied).toBe(0);
+    expect(oneSiege.siegeDebuffApplied).toBeCloseTo(0.10, 5);
+    // Empty military tile → defense is purely the floor; one siege = 30% −
+    // 10% = 20% of attackPower.
+    expect(baseline.defensePower).toBeCloseTo(baseline.attackPower * 0.30, 1);
+    expect(oneSiege.defensePower).toBeCloseTo(oneSiege.attackPower * 0.20, 1);
+  });
+
+  it("siege debuff at the cap (0.30) zeros out a military tile's standing floor", () => {
+    const onCappedSiege = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({ unitsOnTile: stack(0, 0, 0) }),
+      {
+        capacity: 2000,
+        upgradeIds: [],
+        landType: "military",
+        siegeDebuffMagnitude: 0.30,
+      },
+      makeSeededRng("siege-cap")
+    );
+    // Empty tile + zero floor → no defense at all.
+    expect(onCappedSiege.standingDefenseAdded).toBe(0);
+    expect(onCappedSiege.defensePower).toBe(0);
+    expect(onCappedSiege.siegeDebuffApplied).toBeCloseTo(0.30, 5);
+  });
+
+  it("siege debuff exceeding the floor doesn't go negative", () => {
+    // Magic floor is 0.15. A 0.30 siege would push fraction to −0.15 if
+    // unclamped — must clamp at 0, not produce negative defense.
+    const r = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({ unitsOnTile: stack(0, 0, 0) }),
+      {
+        capacity: 2000,
+        upgradeIds: [],
+        landType: "magic",
+        siegeDebuffMagnitude: 0.30,
+      },
+      makeSeededRng("siege-overshoot")
+    );
+    expect(r.standingDefenseAdded).toBe(0);
+    expect(r.defensePower).toBe(0);
+  });
+
+  it("disarm fraction proportionally reduces defender's armed spell contribution", () => {
+    const tile = defaultTile(2000);
+    const baselineNoDisarm = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({
+        caste: "white",
+        armedDefenseSpellId: "white-defense-sanctuary",
+        magicLandCount: 50,
+      }),
+      tile,
+      makeSeededRng("disarm-baseline")
+    );
+    const halfDisarm = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({
+        caste: "white",
+        armedDefenseSpellId: "white-defense-sanctuary",
+        magicLandCount: 50,
+        defenseDisarmFraction: 0.5,
+      }),
+      tile,
+      makeSeededRng("disarm-baseline")
+    );
+    const fullDisarm = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({
+        caste: "white",
+        armedDefenseSpellId: "white-defense-sanctuary",
+        magicLandCount: 50,
+        defenseDisarmFraction: 1.0,
+      }),
+      tile,
+      makeSeededRng("disarm-baseline")
+    );
+    const noSpell = resolveAttack(
+      defaultAttacker({ caste: "red" }),
+      defaultDefender({ caste: "white" }),
+      tile,
+      makeSeededRng("disarm-baseline")
+    );
+    expect(baselineNoDisarm.defenseDisarmApplied).toBe(0);
+    expect(halfDisarm.defenseDisarmApplied).toBeCloseTo(0.5, 5);
+    expect(fullDisarm.defenseDisarmApplied).toBeCloseTo(1, 5);
+    // Half-disarm sits between the spell-armed baseline and a no-spell run.
+    expect(halfDisarm.defensePower).toBeLessThan(baselineNoDisarm.defensePower);
+    expect(halfDisarm.defensePower).toBeGreaterThan(noSpell.defensePower);
+    // Full disarm matches the no-spell baseline exactly (within FP slop).
+    expect(fullDisarm.defensePower).toBeCloseTo(noSpell.defensePower, 1);
+  });
+
+  it("disarm with no armed spell is a no-op (defenseDisarmApplied=0)", () => {
+    const r = resolveAttack(
+      defaultAttacker(),
+      defaultDefender({
+        armedDefenseSpellId: null,
+        defenseDisarmFraction: 0.5,
+      }),
+      defaultTile(2000),
+      makeSeededRng("disarm-no-spell")
+    );
+    expect(r.defenseDisarmApplied).toBe(0);
+  });
+
+  it("pre-cast offense bonus is added to attackPower as a flat increment", () => {
+    const tile = defaultTile(2000);
+    const baseline = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      tile,
+      makeSeededRng("pre-cast-flat")
+    );
+    const buffed = resolveAttack(
+      defaultAttacker({ preCastOffenseBonus: 100 }),
+      defaultDefender(),
+      tile,
+      makeSeededRng("pre-cast-flat")
+    );
+    expect(baseline.preCastOffenseApplied).toBe(0);
+    expect(buffed.preCastOffenseApplied).toBe(100);
+    expect(buffed.attackPower).toBeCloseTo(baseline.attackPower + 100, 1);
+  });
+
+  it("pre-cast does NOT get re-amplified by source-tile magic mult", () => {
+    // The pre-cast spell was rolled and realized at its own moment from
+    // its own tile. If the next attack happens to launch from a magic
+    // tile, the in-flight bonus shouldn't be scaled again — only the
+    // attack-time spell rides the source-tile mult.
+    const tile = defaultTile(2000);
+    const fromMagicSource = resolveAttack(
+      defaultAttacker({
+        sourceLandType: "magic",
+        preCastOffenseBonus: 100,
+      }),
+      defaultDefender(),
+      tile,
+      makeSeededRng("pre-cast-magic-no-stack")
+    );
+    const fromNonMagicSource = resolveAttack(
+      defaultAttacker({ preCastOffenseBonus: 100 }),
+      defaultDefender(),
+      tile,
+      makeSeededRng("pre-cast-magic-no-stack")
+    );
+    // Both runs add the flat 100 after the source-tile mult, so the delta
+    // between them is exactly the magic-source amplification of the
+    // existing (non-pre-cast) attackPower components, not 100×anything.
+    expect(fromMagicSource.preCastOffenseApplied).toBe(100);
+    expect(fromNonMagicSource.preCastOffenseApplied).toBe(100);
+  });
+
+  it("siege + disarm + pre-cast can stack in a single resolution", () => {
+    const tile = {
+      capacity: 2000,
+      upgradeIds: [],
+      landType: "military" as const,
+      siegeDebuffMagnitude: 0.20,
+    };
+    const r = resolveAttack(
+      defaultAttacker({ preCastOffenseBonus: 50 }),
+      defaultDefender({
+        armedDefenseSpellId: "white-defense-sanctuary",
+        magicLandCount: 50,
+        defenseDisarmFraction: 0.5,
+      }),
+      tile,
+      makeSeededRng("stack-everything")
+    );
+    expect(r.siegeDebuffApplied).toBeCloseTo(0.20, 5);
+    expect(r.defenseDisarmApplied).toBeCloseTo(0.5, 5);
+    expect(r.preCastOffenseApplied).toBe(50);
+  });
+});
+
+describe("rollSpellEffectiveness + SPELL_RNG constants", () => {
+  it("constants form a band around 1.0 midpoint", () => {
+    expect(SPELL_RNG_LOWER).toBe(0.5);
+    expect(SPELL_RNG_RANGE).toBe(1.0);
+    expect(SPELL_RNG_MIDPOINT).toBe(1.0);
+  });
+
+  it("rolls fall in [SPELL_RNG_LOWER, SPELL_RNG_LOWER + SPELL_RNG_RANGE]", () => {
+    const rng = makeSeededRng("spell-roll");
+    for (let i = 0; i < 50; i++) {
+      const v = rollSpellEffectiveness(rng);
+      expect(v).toBeGreaterThanOrEqual(SPELL_RNG_LOWER);
+      expect(v).toBeLessThan(SPELL_RNG_LOWER + SPELL_RNG_RANGE);
+    }
+  });
+
+  it("midpoint RNG (() => 0.5) returns exactly SPELL_RNG_MIDPOINT", () => {
+    const v = rollSpellEffectiveness(() => 0.5);
+    expect(v).toBe(SPELL_RNG_MIDPOINT);
+  });
+});
+
+describe("applyFlyoverModifiers", () => {
+  // Build a minimal CombatResult for the helper to chew on. Only the
+  // fields the helper inspects matter; the rest are stubbed to neutral.
+  function combatStub(overrides: Partial<CombatResult> = {}): CombatResult {
+    return {
+      outcome: "captured",
+      unitsDeployed: stack(0, 0, 100),
+      unitsClampedFromCapacity: 0,
+      attackPower: 0,
+      defensePower: 0,
+      attackerLosses: stack(0, 0, 10),
+      defenderLosses: stack(0, 0, 5),
+      underdogApplied: false,
+      supplyMultiplier: 1,
+      sourceLandTypeMultiplier: 1,
+      targetLandTypeMultiplier: 1,
+      standingDefenseAdded: 0,
+      magicTileOffenseSpellBonusApplied: false,
+      magicTileDefenseSpellBonusApplied: false,
+      siegeDebuffApplied: 0,
+      defenseDisarmApplied: 0,
+      preCastOffenseApplied: 0,
+      rng: { attackerRoll: 1, defenderRoll: 1 },
+      appliedSpells: { offenseId: null, defenseId: null },
+      ...overrides,
+    };
+  }
+
+  it("converts a 'captured' outcome to 'repelled'", () => {
+    const r = applyFlyoverModifiers(combatStub({ outcome: "captured" }));
+    expect(r.outcome).toBe("repelled");
+  });
+
+  it("leaves 'repelled' outcomes untouched", () => {
+    const r = applyFlyoverModifiers(combatStub({ outcome: "repelled" }));
+    expect(r.outcome).toBe("repelled");
+  });
+
+  it("leaves 'stalemate' outcomes untouched", () => {
+    const r = applyFlyoverModifiers(combatStub({ outcome: "stalemate" }));
+    expect(r.outcome).toBe("stalemate");
+  });
+
+  it("doubles attacker losses across all unit types", () => {
+    const r = applyFlyoverModifiers(
+      combatStub({
+        unitsDeployed: stack(20, 30, 40),
+        attackerLosses: stack(5, 10, 8),
+      })
+    );
+    expect(r.attackerLosses).toEqual(stack(10, 20, 16));
+  });
+
+  it("clamps doubled losses to deployed (can't lose more than were sent)", () => {
+    const r = applyFlyoverModifiers(
+      combatStub({
+        unitsDeployed: stack(0, 0, 50),
+        // 30 × 2 = 60, but only 50 deployed → clamp to 50.
+        attackerLosses: stack(0, 0, 30),
+      })
+    );
+    expect(r.attackerLosses).toEqual(stack(0, 0, 50));
+  });
+
+  it("preserves defender losses unchanged", () => {
+    const before = combatStub({ defenderLosses: stack(2, 3, 4) });
+    const after = applyFlyoverModifiers(before);
+    expect(after.defenderLosses).toEqual(stack(2, 3, 4));
+  });
+
+  it("preserves all other CombatResult fields verbatim", () => {
+    const before = combatStub({
+      attackPower: 1234,
+      defensePower: 567,
+      siegeDebuffApplied: 0.10,
+      magicTileOffenseSpellBonusApplied: true,
+    });
+    const after = applyFlyoverModifiers(before);
+    expect(after.attackPower).toBe(1234);
+    expect(after.defensePower).toBe(567);
+    expect(after.siegeDebuffApplied).toBe(0.10);
+    expect(after.magicTileOffenseSpellBonusApplied).toBe(true);
+  });
+});
+
+describe("realizedSpellMagnitude", () => {
+  it("midpoint dice (1.0) and 0 magic lands returns baseStrength × casteBonus", () => {
+    // Red's siege bonus is 1.30. Tier-1 base 0.05.
+    const m = realizedSpellMagnitude({
+      baseStrength: 0.05,
+      caste: "red",
+      spellType: "siege",
+      magicLandCount: 0,
+      dice: 1.0,
+    });
+    expect(m).toBeCloseTo(0.05 * 1.30, 5);
+  });
+
+  it("scales with magicMultiplier(magicLandCount)", () => {
+    // 50 magic lands → magicMultiplier = 3.5. White attrition bonus 0.85,
+    // base 30 → 30 × 3.5 × 0.85 × 1.0 = 89.25.
+    const m = realizedSpellMagnitude({
+      baseStrength: 30,
+      caste: "white",
+      spellType: "attrition",
+      magicLandCount: 50,
+      dice: 1.0,
+    });
+    expect(m).toBeCloseTo(30 * 3.5 * 0.85, 1);
+  });
+
+  it("scales linearly with dice", () => {
+    const args = {
+      baseStrength: 0.4,
+      caste: "white" as const,
+      spellType: "disarm" as const,
+      magicLandCount: 0,
+      dice: 1.0,
+    };
+    const mid = realizedSpellMagnitude(args);
+    const low = realizedSpellMagnitude({ ...args, dice: 0.5 });
+    const high = realizedSpellMagnitude({ ...args, dice: 1.5 });
+    expect(low).toBeCloseTo(mid * 0.5, 5);
+    expect(high).toBeCloseTo(mid * 1.5, 5);
+  });
+
+  it("uses the caste's per-spelltype bonus row", () => {
+    // Red siege bonus 1.30; Green siege bonus 1.00. Same inputs otherwise
+    // should differ by 1.30 / 1.00 = 1.30.
+    const red = realizedSpellMagnitude({
+      baseStrength: 0.05,
+      caste: "red",
+      spellType: "siege",
+      magicLandCount: 0,
+      dice: 1.0,
+    });
+    const green = realizedSpellMagnitude({
+      baseStrength: 0.05,
+      caste: "green",
+      spellType: "siege",
+      magicLandCount: 0,
+      dice: 1.0,
+    });
+    expect(red / green).toBeCloseTo(1.3, 2);
+  });
+});
+
+describe("distributeUnitKills", () => {
+  it("returns zero stack when killCount is 0", () => {
+    const u = stack(50, 30, 20);
+    const k = distributeUnitKills(u, 0);
+    expect(k).toEqual(stack(0, 0, 0));
+  });
+
+  it("returns zero stack when target stack is empty", () => {
+    const k = distributeUnitKills(stack(0, 0, 0), 100);
+    expect(k).toEqual(stack(0, 0, 0));
+  });
+
+  it("never kills more than killCount or more than units present", () => {
+    // 20 units total, ask for 100 → cap at 20.
+    const u = stack(10, 5, 5);
+    const k = distributeUnitKills(u, 100);
+    const total = k.ground + k.siege + k.air;
+    expect(total).toBe(20);
+    expect(k.ground).toBeLessThanOrEqual(u.ground);
+    expect(k.siege).toBeLessThanOrEqual(u.siege);
+    expect(k.air).toBeLessThanOrEqual(u.air);
+  });
+
+  it("distributes proportionally — dominant type takes most kills", () => {
+    // 100 kills against (90, 5, 5): roughly 90% of kills land on ground.
+    const k = distributeUnitKills(stack(90, 5, 5), 100);
+    expect(k.ground).toBeGreaterThanOrEqual(85);
+    expect(k.siege).toBeLessThanOrEqual(8);
+    expect(k.air).toBeLessThanOrEqual(8);
+    expect(k.ground + k.siege + k.air).toBe(100);
+  });
+
+  it("distributes evenly across equal stacks", () => {
+    const k = distributeUnitKills(stack(30, 30, 30), 30);
+    // 10 each, with sum=30.
+    expect(k.ground + k.siege + k.air).toBe(30);
+    expect(Math.abs(k.ground - 10)).toBeLessThanOrEqual(1);
+    expect(Math.abs(k.siege - 10)).toBeLessThanOrEqual(1);
+    expect(Math.abs(k.air - 10)).toBeLessThanOrEqual(1);
+  });
+
+  it("handles killCount equal to total — kills everyone", () => {
+    const k = distributeUnitKills(stack(7, 11, 13), 31);
+    expect(k).toEqual(stack(7, 11, 13));
   });
 });

--- a/__tests__/lib/game/content-spells.test.ts
+++ b/__tests__/lib/game/content-spells.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  ALL_SPELLS,
+  SPELLS_BY_ID,
+  getSpellsForCasteAndType,
+} from "@/lib/game/content";
+import type { Caste, SpellType } from "@/lib/game/types";
+
+const CASTES: Caste[] = ["white", "blue", "black", "red", "green"];
+const NEW_SPELL_KINDS: Array<"siege" | "disarm" | "attrition"> = [
+  "siege",
+  "disarm",
+  "attrition",
+];
+
+describe("New spell content (May 2026 sim feature)", () => {
+  it("ALL_SPELLS contains exactly one tier-1 spell per caste × new-kind = 15", () => {
+    const newKindSpells = ALL_SPELLS.filter(
+      (s) =>
+        s.type === "siege" || s.type === "disarm" || s.type === "attrition"
+    );
+    expect(newKindSpells).toHaveLength(15);
+    expect(newKindSpells.every((s) => s.tier === 1)).toBe(true);
+  });
+
+  it("every (caste, kind) pair has a tier-1 spell registered", () => {
+    for (const caste of CASTES) {
+      for (const kind of NEW_SPELL_KINDS) {
+        const tiers = getSpellsForCasteAndType(caste, kind as SpellType);
+        expect(tiers.length).toBeGreaterThanOrEqual(1);
+        expect(tiers[0].tier).toBe(1);
+        expect(tiers[0].caste).toBe(caste);
+        expect(tiers[0].type).toBe(kind);
+      }
+    }
+  });
+
+  it("baseStrength is set to the kind's documented V1 default", () => {
+    // siege → 0.05 fraction · disarm → 0.4 fraction · attrition → 30 units.
+    for (const caste of CASTES) {
+      const siege = getSpellsForCasteAndType(caste, "siege")[0];
+      const disarm = getSpellsForCasteAndType(caste, "disarm")[0];
+      const attrition = getSpellsForCasteAndType(caste, "attrition")[0];
+      expect(siege.baseStrength).toBe(0.05);
+      expect(disarm.baseStrength).toBe(0.4);
+      expect(attrition.baseStrength).toBe(30);
+    }
+  });
+
+  it("turn cost is 5 and minTilesRequired is 0 for all new tier-1 spells", () => {
+    for (const caste of CASTES) {
+      for (const kind of NEW_SPELL_KINDS) {
+        const s = getSpellsForCasteAndType(caste, kind as SpellType)[0];
+        expect(s.turnCost).toBe(5);
+        expect(s.minTilesRequired).toBe(0);
+      }
+    }
+  });
+
+  it("every new spell id is unique and resolves via SPELLS_BY_ID", () => {
+    const ids = new Set<string>();
+    for (const caste of CASTES) {
+      for (const kind of NEW_SPELL_KINDS) {
+        const s = getSpellsForCasteAndType(caste, kind as SpellType)[0];
+        expect(ids.has(s.id)).toBe(false);
+        ids.add(s.id);
+        expect(SPELLS_BY_ID.get(s.id)).toBe(s);
+      }
+    }
+    expect(ids.size).toBe(15);
+  });
+});

--- a/__tests__/lib/game/intel-effects.test.ts
+++ b/__tests__/lib/game/intel-effects.test.ts
@@ -6,10 +6,17 @@
 
 import {
   INTEL_EFFECT_DURATION_CASTER_TURNS,
+  deleteIntelEffectsInTx,
   readAttackContextEffects,
+  recordDefenseDisarmInTx,
   recordIntelEffectInTx,
+  recordPreCastOffenseInTx,
+  recordSiegeDebuffInTx,
 } from "@/lib/game/intel-effects";
-import type { IntelEffect } from "@/lib/game/types";
+import {
+  SIEGE_DEBUFF_MAX_MAGNITUDE,
+  type IntelEffect,
+} from "@/lib/game/types";
 
 describe("INTEL_EFFECT_DURATION_CASTER_TURNS", () => {
   it("is 5 — the canonical lifetime for spy debuffs and Forge Sight", () => {
@@ -27,6 +34,7 @@ describe("recordIntelEffectInTx", () => {
       set: jest.fn((ref: unknown, data: IntelEffect) => {
         sets.push({ ref, data });
       }),
+      delete: jest.fn(),
     };
     const docRef = { __ref: "doc" };
     const collectionFn = jest.fn(() => ({ doc: jest.fn(() => docRef) }));
@@ -77,42 +85,196 @@ describe("recordIntelEffectInTx", () => {
   });
 });
 
+describe("recordSiegeDebuffInTx", () => {
+  function makeFakeTx() {
+    const sets: Array<{ data: IntelEffect }> = [];
+    const tx = {
+      set: jest.fn((_ref: unknown, data: IntelEffect) => {
+        sets.push({ data });
+      }),
+      delete: jest.fn(),
+    };
+    const db = { collection: jest.fn(() => ({ doc: jest.fn(() => ({})) })) };
+    return { tx, db, sets };
+  }
+
+  it("clamps magnitude to SIEGE_DEBUFF_MAX_MAGNITUDE", () => {
+    const { tx, db, sets } = makeFakeTx();
+    recordSiegeDebuffInTx({
+      tx: tx as never,
+      db: db as never,
+      attackerId: "atk",
+      targetTileId: "0_0",
+      magnitude: 0.99,
+      attackerTurnsSpentTotal: 100,
+      now: new Date(),
+    });
+    expect(sets[0].data.magnitude).toBe(SIEGE_DEBUFF_MAX_MAGNITUDE);
+    expect(sets[0].data.kind).toBe("siege-debuff");
+    expect(sets[0].data.expiresAtCasterTurn).toBe(105);
+  });
+
+  it("clamps negative magnitude to 0", () => {
+    const { tx, db, sets } = makeFakeTx();
+    recordSiegeDebuffInTx({
+      tx: tx as never,
+      db: db as never,
+      attackerId: "atk",
+      targetTileId: "0_0",
+      magnitude: -0.5,
+      attackerTurnsSpentTotal: 0,
+      now: new Date(),
+    });
+    expect(sets[0].data.magnitude).toBe(0);
+  });
+});
+
+describe("recordPreCastOffenseInTx + recordDefenseDisarmInTx", () => {
+  function makeFakeTx() {
+    const sets: Array<{ data: IntelEffect }> = [];
+    const tx = {
+      set: jest.fn((_ref: unknown, data: IntelEffect) => {
+        sets.push({ data });
+      }),
+      delete: jest.fn(),
+    };
+    const db = { collection: jest.fn(() => ({ doc: jest.fn(() => ({})) })) };
+    return { tx, db, sets };
+  }
+
+  it("pre-cast offense persists realized power as magnitude", () => {
+    const { tx, db, sets } = makeFakeTx();
+    recordPreCastOffenseInTx({
+      tx: tx as never,
+      db: db as never,
+      attackerId: "atk",
+      targetTileId: "0_0",
+      realizedPower: 250,
+      attackerTurnsSpentTotal: 10,
+      now: new Date(),
+    });
+    expect(sets[0].data.kind).toBe("pre-cast-offense-spell");
+    expect(sets[0].data.magnitude).toBe(250);
+    expect(sets[0].data.targetTileId).toBe("0_0");
+  });
+
+  it("disarm clamps fraction to [0, 1]", () => {
+    const { tx, db, sets } = makeFakeTx();
+    recordDefenseDisarmInTx({
+      tx: tx as never,
+      db: db as never,
+      attackerId: "atk",
+      targetTileId: "0_0",
+      disarmFraction: 1.5,
+      attackerTurnsSpentTotal: 10,
+      now: new Date(),
+    });
+    expect(sets[0].data.kind).toBe("defense-disarm");
+    expect(sets[0].data.magnitude).toBe(1);
+  });
+});
+
+describe("deleteIntelEffectsInTx", () => {
+  it("issues a tx.delete per id", () => {
+    const deleted: unknown[] = [];
+    const tx = {
+      set: jest.fn(),
+      delete: jest.fn((ref: unknown) => {
+        deleted.push(ref);
+      }),
+    };
+    const docs = new Map<string, { __id: string }>();
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn((id: string) => {
+          if (!docs.has(id)) docs.set(id, { __id: id });
+          return docs.get(id);
+        }),
+      })),
+    };
+    deleteIntelEffectsInTx({
+      tx: tx as never,
+      db: db as never,
+      effectIds: ["a", "b", "c"],
+    });
+    expect(deleted).toHaveLength(3);
+    expect(deleted.map((d) => (d as { __id: string }).__id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("is a no-op for an empty list", () => {
+    const tx = { set: jest.fn(), delete: jest.fn() };
+    const db = { collection: jest.fn() };
+    deleteIntelEffectsInTx({
+      tx: tx as never,
+      db: db as never,
+      effectIds: [],
+    });
+    expect(tx.delete).not.toHaveBeenCalled();
+  });
+});
+
 describe("readAttackContextEffects", () => {
   /**
-   * Fake Firestore that records every `where(field, op, value)` call on each
-   * collection() and returns a configurable doc set when .get() resolves.
+   * Fake Firestore that returns a configurable doc set for each kind,
+   * matched by the `kind` clause in the where() chain.
    */
   function makeDb(snaps: {
     forge?: IntelEffect[];
     alert?: IntelEffect[];
-  }): unknown {
-    function makeQuery(docs: IntelEffect[]) {
-      const wrapped = docs.map((d) => ({ data: () => d }));
+    siege?: IntelEffect[];
+    preCast?: IntelEffect[];
+    disarm?: IntelEffect[];
+  }) {
+    function makeQuery(): {
+      where: jest.Mock;
+      get: jest.Mock;
+      _kind: string | null;
+    } {
       const q: {
         where: jest.Mock;
         get: jest.Mock;
+        _kind: string | null;
       } = {
-        where: jest.fn(() => q),
-        get: jest.fn(() => Promise.resolve({ docs: wrapped })),
+        _kind: null,
+        where: jest.fn((field: string, _op: string, value: unknown) => {
+          if (field === "kind") q._kind = value as string;
+          return q;
+        }),
+        get: jest.fn(() => {
+          const docs = (() => {
+            switch (q._kind) {
+              case "forge-sight-offense":
+                return snaps.forge ?? [];
+              case "alert-vs-caster":
+                return snaps.alert ?? [];
+              case "siege-debuff":
+                return snaps.siege ?? [];
+              case "pre-cast-offense-spell":
+                return snaps.preCast ?? [];
+              case "defense-disarm":
+                return snaps.disarm ?? [];
+              default:
+                return [];
+            }
+          })();
+          return Promise.resolve({
+            docs: docs.map((d) => ({ id: d.id, data: () => d })),
+          });
+        }),
       };
       return q;
     }
-    let collectionCallNo = 0;
     return {
-      collection: jest.fn(() => {
-        // The function under test runs the two queries in parallel via
-        // Promise.all([forgeQuery, alertQuery]). Both call db.collection()
-        // for COLLECTION at module load — alternate the answers.
-        const idx = collectionCallNo++;
-        if (idx % 2 === 0) return makeQuery(snaps.forge ?? []);
-        return makeQuery(snaps.alert ?? []);
-      }),
-    };
+      collection: jest.fn(() => makeQuery()),
+    } as unknown;
   }
 
-  function effect(overrides: Partial<IntelEffect>): IntelEffect {
+  function effect(overrides: Partial<IntelEffect> & { id: string }): IntelEffect {
     return {
-      id: "e",
       kind: "alert-vs-caster",
       ownerId: "x",
       casterId: "y",
@@ -123,7 +285,7 @@ describe("readAttackContextEffects", () => {
     };
   }
 
-  it("returns zeros when no effects match", async () => {
+  it("returns zeros and no consume ids when no effects match", async () => {
     const out = await readAttackContextEffects({
       db: makeDb({}) as never,
       attackerId: "atk",
@@ -133,6 +295,10 @@ describe("readAttackContextEffects", () => {
     });
     expect(out.forgeSightOffenseBonus).toBe(0);
     expect(out.alertVsCasterDefenseBonus).toBe(0);
+    expect(out.siegeDebuffMagnitude).toBe(0);
+    expect(out.preCastOffenseBonus).toBe(0);
+    expect(out.defenseDisarmFraction).toBe(0);
+    expect(out.consumeEffectIds).toEqual([]);
   });
 
   it("sums forge-sight magnitudes only when target tile + caster + expiry match", async () => {
@@ -140,28 +306,31 @@ describe("readAttackContextEffects", () => {
       db: makeDb({
         forge: [
           effect({
+            id: "f1",
             kind: "forge-sight-offense",
             ownerId: "atk",
             casterId: "atk",
             targetTileId: "0_0",
             magnitude: 0.1,
-            expiresAtCasterTurn: 60, // 50 < 60 → active
+            expiresAtCasterTurn: 60,
           }),
           effect({
+            id: "f2",
             kind: "forge-sight-offense",
             ownerId: "atk",
             casterId: "atk",
-            targetTileId: "9_9", // wrong target — filtered out
+            targetTileId: "9_9",
             magnitude: 0.5,
             expiresAtCasterTurn: 60,
           }),
           effect({
+            id: "f3",
             kind: "forge-sight-offense",
             ownerId: "atk",
             casterId: "atk",
             targetTileId: "0_0",
             magnitude: 0.5,
-            expiresAtCasterTurn: 40, // expired (50 >= 40) → filtered
+            expiresAtCasterTurn: 40,
           }),
         ],
       }) as never,
@@ -171,7 +340,6 @@ describe("readAttackContextEffects", () => {
       defenderTileId: "0_0",
     });
     expect(out.forgeSightOffenseBonus).toBeCloseTo(0.1, 5);
-    expect(out.alertVsCasterDefenseBonus).toBe(0);
   });
 
   it("sums alert-vs-caster magnitudes only when caster + expiry match", async () => {
@@ -179,6 +347,7 @@ describe("readAttackContextEffects", () => {
       db: makeDb({
         alert: [
           effect({
+            id: "a1",
             kind: "alert-vs-caster",
             ownerId: "def",
             casterId: "atk",
@@ -186,17 +355,19 @@ describe("readAttackContextEffects", () => {
             expiresAtCasterTurn: 60,
           }),
           effect({
+            id: "a2",
             kind: "alert-vs-caster",
             ownerId: "def",
-            casterId: "someone-else", // not this attacker — filtered
+            casterId: "someone-else",
             magnitude: 0.3,
             expiresAtCasterTurn: 60,
           }),
           effect({
+            id: "a3",
             kind: "alert-vs-caster",
             ownerId: "def",
             casterId: "atk",
-            magnitude: 0.1, // expired
+            magnitude: 0.1,
             expiresAtCasterTurn: 30,
           }),
         ],
@@ -209,11 +380,164 @@ describe("readAttackContextEffects", () => {
     expect(out.alertVsCasterDefenseBonus).toBeCloseTo(0.2, 5);
   });
 
-  it("combines forge-sight and alert into a single result object", async () => {
+  it("siege-debuff sums and is clamped to SIEGE_DEBUFF_MAX_MAGNITUDE", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({
+        siege: [
+          effect({
+            id: "s1",
+            kind: "siege-debuff",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.10,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            id: "s2",
+            kind: "siege-debuff",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.10,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            id: "s3",
+            kind: "siege-debuff",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.20,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+      }) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    // Raw sum is 0.40, clamped to SIEGE_DEBUFF_MAX_MAGNITUDE (0.30).
+    expect(out.siegeDebuffMagnitude).toBeCloseTo(SIEGE_DEBUFF_MAX_MAGNITUDE, 5);
+    // Siege is TTL-only, never consumed.
+    expect(out.consumeEffectIds).toEqual([]);
+  });
+
+  it("siege filters by targetTileId and expiry", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({
+        siege: [
+          effect({
+            id: "s1",
+            kind: "siege-debuff",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.10,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            id: "s2",
+            kind: "siege-debuff",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "1_1", // wrong tile
+            magnitude: 0.10,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            id: "s3",
+            kind: "siege-debuff",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.10,
+            expiresAtCasterTurn: 30, // expired
+          }),
+        ],
+      }) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    expect(out.siegeDebuffMagnitude).toBeCloseTo(0.10, 5);
+  });
+
+  it("pre-cast offense sums realized power and lists consume ids", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({
+        preCast: [
+          effect({
+            id: "p1",
+            kind: "pre-cast-offense-spell",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 100,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            id: "p2",
+            kind: "pre-cast-offense-spell",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 50,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+      }) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    expect(out.preCastOffenseBonus).toBe(150);
+    expect(out.consumeEffectIds.sort()).toEqual(["p1", "p2"]);
+  });
+
+  it("multiple disarm effects combine multiplicatively (1 - prod(1 - m_i))", async () => {
+    const out = await readAttackContextEffects({
+      db: makeDb({
+        disarm: [
+          effect({
+            id: "d1",
+            kind: "defense-disarm",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.5,
+            expiresAtCasterTurn: 60,
+          }),
+          effect({
+            id: "d2",
+            kind: "defense-disarm",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.5,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+      }) as never,
+      attackerId: "atk",
+      attackerTurnsSpentTotal: 50,
+      defenderId: "def",
+      defenderTileId: "0_0",
+    });
+    // 1 - (1-0.5)*(1-0.5) = 0.75
+    expect(out.defenseDisarmFraction).toBeCloseTo(0.75, 5);
+    expect(out.consumeEffectIds.sort()).toEqual(["d1", "d2"]);
+  });
+
+  it("combines all five kinds in a single result + lists single-use consume ids", async () => {
     const out = await readAttackContextEffects({
       db: makeDb({
         forge: [
           effect({
+            id: "f",
             kind: "forge-sight-offense",
             ownerId: "atk",
             casterId: "atk",
@@ -224,10 +548,44 @@ describe("readAttackContextEffects", () => {
         ],
         alert: [
           effect({
+            id: "a",
             kind: "alert-vs-caster",
             ownerId: "def",
             casterId: "atk",
             magnitude: 0.2,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+        siege: [
+          effect({
+            id: "s",
+            kind: "siege-debuff",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.1,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+        preCast: [
+          effect({
+            id: "p",
+            kind: "pre-cast-offense-spell",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 75,
+            expiresAtCasterTurn: 60,
+          }),
+        ],
+        disarm: [
+          effect({
+            id: "d",
+            kind: "defense-disarm",
+            ownerId: "atk",
+            casterId: "atk",
+            targetTileId: "0_0",
+            magnitude: 0.4,
             expiresAtCasterTurn: 60,
           }),
         ],
@@ -237,9 +595,13 @@ describe("readAttackContextEffects", () => {
       defenderId: "def",
       defenderTileId: "0_0",
     });
-    expect(out).toEqual({
-      forgeSightOffenseBonus: 0.1,
-      alertVsCasterDefenseBonus: 0.2,
-    });
+    expect(out.forgeSightOffenseBonus).toBeCloseTo(0.1, 5);
+    expect(out.alertVsCasterDefenseBonus).toBeCloseTo(0.2, 5);
+    expect(out.siegeDebuffMagnitude).toBeCloseTo(0.1, 5);
+    expect(out.preCastOffenseBonus).toBe(75);
+    expect(out.defenseDisarmFraction).toBeCloseTo(0.4, 5);
+    // Only single-use kinds (pre-cast, disarm) are consumed; siege and
+    // alert/forge survive.
+    expect(out.consumeEffectIds.sort()).toEqual(["d", "p"]);
   });
 });

--- a/__tests__/lib/game/spells-tier.test.ts
+++ b/__tests__/lib/game/spells-tier.test.ts
@@ -18,11 +18,16 @@ import {
 import type { Caste, SpellType } from "@/lib/game/types";
 
 describe("spell content", () => {
-  it("registers 75 tiered spells (5 castes × 3 types × 5 tiers) plus 5 single-tier intel spells", () => {
+  it("registers 75 tiered spells + 5 intel + 15 sim-feature spells (siege/disarm/attrition tier-1 per caste)", () => {
     // 75 from defense/offense/production tier ladders + 1 intel spell per
-    // caste = 80.
-    expect(ALL_SPELLS.length).toBe(80);
+    // caste (5) + 3 new kinds (siege, disarm, attrition) × 5 castes (15)
+    // = 95 total. The new kinds are tier-1 only in V1; higher tiers can
+    // be added as content follow-ups.
+    expect(ALL_SPELLS.length).toBe(95);
     expect(ALL_SPELLS.filter((s) => s.type === "intel").length).toBe(5);
+    expect(ALL_SPELLS.filter((s) => s.type === "siege").length).toBe(5);
+    expect(ALL_SPELLS.filter((s) => s.type === "disarm").length).toBe(5);
+    expect(ALL_SPELLS.filter((s) => s.type === "attrition").length).toBe(5);
   });
 
   it("spell ids are unique", () => {

--- a/app/api/game/attack/preview/route.ts
+++ b/app/api/game/attack/preview/route.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { attackPreviewServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { gameContract } from "@/lib/api-schemas/game";
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const parsed = gameContract.attackPreview.body.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const result = await attackPreviewServer({
+      attackerId: user.uid,
+      sourceTileId: parsed.data.sourceTileId,
+      targetTileId: parsed.data.targetTileId,
+      units: parsed.data.units,
+      offenseSpellId: parsed.data.offenseSpellId ?? null,
+    });
+    return apiSuccess({
+      combat: result.combat,
+      source: result.source,
+      target: result.target,
+      defender: result.defender,
+      effects: result.effects,
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/flyover/route.ts
+++ b/app/api/game/flyover/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { flyoverTileServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { gameContract } from "@/lib/api-schemas/game";
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const parsed = gameContract.flyover.body.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const result = await flyoverTileServer({
+      attackerId: user.uid,
+      sourceTileId: parsed.data.sourceTileId,
+      targetTileId: parsed.data.targetTileId,
+      units: parsed.data.units,
+    });
+    return apiSuccess({
+      attackerPlayer: result.attackerPlayer,
+      sourceTile: result.sourceTile,
+      targetTile: result.targetTile,
+      report: result.report,
+      combat: result.combat,
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/leaderboard/route.ts
+++ b/app/api/game/leaderboard/route.ts
@@ -25,6 +25,7 @@ export async function GET(request: NextRequest) {
     const queryParse = gameContract.getLeaderboard.query.safeParse({
       limit: url.searchParams.get("limit") ?? undefined,
       cursor: url.searchParams.get("cursor") ?? undefined,
+      audience: url.searchParams.get("audience") ?? undefined,
     });
     if (!queryParse.success) {
       return apiError(queryParse.error.issues[0]?.message ?? "Invalid query", 400);
@@ -32,10 +33,12 @@ export async function GET(request: NextRequest) {
 
     const limit = clampLimit(queryParse.data.limit ?? null, DEFAULT_PAGE_LIMIT);
     const cursor = parseCursor(queryParse.data.cursor ?? null);
+    const audience = queryParse.data.audience ?? "all";
 
     const { items, nextCursor, hasMore } = await getLeaderboardServer({
       limit,
       cursor,
+      audience,
     });
     return apiSuccess({
       players: items.map((p) => ({

--- a/app/api/game/siege/route.ts
+++ b/app/api/game/siege/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { siegeTileServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { gameContract } from "@/lib/api-schemas/game";
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const parsed = gameContract.siege.body.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const result = await siegeTileServer({
+      attackerId: user.uid,
+      sourceTileId: parsed.data.sourceTileId,
+      targetTileId: parsed.data.targetTileId,
+    });
+    return apiSuccess({
+      player: result.player,
+      report: result.report,
+      siegeTotalMagnitude: result.siegeTotalMagnitude,
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/spell/cast/route.ts
+++ b/app/api/game/spell/cast/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { castSpellServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { gameContract } from "@/lib/api-schemas/game";
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const parsed = gameContract.castSpell.body.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const result = await castSpellServer({
+      attackerId: user.uid,
+      spellId: parsed.data.spellId,
+      sourceTileId: parsed.data.sourceTileId,
+      targetTileId: parsed.data.targetTileId,
+    });
+    return apiSuccess({
+      player: result.player,
+      report: result.report,
+      ...(result.siege ? { siege: result.siege } : {}),
+      ...(result.disarm ? { disarm: result.disarm } : {}),
+      ...(result.attrition ? { attrition: result.attrition } : {}),
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/_lib/dashboard-actions.ts
+++ b/app/game/_lib/dashboard-actions.ts
@@ -540,6 +540,179 @@ export async function spendArtifact(
   }
 }
 
+/**
+ * POST /api/game/siege — soften a target tile's standing-defense floor.
+ * 5-turn cost, stacking up to SIEGE_DEBUFF_MAX_MAGNITUDE.
+ */
+export async function siege(
+  user: User,
+  args: { sourceTileId: string; targetTileId: string },
+  mut: DashboardMutators
+): Promise<{
+  reportSummary: string;
+  siegeTotalMagnitude: number;
+} | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/siege", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(args),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Siege failed"));
+    }
+    if (data.player) mut.setPlayer(data.player as GamePlayer);
+    if (data.report) {
+      mut.setRecentReports((prev) =>
+        [data.report as TurnReport, ...prev].slice(0, 50)
+      );
+    }
+    return {
+      reportSummary:
+        (data.report as { summary?: string } | undefined)?.summary ?? "Siege",
+      siegeTotalMagnitude:
+        typeof data.siegeTotalMagnitude === "number"
+          ? data.siegeTotalMagnitude
+          : 0,
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Siege failed");
+    return null;
+  }
+}
+
+/**
+ * POST /api/game/flyover — air-only raid that attrits defenders without
+ * taking the tile. Always resolves to "repelled" / "stalemate"; attacker
+ * losses are doubled.
+ */
+export async function flyover(
+  user: User,
+  args: {
+    sourceTileId: string;
+    targetTileId: string;
+    units: UnitStack;
+  },
+  mut: DashboardMutators
+): Promise<{
+  reportSummary: string;
+  combat: CombatResult | null;
+  report: TurnReport | null;
+  targetTile: GameTile | null;
+} | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/flyover", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(args),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Flyover failed"));
+    }
+    if (data.attackerPlayer) mut.setPlayer(data.attackerPlayer as GamePlayer);
+    if (data.sourceTile) {
+      mut.mergeOwnedTiles([asMapTile(data.sourceTile as GameTile)]);
+    }
+    if (data.targetTile) {
+      mut.mergeBorderTiles([asMapTile(data.targetTile as GameTile)]);
+    }
+    if (data.report) {
+      mut.setRecentReports((prev) =>
+        [data.report as TurnReport, ...prev].slice(0, 50)
+      );
+    }
+    return {
+      reportSummary:
+        (data.report as { summary?: string } | undefined)?.summary ?? "Flyover",
+      combat: (data.combat as CombatResult | undefined) ?? null,
+      report: (data.report as TurnReport | undefined) ?? null,
+      targetTile: (data.targetTile as GameTile | undefined) ?? null,
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Flyover failed");
+    return null;
+  }
+}
+
+/**
+ * POST /api/game/spell/cast — cast a standalone siege/disarm/attrition
+ * spell. Server rolls dice; the response carries the kind-specific outcome.
+ */
+export async function castSpell(
+  user: User,
+  args: {
+    spellId: string;
+    sourceTileId: string;
+    targetTileId: string;
+  },
+  mut: DashboardMutators
+): Promise<{
+  reportSummary: string;
+  siege?: { magnitudeApplied: number; totalMagnitudeAfter: number };
+  disarm?: { fractionApplied: number };
+  attrition?: { unitsKilled: UnitStack };
+} | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/spell/cast", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(args),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Spell cast failed"));
+    }
+    if (data.player) mut.setPlayer(data.player as GamePlayer);
+    if (data.report) {
+      mut.setRecentReports((prev) =>
+        [data.report as TurnReport, ...prev].slice(0, 50)
+      );
+    }
+    // Attrition mutates the target tile; merge into the border-tile cache
+    // so the threat row reflects the new defender unit count without a
+    // page reload.
+    if (data.attrition?.targetTile) {
+      mut.mergeBorderTiles([
+        asMapTile(data.attrition.targetTile as GameTile),
+      ]);
+    }
+    return {
+      reportSummary:
+        (data.report as { summary?: string } | undefined)?.summary ??
+        "Spell cast",
+      ...(data.siege ? { siege: data.siege } : {}),
+      ...(data.disarm ? { disarm: data.disarm } : {}),
+      ...(data.attrition
+        ? {
+            attrition: {
+              unitsKilled: data.attrition.unitsKilled as UnitStack,
+            },
+          }
+        : {}),
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Spell cast failed");
+    return null;
+  }
+}
+
 /** POST /api/game/admin/grant — admin-only manual 100-turn override. */
 export async function adminGrant(
   user: User,

--- a/app/game/_lib/recommend.ts
+++ b/app/game/_lib/recommend.ts
@@ -59,10 +59,18 @@ export function recommendNext(
       tone: "primary",
     };
   }
-  if (army.total === 0 && counts.military > 0) {
+  if (
+    army.total === 0 &&
+    counts.military + counts.food + counts.magic > 0
+  ) {
+    const recruitable = counts.military + counts.food + counts.magic;
+    const detail =
+      counts.military > 0
+        ? `${counts.military} military land${counts.military === 1 ? "" : "s"}`
+        : `${recruitable} recruitable land${recruitable === 1 ? "" : "s"}`;
     return {
       title: "Recruit your first army",
-      body: `You have ${counts.military} military land${counts.military === 1 ? "" : "s"} and a unit cap of ${unitCap}. A recruit batch costs 5 turns.`,
+      body: `You have ${detail} and a unit cap of ${unitCap}. A recruit batch costs 5 turns (military trains 10 units/cycle; food and magic train 5).`,
       ctaLabel: "Recruit →",
       ctaHref: "/game/recruit",
       tone: "primary",

--- a/app/game/_lib/use-dashboard-data.ts
+++ b/app/game/_lib/use-dashboard-data.ts
@@ -24,12 +24,15 @@ import {
   attack,
   bulkDistribute,
   castIntelSpell,
+  castSpell,
   createPlayer,
   distributeTile,
   farExpedition,
+  flyover,
   frontierExplore,
   recruitUnits,
   setPlayerName,
+  siege,
   spendArtifact,
   type DashboardMutators,
 } from "./dashboard-actions";
@@ -307,6 +310,41 @@ export function useDashboardData() {
     [user]
   );
 
+  const handleSiege = useCallback(
+    async (sourceTileId: string, targetTileId: string) => {
+      if (!user) return null;
+      return siege(user, { sourceTileId, targetTileId }, mut);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
+  const handleFlyover = useCallback(
+    async (
+      sourceTileId: string,
+      targetTileId: string,
+      units: UnitStack
+    ) => {
+      if (!user) return null;
+      return flyover(user, { sourceTileId, targetTileId, units }, mut);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
+  const handleCastSpell = useCallback(
+    async (spellId: string, sourceTileId: string, targetTileId: string) => {
+      if (!user) return null;
+      return castSpell(
+        user,
+        { spellId, sourceTileId, targetTileId },
+        mut
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+    [user]
+  );
+
   return {
     user,
     authLoading,
@@ -347,6 +385,9 @@ export function useDashboardData() {
     handleArmDefenseSpell,
     handleDistributeTile,
     handleUseArtifact,
+    handleSiege,
+    handleFlyover,
+    handleCastSpell,
   };
 }
 

--- a/app/game/leaderboard/page.tsx
+++ b/app/game/leaderboard/page.tsx
@@ -32,6 +32,14 @@ interface LeaderboardResponse {
 
 const PAGE_LIMIT = 20;
 
+type Audience = "all" | "real" | "npc";
+
+const AUDIENCE_TABS: { value: Audience; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "real", label: "Real Players" },
+  { value: "npc", label: "NPCs" },
+];
+
 export default function LeaderboardPage() {
   const { user, loading: authLoading } = useAuth();
   const [rows, setRows] = useState<LeaderRow[]>([]);
@@ -39,14 +47,19 @@ export default function LeaderboardPage() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [audience, setAudience] = useState<Audience>("all");
 
   const fetchPage = useCallback(
-    async (cursor: string | null): Promise<LeaderboardResponse | null> => {
+    async (
+      cursor: string | null,
+      aud: Audience
+    ): Promise<LeaderboardResponse | null> => {
       if (!user) return null;
       const token = await user.getIdToken();
       const params = new URLSearchParams();
       params.set("limit", String(PAGE_LIMIT));
       if (cursor) params.set("cursor", cursor);
+      if (aud !== "all") params.set("audience", aud);
       const res = await fetch(`/api/game/leaderboard?${params}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -64,7 +77,7 @@ export default function LeaderboardPage() {
     }
     setError(null);
     try {
-      const data = await fetchPage(null);
+      const data = await fetchPage(null, audience);
       if (!data) return;
       setRows(data.players ?? []);
       setNextCursor(data.nextCursor ?? null);
@@ -73,14 +86,14 @@ export default function LeaderboardPage() {
     } finally {
       setLoading(false);
     }
-  }, [user, fetchPage]);
+  }, [user, fetchPage, audience]);
 
   const loadMore = useCallback(async () => {
     if (!nextCursor || loadingMore) return;
     setLoadingMore(true);
     setError(null);
     try {
-      const data = await fetchPage(nextCursor);
+      const data = await fetchPage(nextCursor, audience);
       if (!data) return;
       setRows((prev) => [...prev, ...(data.players ?? [])]);
       setNextCursor(data.nextCursor ?? null);
@@ -89,7 +102,7 @@ export default function LeaderboardPage() {
     } finally {
       setLoadingMore(false);
     }
-  }, [nextCursor, loadingMore, fetchPage]);
+  }, [nextCursor, loadingMore, fetchPage, audience]);
 
   useEffect(() => {
     if (authLoading) return;
@@ -138,6 +151,36 @@ export default function LeaderboardPage() {
             and drops your opponent&apos;s by the same amount. Your row is
             highlighted.
           </p>
+        </div>
+
+        <div
+          role="tablist"
+          aria-label="Filter leaderboard by player type"
+          className="inline-flex mb-4 rounded-lg border border-neutral-200 dark:border-neutral-800 p-0.5 bg-neutral-50 dark:bg-neutral-900/40"
+        >
+          {AUDIENCE_TABS.map((tab) => {
+            const active = audience === tab.value;
+            return (
+              <button
+                key={tab.value}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => {
+                  if (audience === tab.value) return;
+                  setAudience(tab.value);
+                  setNextCursor(null);
+                }}
+                className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
+                  active
+                    ? "bg-white dark:bg-neutral-800 shadow-sm font-medium"
+                    : "text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-200"
+                }`}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
         </div>
 
         {rows.length === 0 ? (

--- a/app/game/recruit/_components/BulkRecruitPanel.tsx
+++ b/app/game/recruit/_components/BulkRecruitPanel.tsx
@@ -7,14 +7,19 @@
 "use client";
 
 import type { MapTile, UnitType } from "@/lib/game/types";
-import { TURNS_PER_CYCLE, UNITS_PER_CYCLE } from "../_lib/constants";
+import {
+  MIN_UNITS_PER_CYCLE_RECRUITABLE,
+  TURNS_PER_CYCLE,
+  unitsPerCycleForLand,
+} from "../_lib/constants";
 import type { RecruitProgress } from "../_lib/types";
 import { PlanPreview } from "./PlanPreview";
 import { ProgressBar } from "./ProgressBar";
 
 interface Props {
-  militaryTiles: MapTile[];
-  threatRankedMilitaryIds: string[];
+  recruitableTiles: MapTile[];
+  threatRankedRecruitableIds: string[];
+  tilesById: Map<string, MapTile>;
   unitType: UnitType;
   setUnitType: (u: UnitType) => void;
   requestedUnits: number;
@@ -30,6 +35,12 @@ interface Props {
   onRecruit: () => void;
 }
 
+const TYPE_LABEL: Record<string, string> = {
+  military: "Mil",
+  food: "Food",
+  magic: "Magic",
+};
+
 /**
  * The recruit form: unit-type / count / target-tile selectors + the
  * recruit button + the live plan preview + the progress bar. Owns
@@ -37,8 +48,9 @@ interface Props {
  * picker state and the action result).
  */
 export function BulkRecruitPanel({
-  militaryTiles,
-  threatRankedMilitaryIds,
+  recruitableTiles,
+  threatRankedRecruitableIds,
+  tilesById,
   unitType,
   setUnitType,
   requestedUnits,
@@ -53,14 +65,21 @@ export function BulkRecruitPanel({
   progress,
   onRecruit,
 }: Props) {
+  const tilesCount = recruitableTiles.length;
+  const militaryCount = recruitableTiles.filter(
+    (t) => t.type === "military"
+  ).length;
+  const foodMagicCount = tilesCount - militaryCount;
+
   return (
     <div className="rounded-lg border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/50 dark:bg-emerald-900/10 p-4 mb-6">
       <h2 className="font-semibold mb-3">Bulk recruit</h2>
-      {militaryTiles.length === 0 ? (
+      {tilesCount === 0 ? (
         <p className="text-sm text-neutral-500">
-          You have no military tiles. Distribute some unassigned tiles to{" "}
-          <em>military</em> first — head to the dashboard&apos;s bulk-assign
-          panel or any tile&apos;s detail page.
+          You have no recruitable tiles. Distribute some unassigned tiles to{" "}
+          <em>military</em>, <em>food</em>, or <em>magic</em> first — head to
+          the dashboard&apos;s bulk-assign panel or any tile&apos;s detail
+          page.
         </p>
       ) : (
         <div className="space-y-3">
@@ -79,12 +98,12 @@ export function BulkRecruitPanel({
               </select>
             </label>
             <label className="text-sm">
-              Units (multiple of {UNITS_PER_CYCLE}):{" "}
+              Units (multiple of {MIN_UNITS_PER_CYCLE_RECRUITABLE}):{" "}
               <input
                 type="number"
-                step={UNITS_PER_CYCLE}
-                min={UNITS_PER_CYCLE}
-                max={Math.max(UNITS_PER_CYCLE, maxUnits)}
+                step={MIN_UNITS_PER_CYCLE_RECRUITABLE}
+                min={MIN_UNITS_PER_CYCLE_RECRUITABLE}
+                max={Math.max(MIN_UNITS_PER_CYCLE_RECRUITABLE, maxUnits)}
                 value={requestedUnits}
                 onChange={(e) => {
                   const n = Number.parseInt(e.target.value, 10);
@@ -99,16 +118,24 @@ export function BulkRecruitPanel({
               <select
                 value={selectedTileId}
                 onChange={(e) => setSelectedTileId(e.target.value)}
-                disabled={busy || militaryTiles.length === 0}
+                disabled={busy || tilesCount === 0}
                 className="ml-2 px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-transparent"
               >
                 <option value="">Auto — most-threatened tiles first</option>
-                {threatRankedMilitaryIds.map((tileId, idx) => (
-                  <option key={tileId} value={tileId}>
-                    {tileId}
-                    {idx === 0 ? " (top threat)" : ""}
-                  </option>
-                ))}
+                {threatRankedRecruitableIds.map((tileId, idx) => {
+                  const tile = tilesById.get(tileId);
+                  const yieldPerCycle = tile
+                    ? unitsPerCycleForLand(tile.type)
+                    : 0;
+                  const typeLabel = tile ? TYPE_LABEL[tile.type] ?? "" : "";
+                  return (
+                    <option key={tileId} value={tileId}>
+                      {tileId}
+                      {typeLabel ? ` · ${typeLabel} +${yieldPerCycle}` : ""}
+                      {idx === 0 ? " (top threat)" : ""}
+                    </option>
+                  );
+                })}
               </select>
             </label>
             <button
@@ -122,11 +149,14 @@ export function BulkRecruitPanel({
             </button>
           </div>
           <p className="text-xs text-neutral-500">
-            {TURNS_PER_CYCLE} turns / {UNITS_PER_CYCLE} units · across{" "}
-            {militaryTiles.length} military tile
-            {militaryTiles.length === 1 ? "" : "s"}.
+            {TURNS_PER_CYCLE} turns / cycle · {militaryCount} military
+            {militaryCount === 1 ? " tile" : " tiles"} (10/cycle)
+            {foodMagicCount > 0
+              ? ` + ${foodMagicCount} food/magic (5/cycle)`
+              : ""}
+            .
           </p>
-          <PlanPreview plan={planPreview} selectedTileId={selectedTileId} />
+          <PlanPreview plan={planPreview} selectedTileId={selectedTileId} tilesById={tilesById} />
         </div>
       )}
 

--- a/app/game/recruit/_components/MilitaryTilesList.tsx
+++ b/app/game/recruit/_components/MilitaryTilesList.tsx
@@ -8,29 +8,58 @@
 
 import Link from "next/link";
 import type { MapTile } from "@/lib/game/types";
+import { unitsPerCycleForLand } from "../_lib/constants";
 
-export function MilitaryTilesList({ tiles }: { tiles: MapTile[] }) {
+const TYPE_LABEL: Record<string, string> = {
+  military: "Military",
+  food: "Food",
+  magic: "Magic",
+};
+
+const TYPE_BADGE: Record<string, string> = {
+  military:
+    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  food:
+    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  magic:
+    "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300",
+};
+
+export function RecruitableTilesList({ tiles }: { tiles: MapTile[] }) {
   return (
     <>
-      <h2 className="text-lg font-semibold mb-3">Your military tiles</h2>
+      <h2 className="text-lg font-semibold mb-3">Your recruitable tiles</h2>
       {tiles.length === 0 ? (
         <p className="text-sm text-neutral-500 italic">
-          None yet — distribute some unassigned tiles to military first.
+          None yet — distribute some unassigned tiles first. Military tiles
+          train 10 units/cycle; food and magic tiles train 5/cycle.
         </p>
       ) : (
         <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg divide-y divide-neutral-200 dark:divide-neutral-800">
-          {tiles.map((t) => (
-            <Link
-              key={t.tileId}
-              href={`/game/tiles/${encodeURIComponent(t.tileId)}`}
-              className="flex items-center justify-between px-4 py-3 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-900"
-            >
-              <span className="font-mono">{t.tileId}</span>
-              <span className="text-xs text-neutral-500">
-                G {t.units.ground} · S {t.units.siege} · A {t.units.air}
-              </span>
-            </Link>
-          ))}
+          {tiles.map((t) => {
+            const yieldPerCycle = unitsPerCycleForLand(t.type);
+            return (
+              <Link
+                key={t.tileId}
+                href={`/game/tiles/${encodeURIComponent(t.tileId)}`}
+                className="flex items-center justify-between gap-3 px-4 py-3 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-900"
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  <span className="font-mono truncate">{t.tileId}</span>
+                  <span
+                    className={`shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                      TYPE_BADGE[t.type] ?? "bg-neutral-100 text-neutral-600"
+                    }`}
+                  >
+                    {TYPE_LABEL[t.type] ?? t.type} · +{yieldPerCycle}/cycle
+                  </span>
+                </span>
+                <span className="text-xs text-neutral-500 shrink-0">
+                  G {t.units.ground} · S {t.units.siege} · A {t.units.air}
+                </span>
+              </Link>
+            );
+          })}
         </div>
       )}
     </>

--- a/app/game/recruit/_components/PlanPreview.tsx
+++ b/app/game/recruit/_components/PlanPreview.tsx
@@ -6,14 +6,16 @@
 
 "use client";
 
-import { UNITS_PER_CYCLE } from "../_lib/constants";
+import type { MapTile } from "@/lib/game/types";
+import { unitsPerCycleForLand } from "../_lib/constants";
 
 interface Props {
   plan: Array<{ tileId: string; cycles: number }>;
   selectedTileId: string;
+  tilesById: Map<string, MapTile>;
 }
 
-export function PlanPreview({ plan, selectedTileId }: Props) {
+export function PlanPreview({ plan, selectedTileId, tilesById }: Props) {
   if (plan.length === 0) return null;
   return (
     <div className="rounded-md border border-emerald-200 dark:border-emerald-900/50 bg-white dark:bg-neutral-950 px-3 py-2 text-xs">
@@ -21,14 +23,20 @@ export function PlanPreview({ plan, selectedTileId }: Props) {
         {selectedTileId ? "Routing to" : "Auto-routing units"}
       </div>
       <ul className="font-mono text-[11px] space-y-0.5 text-neutral-700 dark:text-neutral-300">
-        {plan.map(({ tileId, cycles }, idx) => (
-          <li key={tileId}>
-            {tileId} +{cycles * UNITS_PER_CYCLE}
-            {!selectedTileId && idx === 0 && plan.length > 1
-              ? "  (most-threatened)"
-              : ""}
-          </li>
-        ))}
+        {plan.map(({ tileId, cycles }, idx) => {
+          const tile = tilesById.get(tileId);
+          const perCycle = tile ? unitsPerCycleForLand(tile.type) : 0;
+          const units = cycles * perCycle;
+          return (
+            <li key={tileId}>
+              {tileId} +{units}
+              {tile ? `  (${tile.type})` : ""}
+              {!selectedTileId && idx === 0 && plan.length > 1
+                ? "  [most-threatened]"
+                : ""}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/app/game/recruit/_components/RecruitView.tsx
+++ b/app/game/recruit/_components/RecruitView.tsx
@@ -19,12 +19,16 @@ import {
   type ThreatOwnerInfo,
 } from "@/lib/game/threat";
 import type { GamePlayer, MapTile, UnitType } from "@/lib/game/types";
-import { TURNS_PER_CYCLE, UNITS_PER_CYCLE } from "../_lib/constants";
+import {
+  MIN_UNITS_PER_CYCLE_RECRUITABLE,
+  TURNS_PER_CYCLE,
+  unitsPerCycleForLand,
+} from "../_lib/constants";
 import { buildThreatPriorityPlan } from "../_lib/threat-priority-plan";
 import type { OwnerSummary } from "../_lib/types";
 import type { RecruitAction } from "../_lib/use-recruit-action";
 import { BulkRecruitPanel } from "./BulkRecruitPanel";
-import { MilitaryTilesList } from "./MilitaryTilesList";
+import { RecruitableTilesList } from "./MilitaryTilesList";
 import { ReportLog } from "./ReportLog";
 import { StatGrid } from "./StatGrid";
 
@@ -63,26 +67,43 @@ export function RecruitView({
     () => tiles.filter((t) => t.type === "military"),
     [tiles]
   );
-  const foodTiles = tiles.filter((t) => t.type === "food");
-  const magicTiles = tiles.filter((t) => t.type === "magic");
+  const foodTiles = useMemo(
+    () => tiles.filter((t) => t.type === "food"),
+    [tiles]
+  );
+  const magicTiles = useMemo(
+    () => tiles.filter((t) => t.type === "magic"),
+    [tiles]
+  );
+  // All tiles where the player can train units. As of the May 2026 rework,
+  // food and magic tiles can recruit (at half the military rate).
+  const recruitableTiles = useMemo(
+    () => [...militaryTiles, ...foodTiles, ...magicTiles],
+    [militaryTiles, foodTiles, magicTiles]
+  );
+  const tilesById = useMemo(() => {
+    const m = new Map<string, MapTile>();
+    for (const t of recruitableTiles) m.set(t.tileId, t);
+    return m;
+  }, [recruitableTiles]);
 
-  // Threat-ranked military-tile ids. Drives the auto-route distribution and
-  // the order tiles appear in the manual-override picker (most exposed at
-  // top is what a player wants to see).
-  const threatRankedMilitaryIds = useMemo(() => {
+  // Threat-ranked recruitable-tile ids. Drives the auto-route distribution
+  // and the order tiles appear in the manual-override picker (most exposed
+  // at top is what a player wants to see).
+  const threatRankedRecruitableIds = useMemo(() => {
     const ownerInfo = new Map<string, ThreatOwnerInfo>();
     for (const [uid, o] of owners) ownerInfo.set(uid, { shielded: o.shielded });
     const threat = computeTileThreat({
-      myTiles: militaryTiles,
+      myTiles: recruitableTiles,
       worldTiles: borderTiles,
       owners: ownerInfo,
       myUserId: player.userId,
     });
     return rankTileIdsByThreat(
-      militaryTiles.map((t) => t.tileId),
+      recruitableTiles.map((t) => t.tileId),
       threat
     );
-  }, [militaryTiles, borderTiles, owners, player.userId]);
+  }, [recruitableTiles, borderTiles, owners, player.userId]);
 
   // Compute the player's current effective unit cap. This mirrors what the
   // server uses inside buildUnitsServer so the displayed numbers match what
@@ -91,28 +112,52 @@ export function RecruitView({
   const unitsAlive = player.stats.unitsAlive ?? 0;
   const availableCap = Math.max(0, cap - unitsAlive);
   const turnsRemaining = player.turnsRemaining;
-  // How many BUILD CYCLES the player can afford right now.
-  const maxCyclesByCap = Math.floor(availableCap / UNITS_PER_CYCLE);
+  // Cap-by-tiles math. Per-cycle yield now varies by tile type, so the
+  // safe upper bound on cycles uses the *minimum* yield (5) — we'd rather
+  // under-predict and let the server cap-stop than ever exceed cap.
+  const maxCyclesByCap = Math.floor(
+    availableCap / MIN_UNITS_PER_CYCLE_RECRUITABLE
+  );
   const maxCyclesByTurns = Math.floor(turnsRemaining / TURNS_PER_CYCLE);
   const maxCycles = Math.min(maxCyclesByCap, maxCyclesByTurns);
-  const maxUnits = maxCycles * UNITS_PER_CYCLE;
 
-  // Final units rounded to a multiple of UNITS_PER_CYCLE and bounded by cap.
-  const effectiveUnits = useMemo(
+  // Project how many actual units a given plan will yield, given each tile's
+  // land type. Used by the input control and the recruit button label.
+  const projectUnits = useMemo(
     () =>
-      Math.max(
-        UNITS_PER_CYCLE,
-        Math.min(
-          maxUnits,
-          Math.floor(requestedUnits / UNITS_PER_CYCLE) * UNITS_PER_CYCLE
-        )
-      ),
-    [maxUnits, requestedUnits]
+      (
+        plan: ReadonlyArray<{ tileId: string; cycles: number }>
+      ): number => {
+        let total = 0;
+        for (const { tileId, cycles } of plan) {
+          const t = tilesById.get(tileId);
+          if (!t) continue;
+          total += cycles * unitsPerCycleForLand(t.type);
+        }
+        return total;
+      },
+    [tilesById]
   );
-  const effectiveCycles = Math.max(
-    0,
-    Math.floor(effectiveUnits / UNITS_PER_CYCLE)
-  );
+
+  // The "max units this session" stat: optimistic projection assuming
+  // auto-route, since that's the likeliest user choice.
+  const maxUnits = useMemo(() => {
+    if (maxCycles === 0) return 0;
+    const plan = buildThreatPriorityPlan(threatRankedRecruitableIds, maxCycles);
+    return projectUnits(plan);
+  }, [maxCycles, threatRankedRecruitableIds, projectUnits]);
+
+  // Convert the user's requested units into a cycle count, then clamp.
+  const effectiveCycles = useMemo(() => {
+    // One cycle costs at least the minimum yield, so divide by that to be
+    // generous with the user's input ("I want at least N units → that many
+    // cycles, clamped to maxCycles"). The actual realized units come back
+    // from projectUnits below.
+    const requestedCycles = Math.floor(
+      requestedUnits / MIN_UNITS_PER_CYCLE_RECRUITABLE
+    );
+    return Math.max(0, Math.min(maxCycles, requestedCycles));
+  }, [requestedUnits, maxCycles]);
 
   // Distribution preview, used to render a transparent "this is where the
   // units are going" line above the recruit button.
@@ -121,19 +166,24 @@ export function RecruitView({
     if (selectedTileId) {
       return [{ tileId: selectedTileId, cycles: effectiveCycles }];
     }
-    return buildThreatPriorityPlan(threatRankedMilitaryIds, effectiveCycles);
-  }, [effectiveCycles, selectedTileId, threatRankedMilitaryIds]);
+    return buildThreatPriorityPlan(threatRankedRecruitableIds, effectiveCycles);
+  }, [effectiveCycles, selectedTileId, threatRankedRecruitableIds]);
+
+  const effectiveUnits = useMemo(
+    () => projectUnits(planPreview),
+    [planPreview, projectUnits]
+  );
 
   const onRecruit = () => {
-    if (militaryTiles.length === 0) {
-      setError("You have no military tiles to recruit from.");
+    if (recruitableTiles.length === 0) {
+      setError("You have no recruitable tiles. Distribute some land first.");
       return;
     }
     void action.handleRecruit({
       unitType,
       totalCycles: effectiveCycles,
       selectedTileId,
-      threatRankedMilitaryIds,
+      threatRankedRecruitableIds,
     });
   };
 
@@ -154,11 +204,13 @@ export function RecruitView({
 
         <div className="rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50 dark:bg-blue-900/10 p-4 mb-6 text-sm leading-relaxed">
           <p>
-            Each recruit cycle trains <strong>{UNITS_PER_CYCLE} units</strong>{" "}
-            of one type on a military tile, costing{" "}
-            <strong>{TURNS_PER_CYCLE} turns</strong>. Bulk recruit fires cycles
-            round-robin across all your military tiles so units distribute
-            evenly. Each cycle rolls a 3% chance for an artifact.
+            Each recruit cycle costs <strong>{TURNS_PER_CYCLE} turns</strong>{" "}
+            and trains units on one of your tiles.{" "}
+            <strong>Military tiles train 10 units/cycle</strong>; food and
+            magic tiles train <strong>5/cycle</strong>. Bulk recruit
+            distributes cycles by threat across your recruitable tiles so
+            exposed lands get reinforced first. Each cycle rolls a 3% chance
+            for an artifact.
           </p>
           <p className="mt-2">
             Your unit cap is set by your <strong>food lands</strong> (+5 cap
@@ -201,8 +253,9 @@ export function RecruitView({
         )}
 
         <BulkRecruitPanel
-          militaryTiles={militaryTiles}
-          threatRankedMilitaryIds={threatRankedMilitaryIds}
+          recruitableTiles={recruitableTiles}
+          threatRankedRecruitableIds={threatRankedRecruitableIds}
+          tilesById={tilesById}
           unitType={unitType}
           setUnitType={setUnitType}
           requestedUnits={requestedUnits}
@@ -218,7 +271,7 @@ export function RecruitView({
           onRecruit={onRecruit}
         />
 
-        <MilitaryTilesList tiles={militaryTiles} />
+        <RecruitableTilesList tiles={recruitableTiles} />
         <ReportLog reports={action.recentReports} />
       </div>
     </div>

--- a/app/game/recruit/_lib/constants.ts
+++ b/app/game/recruit/_lib/constants.ts
@@ -4,8 +4,32 @@
  * See LICENSE file for details.
  */
 
+// Military baseline (kept as the legacy constant for any header copy or
+// fallback math that wants "the number"). The actual per-cycle yield depends
+// on the tile's land type — see UNITS_PER_CYCLE_BY_LAND / unitsPerCycleForLand.
 export const UNITS_PER_CYCLE = 10;
 export const TURNS_PER_CYCLE = 5;
+
+// Per-land-type recruit yield (matches the server's
+// BUILD_UNITS_PER_TURN_BY_LAND in lib/game/data-server.ts). Military trains
+// 10 units per cycle, food and magic train 5 — magic and food tiles can
+// recruit but at half pace, since training soldiers is what military tiles
+// are *for*.
+import type { LandType } from "@/lib/game/types";
+export const UNITS_PER_CYCLE_BY_LAND: Record<LandType, number> = {
+  unrevealed: 0,
+  unassigned: 0,
+  military: 10,
+  food: 5,
+  magic: 5,
+};
+export function unitsPerCycleForLand(landType: LandType): number {
+  return UNITS_PER_CYCLE_BY_LAND[landType] ?? 0;
+}
+// Conservative lower bound on units-per-cycle across recruitable types.
+// Used by the cap-math UI so we never *under-predict* how many cycles fit
+// (worst-case the user fires fewer cycles than predicted, never more).
+export const MIN_UNITS_PER_CYCLE_RECRUITABLE = 5;
 
 export const RARITY_TEXT: Record<string, string> = {
   common: "text-neutral-500 dark:text-neutral-400",

--- a/app/game/recruit/_lib/use-recruit-action.ts
+++ b/app/game/recruit/_lib/use-recruit-action.ts
@@ -15,7 +15,7 @@ import type {
   TurnReport,
   UnitType,
 } from "@/lib/game/types";
-import { UNITS_PER_CYCLE } from "./constants";
+import { MIN_UNITS_PER_CYCLE_RECRUITABLE } from "./constants";
 import { buildThreatPriorityPlan } from "./threat-priority-plan";
 import type { RecruitProgress } from "./types";
 
@@ -30,7 +30,9 @@ interface RecruitArgs {
   unitType: UnitType;
   totalCycles: number;
   selectedTileId: string;
-  threatRankedMilitaryIds: string[];
+  // Threat-ranked recruitable tile ids (military + food + magic). Drives
+  // the auto-route distribution when no specific tile is selected.
+  threatRankedRecruitableIds: string[];
 }
 
 /**
@@ -54,7 +56,7 @@ export function useRecruitAction({
       unitType,
       totalCycles,
       selectedTileId,
-      threatRankedMilitaryIds,
+      threatRankedRecruitableIds,
     }: RecruitArgs) => {
       if (!user) return;
       if (totalCycles === 0) {
@@ -73,7 +75,7 @@ export function useRecruitAction({
         const token = await user.getIdToken();
         const planEntries = selectedTileId
           ? [{ tileId: selectedTileId, cycles: totalCycles }]
-          : buildThreatPriorityPlan(threatRankedMilitaryIds, totalCycles);
+          : buildThreatPriorityPlan(threatRankedRecruitableIds, totalCycles);
         const plan = planEntries.map(({ tileId, cycles }) => ({
           tileId,
           unitType,
@@ -100,10 +102,12 @@ export function useRecruitAction({
           : [];
         let artifactsFound = 0;
         for (const r of reports) if (r.artifactFound) artifactsFound++;
+        // Conservative fallback when the server didn't return data.produced.
+        // Per-tile yield varies (5–10), so we bound below.
         const unitsBuilt =
           typeof data.produced === "number"
             ? data.produced
-            : reports.length * UNITS_PER_CYCLE;
+            : reports.length * MIN_UNITS_PER_CYCLE_RECRUITABLE;
         if (reports.length > 0) {
           setRecentReports((prev) =>
             [...reports.slice().reverse(), ...prev].slice(0, 25)

--- a/app/game/spells/_lib/constants.ts
+++ b/app/game/spells/_lib/constants.ts
@@ -29,6 +29,9 @@ export const TYPE_LABEL: Record<SpellType, string> = {
   offense: "Offense",
   production: "Production",
   intel: "Intel",
+  siege: "Siege",
+  disarm: "Disarm",
+  attrition: "Attrition",
 };
 
 export const RARITY_TEXT: Record<string, string> = {

--- a/app/game/threats/_components/BattleReport.tsx
+++ b/app/game/threats/_components/BattleReport.tsx
@@ -99,6 +99,28 @@ export function BattleReport({
   // Modifier lines — only emit the ones that actually applied. RNG always
   // shows because there's always a roll.
   const modifiers: string[] = [];
+  // Tile-type combat modifiers (May 2026 mechanics rework).
+  if (
+    combat.sourceLandTypeMultiplier !== undefined &&
+    combat.sourceLandTypeMultiplier !== 1
+  ) {
+    modifiers.push(
+      `Source tile · ×${combat.sourceLandTypeMultiplier.toFixed(2)} on attack`
+    );
+  }
+  if (
+    combat.targetLandTypeMultiplier !== undefined &&
+    combat.targetLandTypeMultiplier !== 1
+  ) {
+    modifiers.push(
+      `Target tile · ×${combat.targetLandTypeMultiplier.toFixed(2)} on defense`
+    );
+  }
+  if (combat.standingDefenseAdded && combat.standingDefenseAdded > 0) {
+    modifiers.push(
+      `Standing defense · +${combat.standingDefenseAdded.toFixed(0)} (tile garrison)`
+    );
+  }
   if (combat.underdogApplied) {
     modifiers.push(
       `Underdog bonus active · ×${(1 + UNDERDOG_DEFENSE_BONUS).toFixed(2)} on defense`
@@ -111,18 +133,24 @@ export function BattleReport({
   }
   if (combat.appliedSpells.offenseId) {
     const s = SPELLS_BY_ID.get(combat.appliedSpells.offenseId);
+    const magicBonus = combat.magicTileOffenseSpellBonusApplied
+      ? " (magic-tile ×1.25)"
+      : "";
     modifiers.push(
       s
-        ? `Offense spell · ${s.name} · T${s.tier}`
-        : `Offense spell · ${combat.appliedSpells.offenseId}`
+        ? `Offense spell · ${s.name} · T${s.tier}${magicBonus}`
+        : `Offense spell · ${combat.appliedSpells.offenseId}${magicBonus}`
     );
   }
   if (combat.appliedSpells.defenseId) {
     const s = SPELLS_BY_ID.get(combat.appliedSpells.defenseId);
+    const magicBonus = combat.magicTileDefenseSpellBonusApplied
+      ? " (magic-tile ×1.25)"
+      : "";
     modifiers.push(
       s
-        ? `Defense spell triggered · ${s.name} · T${s.tier}`
-        : `Defense spell triggered · ${combat.appliedSpells.defenseId}`
+        ? `Defense spell triggered · ${s.name} · T${s.tier}${magicBonus}`
+        : `Defense spell triggered · ${combat.appliedSpells.defenseId}${magicBonus}`
     );
   }
   if (combat.airIntel?.weakFace) {

--- a/app/game/threats/_components/BattleSimPanel.tsx
+++ b/app/game/threats/_components/BattleSimPanel.tsx
@@ -1,0 +1,506 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { SPELLS_BY_ID } from "@/lib/game/content";
+import type { SpellDefinition, UnitStack } from "@/lib/game/types";
+import type { AttackPreview } from "../_lib/use-attack-preview";
+
+export interface BattleSimPanelProps {
+  preview: AttackPreview | null;
+  loading: boolean;
+  error: string | null;
+  // True when the calling row has determined the attack is structurally
+  // impossible (e.g. enemy shielded). The panel renders a muted "preview
+  // unavailable" state instead of stale numbers.
+  disabled?: boolean;
+  disabledReason?: string;
+  // Action handlers. Each is independently optional — Phase 4 will wire
+  // onCastSpell after Phase 3's spy/siege/flyover ship. Disabled reasons
+  // come pre-computed from the parent (turn budget, unit availability,
+  // shield, busy) so the panel just renders.
+  busy?: boolean;
+  spy?: { onClick: () => void; turnCost: number; disabledReason: string | null };
+  siege?: { onClick: () => void; turnCost: number; disabledReason: string | null };
+  flyover?: {
+    onClick: () => void;
+    turnCost: number;
+    disabledReason: string | null;
+    airUnits: number;
+  };
+  // Expandable spell-cast picker. The player sees three options (siege /
+  // disarm / attrition) populated by the parent. Clicking the parent
+  // button toggles the picker; clicking a spell row fires onCast.
+  castSpell?: {
+    spells: ReadonlyArray<{
+      spell: SpellDefinition;
+      // Pre-computed midpoint magnitude (dice=1.0) so the picker can
+      // show the player what to expect on average.
+      expectedMagnitude: number;
+      // Already-disabled tooltip if the player can't cast this spell
+      // (turn budget, tile minimum, etc.). null = clickable.
+      disabledReason: string | null;
+    }>;
+    onCast: (spellId: string) => void;
+    turnCost: number;
+    disabledReason: string | null;
+  };
+}
+
+function totalUnits(s: UnitStack): number {
+  return s.ground + s.siege + s.air;
+}
+
+function fmtStack(s: UnitStack): string {
+  return `${s.ground}g ${s.siege}s ${s.air}a`;
+}
+
+/**
+ * Inline live battle simulation panel for the ThreatRow attack form.
+ * Renders the projected combat outcome (midpoint RNG, no commitment) plus
+ * a strip of pre-attack action buttons.
+ *
+ * V1: read-only — the action buttons are present but disabled with a
+ * "Coming soon" tooltip. Phases 3 and 4 wire them up.
+ */
+export function BattleSimPanel({
+  preview,
+  loading,
+  error,
+  disabled,
+  disabledReason,
+  busy,
+  spy,
+  siege,
+  flyover,
+  castSpell,
+}: BattleSimPanelProps) {
+  return (
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50/50 dark:bg-neutral-900/30 my-3">
+      <div className="flex items-baseline justify-between px-3 py-2 border-b border-neutral-200 dark:border-neutral-800">
+        <h4 className="font-semibold uppercase tracking-wide text-[11px] text-neutral-600 dark:text-neutral-300">
+          Battle simulation
+        </h4>
+        <span className="text-[10px] text-neutral-500">
+          midpoint projection · no turns spent
+        </span>
+      </div>
+
+      <div className="px-3 py-3 space-y-3 text-xs text-neutral-700 dark:text-neutral-200">
+        {disabled ? (
+          <p className="text-neutral-500 italic">
+            {disabledReason ?? "Preview unavailable for this configuration."}
+          </p>
+        ) : loading && !preview ? (
+          <p className="text-neutral-500">Computing projection…</p>
+        ) : error ? (
+          <p className="text-red-600 dark:text-red-400">
+            Preview failed: {error}
+          </p>
+        ) : !preview ? (
+          <p className="text-neutral-500 italic">
+            Select units to see a battle projection.
+          </p>
+        ) : (
+          <PreviewBody preview={preview} stale={loading} />
+        )}
+
+        <ActionButtonStrip
+          disabled={disabled}
+          busy={busy}
+          spy={spy}
+          siege={siege}
+          flyover={flyover}
+          castSpell={castSpell}
+        />
+      </div>
+    </div>
+  );
+}
+
+function PreviewBody({
+  preview,
+  stale,
+}: {
+  preview: AttackPreview;
+  stale: boolean;
+}) {
+  const { combat, target, effects } = preview;
+
+  const banner = (() => {
+    if (combat.outcome === "captured") {
+      return {
+        label: "Projected: Captured",
+        classes:
+          "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200",
+      };
+    }
+    if (combat.outcome === "repelled") {
+      return {
+        label: "Projected: Repelled",
+        classes:
+          "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200",
+      };
+    }
+    return {
+      label: "Projected: Stalemate",
+      classes:
+        "bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200",
+    };
+  })();
+
+  const activePreps = buildActivePreps(effects);
+
+  return (
+    <div className={`space-y-2 ${stale ? "opacity-60" : ""}`}>
+      <div
+        className={`inline-block px-2 py-0.5 rounded text-[11px] font-semibold uppercase tracking-wide ${banner.classes}`}
+      >
+        {banner.label}
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+        <div>
+          <span className="text-neutral-500">Attack power · </span>
+          <span className="font-mono">{combat.attackPower.toFixed(0)}</span>
+        </div>
+        <div>
+          <span className="text-neutral-500">Defense power · </span>
+          <span className="font-mono">{combat.defensePower.toFixed(0)}</span>
+        </div>
+        <div>
+          <span className="text-neutral-500">You&apos;d lose · </span>
+          <span className="font-mono">
+            {fmtStack(combat.attackerLosses)} (
+            {totalUnits(combat.attackerLosses)})
+          </span>
+        </div>
+        <div>
+          <span className="text-neutral-500">They&apos;d lose · </span>
+          <span className="font-mono">
+            {fmtStack(combat.defenderLosses)} (
+            {totalUnits(combat.defenderLosses)})
+          </span>
+        </div>
+        <div className="col-span-2">
+          <span className="text-neutral-500">Defender on tile · </span>
+          <span className="font-mono">
+            {fmtStack(target.units)} ({totalUnits(target.units)})
+          </span>
+        </div>
+      </div>
+
+      {activePreps.length > 0 && (
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-neutral-500 mb-1">
+            Active prep
+          </div>
+          <ul className="space-y-0.5">
+            {activePreps.map((p) => (
+              <li key={p.label} className="font-mono text-[11px]">
+                {p.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Tile-type modifiers — only show when non-neutral. Same vocab as
+          BattleReport so post-attack and pre-attack copy match. */}
+      <PreviewModifiers preview={preview} />
+    </div>
+  );
+}
+
+function PreviewModifiers({ preview }: { preview: AttackPreview }) {
+  const { combat } = preview;
+  const lines: string[] = [];
+  if (combat.sourceLandTypeMultiplier !== 1) {
+    lines.push(
+      `Source tile · ×${combat.sourceLandTypeMultiplier.toFixed(2)} attack`
+    );
+  }
+  if (combat.targetLandTypeMultiplier !== 1) {
+    lines.push(
+      `Target tile · ×${combat.targetLandTypeMultiplier.toFixed(2)} defense`
+    );
+  }
+  if (combat.standingDefenseAdded > 0) {
+    lines.push(
+      `Standing defense · +${combat.standingDefenseAdded.toFixed(0)} (tile garrison)`
+    );
+  }
+  if (combat.supplyMultiplier !== 1) {
+    lines.push(`Defender supply · ×${combat.supplyMultiplier.toFixed(2)}`);
+  }
+  if (combat.appliedSpells.offenseId) {
+    const s = SPELLS_BY_ID.get(combat.appliedSpells.offenseId);
+    lines.push(`Offense spell · ${s?.name ?? combat.appliedSpells.offenseId}`);
+  }
+  if (combat.appliedSpells.defenseId) {
+    const s = SPELLS_BY_ID.get(combat.appliedSpells.defenseId);
+    lines.push(
+      `Defender's armed spell · ${s?.name ?? combat.appliedSpells.defenseId}`
+    );
+  }
+  if (lines.length === 0) return null;
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wide text-neutral-500 mb-1">
+        Modifiers (this projection)
+      </div>
+      <ul className="space-y-0.5">
+        {lines.map((l) => (
+          <li key={l} className="font-mono text-[11px] text-neutral-600 dark:text-neutral-400">
+            {l}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function buildActivePreps(effects: AttackPreview["effects"]): {
+  label: string;
+}[] {
+  const out: { label: string }[] = [];
+  if (effects.forgeSightOffenseBonus > 0) {
+    out.push({
+      label: `⚔ Forge Sight · +${(effects.forgeSightOffenseBonus * 100).toFixed(
+        0
+      )}% offense`,
+    });
+  }
+  if (effects.alertVsCasterDefenseBonus > 0) {
+    out.push({
+      label: `🚨 Defender alert · +${(
+        effects.alertVsCasterDefenseBonus * 100
+      ).toFixed(0)}% defense vs you`,
+    });
+  }
+  if (effects.siegeDebuffMagnitude > 0) {
+    out.push({
+      label: `🏰 Siege debuff · −${(effects.siegeDebuffMagnitude * 100).toFixed(
+        0
+      )}% standing floor`,
+    });
+  }
+  if (effects.preCastOffenseBonus > 0) {
+    out.push({
+      label: `🪄 Pre-cast offense · +${effects.preCastOffenseBonus.toFixed(
+        0
+      )} attack power (consumed on attack)`,
+    });
+  }
+  if (effects.defenseDisarmFraction > 0) {
+    out.push({
+      label: `✨ Disarm queued · ${(effects.defenseDisarmFraction * 100).toFixed(
+        0
+      )}% nullification (consumed on attack)`,
+    });
+  }
+  return out;
+}
+
+interface ActionButton {
+  key: string;
+  label: string;
+  onClick?: () => void;
+  disabled: boolean;
+  title: string;
+}
+
+function ActionButtonStrip({
+  disabled,
+  busy,
+  spy,
+  siege,
+  flyover,
+  castSpell,
+}: {
+  disabled?: boolean;
+  busy?: boolean;
+  spy?: BattleSimPanelProps["spy"];
+  siege?: BattleSimPanelProps["siege"];
+  flyover?: BattleSimPanelProps["flyover"];
+  castSpell?: BattleSimPanelProps["castSpell"];
+}) {
+  const [castOpen, setCastOpen] = useState(false);
+
+  const wholePanelDisabledReason = disabled
+    ? "Preview disabled — pre-actions unavailable."
+    : busy
+      ? "Another action is in progress…"
+      : null;
+
+  const buttons: ActionButton[] = [];
+  if (spy) {
+    const reason = wholePanelDisabledReason ?? spy.disabledReason;
+    buttons.push({
+      key: "spy",
+      label: `Spy +${spy.turnCost}T`,
+      onClick: reason ? undefined : spy.onClick,
+      disabled: reason !== null,
+      title: reason ?? `Cast intel spell · ${spy.turnCost} turns`,
+    });
+  }
+  if (siege) {
+    const reason = wholePanelDisabledReason ?? siege.disabledReason;
+    buttons.push({
+      key: "siege",
+      label: `Siege +${siege.turnCost}T`,
+      onClick: reason ? undefined : siege.onClick,
+      disabled: reason !== null,
+      title: reason ?? `Soften standing defense · ${siege.turnCost} turns`,
+    });
+  }
+  if (flyover) {
+    const reason = wholePanelDisabledReason ?? flyover.disabledReason;
+    buttons.push({
+      key: "flyover",
+      label: `Flyover (${flyover.airUnits}a) +${flyover.turnCost}T`,
+      onClick: reason ? undefined : flyover.onClick,
+      disabled: reason !== null,
+      title:
+        reason ??
+        `Send ${flyover.airUnits} air to attrit defenders · 2× attacker losses · ${flyover.turnCost} turn`,
+    });
+  }
+  if (castSpell) {
+    const reason = wholePanelDisabledReason ?? castSpell.disabledReason;
+    buttons.push({
+      key: "cast",
+      label: `Cast +${castSpell.turnCost}T ${castOpen ? "▾" : "▸"}`,
+      onClick: reason ? undefined : () => setCastOpen((o) => !o),
+      disabled: reason !== null,
+      title:
+        reason ??
+        `Pick a siege/disarm/attrition spell · ${castSpell.turnCost} turns`,
+    });
+  }
+  if (buttons.length === 0) {
+    return (
+      <div className="flex flex-wrap gap-2 pt-1">
+        {[
+          { label: "Spy +5T", note: "Not wired" },
+          { label: "Siege +5T", note: "Not wired" },
+          { label: "Flyover ▸", note: "Not wired" },
+          { label: "Cast ▸", note: "Not wired" },
+        ].map((b) => (
+          <button
+            key={b.label}
+            type="button"
+            disabled
+            title={b.note}
+            className="px-3 py-1 text-[11px] rounded border border-neutral-200 dark:border-neutral-800 text-neutral-400 dark:text-neutral-600 bg-neutral-50 dark:bg-neutral-900/40 cursor-not-allowed"
+          >
+            {b.label}
+          </button>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2 pt-1">
+        {buttons.map((b) => (
+          <button
+            key={b.key}
+            type="button"
+            onClick={b.onClick}
+            disabled={b.disabled}
+            title={b.title}
+            className={`px-3 py-1 text-[11px] rounded border transition-colors ${
+              b.disabled
+                ? "border-neutral-200 dark:border-neutral-800 text-neutral-400 dark:text-neutral-600 bg-neutral-50 dark:bg-neutral-900/40 cursor-not-allowed"
+                : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-700 dark:text-neutral-300"
+            }`}
+          >
+            {b.label}
+          </button>
+        ))}
+      </div>
+      {castOpen && castSpell && (
+        <CastSpellPicker
+          castSpell={castSpell}
+          wholePanelDisabledReason={wholePanelDisabledReason}
+          onAfterCast={() => setCastOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function CastSpellPicker({
+  castSpell,
+  wholePanelDisabledReason,
+  onAfterCast,
+}: {
+  castSpell: NonNullable<BattleSimPanelProps["castSpell"]>;
+  wholePanelDisabledReason: string | null;
+  onAfterCast: () => void;
+}) {
+  function fmtMagnitude(spell: SpellDefinition, expected: number): string {
+    if (spell.type === "siege") {
+      return `~−${(expected * 100).toFixed(0)}% standing floor`;
+    }
+    if (spell.type === "disarm") {
+      return `~${(Math.min(1, expected) * 100).toFixed(0)}% disarm`;
+    }
+    if (spell.type === "attrition") {
+      return `~${Math.round(expected)} enemies lost`;
+    }
+    return "";
+  }
+  return (
+    <div className="rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
+      <div className="px-3 py-1.5 border-b border-neutral-200 dark:border-neutral-800 text-[10px] uppercase tracking-wide text-neutral-500">
+        Choose spell · {castSpell.turnCost} turns each · dice 0.5–1.5×
+      </div>
+      <ul className="divide-y divide-neutral-100 dark:divide-neutral-900">
+        {castSpell.spells.map((entry) => {
+          const reason = wholePanelDisabledReason ?? entry.disabledReason;
+          const blocked = reason !== null;
+          const labelKind =
+            entry.spell.type === "siege"
+              ? "🏰 Siege"
+              : entry.spell.type === "disarm"
+                ? "✨ Disarm"
+                : "☠ Attrition";
+          return (
+            <li key={entry.spell.id}>
+              <button
+                type="button"
+                disabled={blocked}
+                title={reason ?? "Cast this spell on the target"}
+                onClick={() => {
+                  if (blocked) return;
+                  castSpell.onCast(entry.spell.id);
+                  onAfterCast();
+                }}
+                className={`w-full flex items-center justify-between gap-3 px-3 py-2 text-left text-[11px] transition-colors ${
+                  blocked
+                    ? "text-neutral-400 dark:text-neutral-600 cursor-not-allowed"
+                    : "hover:bg-neutral-100 dark:hover:bg-neutral-900"
+                }`}
+              >
+                <span className="flex items-baseline gap-2 min-w-0">
+                  <span className="font-medium shrink-0">{labelKind}</span>
+                  <span className="truncate">· {entry.spell.name}</span>
+                </span>
+                <span className="font-mono text-neutral-500 shrink-0">
+                  {fmtMagnitude(entry.spell, entry.expectedMagnitude)}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -8,6 +8,7 @@
 
 import { useMemo, useState } from "react";
 import { ARTIFACTS_BY_ID, getSpellsForCasteAndType } from "@/lib/game/content";
+import { realizedSpellMagnitude } from "@/lib/game/combat";
 import type {
   CombatResult,
   GameArtifact,
@@ -20,7 +21,9 @@ import type {
   UnitType,
 } from "@/lib/game/types";
 import type { ThreatEntry } from "../_lib/threats-derive";
+import { useAttackPreview } from "../_lib/use-attack-preview";
 import { BattleReport } from "./BattleReport";
+import { BattleSimPanel } from "./BattleSimPanel";
 
 const UNIT_TYPES: UnitType[] = ["ground", "siege", "air"];
 const LAND_TYPES: { type: LandType; label: string }[] = [
@@ -35,6 +38,10 @@ export interface ThreatRowProps {
   player: GamePlayer;
   artifacts: ReadonlyArray<GameArtifact>;
   busy: boolean;
+  // Count of the player's magic-land tiles. Drives the magic multiplier
+  // in the spell-cast picker's expected-magnitude readout. Passed from
+  // the page so the row doesn't need the full tile list.
+  myMagicLandCount: number;
   onAttack: (args: {
     sourceTileId: string;
     targetTileId: string;
@@ -68,6 +75,33 @@ export interface ThreatRowProps {
     tileId: string,
     type: LandType
   ) => Promise<{ reportSummary: string } | null>;
+  onSiege: (
+    sourceTileId: string,
+    targetTileId: string
+  ) => Promise<{
+    reportSummary: string;
+    siegeTotalMagnitude: number;
+  } | null>;
+  onFlyover: (
+    sourceTileId: string,
+    targetTileId: string,
+    units: { ground: number; siege: number; air: number }
+  ) => Promise<{
+    reportSummary: string;
+    combat: CombatResult | null;
+    report: TurnReport | null;
+    targetTile: GameTile | null;
+  } | null>;
+  onCastSpell: (
+    spellId: string,
+    sourceTileId: string,
+    targetTileId: string
+  ) => Promise<{
+    reportSummary: string;
+    siege?: { magnitudeApplied: number; totalMagnitudeAfter: number };
+    disarm?: { fractionApplied: number };
+    attrition?: { unitsKilled: { ground: number; siege: number; air: number } };
+  } | null>;
 }
 
 /**
@@ -80,7 +114,7 @@ export interface ThreatRowProps {
  * that will 4xx out — the row tells them up-front why it's not allowed.
  */
 export function ThreatRow(props: ThreatRowProps) {
-  const { entry, player, artifacts, busy } = props;
+  const { entry, player, artifacts, busy, myMagicLandCount } = props;
   const [expanded, setExpanded] = useState(false);
   const [sourceTileId, setSourceTileId] = useState(entry.bestSource.tileId);
   const [ground, setGround] = useState(0);
@@ -111,6 +145,27 @@ export function ThreatRow(props: ThreatRowProps) {
     () => (myCaste ? getSpellsForCasteAndType(myCaste, "defense") : []),
     [myCaste]
   );
+  const siegeSpell = useMemo<SpellDefinition | null>(
+    () =>
+      myCaste
+        ? getSpellsForCasteAndType(myCaste, "siege")[0] ?? null
+        : null,
+    [myCaste]
+  );
+  const disarmSpell = useMemo<SpellDefinition | null>(
+    () =>
+      myCaste
+        ? getSpellsForCasteAndType(myCaste, "disarm")[0] ?? null
+        : null,
+    [myCaste]
+  );
+  const attritionSpell = useMemo<SpellDefinition | null>(
+    () =>
+      myCaste
+        ? getSpellsForCasteAndType(myCaste, "attrition")[0] ?? null
+        : null,
+    [myCaste]
+  );
   const intelSpell = useMemo<SpellDefinition | null>(
     () =>
       myCaste
@@ -137,6 +192,25 @@ export function ThreatRow(props: ThreatRowProps) {
     if (player.phase !== "play") return "Not in play phase";
     return null;
   })();
+
+  // Battle simulation preview — fires for every (source, units, spell) tweak
+  // unless the matchup is structurally impossible (shielded enemy, wrong
+  // phase). Insufficient turns / cap overflow don't gate the preview, since
+  // the player can recover by adjusting before they actually swing.
+  const previewDisabled =
+    enemyShielded || player.phase !== "play";
+  // Bumped on every successful pre-action (spy / siege / flyover) so the
+  // preview refetches even when the form fields haven't changed — those
+  // actions mutate server-side intel-effects that the projection reads.
+  const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
+  const attackPreview = useAttackPreview({
+    sourceTileId: source.tileId,
+    targetTileId: entry.enemyTile.tileId,
+    units: { ground, siege, air },
+    offenseSpellId: offenseSpellId || null,
+    disabled: previewDisabled,
+    refreshKey: previewRefreshKey,
+  });
 
   async function handleAttack() {
     setToast(null);
@@ -177,6 +251,9 @@ export function ThreatRow(props: ThreatRowProps) {
     if (res?.intelReport) {
       setIntelReport(res.intelReport as IntelReport);
       setToast(`Intel captured · detected: ${res.detected ? "yes" : "no"}`);
+      // Forge Sight (Red caste) creates a forge-sight-offense effect that
+      // tightens the projection; bump so the panel re-fetches.
+      setPreviewRefreshKey((k) => k + 1);
     }
   }
 
@@ -209,6 +286,55 @@ export function ThreatRow(props: ThreatRowProps) {
     setToast(null);
     const res = await props.onDistributeTile(source.tileId, type);
     if (res) setToast(res.reportSummary || `Tile set to ${type}`);
+  }
+
+  async function handleSiegeFromPanel() {
+    setToast(null);
+    const res = await props.onSiege(source.tileId, entry.enemyTile.tileId);
+    if (res) {
+      setToast(
+        `${res.reportSummary} · total siege −${(
+          res.siegeTotalMagnitude * 100
+        ).toFixed(0)}%`
+      );
+      setPreviewRefreshKey((k) => k + 1);
+    }
+  }
+
+  async function handleCastSpellFromPanel(spellId: string) {
+    setToast(null);
+    const res = await props.onCastSpell(
+      spellId,
+      source.tileId,
+      entry.enemyTile.tileId
+    );
+    if (res) {
+      setToast(res.reportSummary || "Spell cast");
+      setPreviewRefreshKey((k) => k + 1);
+    }
+  }
+
+  async function handleFlyoverFromPanel() {
+    setToast(null);
+    setBattle(null);
+    const res = await props.onFlyover(source.tileId, entry.enemyTile.tileId, {
+      ground: 0,
+      siege: 0,
+      air,
+    });
+    if (res) {
+      if (res.combat && res.report && res.targetTile) {
+        setBattle({
+          combat: res.combat,
+          report: res.report,
+          targetTile: res.targetTile,
+        });
+      } else {
+        setToast(res.reportSummary || "Flyover");
+      }
+      setAir(0);
+      setPreviewRefreshKey((k) => k + 1);
+    }
   }
 
   const enemyName = entry.enemyOwner?.displayName ?? entry.enemyTile.ownerId?.slice(0, 6) ?? "??";
@@ -375,6 +501,104 @@ export function ThreatRow(props: ThreatRowProps) {
           Attack disabled: {attackDisabledReason}.
         </div>
       )}
+
+      {/* ─── Battle simulation panel (live projection) ───────────────────── */}
+      <div className="mx-4">
+        <BattleSimPanel
+          preview={attackPreview.preview}
+          loading={attackPreview.loading}
+          error={attackPreview.error}
+          disabled={previewDisabled}
+          disabledReason={
+            previewDisabled
+              ? enemyShielded
+                ? "Enemy is shielded — no preview while shielded."
+                : "Not in play phase — preview unavailable."
+              : undefined
+          }
+          busy={busy}
+          spy={
+            intelSpell
+              ? {
+                  onClick: () => void handleCastIntel(),
+                  turnCost: intelSpell.turnCost,
+                  disabledReason:
+                    player.turnsRemaining < intelSpell.turnCost
+                      ? `Need ${intelSpell.turnCost} turns (you have ${player.turnsRemaining})`
+                      : null,
+                }
+              : undefined
+          }
+          siege={{
+            onClick: () => void handleSiegeFromPanel(),
+            turnCost: 5,
+            disabledReason:
+              player.turnsRemaining < 5
+                ? `Need 5 turns (you have ${player.turnsRemaining})`
+                : null,
+          }}
+          flyover={{
+            onClick: () => void handleFlyoverFromPanel(),
+            turnCost: 1,
+            airUnits: air,
+            disabledReason: (() => {
+              if (air <= 0) return "Set air units in the form first";
+              if (air > source.units.air)
+                return `Source has only ${source.units.air} air`;
+              if (player.turnsRemaining < 1)
+                return `Need 1 turn (you have ${player.turnsRemaining})`;
+              return null;
+            })(),
+          }}
+          castSpell={(() => {
+            // Build the picker entries for the player's caste-specific
+            // tier-1 spells of the new kinds. Expected magnitude uses
+            // dice=1.0 (midpoint of [0.5, 1.5]) so the player sees the
+            // average outcome before the actual roll.
+            const ownedMagic = myMagicLandCount;
+            const turnCost = 5;
+            const baseDisabled =
+              player.turnsRemaining < turnCost
+                ? `Need ${turnCost} turns (you have ${player.turnsRemaining})`
+                : null;
+            const candidates: SpellDefinition[] = [
+              siegeSpell,
+              disarmSpell,
+              attritionSpell,
+            ].filter((s): s is SpellDefinition => s !== null);
+            return {
+              spells: candidates.map((s) => {
+                const expected = realizedSpellMagnitude({
+                  baseStrength: s.baseStrength,
+                  caste: s.caste,
+                  spellType: s.type,
+                  magicLandCount: ownedMagic,
+                  activeUpgrades: player.activeUpgrades ?? {},
+                  dice: 1.0,
+                });
+                let entryDisabled = baseDisabled;
+                if (
+                  !entryDisabled &&
+                  player.stats.tilesHeld < s.minTilesRequired
+                ) {
+                  entryDisabled = `Need ${s.minTilesRequired} tiles held (you have ${player.stats.tilesHeld})`;
+                }
+                return {
+                  spell: s,
+                  expectedMagnitude: expected,
+                  disabledReason: entryDisabled,
+                };
+              }),
+              onCast: (spellId) => void handleCastSpellFromPanel(spellId),
+              turnCost,
+              disabledReason:
+                candidates.length === 0
+                  ? "No castable spells for your caste"
+                  : baseDisabled,
+            };
+          })()}
+        />
+      </div>
 
       {/* ─── Battle report (full structured readout after an attack) ─────── */}
       {battle && (

--- a/app/game/threats/_lib/use-attack-preview.ts
+++ b/app/game/threats/_lib/use-attack-preview.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { Caste, CombatResult, GameTile } from "@/lib/game/types";
+
+export interface AttackPreviewEffects {
+  forgeSightOffenseBonus: number;
+  alertVsCasterDefenseBonus: number;
+  siegeDebuffMagnitude: number;
+  preCastOffenseBonus: number;
+  defenseDisarmFraction: number;
+}
+
+export interface AttackPreview {
+  combat: CombatResult;
+  source: GameTile;
+  target: GameTile;
+  defender: {
+    userId: string;
+    displayName: string;
+    caste: Caste | null;
+    shielded: boolean;
+  };
+  effects: AttackPreviewEffects;
+}
+
+interface PreviewArgs {
+  sourceTileId: string;
+  targetTileId: string;
+  units: { ground: number; siege: number; air: number };
+  offenseSpellId: string | null;
+  // When true, the hook skips the fetch entirely (e.g. attack is gated for
+  // a non-recoverable reason like the enemy being shielded). Returns the
+  // last good preview or null.
+  disabled?: boolean;
+  // Bump this key any time a side-effect could have changed server state
+  // that the preview reads (siege landed, spell cast, intel-effect
+  // expired). The hook will re-fetch whenever this value changes, even
+  // when the form-state primitives haven't.
+  refreshKey?: number;
+}
+
+interface PreviewState {
+  preview: AttackPreview | null;
+  loading: boolean;
+  error: string | null;
+}
+
+// Debounce window before we fire the preview fetch. Picked to feel snappy
+// while letting users finish dragging a slider before incurring the
+// roundtrip.
+const DEBOUNCE_MS = 250;
+
+/**
+ * Owns the `/api/game/attack/preview` lifecycle for a single ThreatRow.
+ * Debounces form-state changes and cancels in-flight requests so a fast
+ * scrubber doesn't render an out-of-order projection.
+ */
+export function useAttackPreview(args: PreviewArgs): PreviewState {
+  const { user, loading: authLoading } = useAuth();
+  const [state, setState] = useState<PreviewState>({
+    preview: null,
+    loading: false,
+    error: null,
+  });
+
+  // Request counter so a slower in-flight preview can't overwrite a newer
+  // one when both resolve out of order (a fast scrubber on the units
+  // sliders is the realistic stress case).
+  const reqIdRef = useRef(0);
+
+  // Compute "should we fetch" outside the effect so the effect body itself
+  // is purely a fetch+cleanup loop with no early-return setState calls
+  // (which the react-hooks/set-state-in-effect rule rightly flags).
+  const totalUnits = args.units.ground + args.units.siege + args.units.air;
+  const shouldFetch =
+    !authLoading &&
+    !!user &&
+    !args.disabled &&
+    totalUnits > 0 &&
+    !!args.sourceTileId &&
+    !!args.targetTileId;
+
+  useEffect(() => {
+    if (!shouldFetch) return;
+
+    const myReqId = ++reqIdRef.current;
+    let cancelled = false;
+    const timeout = setTimeout(async () => {
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/game/attack/preview", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            sourceTileId: args.sourceTileId,
+            targetTileId: args.targetTileId,
+            units: args.units,
+            ...(args.offenseSpellId
+              ? { offenseSpellId: args.offenseSpellId }
+              : {}),
+          }),
+        });
+        const data = (await res.json()) as
+          | (AttackPreview & { success: true })
+          | { success: false; error: string };
+        // Stale-result guard: if a newer request fired while we waited,
+        // discard this response.
+        if (cancelled || myReqId !== reqIdRef.current) return;
+        if (!data.success) {
+          setState({ preview: null, loading: false, error: data.error });
+          return;
+        }
+        setState({
+          preview: {
+            combat: data.combat,
+            source: data.source,
+            target: data.target,
+            defender: data.defender,
+            effects: data.effects,
+          },
+          loading: false,
+          error: null,
+        });
+      } catch (e) {
+        if (cancelled || myReqId !== reqIdRef.current) return;
+        setState({
+          preview: null,
+          loading: false,
+          error: e instanceof Error ? e.message : "Preview failed",
+        });
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+    };
+    // We deliberately depend on the *primitive* fields rather than the
+    // `args` object identity so a parent re-render with the same form
+    // values doesn't re-fire the preview. eslint-react-hooks can't see
+    // through the destructured primitive deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    shouldFetch,
+    args.sourceTileId,
+    args.targetTileId,
+    args.units.ground,
+    args.units.siege,
+    args.units.air,
+    args.offenseSpellId,
+    args.refreshKey,
+  ]);
+
+  // Separate effect: when fetching is gated off (zero units, disabled, no
+  // user), drop any in-flight loading state so the panel doesn't sit
+  // forever on "Computing projection…". The no-op short-circuit
+  // (`prev.loading ? new : prev`) returns the same prev when not loading,
+  // so React skips the update — no cascade. eslint-react-hooks can't see
+  // through the short-circuit.
+  useEffect(() => {
+    if (shouldFetch) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- no-op short-circuit on prev.loading prevents the cascade the rule warns about
+    setState((prev) => (prev.loading ? { ...prev, loading: false } : prev));
+  }, [shouldFetch]);
+
+  return state;
+}

--- a/app/game/threats/page.tsx
+++ b/app/game/threats/page.tsx
@@ -40,7 +40,17 @@ export default function ThreatsPage() {
     handleRecruit,
     handleArmDefenseSpell,
     handleDistributeTile,
+    handleSiege,
+    handleFlyover,
+    handleCastSpell,
   } = data;
+
+  // Player's magic-land count drives spell-cast magnitudes via
+  // magicMultiplier. Computed once here and passed down to ThreatRow.
+  const myMagicLandCount = useMemo(
+    () => tiles.filter((t) => t.type === "magic").length,
+    [tiles]
+  );
 
   const [hideShielded, setHideShielded] = useState(true);
   const [hideOverwhelming, setHideOverwhelming] = useState(false);
@@ -178,6 +188,10 @@ export default function ThreatsPage() {
               onRecruit={withBusy(handleRecruit)}
               onArmDefenseSpell={withBusy(handleArmDefenseSpell)}
               onDistributeTile={withBusy(handleDistributeTile)}
+              onSiege={withBusy(handleSiege)}
+              onFlyover={withBusy(handleFlyover)}
+              onCastSpell={withBusy(handleCastSpell)}
+              myMagicLandCount={myMagicLandCount}
             />
           ))}
         </div>

--- a/app/summer-cohort/_components/CohortTabs.tsx
+++ b/app/summer-cohort/_components/CohortTabs.tsx
@@ -9,6 +9,8 @@
 export type CohortTabId =
   | "info"
   | "intake-survey"
+  | "setup"
+  | "game"
   | "week-1"
   | "week-2"
   | "week-3"
@@ -27,6 +29,8 @@ const ALL_TABS: readonly TabSpec[] = [
   { id: "info", label: "Cohort Info", shortLabel: "Cohort" },
   { id: "intake-survey", label: "Intake Survey", shortLabel: "Survey" },
   { id: "my-info", label: "My Info", shortLabel: "Me" },
+  { id: "setup", label: "Setup Instructions", shortLabel: "Setup" },
+  { id: "game", label: "Game", shortLabel: "Game" },
   { id: "week-1", label: "Week 1: PM", shortLabel: "W1" },
   { id: "week-2", label: "Week 2: Comms", shortLabel: "W2" },
   { id: "week-3", label: "Week 3: Vibe Marketing", shortLabel: "W3" },

--- a/app/summer-cohort/_components/GamePromoPanel.tsx
+++ b/app/summer-cohort/_components/GamePromoPanel.tsx
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowRight,
+  ExternalLink,
+  GitPullRequest,
+  Lightbulb,
+  Swords,
+} from "lucide-react";
+
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+export function GamePromoPanel() {
+  return (
+    <section
+      role="tabpanel"
+      id="tabpanel-game"
+      aria-labelledby="tab-game"
+      className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-purple-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+          For fun (and PRs)
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-purple-500/10 px-2 py-0.5 text-xs font-semibold text-purple-700 dark:text-purple-400">
+          <Swords className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
+          /game
+        </span>
+      </div>
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        The Cursor Boston game
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        A persistent web game we built into this same repo. Recruit, run
+        threats, cast spells, climb the leaderboard. It&apos;s small and
+        opinionated on purpose — and it&apos;s the easiest place in the
+        codebase to ship something visible.
+      </p>
+
+      <Link
+        href="/game"
+        className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-purple-500 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-purple-400 sm:w-auto"
+      >
+        Open /game
+        <ArrowRight className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+      </Link>
+
+      <div className="mt-6 rounded-lg border-2 border-purple-300 bg-purple-50/50 p-5 dark:border-purple-800 dark:bg-purple-950/20">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-purple-700 dark:text-purple-400">
+          <Lightbulb className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          Help shape it
+        </div>
+        <h3 className="mt-2 text-base font-semibold text-neutral-900 dark:text-neutral-100">
+          Have an idea? Open a PR.
+        </h3>
+        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+          New spells, new threat types, balance tweaks, cleaner UI, a whole new
+          game mode — anything goes. The PR fast-lane that got most of you
+          admitted is still active, and contributions to <code>/game</code> are
+          exactly the kind of work we want to see.
+        </p>
+        <ul className="mt-3 space-y-2 text-sm text-neutral-700 dark:text-neutral-300">
+          <li className="flex gap-2">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              Game logic lives under <code>lib/game/</code>; UI is under{" "}
+              <code>app/game/</code>.
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              Pick something small for your first PR — a new spell or a tile
+              tweak ships in an afternoon.
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-neutral-400" aria-hidden="true">•</span>
+            <span>
+              Wild ideas welcome. Open an issue first if you want a sanity
+              check before you build.
+            </span>
+          </li>
+        </ul>
+
+        <a
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 inline-flex items-center gap-2 rounded-lg border border-purple-400 bg-white px-4 py-2.5 text-sm font-semibold text-purple-700 transition-colors hover:bg-purple-50 dark:border-purple-700 dark:bg-neutral-900 dark:text-purple-300 dark:hover:bg-purple-950/40"
+        >
+          <GitPullRequest className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+          Open the repo on GitHub
+          <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/app/summer-cohort/_components/SetupInstructionsPanel.tsx
+++ b/app/summer-cohort/_components/SetupInstructionsPanel.tsx
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { CheckCircle2, ExternalLink, Laptop, MessageCircle } from "lucide-react";
+
+const ALC_URL = "https://ludwitt.com/alc";
+
+export function SetupInstructionsPanel() {
+  return (
+    <section
+      role="tabpanel"
+      id="tabpanel-setup"
+      aria-labelledby="tab-setup"
+      className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
+          Before kickoff
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+          <Laptop className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
+          Local machine
+        </span>
+      </div>
+      <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        Get your machine ready
+      </h2>
+      <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+        You&apos;ll be writing and shipping code from your laptop starting Mon
+        May 11. Three things have to be installed and working:
+      </p>
+
+      <ul className="mt-5 space-y-3 text-sm text-neutral-800 dark:text-neutral-200">
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <CheckCircle2
+            className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-semibold">Node.js (LTS)</p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              The runtime everything else builds on. Install the LTS version.
+            </p>
+          </div>
+        </li>
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <CheckCircle2
+            className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-semibold">Git</p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              Install it and sign in with the GitHub account you connected on
+              the My Info tab — your PRs need to come from the same identity.
+            </p>
+          </div>
+        </li>
+        <li className="flex gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <CheckCircle2
+            className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-semibold">Cursor (or Claude Code)</p>
+            <p className="mt-0.5 text-neutral-600 dark:text-neutral-400">
+              Pick one. Cursor is recommended for cohort live work since the
+              walkthroughs assume it, but Claude Code is fully fine if you
+              already have a flow.
+            </p>
+          </div>
+        </li>
+      </ul>
+
+      <a
+        href={ALC_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-500 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 sm:w-auto"
+      >
+        Open the full setup walkthrough
+        <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+      </a>
+
+      <p className="mt-5 flex items-start gap-2 border-t border-neutral-200 pt-4 text-xs text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
+        <MessageCircle
+          className="mt-0.5 h-3.5 w-3.5 shrink-0"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        <span>
+          Hit a snag during install? Drop a question in the cohort Discord —
+          someone is almost certainly already past it.
+        </span>
+      </p>
+    </section>
+  );
+}

--- a/app/summer-cohort/_components/SetupReadinessModal.tsx
+++ b/app/summer-cohort/_components/SetupReadinessModal.tsx
@@ -1,0 +1,240 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  CircleAlert,
+  ExternalLink,
+  Laptop,
+  X,
+} from "lucide-react";
+
+const ALC_URL = "https://ludwitt.com/alc";
+
+interface SetupReadinessModalProps {
+  /** Discord is not connected — triggers the modal to pop. */
+  needsDiscord: boolean;
+  /** GitHub is not connected — triggers the modal to pop. */
+  needsGithub: boolean;
+  /** Intake survey not yet submitted — displayed only, never triggers pop. */
+  needsSurvey: boolean;
+  onConnectDiscord: () => void;
+  onConnectGithub: () => void;
+  /** Closes the modal and switches the page to the intake-survey tab. */
+  onGoToSurvey: () => void;
+}
+
+/**
+ * Sticky readiness modal for admitted Cohort 1 admits.
+ * Pops on every page load while Discord OR GitHub is missing.
+ * Closing only suppresses for the current page-load — no localStorage flag
+ * — so users keep being nudged until they connect both.
+ */
+export function SetupReadinessModal({
+  needsDiscord,
+  needsGithub,
+  needsSurvey,
+  onConnectDiscord,
+  onConnectGithub,
+  onGoToSurvey,
+}: SetupReadinessModalProps) {
+  const shouldOpen = needsDiscord || needsGithub;
+  const [isOpen, setIsOpen] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Open whenever the trigger condition becomes true. We only auto-open on
+  // the rising edge so that closing the modal doesn't immediately re-open it
+  // within the same page-load.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (shouldOpen && !wasOpenRef.current) {
+       
+      setIsOpen(true);
+      wasOpenRef.current = true;
+    }
+    if (!shouldOpen) {
+      wasOpenRef.current = false;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- hide modal once user has completed both connections
+      setIsOpen(false);
+    }
+  }, [shouldOpen]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      closeButtonRef.current?.focus();
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) handleClose();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, handleClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="setup-readiness-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full max-w-lg rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl md:p-8">
+        <button
+          ref={closeButtonRef}
+          onClick={handleClose}
+          className="absolute right-4 top-4 rounded-lg p-1 text-neutral-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          aria-label="Close readiness check"
+        >
+          <X className="h-5 w-5" strokeWidth={2.25} aria-hidden="true" />
+        </button>
+
+        <h2
+          id="setup-readiness-title"
+          className="pr-8 text-xl font-bold text-white md:text-2xl"
+        >
+          Cohort 1 kicks off Mon, May 11 — let&apos;s get you ready
+        </h2>
+        <p className="mt-2 text-sm text-neutral-400">
+          A few quick checks before kickoff. Knock these out now and you can
+          show up Monday focused on the work, not the setup.
+        </p>
+
+        <ul className="mt-5 space-y-2">
+          <StatusRow
+            label="Connect Discord"
+            done={!needsDiscord}
+            doneCopy="Connected — we'll add you to the cohort channel."
+            actionLabel="Connect Discord"
+            onAction={onConnectDiscord}
+          />
+          <StatusRow
+            label="Connect GitHub"
+            done={!needsGithub}
+            doneCopy="Connected — your PRs will count toward the cohort."
+            actionLabel="Connect GitHub"
+            onAction={onConnectGithub}
+          />
+          <StatusRow
+            label="Intake survey (~5 min)"
+            done={!needsSurvey}
+            doneCopy="Submitted. Thanks!"
+            actionLabel="Take the survey"
+            onAction={() => {
+              onGoToSurvey();
+              handleClose();
+            }}
+          />
+        </ul>
+
+        <div className="mt-5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-300">
+            <Laptop className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+            On your laptop
+          </div>
+          <p className="mt-1.5 text-sm text-neutral-200">
+            Install <strong>Node</strong>, <strong>Git</strong>, and{" "}
+            <strong>Cursor</strong> (or Claude Code) before Monday. The full
+            walkthrough is at <span className="font-mono">ludwitt.com/alc</span>.
+          </p>
+          <a
+            href={ALC_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+          >
+            Open the setup walkthrough
+            <ExternalLink className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+          </a>
+        </div>
+
+        <button
+          onClick={handleClose}
+          className="mt-5 w-full text-center text-sm text-neutral-500 transition-colors hover:text-neutral-300 focus-visible:text-white focus-visible:underline focus-visible:outline-none"
+        >
+          I&apos;ll come back to this
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface StatusRowProps {
+  label: string;
+  done: boolean;
+  doneCopy: string;
+  actionLabel: string;
+  onAction: () => void;
+}
+
+function StatusRow({
+  label,
+  done,
+  doneCopy,
+  actionLabel,
+  onAction,
+}: StatusRowProps) {
+  return (
+    <li
+      className={`flex items-center gap-3 rounded-lg border px-4 py-3 ${
+        done
+          ? "border-emerald-700/40 bg-emerald-500/5"
+          : "border-amber-700/60 bg-amber-500/10"
+      }`}
+    >
+      {done ? (
+        <CheckCircle2
+          className="h-5 w-5 shrink-0 text-emerald-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+      ) : (
+        <CircleAlert
+          className="h-5 w-5 shrink-0 text-amber-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-white">{label}</p>
+        <p className="mt-0.5 text-xs text-neutral-400">
+          {done ? doneCopy : "Not done yet."}
+        </p>
+      </div>
+      {!done ? (
+        <button
+          type="button"
+          onClick={onAction}
+          className="shrink-0 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-amber-950 transition-colors hover:bg-amber-400"
+        >
+          {actionLabel}
+        </button>
+      ) : null}
+    </li>
+  );
+}

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -34,8 +34,11 @@ import {
 import { ClaimSpotByPRCard } from "./_components/ClaimSpotByPRCard";
 import { CohortProgramBreakdown } from "./_components/CohortProgramBreakdown";
 import { CohortTabs, type CohortTabId } from "./_components/CohortTabs";
+import { GamePromoPanel } from "./_components/GamePromoPanel";
 import { InfoTabPanel } from "./_components/InfoTabPanel";
 import { IntakeSurveyForm } from "./_components/IntakeSurveyForm";
+import { SetupInstructionsPanel } from "./_components/SetupInstructionsPanel";
+import { SetupReadinessModal } from "./_components/SetupReadinessModal";
 import { Week4LudwittPanel } from "./_components/Week4LudwittPanel";
 import { Week5StartupPanel } from "./_components/Week5StartupPanel";
 import { Week6OssPanel } from "./_components/Week6OssPanel";
@@ -789,6 +792,16 @@ function SummerCohortPageInner() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      {showTabs ? (
+        <SetupReadinessModal
+          needsDiscord={!discord.discordInfo}
+          needsGithub={!github.githubInfo?.login}
+          needsSurvey={intakeStatus === "incomplete"}
+          onConnectDiscord={discord.connect}
+          onConnectGithub={github.connect}
+          onGoToSurvey={() => setActiveTab("intake-survey")}
+        />
+      ) : null}
       <header className="mb-8">
         <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
           <Sun className="h-3.5 w-3.5" strokeWidth={2.25} />
@@ -957,6 +970,10 @@ function SummerCohortPageInner() {
                     <Week5StartupPanel />
                   ) : activeTab === "week-6" ? (
                     <Week6OssPanel />
+                  ) : activeTab === "setup" ? (
+                    <SetupInstructionsPanel />
+                  ) : activeTab === "game" ? (
+                    <GamePromoPanel />
                   ) : null}
                 </div>
                 <CohortCodeOfConductFooter />

--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -40,6 +40,7 @@ const LandTypeEnum = z.enum([
 ]);
 const UnitTypeEnum = z.enum(["ground", "siege", "air"]);
 const AttackSideEnum = z.enum(["sent", "received", "all"]);
+const LeaderboardAudienceEnum = z.enum(["all", "npc", "real"]);
 
 const UnitStackSchema = z.object({
   ground: z.number().int().nonnegative(),
@@ -278,6 +279,49 @@ const AttackBody = z
   })
   .openapi("GameAttackBody");
 
+// Same shape as AttackBody — preview reuses the same input but never
+// deducts turns or writes state. Validation rules are softer: cap-overflow
+// and insufficient-units are reported in the response, not thrown.
+const AttackPreviewBody = AttackBody.openapi("GameAttackPreviewBody");
+
+const SiegeBody = z
+  .object({
+    sourceTileId: z.string().min(1),
+    targetTileId: z.string().min(1),
+  })
+  .openapi("GameSiegeBody");
+
+const FlyoverBody = z
+  .object({
+    sourceTileId: z.string().min(1),
+    targetTileId: z.string().min(1),
+    // Air units only. Server enforces ground/siege == 0; we keep the full
+    // UnitStack shape to share validation with the attack call site.
+    units: UnitStackSchema,
+  })
+  .openapi("GameFlyoverBody");
+
+const CastSpellBody = z
+  .object({
+    spellId: z.string().min(1),
+    sourceTileId: z.string().min(1),
+    targetTileId: z.string().min(1),
+  })
+  .openapi("GameCastSpellBody");
+
+// Aggregated active prep-effect summary surfaced to the sim panel. Mirrors
+// readAttackContextEffects' shape but with display-friendly fields. All
+// magnitudes are zero (and `count` zero) when no effects of that kind apply.
+const AttackPreviewEffectsSchema = z
+  .object({
+    forgeSightOffenseBonus: z.number(),
+    alertVsCasterDefenseBonus: z.number(),
+    siegeDebuffMagnitude: z.number(),
+    preCastOffenseBonus: z.number(),
+    defenseDisarmFraction: z.number(),
+  })
+  .openapi("GameAttackPreviewEffects");
+
 const BuildBody = z
   .object({
     tileId: z.string().min(1),
@@ -447,8 +491,10 @@ export const gameContract = c.router(
       path: "/api/game/leaderboard",
       summary: "Get the leaderboard ranked by tiles held",
       description:
-        "Returns players ranked by `stats.tilesHeld` descending. Cursor-paginated; default page size is 20 (max 100).",
-      query: PaginationQuerySchema,
+        "Returns players ranked by `stats.tilesHeld` descending. Cursor-paginated; default page size is 20 (max 100). `audience` filters to `npc`, `real`, or `all` (default).",
+      query: PaginationQuerySchema.extend({
+        audience: LeaderboardAudienceEnum.optional(),
+      }),
       responses: { 200: LeaderboardOk, ...baseErrorResponses },
       metadata: { errorCodes: ["UNAUTHORIZED", "SERVER_ERROR"] as const },
     },
@@ -739,6 +785,116 @@ export const gameContract = c.router(
           report: TurnReportSchema,
           combat: CombatResultSchema.optional(),
           intelReport: z.object({}).passthrough().optional(),
+        }),
+        ...actionErrorResponses,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "VALIDATION_ERROR", "SERVER_ERROR"] as const,
+      },
+    },
+    attackPreview: {
+      method: "POST",
+      path: "/api/game/attack/preview",
+      summary: "Project the outcome of a hypothetical attack",
+      description:
+        "Runs the same combat math as `/api/game/attack` but with a fixed midpoint RNG seed and no writes / turn deduction. The resulting CombatResult is the 'expected' outcome a player would see if they swung now with the supplied stack. Active prep effects (siege, pre-cast, disarm, forge-sight, alert) are also reflected.",
+      body: AttackPreviewBody,
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          combat: CombatResultSchema,
+          source: GameTileSchema,
+          target: GameTileSchema,
+          defender: z.object({
+            userId: z.string(),
+            displayName: z.string(),
+            caste: CasteEnum.nullable(),
+            shielded: z.boolean(),
+          }),
+          effects: AttackPreviewEffectsSchema,
+        }),
+        ...actionErrorResponses,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "VALIDATION_ERROR", "SERVER_ERROR"] as const,
+      },
+    },
+    siege: {
+      method: "POST",
+      path: "/api/game/siege",
+      summary: "Soften a target tile's standing-defense floor",
+      description:
+        "Costs 5 turns. Records a `siege-debuff` IntelEffect on the target with magnitude `SIEGE_ACTION_MAGNITUDE` (0.10) and a 5-attacker-turn TTL. Stacks across calls until SIEGE_DEBUFF_MAX_MAGNITUDE (0.30). Source must be owned and adjacent to target.",
+      body: SiegeBody,
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          player: GamePlayerSchema,
+          report: TurnReportSchema,
+          // Total siege debuff currently applied to the target after this
+          // siege (capped at SIEGE_DEBUFF_MAX_MAGNITUDE).
+          siegeTotalMagnitude: z.number(),
+        }),
+        ...actionErrorResponses,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "VALIDATION_ERROR", "SERVER_ERROR"] as const,
+      },
+    },
+    flyover: {
+      method: "POST",
+      path: "/api/game/flyover",
+      summary: "Air raid that attrits defenders without taking the tile",
+      description:
+        "Air-only attack with the capture branch disabled. Always resolves to 'repelled' or 'stalemate'; tile ownership never changes. Attacker losses are doubled (`2× resolveAttack` losses, clamped to deployed) — a deliberate suicide-mission trade. Costs `ATTACK_TURN_COST` (1 turn).",
+      body: FlyoverBody,
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          attackerPlayer: GamePlayerSchema,
+          sourceTile: GameTileSchema,
+          targetTile: GameTileSchema,
+          report: TurnReportSchema,
+          combat: CombatResultSchema,
+        }),
+        ...actionErrorResponses,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "VALIDATION_ERROR", "SERVER_ERROR"] as const,
+      },
+    },
+    castSpell: {
+      method: "POST",
+      path: "/api/game/spell/cast",
+      summary:
+        "Cast a standalone siege/disarm/attrition spell against a target tile",
+      description:
+        "Dispatches on the spell's `type`. Each kind rolls dice once (SPELL_RNG band 0.5–1.5) and either persists an IntelEffect (siege, disarm) or commits unit losses immediately (attrition). Validates ownership + adjacency + non-shield + caste-match + tier tile-min + turn budget.",
+      body: CastSpellBody,
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          player: GamePlayerSchema,
+          report: TurnReportSchema,
+          // Kind-specific outcome payload. All optional so each kind can
+          // populate the slice it cares about.
+          siege: z
+            .object({
+              magnitudeApplied: z.number(),
+              totalMagnitudeAfter: z.number(),
+            })
+            .optional(),
+          disarm: z
+            .object({
+              fractionApplied: z.number(),
+            })
+            .optional(),
+          attrition: z
+            .object({
+              unitsKilled: UnitStackSchema,
+              targetTile: GameTileSchema,
+            })
+            .optional(),
         }),
         ...actionErrorResponses,
       },

--- a/lib/game/combat.ts
+++ b/lib/game/combat.ts
@@ -26,6 +26,7 @@ import type {
   CombatTileInput,
   LandType,
   SpellTier,
+  SpellType,
   UnitStack,
   UnitType,
 } from "./types";
@@ -55,10 +56,169 @@ const LAND_TYPE_CAPACITY_DELTA: Record<LandType, number> = {
   magic: -100,
 };
 
+// Tile-type combat modifiers. Applied multiplicatively to attack/defense
+// power before RNG. See game design docs (May 2026): military tiles are
+// fortified, food tiles trade attack power for production, magic tiles
+// turn into bastions for spellcraft and resilience.
+//
+// Source-tile attack multiplier: applied to the attacker's *total* attack
+// power based on the launch tile's land type. A magic launch tile is
+// neutral on attack (×1) but receives a separate spell-power bonus.
+export const LAND_TYPE_ATTACK_MULT: Record<LandType, number> = {
+  unrevealed: 1,
+  unassigned: 1,
+  military: 1.20,
+  food: 0.75,
+  magic: 1.0,
+};
+
+// Defender-tile defense multiplier: applied to the defender's total
+// defense power based on the contested tile's land type. Military and
+// magic tiles fortify themselves; food tiles do not.
+export const LAND_TYPE_DEFENSE_MULT: Record<LandType, number> = {
+  unrevealed: 1,
+  unassigned: 1,
+  military: 1.25,
+  food: 1.0,
+  magic: 1.25,
+};
+
+// Standing defense floor: a fraction of the incoming attack power that is
+// added to defense even if the tile holds zero units. Lets military and
+// magic tiles "garrison themselves" — an empty military tile still
+// resists at 30% of attacker strength, an empty magic tile at 15%.
+export const STANDING_DEFENSE_FRACTION: Record<LandType, number> = {
+  unrevealed: 0,
+  unassigned: 0,
+  military: 0.30,
+  food: 0,
+  magic: 0.15,
+};
+
+// Magic-tile spell amplifier: spells cast from / armed on a magic tile
+// have their contribution multiplied by this factor. Stacks
+// multiplicatively on top of the existing magicMultiplier(magicLandCount).
+export const MAGIC_TILE_SPELL_MULT = 1.25;
+
 const UNDERDOG_SIZE_RATIO = 0.5;
 const UNDERDOG_DEFENSE_BONUS = 0.25;
 const RNG_LOWER = 0.9;
 const RNG_RANGE = 0.2;
+
+// Wider RNG band for pre-attack spell casts (siege-spell, disarm-spell,
+// attrition-spell). A weak roll fizzles meaningfully; a strong roll lands
+// solid effects. Midpoint = 1.0 (no scaling). Surfaced from this module so
+// the sim panel can reproduce the expected midpoint.
+export const SPELL_RNG_LOWER = 0.5;
+export const SPELL_RNG_RANGE = 1.0;
+export const SPELL_RNG_MIDPOINT = SPELL_RNG_LOWER + SPELL_RNG_RANGE / 2;
+
+// Rolls a spell-effectiveness factor in [SPELL_RNG_LOWER, SPELL_RNG_LOWER+
+// SPELL_RNG_RANGE]. Caller multiplies by baseStrength × magicMultiplier
+// × casteSpellTypeBonus to get realized magnitude.
+export function rollSpellEffectiveness(rng: () => number): number {
+  return SPELL_RNG_LOWER + rng() * SPELL_RNG_RANGE;
+}
+
+/**
+ * Realized magnitude for a standalone siege/disarm/attrition spell cast.
+ * Pure: baseStrength × magicMultiplier(magicLands, upgrades) ×
+ * casteSpellTypeBonus[spellType] × dice.
+ *
+ * Caller is responsible for any kind-specific clamping
+ * (SIEGE_DEBUFF_MAX_MAGNITUDE for siege, [0,1] for disarm, defender-unit
+ * count for attrition).
+ */
+export function realizedSpellMagnitude(args: {
+  baseStrength: number;
+  caste: Caste;
+  spellType: SpellType;
+  magicLandCount: number;
+  activeUpgrades?: Record<string, string>;
+  dice: number;
+}): number {
+  const profile = getCasteProfile(args.caste);
+  const casteBonus = profile.spellTypeBonuses[args.spellType] ?? 1;
+  const magicMult = magicMultiplier(args.magicLandCount, args.activeUpgrades);
+  return args.baseStrength * magicMult * casteBonus * args.dice;
+}
+
+/**
+ * Distribute a flat unit-kill count across a UnitStack proportional to its
+ * current composition. Sum of returned losses equals min(killCount, total).
+ * Used by attrition spells (and could be reused for similar AOE effects).
+ *
+ * Distribution method: per-type round-share with descending-remainder
+ * tiebreaks, so a single big stack absorbs the bulk of losses naturally.
+ */
+export function distributeUnitKills(
+  units: UnitStack,
+  killCount: number
+): UnitStack {
+  const total = units.ground + units.siege + units.air;
+  if (killCount <= 0 || total <= 0) {
+    return { ground: 0, siege: 0, air: 0 };
+  }
+  const cap = Math.min(killCount, total);
+  const raw: Record<UnitType, number> = {
+    ground: (units.ground / total) * cap,
+    siege: (units.siege / total) * cap,
+    air: (units.air / total) * cap,
+  };
+  const floored: Record<UnitType, number> = {
+    ground: Math.floor(raw.ground),
+    siege: Math.floor(raw.siege),
+    air: Math.floor(raw.air),
+  };
+  let assigned = floored.ground + floored.siege + floored.air;
+  // Distribute remainder by largest-fractional-part first; ties broken
+  // by larger absolute unit count (so the dominant type absorbs more).
+  const targetTotal = Math.floor(cap);
+  const order: UnitType[] = (["ground", "siege", "air"] as const)
+    .slice()
+    .sort((a, b) => {
+      const fa = raw[a] - floored[a];
+      const fb = raw[b] - floored[b];
+      if (fa !== fb) return fb - fa;
+      return units[b] - units[a];
+    });
+  let cursor = 0;
+  while (assigned < targetTotal && cursor < order.length * 4) {
+    const t = order[cursor % order.length];
+    if (floored[t] < units[t]) {
+      floored[t] += 1;
+      assigned += 1;
+    }
+    cursor += 1;
+  }
+  return floored;
+}
+
+// Flyover post-processing: cap "captured" outcomes (the tile never changes
+// hands during a raid) and double attacker losses (clamped to deployed —
+// can't lose more units than were sent). Pure transform on a CombatResult;
+// callers run resolveAttack first, then this. Lives in combat.ts so the
+// rules sit alongside the math they modify.
+export function applyFlyoverModifiers(combat: CombatResult): CombatResult {
+  const cappedOutcome: AttackOutcome =
+    combat.outcome === "captured" ? "repelled" : combat.outcome;
+  const doubledLosses: UnitStack = {
+    ground: Math.min(
+      combat.unitsDeployed.ground,
+      combat.attackerLosses.ground * 2
+    ),
+    siege: Math.min(
+      combat.unitsDeployed.siege,
+      combat.attackerLosses.siege * 2
+    ),
+    air: Math.min(combat.unitsDeployed.air, combat.attackerLosses.air * 2),
+  };
+  return {
+    ...combat,
+    outcome: cappedOutcome,
+    attackerLosses: doubledLosses,
+  };
+}
 
 // Supply: each friendly neighbor contributes 5% × type weight × caste mult,
 // then clamped between the isolation floor and the cap.
@@ -156,6 +316,12 @@ function clampStackToCapacity(
     air: Math.floor(stack.air * factor),
   };
   return { clamped, dropped: total - sumStack(clamped) };
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  if (n >= 1) return 1;
+  return n;
 }
 
 function applyLossFraction(units: UnitStack, fraction: number): UnitStack {
@@ -315,6 +481,14 @@ export function resolveAttack(
       defenderLosses: emptyStack(),
       underdogApplied: false,
       supplyMultiplier: 1,
+      sourceLandTypeMultiplier: 1,
+      targetLandTypeMultiplier: 1,
+      standingDefenseAdded: 0,
+      magicTileOffenseSpellBonusApplied: false,
+      magicTileDefenseSpellBonusApplied: false,
+      siegeDebuffApplied: 0,
+      defenseDisarmApplied: 0,
+      preCastOffenseApplied: 0,
       rng: { attackerRoll: 0, defenderRoll: 0 },
       appliedSpells,
     };
@@ -343,13 +517,22 @@ export function resolveAttack(
     defenderUpgrades
   );
 
-  attackPower += spellContribution(
+  // Offense spell contribution. If the source tile is a magic tile, scale
+  // the spell by MAGIC_TILE_SPELL_MULT — magic tiles are bastions for
+  // spellcraft. Stacks multiplicatively with magicMultiplier(magicLandCount).
+  const offenseSpellRaw = spellContribution(
     attacker.offenseSpellId,
     "offense",
     attacker.caste,
     attacker.magicLandCount,
     attackerUpgrades
   );
+  const magicOffenseBonusApplied =
+    offenseSpellRaw > 0 && attacker.sourceLandType === "magic";
+  attackPower +=
+    magicOffenseBonusApplied
+      ? offenseSpellRaw * MAGIC_TILE_SPELL_MULT
+      : offenseSpellRaw;
 
   // Red Forge Scouts: +5% offense when attacker air ≥ defender air.
   let forgeScoutsBonusApplied = false;
@@ -366,13 +549,42 @@ export function resolveAttack(
   if (attacker.intelOffenseBonus && attacker.intelOffenseBonus > 0) {
     attackPower *= 1 + attacker.intelOffenseBonus;
   }
-  defensePower += spellContribution(
+
+  // Source-tile attack multiplier (military ×1.20, food ×0.75). Applied
+  // after spell + intel offense bonuses so the multiplier scales the full
+  // realized attack value the way a player would expect ("my army is
+  // marching from a fortress" / "from a hayfield").
+  const sourceLandType = attacker.sourceLandType;
+  const sourceLandTypeMult =
+    sourceLandType !== undefined ? LAND_TYPE_ATTACK_MULT[sourceLandType] : 1;
+  attackPower *= sourceLandTypeMult;
+
+  // Pre-cast offense bonus (May 2026 sim feature). Added flat AFTER the
+  // source-tile mult — the spell was cast and rolled at its own moment from
+  // its own tile, so it shouldn't be re-amplified by THIS attack's source.
+  const preCastOffenseApplied = Math.max(0, attacker.preCastOffenseBonus ?? 0);
+  attackPower += preCastOffenseApplied;
+
+  // Defense spell contribution, with the same magic-tile amplifier as
+  // offense — armed on a magic tile, the warding doubles down. Then apply
+  // any active disarm (a fraction in [0,1] zeroes out the contribution
+  // proportionally; 1 fully nullifies).
+  const defenseSpellRawUnreduced = spellContribution(
     defender.armedDefenseSpellId,
     "defense",
     defender.caste,
     defender.magicLandCount,
     defenderUpgrades
   );
+  const disarmFraction = clamp01(defender.defenseDisarmFraction ?? 0);
+  const defenseDisarmApplied = defenseSpellRawUnreduced > 0 ? disarmFraction : 0;
+  const defenseSpellRaw = defenseSpellRawUnreduced * (1 - disarmFraction);
+  const magicDefenseBonusApplied =
+    defenseSpellRaw > 0 && tile.landType === "magic";
+  defensePower +=
+    magicDefenseBonusApplied
+      ? defenseSpellRaw * MAGIC_TILE_SPELL_MULT
+      : defenseSpellRaw;
 
   // Supply: scale defense by how cohesive the defender's territory is around
   // this tile. Skipped when callers don't supply neighbor info (legacy/tests).
@@ -396,6 +608,35 @@ export function resolveAttack(
     defensePower *= 1 + UNDERDOG_DEFENSE_BONUS;
     underdogApplied = true;
   }
+
+  // Defender-tile defense multiplier (military/magic ×1.25). Applied last
+  // among the multiplicative scalers so it stacks predictably on top of
+  // supply, intel alerts, and underdog.
+  const targetLandType = tile.landType;
+  const targetLandTypeMult =
+    targetLandType !== undefined ? LAND_TYPE_DEFENSE_MULT[targetLandType] : 1;
+  defensePower *= targetLandTypeMult;
+
+  // Standing defense floor: a land-type-dependent fraction of the
+  // (already-modified) attack power that adds to defense even when the
+  // tile holds no units. Lets military and magic tiles "garrison
+  // themselves." Computed AFTER the source-tile attack multiplier so the
+  // floor scales with the realized incoming threat.
+  //
+  // Pre-attack siege debuffs subtract from the fraction (clamped at 0).
+  // Caller is expected to clamp the cumulative siege magnitude to
+  // SIEGE_DEBUFF_MAX_MAGNITUDE before passing it in.
+  const baseStandingFraction =
+    targetLandType !== undefined
+      ? STANDING_DEFENSE_FRACTION[targetLandType]
+      : 0;
+  const siegeDebuffApplied = Math.max(0, tile.siegeDebuffMagnitude ?? 0);
+  const standingDefenseFraction = Math.max(
+    0,
+    baseStandingFraction - siegeDebuffApplied
+  );
+  const standingDefenseAdded = attackPower * standingDefenseFraction;
+  defensePower += standingDefenseAdded;
 
   const attackerRoll = RNG_LOWER + rng() * RNG_RANGE;
   const defenderRoll = RNG_LOWER + rng() * RNG_RANGE;
@@ -452,6 +693,14 @@ export function resolveAttack(
     defenderLosses,
     underdogApplied,
     supplyMultiplier: supplyMult,
+    sourceLandTypeMultiplier: sourceLandTypeMult,
+    targetLandTypeMultiplier: targetLandTypeMult,
+    standingDefenseAdded,
+    magicTileOffenseSpellBonusApplied: magicOffenseBonusApplied,
+    magicTileDefenseSpellBonusApplied: magicDefenseBonusApplied,
+    siegeDebuffApplied,
+    defenseDisarmApplied,
+    preCastOffenseApplied,
     rng: { attackerRoll, defenderRoll },
     appliedSpells,
     ...(airIntel ? { airIntel } : {}),

--- a/lib/game/content/castes.ts
+++ b/lib/game/content/castes.ts
@@ -14,40 +14,89 @@ import type { Caste, CasteProfile } from "../types";
 // lean concentrated (held-line / long-defense lore); Blue/Black are happy
 // spread out (patient tide / cost-paid-forward). Isolated tiles always get
 // the -15% floor regardless of caste.
+// May 2026 (sim feature): three new SpellType bonuses per caste —
+// siege / disarm / attrition. Each row sums to ~3.0 across the new types
+// to mirror the ~3.15 sum on offense/defense/production/intel. Per-caste
+// flavor:
+//   white  — purifier; light disarms wards, not built for siege/attrition
+//   blue   — sly raider; even attrition; modest disarm; little stomach for siege
+//   black  — pestilence; attrition is its bread and butter
+//   red    — fire breaks walls; siege is its specialty
+//   green  — patient growth; disarm via grove-magic; little raid potential
 export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
   white: {
     caste: "white",
     tileCapacityMultiplier: 1.0,
     unitTypeBonuses: { ground: 1.2, siege: 0.9, air: 1.0 },
-    spellTypeBonuses: { defense: 1.3, offense: 0.85, production: 1.0, intel: 1.0 },
+    spellTypeBonuses: {
+      defense: 1.3,
+      offense: 0.85,
+      production: 1.0,
+      intel: 1.0,
+      siege: 0.85,
+      disarm: 1.30,
+      attrition: 0.85,
+    },
     supplyMultiplier: 1.25,
   },
   blue: {
     caste: "blue",
     tileCapacityMultiplier: 0.9,
     unitTypeBonuses: { ground: 0.95, siege: 0.95, air: 1.2 },
-    spellTypeBonuses: { defense: 0.95, offense: 0.95, production: 1.3, intel: 1.2 },
+    spellTypeBonuses: {
+      defense: 0.95,
+      offense: 0.95,
+      production: 1.3,
+      intel: 1.2,
+      siege: 0.85,
+      disarm: 1.10,
+      attrition: 1.05,
+    },
     supplyMultiplier: 0.75,
   },
   black: {
     caste: "black",
     tileCapacityMultiplier: 1.0,
     unitTypeBonuses: { ground: 1.05, siege: 1.05, air: 1.05 },
-    spellTypeBonuses: { defense: 0.9, offense: 1.3, production: 0.9, intel: 1.0 },
+    spellTypeBonuses: {
+      defense: 0.9,
+      offense: 1.3,
+      production: 0.9,
+      intel: 1.0,
+      siege: 1.00,
+      disarm: 0.95,
+      attrition: 1.30,
+    },
     supplyMultiplier: 0.5,
   },
   red: {
     caste: "red",
     tileCapacityMultiplier: 1.0,
     unitTypeBonuses: { ground: 1.0, siege: 1.2, air: 1.0 },
-    spellTypeBonuses: { defense: 0.85, offense: 1.3, production: 0.95, intel: 0.9 },
+    spellTypeBonuses: {
+      defense: 0.85,
+      offense: 1.3,
+      production: 0.95,
+      intel: 0.9,
+      siege: 1.30,
+      disarm: 0.85,
+      attrition: 1.00,
+    },
     supplyMultiplier: 1.0,
   },
   green: {
     caste: "green",
     tileCapacityMultiplier: 1.2,
     unitTypeBonuses: { ground: 1.2, siege: 0.95, air: 0.95 },
-    spellTypeBonuses: { defense: 1.0, offense: 0.95, production: 1.1, intel: 1.3 },
+    spellTypeBonuses: {
+      defense: 1.0,
+      offense: 0.95,
+      production: 1.1,
+      intel: 1.3,
+      siege: 1.00,
+      disarm: 1.10,
+      attrition: 0.85,
+    },
     supplyMultiplier: 1.5,
   },
 };

--- a/lib/game/content/index.ts
+++ b/lib/game/content/index.ts
@@ -39,22 +39,37 @@ import { BLACK_DEFENSE_SPELLS } from "./spells/black/defense";
 import { BLACK_INTEL_SPELLS } from "./spells/black/intel";
 import { BLACK_OFFENSE_SPELLS } from "./spells/black/offense";
 import { BLACK_PRODUCTION_SPELLS } from "./spells/black/production";
+import { BLACK_SIEGE_SPELLS } from "./spells/black/siege";
+import { BLACK_DISARM_SPELLS } from "./spells/black/disarm";
+import { BLACK_ATTRITION_SPELLS } from "./spells/black/attrition";
 import { BLUE_DEFENSE_SPELLS } from "./spells/blue/defense";
 import { BLUE_INTEL_SPELLS } from "./spells/blue/intel";
 import { BLUE_OFFENSE_SPELLS } from "./spells/blue/offense";
 import { BLUE_PRODUCTION_SPELLS } from "./spells/blue/production";
+import { BLUE_SIEGE_SPELLS } from "./spells/blue/siege";
+import { BLUE_DISARM_SPELLS } from "./spells/blue/disarm";
+import { BLUE_ATTRITION_SPELLS } from "./spells/blue/attrition";
 import { GREEN_DEFENSE_SPELLS } from "./spells/green/defense";
 import { GREEN_INTEL_SPELLS } from "./spells/green/intel";
 import { GREEN_OFFENSE_SPELLS } from "./spells/green/offense";
 import { GREEN_PRODUCTION_SPELLS } from "./spells/green/production";
+import { GREEN_SIEGE_SPELLS } from "./spells/green/siege";
+import { GREEN_DISARM_SPELLS } from "./spells/green/disarm";
+import { GREEN_ATTRITION_SPELLS } from "./spells/green/attrition";
 import { RED_DEFENSE_SPELLS } from "./spells/red/defense";
 import { RED_INTEL_SPELLS } from "./spells/red/intel";
 import { RED_OFFENSE_SPELLS } from "./spells/red/offense";
 import { RED_PRODUCTION_SPELLS } from "./spells/red/production";
+import { RED_SIEGE_SPELLS } from "./spells/red/siege";
+import { RED_DISARM_SPELLS } from "./spells/red/disarm";
+import { RED_ATTRITION_SPELLS } from "./spells/red/attrition";
 import { WHITE_DEFENSE_SPELLS } from "./spells/white/defense";
 import { WHITE_INTEL_SPELLS } from "./spells/white/intel";
 import { WHITE_OFFENSE_SPELLS } from "./spells/white/offense";
 import { WHITE_PRODUCTION_SPELLS } from "./spells/white/production";
+import { WHITE_SIEGE_SPELLS } from "./spells/white/siege";
+import { WHITE_DISARM_SPELLS } from "./spells/white/disarm";
+import { WHITE_ATTRITION_SPELLS } from "./spells/white/attrition";
 
 import { BUILDINGS } from "./buildings";
 import { ALL_UPGRADES } from "./upgrades";
@@ -72,14 +87,19 @@ export const ALL_UNITS: UnitDefinition[] = [
 export const ALL_SPELLS: SpellDefinition[] = [
   ...WHITE_DEFENSE_SPELLS, ...WHITE_OFFENSE_SPELLS, ...WHITE_PRODUCTION_SPELLS,
   ...WHITE_INTEL_SPELLS,
+  ...WHITE_SIEGE_SPELLS, ...WHITE_DISARM_SPELLS, ...WHITE_ATTRITION_SPELLS,
   ...BLUE_DEFENSE_SPELLS, ...BLUE_OFFENSE_SPELLS, ...BLUE_PRODUCTION_SPELLS,
   ...BLUE_INTEL_SPELLS,
+  ...BLUE_SIEGE_SPELLS, ...BLUE_DISARM_SPELLS, ...BLUE_ATTRITION_SPELLS,
   ...BLACK_DEFENSE_SPELLS, ...BLACK_OFFENSE_SPELLS, ...BLACK_PRODUCTION_SPELLS,
   ...BLACK_INTEL_SPELLS,
+  ...BLACK_SIEGE_SPELLS, ...BLACK_DISARM_SPELLS, ...BLACK_ATTRITION_SPELLS,
   ...RED_DEFENSE_SPELLS, ...RED_OFFENSE_SPELLS, ...RED_PRODUCTION_SPELLS,
   ...RED_INTEL_SPELLS,
+  ...RED_SIEGE_SPELLS, ...RED_DISARM_SPELLS, ...RED_ATTRITION_SPELLS,
   ...GREEN_DEFENSE_SPELLS, ...GREEN_OFFENSE_SPELLS, ...GREEN_PRODUCTION_SPELLS,
   ...GREEN_INTEL_SPELLS,
+  ...GREEN_SIEGE_SPELLS, ...GREEN_DISARM_SPELLS, ...GREEN_ATTRITION_SPELLS,
 ];
 
 export const ALL_BUILDINGS: BuildingDefinition[] = BUILDINGS;

--- a/lib/game/content/spells/black/attrition.ts
+++ b/lib/game/content/spells/black/attrition.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Black's attrition bonus is 1.30 — pestilence is what Black does, and it
+// shows in the realized magnitude.
+export const BLACK_ATTRITION_SPELLS: SpellDefinition[] = [
+  {
+    id: "black-attrition-bone-fever",
+    caste: "black",
+    type: "attrition",
+    name: "Bone Fever",
+    description:
+      "A dry sickness moves through the garrison faster than orders can. By morning, the surgeon is the busiest officer on the wall.",
+    baseStrength: 30,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/black/disarm.ts
+++ b/lib/game/content/spells/black/disarm.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const BLACK_DISARM_SPELLS: SpellDefinition[] = [
+  {
+    id: "black-disarm-grave-bargain",
+    caste: "black",
+    type: "disarm",
+    name: "Grave Bargain",
+    description:
+      "Black offers each ward a deal it cannot refuse — and a price it didn't know it had been paying.",
+    baseStrength: 0.4,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/black/siege.ts
+++ b/lib/game/content/spells/black/siege.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const BLACK_SIEGE_SPELLS: SpellDefinition[] = [
+  {
+    id: "black-siege-rotgnaw",
+    caste: "black",
+    type: "siege",
+    name: "Rotgnaw",
+    description:
+      "The walls were always going to age. Black just gives them a reason to do it tonight.",
+    baseStrength: 0.05,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/blue/attrition.ts
+++ b/lib/game/content/spells/blue/attrition.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const BLUE_ATTRITION_SPELLS: SpellDefinition[] = [
+  {
+    id: "blue-attrition-cold-current",
+    caste: "blue",
+    type: "attrition",
+    name: "Cold Current",
+    description:
+      "An undertow finds the soldiers' boots. Drilled men keep their footing; the rest go where the river decides.",
+    baseStrength: 30,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/blue/disarm.ts
+++ b/lib/game/content/spells/blue/disarm.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const BLUE_DISARM_SPELLS: SpellDefinition[] = [
+  {
+    id: "blue-disarm-mistwhisper",
+    caste: "blue",
+    type: "disarm",
+    name: "Mistwhisper",
+    description:
+      "Fog rolls across the tile carrying a single instruction in a voice the wards already trust. Most listen.",
+    baseStrength: 0.4,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/blue/siege.ts
+++ b/lib/game/content/spells/blue/siege.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const BLUE_SIEGE_SPELLS: SpellDefinition[] = [
+  {
+    id: "blue-siege-tideworks",
+    caste: "blue",
+    type: "siege",
+    name: "Tideworks",
+    description:
+      "Salt water finds the cracks in the foundation and patiently widens them. Stones never invited it; stones can't ask it to leave.",
+    baseStrength: 0.05,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/green/attrition.ts
+++ b/lib/game/content/spells/green/attrition.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const GREEN_ATTRITION_SPELLS: SpellDefinition[] = [
+  {
+    id: "green-attrition-thornbloom",
+    caste: "green",
+    type: "attrition",
+    name: "Thornbloom",
+    description:
+      "Briars push up through the parade ground overnight. Soldiers know to step over them; horses don't.",
+    baseStrength: 30,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/green/disarm.ts
+++ b/lib/game/content/spells/green/disarm.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const GREEN_DISARM_SPELLS: SpellDefinition[] = [
+  {
+    id: "green-disarm-grovebind",
+    caste: "green",
+    type: "disarm",
+    name: "Grovebind",
+    description:
+      "Grove-magic notices the defender's wards are not from the grove. It politely shows them to the door.",
+    baseStrength: 0.4,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/green/siege.ts
+++ b/lib/game/content/spells/green/siege.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const GREEN_SIEGE_SPELLS: SpellDefinition[] = [
+  {
+    id: "green-siege-rootbreak",
+    caste: "green",
+    type: "siege",
+    name: "Rootbreak",
+    description:
+      "Roots from a tree the defenders cleared a generation ago remember where the wall was put. They come up to take a look.",
+    baseStrength: 0.05,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/red/attrition.ts
+++ b/lib/game/content/spells/red/attrition.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const RED_ATTRITION_SPELLS: SpellDefinition[] = [
+  {
+    id: "red-attrition-emberswarm",
+    caste: "red",
+    type: "attrition",
+    name: "Emberswarm",
+    description:
+      "A drift of orange motes settles on the tile and never quite goes out. The garrison spends the night putting itself out.",
+    baseStrength: 30,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/red/disarm.ts
+++ b/lib/game/content/spells/red/disarm.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+export const RED_DISARM_SPELLS: SpellDefinition[] = [
+  {
+    id: "red-disarm-cinderbreak",
+    caste: "red",
+    type: "disarm",
+    name: "Cinderbreak",
+    description:
+      "A blacksmith's hammer, swung in a small forge in the caster's mind, lands on the defender's brightest enchantment.",
+    baseStrength: 0.4,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/red/siege.ts
+++ b/lib/game/content/spells/red/siege.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Red's siege bonus is 1.30 — fire is what breaks walls, and Red owns it.
+export const RED_SIEGE_SPELLS: SpellDefinition[] = [
+  {
+    id: "red-siege-firebreath",
+    caste: "red",
+    type: "siege",
+    name: "Firebreath",
+    description:
+      "A long, low column of flame plays across the rampart until the mortar gives. The defenders will rebuild — but later.",
+    baseStrength: 0.05,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/white/attrition.ts
+++ b/lib/game/content/spells/white/attrition.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Attrition-spell baseStrength is the *count* of defender units killed at
+// midpoint dice (1.0). Realized magnitude = baseStrength × magicMultiplier
+// × casteSpellTypeBonus × dice; distributed across unit types proportional
+// to current composition. White's caste bonus is 0.85 — Order doesn't
+// poison wells.
+export const WHITE_ATTRITION_SPELLS: SpellDefinition[] = [
+  {
+    id: "white-attrition-decree-of-decimation",
+    caste: "white",
+    type: "attrition",
+    name: "Decree of Decimation",
+    description:
+      "A formal pronouncement, read aloud at the gates. By dawn, every tenth defender has laid down arms — or worse.",
+    baseStrength: 30,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/white/disarm.ts
+++ b/lib/game/content/spells/white/disarm.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Disarm-spell baseStrength is the *fraction* of the defender's armed
+// defense spell that gets nullified at midpoint dice (1.0). Realized
+// magnitude clamped to [0, 1]. White's caste bonus is 1.30 — purification
+// is a White specialty.
+export const WHITE_DISARM_SPELLS: SpellDefinition[] = [
+  {
+    id: "white-disarm-purification",
+    caste: "white",
+    type: "disarm",
+    name: "Purification",
+    description:
+      "A clean light passes through the tile. Wards drawn in haste come undone first; the careful ones, second.",
+    baseStrength: 0.4,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/content/spells/white/siege.ts
+++ b/lib/game/content/spells/white/siege.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { SpellDefinition } from "../../../types";
+
+// Siege-spell baseStrength is the *fraction* subtracted from the target
+// tile's standing-defense floor at midpoint dice (1.0). Realized magnitude
+// = baseStrength × magicMultiplier × casteSpellTypeBonus × dice. Caps at
+// SIEGE_DEBUFF_MAX_MAGNITUDE (0.30) per call. White's caste bonus is 0.85
+// — order is good at holding lines, less suited to breaking them.
+export const WHITE_SIEGE_SPELLS: SpellDefinition[] = [
+  {
+    id: "white-siege-judgement-light",
+    caste: "white",
+    type: "siege",
+    name: "Judgement Light",
+    description:
+      "A blade of sunlight rests on a section of wall and never moves. Stone gives up first.",
+    baseStrength: 0.05,
+    tier: 1,
+    minTilesRequired: 0,
+    turnCost: 5,
+  },
+];

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -8,24 +8,34 @@ import { randomUUID } from "node:crypto";
 import type { Firestore, Transaction } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import {
+  applyFlyoverModifiers,
   computeTileCapacity,
+  distributeUnitKills,
   makeSeededRng,
+  realizedSpellMagnitude,
   resolveAttack,
+  rollSpellEffectiveness,
 } from "./combat";
 import { ARTIFACTS_BY_ID, SPELLS_BY_ID } from "./content";
 import { rollArtifact } from "./artifacts";
 import { buildIntelReportServer } from "./intel";
 import {
+  deleteIntelEffectsInTx,
   readAttackContextEffects,
+  recordDefenseDisarmInTx,
   recordIntelEffectInTx,
+  recordSiegeDebuffInTx,
 } from "./intel-effects";
 import {
   buildArmDefenseReport,
   buildAttackReport,
   buildBuildReport,
+  buildCastSpellReport,
   buildDistributeReport,
   buildExploreReport,
+  buildFlyoverReport,
   buildProduceReport,
+  buildSiegeReport,
 } from "./turn-report";
 import { notifyConquest } from "./discord-game";
 import { logger } from "@/lib/logger";
@@ -53,21 +63,23 @@ import {
   validateApplyUpgrade,
   validateRemoveUpgrade,
 } from "./upgrades";
-import type {
-  ArtifactDefinition,
-  Caste,
-  CombatResult,
-  GameArtifact,
-  GameAttack,
-  GamePlayer,
-  GameTile,
-  IntelReport,
-  LandType,
-  MapTile,
-  TurnAction,
-  TurnReport,
-  UnitStack,
-  UnitType,
+import {
+  SIEGE_ACTION_MAGNITUDE,
+  SIEGE_DEBUFF_MAX_MAGNITUDE,
+  type ArtifactDefinition,
+  type Caste,
+  type CombatResult,
+  type GameArtifact,
+  type GameAttack,
+  type GamePlayer,
+  type GameTile,
+  type IntelReport,
+  type LandType,
+  type MapTile,
+  type TurnAction,
+  type TurnReport,
+  type UnitStack,
+  type UnitType,
 } from "./types";
 import {
   type AxialCoord,
@@ -90,7 +102,29 @@ import {
 export const ATTACK_TURN_COST = 1;
 export const SPELL_TURN_COST = 5;
 export const BUILD_UNITS_TURN_COST = 5;
+// Siege action: a deterministic infrastructure-degrading move. Costs 5
+// turns, applies SIEGE_ACTION_MAGNITUDE (0.10) to the target's
+// standing-defense floor, stacks up to SIEGE_DEBUFF_MAX_MAGNITUDE.
+export const SIEGE_TURN_COST = 5;
+// Recruit rate is per-land-type as of the May 2026 mechanics rework:
+// food/magic tiles now recruit at half the military rate, since training
+// soldiers is what military tiles are *for*. The gate that limited recruit
+// to military-only was removed at the same time.
+//
+// `BUILD_UNITS_PER_TURN` is kept exported as the military baseline so any
+// external consumer reading "the recruit rate" still sees a sensible value;
+// internal cycle math uses `unitsPerTurnForLand(landType)`.
 export const BUILD_UNITS_PER_TURN = 10;
+export const BUILD_UNITS_PER_TURN_BY_LAND: Record<LandType, number> = {
+  unrevealed: 0,
+  unassigned: 0,
+  military: 10,
+  food: 5,
+  magic: 5,
+};
+export function unitsPerTurnForLand(landType: LandType): number {
+  return BUILD_UNITS_PER_TURN_BY_LAND[landType] ?? 0;
+}
 // Far expedition: 2× the normal explore cost. Lands a tile adjacent to a
 // random enemy tile, marked isolatedSpawn so the supply system applies the
 // -15% defense floor until the player grows neighbors around it.
@@ -1159,8 +1193,10 @@ async function getOwnedLandCounts(
   return counts;
 }
 
-// Builds units of `unitType` on `tileId`. Tile must be military and owned by
-// player. Costs BUILD_UNITS_TURN_COST and produces BUILD_UNITS_PER_TURN units.
+// Builds units of `unitType` on `tileId`. Tile must be owned by the player
+// and be a recruitable land type (military, food, or magic). Costs
+// BUILD_UNITS_TURN_COST and produces unitsPerTurnForLand(tile.type) units —
+// military trains 10/turn, food/magic 5/turn (May 2026 mechanics rework).
 export async function buildUnitsServer(
   userId: string,
   tileId: string,
@@ -1191,7 +1227,10 @@ export async function buildUnitsServer(
     const tile = tileSnap.data() as GameTile;
 
     if (tile.ownerId !== userId) throw new GameTileNotOwnedError();
-    if (tile.type !== "military") {
+    const unitsThisCycle = unitsPerTurnForLand(tile.type);
+    if (unitsThisCycle <= 0) {
+      // unrevealed/unassigned tiles can't recruit. Reuse the existing
+      // tile-type error so clients see a familiar shape.
       throw new GameTileTypeError("military", tile.type);
     }
     if (player.phase !== "play") {
@@ -1205,7 +1244,7 @@ export async function buildUnitsServer(
     }
 
     const cap = effectiveUnitCap(player, counts.food, counts.magic);
-    if (player.stats.unitsAlive + BUILD_UNITS_PER_TURN > cap) {
+    if (player.stats.unitsAlive + unitsThisCycle > cap) {
       throw new GameUnitCapExceededError(cap, player.stats.unitsAlive);
     }
 
@@ -1220,14 +1259,14 @@ export async function buildUnitsServer(
     );
     const artifact = rolled?.definition ?? null;
 
-    const newUnits: UnitStack = { ...tile.units, [unitType]: tile.units[unitType] + BUILD_UNITS_PER_TURN };
+    const newUnits: UnitStack = { ...tile.units, [unitType]: tile.units[unitType] + unitsThisCycle };
     tx.update(tileRef, { units: newUnits, updatedAt: now });
     tx.update(playerRef, {
       turnsRemaining: player.turnsRemaining - BUILD_UNITS_TURN_COST,
       turnsSpentTotal,
       stats: {
         ...player.stats,
-        unitsAlive: player.stats.unitsAlive + BUILD_UNITS_PER_TURN,
+        unitsAlive: player.stats.unitsAlive + unitsThisCycle,
       },
       updatedAt: now,
     });
@@ -1237,7 +1276,7 @@ export async function buildUnitsServer(
       cost: BUILD_UNITS_TURN_COST,
       tileId,
       unitType,
-      unitsBuilt: BUILD_UNITS_PER_TURN,
+      unitsBuilt: unitsThisCycle,
       artifactFound: artifact,
       rng: makeNarrativeRng(userId, turnsSpentTotal, "build"),
     });
@@ -1249,12 +1288,12 @@ export async function buildUnitsServer(
         turnsSpentTotal,
         stats: {
           ...player.stats,
-          unitsAlive: player.stats.unitsAlive + BUILD_UNITS_PER_TURN,
+          unitsAlive: player.stats.unitsAlive + unitsThisCycle,
         },
         updatedAt: now,
       },
       tile: { ...tile, units: newUnits, updatedAt: now },
-      produced: BUILD_UNITS_PER_TURN,
+      produced: unitsThisCycle,
       report,
       artifact: rolled?.doc ?? null,
     };
@@ -1264,13 +1303,16 @@ export async function buildUnitsServer(
 export interface BulkBuildPlanEntry {
   tileId: string;
   unitType: UnitType;
-  cycles: number; // each cycle = BUILD_UNITS_TURN_COST turns + BUILD_UNITS_PER_TURN units
+  // Each cycle = BUILD_UNITS_TURN_COST turns + unitsPerTurnForLand(tile.type)
+  // units. Military tiles produce 10/cycle, food/magic 5/cycle.
+  cycles: number;
 }
 
-// Bulk build. Reads {player + 1 land-counts query + N military tile refs} once,
-// runs each plan entry's `cycles` build steps in memory (each step costs
-// BUILD_UNITS_TURN_COST turns and adds BUILD_UNITS_PER_TURN units), accumulates
-// artifact rolls + reports, and writes everything in one transaction.
+// Bulk build. Reads {player + 1 land-counts query + N tile refs} once, runs
+// each plan entry's `cycles` build steps in memory (each step costs
+// BUILD_UNITS_TURN_COST turns and adds unitsPerTurnForLand(tile.type) units),
+// accumulates artifact rolls + reports, and writes everything in one
+// transaction.
 //
 // Stops cleanly with stoppedEarly if a step would exceed the unit cap or
 // the player runs out of turns mid-batch — earlier-succeeded steps still commit.
@@ -1339,7 +1381,9 @@ export async function bulkBuildUnitsServer(
       if (!snap.exists) throw new GameTileNotFoundError();
       const tile = snap.data() as GameTile;
       if (tile.ownerId !== userId) throw new GameTileNotOwnedError();
-      if (tile.type !== "military") {
+      if (unitsPerTurnForLand(tile.type) <= 0) {
+        // unrevealed/unassigned can't recruit. Reuse the existing tile-type
+        // error shape for client compatibility.
         throw new GameTileTypeError("military", tile.type);
       }
       tilesById.set(id, tile);
@@ -1359,6 +1403,8 @@ export async function bulkBuildUnitsServer(
     outer: for (const entry of plan) {
       for (let c = 0; c < entry.cycles; c++) {
         const isFirst = stepIndex === 0;
+        const before = tilesById.get(entry.tileId)!;
+        const unitsThisCycle = unitsPerTurnForLand(before.type);
 
         if (turnsRemaining < BUILD_UNITS_TURN_COST) {
           if (isFirst) {
@@ -1370,7 +1416,7 @@ export async function bulkBuildUnitsServer(
           stoppedEarly = `out of turns at cycle ${stepIndex}`;
           break outer;
         }
-        if (unitsAlive + BUILD_UNITS_PER_TURN > cap) {
+        if (unitsAlive + unitsThisCycle > cap) {
           if (isFirst) {
             throw new GameUnitCapExceededError(cap, unitsAlive);
           }
@@ -1380,8 +1426,8 @@ export async function bulkBuildUnitsServer(
 
         turnsRemaining -= BUILD_UNITS_TURN_COST;
         turnsSpentTotal += BUILD_UNITS_TURN_COST;
-        unitsAlive += BUILD_UNITS_PER_TURN;
-        producedTotal += BUILD_UNITS_PER_TURN;
+        unitsAlive += unitsThisCycle;
+        producedTotal += unitsThisCycle;
 
         const rolled = rollAndStageArtifact(
           tx,
@@ -1394,13 +1440,12 @@ export async function bulkBuildUnitsServer(
         const artifact = rolled?.definition ?? null;
         if (rolled) artifacts.push(rolled.doc);
 
-        const before = tilesById.get(entry.tileId)!;
         const after: GameTile = {
           ...before,
           units: {
             ...before.units,
             [entry.unitType]:
-              before.units[entry.unitType] + BUILD_UNITS_PER_TURN,
+              before.units[entry.unitType] + unitsThisCycle,
           },
           updatedAt: now,
         };
@@ -1412,7 +1457,7 @@ export async function bulkBuildUnitsServer(
             cost: BUILD_UNITS_TURN_COST,
             tileId: entry.tileId,
             unitType: entry.unitType,
-            unitsBuilt: BUILD_UNITS_PER_TURN,
+            unitsBuilt: unitsThisCycle,
             artifactFound: artifact,
             rng: makeNarrativeRng(userId, turnsSpentTotal, "build"),
           })
@@ -2068,6 +2113,8 @@ export async function attackTileServer(args: {
         unitsAlive: attacker.stats.unitsAlive,
         activeUpgrades: attackerActiveUpgrades,
         intelOffenseBonus: intelContext.forgeSightOffenseBonus,
+        sourceLandType: source.type,
+        preCastOffenseBonus: intelContext.preCastOffenseBonus,
       },
       {
         caste: defender.caste,
@@ -2077,14 +2124,28 @@ export async function attackTileServer(args: {
         unitsAlive: defender.stats.unitsAlive,
         activeUpgrades: defenderActiveUpgrades,
         intelDefenseBonus: intelContext.alertVsCasterDefenseBonus,
+        defenseDisarmFraction: intelContext.defenseDisarmFraction,
       },
       {
         capacity: tileCapacity,
         upgradeIds: target.upgradeIds,
         friendlyNeighbors,
+        landType: target.type,
+        siegeDebuffMagnitude: intelContext.siegeDebuffMagnitude,
       },
       makeSeededRng(`attack-${attackId}`)
     );
+
+    // Consume single-use effects (pre-cast offense, defense disarm) that
+    // were folded into this resolution. Siege debuffs are TTL-only and
+    // remain in the collection until they expire.
+    if (intelContext.consumeEffectIds.length > 0) {
+      deleteIntelEffectsInTx({
+        tx,
+        db,
+        effectIds: intelContext.consumeEffectIds,
+      });
+    }
 
     const survivors = subtractStack(result.unitsDeployed, result.attackerLosses);
     const sourceAfterDispatch = subtractStack(source.units, args.units);
@@ -2264,6 +2325,816 @@ export async function attackTileServer(args: {
   // Strip the internal-only context off the response.
   const { _airIntelContext: _, ...publicResult } = result;
   return { ...publicResult, ...(intelReport ? { intelReport } : {}) };
+}
+
+/**
+ * Read-only projection of what `attackTileServer` would do if called with the
+ * same arguments right now. Runs `resolveAttack` with a fixed-midpoint RNG so
+ * the result is the deterministic "expected" outcome — no telescope-into-future
+ * exploit is possible (the same seed string is used for every preview, so the
+ * RNG draws are always the midpoint of [0.9, 1.1] = 1.0). No writes, no turn
+ * deduction, no transaction. Same validation rules as the real attack except:
+ *   - Player turn-cost not enforced (preview is free).
+ *   - Insufficient units → returned as a soft hint via `combat.unitsDeployed`,
+ *     which clamps to source.units in resolveAttack.
+ *
+ * Returns the projected CombatResult plus enough context for the sim panel to
+ * render active prep effects and defender info.
+ */
+export async function attackPreviewServer(args: {
+  attackerId: string;
+  sourceTileId: string;
+  targetTileId: string;
+  units: UnitStack;
+  offenseSpellId: string | null;
+  now?: Date;
+}): Promise<{
+  combat: CombatResult;
+  source: GameTile;
+  target: GameTile;
+  defender: {
+    userId: string;
+    displayName: string;
+    caste: Caste | null;
+    shielded: boolean;
+  };
+  effects: {
+    forgeSightOffenseBonus: number;
+    alertVsCasterDefenseBonus: number;
+    siegeDebuffMagnitude: number;
+    preCastOffenseBonus: number;
+    defenseDisarmFraction: number;
+  };
+}> {
+  const now = args.now ?? new Date();
+  if (!isValidUnitStack(args.units)) {
+    throw new Error("Invalid units stack: must be {ground, siege, air} non-negative integers");
+  }
+
+  let offenseSpell = null;
+  if (args.offenseSpellId) {
+    offenseSpell = SPELLS_BY_ID.get(args.offenseSpellId) ?? null;
+    if (!offenseSpell || offenseSpell.type !== "offense") {
+      throw new GameInvalidSpellError(
+        `spellId ${args.offenseSpellId} is not a valid offense spell`
+      );
+    }
+  }
+
+  const db = adminDbOrThrow();
+  const attackerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.attackerId);
+  const sourceRef = db.collection(COLLECTIONS.TILES).doc(args.sourceTileId);
+  const targetRef = db.collection(COLLECTIONS.TILES).doc(args.targetTileId);
+
+  const [attackerSnap, sourceSnap, targetSnap] = await Promise.all([
+    attackerRef.get(),
+    sourceRef.get(),
+    targetRef.get(),
+  ]);
+  if (!attackerSnap.exists) throw new GamePlayerNotFoundError();
+  if (!sourceSnap.exists) throw new GameTileNotFoundError();
+  if (!targetSnap.exists) throw new GameTileNotFoundError();
+
+  const attacker = attackerSnap.data() as GamePlayer;
+  const source = sourceSnap.data() as GameTile;
+  const target = targetSnap.data() as GameTile;
+
+  if (attacker.phase !== "play") {
+    throw new GameInvalidPhaseError("play", attacker.phase);
+  }
+  if (attacker.caste === null) {
+    throw new GameInvalidPhaseError("play (caste required)", attacker.phase);
+  }
+  if (source.ownerId !== args.attackerId) throw new GameTileNotOwnedError();
+  if (!target.ownerId) throw new GameSelfAttackError();
+  if (target.ownerId === args.attackerId) throw new GameSelfAttackError();
+  if (!source.neighborTileIds.includes(args.targetTileId)) {
+    throw new GameNotAdjacentError();
+  }
+  if (offenseSpell && offenseSpell.caste !== attacker.caste) {
+    throw new GameInvalidSpellError(
+      `offense spell requires caste ${offenseSpell.caste}`
+    );
+  }
+  if (
+    offenseSpell &&
+    attacker.stats.tilesHeld < offenseSpell.minTilesRequired
+  ) {
+    throw new GameInvalidSpellError(
+      `offense spell ${offenseSpell.id} requires ${offenseSpell.minTilesRequired} tiles held`
+    );
+  }
+
+  const defenderId = target.ownerId;
+  const defenderSnap = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .doc(defenderId)
+    .get();
+  if (!defenderSnap.exists) throw new GamePlayerNotFoundError();
+  const defender = defenderSnap.data() as GamePlayer;
+  if (defender.caste === null) {
+    throw new GameInvalidPhaseError("defender must be in play", defender.phase);
+  }
+  if (isShieldActive(attacker, now)) throw new GameShieldedError("attacker");
+  if (isShieldActive(defender, now)) throw new GameShieldedError("defender");
+
+  const intelContext = await readAttackContextEffects({
+    db,
+    attackerId: args.attackerId,
+    attackerTurnsSpentTotal: attacker.turnsSpentTotal,
+    defenderId,
+    defenderTileId: args.targetTileId,
+  });
+
+  const defenderActiveUpgrades = defender.activeUpgrades ?? {};
+  const attackerActiveUpgrades = attacker.activeUpgrades ?? {};
+  const tileCapacity = computeTileCapacity(
+    target.type,
+    defender.caste,
+    target.upgradeIds,
+    defenderActiveUpgrades
+  );
+
+  // Read the 6 neighbor tiles to compute supply (mirrors attackTileServer).
+  const nIds = neighborTileIds(target.q, target.r);
+  const neighborSnaps = await Promise.all(
+    nIds.map((id) => db.collection(COLLECTIONS.TILES).doc(id).get())
+  );
+  const friendlyNeighbors: Array<{ landType: LandType }> = [];
+  for (const snap of neighborSnaps) {
+    if (!snap.exists) continue;
+    const t = snap.data() as GameTile;
+    if (t.ownerId !== defenderId) continue;
+    if (t.type === "unrevealed" || t.type === "unassigned") continue;
+    friendlyNeighbors.push({ landType: t.type });
+  }
+
+  // Fixed-midpoint RNG: every draw returns 0.5 → finalAttack/Defense both
+  // get ×1.0 multipliers. Using a constant rather than makeSeededRng so the
+  // result is identical across previews and players can't fish for outcomes.
+  const midpointRng = (): number => 0.5;
+
+  // Clamp requested units to what's actually on the source tile so the
+  // projection reflects what the player could actually deploy. The real
+  // attack call rejects over-spec; here we soft-clamp instead so the panel
+  // stays useful while a player tweaks numbers.
+  const clampedUnits: UnitStack = {
+    ground: Math.min(args.units.ground, source.units.ground),
+    siege: Math.min(args.units.siege, source.units.siege),
+    air: Math.min(args.units.air, source.units.air),
+  };
+
+  const combat = resolveAttack(
+    {
+      caste: attacker.caste,
+      units: clampedUnits,
+      offenseSpellId: args.offenseSpellId,
+      magicLandCount: 0,
+      unitsAlive: attacker.stats.unitsAlive,
+      activeUpgrades: attackerActiveUpgrades,
+      intelOffenseBonus: intelContext.forgeSightOffenseBonus,
+      sourceLandType: source.type,
+      preCastOffenseBonus: intelContext.preCastOffenseBonus,
+    },
+    {
+      caste: defender.caste,
+      unitsOnTile: target.units,
+      armedDefenseSpellId: target.armedDefenseSpellId,
+      magicLandCount: 0,
+      unitsAlive: defender.stats.unitsAlive,
+      activeUpgrades: defenderActiveUpgrades,
+      intelDefenseBonus: intelContext.alertVsCasterDefenseBonus,
+      defenseDisarmFraction: intelContext.defenseDisarmFraction,
+    },
+    {
+      capacity: tileCapacity,
+      upgradeIds: target.upgradeIds,
+      friendlyNeighbors,
+      landType: target.type,
+      siegeDebuffMagnitude: intelContext.siegeDebuffMagnitude,
+    },
+    midpointRng
+  );
+
+  return {
+    combat,
+    source,
+    target,
+    defender: {
+      userId: defenderId,
+      displayName: defender.displayName,
+      caste: defender.caste,
+      shielded: isShieldActive(defender, now),
+    },
+    effects: {
+      forgeSightOffenseBonus: intelContext.forgeSightOffenseBonus,
+      alertVsCasterDefenseBonus: intelContext.alertVsCasterDefenseBonus,
+      siegeDebuffMagnitude: intelContext.siegeDebuffMagnitude,
+      preCastOffenseBonus: intelContext.preCastOffenseBonus,
+      defenseDisarmFraction: intelContext.defenseDisarmFraction,
+    },
+  };
+}
+
+/**
+ * Siege a target tile to soften its standing-defense floor. Costs
+ * SIEGE_TURN_COST. Records a `siege-debuff` IntelEffect of
+ * SIEGE_ACTION_MAGNITUDE that stacks with prior sieges (read-time clamp at
+ * SIEGE_DEBUFF_MAX_MAGNITUDE). Source must be owned and adjacent to target.
+ */
+export async function siegeTileServer(args: {
+  attackerId: string;
+  sourceTileId: string;
+  targetTileId: string;
+  now?: Date;
+}): Promise<{
+  player: GamePlayer;
+  report: TurnReport;
+  siegeTotalMagnitude: number;
+}> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const attackerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.attackerId);
+  const sourceRef = db.collection(COLLECTIONS.TILES).doc(args.sourceTileId);
+  const targetRef = db.collection(COLLECTIONS.TILES).doc(args.targetTileId);
+
+  // Pre-read target outside the txn to derive defenderId for shielded check.
+  const targetPreSnap = await targetRef.get();
+  if (!targetPreSnap.exists) throw new GameTileNotFoundError();
+  const targetPre = targetPreSnap.data() as GameTile;
+  if (!targetPre.ownerId) throw new GameSelfAttackError();
+  if (targetPre.ownerId === args.attackerId) throw new GameSelfAttackError();
+  const defenderId = targetPre.ownerId;
+  const defenderRef = db.collection(COLLECTIONS.PLAYERS).doc(defenderId);
+
+  // Read existing siege magnitude pre-tx so we can return the post-cast
+  // total. Slight staleness is fine — same justification as
+  // readAttackContextEffects.
+  const attackerPreSnap = await attackerRef.get();
+  if (!attackerPreSnap.exists) throw new GamePlayerNotFoundError();
+  const attackerPre = attackerPreSnap.data() as GamePlayer;
+  const intelContext = await readAttackContextEffects({
+    db,
+    attackerId: args.attackerId,
+    attackerTurnsSpentTotal: attackerPre.turnsSpentTotal,
+    defenderId,
+    defenderTileId: args.targetTileId,
+  });
+  const projectedTotal = Math.min(
+    SIEGE_DEBUFF_MAX_MAGNITUDE,
+    intelContext.siegeDebuffMagnitude + SIEGE_ACTION_MAGNITUDE
+  );
+
+  return db.runTransaction(async (tx) => {
+    const [attackerSnap, defenderSnap, sourceSnap, targetSnap] =
+      await Promise.all([
+        tx.get(attackerRef),
+        tx.get(defenderRef),
+        tx.get(sourceRef),
+        tx.get(targetRef),
+      ]);
+    if (!attackerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!defenderSnap.exists) throw new GamePlayerNotFoundError();
+    if (!sourceSnap.exists) throw new GameTileNotFoundError();
+    if (!targetSnap.exists) throw new GameTileNotFoundError();
+
+    const attacker = attackerSnap.data() as GamePlayer;
+    const defender = defenderSnap.data() as GamePlayer;
+    const source = sourceSnap.data() as GameTile;
+    const target = targetSnap.data() as GameTile;
+
+    if (target.ownerId !== defenderId) throw new GameSelfAttackError();
+    if (attacker.phase !== "play") {
+      throw new GameInvalidPhaseError("play", attacker.phase);
+    }
+    if (source.ownerId !== args.attackerId) throw new GameTileNotOwnedError();
+    if (!source.neighborTileIds.includes(args.targetTileId)) {
+      throw new GameNotAdjacentError();
+    }
+    if (isShieldActive(attacker, now)) throw new GameShieldedError("attacker");
+    if (isShieldActive(defender, now)) throw new GameShieldedError("defender");
+    if (attacker.turnsRemaining < SIEGE_TURN_COST) {
+      throw new GameInsufficientTurnsError(
+        SIEGE_TURN_COST,
+        attacker.turnsRemaining
+      );
+    }
+
+    const turnsSpentTotal = attacker.turnsSpentTotal + SIEGE_TURN_COST;
+
+    recordSiegeDebuffInTx({
+      tx,
+      db,
+      attackerId: args.attackerId,
+      targetTileId: args.targetTileId,
+      magnitude: SIEGE_ACTION_MAGNITUDE,
+      attackerTurnsSpentTotal: turnsSpentTotal,
+      now,
+    });
+
+    tx.update(attackerRef, {
+      turnsRemaining: attacker.turnsRemaining - SIEGE_TURN_COST,
+      turnsSpentTotal,
+      updatedAt: now,
+    });
+
+    const report = buildSiegeReport({
+      turnIndex: turnsSpentTotal,
+      cost: SIEGE_TURN_COST,
+      targetTileId: args.targetTileId,
+      magnitudeApplied: SIEGE_ACTION_MAGNITUDE,
+      totalMagnitudeAfter: projectedTotal,
+      rng: makeNarrativeRng(args.attackerId, turnsSpentTotal, "siege"),
+    });
+
+    const updatedPlayer: GamePlayer = {
+      ...attacker,
+      turnsRemaining: attacker.turnsRemaining - SIEGE_TURN_COST,
+      turnsSpentTotal,
+      updatedAt: now,
+    };
+
+    return {
+      player: updatedPlayer,
+      report,
+      siegeTotalMagnitude: projectedTotal,
+    };
+  });
+}
+
+/**
+ * Air-only raid that attrits defenders without taking the tile. Reuses
+ * resolveAttack for the math, then post-processes:
+ *   - Forces outcome to "repelled" or "stalemate" (never "captured").
+ *   - Doubles attacker losses, clamped to deployed.
+ * Tile ownership is never transferred; defender unit losses are committed.
+ * Costs ATTACK_TURN_COST (1 turn) — same as a regular attack. No
+ * artifact-rolling or attack-record write — flyovers are softening moves,
+ * not the main bout.
+ */
+export async function flyoverTileServer(args: {
+  attackerId: string;
+  sourceTileId: string;
+  targetTileId: string;
+  units: UnitStack;
+  now?: Date;
+}): Promise<{
+  attackerPlayer: GamePlayer;
+  sourceTile: GameTile;
+  targetTile: GameTile;
+  report: TurnReport;
+  combat: CombatResult;
+}> {
+  const now = args.now ?? new Date();
+  if (!isValidUnitStack(args.units)) {
+    throw new Error("Invalid units stack: must be {ground, siege, air} non-negative integers");
+  }
+  if (sumStack(args.units) === 0) {
+    throw new Error("Must send at least 1 unit");
+  }
+  if (args.units.ground !== 0 || args.units.siege !== 0) {
+    throw new Error("Flyover requires air units only (ground=0, siege=0)");
+  }
+
+  const turnCost = ATTACK_TURN_COST;
+  const db = adminDbOrThrow();
+  const attackerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.attackerId);
+  const sourceRef = db.collection(COLLECTIONS.TILES).doc(args.sourceTileId);
+  const targetRef = db.collection(COLLECTIONS.TILES).doc(args.targetTileId);
+
+  const targetPreSnap = await targetRef.get();
+  if (!targetPreSnap.exists) throw new GameTileNotFoundError();
+  const targetPre = targetPreSnap.data() as GameTile;
+  if (!targetPre.ownerId) throw new GameSelfAttackError();
+  if (targetPre.ownerId === args.attackerId) throw new GameSelfAttackError();
+  const defenderId = targetPre.ownerId;
+  const defenderRef = db.collection(COLLECTIONS.PLAYERS).doc(defenderId);
+
+  const attackerPreSnap = await attackerRef.get();
+  if (!attackerPreSnap.exists) throw new GamePlayerNotFoundError();
+  const attackerPre = attackerPreSnap.data() as GamePlayer;
+  const intelContext = await readAttackContextEffects({
+    db,
+    attackerId: args.attackerId,
+    attackerTurnsSpentTotal: attackerPre.turnsSpentTotal,
+    defenderId,
+    defenderTileId: args.targetTileId,
+  });
+
+  return db.runTransaction(async (tx) => {
+    const [attackerSnap, defenderSnap, sourceSnap, targetSnap] =
+      await Promise.all([
+        tx.get(attackerRef),
+        tx.get(defenderRef),
+        tx.get(sourceRef),
+        tx.get(targetRef),
+      ]);
+    if (!attackerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!defenderSnap.exists) throw new GamePlayerNotFoundError();
+    if (!sourceSnap.exists) throw new GameTileNotFoundError();
+    if (!targetSnap.exists) throw new GameTileNotFoundError();
+
+    const attacker = attackerSnap.data() as GamePlayer;
+    const defender = defenderSnap.data() as GamePlayer;
+    const source = sourceSnap.data() as GameTile;
+    const target = targetSnap.data() as GameTile;
+
+    if (target.ownerId !== defenderId) throw new GameSelfAttackError();
+    if (attacker.phase !== "play") {
+      throw new GameInvalidPhaseError("play", attacker.phase);
+    }
+    if (attacker.caste === null) {
+      throw new GameInvalidPhaseError("play (caste required)", attacker.phase);
+    }
+    if (defender.caste === null) {
+      throw new GameInvalidPhaseError(
+        "defender must be in play",
+        defender.phase
+      );
+    }
+    if (isShieldActive(attacker, now)) throw new GameShieldedError("attacker");
+    if (isShieldActive(defender, now)) throw new GameShieldedError("defender");
+    if (source.ownerId !== args.attackerId) throw new GameTileNotOwnedError();
+    if (!source.neighborTileIds.includes(args.targetTileId)) {
+      throw new GameNotAdjacentError();
+    }
+    if (attacker.turnsRemaining < turnCost) {
+      throw new GameInsufficientTurnsError(
+        turnCost,
+        attacker.turnsRemaining
+      );
+    }
+    if (!stackHasAtLeast(source.units, args.units)) {
+      throw new GameInsufficientUnitsError();
+    }
+
+    const defenderActiveUpgrades = defender.activeUpgrades ?? {};
+    const attackerActiveUpgrades = attacker.activeUpgrades ?? {};
+    const tileCapacity = computeTileCapacity(
+      target.type,
+      defender.caste,
+      target.upgradeIds,
+      defenderActiveUpgrades
+    );
+
+    // Read neighbors for supply (mirrors attackTileServer).
+    const nIds = neighborTileIds(target.q, target.r);
+    const neighborSnaps = await Promise.all(
+      nIds.map((id) => tx.get(db.collection(COLLECTIONS.TILES).doc(id)))
+    );
+    const friendlyNeighbors: Array<{ landType: LandType }> = [];
+    for (const snap of neighborSnaps) {
+      if (!snap.exists) continue;
+      const t = snap.data() as GameTile;
+      if (t.ownerId !== defenderId) continue;
+      if (t.type === "unrevealed" || t.type === "unassigned") continue;
+      friendlyNeighbors.push({ landType: t.type });
+    }
+
+    const flyoverId = randomUUID();
+    const baseCombat = resolveAttack(
+      {
+        caste: attacker.caste,
+        units: args.units,
+        offenseSpellId: null,
+        magicLandCount: 0,
+        unitsAlive: attacker.stats.unitsAlive,
+        activeUpgrades: attackerActiveUpgrades,
+        intelOffenseBonus: intelContext.forgeSightOffenseBonus,
+        sourceLandType: source.type,
+      },
+      {
+        caste: defender.caste,
+        unitsOnTile: target.units,
+        armedDefenseSpellId: target.armedDefenseSpellId,
+        magicLandCount: 0,
+        unitsAlive: defender.stats.unitsAlive,
+        activeUpgrades: defenderActiveUpgrades,
+        intelDefenseBonus: intelContext.alertVsCasterDefenseBonus,
+      },
+      {
+        capacity: tileCapacity,
+        upgradeIds: target.upgradeIds,
+        friendlyNeighbors,
+        landType: target.type,
+        siegeDebuffMagnitude: intelContext.siegeDebuffMagnitude,
+      },
+      makeSeededRng(`flyover-${flyoverId}`)
+    );
+
+    // Flyover post-processing: capture is impossible (tile never changes
+    // hands in a raid) + attacker losses doubled. Logic lives in
+    // applyFlyoverModifiers so it's covered by combat tests.
+    const combat = applyFlyoverModifiers(baseCombat);
+
+    // Commit unit deltas. Source loses what was sent + the doubled losses
+    // never came back; survivors return.
+    const attackerLossesTotal = sumStack(combat.attackerLosses);
+    const defenderLossesTotal = sumStack(combat.defenderLosses);
+    const survivors = subtractStack(combat.unitsDeployed, combat.attackerLosses);
+    const sourceAfterDispatch = subtractStack(source.units, args.units);
+    const updatedSourceUnits = addStack(sourceAfterDispatch, survivors);
+    const updatedTargetUnits = subtractStack(target.units, combat.defenderLosses);
+
+    const turnsSpentTotal = attacker.turnsSpentTotal + turnCost;
+
+    tx.update(sourceRef, { units: updatedSourceUnits, updatedAt: now });
+    tx.update(targetRef, {
+      units: updatedTargetUnits,
+      lastAttackedAt: now,
+      updatedAt: now,
+    });
+
+    const attackerStats = {
+      ...attacker.stats,
+      unitsAlive: Math.max(0, attacker.stats.unitsAlive - attackerLossesTotal),
+    };
+    const defenderStats = {
+      ...defender.stats,
+      unitsAlive: Math.max(0, defender.stats.unitsAlive - defenderLossesTotal),
+    };
+
+    tx.update(attackerRef, {
+      turnsRemaining: attacker.turnsRemaining - turnCost,
+      turnsSpentTotal,
+      stats: attackerStats,
+      updatedAt: now,
+    });
+    tx.update(defenderRef, { stats: defenderStats, updatedAt: now });
+
+    const report = buildFlyoverReport({
+      turnIndex: turnsSpentTotal,
+      cost: turnCost,
+      targetTileId: args.targetTileId,
+      unitsSent: args.units,
+      combat,
+      artifactFound: null,
+      rng: makeNarrativeRng(args.attackerId, turnsSpentTotal, "flyover"),
+    });
+
+    return {
+      attackerPlayer: {
+        ...attacker,
+        turnsRemaining: attacker.turnsRemaining - turnCost,
+        turnsSpentTotal,
+        stats: attackerStats,
+        updatedAt: now,
+      },
+      sourceTile: { ...source, units: updatedSourceUnits, updatedAt: now },
+      targetTile: { ...target, units: updatedTargetUnits, lastAttackedAt: now, updatedAt: now },
+      report,
+      combat,
+    };
+  });
+}
+
+/**
+ * Standalone spell-cast against a target tile. Dispatches on
+ * `spell.type ∈ {"siege", "disarm", "attrition"}`. Rolls dice once
+ * (rollSpellEffectiveness, band 0.5–1.5), computes realized magnitude
+ * via `realizedSpellMagnitude`, and either persists an IntelEffect
+ * (siege, disarm) or commits unit kills (attrition).
+ *
+ * Costs `spell.turnCost` (5 for tier 1). Validates ownership + adjacency
+ * + non-shield + caste-match + tier tile-min + turn budget.
+ */
+export async function castSpellServer(args: {
+  attackerId: string;
+  spellId: string;
+  sourceTileId: string;
+  targetTileId: string;
+  now?: Date;
+}): Promise<{
+  player: GamePlayer;
+  report: TurnReport;
+  // Kind-specific outcome — only one populated based on spell.type.
+  siege?: { magnitudeApplied: number; totalMagnitudeAfter: number };
+  disarm?: { fractionApplied: number };
+  attrition?: { unitsKilled: UnitStack; targetTile: GameTile };
+}> {
+  const now = args.now ?? new Date();
+  const spell = SPELLS_BY_ID.get(args.spellId);
+  if (!spell) throw new GameInvalidSpellError(`unknown spellId ${args.spellId}`);
+  if (
+    spell.type !== "siege" &&
+    spell.type !== "disarm" &&
+    spell.type !== "attrition"
+  ) {
+    throw new GameInvalidSpellError(
+      `spellId ${args.spellId} (type=${spell.type}) is not a cast-able pre-attack spell`
+    );
+  }
+
+  const db = adminDbOrThrow();
+  const attackerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.attackerId);
+  const sourceRef = db.collection(COLLECTIONS.TILES).doc(args.sourceTileId);
+  const targetRef = db.collection(COLLECTIONS.TILES).doc(args.targetTileId);
+
+  const targetPreSnap = await targetRef.get();
+  if (!targetPreSnap.exists) throw new GameTileNotFoundError();
+  const targetPre = targetPreSnap.data() as GameTile;
+  if (!targetPre.ownerId) throw new GameSelfAttackError();
+  if (targetPre.ownerId === args.attackerId) throw new GameSelfAttackError();
+  const defenderId = targetPre.ownerId;
+  const defenderRef = db.collection(COLLECTIONS.PLAYERS).doc(defenderId);
+
+  // Pre-read attacker for owned-land counts (drives the magicMultiplier in
+  // the realized-magnitude formula). Same staleness trade-off as the
+  // attack server uses for intel-effects.
+  const attackerLandCounts = await getOwnedLandCounts(args.attackerId);
+
+  // Pre-read for siege total projection (so we can return the post-cast
+  // total without a follow-up query).
+  const attackerPreSnap = await attackerRef.get();
+  if (!attackerPreSnap.exists) throw new GamePlayerNotFoundError();
+  const attackerPre = attackerPreSnap.data() as GamePlayer;
+  const intelContext = await readAttackContextEffects({
+    db,
+    attackerId: args.attackerId,
+    attackerTurnsSpentTotal: attackerPre.turnsSpentTotal,
+    defenderId,
+    defenderTileId: args.targetTileId,
+  });
+
+  return db.runTransaction(async (tx) => {
+    const [attackerSnap, defenderSnap, sourceSnap, targetSnap] =
+      await Promise.all([
+        tx.get(attackerRef),
+        tx.get(defenderRef),
+        tx.get(sourceRef),
+        tx.get(targetRef),
+      ]);
+    if (!attackerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!defenderSnap.exists) throw new GamePlayerNotFoundError();
+    if (!sourceSnap.exists) throw new GameTileNotFoundError();
+    if (!targetSnap.exists) throw new GameTileNotFoundError();
+
+    const attacker = attackerSnap.data() as GamePlayer;
+    const defender = defenderSnap.data() as GamePlayer;
+    const source = sourceSnap.data() as GameTile;
+    const target = targetSnap.data() as GameTile;
+
+    if (target.ownerId !== defenderId) throw new GameSelfAttackError();
+    if (attacker.phase !== "play") {
+      throw new GameInvalidPhaseError("play", attacker.phase);
+    }
+    if (attacker.caste === null) {
+      throw new GameInvalidPhaseError("play (caste required)", attacker.phase);
+    }
+    if (spell.caste !== attacker.caste) {
+      throw new GameInvalidSpellError(
+        `spell ${spell.id} requires caste ${spell.caste}`
+      );
+    }
+    if (attacker.stats.tilesHeld < spell.minTilesRequired) {
+      throw new GameInvalidSpellError(
+        `spell ${spell.id} requires ${spell.minTilesRequired} tiles held; you have ${attacker.stats.tilesHeld}`
+      );
+    }
+    if (source.ownerId !== args.attackerId) throw new GameTileNotOwnedError();
+    if (!source.neighborTileIds.includes(args.targetTileId)) {
+      throw new GameNotAdjacentError();
+    }
+    if (isShieldActive(attacker, now)) throw new GameShieldedError("attacker");
+    if (isShieldActive(defender, now)) throw new GameShieldedError("defender");
+    if (attacker.turnsRemaining < spell.turnCost) {
+      throw new GameInsufficientTurnsError(
+        spell.turnCost,
+        attacker.turnsRemaining
+      );
+    }
+
+    // Roll dice + compute realized magnitude. Seed includes the cast time
+    // so re-cast on the same target rolls fresh; players cannot fish.
+    const castId = randomUUID();
+    const rng = makeSeededRng(`cast-${castId}`);
+    const dice = rollSpellEffectiveness(rng);
+    const rawMagnitude = realizedSpellMagnitude({
+      baseStrength: spell.baseStrength,
+      caste: attacker.caste,
+      spellType: spell.type,
+      magicLandCount: attackerLandCounts.magic,
+      activeUpgrades: attacker.activeUpgrades ?? {},
+      dice,
+    });
+
+    const turnsSpentTotal = attacker.turnsSpentTotal + spell.turnCost;
+    let kindPayload: {
+      siege?: { magnitudeApplied: number; totalMagnitudeAfter: number };
+      disarm?: { fractionApplied: number };
+      attrition?: { unitsKilled: UnitStack; targetTile: GameTile };
+    } = {};
+
+    if (spell.type === "siege") {
+      const magnitudeApplied = Math.max(
+        0,
+        Math.min(SIEGE_DEBUFF_MAX_MAGNITUDE, rawMagnitude)
+      );
+      recordSiegeDebuffInTx({
+        tx,
+        db,
+        attackerId: args.attackerId,
+        targetTileId: args.targetTileId,
+        magnitude: magnitudeApplied,
+        attackerTurnsSpentTotal: turnsSpentTotal,
+        now,
+      });
+      const totalMagnitudeAfter = Math.min(
+        SIEGE_DEBUFF_MAX_MAGNITUDE,
+        intelContext.siegeDebuffMagnitude + magnitudeApplied
+      );
+      kindPayload = {
+        siege: { magnitudeApplied, totalMagnitudeAfter },
+      };
+    } else if (spell.type === "disarm") {
+      const fractionApplied = Math.max(0, Math.min(1, rawMagnitude));
+      recordDefenseDisarmInTx({
+        tx,
+        db,
+        attackerId: args.attackerId,
+        targetTileId: args.targetTileId,
+        disarmFraction: fractionApplied,
+        attackerTurnsSpentTotal: turnsSpentTotal,
+        now,
+      });
+      kindPayload = { disarm: { fractionApplied } };
+    } else {
+      // attrition: kill units immediately, distributed across types.
+      const unitsKilled = distributeUnitKills(
+        target.units,
+        Math.max(0, Math.round(rawMagnitude))
+      );
+      const newUnits: UnitStack = {
+        ground: Math.max(0, target.units.ground - unitsKilled.ground),
+        siege: Math.max(0, target.units.siege - unitsKilled.siege),
+        air: Math.max(0, target.units.air - unitsKilled.air),
+      };
+      const totalKilled =
+        unitsKilled.ground + unitsKilled.siege + unitsKilled.air;
+      tx.update(targetRef, {
+        units: newUnits,
+        lastAttackedAt: now,
+        updatedAt: now,
+      });
+      // Decrement defender's denormalized unitsAlive too so kingdom-wide
+      // displays stay consistent.
+      const defenderStats = {
+        ...defender.stats,
+        unitsAlive: Math.max(0, defender.stats.unitsAlive - totalKilled),
+      };
+      tx.update(defenderRef, { stats: defenderStats, updatedAt: now });
+      kindPayload = {
+        attrition: {
+          unitsKilled,
+          targetTile: {
+            ...target,
+            units: newUnits,
+            lastAttackedAt: now,
+            updatedAt: now,
+          },
+        },
+      };
+    }
+
+    tx.update(attackerRef, {
+      turnsRemaining: attacker.turnsRemaining - spell.turnCost,
+      turnsSpentTotal,
+      updatedAt: now,
+    });
+
+    // Re-narrow spell.type for buildCastSpellReport — the TS flow analysis
+    // doesn't see through the early throw when traversing through the
+    // closure boundary.
+    const spellType: "siege" | "disarm" | "attrition" =
+      spell.type === "siege" || spell.type === "disarm" ? spell.type : "attrition";
+    const report = buildCastSpellReport({
+      turnIndex: turnsSpentTotal,
+      cost: spell.turnCost,
+      spellId: spell.id,
+      spellName: spell.name,
+      spellType,
+      targetTileId: args.targetTileId,
+      siege: kindPayload.siege,
+      disarm: kindPayload.disarm,
+      attrition: kindPayload.attrition
+        ? { unitsKilled: kindPayload.attrition.unitsKilled }
+        : undefined,
+      rng: makeNarrativeRng(args.attackerId, turnsSpentTotal, "spell-cast"),
+    });
+
+    const updatedPlayer: GamePlayer = {
+      ...attacker,
+      turnsRemaining: attacker.turnsRemaining - spell.turnCost,
+      turnsSpentTotal,
+      updatedAt: now,
+    };
+
+    return {
+      player: updatedPlayer,
+      report,
+      ...kindPayload,
+    };
+  });
 }
 
 export async function getRecentAttacksServer(opts: {
@@ -2538,17 +3409,44 @@ export async function setGeneralNameServer(
 export async function getLeaderboardServer(opts: {
   limit: number;
   cursor: string | null;
+  audience?: "all" | "npc" | "real";
 }): Promise<PaginatedQueryResult<GamePlayer>> {
   const db = adminDbOrThrow();
   const players = db.collection(COLLECTIONS.PLAYERS);
-  const query = players.orderBy("stats.tilesHeld", "desc");
-  return paginateFirestoreQuery({
-    query,
-    collection: players,
-    cursor: opts.cursor,
-    limit: opts.limit,
-    mapDoc: (d) => d.data() as GamePlayer,
+  const baseQuery = players.orderBy("stats.tilesHeld", "desc");
+  const audience = opts.audience ?? "all";
+
+  if (audience === "all") {
+    return paginateFirestoreQuery({
+      query: baseQuery,
+      collection: players,
+      cursor: opts.cursor,
+      limit: opts.limit,
+      mapDoc: (d) => d.data() as GamePlayer,
+    });
+  }
+
+  // Real players don't store `isNpc` at all, so a Firestore where(==false)
+  // would miss them. Overfetch + filter in memory — players collection is
+  // small (≲ a few hundred docs) and this avoids needing a composite index
+  // on (isNpc, stats.tilesHeld).
+  const overFetch = opts.limit * 4 + 1;
+  let q = baseQuery.limit(overFetch);
+  if (opts.cursor) {
+    const cursorDoc = await players.doc(opts.cursor).get();
+    if (cursorDoc.exists) q = q.startAfter(cursorDoc);
+  }
+  const snap = await q.get();
+  const matches = snap.docs.filter((d) => {
+    const isNpc = (d.data() as { isNpc?: boolean }).isNpc === true;
+    return audience === "npc" ? isNpc : !isNpc;
   });
+  const sliced = matches.slice(0, opts.limit);
+  const items = sliced.map((d) => d.data() as GamePlayer);
+  const hasMore = matches.length > opts.limit || snap.size === overFetch;
+  const nextCursor =
+    hasMore && sliced.length > 0 ? sliced[sliced.length - 1].id : null;
+  return { items, nextCursor, hasMore };
 }
 
 // Admin-only testing helper. Kept as a manual override even after the cron

--- a/lib/game/intel-effects.ts
+++ b/lib/game/intel-effects.ts
@@ -6,7 +6,11 @@
 
 import { randomUUID } from "node:crypto";
 import type { Firestore, Transaction } from "firebase-admin/firestore";
-import type { IntelEffect, IntelEffectKind } from "./types";
+import {
+  SIEGE_DEBUFF_MAX_MAGNITUDE,
+  type IntelEffect,
+  type IntelEffectKind,
+} from "./types";
 
 // Effects live in their own top-level collection so we can index by ownerId
 // + kind without bloating the player or tile docs. Lifetimes are bounded
@@ -61,16 +65,39 @@ interface AttackContextEffects {
   // Sum of magnitudes for currently-active "alert-vs-caster" effects owned
   // by `defenderId` against `attackerId`. Additive: 0.30 → +30% defense.
   alertVsCasterDefenseBonus: number;
+  // Sum of "siege-debuff" magnitudes (clamped to SIEGE_DEBUFF_MAX_MAGNITUDE)
+  // owned by `attackerId` against `defenderTileId`. Subtracted from the
+  // tile's standing-defense floor in resolveAttack. NOT consumed on attack.
+  siegeDebuffMagnitude: number;
+  // Realized power from "pre-cast-offense-spell" effects owned by
+  // `attackerId` targeting `defenderTileId`. Added flat to attackPower.
+  // SINGLE-USE: ids returned in `consumeEffectIds` should be deleted by
+  // the attack transaction.
+  preCastOffenseBonus: number;
+  // Fraction in [0, 1] from "defense-disarm" effects owned by `attackerId`
+  // targeting `defenderTileId`. Reduces defender spell contribution
+  // proportionally. SINGLE-USE: combined fraction is clamped to 1; ids
+  // returned in `consumeEffectIds` should be deleted.
+  defenseDisarmFraction: number;
+  // Document ids of single-use effects (pre-cast-offense-spell,
+  // defense-disarm) that should be deleted in the attack transaction.
+  consumeEffectIds: string[];
 }
 
 /**
  * Read intel effects relevant to a single attack. Run OUTSIDE the attack
- * transaction — slight staleness is acceptable since alerts decay naturally
+ * transaction — slight staleness is acceptable since effects decay naturally
  * and the caster's own turn count is the trigger for expiry.
  *
- * Two effect classes are aggregated:
- *   - Forge Sight: caster armed against the target tile they're now attacking.
- *   - Alert-vs-caster: defender was alerted by the attacker (Black/Green spy).
+ * Aggregates five effect classes:
+ *   - "forge-sight-offense" — caster armed against the target tile.
+ *   - "alert-vs-caster" — defender alerted by the attacker (Black/Green spy).
+ *   - "siege-debuff" — sum of attacker's siege actions / spells against tile.
+ *   - "pre-cast-offense-spell" — attacker's queued offense spells (single-use).
+ *   - "defense-disarm" — attacker's queued disarm rolls (single-use).
+ *
+ * `consumeEffectIds` lists the doc ids of single-use effects that the
+ * attack transaction should delete via `deleteIntelEffectsInTx`.
  */
 export async function readAttackContextEffects(args: {
   db: Firestore;
@@ -82,22 +109,38 @@ export async function readAttackContextEffects(args: {
   const { db, attackerId, attackerTurnsSpentTotal, defenderId, defenderTileId } =
     args;
 
-  // Two equality clauses each — within Firestore's single-field index defaults,
-  // no composite index needed. The remaining filters (targetTileId, casterId)
-  // are applied client-side; the result sets are tiny (≤5-turn lifetimes,
-  // small per-player effect counts).
-  const [forgeSnap, alertSnap] = await Promise.all([
-    db
-      .collection(COLLECTION)
-      .where("ownerId", "==", attackerId)
-      .where("kind", "==", "forge-sight-offense")
-      .get(),
-    db
-      .collection(COLLECTION)
-      .where("ownerId", "==", defenderId)
-      .where("kind", "==", "alert-vs-caster")
-      .get(),
-  ]);
+  // Two attacker-owned kinds against the target tile, plus the defender's
+  // alert against the attacker. We could merge attacker queries via
+  // `kind in [...]`, but Firestore counts that as 4 fan-outs; parallel
+  // single-kind queries stay cheap and let us reuse single-field indexes.
+  const [forgeSnap, alertSnap, siegeSnap, preCastSnap, disarmSnap] =
+    await Promise.all([
+      db
+        .collection(COLLECTION)
+        .where("ownerId", "==", attackerId)
+        .where("kind", "==", "forge-sight-offense")
+        .get(),
+      db
+        .collection(COLLECTION)
+        .where("ownerId", "==", defenderId)
+        .where("kind", "==", "alert-vs-caster")
+        .get(),
+      db
+        .collection(COLLECTION)
+        .where("ownerId", "==", attackerId)
+        .where("kind", "==", "siege-debuff")
+        .get(),
+      db
+        .collection(COLLECTION)
+        .where("ownerId", "==", attackerId)
+        .where("kind", "==", "pre-cast-offense-spell")
+        .get(),
+      db
+        .collection(COLLECTION)
+        .where("ownerId", "==", attackerId)
+        .where("kind", "==", "defense-disarm")
+        .get(),
+    ]);
 
   let forgeSightOffenseBonus = 0;
   for (const d of forgeSnap.docs) {
@@ -118,5 +161,154 @@ export async function readAttackContextEffects(args: {
     }
   }
 
-  return { forgeSightOffenseBonus, alertVsCasterDefenseBonus };
+  let siegeDebuffMagnitude = 0;
+  for (const d of siegeSnap.docs) {
+    const e = d.data() as IntelEffect;
+    if (e.targetTileId !== defenderTileId) continue;
+    if (attackerTurnsSpentTotal < e.expiresAtCasterTurn) {
+      siegeDebuffMagnitude += e.magnitude;
+    }
+  }
+  // Clamp accumulated debuff to the documented cap. Cast-time recorders
+  // also clamp per-effect, but multi-effect totals can exceed if recorders
+  // are buggy — defense in depth.
+  if (siegeDebuffMagnitude > SIEGE_DEBUFF_MAX_MAGNITUDE) {
+    siegeDebuffMagnitude = SIEGE_DEBUFF_MAX_MAGNITUDE;
+  }
+
+  let preCastOffenseBonus = 0;
+  const preCastIds: string[] = [];
+  for (const d of preCastSnap.docs) {
+    const e = d.data() as IntelEffect;
+    if (e.targetTileId !== defenderTileId) continue;
+    if (attackerTurnsSpentTotal < e.expiresAtCasterTurn) {
+      preCastOffenseBonus += e.magnitude;
+      preCastIds.push(d.id);
+    }
+  }
+
+  // Disarm effects combine multiplicatively if multiple are stacked on the
+  // same target: each one nullifies a fraction of what's left. Combined
+  // fraction = 1 - prod(1 - m_i). Clamped to [0, 1].
+  let disarmRemaining = 1;
+  const disarmIds: string[] = [];
+  for (const d of disarmSnap.docs) {
+    const e = d.data() as IntelEffect;
+    if (e.targetTileId !== defenderTileId) continue;
+    if (attackerTurnsSpentTotal < e.expiresAtCasterTurn) {
+      const m = Math.min(1, Math.max(0, e.magnitude));
+      disarmRemaining *= 1 - m;
+      disarmIds.push(d.id);
+    }
+  }
+  const defenseDisarmFraction = Math.max(0, Math.min(1, 1 - disarmRemaining));
+
+  return {
+    forgeSightOffenseBonus,
+    alertVsCasterDefenseBonus,
+    siegeDebuffMagnitude,
+    preCastOffenseBonus,
+    defenseDisarmFraction,
+    consumeEffectIds: [...preCastIds, ...disarmIds],
+  };
+}
+
+/**
+ * Delete a list of intel-effect docs inside an active transaction. Used
+ * by attackTileServer to consume single-use effects (pre-cast offense,
+ * disarm) once they've been read into combat. No-op for an empty list.
+ */
+export function deleteIntelEffectsInTx(args: {
+  tx: Transaction;
+  db: Firestore;
+  effectIds: ReadonlyArray<string>;
+}): void {
+  for (const id of args.effectIds) {
+    args.tx.delete(args.db.collection(COLLECTION).doc(id));
+  }
+}
+
+/**
+ * Record a siege-debuff effect against a target tile. Magnitude is the
+ * fraction subtracted from the tile's standing-defense floor; capped at
+ * SIEGE_DEBUFF_MAX_MAGNITUDE per record. TTL: INTEL_EFFECT_DURATION_CASTER_TURNS.
+ *
+ * Multiple records stack additively (read-time clamps the sum to the cap).
+ */
+export function recordSiegeDebuffInTx(args: {
+  tx: Transaction;
+  db: Firestore;
+  attackerId: string;
+  targetTileId: string;
+  magnitude: number;
+  attackerTurnsSpentTotal: number;
+  now: Date;
+}): IntelEffect {
+  const clamped = Math.max(0, Math.min(SIEGE_DEBUFF_MAX_MAGNITUDE, args.magnitude));
+  return recordIntelEffectInTx({
+    tx: args.tx,
+    db: args.db,
+    kind: "siege-debuff",
+    ownerId: args.attackerId,
+    casterId: args.attackerId,
+    targetTileId: args.targetTileId,
+    magnitude: clamped,
+    casterTurnsSpentTotalAtCast: args.attackerTurnsSpentTotal,
+    now: args.now,
+  });
+}
+
+/**
+ * Record a pre-cast offense-spell effect against a target tile. Magnitude
+ * is the realized power (already × magicMultiplier × caste bonus × dice).
+ * Single-use: consumed by next attack against the target.
+ */
+export function recordPreCastOffenseInTx(args: {
+  tx: Transaction;
+  db: Firestore;
+  attackerId: string;
+  targetTileId: string;
+  realizedPower: number;
+  attackerTurnsSpentTotal: number;
+  now: Date;
+}): IntelEffect {
+  return recordIntelEffectInTx({
+    tx: args.tx,
+    db: args.db,
+    kind: "pre-cast-offense-spell",
+    ownerId: args.attackerId,
+    casterId: args.attackerId,
+    targetTileId: args.targetTileId,
+    magnitude: Math.max(0, args.realizedPower),
+    casterTurnsSpentTotalAtCast: args.attackerTurnsSpentTotal,
+    now: args.now,
+  });
+}
+
+/**
+ * Record a defense-disarm effect against a target tile. Magnitude is the
+ * disarm fraction in [0, 1] rolled at cast time. Single-use: consumed by
+ * next attack against the target.
+ */
+export function recordDefenseDisarmInTx(args: {
+  tx: Transaction;
+  db: Firestore;
+  attackerId: string;
+  targetTileId: string;
+  disarmFraction: number;
+  attackerTurnsSpentTotal: number;
+  now: Date;
+}): IntelEffect {
+  const clamped = Math.max(0, Math.min(1, args.disarmFraction));
+  return recordIntelEffectInTx({
+    tx: args.tx,
+    db: args.db,
+    kind: "defense-disarm",
+    ownerId: args.attackerId,
+    casterId: args.attackerId,
+    targetTileId: args.targetTileId,
+    magnitude: clamped,
+    casterTurnsSpentTotalAtCast: args.attackerTurnsSpentTotal,
+    now: args.now,
+  });
 }

--- a/lib/game/turn-report.ts
+++ b/lib/game/turn-report.ts
@@ -235,6 +235,170 @@ export function buildAttackReport(args: {
       attackPower: args.combat.attackPower,
       defensePower: args.combat.defensePower,
       underdogApplied: args.combat.underdogApplied,
+      // Tile-type modifiers (May 2026 mechanics rework). Surfaced so the
+      // battle readout on /game/threats can show "Military source ×1.20",
+      // "Magic tile floor +X", etc.
+      sourceLandTypeMultiplier: args.combat.sourceLandTypeMultiplier,
+      targetLandTypeMultiplier: args.combat.targetLandTypeMultiplier,
+      standingDefenseAdded: args.combat.standingDefenseAdded,
+      magicTileOffenseSpellBonusApplied:
+        args.combat.magicTileOffenseSpellBonusApplied,
+      magicTileDefenseSpellBonusApplied:
+        args.combat.magicTileDefenseSpellBonusApplied,
+      siegeDebuffApplied: args.combat.siegeDebuffApplied,
+      defenseDisarmApplied: args.combat.defenseDisarmApplied,
+      preCastOffenseApplied: args.combat.preCastOffenseApplied,
+    },
+  };
+  return attachArtifact(base, args.artifactFound);
+}
+
+// ───────── siege ─────────
+//
+// Siege is a deterministic infrastructure-degrading move (no dice). Each
+// cast deposits SIEGE_ACTION_MAGNITUDE on the target's standing-defense
+// floor and stacks up to SIEGE_DEBUFF_MAX_MAGNITUDE. The narrative is
+// short — players are about to read it many times across a campaign.
+const SIEGE_NARRATIVES = [
+  "Trenches inch forward. The walls answer with arrows; the dirt answers with patience.",
+  "Sappers tunnel through the night. By dawn, a fault line in the rampart.",
+  "Your engineers measure, mark, and break. The garrison hears the work and counts.",
+  "A siege tower rolls into range. The defenders feed it bolts; you feed it more wood.",
+  "Catapults find their cadence. Stone after stone tests where the wall is weakest.",
+];
+
+export function buildSiegeReport(args: {
+  turnIndex: number;
+  cost: number;
+  targetTileId: string;
+  magnitudeApplied: number;
+  totalMagnitudeAfter: number;
+  rng: () => number;
+}): TurnReport {
+  const summary = `Siege at ${args.targetTileId} · −${(args.magnitudeApplied * 100).toFixed(0)}% standing floor`;
+  return {
+    turnIndex: args.turnIndex,
+    action: "siege",
+    cost: args.cost,
+    summary,
+    narrative: [pickLine(SIEGE_NARRATIVES, args.rng)],
+    outcome: {
+      targetTileId: args.targetTileId,
+      magnitudeApplied: args.magnitudeApplied,
+      totalMagnitudeAfter: args.totalMagnitudeAfter,
+    },
+  };
+}
+
+// ───────── cast spell (siege / disarm / attrition) ─────────
+//
+// Standalone spell-cast report. The kind-specific outcome is encoded in
+// `outcome.kind` and a payload field; the narrative line picks from a
+// shared bank flavored by kind.
+
+const CAST_SIEGE_NARRATIVES = [
+  "The casting holds for a long heartbeat. The wall remembers being a quarry, briefly, and a section gives.",
+  "A magical pressure plays across the rampart. Not a spell that breaks; a spell that tires.",
+  "The siegework is finished by spellcraft what hands could not finish in a week.",
+];
+const CAST_DISARM_NARRATIVES = [
+  "The defender's wards flicker. A few hold; most don't.",
+  "Glyphs unwind themselves, one careful loop at a time, as if confused by their own purpose.",
+  "Whatever the defender hung on the gate stops being there.",
+];
+const CAST_ATTRITION_NARRATIVES = [
+  "The garrison thins by a count it will not write down.",
+  "A bad night for the defender's roll-call. By dawn, gaps in the line.",
+  "The spell does not announce itself. The casualties are quiet about it too.",
+];
+
+export function buildCastSpellReport(args: {
+  turnIndex: number;
+  cost: number;
+  spellId: string;
+  spellName: string;
+  spellType: "siege" | "disarm" | "attrition";
+  targetTileId: string;
+  // Kind-specific payload. Exactly one of these is populated, matching
+  // `spellType`.
+  siege?: { magnitudeApplied: number; totalMagnitudeAfter: number };
+  disarm?: { fractionApplied: number };
+  attrition?: { unitsKilled: UnitStack };
+  rng: () => number;
+}): TurnReport {
+  let summary: string;
+  let narrativeBank: string[];
+  if (args.spellType === "siege") {
+    const m = args.siege?.magnitudeApplied ?? 0;
+    summary = `${args.spellName} on ${args.targetTileId} · −${(m * 100).toFixed(0)}% standing floor`;
+    narrativeBank = CAST_SIEGE_NARRATIVES;
+  } else if (args.spellType === "disarm") {
+    const f = args.disarm?.fractionApplied ?? 0;
+    summary = `${args.spellName} on ${args.targetTileId} · ${(f * 100).toFixed(0)}% disarm queued`;
+    narrativeBank = CAST_DISARM_NARRATIVES;
+  } else {
+    const k = args.attrition?.unitsKilled;
+    const total = k ? k.ground + k.siege + k.air : 0;
+    summary = `${args.spellName} on ${args.targetTileId} · ${total} defenders lost`;
+    narrativeBank = CAST_ATTRITION_NARRATIVES;
+  }
+  return {
+    turnIndex: args.turnIndex,
+    action: "spell-cast",
+    cost: args.cost,
+    summary,
+    narrative: [pickLine(narrativeBank, args.rng)],
+    outcome: {
+      spellId: args.spellId,
+      spellName: args.spellName,
+      spellType: args.spellType,
+      targetTileId: args.targetTileId,
+      ...(args.siege ? { siege: args.siege } : {}),
+      ...(args.disarm ? { disarm: args.disarm } : {}),
+      ...(args.attrition ? { attrition: args.attrition } : {}),
+    },
+  };
+}
+
+// ───────── flyover ─────────
+//
+// Air-only raid that attrits defenders without taking the tile. Always
+// resolves to "repelled" (or "stalemate"). Attacker losses are doubled —
+// flagged here in the report copy so players see the trade. The combat
+// payload is the post-processed CombatResult.
+const FLYOVER_NARRATIVES = [
+  "Air units strafe the tile and pull up before the spears reach. They leave smoke and arithmetic behind.",
+  "Wings overhead. Bolts up; bodies down. The raid pulls clear before the gates open.",
+  "A flyover, sharp and brief. The defenders learn that the sky is not theirs.",
+  "Your air column harasses the tile and breaks off — a bruise, not a wound.",
+];
+
+export function buildFlyoverReport(args: {
+  turnIndex: number;
+  cost: number;
+  targetTileId: string;
+  unitsSent: UnitStack;
+  combat: CombatResult;
+  artifactFound: ArtifactDefinition | null;
+  rng: () => number;
+}): TurnReport {
+  const summary = `Flyover at ${args.targetTileId}`;
+  const line1 = pickLine(FLYOVER_NARRATIVES, args.rng);
+  const line2 = `Sent ${fmtStack(args.unitsSent)} air. Lost ${fmtStack(args.combat.attackerLosses)} (2× penalty); defenders lost ${fmtStack(args.combat.defenderLosses)}.`;
+  const base: TurnReport = {
+    turnIndex: args.turnIndex,
+    action: "flyover",
+    cost: args.cost,
+    summary,
+    narrative: [line1, line2],
+    outcome: {
+      targetTileId: args.targetTileId,
+      result: args.combat.outcome,
+      unitsSent: args.unitsSent,
+      attackerLosses: args.combat.attackerLosses,
+      defenderLosses: args.combat.defenderLosses,
+      attackPower: args.combat.attackPower,
+      defensePower: args.combat.defensePower,
     },
   };
   return attachArtifact(base, args.artifactFound);

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -10,7 +10,26 @@ export type Caste = "black" | "red" | "white" | "green" | "blue";
 
 export type UnitType = "ground" | "siege" | "air";
 
-export type SpellType = "defense" | "offense" | "production" | "intel";
+export type SpellType =
+  | "defense"
+  | "offense"
+  | "production"
+  | "intel"
+  // May 2026 sim feature additions. These spell kinds are cast standalone
+  // (not bundled with attack) and resolve with a dice roll. See
+  // lib/game/data-server.ts:castSpellServer for runtime semantics.
+  //  - "siege"     → records a siege-debuff IntelEffect; magnitude is the
+  //                  rolled fraction subtracted from the target tile's
+  //                  standing-defense floor.
+  //  - "disarm"    → records a defense-disarm IntelEffect; magnitude is
+  //                  the rolled fraction (0..1) by which the next attack
+  //                  nullifies the defender's armed defense spell.
+  //  - "attrition" → applied immediately at cast: defender units on the
+  //                  target tile are killed, distributed across types
+  //                  proportionally to current composition.
+  | "siege"
+  | "disarm"
+  | "attrition";
 
 // Reveal scope for intel-type artifacts and spells. Used by both
 // SpellDefinition.intelScope and ArtifactDefinition.intelDepth (the latter
@@ -247,6 +266,16 @@ export interface CombatAttackerInput {
   // Red Forge Sight = +0.10 against the targeted tile). Stacks
   // multiplicatively on attackPower after spell contribution.
   intelOffenseBonus?: number;
+  // Land type of the source tile the attack is launching from. Drives the
+  // tile-type attack multiplier (military ×1.20, food ×0.75) and the
+  // magic-tile offense-spell amplifier. Optional for legacy/test callers
+  // that haven't been updated; resolveAttack treats undefined as neutral.
+  sourceLandType?: LandType;
+  // Already-realized offense power from a pre-cast offense spell against
+  // this target (kind = "pre-cast-offense-spell"). Flat addition to
+  // attackPower; not re-amplified by source-tile magic mult (the spell was
+  // cast and rolled already). Optional; legacy callers default to 0.
+  preCastOffenseBonus?: number;
 }
 
 export interface CombatDefenderInput {
@@ -261,6 +290,10 @@ export interface CombatDefenderInput {
   // against the specific attacker). Stacks multiplicatively on defensePower
   // after supply.
   intelDefenseBonus?: number;
+  // Fraction in [0, 1] by which the armed defense spell's contribution is
+  // nullified ("defense-disarm" effect rolled by the attacker). 1 fully
+  // dispels; 0.5 halves; 0 is a no-op. Optional; legacy callers default 0.
+  defenseDisarmFraction?: number;
 }
 
 export interface CombatTileInput {
@@ -272,6 +305,17 @@ export interface CombatTileInput {
   // is unmodified. When present and empty, the tile is treated as isolated
   // and gets the -15% defense floor.
   friendlyNeighbors?: ReadonlyArray<{ landType: LandType }>;
+  // Land type of the contested tile itself. Drives the defender-tile
+  // defense multiplier (military/magic ×1.25), the standing-defense floor
+  // (military 30%, magic 15% of attack power), and the magic-tile
+  // defense-spell amplifier. Optional for legacy/test callers; resolveAttack
+  // treats undefined as neutral.
+  landType?: LandType;
+  // Cumulative siege-debuff magnitude (0..SIEGE_DEBUFF_MAX_MAGNITUDE)
+  // softening this tile's standing-defense floor. Caller is responsible
+  // for clamping to the cap; resolveAttack does not re-clamp. Optional;
+  // legacy callers default to 0.
+  siegeDebuffMagnitude?: number;
 }
 
 // ──── v2: Artifacts (single-use, caste-agnostic, found on turn-spend) ────
@@ -307,8 +351,8 @@ export interface ArtifactDefinition {
   intelDepth?: IntelDepth;
 }
 
-// Persisted, time-bounded combat effects produced by intel spells. Read by
-// resolveAttack via the data-server attack handler.
+// Persisted, time-bounded combat effects produced by intel spells and
+// pre-attack actions. Read by resolveAttack via the data-server attack handler.
 //
 // "alert-vs-caster" — the defender (ownerId) holds an alert against a
 //   specific caster: when that caster attacks the owner, the defender gets a
@@ -318,7 +362,38 @@ export interface ArtifactDefinition {
 // "forge-sight-offense" — the attacker (ownerId) gets a `magnitude` offense
 //   bonus when attacking a specific `targetTileId`. Created by Red Forge
 //   Sight (+0.10). Stacks with the Red Forge Scouts air-upgrade bonus.
-export type IntelEffectKind = "alert-vs-caster" | "forge-sight-offense";
+//
+// "siege-debuff" — the attacker (ownerId) has softened the target tile's
+//   standing-defense floor by `magnitude` (0..1 fraction). Stackable up to
+//   SIEGE_DEBUFF_MAX_MAGNITUDE; combat reads the SUM of active effects.
+//   TTL-only — not consumed by attack.
+//
+// "pre-cast-offense-spell" — the attacker (ownerId) pre-cast an offense
+//   spell pointed at `targetTileId`; `magnitude` is the realized
+//   spell-contribution power (already × magicMultiplier × caste bonus ×
+//   dice). Single-use: combat consumes (deletes) on next attack.
+//
+// "defense-disarm" — the attacker (ownerId) disarmed the target tile's
+//   armed defense spell by `magnitude` (0..1 fraction; 1 = fully nullified).
+//   Single-use: combat consumes on next attack.
+export type IntelEffectKind =
+  | "alert-vs-caster"
+  | "forge-sight-offense"
+  | "siege-debuff"
+  | "pre-cast-offense-spell"
+  | "defense-disarm";
+
+// Cap on stacked siege-debuff magnitude. Three siege actions × 0.10 each →
+// 0.30, which fully neutralizes the military standing floor (0.30) and
+// halves the magic floor (0.15) twice. Spell-cast siege adds on top up to
+// the same cap.
+export const SIEGE_DEBUFF_MAX_MAGNITUDE = 0.30;
+// Per-action siege magnitude (deterministic; spell-cast siege uses dice).
+export const SIEGE_ACTION_MAGNITUDE = 0.10;
+// Kinds that are consumed (deleted) on the next attack against the target
+// tile. Read once, deleted in-tx.
+export const SINGLE_USE_INTEL_EFFECT_KINDS: ReadonlySet<IntelEffectKind> =
+  new Set<IntelEffectKind>(["pre-cast-offense-spell", "defense-disarm"]);
 
 export interface IntelEffect {
   id: string;
@@ -397,7 +472,10 @@ export type TurnAction =
   | "distribute"
   | "spell-arm"
   | "spell-produce"
-  | "attack";
+  | "spell-cast"
+  | "attack"
+  | "siege"
+  | "flyover";
 
 export interface TurnReport {
   // The player.turnsSpentTotal at the time this report was generated.
@@ -433,6 +511,23 @@ export interface CombatResult {
   // 1.0 if the supply system was not consulted (legacy callers); else the
   // multiplier that scaled defense before underdog stacking. 0.85 = isolated.
   supplyMultiplier: number;
+  // Tile-type combat modifiers applied this resolution. 1.0 means neutral
+  // (the legacy default when callers don't pass landType / sourceLandType).
+  // Surfaced so the battle readout can show "Military source ×1.20" etc.
+  sourceLandTypeMultiplier: number;
+  targetLandTypeMultiplier: number;
+  // Absolute defense power added by the standing-defense floor (military
+  // 30% / magic 15% of attack power). 0 for food / unrevealed / unassigned.
+  standingDefenseAdded: number;
+  // True when the offense spell or defense spell was cast from / armed on a
+  // magic tile and received the MAGIC_TILE_SPELL_MULT amplifier.
+  magicTileOffenseSpellBonusApplied: boolean;
+  magicTileDefenseSpellBonusApplied: boolean;
+  // Pre-attack mods (May 2026 sim feature). 0 / false when no effect was
+  // active; surfaced so the BattleReport can render Modifiers lines.
+  siegeDebuffApplied: number;
+  defenseDisarmApplied: number;
+  preCastOffenseApplied: number;
   rng: { attackerRoll: number; defenderRoll: number };
   appliedSpells: { offenseId: string | null; defenseId: string | null };
   // Pre-commit intel produced by the attacker's air-unit intel passive (if

--- a/scripts/send-cohort1-status-and-game.ts
+++ b/scripts/send-cohort1-status-and-game.ts
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+/**
+ * Cohort 1 — pre-kickoff personalized checklist + /game promo.
+ *
+ * For each admitted cohort-1 applicant, send an email that lays out
+ * (per-recipient) what they still owe before Mon May 11:
+ *   - Discord connected?       (users/{uid}.discord.id)
+ *   - GitHub connected?        (users/{uid}.github.login)
+ *   - Intake survey submitted? (summerCohortIntakeSurveys collection by email)
+ *   - Local setup walkthrough  (always shown — there's no completion field)
+ * And promote /game with a "PR your ideas" CTA.
+ *
+ * Idempotent via `cohort1StatusCheckEmailedAt` on the application doc —
+ * re-runs skip anyone already stamped. Use --force to re-send.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-status-and-game.ts --dry-run
+ *   npx tsx scripts/send-cohort1-status-and-game.ts --send
+ *   npx tsx scripts/send-cohort1-status-and-game.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION, isValidCohortId } from "../lib/summer-cohort";
+import { SUMMER_COHORT_INTAKE_COLLECTION } from "../lib/summer-cohort-intake";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const GAME_URL = "https://cursorboston.com/game";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const ALC_URL = "https://ludwitt.com/alc";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  name: string;
+  discordUsername: string | null;
+  githubLogin: string | null;
+  surveyDone: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function row({
+  done,
+  label,
+  doneCopy,
+  todoCopy,
+  ctaUrl,
+  ctaLabel,
+}: {
+  done: boolean;
+  label: string;
+  doneCopy: string;
+  todoCopy: string;
+  ctaUrl: string;
+  ctaLabel: string;
+}): string {
+  if (done) {
+    return `<li style="margin:6px 0;padding:10px 14px;border-left:4px solid #10b981;background:#ecfdf5;border-radius:6px;">
+  <strong>✅ ${escapeHtml(label)}</strong> — ${escapeHtml(doneCopy)}
+</li>`;
+  }
+  return `<li style="margin:6px 0;padding:10px 14px;border-left:4px solid #f59e0b;background:#fffbeb;border-radius:6px;">
+  <strong>⚠️ ${escapeHtml(label)}</strong> — ${escapeHtml(todoCopy)}
+  &nbsp;<a href="${ctaUrl}" style="color:#92400e;font-weight:600;">${escapeHtml(ctaLabel)} →</a>
+</li>`;
+}
+
+function rowText({
+  done,
+  label,
+  doneCopy,
+  todoCopy,
+  ctaUrl,
+  ctaLabel,
+}: {
+  done: boolean;
+  label: string;
+  doneCopy: string;
+  todoCopy: string;
+  ctaUrl: string;
+  ctaLabel: string;
+}): string {
+  if (done) return `  [✓] ${label} — ${doneCopy}`;
+  return `  [ ] ${label} — ${todoCopy}\n      ${ctaLabel}: ${ctaUrl}`;
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(r.name?.split(" ")[0]?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const discordDone = r.discordUsername !== null;
+  const githubDone = r.githubLogin !== null;
+  const allReady = discordDone && githubDone && r.surveyDone;
+
+  const subject = "Cohort 1 — Monday checklist + try /game";
+
+  const checklistHtml = [
+    row({
+      done: discordDone,
+      label: "Discord",
+      doneCopy: `connected as @${r.discordUsername ?? ""}`,
+      todoCopy: "not connected — we can't add you to the cohort channel without this",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect Discord",
+    }),
+    row({
+      done: githubDone,
+      label: "GitHub",
+      doneCopy: `connected as @${r.githubLogin ?? ""}`,
+      todoCopy: "not connected — your PRs need this to count",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect GitHub",
+    }),
+    row({
+      done: r.surveyDone,
+      label: "Intake survey",
+      doneCopy: "submitted — thank you",
+      todoCopy: "~5 min, helps us tailor the program to who's in the room",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Take the survey",
+    }),
+  ].join("");
+
+  const checklistText = [
+    rowText({
+      done: discordDone,
+      label: "Discord",
+      doneCopy: `connected as @${r.discordUsername ?? ""}`,
+      todoCopy: "not connected — we can't add you to the cohort channel without this",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect Discord",
+    }),
+    rowText({
+      done: githubDone,
+      label: "GitHub",
+      doneCopy: `connected as @${r.githubLogin ?? ""}`,
+      todoCopy: "not connected — your PRs need this to count",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Connect GitHub",
+    }),
+    rowText({
+      done: r.surveyDone,
+      label: "Intake survey",
+      doneCopy: "submitted — thank you",
+      todoCopy: "~5 min, helps us tailor the program to who's in the room",
+      ctaUrl: COHORT_URL,
+      ctaLabel: "Take the survey",
+    }),
+  ].join("\n");
+
+  const lead = allReady
+    ? `<p>Hi ${first},</p>
+<p><strong>You're all set for Monday.</strong> Cohort 1 kicks off <strong>Mon, May 11</strong> — see below for one last laptop check, plus something fun to play with this weekend.</p>`
+    : `<p>Hi ${first},</p>
+<p>Cohort 1 kicks off <strong>Mon, May 11</strong>. Quick personalized check on what you still owe so you can show up Monday focused on the work, not the setup:</p>`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+${lead}
+
+<ul style="list-style:none;padding:0;margin:16px 0;">${checklistHtml}</ul>
+
+<p style="margin:18px 0 6px 0;"><strong>💻 On your laptop, before Monday:</strong></p>
+<p style="margin:0 0 10px 0;">Install <strong>Node</strong> (LTS), <strong>Git</strong>, and <strong>Cursor</strong> (or Claude Code if you already have a flow). Full walkthrough — every step, every gotcha — is here:</p>
+<p style="margin:0 0 18px 0;">
+  <a href="${ALC_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;">Open the setup walkthrough →</a>
+</p>
+
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:24px 0;"/>
+
+<p style="margin:0 0 8px 0;"><strong>🎮 While you wait — try /game</strong></p>
+<p style="margin:0 0 12px 0;">We built a small persistent web game right inside this same repo: recruit, run threats, cast spells, climb the leaderboard. Play it for 10 minutes — and if you have ideas for new spells, threat types, balance tweaks, or UI improvements, <strong>open a PR</strong>. The PR fast-lane that admitted most of you is still active, and contributions to <code>/game</code> are exactly the kind of work we want to see this summer.</p>
+<p style="margin:0 0 6px 0;">
+  <a href="${GAME_URL}" style="display:inline-block;background:#7c3aed;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;margin-right:6px;">Open /game →</a>
+  <a href="${REPO_URL}" style="display:inline-block;background:#fff;color:#7c3aed;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;border:1px solid #7c3aed;">Open the repo →</a>
+</p>
+<p style="margin:8px 0 0 0;font-size:13px;color:#555;">Game logic lives under <code>lib/game/</code>; UI under <code>app/game/</code>. Pick something small for your first PR — a new spell ships in an afternoon.</p>
+
+<p style="margin-top:24px;">Reply with anything — questions, install snags, ideas you want to sanity-check before building.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you're an admitted Cohort 1 participant.<br/>
+Don't want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const leadText = allReady
+    ? `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+YOU'RE ALL SET FOR MONDAY. Cohort 1 kicks off Mon, May 11 — see below for one last laptop check, plus something fun to play with this weekend.`
+    : `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+Cohort 1 kicks off Mon, May 11. Quick personalized check on what you still owe so you can show up Monday focused on the work, not the setup:`;
+
+  const text = `${leadText}
+
+YOUR CHECKLIST
+${checklistText}
+
+ON YOUR LAPTOP, BEFORE MONDAY
+Install Node (LTS), Git, and Cursor (or Claude Code if you already have a flow). Full walkthrough — every step, every gotcha:
+  ${ALC_URL}
+
+----
+
+WHILE YOU WAIT — TRY /game
+We built a small persistent web game right inside this same repo: recruit, run threats, cast spells, climb the leaderboard. Play it for 10 minutes — and if you have ideas for new spells, threat types, balance tweaks, or UI improvements, OPEN A PR. The PR fast-lane that admitted most of you is still active, and contributions to /game are exactly the kind of work we want to see this summer.
+
+  Play: ${GAME_URL}
+  Repo: ${REPO_URL}
+
+Game logic lives under lib/game/; UI under app/game/. Pick something small for your first PR — a new spell ships in an afternoon.
+
+Reply with anything — questions, install snags, ideas you want to sanity-check before building.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you're an admitted Cohort 1 participant.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  const force = args.includes("--force");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Loading existing intake submissions from ${SUMMER_COHORT_INTAKE_COLLECTION}…`);
+  const intakeSnap = await db.collection(SUMMER_COHORT_INTAKE_COLLECTION).get();
+  const intakeEmails = new Set<string>();
+  for (const doc of intakeSnap.docs) {
+    const email = (doc.data().email || "").toString().trim().toLowerCase();
+    if (email) intakeEmails.add(email);
+  }
+  console.log(`Existing intake submissions: ${intakeEmails.size}`);
+
+  console.log(`Loading cohort-1 admits from ${SUMMER_COHORT_COLLECTION}…`);
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .where("cohorts", "array-contains", "cohort-1")
+    .where("status", "==", "admitted")
+    .get();
+
+  const recipients: Recipient[] = [];
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let withDiscord = 0;
+  let withGithub = 0;
+  let withSurvey = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    const cohorts = Array.isArray(data.cohorts)
+      ? data.cohorts.filter(isValidCohortId)
+      : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    if (!force && data.cohort1StatusCheckEmailedAt) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+
+    const uid = (data.userId || doc.id).toString();
+    let discordUsername: string | null = null;
+    let githubLogin: string | null = null;
+    if (uid) {
+      const userSnap = await db.collection("users").doc(uid).get();
+      const ud = userSnap.data();
+      const d = ud?.discord;
+      const g = ud?.github;
+      if (d?.id && typeof d.username === "string") discordUsername = d.username;
+      if (g?.login && typeof g.login === "string") githubLogin = g.login;
+    }
+    const surveyDone = intakeEmails.has(email.toLowerCase());
+
+    if (discordUsername) withDiscord++;
+    if (githubLogin) withGithub++;
+    if (surveyDone) withSurvey++;
+
+    recipients.push({
+      applicationId: doc.id,
+      email,
+      name: typeof data.name === "string" ? data.name : "",
+      discordUsername,
+      githubLogin,
+      surveyDone,
+    });
+  }
+
+  console.log(
+    `Eligible to email: ${recipients.length} | already emailed: ${skippedAlreadyEmailed} | no email: ${skippedNoEmail}`
+  );
+  console.log(
+    `  state breakdown — Discord: ${withDiscord}/${recipients.length}, GitHub: ${withGithub}/${recipients.length}, Survey: ${withSurvey}/${recipients.length}`
+  );
+
+  if (recipients.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const allMissing = recipients.find(
+      (r) => !r.discordUsername && !r.githubLogin && !r.surveyDone
+    );
+    const allDone = recipients.find(
+      (r) => r.discordUsername && r.githubLogin && r.surveyDone
+    );
+    const samples = [
+      { label: "ALL MISSING", recipient: allMissing },
+      { label: "ALL DONE", recipient: allDone },
+      { label: "FIRST", recipient: recipients[0] },
+    ].filter((s, i, arr) => {
+      if (!s.recipient) return false;
+      // dedupe by recipient identity
+      return arr.findIndex((x) => x.recipient?.applicationId === s.recipient!.applicationId) === i;
+    });
+
+    for (const s of samples) {
+      const r = s.recipient!;
+      const { subject, html } = buildEmail(r);
+      console.log("============================================================");
+      console.log(`SAMPLE — ${s.label}`);
+      console.log("============================================================");
+      console.log(`To:      ${r.email} (${r.name || "(no name)"})`);
+      console.log(`Discord: ${r.discordUsername ?? "(not connected)"}`);
+      console.log(`GitHub:  ${r.githubLogin ?? "(not connected)"}`);
+      console.log(`Survey:  ${r.surveyDone ? "submitted" : "not submitted"}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- HTML preview (first 2400 chars) ----\n${html.slice(0, 2400)}\n…\n`);
+    }
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(r.applicationId).set(
+        { cohort1StatusCheckEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      sent++;
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Two feature PRs from develop, both authored by @rogerSuperBuilderAlpha (Roger Hunt):

- **#769** — feat(game): battle sim, tile-type mechanics, leaderboard filter
  - Live battle sim panel on `/game/threats` (preview combat result before commit; spy/siege/flyover/cast pre-attack actions)
  - Three new spell types: `siege`, `disarm`, `attrition` (15 new content files: 5 castes × 3 kinds)
  - Tile-type mechanics: recruit on every tile; military/magic/food modifiers; standing-defense floor
  - Leaderboard All/Real/NPC audience filter
  - 30 new combat tests, 13 new intel-effect tests; suite green at 1,781 tests
- **#770** — feat(cohort): readiness modal, setup + game tabs, status email
  - `SetupReadinessModal` pops on `/summer-cohort` for admitted cohort-1 users until Discord + GitHub connected
  - New tabs: Setup Instructions, Game promo
  - `scripts/send-cohort1-status-and-game.ts` — already sent to all 103 admits (idempotent via `cohort1StatusCheckEmailedAt`)

## Contributors
- @rogerSuperBuilderAlpha — #769, #770

## Test plan
- [x] `npm run build` — green locally
- [ ] Verify `/game/threats` battle sim end-to-end on prod
- [ ] Verify `/summer-cohort` readiness modal renders for admitted cohort-1 user without Discord/GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)