### PR TITLE
release: hotfix attack 400 (null offenseSpellId)

### DIFF
--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -275,7 +275,7 @@ const AttackBody = z
     sourceTileId: z.string().min(1),
     targetTileId: z.string().min(1),
     units: UnitStackSchema,
-    offenseSpellId: z.string().optional(),
+    offenseSpellId: z.string().nullish(),
   })
   .openapi("GameAttackBody");
 


### PR DESCRIPTION
## Summary
Forwards #773 — a one-line schema fix for `POST /api/game/attack` returning 400 on every spell-less attack. Schema accepted `undefined` but not `null`; client sends `null`.

## Contributors
- @rogerSuperBuilderAlpha — #773

## Test plan
- [x] Typecheck clean
- [ ] Smoke test on prod: attack with Spell = \"— none —\" returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)