### PR TITLE
fix(game): 'Defender had' label after capture + recruit on food/magic tiles from threats

### DIFF
--- a/app/game/threats/_components/BattleReport.tsx
+++ b/app/game/threats/_components/BattleReport.tsx
@@ -20,8 +20,11 @@ export interface BattleReportProps {
   /** The TurnReport produced by the same attack — used for the prose
    *  narrative and the cost-in-turns banner. */
   report: TurnReport;
-  /** Post-combat enemy tile state. We derive defender pre-attack units as
-   *  `targetTile.units + combat.defenderLosses`. */
+  /** Post-combat enemy tile state. For repelled/stalemate we derive defender
+   *  pre-attack units as `targetTile.units + combat.defenderLosses`. For a
+   *  captured tile, `targetTile.units` is the attacker's survivors so we
+   *  fall back to `combat.defenderLosses` directly (which combat.ts sets to
+   *  the defender's full pre-attack stack on capture). */
   targetTile: GameTile;
   /** Click-to-dismiss handler. The card persists until cleared (or the
    *  next attack on the same row overwrites it). */
@@ -64,7 +67,10 @@ export function BattleReport({
   targetTile,
   onDismiss,
 }: BattleReportProps) {
-  const defenderPreAttack = addStacks(targetTile.units, combat.defenderLosses);
+  const defenderPreAttack =
+    combat.outcome === "captured"
+      ? combat.defenderLosses
+      : addStacks(targetTile.units, combat.defenderLosses);
   const sent = combat.unitsDeployed;
   const sentTotal = totalUnits(sent);
   const defenderHadTotal = totalUnits(defenderPreAttack);

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -20,6 +20,7 @@ import type {
   TurnReport,
   UnitType,
 } from "@/lib/game/types";
+import { unitsPerCycleForLand } from "@/app/game/recruit/_lib/constants";
 import type { ThreatEntry } from "../_lib/threats-derive";
 import { useAttackPreview } from "../_lib/use-attack-preview";
 import { BattleReport } from "./BattleReport";
@@ -411,13 +412,15 @@ export function ThreatRow(props: ThreatRowProps) {
             );
           })}
         </div>
-        {/* Recruit */}
+        {/* Recruit — military/food/magic recruit at different rates;
+            unrevealed/unassigned can't recruit (must assign first). */}
         <div className="flex flex-wrap items-center gap-1.5 text-xs">
           <span className="text-neutral-500 mr-1">Recruit · 5t:</span>
           {UNIT_TYPES.map((u) => {
+            const yieldPerCycle = unitsPerCycleForLand(source.type);
             const reason =
-              source.type !== "military"
-                ? "Tile is not military — assign first"
+              yieldPerCycle <= 0
+                ? "Tile cannot recruit — assign land type first"
                 : player.turnsRemaining < 5
                   ? "Need 5 turns"
                   : null;
@@ -426,10 +429,12 @@ export function ThreatRow(props: ThreatRowProps) {
                 key={u}
                 onClick={() => handleRecruit(u)}
                 disabled={busy || reason !== null}
-                title={reason ?? `Recruit +10 ${u} on source`}
+                title={
+                  reason ?? `Recruit +${yieldPerCycle} ${u} on source`
+                }
                 className="px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 capitalize"
               >
-                +10 {u}
+                +{yieldPerCycle || 10} {u}
               </button>
             );
           })}


### PR DESCRIPTION
## Summary
Two playtest-surfaced bugs in the post-#769 Threats UI.

### 1. \"Defender had\" mislabeled after a capture
`BattleReport.tsx` derived defender pre-attack units as `targetTile.units + combat.defenderLosses`. After a capture, the server sets `targetTile.units` to the attacker's surviving stack (it occupies the tile now). The formula returned `survivors + 0`, which the UI then labeled \"Defender had Gx\".

This is the source of the \"no base defense\" confusion in the latest playtest screenshot: report said defender had G10 but defense=0. In fact the tile had **0 defenders** on a food tile (no standing-defense floor by design), and G10 was the attacker's survivors.

Fix: when `combat.outcome === \"captured\"`, use `combat.defenderLosses` directly (combat.ts sets this to the defender's full pre-attack stack on capture).

### 2. Recruit blocked on food/magic tiles from threats screen
`ThreatRow.tsx` still gated recruit on `source.type !== \"military\"`. #769 opened recruit to all recruitable land types (military/food/magic) — the dedicated `/game/recruit` page got updated but the inline recruit on `/game/threats` was missed.

Fix: use the shared `unitsPerCycleForLand` helper. The +N label reflects actual yield (military 10, food/magic 5).

## Test plan
- [x] Typecheck clean
- [ ] On `/game/threats` with a food source tile, the recruit buttons should be enabled and produce 5 units per cycle
- [ ] Capture a tile with 0 defenders — \"Defender had\" should read G0 (not the attacker's stack)
- [ ] Repel/stalemate paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)