### PR TITLE
release: 'Defender had' label fix + recruit-on-food from threats

### DIFF
--- a/app/game/threats/_components/BattleReport.tsx
+++ b/app/game/threats/_components/BattleReport.tsx
@@ -20,8 +20,11 @@ export interface BattleReportProps {
   /** The TurnReport produced by the same attack — used for the prose
    *  narrative and the cost-in-turns banner. */
   report: TurnReport;
-  /** Post-combat enemy tile state. We derive defender pre-attack units as
-   *  `targetTile.units + combat.defenderLosses`. */
+  /** Post-combat enemy tile state. For repelled/stalemate we derive defender
+   *  pre-attack units as `targetTile.units + combat.defenderLosses`. For a
+   *  captured tile, `targetTile.units` is the attacker's survivors so we
+   *  fall back to `combat.defenderLosses` directly (which combat.ts sets to
+   *  the defender's full pre-attack stack on capture). */
   targetTile: GameTile;
   /** Click-to-dismiss handler. The card persists until cleared (or the
    *  next attack on the same row overwrites it). */
@@ -64,7 +67,10 @@ export function BattleReport({
   targetTile,
   onDismiss,
 }: BattleReportProps) {
-  const defenderPreAttack = addStacks(targetTile.units, combat.defenderLosses);
+  const defenderPreAttack =
+    combat.outcome === "captured"
+      ? combat.defenderLosses
+      : addStacks(targetTile.units, combat.defenderLosses);
   const sent = combat.unitsDeployed;
   const sentTotal = totalUnits(sent);
   const defenderHadTotal = totalUnits(defenderPreAttack);

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -20,6 +20,7 @@ import type {
   TurnReport,
   UnitType,
 } from "@/lib/game/types";
+import { unitsPerCycleForLand } from "@/app/game/recruit/_lib/constants";
 import type { ThreatEntry } from "../_lib/threats-derive";
 import { useAttackPreview } from "../_lib/use-attack-preview";
 import { BattleReport } from "./BattleReport";
@@ -411,13 +412,15 @@ export function ThreatRow(props: ThreatRowProps) {
             );
           })}
         </div>
-        {/* Recruit */}
+        {/* Recruit — military/food/magic recruit at different rates;
+            unrevealed/unassigned can't recruit (must assign first). */}
         <div className="flex flex-wrap items-center gap-1.5 text-xs">
           <span className="text-neutral-500 mr-1">Recruit · 5t:</span>
           {UNIT_TYPES.map((u) => {
+            const yieldPerCycle = unitsPerCycleForLand(source.type);
             const reason =
-              source.type !== "military"
-                ? "Tile is not military — assign first"
+              yieldPerCycle <= 0
+                ? "Tile cannot recruit — assign land type first"
                 : player.turnsRemaining < 5
                   ? "Need 5 turns"
                   : null;
@@ -426,10 +429,12 @@ export function ThreatRow(props: ThreatRowProps) {
                 key={u}
                 onClick={() => handleRecruit(u)}
                 disabled={busy || reason !== null}
-                title={reason ?? `Recruit +10 ${u} on source`}
+                title={
+                  reason ?? `Recruit +${yieldPerCycle} ${u} on source`
+                }
                 className="px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 capitalize"
               >
-                +10 {u}
+                +{yieldPerCycle || 10} {u}
               </button>
             );
           })}


### PR DESCRIPTION
## Summary
Forwards #775 — two playtest-surfaced bugs in the post-#769 Threats UI:

- BattleReport's \"Defender had\" was wrong after a capture (showed attacker's survivors).
- Inline recruit on threats screen still gated on military-only; #769 opened recruit to food/magic too.

## Contributors
- @rogerSuperBuilderAlpha — #775

## Test plan
- [x] Typecheck clean
- [ ] Smoke on prod: recruit from a food tile in `/game/threats`; capture an undefended tile and verify \"Defender had G0\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)