### PR TITLE
fix(game): accept null offenseSpellId on /api/game/attack

### DIFF
--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -275,7 +275,7 @@ const AttackBody = z
     sourceTileId: z.string().min(1),
     targetTileId: z.string().min(1),
     units: UnitStackSchema,
-    offenseSpellId: z.string().optional(),
+    offenseSpellId: z.string().nullish(),
   })
   .openapi("GameAttackBody");
 


### PR DESCRIPTION
## Summary
Production hotfix for the new battle-sim path. `POST /api/game/attack` was returning 400 \"Expected string, received null\" on every attack without a spell, because:

- The Threats UI client field is `offenseSpellId: string \| null` (`ThreatRow.tsx:210`, `dashboard-actions.ts:318`).
- `JSON.stringify(args)` serializes `null` literally.
- The Zod schema had `offenseSpellId: z.string().optional()` — accepts `undefined`, rejects `null`.

Switched to `.nullish()`. The route handler already does `parsed.data.offenseSpellId ?? null`, so downstream is unchanged.

## Repro
- Vercel runtime log: `POST /api/game/attack → 400, 106ms`, body `{ \"offenseSpellId\": null, ... }`.
- UI surfaced the error string: \"Expected string, received null\".

## Test plan
- [x] Typecheck clean
- [ ] Verify on prod: pick a target on `/game/threats`, leave Spell as \"— none —\", click Attack → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)