### PR TITLE
release: real-time world map + gated snapshot rebuilds

### DIFF
--- a/app/game/_lib/use-world-snapshot-listener.ts
+++ b/app/game/_lib/use-world-snapshot-listener.ts
@@ -1,0 +1,253 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { doc, onSnapshot, Timestamp } from "firebase/firestore";
+import { useEffect, useRef, useState } from "react";
+import { db as firestoreDb } from "@/lib/firebase";
+import type { Caste, MapTile } from "@/lib/game/types";
+
+// Mirrors WorldSnapshot in lib/game/world-snapshot.ts (which we can't
+// import here because it pulls firebase-admin). When the snapshot doc is
+// read by the client SDK, Firestore Timestamps stay as Timestamp
+// instances; we coerce to ISO strings on parse so the rest of the UI
+// treats it as plain JSON.
+export interface ClientWorldSnapshotOwner {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+  isNpc: boolean;
+}
+
+export interface ClientWorldSnapshot {
+  tiles: MapTile[];
+  owners: ClientWorldSnapshotOwner[];
+  generatedAt: string;
+  tileCount: number;
+  ownerCount: number;
+}
+
+// Detach from the live listener when the tab is hidden OR the user has
+// been idle for this long. Firestore bills 1 read per delivered change,
+// so a tab left open all weekend would otherwise stack up cron-rebuild
+// reads (12/hour, possibly skipped by the gating but still potentially
+// delivering on actual changes). Five minutes of inactivity is the same
+// staleness bound the snapshot itself targets.
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+const ACTIVITY_EVENTS: ReadonlyArray<keyof DocumentEventMap> = [
+  "mousemove",
+  "mousedown",
+  "keydown",
+  "scroll",
+  "touchstart",
+  "click",
+];
+
+export interface WorldSnapshotListenerState {
+  /** Latest delivered snapshot, or null while waiting for the first one. */
+  snapshot: ClientWorldSnapshot | null;
+  /** True when the live listener is currently attached. False while
+   *  detached due to tab-hidden / idle / no Firestore SDK / no auth. */
+  connected: boolean;
+  /** ms-epoch timestamp of the most recent snapshot delivery, or null. */
+  lastReceivedAt: number | null;
+  /** Last error observed from the listener (e.g. permission denied
+   *  before sign-in). Cleared on a successful delivery. */
+  error: string | null;
+}
+
+function parseSnapshotDoc(data: Record<string, unknown>): ClientWorldSnapshot {
+  const generatedAtRaw = data.generatedAt;
+  let generatedAt: string;
+  if (generatedAtRaw instanceof Timestamp) {
+    generatedAt = generatedAtRaw.toDate().toISOString();
+  } else if (generatedAtRaw instanceof Date) {
+    generatedAt = generatedAtRaw.toISOString();
+  } else if (typeof generatedAtRaw === "string") {
+    generatedAt = generatedAtRaw;
+  } else {
+    generatedAt = new Date().toISOString();
+  }
+  const tiles = Array.isArray(data.tiles) ? (data.tiles as MapTile[]) : [];
+  const owners = Array.isArray(data.owners)
+    ? (data.owners as ClientWorldSnapshotOwner[])
+    : [];
+  return {
+    tiles,
+    owners,
+    generatedAt,
+    tileCount: typeof data.tileCount === "number" ? data.tileCount : tiles.length,
+    ownerCount:
+      typeof data.ownerCount === "number" ? data.ownerCount : owners.length,
+  };
+}
+
+/**
+ * Real-time subscription to `game_world_snapshots/latest`.
+ *
+ * Behaviour:
+ *   - Attaches a Firestore listener on mount (when the tab is visible
+ *     and the user is active).
+ *   - Detaches when the tab becomes hidden (`document.visibilityState
+ *     === "hidden"`) and reattaches when it becomes visible again.
+ *   - Detaches after IDLE_TIMEOUT_MS without keyboard / mouse / touch
+ *     activity. Reattaches on the next activity event.
+ *   - Cleans up on unmount.
+ *
+ * The hook gracefully no-ops in environments without the Web SDK
+ * configured (e.g. SSR, test envs with placeholder env vars).
+ */
+export function useWorldSnapshotListener(opts: {
+  /** Set to false to keep the listener detached entirely (e.g. while
+   *  the user isn't authenticated). The snapshot doc requires auth. */
+  enabled?: boolean;
+} = {}): WorldSnapshotListenerState {
+  const enabled = opts.enabled ?? true;
+
+  const [state, setState] = useState<WorldSnapshotListenerState>({
+    snapshot: null,
+    connected: false,
+    lastReceivedAt: null,
+    error: null,
+  });
+
+  // Refs for the imperative connection lifecycle. Keeping these in refs
+  // (rather than state) avoids re-running the effect every time the
+  // listener attaches / detaches.
+  const unsubRef = useRef<(() => void) | null>(null);
+  const idleTimerRef = useRef<number | null>(null);
+  const lastActivityAtRef = useRef<number>(Date.now());
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined") return;
+    if (!firestoreDb) {
+      // Web SDK not configured — leave detached. The map UI keeps any
+      // HTTP-fetched fallback data it already had.
+      return;
+    }
+    const fdb = firestoreDb;
+
+    const ref = doc(fdb, "game_world_snapshots", "latest");
+
+    const attach = () => {
+      if (unsubRef.current) return;
+      const unsub = onSnapshot(
+        ref,
+        (snap) => {
+          if (!snap.exists()) return;
+          try {
+            const parsed = parseSnapshotDoc(snap.data());
+            setState({
+              snapshot: parsed,
+              connected: true,
+              lastReceivedAt: Date.now(),
+              error: null,
+            });
+          } catch (e) {
+            setState((prev) => ({
+              ...prev,
+              connected: true,
+              error: e instanceof Error ? e.message : "snapshot parse error",
+            }));
+          }
+        },
+        (err) => {
+          setState((prev) => ({
+            ...prev,
+            connected: false,
+            error: err.message ?? "snapshot listener error",
+          }));
+        }
+      );
+      unsubRef.current = unsub;
+      setState((prev) => ({ ...prev, connected: true, error: null }));
+    };
+
+    const detach = () => {
+      if (unsubRef.current) {
+        unsubRef.current();
+        unsubRef.current = null;
+        setState((prev) => ({ ...prev, connected: false }));
+      }
+    };
+
+    const armIdleTimer = () => {
+      if (idleTimerRef.current !== null) {
+        window.clearTimeout(idleTimerRef.current);
+      }
+      idleTimerRef.current = window.setTimeout(() => {
+        idleTimerRef.current = null;
+        // Detach only if no activity arrived during the window.
+        if (Date.now() - lastActivityAtRef.current >= IDLE_TIMEOUT_MS) {
+          detach();
+        } else {
+          armIdleTimer();
+        }
+      }, IDLE_TIMEOUT_MS);
+    };
+
+    const onActivity = () => {
+      lastActivityAtRef.current = Date.now();
+      // If we were detached because of idle, reattach on the next
+      // user input. Tab-hidden detaches stay detached until the
+      // visibility event fires.
+      if (
+        !unsubRef.current &&
+        document.visibilityState === "visible"
+      ) {
+        attach();
+      }
+      // Reset the idle countdown — we're alive.
+      armIdleTimer();
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        detach();
+        if (idleTimerRef.current !== null) {
+          window.clearTimeout(idleTimerRef.current);
+          idleTimerRef.current = null;
+        }
+      } else {
+        // Visible again — refresh the activity stamp and attach.
+        lastActivityAtRef.current = Date.now();
+        attach();
+        armIdleTimer();
+      }
+    };
+
+    // Initial wiring.
+    document.addEventListener("visibilitychange", onVisibility);
+    for (const evt of ACTIVITY_EVENTS) {
+      document.addEventListener(evt, onActivity, { passive: true });
+    }
+
+    // Only attach if the page is visible right now. SSR hydration may
+    // mount this hook on a hidden tab (preloaded link, etc.).
+    if (document.visibilityState === "visible") {
+      attach();
+      armIdleTimer();
+    }
+
+    return () => {
+      detach();
+      if (idleTimerRef.current !== null) {
+        window.clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+      document.removeEventListener("visibilitychange", onVisibility);
+      for (const evt of ACTIVITY_EVENTS) {
+        document.removeEventListener(evt, onActivity);
+      }
+    };
+  }, [enabled]);
+
+  return state;
+}

--- a/app/game/tiles/_components/PersonalMapToolbar.tsx
+++ b/app/game/tiles/_components/PersonalMapToolbar.tsx
@@ -18,6 +18,10 @@ interface Props {
   cachedView: CachedMapView | null;
   refreshing: boolean;
   onRefresh: () => void;
+  /** True while the live snapshot listener is attached. False when
+   *  detached due to tab-hidden / idle / no Web SDK. Surfaced so the
+   *  player can see whether their map is updating in real time. */
+  liveConnected?: boolean;
 }
 
 export function PersonalMapToolbar({
@@ -26,6 +30,7 @@ export function PersonalMapToolbar({
   cachedView,
   refreshing,
   onRefresh,
+  liveConnected,
 }: Props) {
   const ms = msUntilRefresh(cachedView);
   const allowed = ms === 0;
@@ -88,6 +93,28 @@ export function PersonalMapToolbar({
             </span>
           )}
         </>
+      )}
+      {liveConnected !== undefined && (
+        <span
+          className={`ml-auto inline-flex items-center gap-1.5 text-xs ${
+            liveConnected
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-neutral-400"
+          }`}
+          title={
+            liveConnected
+              ? "Live updates on — map refreshes automatically when the world changes"
+              : "Live updates paused (tab idle or hidden) — will resume on activity"
+          }
+        >
+          <span
+            className={`inline-block h-2 w-2 rounded-full ${
+              liveConnected ? "bg-emerald-500 animate-pulse" : "bg-neutral-400"
+            }`}
+            aria-hidden="true"
+          />
+          {liveConnected ? "Live" : "Paused"}
+        </span>
       )}
     </div>
   );

--- a/app/game/tiles/_lib/use-tiles-data.ts
+++ b/app/game/tiles/_lib/use-tiles-data.ts
@@ -8,10 +8,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useWorldSnapshotListener } from "@/app/game/_lib/use-world-snapshot-listener";
+import { neighborTileIds } from "@/lib/game/world-gen";
 import {
   loadCachedMap,
   saveCachedMap,
   type CachedMapView,
+  type CachedOwnerSummary,
 } from "@/lib/game/local-map-cache";
 import type { GamePlayer, MapTile } from "@/lib/game/types";
 import type {
@@ -126,6 +129,88 @@ export function useTilesData() {
     return () => clearInterval(id);
   }, [cachedView]);
 
+  // Real-time push from `game_world_snapshots/latest`. The listener
+  // auto-detaches when the tab is hidden or the user is idle for 5 min
+  // (see use-world-snapshot-listener.ts) so a long-open background tab
+  // doesn't keep billing reads for cron-rebuild deliveries.
+  const live = useWorldSnapshotListener({ enabled: !!user });
+
+  // When the listener delivers a fresh snapshot, refresh both the
+  // personal cache (derived from the snapshot via the same logic the
+  // server's deriveMyMapFromSnapshot uses) and the world view. Server
+  // gating ensures the doc only changes when game state actually
+  // changed, so each delivery is a meaningful update — no spurious
+  // cache thrash.
+  //
+  // The setCachedView/setWorldView calls inside this effect are the
+  // canonical "subscribe to external system, mirror into local state"
+  // pattern from the React docs — the lint rule flags it conservatively
+  // because it can't see past the upstream listener.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!user) return;
+    if (!live.snapshot) return;
+    const snap = live.snapshot;
+
+    // Personal-mode derivation: my tiles + the enemy ring touching my
+    // borders + owner summaries for those enemies.
+    const tilesById = new Map<string, MapTile>();
+    for (const t of snap.tiles) tilesById.set(t.tileId, t);
+    const myTiles = snap.tiles.filter((t) => t.ownerId === user.uid);
+    const myIds = new Set(myTiles.map((t) => t.tileId));
+    const borderTiles: MapTile[] = [];
+    const enemyOwnerIds = new Set<string>();
+    const seen = new Set<string>();
+    for (const t of myTiles) {
+      for (const nid of neighborTileIds(t.q, t.r)) {
+        if (myIds.has(nid)) continue;
+        if (seen.has(nid)) continue;
+        seen.add(nid);
+        const neighbor = tilesById.get(nid);
+        if (!neighbor) continue;
+        if (!neighbor.ownerId || neighbor.ownerId === user.uid) continue;
+        borderTiles.push(neighbor);
+        enemyOwnerIds.add(neighbor.ownerId);
+      }
+    }
+    const cachedOwners: CachedOwnerSummary[] = [];
+    for (const o of snap.owners) {
+      if (enemyOwnerIds.has(o.userId)) {
+        cachedOwners.push({
+          userId: o.userId,
+          displayName: o.displayName,
+          caste: o.caste,
+          shielded: o.shielded,
+          isNpc: o.isNpc,
+        });
+      }
+    }
+    const view: CachedMapView = {
+      myTiles,
+      borderTiles,
+      owners: cachedOwners,
+      lastFetchedAt: Date.now(),
+    };
+    saveCachedMap(user.uid, view);
+    setCachedView(view);
+
+    // World view stays in sync too — when the user toggles to 🌐 it's
+    // already ready, no extra HTTP fetch needed.
+    setWorldView({
+      tiles: snap.tiles,
+      owners: snap.owners.map((o) => ({
+        userId: o.userId,
+        displayName: o.displayName,
+        caste: o.caste,
+        shielded: o.shielded,
+        isNpc: o.isNpc,
+      })),
+    });
+    // Listener supplied data; no need to leave the loading skeleton up.
+    setLoading(false);
+  }, [live.snapshot, user]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
   // Whole-world snapshot for the 🌐 button. Lazy: only runs when the user
   // explicitly switches modes. Surfaces fetch errors inline so a failed
   // request doesn't silently look like an empty world.
@@ -205,6 +290,7 @@ export function useTilesData() {
     ownersById,
     refreshPersonalMap,
     fetchWorldOnce,
+    liveConnected: live.connected,
   };
 }
 

--- a/app/game/tiles/page.tsx
+++ b/app/game/tiles/page.tsx
@@ -40,6 +40,7 @@ export default function TilesMapPage() {
     ownersById,
     refreshPersonalMap,
     fetchWorldOnce,
+    liveConnected,
   } = data;
 
   const panZoom = usePanZoom();
@@ -160,6 +161,7 @@ export default function TilesMapPage() {
             if (cachedView && !mayRefresh(cachedView)) return;
             void refreshPersonalMap();
           }}
+          liveConnected={liveConnected}
         />
 
         <ScopeFilterRow

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -422,6 +422,16 @@ service cloud.firestore {
       allow create, update, delete: if false;
     }
 
+    // Game — World snapshot (denormalized tiles + owner summaries). The
+    // map view subscribes to `latest` via a Firestore real-time listener,
+    // which auto-detaches when the tab is hidden or the user goes idle
+    // for ~5 min. Authenticated read only. All writes are Admin SDK
+    // (cron + post-action freshness rebuild).
+    match /game_world_snapshots/{docId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
+
     // Game — Artifacts (v2): a player can only read their own inventory.
     // All writes go through the Admin SDK via turn-spending API routes.
     match /game_artifacts/{artifactId} {

--- a/lib/game/world-snapshot.ts
+++ b/lib/game/world-snapshot.ts
@@ -123,14 +123,81 @@ export async function computeWorldSnapshot(
   };
 }
 
-// Reads + writes the snapshot doc. Idempotent. Logs the size so we can
-// monitor when we approach the 1MB Firestore doc limit (will need
-// sharding around ~12K tiles — see comment at end of file).
+// Cheap pre-check: are there any tile or player writes since the current
+// snapshot's `generatedAt`? Both queries are `.where(...).limit(1)` so
+// each costs at most 1 Firestore read (Firestore charges 1 read for an
+// empty result set). Skipping the rebuild on a no-op cron tick saves
+// ~3K reads — at 12 ticks/hr that's the dominant cost in the system.
+async function worldHasChangedSince(
+  db: Firestore,
+  since: Date
+): Promise<boolean> {
+  const [tilesSnap, playersSnap] = await Promise.all([
+    db
+      .collection("game_tiles")
+      .where("updatedAt", ">", since)
+      .limit(1)
+      .get(),
+    db
+      .collection("game_players")
+      .where("updatedAt", ">", since)
+      .limit(1)
+      .get(),
+  ]);
+  return !tilesSnap.empty || !playersSnap.empty;
+}
+
+// Reads + writes the snapshot doc. Idempotent. Skips the (~3K-read)
+// recompute when no game_tiles or game_players have been updated since
+// the existing snapshot's generatedAt — the cron fires every 5 minutes
+// and most ticks have nothing to do. Logs the size so we can monitor
+// when we approach the 1MB Firestore doc limit (will need sharding
+// around ~12K tiles — see comment at end of file).
+//
+// Pass `force: true` to rebuild unconditionally (used by the post-action
+// freshness path so a player's own attack capture is reflected on the
+// map without waiting for the next cron tick).
 export async function rebuildWorldSnapshotServer(
-  now: Date = new Date()
-): Promise<{ tileCount: number; ownerCount: number; bytes: number }> {
+  now: Date = new Date(),
+  opts: { force?: boolean } = {}
+): Promise<{
+  tileCount: number;
+  ownerCount: number;
+  bytes: number;
+  skipped: boolean;
+}> {
   const db = getAdminDb();
   if (!db) throw new Error("Firebase Admin not initialized");
+
+  // Cheap gate — only check when we have a previous snapshot to compare
+  // against. Empty-snapshot case (first deploy) falls through to rebuild.
+  if (!opts.force) {
+    const ref = db
+      .collection(WORLD_SNAPSHOT_COLLECTION)
+      .doc(WORLD_SNAPSHOT_DOC);
+    const existing = await ref.get();
+    if (existing.exists) {
+      const data = existing.data() as StoredWorldSnapshot;
+      const generatedAt =
+        data.generatedAt instanceof Date
+          ? data.generatedAt
+          : (data.generatedAt as FirebaseFirestore.Timestamp).toDate();
+      const changed = await worldHasChangedSince(db, generatedAt);
+      if (!changed) {
+        logger.info("Game world snapshot rebuild skipped — no changes", {
+          lastGeneratedAt: generatedAt.toISOString(),
+          tileCount: data.tileCount,
+          ownerCount: data.ownerCount,
+        });
+        return {
+          tileCount: data.tileCount ?? 0,
+          ownerCount: data.ownerCount ?? 0,
+          bytes: 0,
+          skipped: true,
+        };
+      }
+    }
+  }
 
   const snapshot = await computeWorldSnapshot(db, now);
   const stored: StoredWorldSnapshot = {
@@ -161,6 +228,7 @@ export async function rebuildWorldSnapshotServer(
     tileCount: snapshot.tileCount,
     ownerCount: snapshot.ownerCount,
     bytes,
+    skipped: false,
   };
 }
 

--- a/scripts/count-game-players.ts
+++ b/scripts/count-game-players.ts
@@ -1,0 +1,62 @@
+/**
+ * Counts game_players by audience (real humans vs NPCs) and phase.
+ * Usage: npx tsx scripts/count-game-players.ts
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+import { getAdminDb } from "../lib/firebase-admin";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+  const snap = await db.collection("game_players").get();
+  let total = 0;
+  let npc = 0;
+  let real = 0;
+  const realByPhase: Record<string, number> = {};
+  const realCasteSet: Record<string, number> = {};
+  let realInPlay = 0;
+  let realWithCaste = 0;
+  let realWithTiles = 0;
+  for (const doc of snap.docs) {
+    total++;
+    const d = doc.data() as { isNpc?: boolean; phase?: string; caste?: string | null; stats?: { tilesHeld?: number } };
+    if (d.isNpc === true) {
+      npc++;
+      continue;
+    }
+    real++;
+    const phase = d.phase ?? "<missing>";
+    realByPhase[phase] = (realByPhase[phase] ?? 0) + 1;
+    if (phase === "play") realInPlay++;
+    if (d.caste != null) {
+      realWithCaste++;
+      const c = d.caste;
+      realCasteSet[c] = (realCasteSet[c] ?? 0) + 1;
+    }
+    if ((d.stats?.tilesHeld ?? 0) > 0) realWithTiles++;
+  }
+  console.log(
+    JSON.stringify(
+      {
+        total,
+        npc,
+        real,
+        realInPlay,
+        realWithCaste,
+        realWithTiles,
+        realByPhase,
+        realCasteSet,
+      },
+      null,
+      2
+    )
+  );
+}
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-generals-contributors-call.ts
+++ b/scripts/send-generals-contributors-call.ts
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-off broadcast to all eventContacts inviting people to contribute to
+ * Generals — the in-repo strategy game. Lead with the game pitch + how to
+ * play, then call out the four contribution lanes (logic, balancing,
+ * graphic design, live playtesting) and how this slots into open-source
+ * experience that's portfolio-worthy.
+ *
+ * Mirrors send-broadcast-2026-05-07.ts mechanics: pulls from eventContacts,
+ * skips unsubscribed, syncs Mailgun suppressions first, HMAC unsubscribe
+ * link.
+ *
+ * Usage:
+ *   npx tsx scripts/send-generals-contributors-call.ts --dry-run
+ *   npx tsx scripts/send-generals-contributors-call.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const GAME_URL = "https://www.cursorboston.com/game";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const ISSUES_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues?q=is%3Aissue+is%3Aopen+label%3Agame";
+const HELP_URL = "https://www.cursorboston.com/game/help";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+}
+
+function buildEmail(contact: ContactData): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(
+    contact.firstName?.trim() ||
+      contact.name?.split(" ")[0]?.trim() ||
+      "there"
+  );
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  const subject =
+    "Cursor Boston is building a game — come help shape it";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick note about something we'd love your help with: <strong>Generals</strong>, the strategy game we've been quietly building inside the Cursor Boston repo. It's playable today at <a href="${GAME_URL}">cursorboston.com/game</a> — and we're opening up four clear lanes for people who want to contribute.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">What is it?</h3>
+
+<p>Generals is a turn-based, browser-based strategy game on a hex map. You pick one of five castes (Black, Blue, Green, Red, White — each plays differently), explore land, assign tiles to <em>military</em>, <em>food</em>, or <em>magic</em>, recruit ground/siege/air armies, and attack neighbors. There's a rock-paper-scissors layer (air > ground > siege > air), supply-line bonuses, defense spells you can pre-arm on tiles, offense spells, intel/spy spells with caste-specific reveals, and now a live battle-simulation panel that projects outcomes <em>before</em> you commit turns.</p>
+
+<p>Everyone gets <strong>100 turns per week</strong>. Attacks cost 1 turn, recruits 5, big spells 5+. So a week is roughly 30–60 deliberate decisions. Easy to dip into; deep enough that "what if I had cast a Siege debuff first" is a real question.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Why it's fun</h3>
+
+<p>It's the kind of game where you check in once a day, look at your borders, run a sim against a tempting target, decide to <em>not</em> attack and instead reinforce, and feel smart about it. Or you go for it, lose, and learn what spell stack would have worked. The community plays alongside NPCs and a small but growing set of real players, with a leaderboard you can filter to humans-only.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">How to start playing (5 minutes)</h3>
+
+<ol>
+  <li>Sign in at <a href="${GAME_URL}">cursorboston.com/game</a>.</li>
+  <li>Explore a few starting tiles, distribute land types, pick a caste.</li>
+  <li>Visit <a href="${HELP_URL}">/game/help</a> if you want the full mechanics tour.</li>
+  <li>Open <strong>/game/threats</strong> and try the battle-simulation panel against a neighbor.</li>
+</ol>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Where you can plug in as a contributor</h3>
+
+<p>This is where it gets interesting. The whole game is in our open-source repo — TypeScript, Next.js, Firestore. <strong>Four contribution lanes</strong>, pick whichever calls to you:</p>
+
+<ul>
+  <li><strong>Game logic</strong> — new spells, new unit types, new tile mechanics, intel passives. Core math lives in <code>lib/game/combat.ts</code> and <code>lib/game/data-server.ts</code>.</li>
+  <li><strong>Balancing</strong> — units, spells, supply curves, RNG bands, tile-type modifiers. We have ~1,800 tests in <code>__tests__/lib/game/</code> that make it safe to tune values and ship.</li>
+  <li><strong>Graphic design</strong> — tile art, faction iconography, battle-readout polish, map UI. The game is currently text-and-grid forward; visual upgrades have huge leverage.</li>
+  <li><strong>Live playtesting</strong> — play the game, file good bug reports, propose mechanics changes from a player's perspective. The two best bug fixes shipped <em>today</em> came from a single playtest screenshot.</li>
+</ul>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Why bother?</h3>
+
+<p>This is a real, deployed product with users, not a toy repo. Working on it means:</p>
+<ul>
+  <li>Genuine open-source experience — PRs get reviewed, merged, and shipped to production typically the same day.</li>
+  <li>A portfolio piece you can point a hiring manager at: "I designed and shipped this spell mechanic" or "I rebalanced the air-unit RPS modifier and here's the data."</li>
+  <li>Skills that compound: game logic teaches you state machines, transactions, and adversarial testing in a domain that's fun to talk about.</li>
+  <li>Community: you're building something other people in Cursor Boston actually play.</li>
+</ul>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">How to start contributing</h3>
+
+<ol>
+  <li><strong>Play first.</strong> Even a 10-minute session gives you ideas. <a href="${GAME_URL}">cursorboston.com/game</a></li>
+  <li><strong>Look at open issues</strong> labeled <code>game</code>: <a href="${ISSUES_URL}">github.com/rogerSuperBuilderAlpha/cursor-boston/issues</a></li>
+  <li><strong>Read the repo</strong>: <a href="${REPO_URL}">github.com/rogerSuperBuilderAlpha/cursor-boston</a> — start with <code>lib/game/</code> and <code>app/game/</code></li>
+  <li><strong>Open a PR</strong> with the change you want to see. Even a one-line balance tweak with a test is a great first contribution.</li>
+  <li><strong>Stuck or want a starter task?</strong> Reply to this email and I'll point you at something sized to your interest and skill level.</li>
+</ol>
+
+<p>If any of this lights you up — game logic, the math of balancing, the design surface, or just being a really vocal playtester — I'd genuinely love to hear from you.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you registered for a Cursor Boston event.<br/>
+Don't want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"},
+
+Quick note about something we'd love your help with: Generals, the strategy game we've been quietly building inside the Cursor Boston repo. It's playable today at ${GAME_URL} — and we're opening up four clear lanes for people who want to contribute.
+
+WHAT IS IT?
+
+Generals is a turn-based, browser-based strategy game on a hex map. You pick one of five castes (Black, Blue, Green, Red, White — each plays differently), explore land, assign tiles to military, food, or magic, recruit ground/siege/air armies, and attack neighbors. There's a rock-paper-scissors layer (air > ground > siege > air), supply-line bonuses, defense spells you can pre-arm on tiles, offense spells, intel/spy spells with caste-specific reveals, and now a live battle-simulation panel that projects outcomes before you commit turns.
+
+Everyone gets 100 turns per week. Attacks cost 1 turn, recruits 5, big spells 5+. So a week is roughly 30–60 deliberate decisions. Easy to dip into; deep enough that "what if I had cast a Siege debuff first" is a real question.
+
+WHY IT'S FUN
+
+It's the kind of game where you check in once a day, look at your borders, run a sim against a tempting target, decide to not attack and instead reinforce, and feel smart about it. Or you go for it, lose, and learn what spell stack would have worked. The community plays alongside NPCs and a small but growing set of real players, with a leaderboard you can filter to humans-only.
+
+HOW TO START PLAYING (5 minutes)
+
+  1. Sign in at ${GAME_URL}.
+  2. Explore a few starting tiles, distribute land types, pick a caste.
+  3. Visit ${HELP_URL} if you want the full mechanics tour.
+  4. Open /game/threats and try the battle-simulation panel against a neighbor.
+
+WHERE YOU CAN PLUG IN AS A CONTRIBUTOR
+
+This is where it gets interesting. The whole game is in our open-source repo — TypeScript, Next.js, Firestore. Four contribution lanes, pick whichever calls to you:
+
+  - Game logic — new spells, new unit types, new tile mechanics, intel passives. Core math lives in lib/game/combat.ts and lib/game/data-server.ts.
+  - Balancing — units, spells, supply curves, RNG bands, tile-type modifiers. We have ~1,800 tests in __tests__/lib/game/ that make it safe to tune values and ship.
+  - Graphic design — tile art, faction iconography, battle-readout polish, map UI. The game is currently text-and-grid forward; visual upgrades have huge leverage.
+  - Live playtesting — play the game, file good bug reports, propose mechanics changes from a player's perspective. The two best bug fixes shipped today came from a single playtest screenshot.
+
+WHY BOTHER?
+
+This is a real, deployed product with users, not a toy repo. Working on it means:
+
+  - Genuine open-source experience — PRs get reviewed, merged, and shipped to production typically the same day.
+  - A portfolio piece you can point a hiring manager at: "I designed and shipped this spell mechanic" or "I rebalanced the air-unit RPS modifier and here's the data."
+  - Skills that compound: game logic teaches you state machines, transactions, and adversarial testing in a domain that's fun to talk about.
+  - Community: you're building something other people in Cursor Boston actually play.
+
+HOW TO START CONTRIBUTING
+
+  1. Play first. Even a 10-minute session gives you ideas. ${GAME_URL}
+  2. Look at open issues labeled "game": ${ISSUES_URL}
+  3. Read the repo: ${REPO_URL} — start with lib/game/ and app/game/
+  4. Open a PR with the change you want to see. Even a one-line balance tweak with a test is a great first contribution.
+  5. Stuck or want a starter task? Reply to this email and I'll point you at something sized to your interest and skill level.
+
+If any of this lights you up — game logic, the math of balancing, the design surface, or just being a really vocal playtester — I'd genuinely love to hear from you.
+
+— Roger
+roger@cursorboston.com
+https://cursorboston.com
+
+---
+You're receiving this because you registered for a Cursor Boston event.
+Don't want to hear from us? ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  await syncMailgunSuppressions(db);
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    contacts.push({
+      email: data.email || doc.id,
+      name: data.name || "",
+      firstName: data.firstName || "",
+    });
+  }
+
+  console.log(
+    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = contacts[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview (first 1500 chars) ---");
+      console.log(html.slice(0, 1500));
+      console.log("\n--- Text preview (first 1500 chars) ---");
+      console.log(text.slice(0, 1500));
+    }
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 50 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(
+    `\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed}.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Forwards #779 — major reduction in Firestore read cost (~85% on the snapshot cron) plus real-time map updates with idle/visibility-aware detach so a background tab doesn't bill reads.

## Contributors
- @rogerSuperBuilderAlpha — #779

## Post-deploy
1. Firestore rules need to be deployed for the client listener to authorize. Run `firebase deploy --only firestore:rules` if not done as part of the pipeline.
2. The first cron tick after deploy will rebuild the snapshot (now including `isNpc` per the previous PR #778) and listeners will pick up live updates from there.

## Test plan
- [x] Typecheck + lint clean
- [ ] Smoke on prod: `/game/tiles` shows \"● Live\" indicator when active; updates after another player's action arrive within seconds, not 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)