### PR TITLE
release: onboarding wizard + 1000-tile caste switch + audience-filter snapshot fix

### DIFF
--- a/__tests__/app/game/onboarding-wizard-step.test.ts
+++ b/__tests__/app/game/onboarding-wizard-step.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { pickCurrentStep } from "@/app/game/_components/onboarding/use-onboarding-wizard";
+import type { GamePlayer, Caste } from "@/lib/game/types";
+import type {
+  ArmyTotals,
+  LandCounts,
+} from "@/app/game/_lib/dashboard-types";
+
+function makePlayer(overrides: Partial<GamePlayer> = {}): GamePlayer {
+  return {
+    userId: "u1",
+    displayName: "Tester",
+    caste: null,
+    turnsRemaining: 300,
+    turnsSpentTotal: 0,
+    phase: "explore",
+    tilesExplored: 0,
+    shieldUntil: new Date(0),
+    shieldDropAtTurn: 100,
+    productionSpellsActive: [],
+    stats: {
+      attacksWon: 0,
+      attacksLost: 0,
+      tilesHeld: 100,
+      unitsAlive: 0,
+    },
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  } satisfies GamePlayer;
+}
+
+function makeCounts(overrides: Partial<LandCounts> = {}): LandCounts {
+  return {
+    military: 0,
+    food: 0,
+    magic: 0,
+    unassigned: 0,
+    total: 0,
+    ...overrides,
+  };
+}
+
+function makeArmy(overrides: Partial<ArmyTotals> = {}): ArmyTotals {
+  return {
+    ground: 0,
+    siege: 0,
+    air: 0,
+    total: 0,
+    ...overrides,
+  };
+}
+
+describe("pickCurrentStep", () => {
+  it("phase=explore → 'explore' regardless of other state", () => {
+    expect(
+      pickCurrentStep(
+        makePlayer({ phase: "explore" }),
+        makeCounts(),
+        makeArmy()
+      )
+    ).toBe("explore");
+  });
+
+  it("phase=distribute with unassigned > 0 → 'distribute'", () => {
+    expect(
+      pickCurrentStep(
+        makePlayer({ phase: "distribute" }),
+        makeCounts({ unassigned: 25, total: 100 }),
+        makeArmy()
+      )
+    ).toBe("distribute");
+  });
+
+  it("phase=distribute, unassigned=0, caste=null → 'caste'", () => {
+    expect(
+      pickCurrentStep(
+        makePlayer({ phase: "distribute" }),
+        makeCounts({ military: 33, food: 33, magic: 34, total: 100 }),
+        makeArmy()
+      )
+    ).toBe("caste");
+  });
+
+  it("phase=play, caste=set, no army, has military tile → 'recruit'", () => {
+    const caste: Caste = "black";
+    expect(
+      pickCurrentStep(
+        makePlayer({ phase: "play", caste }),
+        makeCounts({ military: 33, food: 33, magic: 34, total: 100 }),
+        makeArmy({ ground: 0, total: 0 })
+      )
+    ).toBe("recruit");
+  });
+
+  it("phase=play, caste=set, army > 0 → 'done' (graduated)", () => {
+    const caste: Caste = "red";
+    expect(
+      pickCurrentStep(
+        makePlayer({ phase: "play", caste }),
+        makeCounts({ military: 33, food: 33, magic: 34, total: 100 }),
+        makeArmy({ ground: 10, total: 10 })
+      )
+    ).toBe("done");
+  });
+
+  it("phase=play, no military tile, no army → 'done' (no recruit possible)", () => {
+    const caste: Caste = "blue";
+    expect(
+      pickCurrentStep(
+        makePlayer({ phase: "play", caste }),
+        makeCounts({ military: 0, food: 50, magic: 50, total: 100 }),
+        makeArmy({ total: 0 })
+      )
+    ).toBe("done");
+  });
+
+  it("legacy distribute spawn (caste null, all assigned) advances to 'caste'", () => {
+    // Migration path: existing players in 'distribute' phase with the old
+    // 25-tile spawn that already had everything assigned. Wizard should
+    // pick up at the caste step rather than re-firing distribute.
+    expect(
+      pickCurrentStep(
+        makePlayer({ phase: "distribute", caste: null }),
+        makeCounts({ military: 8, food: 9, magic: 8, total: 25 }),
+        makeArmy()
+      )
+    ).toBe("caste");
+  });
+});

--- a/__tests__/app/game/threats/battle-report.test.tsx
+++ b/__tests__/app/game/threats/battle-report.test.tsx
@@ -109,19 +109,44 @@ describe("BattleReport", () => {
     expect(screen.getByText(/6 turns spent/i)).toBeInTheDocument();
   });
 
-  it("derives Defender-had as targetTile.units + defenderLosses", () => {
-    // post-attack target tile has 10/5/5; defender lost 40/15/15.
-    // → defender had 50/20/20 (90 total).
+  it("derives Defender-had from targetTile.units + losses for non-captured outcomes", () => {
+    // Repelled / stalemate: targetTile.units is the defender's surviving
+    // garrison after the swing, so pre-attack = surviving + lost.
     render(
       <BattleReport
-        combat={makeCombat()}
-        report={makeReport()}
+        combat={makeCombat({ outcome: "repelled" })}
+        report={makeReport({ summary: "Repelled at -149_47" })}
         targetTile={makeTargetTile(stack(10, 5, 5))}
         onDismiss={jest.fn()}
       />
     );
+    // 10+40, 5+15, 5+15 = 50/20/20 (90 total).
     expect(screen.getByText(/G50 · S20 · A20/)).toBeInTheDocument();
     expect(screen.getByText(/\(90 total\)/)).toBeInTheDocument();
+  });
+
+  it("derives Defender-had from defenderLosses alone for captured outcomes", () => {
+    // After a capture, targetTile.units holds the attacker's survivors
+    // (the captured tile is now ours). The combat result records
+    // defenderLosses = the defender's full pre-attack stack on capture,
+    // so the wizard reads from there directly.
+    render(
+      <BattleReport
+        combat={makeCombat({ outcome: "captured" })}
+        report={makeReport()}
+        // Attacker survivors live on the captured tile post-swing.
+        targetTile={makeTargetTile(stack(7, 4, 0))}
+        onDismiss={jest.fn()}
+      />
+    );
+    // 40/15/15 → 70 total. NOT 47/19/15.
+    // The same value renders twice in this case — once as "Defender had"
+    // and once as "Defender lost" — since on a capture the defender
+    // loses everything they had.
+    expect(screen.getAllByText(/G40 · S15 · A15/).length).toBeGreaterThanOrEqual(
+      1
+    );
+    expect(screen.getByText(/\(70 total\)/)).toBeInTheDocument();
   });
 
   it("renders You-sent stack from combat.unitsDeployed", () => {
@@ -143,13 +168,17 @@ describe("BattleReport", () => {
   });
 
   it("renders losses for both sides per unit type", () => {
+    // Use a repelled outcome so the "Defender had" line is distinct from
+    // the "Defender lost" line; with `captured` they'd render the same
+    // stack (defender lost everything they had).
     render(
       <BattleReport
         combat={makeCombat({
+          outcome: "repelled",
           attackerLosses: stack(3, 1, 0),
           defenderLosses: stack(40, 15, 15),
         })}
-        report={makeReport()}
+        report={makeReport({ summary: "Repelled at -149_47" })}
         targetTile={makeTargetTile()}
         onDismiss={jest.fn()}
       />

--- a/__tests__/lib/game/local-map-cache.test.ts
+++ b/__tests__/lib/game/local-map-cache.test.ts
@@ -141,7 +141,7 @@ describe("local-map-cache", () => {
     });
 
     it("rejects an entry with a corrupt JSON payload", () => {
-      mem.setItem("cb-game-map-v1:" + USER, "not-json");
+      mem.setItem("cb-game-map-v2:" + USER, "not-json");
       expect(loadCachedMap(USER)).toBeNull();
     });
 
@@ -153,10 +153,10 @@ describe("local-map-cache", () => {
         lastFetchedAt: 1_000_000,
       });
       // Tamper: load, swap, write back under USER's key.
-      const raw = mem.getItem("cb-game-map-v1:" + USER)!;
+      const raw = mem.getItem("cb-game-map-v2:" + USER)!;
       const parsed = JSON.parse(raw);
       parsed.userId = OTHER;
-      mem.setItem("cb-game-map-v1:" + USER, JSON.stringify(parsed));
+      mem.setItem("cb-game-map-v2:" + USER, JSON.stringify(parsed));
       expect(loadCachedMap(USER)).toBeNull();
     });
   });

--- a/app/api/game/caste/change/route.ts
+++ b/app/api/game/caste/change/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { changeCasteServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { gameContract } from "@/lib/api-schemas/game";
+
+// @contracts: gameContract.changeCaste (lib/api-schemas/game.ts)
+//
+// One-time caste switch after the player reaches `stats.tilesHeld >= 1000`.
+// The first caste pick (POST /api/game/setup/caste) is treated as
+// experimental; this endpoint flips the player to a new caste once and
+// then locks them permanently (`casteChangesUsed` becomes 1).
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+
+    const parsed = gameContract.changeCaste.body.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const player = await changeCasteServer(user.uid, parsed.data.caste);
+    return apiSuccess({ player });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/_components/dashboard/CasteChangeCard.tsx
+++ b/app/game/_components/dashboard/CasteChangeCard.tsx
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { Sparkles, X } from "lucide-react";
+import type { User } from "firebase/auth";
+import { CastePickCard } from "@/app/game/setup/_components/CastePickCard";
+import { CASTES } from "@/app/game/setup/_lib/constants";
+import type { Caste, GamePlayer } from "@/lib/game/types";
+
+const TILES_THRESHOLD = 1000;
+
+interface Props {
+  player: GamePlayer;
+  user: User | null;
+  onRefresh: () => Promise<void>;
+}
+
+/**
+ * Conditional dashboard card. Shown once the player has reached the
+ * `TILES_THRESHOLD` tiles-held mark and has not yet used their one-time
+ * caste-change. Click to expand into a confirm-then-pick flow that POSTs
+ * to /api/game/caste/change.
+ *
+ * Mounting is fully gated by the parent — this component renders nothing
+ * if the player isn't eligible.
+ */
+export function CasteChangeCard({ player, user, onRefresh }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const eligible =
+    player.phase === "play" &&
+    player.caste !== null &&
+    player.stats.tilesHeld >= TILES_THRESHOLD &&
+    (player.casteChangesUsed ?? 0) === 0;
+
+  if (!eligible) return null;
+
+  async function changeTo(newCaste: Caste) {
+    if (!user) return;
+    if (newCaste === player.caste) {
+      setError("That's your current caste — pick a different one.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/caste/change", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ caste: newCaste }),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        throw new Error(
+          data.error?.message ?? data.error ?? "Caste change failed"
+        );
+      }
+      await onRefresh();
+      setExpanded(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Caste change failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mb-6 rounded-lg border border-purple-300 bg-purple-50 p-4 dark:border-purple-900/60 dark:bg-purple-900/10">
+      <div className="flex items-start gap-3">
+        <Sparkles
+          className="mt-0.5 h-5 w-5 shrink-0 text-purple-600 dark:text-purple-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-purple-900 dark:text-purple-200">
+            You&apos;ve hit 1,000 tiles — caste switch unlocked
+          </h3>
+          <p className="mt-1 text-sm leading-relaxed text-purple-900/80 dark:text-purple-200/80">
+            One-time switch. Your current caste is{" "}
+            <strong className="capitalize">{player.caste}</strong>. After
+            you switch, your caste is <strong>permanent</strong> — there
+            are no further changes. Skipping is fine; the unlock stays
+            here until you use it.
+          </p>
+          {!expanded ? (
+            <button
+              onClick={() => setExpanded(true)}
+              className="mt-3 rounded-lg bg-purple-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-purple-500"
+            >
+              Switch my caste…
+            </button>
+          ) : (
+            <div className="mt-4">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-xs uppercase tracking-wide text-purple-700 dark:text-purple-300">
+                  Pick the caste you want to keep forever
+                </p>
+                <button
+                  onClick={() => setExpanded(false)}
+                  className="rounded-lg p-1 text-purple-700 transition-colors hover:bg-purple-100 dark:text-purple-300 dark:hover:bg-purple-900/30"
+                  aria-label="Cancel caste change"
+                >
+                  <X
+                    className="h-4 w-4"
+                    strokeWidth={2.25}
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                {CASTES.filter((c) => c !== player.caste).map((c) => (
+                  <CastePickCard
+                    key={c}
+                    caste={c}
+                    busy={busy}
+                    onChoose={() => void changeTo(c)}
+                  />
+                ))}
+              </div>
+              {error && (
+                <p className="mt-3 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-900/10 dark:text-red-300">
+                  {error}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/game/_components/dashboard/DashboardView.tsx
+++ b/app/game/_components/dashboard/DashboardView.tsx
@@ -31,6 +31,8 @@ import { BulkUnassign } from "./BulkUnassign";
 import { MiniMap } from "./MiniMap";
 import { NavGrid } from "./NavGrid";
 import { DashboardReports } from "./DashboardReports";
+import { CasteChangeCard } from "./CasteChangeCard";
+import { OnboardingWizard } from "../onboarding/OnboardingWizard";
 import type { GamePlayer } from "@/lib/game/types";
 
 interface DashboardViewProps {
@@ -121,6 +123,14 @@ export function DashboardView({ player, data }: DashboardViewProps) {
 
   return (
     <div className="min-h-screen py-12 px-6">
+      <OnboardingWizard
+        user={data.user}
+        player={player}
+        counts={counts}
+        army={army}
+        tiles={tiles}
+        onRefresh={data.refresh}
+      />
       <div className="max-w-5xl mx-auto">
         <DashboardHeader
           player={player}
@@ -146,6 +156,12 @@ export function DashboardView({ player, data }: DashboardViewProps) {
         )}
 
         {eligibility && <EligibilityBanner eligibility={eligibility} />}
+
+        <CasteChangeCard
+          player={player}
+          user={data.user}
+          onRefresh={data.refresh}
+        />
 
         <HeroCard
           turnsRemaining={player.turnsRemaining}

--- a/app/game/_components/onboarding/OnboardingWizard.tsx
+++ b/app/game/_components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,440 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { CheckCircle2, Compass, Map, Sparkles, Sword, X } from "lucide-react";
+import type { User } from "firebase/auth";
+import { CastePickCard } from "@/app/game/setup/_components/CastePickCard";
+import { CASTES } from "@/app/game/setup/_lib/constants";
+import type {
+  ArmyTotals,
+  LandCounts,
+} from "@/app/game/_lib/dashboard-types";
+import type { Caste, GamePlayer, MapTile } from "@/lib/game/types";
+import {
+  pickCurrentStep,
+  useOnboardingWizard,
+  type OnboardingStep,
+} from "./use-onboarding-wizard";
+
+interface Props {
+  user: User | null;
+  player: GamePlayer | null;
+  counts: LandCounts;
+  army: ArmyTotals;
+  tiles: ReadonlyArray<MapTile>;
+  onRefresh: () => Promise<void>;
+}
+
+const STEP_LABELS: Record<Exclude<OnboardingStep, "done">, string> = {
+  explore: "Explore",
+  distribute: "Distribute",
+  caste: "Caste",
+  recruit: "Recruit",
+};
+
+const STEP_ORDER: ReadonlyArray<Exclude<OnboardingStep, "done">> = [
+  "explore",
+  "distribute",
+  "caste",
+  "recruit",
+];
+
+/**
+ * First-run modal wizard mounted on the dashboard. Walks new players
+ * through:
+ *
+ *   1. Explore — reveal claimed tiles via /api/game/setup/explore
+ *   2. Distribute — auto-balance 33/33/34 across military/food/magic
+ *   3. Caste — pick a starting caste
+ *   4. Recruit — first build cycle on a military tile
+ *
+ * Auto-derives the current step from `player.phase`/`caste` + counts.
+ * Soft-dismiss only — re-pops on each visit until the player graduates.
+ */
+export function OnboardingWizard({
+  user,
+  player,
+  counts,
+  army,
+  tiles,
+  onRefresh,
+}: Props) {
+  const wizard = useOnboardingWizard({
+    user,
+    player,
+    counts,
+    army,
+    tiles,
+    onRefresh,
+  });
+
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (wizard.isOpen) {
+      closeButtonRef.current?.focus();
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [wizard.isOpen]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && wizard.isOpen) wizard.dismiss();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [wizard]);
+
+  const handleDismiss = useCallback(() => wizard.dismiss(), [wizard]);
+
+  if (!wizard.isOpen || !player) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-wizard-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+        onClick={handleDismiss}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full max-w-3xl max-h-[90vh] overflow-y-auto rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl md:p-8">
+        <button
+          ref={closeButtonRef}
+          onClick={handleDismiss}
+          className="absolute right-4 top-4 rounded-lg p-1 text-neutral-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          aria-label="Dismiss onboarding wizard"
+        >
+          <X className="h-5 w-5" strokeWidth={2.25} aria-hidden="true" />
+        </button>
+
+        <h2
+          id="onboarding-wizard-title"
+          className="pr-8 text-xl font-bold text-white md:text-2xl"
+        >
+          Build your kingdom
+        </h2>
+        <p className="mt-2 text-sm text-neutral-400">
+          Four quick steps. We&apos;ll leave you with about 100 turns to
+          actually play.
+        </p>
+
+        <StepRibbon current={wizard.step} />
+
+        <div className="mt-6">
+          {wizard.step === "explore" && (
+            <ExploreStep
+              tilesExplored={player.tilesExplored}
+              turnsRemaining={player.turnsRemaining}
+              busy={wizard.busy}
+              progress={wizard.exploreProgress}
+              onExplore={wizard.runExplore}
+            />
+          )}
+          {wizard.step === "distribute" && (
+            <DistributeStep
+              counts={counts}
+              busy={wizard.busy}
+              onAutoBalance={wizard.runAutoBalance}
+            />
+          )}
+          {wizard.step === "caste" && (
+            <CasteStep busy={wizard.busy} onPickCaste={wizard.pickCaste} />
+          )}
+          {wizard.step === "recruit" && (
+            <RecruitStep
+              busy={wizard.busy}
+              counts={counts}
+              turnsRemaining={player.turnsRemaining}
+              onRecruit={wizard.runRecruit}
+            />
+          )}
+        </div>
+
+        {wizard.error && (
+          <p className="mt-4 rounded-lg border border-red-700/60 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {wizard.error}
+          </p>
+        )}
+
+        <button
+          onClick={handleDismiss}
+          className="mt-6 w-full text-center text-sm text-neutral-500 transition-colors hover:text-neutral-300 focus-visible:text-white focus-visible:underline focus-visible:outline-none"
+        >
+          I&apos;ll come back to this
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Re-export so other code (DashboardView) only needs to import from the
+// wizard file itself.
+export { pickCurrentStep };
+
+// ---------------------------------------------------------------------------
+// Step ribbon — shows [1 Explore] [2 Distribute] [3 Caste] [4 Recruit] with
+// the current step highlighted and earlier steps marked complete.
+// ---------------------------------------------------------------------------
+
+function StepRibbon({ current }: { current: OnboardingStep }) {
+  const currentIdx =
+    current === "done" ? STEP_ORDER.length : STEP_ORDER.indexOf(current);
+  return (
+    <ol className="mt-4 flex items-center gap-2 text-xs">
+      {STEP_ORDER.map((step, idx) => {
+        const isDone = idx < currentIdx;
+        const isCurrent = idx === currentIdx;
+        return (
+          <li
+            key={step}
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1 ${
+              isCurrent
+                ? "bg-emerald-500 text-white"
+                : isDone
+                  ? "bg-emerald-500/20 text-emerald-300"
+                  : "bg-neutral-800 text-neutral-500"
+            }`}
+          >
+            {isDone ? (
+              <CheckCircle2
+                className="h-3.5 w-3.5"
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+            ) : (
+              <span className="font-mono">{idx + 1}</span>
+            )}
+            <span className="font-semibold">{STEP_LABELS[step]}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Explore
+// ---------------------------------------------------------------------------
+
+interface ExploreStepProps {
+  tilesExplored: number;
+  turnsRemaining: number;
+  busy: boolean;
+  progress: { done: number; total: number } | null;
+  onExplore: (count: number) => Promise<void>;
+}
+
+function ExploreStep({
+  tilesExplored,
+  turnsRemaining,
+  busy,
+  progress,
+  onExplore,
+}: ExploreStepProps) {
+  const remaining = Math.max(0, 100 - tilesExplored);
+  const canExploreAll = turnsRemaining >= remaining && remaining > 0;
+  const canExplore25 = turnsRemaining >= Math.min(25, remaining) && remaining > 0;
+  return (
+    <section>
+      <header className="mb-3 flex items-center gap-2 text-sm font-semibold text-white">
+        <Compass className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+        Step 1 — Reveal your starting lands
+      </header>
+      <p className="text-sm leading-relaxed text-neutral-300">
+        You&apos;ve claimed 100 hex tiles, but they&apos;re hidden under fog.
+        Reveal them so you can decide what to do with each. Each reveal
+        costs <strong>1 turn</strong>.
+      </p>
+      <div className="mt-3 grid grid-cols-3 gap-3 text-center text-xs">
+        <Stat label="Tiles revealed" value={`${tilesExplored} / 100`} />
+        <Stat label="Tiles remaining" value={`${remaining}`} />
+        <Stat label="Turns left" value={`${turnsRemaining}`} />
+      </div>
+      {progress ? (
+        <p className="mt-4 text-center text-sm text-emerald-300">
+          Revealing… {progress.done} / {progress.total}
+        </p>
+      ) : null}
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button
+          onClick={() => void onExplore(Math.min(25, remaining))}
+          disabled={busy || !canExplore25}
+          className="rounded-lg bg-neutral-800 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Explore 25 tiles
+        </button>
+        <button
+          onClick={() => void onExplore(remaining)}
+          disabled={busy || !canExploreAll}
+          className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Reveal all {remaining} tiles
+        </button>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Distribute (auto-balance)
+// ---------------------------------------------------------------------------
+
+interface DistributeStepProps {
+  counts: LandCounts;
+  busy: boolean;
+  onAutoBalance: () => Promise<void>;
+}
+
+function DistributeStep({ counts, busy, onAutoBalance }: DistributeStepProps) {
+  return (
+    <section>
+      <header className="mb-3 flex items-center gap-2 text-sm font-semibold text-white">
+        <Map className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+        Step 2 — Set up your land
+      </header>
+      <p className="text-sm leading-relaxed text-neutral-300">
+        Each tile becomes a <strong>military</strong> (recruits faster),{" "}
+        <strong>food</strong> (raises your unit cap), or{" "}
+        <strong>magic</strong> (boosts your spells). A balanced 1/3 split is
+        a strong default — you can always re-balance later.
+      </p>
+      <div className="mt-4 grid grid-cols-4 gap-3 text-center text-xs">
+        <Stat label="Military" value={`${counts.military}`} />
+        <Stat label="Food" value={`${counts.food}`} />
+        <Stat label="Magic" value={`${counts.magic}`} />
+        <Stat label="Unassigned" value={`${counts.unassigned}`} />
+      </div>
+      <div className="mt-5">
+        <button
+          onClick={() => void onAutoBalance()}
+          disabled={busy || counts.unassigned === 0}
+          className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Auto-balance 33 / 33 / 34
+        </button>
+      </div>
+      <p className="mt-2 text-xs text-neutral-500">
+        Or fine-tune any time on{" "}
+        <span className="font-mono">/game/setup</span>.
+      </p>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — Caste
+// ---------------------------------------------------------------------------
+
+interface CasteStepProps {
+  busy: boolean;
+  onPickCaste: (caste: Caste) => Promise<void>;
+}
+
+function CasteStep({ busy, onPickCaste }: CasteStepProps) {
+  return (
+    <section>
+      <header className="mb-3 flex items-center gap-2 text-sm font-semibold text-white">
+        <Sparkles className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+        Step 3 — Pick your caste
+      </header>
+      <p className="text-sm leading-relaxed text-neutral-300">
+        Each caste has its own units, spells, and identity. Pick the
+        playstyle that calls to you — this first pick is{" "}
+        <strong>experimental</strong>: once you reach{" "}
+        <strong>1,000 tiles</strong>, you can switch castes one time, and
+        that second pick is permanent.
+      </p>
+      <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {CASTES.map((c) => (
+          <CastePickCard
+            key={c}
+            caste={c}
+            busy={busy}
+            onChoose={() => void onPickCaste(c)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — Recruit
+// ---------------------------------------------------------------------------
+
+interface RecruitStepProps {
+  busy: boolean;
+  counts: LandCounts;
+  turnsRemaining: number;
+  onRecruit: () => Promise<void>;
+}
+
+function RecruitStep({
+  busy,
+  counts,
+  turnsRemaining,
+  onRecruit,
+}: RecruitStepProps) {
+  const canRecruit = counts.military > 0 && turnsRemaining >= 5;
+  return (
+    <section>
+      <header className="mb-3 flex items-center gap-2 text-sm font-semibold text-white">
+        <Sword className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+        Step 4 — Plant your first army
+      </header>
+      <p className="text-sm leading-relaxed text-neutral-300">
+        Run one recruit cycle on a military tile —{" "}
+        <strong>5 turns → +10 ground units</strong>. They&apos;ll defend
+        your tile and let you start attacking neighbors.
+      </p>
+      <div className="mt-4 grid grid-cols-2 gap-3 text-center text-xs">
+        <Stat label="Military tiles" value={`${counts.military}`} />
+        <Stat label="Turns left" value={`${turnsRemaining}`} />
+      </div>
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button
+          onClick={() => void onRecruit()}
+          disabled={busy || !canRecruit}
+          className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Recruit +10 ground (5 turns)
+        </button>
+      </div>
+      <p className="mt-2 text-xs text-neutral-500">
+        Or close this and recruit on your own at{" "}
+        <span className="font-mono">/game/recruit</span>.
+      </p>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tiny shared stat tile
+// ---------------------------------------------------------------------------
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-neutral-800 bg-neutral-950 px-2 py-2">
+      <div className="text-[10px] uppercase tracking-wide text-neutral-500">
+        {label}
+      </div>
+      <div className="mt-0.5 text-base font-semibold text-white">{value}</div>
+    </div>
+  );
+}

--- a/app/game/_components/onboarding/use-onboarding-wizard.ts
+++ b/app/game/_components/onboarding/use-onboarding-wizard.ts
@@ -1,0 +1,309 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { User } from "firebase/auth";
+import type {
+  ArmyTotals,
+  LandCounts,
+} from "@/app/game/_lib/dashboard-types";
+import type { Caste, GamePlayer, MapTile } from "@/lib/game/types";
+
+export type OnboardingStep =
+  | "explore"
+  | "distribute"
+  | "caste"
+  | "recruit"
+  | "done";
+
+/**
+ * Pure step-derivation. Given the current player + derived counts/army,
+ * returns which wizard page should render. Used by the wizard component
+ * AND by tests to assert the funnel logic without mounting React.
+ *
+ * Order matches the user's onboarding ramp:
+ *   1. explore   — fog of war over claimed tiles (phase === "explore")
+ *   2. distribute — assign land types (any unassigned remaining)
+ *   3. caste     — pick a starter caste
+ *   4. recruit   — first build cycle to plant an army
+ *   5. done      — graduated; wizard hides
+ */
+export function pickCurrentStep(
+  player: GamePlayer,
+  counts: LandCounts,
+  army: ArmyTotals
+): OnboardingStep {
+  if (player.phase === "explore") return "explore";
+  if (player.phase === "distribute" && counts.unassigned > 0) {
+    return "distribute";
+  }
+  if (player.caste === null) return "caste";
+  if (
+    player.phase === "play" &&
+    army.total === 0 &&
+    counts.military > 0
+  ) {
+    return "recruit";
+  }
+  return "done";
+}
+
+interface Args {
+  user: User | null;
+  player: GamePlayer | null;
+  counts: LandCounts;
+  army: ArmyTotals;
+  tiles: ReadonlyArray<MapTile>;
+  /** Refresh callback from useDashboardData — rerun after each successful
+   *  action so the player/tiles/counts reflect the new state. */
+  onRefresh: () => Promise<void>;
+}
+
+export interface OnboardingWizardState {
+  /** Whether the modal should be rendered as open. */
+  isOpen: boolean;
+  /** Current page (deterministic; recomputed on every render from
+   *  player+counts+army). */
+  step: OnboardingStep;
+  /** True while an in-flight API call is processing. */
+  busy: boolean;
+  /** Most-recent error from a failed action, surfaced inline. */
+  error: string | null;
+  /** Per-batch progress for the explore step. */
+  exploreProgress: { done: number; total: number } | null;
+  /** Soft-dismiss the modal for the current page-load (re-pops on
+   *  reload until the player graduates). */
+  dismiss: () => void;
+  /** Reveal `count` tiles via /api/game/setup/explore. */
+  runExplore: (count: number) => Promise<void>;
+  /** One-click 33/33/34 split via 3 sequential POSTs to
+   *  /api/game/distribute/bulk. */
+  runAutoBalance: () => Promise<void>;
+  /** Lock initial caste via /api/game/setup/caste. */
+  pickCaste: (caste: Caste) => Promise<void>;
+  /** Recruit one cycle of ground units on the first owned military
+   *  tile via /api/game/build. */
+  runRecruit: () => Promise<void>;
+}
+
+/**
+ * Onboarding-wizard state machine. Combines the rising-edge auto-open
+ * behaviour from SetupReadinessModal with action helpers that wrap the
+ * existing setup endpoints. Designed to mount once at the dashboard
+ * root and observe player state — no localStorage, no per-step
+ * navigation state (the step is derived from the canonical phase +
+ * caste + counts).
+ */
+export function useOnboardingWizard({
+  user,
+  player,
+  counts,
+  army,
+  tiles,
+  onRefresh,
+}: Args): OnboardingWizardState {
+  const step: OnboardingStep = player
+    ? pickCurrentStep(player, counts, army)
+    : "done";
+  const shouldBeOpen = player !== null && step !== "done";
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [exploreProgress, setExploreProgress] = useState<{
+    done: number;
+    total: number;
+  } | null>(null);
+  // Rising-edge: only auto-open when shouldBeOpen flips false → true.
+  // Once the user soft-dismisses, isOpen stays false even if shouldBeOpen
+  // is still true; another reload (which resets this hook) will re-open.
+  // Mirrors SetupReadinessModal's rising-edge pattern; the lint rule
+  // flags setState-in-effect which is correct for the auto-close branch
+  // — that branch is the canonical "external state changed, mirror into
+  // local state" case.
+  const wasOpenRef = useRef(false);
+
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (shouldBeOpen && !wasOpenRef.current) {
+      setIsOpen(true);
+      wasOpenRef.current = true;
+    } else if (!shouldBeOpen) {
+      setIsOpen(false);
+      wasOpenRef.current = false;
+    }
+  }, [shouldBeOpen]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const dismiss = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const callApi = useCallback(
+    async (path: string, body?: unknown) => {
+      if (!user) return;
+      setBusy(true);
+      setError(null);
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(path, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: body ? JSON.stringify(body) : undefined,
+        });
+        const data = await res.json();
+        if (!data.success) {
+          throw new Error(
+            data.error?.message ?? data.error ?? "Action failed"
+          );
+        }
+        await onRefresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Action failed");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [user, onRefresh]
+  );
+
+  const runExplore = useCallback(
+    async (count: number) => {
+      if (!user) return;
+      const total = Math.max(1, Math.min(100, Math.floor(count)));
+      setBusy(true);
+      setError(null);
+      setExploreProgress({ done: 0, total });
+      try {
+        const token = await user.getIdToken();
+        for (let i = 0; i < total; i++) {
+          const res = await fetch("/api/game/setup/explore", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+          });
+          const data = await res.json();
+          if (!data.success) {
+            const msg =
+              data.error?.message ?? data.error ?? "Exploration failed";
+            setError(`Stopped at ${i} / ${total}: ${msg}`);
+            break;
+          }
+          setExploreProgress({ done: i + 1, total });
+        }
+        await onRefresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Action failed");
+      } finally {
+        setBusy(false);
+        setExploreProgress(null);
+      }
+    },
+    [user, onRefresh]
+  );
+
+  const runAutoBalance = useCallback(async () => {
+    // Determine target counts for ~33/33/34 (military/food/magic) across
+    // the player's distributable tiles. Uses the post-explore tile set
+    // from the dashboard data (revealed tiles only — `unrevealed` should
+    // not exist at this point, but skip them defensively).
+    const distributable = tiles.filter(
+      (t) => t.type !== "unrevealed" && t.ownerId === player?.userId
+    );
+    const ids = distributable.map((t) => t.tileId);
+    const n = ids.length;
+    if (n === 0) {
+      setError("No tiles available to distribute");
+      return;
+    }
+    // Split into three buckets — remainder rolls into magic so the sum
+    // equals N exactly.
+    const milN = Math.floor(n / 3);
+    const foodN = Math.floor(n / 3);
+    const military = ids.slice(0, milN);
+    const food = ids.slice(milN, milN + foodN);
+    const magic = ids.slice(milN + foodN);
+    setBusy(true);
+    setError(null);
+    try {
+      // Three sequential POSTs — the bulk endpoint accepts up to 100
+      // tile ids per call which fits since we cap at NEW_PLAYER_TILE_COUNT
+      // = 100 total.
+      const token = await user!.getIdToken();
+      const callBulk = async (
+        tileIds: string[],
+        type: "military" | "food" | "magic"
+      ) => {
+        if (tileIds.length === 0) return;
+        const res = await fetch("/api/game/distribute/bulk", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ tileIds, type }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          throw new Error(
+            data.error?.message ?? data.error ?? "Distribute failed"
+          );
+        }
+      };
+      await callBulk(military, "military");
+      await callBulk(food, "food");
+      await callBulk(magic, "magic");
+      await onRefresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Action failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [user, player, tiles, onRefresh]);
+
+  const pickCaste = useCallback(
+    async (caste: Caste) => {
+      await callApi("/api/game/setup/caste", { caste });
+    },
+    [callApi]
+  );
+
+  const runRecruit = useCallback(async () => {
+    // Pick the first owned military tile and run one build cycle of
+    // ground units (5 turns → +10 ground per BUILD_UNITS_PER_TURN_BY_LAND).
+    const target = tiles.find(
+      (t) => t.ownerId === player?.userId && t.type === "military"
+    );
+    if (!target) {
+      setError("No military tile found — assign one first");
+      return;
+    }
+    await callApi("/api/game/build", {
+      tileId: target.tileId,
+      unitType: "ground",
+    });
+  }, [tiles, player, callApi]);
+
+  return {
+    isOpen,
+    step,
+    busy,
+    error,
+    exploreProgress,
+    dismiss,
+    runExplore,
+    runAutoBalance,
+    pickCaste,
+    runRecruit,
+  };
+}

--- a/app/game/_lib/recommend.ts
+++ b/app/game/_lib/recommend.ts
@@ -33,9 +33,9 @@ export function recommendNext(
     return {
       title: "Reveal your starting lands",
       body:
-        "Each tile you reveal costs 1 turn. The setup page walks you through it.",
-      ctaLabel: "Continue setup →",
-      ctaHref: "/game/setup",
+        "Each tile you reveal costs 1 turn. The onboarding wizard walks you through it.",
+      ctaLabel: "Open the wizard →",
+      ctaHref: "/game",
       tone: "primary",
     };
   }
@@ -53,9 +53,9 @@ export function recommendNext(
     return {
       title: "Pick your caste",
       body:
-        "Five factions, each with its own units, spells, and identity. The choice is permanent — read each card on the setup page before you commit.",
+        "Five factions, each with its own units, spells, and identity. Pick the one that calls to you — once you reach 1,000 tiles you can switch one time, and that second pick is permanent.",
       ctaLabel: "Pick a caste →",
-      ctaHref: "/game/setup",
+      ctaHref: "/game",
       tone: "primary",
     };
   }

--- a/app/game/_lib/use-dashboard-data.ts
+++ b/app/game/_lib/use-dashboard-data.ts
@@ -357,6 +357,10 @@ export function useDashboardData() {
     loading,
     creating,
     error,
+    // Refetch player + tiles. Used by surfaces (e.g. the onboarding
+    // wizard) that drive setup endpoints which don't patch local state
+    // through the existing per-action mutators.
+    refresh: fetchPlayer,
     exploring,
     exploreCount,
     setExploreCount,

--- a/app/game/setup/page.tsx
+++ b/app/game/setup/page.tsx
@@ -41,7 +41,12 @@ export default function GameSetupPage() {
           <h1 className="text-3xl font-bold">Setup</h1>
           <p className="text-sm text-neutral-500 mt-1">
             Finish the setup ramp here, then return to the dashboard to manage
-            tiles, build units, and attack.
+            tiles, build units, and attack.{" "}
+            <span className="text-neutral-400">
+              Tip: the onboarding wizard on{" "}
+              <span className="font-mono">/game</span> walks you through
+              this faster.
+            </span>
           </p>
         </div>
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**151 paths, 184 operations across 31 areas.**
+**152 paths, 185 operations across 31 areas.**
 
 ---
 
@@ -140,6 +140,7 @@ _Strategy game endpoints (leaderboard, attacks, artifacts, turns)._
 | GET | `/api/game/attacks` | Yes | List the player's attacks (sent/received/all) |
 | POST | `/api/game/build` | Yes | Build units on a tile |
 | POST | `/api/game/build/bulk` | Yes | Execute a bulk build plan across tiles |
+| POST | `/api/game/caste/change` | Yes | Switch castes (one-time, after reaching 1000 tiles) |
 | POST | `/api/game/distribute/bulk` | Yes | Distribute one land type across multiple tiles |
 | GET | `/api/game/eligibility` | Yes | Get the current user's game eligibility state |
 | POST | `/api/game/explore` | Yes | Frontier-explore one or more new tiles |

--- a/lib/account-deletion/registry.ts
+++ b/lib/account-deletion/registry.ts
@@ -224,6 +224,12 @@ export const KNOWN_NON_USER_COLLECTIONS: ReadonlySet<string> = new Set([
   // Game world singletons / reference
   "game_tiles",
   "game_world_meta",
+  // Denormalized world snapshot doc rebuilt from game_tiles + game_players
+  // by a periodic cron and post-action triggers. Contains a derived view
+  // of player+tile data; deleting the source player doc + tile docs (which
+  // ARE handled above) drops them out of the next snapshot rebuild
+  // automatically.
+  "game_world_snapshots",
 
   // Q&A nested collections (handled via parent `questions` registry entry)
   "answers",

--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -644,6 +644,23 @@ export const gameContract = c.router(
         ] as const,
       },
     },
+    changeCaste: {
+      method: "POST",
+      path: "/api/game/caste/change",
+      summary: "Switch castes (one-time, after reaching 1000 tiles)",
+      description:
+        "Allows a single permanent caste change once `stats.tilesHeld >= 1000`. The first caste pick is treated as experimental; this endpoint flips the player to a new caste and increments `casteChangesUsed` to 1. Subsequent attempts return CONFLICT.",
+      body: SetupCasteBody,
+      responses: { 200: PlayerOkResponse, ...actionErrorResponses },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "VALIDATION_ERROR",
+          "CONFLICT",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
     setupDistribute: {
       method: "POST",
       path: "/api/game/setup/distribute",

--- a/lib/game/api-error-map.ts
+++ b/lib/game/api-error-map.ts
@@ -12,6 +12,7 @@ import {
   GameArtifactAlreadyUsedError,
   GameArtifactNotFoundError,
   GameCasteAlreadySetError,
+  GameCasteChangeUnavailableError,
   GameFrontierExhaustedError,
   GameInsufficientTurnsError,
   GameInsufficientUnitsError,
@@ -63,6 +64,7 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GamePlayerAlreadyExistsError ||
     error instanceof GameAlreadyRevealedError ||
     error instanceof GameCasteAlreadySetError ||
+    error instanceof GameCasteChangeUnavailableError ||
     error instanceof GameInvalidPhaseError ||
     error instanceof GameInsufficientTurnsError ||
     error instanceof GameInsufficientUnitsError ||

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -190,6 +190,12 @@ export class GameCasteAlreadySetError extends Error {
     this.name = "GameCasteAlreadySetError";
   }
 }
+export class GameCasteChangeUnavailableError extends Error {
+  constructor(reason: string) {
+    super(`Caste change unavailable: ${reason}`);
+    this.name = "GameCasteChangeUnavailableError";
+  }
+}
 export class GameInvalidLandTypeError extends Error {
   constructor(t: string) {
     super(`Invalid land type for distribute: ${t}`);
@@ -624,8 +630,12 @@ export async function getTileServer(tileId: string): Promise<GameTile | null> {
 
 // v2 — new players spawn with 25 already-revealed unassigned tiles, skipping
 // the v1 "explore" phase entirely. Existing v1 player records aren't touched.
-export const NEW_PLAYER_TILE_COUNT = 25;
-const NEW_PLAYER_CONTIGUOUS = 20;
+// Total claimed tiles per spawn. Increased from 25 → 100 (May 2026) when
+// the v1 "explore" phase was reinstated as the first step of the onboarding
+// wizard. All 100 are claimed-but-unrevealed at spawn; the wizard drives the
+// player through revealing them via setupExploreServer (1 turn each).
+export const NEW_PLAYER_TILE_COUNT = 100;
+const NEW_PLAYER_CONTIGUOUS = 80;
 const NEW_PLAYER_EXCLAVES_MIN = 3;
 const NEW_PLAYER_EXCLAVES_MAX = 5;
 
@@ -696,11 +706,13 @@ export async function createPlayerWithSpawnServer(
     });
 
     const player = newPlayer(userId, now, {
-      // Skip the v1 "explore" phase entirely — new players land in
-      // distribute with all their tiles already revealed.
-      initialPhase: "distribute",
+      // Spawn into v1 "explore" phase with all 100 tiles claimed but
+      // unrevealed. The onboarding wizard drives the player through
+      // revealing each tile via setupExploreServer (1 turn each); the
+      // server auto-advances phase → "distribute" at tilesExplored >= 100.
+      initialPhase: "explore",
       tilesHeld: spawn.tileIds.length,
-      tilesExplored: spawn.tileIds.length,
+      tilesExplored: 0,
       displayName: cleanedName,
     });
     tx.set(playerRef, {
@@ -716,13 +728,15 @@ export async function createPlayerWithSpawnServer(
         q,
         r,
         ownerId: userId,
-        type: "unassigned" as LandType,
+        // Claimed but hidden under fog. Wizard step 1 reveals each via
+        // setupExploreServer, which flips type → "unassigned" and stamps
+        // revealedAt at the moment of reveal.
+        type: "unrevealed" as LandType,
         level: 0,
         units: { ground: 0, siege: 0, air: 0 },
         armedDefenseSpellId: null,
         neighborTileIds: neighborTileIds(q, r),
         upgradeIds: [],
-        revealedAt: now,
         createdAt: now,
         updatedAt: now,
       });
@@ -1100,6 +1114,70 @@ export async function bulkDistributeTilesServer(
       artifacts,
       stoppedEarly,
     };
+  });
+}
+
+// Threshold at which a player unlocks a one-time caste change. The first
+// caste pick (chooseCasteServer) is treated as "experimental" — once the
+// player reaches this many tiles held they can switch castes once more,
+// and that second pick is permanent (casteChangesUsed flips to 1).
+export const CASTE_CHANGE_TILES_THRESHOLD = 1000;
+
+// One-time caste switch after the player has built up real territory. Same
+// shape as chooseCasteServer (free of turn cost; Admin SDK only) but with a
+// different precondition set: player must already be in `play` with a caste,
+// must have hit the tilesHeld threshold, must not have switched before, and
+// must be picking a different caste than they currently have.
+//
+// Increments `casteChangesUsed` to 1 — after this call, subsequent attempts
+// throw `GameCasteChangeUnavailableError`.
+export async function changeCasteServer(
+  userId: string,
+  newCaste: Caste,
+  now: Date = new Date()
+): Promise<GamePlayer> {
+  if (!VALID_CASTES.has(newCaste)) throw new GameInvalidCasteError(newCaste);
+
+  const db = adminDbOrThrow();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(userId);
+
+  return db.runTransaction(async (tx) => {
+    const playerSnap = await tx.get(playerRef);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+
+    if (player.phase !== "play") {
+      throw new GameInvalidPhaseError("play", player.phase);
+    }
+    if (player.caste === null) {
+      throw new GameCasteChangeUnavailableError(
+        "no caste set — pick one first via /api/game/setup/caste"
+      );
+    }
+    if (player.caste === newCaste) {
+      throw new GameCasteChangeUnavailableError(
+        `already playing as ${newCaste}`
+      );
+    }
+    if (player.stats.tilesHeld < CASTE_CHANGE_TILES_THRESHOLD) {
+      throw new GameCasteChangeUnavailableError(
+        `requires tilesHeld >= ${CASTE_CHANGE_TILES_THRESHOLD} (have ${player.stats.tilesHeld})`
+      );
+    }
+    if ((player.casteChangesUsed ?? 0) >= 1) {
+      throw new GameCasteChangeUnavailableError(
+        "caste change already used; further changes are not allowed"
+      );
+    }
+
+    const updates = {
+      caste: newCaste,
+      casteLockedAt: now,
+      casteChangesUsed: 1,
+      updatedAt: now,
+    };
+    tx.update(playerRef, updates);
+    return { ...player, ...updates };
   });
 }
 

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -176,6 +176,12 @@ export interface GamePlayer {
   displayName: string;
   caste: Caste | null;
   casteLockedAt?: Timestamp | Date;
+  // Number of times the player has changed castes after the initial pick.
+  // The first caste pick (chooseCasteServer) does not increment this.
+  // Players can change once after reaching `stats.tilesHeld >= 1000`; that
+  // change increments to 1 and locks caste permanently. Optional on the
+  // type so existing player docs parse without backfill (treated as 0).
+  casteChangesUsed?: number;
   turnsRemaining: number;
   turnsSpentTotal: number;
   phase: Phase;

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -108,7 +108,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (184 endpoints)
+## API (185 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -197,6 +197,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     GET    /api/game/attacks [Yes] — List the player's attacks (sent/received/all)
     POST   /api/game/build [Yes] — Build units on a tile
     POST   /api/game/build/bulk [Yes] — Execute a bulk build plan across tiles
+    POST   /api/game/caste/change [Yes] — Switch castes (one-time, after reaching 1000 tiles)
     POST   /api/game/distribute/bulk [Yes] — Distribute one land type across multiple tiles
     GET    /api/game/eligibility [Yes] — Get the current user's game eligibility state
     POST   /api/game/explore [Yes] — Frontier-explore one or more new tiles

--- a/scripts/rebuild-world-snapshot.ts
+++ b/scripts/rebuild-world-snapshot.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Force-rebuilds `game_world_snapshots/latest` once. Bypasses the cron
+ * route's CRON_SECRET check by calling the server function directly via
+ * Firebase Admin (service-account auth). Useful for:
+ *
+ *   - Recovering when the cron has been failing (e.g., missing
+ *     CRON_SECRET in the Vercel env) and the snapshot has gone stale.
+ *   - Smoke-testing snapshot shape changes after a backend deploy
+ *     without waiting for the next 5-min cron tick.
+ *
+ * Usage:
+ *   npx tsx scripts/rebuild-world-snapshot.ts
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { rebuildWorldSnapshotServer } from "../lib/game/world-snapshot";
+
+async function main() {
+  console.log("Forcing world-snapshot rebuild…");
+  const result = await rebuildWorldSnapshotServer(new Date(), { force: true });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Forwards #781 — first-run onboarding wizard, 1000-tile caste-switch mechanic, and the snapshot-rebuild script that fixed the audience filter bug today.

## Contributors
- @rogerSuperBuilderAlpha — #781

## Post-deploy actions required
1. **Set `CRON_SECRET` in Vercel env** (Settings → Environment Variables → Production + Preview). The cron has been failing for 33 hours because this var is missing; the audience filter has been showing 54 humans / 0 NPCs as a result. Without setting this, the cron will continue to fail and the snapshot will go stale again the moment any tile/player change happens.
2. **Deploy Firestore rules + indexes** (`firebase deploy --only firestore:rules,firestore:indexes`) — no rule changes in this PR, but indexes file may need a sync.

## Test plan
- [x] Typecheck + lint clean, 1,789 jest tests pass, `npm run build` clean.
- [ ] Smoke on prod: reset a test player → wizard walks them through to `play` with ~115 turns left.
- [ ] Audience filter on `/game/tiles` shows real human / NPC counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)