### PR TITLE
release: Humans/NPCs audience filter on world map

### DIFF
--- a/app/game/tiles/_components/AudienceFilterRow.tsx
+++ b/app/game/tiles/_components/AudienceFilterRow.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import type { AudienceFilter } from "../_lib/types";
+
+interface Props {
+  audience: AudienceFilter;
+  onChange: (next: AudienceFilter) => void;
+  humanCount: number;
+  npcCount: number;
+}
+
+export function AudienceFilterRow({
+  audience,
+  onChange,
+  humanCount,
+  npcCount,
+}: Props) {
+  const options: Array<{ key: AudienceFilter; label: string }> = [
+    { key: "all", label: `All (${humanCount + npcCount})` },
+    { key: "humans", label: `Humans (${humanCount})` },
+    { key: "npcs", label: `NPCs (${npcCount})` },
+  ];
+  return (
+    <div className="flex flex-wrap gap-2 mb-3">
+      <span className="text-xs uppercase tracking-wide text-neutral-500 self-center mr-1">
+        Audience
+      </span>
+      {options.map((opt) => (
+        <button
+          key={opt.key}
+          onClick={() => onChange(opt.key)}
+          className={`px-3 py-1.5 rounded-lg text-sm border ${
+            audience === opt.key
+              ? "bg-emerald-500 text-white border-emerald-500"
+              : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/game/tiles/_lib/types.ts
+++ b/app/game/tiles/_lib/types.ts
@@ -19,7 +19,12 @@ export interface OwnerSummary {
   displayName: string;
   caste: Caste | null;
   shielded: boolean;
+  /** True for seeded NPCs; false for real humans. Used by the audience
+   *  filter on the world map. */
+  isNpc?: boolean;
 }
+
+export type AudienceFilter = "all" | "humans" | "npcs";
 
 export interface MapMeResponse {
   success: boolean;

--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -10,13 +10,14 @@ import Link from "next/link";
 import { useCallback, useState } from "react";
 import { mayRefresh, mergeTiles as mergeTilesIntoCache } from "@/lib/game/local-map-cache";
 import type { LandType, MapTile } from "@/lib/game/types";
+import { AudienceFilterRow } from "./_components/AudienceFilterRow";
 import { LandTypeFilterRow } from "./_components/LandTypeFilterRow";
 import { MapCanvas } from "./_components/MapCanvas";
 import { MapLegend } from "./_components/MapLegend";
 import { PersonalMapToolbar } from "./_components/PersonalMapToolbar";
 import { ScopeFilterRow } from "./_components/ScopeFilterRow";
 import { TileActionsModal } from "./_components/TileActionsModal";
-import type { ScopeFilter } from "./_lib/types";
+import type { AudienceFilter, ScopeFilter } from "./_lib/types";
 import { usePanZoom } from "./_lib/use-pan-zoom";
 import { useTilesData } from "./_lib/use-tiles-data";
 
@@ -44,6 +45,7 @@ export default function TilesMapPage() {
   const panZoom = usePanZoom();
   const [filter, setFilter] = useState<LandType | "all">("all");
   const [scope, setScope] = useState<ScopeFilter>("everyone");
+  const [audience, setAudience] = useState<AudienceFilter>("all");
   // Tile-actions modal: open when the user clicks a tile. Holds a tileId
   // (not the MapTile itself) so it stays in sync with mutations.
   const [modalTileId, setModalTileId] = useState<string | null>(null);
@@ -77,9 +79,28 @@ export default function TilesMapPage() {
   }
 
   const ownTiles = tiles.filter((t) => t.ownerId === player.userId);
+  // Audience counts by owner (not by tile) — filter dropdown labels show
+  // how many distinct opponents fall in each bucket, since one player
+  // typically owns many tiles.
+  let humanCount = 0;
+  let npcCount = 0;
+  for (const owner of ownersById.values()) {
+    if (owner.userId === player.userId) continue;
+    if (owner.isNpc) npcCount++;
+    else humanCount++;
+  }
   const visibleTiles = tiles.filter((t) => {
     if (scope === "mine" && t.ownerId !== player.userId) return false;
     if (scope === "foreign" && t.ownerId === player.userId) return false;
+    // Audience filter only applies to enemy-owned tiles. Own tiles and
+    // unowned (frontier/wilderness) always pass — hiding either would be
+    // confusing for the player.
+    if (audience !== "all" && t.ownerId && t.ownerId !== player.userId) {
+      const owner = ownersById.get(t.ownerId);
+      const isNpc = owner?.isNpc === true;
+      if (audience === "humans" && isNpc) return false;
+      if (audience === "npcs" && !isNpc) return false;
+    }
     return true;
   });
 
@@ -146,6 +167,13 @@ export default function TilesMapPage() {
           onChange={setScope}
           totalCount={tiles.length}
           ownCount={ownTiles.length}
+        />
+
+        <AudienceFilterRow
+          audience={audience}
+          onChange={setAudience}
+          humanCount={humanCount}
+          npcCount={npcCount}
         />
 
         <LandTypeFilterRow

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -493,6 +493,10 @@ export interface OwnerSummary {
   displayName: string;
   caste: Caste | null;
   shielded: boolean;
+  /** True when this player is a seeded NPC. Real humans have the field
+   *  unset on their player doc; we surface explicit `false` for them so
+   *  client-side filters can rely on the boolean. */
+  isNpc: boolean;
 }
 
 // Personal map view: my tiles + the *enemy* tiles that share an edge with
@@ -574,6 +578,7 @@ export async function getMyMapServer(
         displayName: p.displayName ?? "",
         caste: p.caste ?? null,
         shielded: isShieldActive(p, now),
+        isNpc: (p as { isNpc?: boolean }).isNpc === true,
       });
     }
   }
@@ -595,16 +600,18 @@ export async function getAllOwnerSummariesServer(
       "caste",
       "shieldUntil",
       "shieldDropAtTurn",
-      "turnsSpentTotal"
+      "turnsSpentTotal",
+      "isNpc"
     )
     .get();
   return snap.docs.map((d) => {
-    const data = d.data() as GamePlayer;
+    const data = d.data() as GamePlayer & { isNpc?: boolean };
     return {
       userId: data.userId,
       displayName: data.displayName ?? "",
       caste: data.caste ?? null,
       shielded: isShieldActive(data, now),
+      isNpc: data.isNpc === true,
     };
   });
 }

--- a/lib/game/local-map-cache.ts
+++ b/lib/game/local-map-cache.ts
@@ -25,7 +25,11 @@
 
 import type { Caste, MapTile } from "./types";
 
-const CACHE_VERSION = 1;
+// v2: added `isNpc` to CachedOwnerSummary so the world-map audience filter
+// (Humans / NPCs) has the data it needs without a re-fetch. Bumping the
+// version invalidates v1 caches; clients rehydrate from /api/game/map/me
+// on next load.
+const CACHE_VERSION = 2;
 const KEY_PREFIX = "cb-game-map-v" + CACHE_VERSION + ":";
 export const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -34,6 +38,9 @@ export interface CachedOwnerSummary {
   displayName: string;
   caste: Caste | null;
   shielded: boolean;
+  /** True for seeded NPCs; false for real human players. Optional only for
+   *  defensive parsing of older cache entries — fresh data always sets it. */
+  isNpc?: boolean;
 }
 
 export interface CachedMapView {

--- a/lib/game/world-snapshot.ts
+++ b/lib/game/world-snapshot.ts
@@ -38,6 +38,10 @@ export interface WorldSnapshotOwner {
   displayName: string;
   caste: Caste | null;
   shielded: boolean;
+  /** True for seeded NPCs. Real humans surface `false` (their player doc
+   *  has no `isNpc` field; we coerce the missing case to `false` for the
+   *  client). Used by the map's audience filter. */
+  isNpc: boolean;
 }
 
 export interface WorldSnapshot {
@@ -80,7 +84,8 @@ export async function computeWorldSnapshot(
         "caste",
         "shieldUntil",
         "shieldDropAtTurn",
-        "turnsSpentTotal"
+        "turnsSpentTotal",
+        "isNpc"
       )
       .get(),
   ]);
@@ -99,12 +104,13 @@ export async function computeWorldSnapshot(
   });
 
   const owners: WorldSnapshotOwner[] = playersSnap.docs.map((d) => {
-    const p = d.data() as GamePlayer;
+    const p = d.data() as GamePlayer & { isNpc?: boolean };
     return {
       userId: p.userId,
       displayName: p.displayName ?? "",
       caste: p.caste ?? null,
       shielded: isShieldActive(p, now),
+      isNpc: p.isNpc === true,
     };
   });
 


### PR DESCRIPTION
## Summary
Forwards #777 — adds a Humans/NPCs filter row to `/game/tiles`. Backend carries `isNpc` through `OwnerSummary` + `WorldSnapshotOwner`; UI gets a third filter row alongside Show / Land Type.

## Contributors
- @rogerSuperBuilderAlpha — #777

## Post-deploy
Once Vercel ships, hit `POST /api/internal/snapshots/rebuild?only=game-world` (or wait ≤5 min for the cron) so the snapshot doc carries `isNpc` on owners. Until then, NPCs render as humans on the map.

## Test plan
- [x] Typecheck clean
- [ ] On prod, audience row renders at `/game/tiles` with non-zero counts (after snapshot rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)