### PR TITLE
feat(game): community feed + chat panel on dashboard

### DIFF
--- a/app/api/game/community/chat/[messageId]/route.ts
+++ b/app/api/game/community/chat/[messageId]/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { gameContract } from "@/lib/api-schemas/game";
+import {
+  CommunityMessageForbiddenError,
+  CommunityMessageNotFoundError,
+  deleteCommunityMessage,
+} from "@/lib/game/community";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+// @contracts: gameContract.deleteCommunityChat
+void gameContract.deleteCommunityChat;
+
+// DELETE /api/game/community/chat/[messageId]
+//
+// Soft-delete a chat message. Author can delete their own; admins can
+// delete any. Sets `deletedAt` (and `deletedByAdmin` for admin deletes)
+// rather than hard-deleting so the audit trail is preserved.
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ messageId: string }> }
+) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const { messageId } = await params;
+    if (!messageId) return apiError("messageId is required", 400);
+
+    const message = await deleteCommunityMessage({
+      messageId,
+      callerUserId: user.uid,
+      callerIsAdmin: user.isAdmin === true,
+    });
+    return apiSuccess({ message });
+  } catch (error) {
+    if (error instanceof CommunityMessageNotFoundError) {
+      return apiError(error.message, 404);
+    }
+    if (error instanceof CommunityMessageForbiddenError) {
+      return apiError(error.message, 403);
+    }
+    return apiError(
+      error instanceof Error ? error.message : "Server error",
+      500
+    );
+  }
+}

--- a/app/api/game/community/chat/route.ts
+++ b/app/api/game/community/chat/route.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { gameContract } from "@/lib/api-schemas/game";
+import {
+  COMMUNITY_PAGE_SIZE,
+  CommunityMessageEmptyError,
+  CommunityMessageTooLongError,
+  MAX_MESSAGE_LENGTH,
+  createCommunityMessage,
+  listRecentCommunityMessages,
+} from "@/lib/game/community";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import type { GamePlayer } from "@/lib/game/types";
+
+// @contracts: gameContract.getCommunityChat, gameContract.postCommunityChat
+void gameContract.getCommunityChat;
+void gameContract.postCommunityChat;
+
+const PostBody = z.object({
+  body: z.string().min(1).max(MAX_MESSAGE_LENGTH),
+});
+
+// GET /api/game/community/chat
+//
+// Returns the most recent non-deleted chat messages for the community
+// board. Authenticated read so unsigned-in visitors don't see the
+// firehose; matches the rest of the game endpoints.
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const messages = await listRecentCommunityMessages(COMMUNITY_PAGE_SIZE);
+    const res = apiSuccess({ messages });
+    res.headers.set(
+      "Cache-Control",
+      "private, max-age=10, must-revalidate"
+    );
+    return res;
+  } catch (error) {
+    return apiError(
+      error instanceof Error ? error.message : "Server error",
+      500
+    );
+  }
+}
+
+// POST /api/game/community/chat
+//
+// Authenticated players post a chat message. Rate-limited per-user to
+// 10 posts per 60s via Upstash (in-memory fallback if Redis isn't
+// configured). Body must be 1–500 chars after trimming. The author's
+// displayName + caste are read from their player doc and denormalized
+// onto the message at write time so the chat renderer doesn't need a
+// join.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const limit = await checkUpstashRateLimit(`chat-post:${user.uid}`, {
+      windowMs: 60_000,
+      maxRequests: 10,
+    });
+    if (!limit.success) {
+      return apiError(
+        `Slow down — rate-limited. Try again in ${limit.retryAfter ?? 30}s.`,
+        429
+      );
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const parsed = PostBody.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    // Pull author display info from the player doc so the chat row can
+    // render without a follow-up read.
+    const db = getAdminDb();
+    if (!db) return apiError("Server not configured", 500);
+    const playerSnap = await db
+      .collection("game_players")
+      .doc(user.uid)
+      .get();
+    const player = playerSnap.exists
+      ? (playerSnap.data() as GamePlayer)
+      : null;
+
+    const message = await createCommunityMessage({
+      userId: user.uid,
+      displayName: player?.displayName?.trim() || "Unknown general",
+      caste: player?.caste ?? null,
+      body: parsed.data.body,
+    });
+    return apiSuccess({ message });
+  } catch (error) {
+    if (error instanceof CommunityMessageEmptyError) {
+      return apiError(error.message, 400);
+    }
+    if (error instanceof CommunityMessageTooLongError) {
+      return apiError(error.message, 400);
+    }
+    return apiError(
+      error instanceof Error ? error.message : "Server error",
+      500
+    );
+  }
+}

--- a/app/api/game/community/feed/route.ts
+++ b/app/api/game/community/feed/route.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { gameContract } from "@/lib/api-schemas/game";
+import {
+  COMMUNITY_PAGE_SIZE,
+  listRecentCommunityEvents,
+} from "@/lib/game/community";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+// @contracts: gameContract.getCommunityFeed (lib/api-schemas/game.ts)
+void gameContract.getCommunityFeed;
+
+// GET /api/game/community/feed
+//
+// Returns the most recent COMMUNITY_PAGE_SIZE events for the dashboard's
+// CommunityPanel activity feed. Single ordered query (.orderBy(createdAt
+// desc).limit) so the read cost is bounded regardless of total event
+// count.
+//
+// Cache-Control mirrors the leaderboard route: short s-maxage so multiple
+// dashboard mounts within the same minute hit the CDN, not Firestore.
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const events = await listRecentCommunityEvents(COMMUNITY_PAGE_SIZE);
+    const res = apiSuccess({ events });
+    res.headers.set(
+      "Cache-Control",
+      "public, max-age=15, s-maxage=30, stale-while-revalidate=60"
+    );
+    return res;
+  } catch (error) {
+    return apiError(
+      error instanceof Error ? error.message : "Server error",
+      500
+    );
+  }
+}

--- a/app/game/_components/dashboard/CommunityPanel.tsx
+++ b/app/game/_components/dashboard/CommunityPanel.tsx
@@ -1,0 +1,530 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import {
+  ChevronDown,
+  ChevronRight,
+  MessageSquare,
+  RefreshCw,
+  Send,
+  Sparkles,
+  Sword,
+  Trash2,
+  UserPlus,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import type { User } from "firebase/auth";
+import type {
+  Caste,
+  CommunityEvent,
+  CommunityMessage,
+} from "@/lib/game/types";
+
+const CASTE_SWATCH: Record<Caste, string> = {
+  white: "#e5e7eb",
+  blue: "#60a5fa",
+  black: "#a78bfa",
+  red: "#f87171",
+  green: "#4ade80",
+};
+
+const MAX_BODY = 500;
+
+interface Props {
+  user: User | null;
+  isAdmin: boolean;
+}
+
+/**
+ * Collapsible community panel mounted at the bottom of the dashboard.
+ * Default-collapsed so it doesn't compete with the action surface for
+ * attention; expand on click. When expanded:
+ *   - Left: most recent 50 community events (player joins, caste picks,
+ *     attacks, 1k-tile milestones).
+ *   - Right: most recent 50 chat messages with a post-message input.
+ *
+ * No real-time listeners — refresh button + auto-fetch on first
+ * expansion. Cheaper and more predictable than push.
+ */
+export function CommunityPanel({ user, isAdmin }: Props) {
+  const [open, setOpen] = useState(false);
+  const [events, setEvents] = useState<CommunityEvent[]>([]);
+  const [messages, setMessages] = useState<CommunityMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [posting, setPosting] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const headers = { Authorization: `Bearer ${token}` };
+      const [feedRes, chatRes] = await Promise.all([
+        fetch("/api/game/community/feed", { headers }),
+        fetch("/api/game/community/chat", { headers }),
+      ]);
+      const feedData = await feedRes.json();
+      const chatData = await chatRes.json();
+      if (feedData.success) setEvents(feedData.events ?? []);
+      if (chatData.success) setMessages(chatData.messages ?? []);
+      if (!feedData.success || !chatData.success) {
+        setError(
+          feedData.error?.message ??
+            chatData.error?.message ??
+            "Failed to load"
+        );
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  // Lazy-load on first expansion. The refresh() call sets state via
+  // setEvents/setMessages which the lint rule flags conservatively —
+  // suppressed because that's the canonical "kick off async fetch on
+  // open" pattern.
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+  useEffect(() => {
+    if (open && events.length === 0 && messages.length === 0 && !loading) {
+      void refresh();
+    }
+  }, [open]);
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+
+  async function postMessage() {
+    if (!user) return;
+    const trimmed = draft.trim();
+    if (trimmed.length === 0) return;
+    setPosting(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/community/chat", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ body: trimmed }),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        throw new Error(
+          data.error?.message ?? data.error ?? "Failed to post"
+        );
+      }
+      setDraft("");
+      // Optimistic prepend; refresh on next manual hit.
+      setMessages((prev) => [data.message as CommunityMessage, ...prev]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to post");
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  async function deleteMessage(messageId: string) {
+    if (!user) return;
+    if (!confirm("Delete this message?")) return;
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/game/community/chat/${messageId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (!data.success) {
+        throw new Error(
+          data.error?.message ?? data.error ?? "Failed to delete"
+        );
+      }
+      // Drop locally without a refetch.
+      setMessages((prev) => prev.filter((m) => m.id !== messageId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete");
+    }
+  }
+
+  return (
+    <section className="mb-8 rounded-lg border border-neutral-200 dark:border-neutral-800">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left hover:bg-neutral-50 dark:hover:bg-neutral-900"
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold">
+          {open ? (
+            <ChevronDown
+              className="h-4 w-4"
+              strokeWidth={2.25}
+              aria-hidden="true"
+            />
+          ) : (
+            <ChevronRight
+              className="h-4 w-4"
+              strokeWidth={2.25}
+              aria-hidden="true"
+            />
+          )}
+          Community — recent events &amp; chat
+        </span>
+        <span className="text-xs text-neutral-500">
+          {open ? "click to collapse" : "click to expand"}
+        </span>
+      </button>
+
+      {open && (
+        <div className="border-t border-neutral-200 dark:border-neutral-800 px-4 py-4">
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-xs text-neutral-500">
+              {events.length} event{events.length === 1 ? "" : "s"} ·{" "}
+              {messages.length} message{messages.length === 1 ? "" : "s"}
+            </p>
+            <button
+              onClick={() => void refresh()}
+              disabled={loading}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-300 px-3 py-1 text-xs hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800 disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`}
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+              {loading ? "Refreshing…" : "Refresh"}
+            </button>
+          </div>
+
+          {error && (
+            <p className="mb-3 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-900/10 dark:text-red-300">
+              {error}
+            </p>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <ActivityFeed events={events} />
+            <ChatBoard
+              messages={messages}
+              draft={draft}
+              setDraft={setDraft}
+              posting={posting}
+              onPost={() => void postMessage()}
+              onDelete={(id) => void deleteMessage(id)}
+              currentUserId={user?.uid ?? null}
+              isAdmin={isAdmin}
+            />
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Activity feed (left column)
+// ---------------------------------------------------------------------------
+
+function ActivityFeed({ events }: { events: CommunityEvent[] }) {
+  return (
+    <div>
+      <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+        <Sparkles
+          className="h-4 w-4 text-emerald-600 dark:text-emerald-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        Recent events
+      </h3>
+      {events.length === 0 ? (
+        <p className="text-sm text-neutral-500 italic">
+          No events yet. Be the first to attack a neighbor.
+        </p>
+      ) : (
+        <ul className="max-h-[400px] space-y-1.5 overflow-y-auto pr-1 text-sm">
+          {events.map((e) => (
+            <EventRow key={e.id} event={e} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function EventRow({ event }: { event: CommunityEvent }) {
+  const at = parseTimestamp(event.createdAt);
+  const swatch = event.actorCaste
+    ? CASTE_SWATCH[event.actorCaste]
+    : "#737373";
+  return (
+    <li className="flex items-start gap-2 rounded-lg border border-neutral-200 bg-white px-2 py-1.5 dark:border-neutral-800 dark:bg-neutral-950">
+      <span
+        className="mt-1 inline-block h-2 w-2 shrink-0 rounded-full"
+        style={{ background: swatch }}
+        aria-hidden="true"
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-[12.5px] leading-snug">
+          <EventBody event={event} />
+        </p>
+        <p className="text-[10px] text-neutral-500">
+          {at ? at.toLocaleString() : ""}
+        </p>
+      </div>
+      <EventIcon kind={event.kind} />
+    </li>
+  );
+}
+
+function EventBody({ event }: { event: CommunityEvent }) {
+  const actor = (
+    <strong className="capitalize">{event.actorDisplayName}</strong>
+  );
+  switch (event.kind) {
+    case "player_join":
+      return <>{actor} joined the world.</>;
+    case "caste_pick":
+      return (
+        <>
+          {actor} chose <strong className="capitalize">{event.actorCaste}</strong>.
+        </>
+      );
+    case "caste_change":
+      return (
+        <>
+          {actor} switched from{" "}
+          <strong className="capitalize">{event.fromCaste}</strong> to{" "}
+          <strong className="capitalize">{event.toCaste}</strong> (final).
+        </>
+      );
+    case "attack": {
+      const target = (
+        <strong className="capitalize">{event.targetDisplayName}</strong>
+      );
+      const tile = event.tileId ? (
+        <span className="font-mono text-[11px]">{event.tileId}</span>
+      ) : null;
+      if (event.outcome === "captured") {
+        return (
+          <>
+            {actor} captured {tile} from {target}.
+          </>
+        );
+      }
+      if (event.outcome === "repelled") {
+        return (
+          <>
+            {actor} attacked {target} at {tile} — repelled.
+          </>
+        );
+      }
+      return (
+        <>
+          {actor} attacked {target} at {tile} — stalemate.
+        </>
+      );
+    }
+    case "milestone_1k_tiles":
+      return <>{actor} crossed 1,000 tiles. Caste switch unlocked.</>;
+    default:
+      return <>{actor} did something.</>;
+  }
+}
+
+function EventIcon({
+  kind,
+}: {
+  kind: CommunityEvent["kind"];
+}) {
+  const cls = "h-3.5 w-3.5 text-neutral-500 mt-0.5 shrink-0";
+  if (kind === "player_join") {
+    return <UserPlus className={cls} strokeWidth={2.25} aria-hidden="true" />;
+  }
+  if (kind === "attack") {
+    return <Sword className={cls} strokeWidth={2.25} aria-hidden="true" />;
+  }
+  if (kind === "milestone_1k_tiles") {
+    return (
+      <Sparkles
+        className="h-3.5 w-3.5 text-amber-500 mt-0.5 shrink-0"
+        strokeWidth={2.25}
+        aria-hidden="true"
+      />
+    );
+  }
+  return <Sparkles className={cls} strokeWidth={2.25} aria-hidden="true" />;
+}
+
+// ---------------------------------------------------------------------------
+// Chat board (right column)
+// ---------------------------------------------------------------------------
+
+interface ChatBoardProps {
+  messages: CommunityMessage[];
+  draft: string;
+  setDraft: (s: string) => void;
+  posting: boolean;
+  onPost: () => void;
+  onDelete: (id: string) => void;
+  currentUserId: string | null;
+  isAdmin: boolean;
+}
+
+function ChatBoard({
+  messages,
+  draft,
+  setDraft,
+  posting,
+  onPost,
+  onDelete,
+  currentUserId,
+  isAdmin,
+}: ChatBoardProps) {
+  const remaining = MAX_BODY - draft.length;
+  return (
+    <div className="flex min-h-0 flex-col">
+      <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+        <MessageSquare
+          className="h-4 w-4 text-emerald-600 dark:text-emerald-400"
+          strokeWidth={2.25}
+          aria-hidden="true"
+        />
+        Chat
+      </h3>
+      {messages.length === 0 ? (
+        <p className="mb-3 text-sm text-neutral-500 italic">
+          No messages yet. Say hi.
+        </p>
+      ) : (
+        <ul className="mb-3 max-h-[340px] space-y-1.5 overflow-y-auto pr-1 text-sm">
+          {messages.map((m) => (
+            <MessageRow
+              key={m.id}
+              message={m}
+              canDelete={
+                currentUserId === m.userId || isAdmin
+              }
+              onDelete={() => onDelete(m.id)}
+            />
+          ))}
+        </ul>
+      )}
+      <div className="mt-auto flex flex-col gap-2">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value.slice(0, MAX_BODY))}
+          placeholder="Say something to the kingdom…"
+          rows={2}
+          className="w-full resize-none rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-neutral-700 dark:bg-neutral-950"
+          maxLength={MAX_BODY}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              onPost();
+            }
+          }}
+        />
+        <div className="flex items-center justify-between">
+          <span
+            className={`text-[11px] ${
+              remaining < 50
+                ? "text-amber-600"
+                : "text-neutral-500"
+            }`}
+          >
+            {remaining} chars left · ⌘/Ctrl + Enter to send
+          </span>
+          <button
+            onClick={onPost}
+            disabled={posting || draft.trim().length === 0}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Send
+              className="h-3.5 w-3.5"
+              strokeWidth={2.25}
+              aria-hidden="true"
+            />
+            {posting ? "Sending…" : "Send"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MessageRow({
+  message,
+  canDelete,
+  onDelete,
+}: {
+  message: CommunityMessage;
+  canDelete: boolean;
+  onDelete: () => void;
+}) {
+  const at = parseTimestamp(message.createdAt);
+  const swatch = message.caste ? CASTE_SWATCH[message.caste] : "#737373";
+  return (
+    <li className="group flex items-start gap-2 rounded-lg border border-neutral-200 bg-white px-2 py-1.5 dark:border-neutral-800 dark:bg-neutral-950">
+      <span
+        className="mt-1 inline-block h-2 w-2 shrink-0 rounded-full"
+        style={{ background: swatch }}
+        aria-hidden="true"
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-[12.5px] leading-snug">
+          <strong className="capitalize">{message.displayName}</strong>{" "}
+          <span className="text-[10px] text-neutral-500">
+            {at ? at.toLocaleString() : ""}
+          </span>
+        </p>
+        <p className="whitespace-pre-wrap break-words text-[12.5px] leading-snug text-neutral-700 dark:text-neutral-200">
+          {message.body}
+        </p>
+      </div>
+      {canDelete && (
+        <button
+          onClick={onDelete}
+          className="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+          aria-label="Delete message"
+          title="Delete"
+        >
+          <Trash2
+            className="h-3.5 w-3.5 text-neutral-500 hover:text-red-500"
+            strokeWidth={2.25}
+            aria-hidden="true"
+          />
+        </button>
+      )}
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FirestoreTimestampLike {
+  _seconds?: number;
+  seconds?: number;
+}
+
+function parseTimestamp(t: unknown): Date | null {
+  if (!t) return null;
+  if (t instanceof Date) return t;
+  if (typeof t === "string") return new Date(t);
+  if (typeof t === "object") {
+    const ts = t as FirestoreTimestampLike;
+    if (typeof ts._seconds === "number") return new Date(ts._seconds * 1000);
+    if (typeof ts.seconds === "number") return new Date(ts.seconds * 1000);
+  }
+  return null;
+}

--- a/app/game/_components/dashboard/DashboardView.tsx
+++ b/app/game/_components/dashboard/DashboardView.tsx
@@ -32,6 +32,7 @@ import { MiniMap } from "./MiniMap";
 import { NavGrid } from "./NavGrid";
 import { DashboardReports } from "./DashboardReports";
 import { CasteChangeCard } from "./CasteChangeCard";
+import { CommunityPanel } from "./CommunityPanel";
 import { OnboardingWizard } from "../onboarding/OnboardingWizard";
 import type { GamePlayer } from "@/lib/game/types";
 
@@ -276,6 +277,8 @@ export function DashboardView({ player, data }: DashboardViewProps) {
         )}
 
         <DashboardReports reports={recentReports} />
+
+        <CommunityPanel user={data.user} isAdmin={isAdmin} />
       </div>
     </div>
   );

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -432,6 +432,26 @@ service cloud.firestore {
       allow create, update, delete: if false;
     }
 
+    // Game — Community feed (append-only event log of player joins,
+    // caste picks, attacks, milestones). Surfaced in the dashboard's
+    // CommunityPanel. Authenticated read; all writes flow through the
+    // Admin SDK in lib/game/community.ts (logCommunityEventInTx /
+    // logCommunityEvent), so direct client writes are denied.
+    match /game_community_events/{eventId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
+
+    // Game — Community chat (free-form message board). Reads are
+    // authenticated. All writes (create + soft-delete) flow through
+    // /api/game/community/chat which validates ownership and admin
+    // status before delegating to the Admin SDK. Direct client writes
+    // would bypass the rate-limit + length checks, so deny.
+    match /game_community_messages/{messageId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
+
     // Game — Artifacts (v2): a player can only read their own inventory.
     // All writes go through the Admin SDK via turn-spending API routes.
     match /game_artifacts/{artifactId} {

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**152 paths, 185 operations across 31 areas.**
+**155 paths, 189 operations across 31 areas.**
 
 ---
 
@@ -141,6 +141,10 @@ _Strategy game endpoints (leaderboard, attacks, artifacts, turns)._
 | POST | `/api/game/build` | Yes | Build units on a tile |
 | POST | `/api/game/build/bulk` | Yes | Execute a bulk build plan across tiles |
 | POST | `/api/game/caste/change` | Yes | Switch castes (one-time, after reaching 1000 tiles) |
+| GET | `/api/game/community/chat` | Yes | Recent community chat messages |
+| POST | `/api/game/community/chat` | Yes | Post a chat message (rate-limited: 10 / 60s per user) |
+| DELETE | `/api/game/community/chat/{messageId}` | Yes | Delete a chat message (own or admin) |
+| GET | `/api/game/community/feed` | Yes | Recent community events (player joins, caste picks, attacks) |
 | POST | `/api/game/distribute/bulk` | Yes | Distribute one land type across multiple tiles |
 | GET | `/api/game/eligibility` | Yes | Get the current user's game eligibility state |
 | POST | `/api/game/explore` | Yes | Frontier-explore one or more new tiles |

--- a/lib/account-deletion/registry.ts
+++ b/lib/account-deletion/registry.ts
@@ -99,6 +99,13 @@ export const userOwnedCollections: ReadonlyArray<UserOwnedCollection> = [
   // covers ownerId; the casterId column is a foreign key so it'll naturally
   // disappear when the caster's effects are deleted on their side.
   { collection: "game_intel_effects", mode: "fieldEqualsUid", field: "ownerId", behavior: { type: "delete" } },
+  // Community feed: events authored by the deleted user (player join,
+  // caste pick, attacks they initiated). Hard-delete so the deleted
+  // user's name + UID don't continue to appear in the public feed.
+  { collection: "game_community_events", mode: "fieldEqualsUid", field: "actorUserId", behavior: { type: "delete" } },
+  // Community chat: messages authored by the deleted user. Hard-delete
+  // so private messages don't linger after a GDPR Article 17 request.
+  { collection: "game_community_messages", mode: "fieldEqualsUid", field: "userId", behavior: { type: "delete" } },
 
   // ---------------------------------------------------------------------
   // fieldEqualsUid — anonymize (preserve thread/content; scrub author)

--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -443,6 +443,46 @@ const UpgradesRemoveBody = z
   })
   .openapi("GameUpgradesRemoveBody");
 
+// Community feed + chat schemas. Denormalized at write-time so the
+// renderer doesn't need to join against game_players.
+const CommunityEventKindEnum = z.enum([
+  "player_join",
+  "caste_pick",
+  "caste_change",
+  "attack",
+  "milestone_1k_tiles",
+]);
+const AttackOutcomeEnum = z.enum(["captured", "repelled", "stalemate"]);
+
+const CommunityEventSchema = z
+  .object({
+    id: z.string(),
+    kind: CommunityEventKindEnum,
+    actorUserId: z.string(),
+    actorDisplayName: z.string(),
+    actorCaste: SetupCasteEnum.nullable(),
+    targetUserId: z.string().optional(),
+    targetDisplayName: z.string().optional(),
+    tileId: z.string().optional(),
+    outcome: AttackOutcomeEnum.optional(),
+    fromCaste: SetupCasteEnum.optional(),
+    toCaste: SetupCasteEnum.optional(),
+  })
+  .passthrough()
+  .openapi("GameCommunityEvent");
+
+const CommunityMessageSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string(),
+    displayName: z.string(),
+    caste: SetupCasteEnum.nullable(),
+    body: z.string(),
+    deletedByAdmin: z.boolean().optional(),
+  })
+  .passthrough()
+  .openapi("GameCommunityMessage");
+
 const WorldQuery = z
   .object({
     qMin: z.string().regex(/^-?\d+$/).optional(),
@@ -1051,6 +1091,95 @@ export const gameContract = c.router(
           "UNAUTHORIZED",
           "FORBIDDEN",
           "VALIDATION_ERROR",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+
+    // Community feed + chat — append-only event log + global chat board
+    // surfaced in the dashboard's CommunityPanel.
+    getCommunityFeed: {
+      method: "GET",
+      path: "/api/game/community/feed",
+      summary: "Recent community events (player joins, caste picks, attacks)",
+      description:
+        "Returns the most recent 50 community-events ordered by createdAt desc. CDN-cached for ~30s.",
+      query: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          events: z.array(CommunityEventSchema),
+        }),
+        ...baseErrorResponses,
+      },
+      metadata: { errorCodes: ["UNAUTHORIZED", "SERVER_ERROR"] as const },
+    },
+    getCommunityChat: {
+      method: "GET",
+      path: "/api/game/community/chat",
+      summary: "Recent community chat messages",
+      description:
+        "Returns the most recent 50 non-deleted chat messages ordered by createdAt desc.",
+      query: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          messages: z.array(CommunityMessageSchema),
+        }),
+        ...baseErrorResponses,
+      },
+      metadata: { errorCodes: ["UNAUTHORIZED", "SERVER_ERROR"] as const },
+    },
+    postCommunityChat: {
+      method: "POST",
+      path: "/api/game/community/chat",
+      summary: "Post a chat message (rate-limited: 10 / 60s per user)",
+      body: z.object({
+        body: z.string().min(1).max(500),
+      }),
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          message: CommunityMessageSchema,
+        }),
+        429: ApiErrorSchema.openapi({
+          description: "Rate-limited; retry-after in body",
+        }),
+        ...actionErrorResponses,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "VALIDATION_ERROR",
+          "RATE_LIMITED",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+    deleteCommunityChat: {
+      method: "DELETE",
+      path: "/api/game/community/chat/:messageId",
+      summary: "Delete a chat message (own or admin)",
+      description:
+        "Soft-delete: sets deletedAt + deletedByAdmin. Author can delete their own; admins can delete any.",
+      pathParams: z.object({ messageId: z.string().min(1) }),
+      body: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          success: z.literal(true),
+          message: CommunityMessageSchema,
+        }),
+        403: ApiErrorSchema.openapi({
+          description: "Not the author and not an admin",
+        }),
+        404: ApiErrorSchema.openapi({ description: "Message not found" }),
+        ...baseErrorResponses,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "FORBIDDEN",
+          "NOT_FOUND",
           "SERVER_ERROR",
         ] as const,
       },

--- a/lib/game/community.ts
+++ b/lib/game/community.ts
@@ -1,0 +1,293 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Community feed + chat data-server. Surfaces:
+ *
+ *   - Append-only event log (`game_community_events`) consumed by the
+ *     dashboard's CommunityPanel activity feed. Each entry is a
+ *     denormalized snapshot — no joins required at read-time.
+ *   - Chat collection (`game_community_messages`) with create + soft-
+ *     delete by author + admin force-delete.
+ *
+ * Event writes are append-only and live inside existing game-action
+ * transactions (chooseCasteServer, attackTileServer, etc.) — see
+ * `logCommunityEventInTx`. Read paths are POST-less GET endpoints with
+ * Cache-Control headers so the dashboard's "Refresh" button doesn't
+ * hammer Firestore.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import type {
+  AttackOutcome,
+  Caste,
+  CommunityEvent,
+  CommunityMessage,
+} from "./types";
+
+function adminDbOrThrow(): Firestore {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not initialized");
+  return db;
+}
+
+const COMMUNITY_EVENTS = "game_community_events";
+const COMMUNITY_MESSAGES = "game_community_messages";
+
+/** Maximum chat-message body length. Anything longer is rejected at the
+ *  route layer with a 400. Keeps the listener payload small and
+ *  discourages walls-of-text spam. */
+export const MAX_MESSAGE_LENGTH = 500;
+
+/** How many of the most-recent events / messages the public read paths
+ *  return. Picked to fit on a single dashboard panel without paging. */
+export const COMMUNITY_PAGE_SIZE = 50;
+
+interface BaseEventInput {
+  actorUserId: string;
+  actorDisplayName: string;
+  actorCaste: Caste | null;
+}
+
+interface PlayerJoinEvent extends BaseEventInput {
+  kind: "player_join";
+}
+
+interface CastePickEvent extends BaseEventInput {
+  kind: "caste_pick";
+}
+
+interface CasteChangeEvent extends BaseEventInput {
+  kind: "caste_change";
+  fromCaste: Caste;
+  toCaste: Caste;
+}
+
+interface AttackEvent extends BaseEventInput {
+  kind: "attack";
+  targetUserId: string;
+  targetDisplayName: string;
+  tileId: string;
+  outcome: AttackOutcome;
+}
+
+interface MilestoneEvent extends BaseEventInput {
+  kind: "milestone_1k_tiles";
+}
+
+export type CommunityEventInput =
+  | PlayerJoinEvent
+  | CastePickEvent
+  | CasteChangeEvent
+  | AttackEvent
+  | MilestoneEvent;
+
+/**
+ * Writes one community-event doc inside an existing transaction.
+ * Called from the action-server txns so the event is created
+ * atomically with the underlying state change. If a write outside the
+ * txn is needed (e.g. player creation does its own txn already), use
+ * `logCommunityEvent` instead.
+ *
+ * No-throw: a failed write here must NOT abort the parent txn. Errors
+ * are swallowed and logged at the caller's discretion. (For now we let
+ * Firestore reject and bubble up; adopt try/catch if it becomes a
+ * source of phantom rollbacks.)
+ */
+export function logCommunityEventInTx(
+  tx: Transaction,
+  db: Firestore,
+  input: CommunityEventInput,
+  now: Date
+): void {
+  const id = randomUUID();
+  const ref = db.collection(COMMUNITY_EVENTS).doc(id);
+  // Build a doc shape with only the fields relevant to the kind so we
+  // don't pollute Firestore with a bunch of `undefined`s.
+  const base = {
+    id,
+    kind: input.kind,
+    createdAt: now,
+    actorUserId: input.actorUserId,
+    actorDisplayName: input.actorDisplayName,
+    actorCaste: input.actorCaste,
+  };
+  let extra: Partial<CommunityEvent> = {};
+  if (input.kind === "attack") {
+    extra = {
+      targetUserId: input.targetUserId,
+      targetDisplayName: input.targetDisplayName,
+      tileId: input.tileId,
+      outcome: input.outcome,
+    };
+  } else if (input.kind === "caste_change") {
+    extra = { fromCaste: input.fromCaste, toCaste: input.toCaste };
+  }
+  tx.set(ref, { ...base, ...extra });
+}
+
+/** Out-of-transaction event writer for callers that aren't running
+ *  inside a Firestore txn (e.g. seed scripts, simple `set` flows). */
+export async function logCommunityEvent(
+  input: CommunityEventInput,
+  now: Date = new Date()
+): Promise<void> {
+  const db = adminDbOrThrow();
+  const id = randomUUID();
+  const ref = db.collection(COMMUNITY_EVENTS).doc(id);
+  const base = {
+    id,
+    kind: input.kind,
+    createdAt: now,
+    actorUserId: input.actorUserId,
+    actorDisplayName: input.actorDisplayName,
+    actorCaste: input.actorCaste,
+  };
+  let extra: Partial<CommunityEvent> = {};
+  if (input.kind === "attack") {
+    extra = {
+      targetUserId: input.targetUserId,
+      targetDisplayName: input.targetDisplayName,
+      tileId: input.tileId,
+      outcome: input.outcome,
+    };
+  } else if (input.kind === "caste_change") {
+    extra = { fromCaste: input.fromCaste, toCaste: input.toCaste };
+  }
+  await ref.set({ ...base, ...extra });
+}
+
+/** Fetches the N most-recent community events. Single ordered query;
+ *  no joins (events are denormalized at write-time). */
+export async function listRecentCommunityEvents(
+  limit: number = COMMUNITY_PAGE_SIZE
+): Promise<CommunityEvent[]> {
+  const db = adminDbOrThrow();
+  const snap = await db
+    .collection(COMMUNITY_EVENTS)
+    .orderBy("createdAt", "desc")
+    .limit(Math.max(1, Math.min(200, limit)))
+    .get();
+  return snap.docs.map((d) => d.data() as CommunityEvent);
+}
+
+// =====================================================================
+// Chat
+// =====================================================================
+
+export class CommunityMessageNotFoundError extends Error {
+  constructor() {
+    super("Community message not found");
+    this.name = "CommunityMessageNotFoundError";
+  }
+}
+export class CommunityMessageForbiddenError extends Error {
+  constructor() {
+    super(
+      "Cannot delete this message: not authored by you and not an admin"
+    );
+    this.name = "CommunityMessageForbiddenError";
+  }
+}
+export class CommunityMessageEmptyError extends Error {
+  constructor() {
+    super("Message body cannot be empty");
+    this.name = "CommunityMessageEmptyError";
+  }
+}
+export class CommunityMessageTooLongError extends Error {
+  constructor() {
+    super(`Message body exceeds ${MAX_MESSAGE_LENGTH} characters`);
+    this.name = "CommunityMessageTooLongError";
+  }
+}
+
+/**
+ * Creates a chat message authored by the given user. Validates
+ * non-empty body + body length. Caller is responsible for any rate-
+ * limiting (use checkUpstashRateLimit before calling this).
+ */
+export async function createCommunityMessage(args: {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  body: string;
+  now?: Date;
+}): Promise<CommunityMessage> {
+  const trimmed = args.body.trim();
+  if (trimmed.length === 0) throw new CommunityMessageEmptyError();
+  if (trimmed.length > MAX_MESSAGE_LENGTH) {
+    throw new CommunityMessageTooLongError();
+  }
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const id = randomUUID();
+  const ref = db.collection(COMMUNITY_MESSAGES).doc(id);
+  const message: CommunityMessage = {
+    id,
+    userId: args.userId,
+    displayName: args.displayName,
+    caste: args.caste,
+    body: trimmed,
+    createdAt: now,
+  };
+  await ref.set(message);
+  return message;
+}
+
+/**
+ * Soft-deletes a chat message. Author can delete their own; an admin
+ * can delete any. Sets `deletedAt` (and `deletedByAdmin` for admin
+ * deletes) so the audit trail is preserved.
+ */
+export async function deleteCommunityMessage(args: {
+  messageId: string;
+  callerUserId: string;
+  callerIsAdmin: boolean;
+  now?: Date;
+}): Promise<CommunityMessage> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const ref = db.collection(COMMUNITY_MESSAGES).doc(args.messageId);
+  const snap = await ref.get();
+  if (!snap.exists) throw new CommunityMessageNotFoundError();
+  const data = snap.data() as CommunityMessage;
+  if (data.userId !== args.callerUserId && !args.callerIsAdmin) {
+    throw new CommunityMessageForbiddenError();
+  }
+  const updates: Partial<CommunityMessage> = {
+    deletedAt: now,
+    deletedByAdmin: args.callerIsAdmin && data.userId !== args.callerUserId,
+  };
+  await ref.update(updates);
+  return { ...data, ...updates };
+}
+
+/** Returns the N most-recent non-deleted chat messages. */
+export async function listRecentCommunityMessages(
+  limit: number = COMMUNITY_PAGE_SIZE
+): Promise<CommunityMessage[]> {
+  const db = adminDbOrThrow();
+  // Fetch overhead — we want N visible messages, but some may have been
+  // soft-deleted. Overfetch a bit so the result still has N when there
+  // are recent deletes. Cheap (~0.06¢ per 100 reads).
+  const overFetch = Math.max(1, Math.min(300, limit * 2));
+  const snap = await db
+    .collection(COMMUNITY_MESSAGES)
+    .orderBy("createdAt", "desc")
+    .limit(overFetch)
+    .get();
+  const out: CommunityMessage[] = [];
+  for (const doc of snap.docs as ReadonlyArray<FirebaseFirestore.QueryDocumentSnapshot>) {
+    const data = doc.data() as CommunityMessage;
+    if (data.deletedAt) continue;
+    out.push(data);
+    if (out.length >= limit) break;
+  }
+  return out;
+}

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -18,6 +18,7 @@ import {
 } from "./combat";
 import { ARTIFACTS_BY_ID, SPELLS_BY_ID } from "./content";
 import { rollArtifact } from "./artifacts";
+import { logCommunityEventInTx } from "./community";
 import { buildIntelReportServer } from "./intel";
 import {
   deleteIntelEffectsInTx,
@@ -307,6 +308,13 @@ const COLLECTIONS = {
   ATTACKS: "game_attacks",
   WORLD_META: "game_world_meta",
   ARTIFACTS: "game_artifacts",
+  // Community feed: append-only event log of player actions (joins,
+  // caste picks, attacks, milestones). Read by the dashboard's
+  // CommunityPanel. Writes are Admin-SDK only.
+  COMMUNITY_EVENTS: "game_community_events",
+  // Community chat: free-form messages from authenticated players,
+  // moderated by author or by an admin (delete-only).
+  COMMUNITY_MESSAGES: "game_community_messages",
 } as const;
 
 const WORLD_META_DOC = "singleton";
@@ -748,6 +756,21 @@ export async function createPlayerWithSpawnServer(
       { merge: true }
     );
 
+    // Community feed: announce the new general so existing players see
+    // who just joined. Caste is null at this point (set later via
+    // chooseCasteServer); we still log a join entry for funnel-tracking.
+    logCommunityEventInTx(
+      tx,
+      db,
+      {
+        kind: "player_join",
+        actorUserId: userId,
+        actorDisplayName: cleanedName,
+        actorCaste: null,
+      },
+      now
+    );
+
     return { player, tileIds: spawn.tileIds };
   });
 }
@@ -1177,6 +1200,19 @@ export async function changeCasteServer(
       updatedAt: now,
     };
     tx.update(playerRef, updates);
+    logCommunityEventInTx(
+      tx,
+      db,
+      {
+        kind: "caste_change",
+        actorUserId: userId,
+        actorDisplayName: player.displayName,
+        actorCaste: newCaste,
+        fromCaste: player.caste,
+        toCaste: newCaste,
+      },
+      now
+    );
     return { ...player, ...updates };
   });
 }
@@ -1210,6 +1246,17 @@ export async function chooseCasteServer(
       updatedAt: now,
     };
     tx.update(playerRef, updates);
+    logCommunityEventInTx(
+      tx,
+      db,
+      {
+        kind: "caste_pick",
+        actorUserId: userId,
+        actorDisplayName: player.displayName,
+        actorCaste: caste,
+      },
+      now
+    );
     return { ...player, ...updates };
   });
 }
@@ -2301,6 +2348,40 @@ export async function attackTileServer(args: {
       updatedAt: now,
     });
     tx.update(defenderRef, { stats: defenderStats, updatedAt: now });
+
+    // Community feed: announce the attack and any 1k-tile milestone
+    // crossed by the attacker as a result of this capture.
+    logCommunityEventInTx(
+      tx,
+      db,
+      {
+        kind: "attack",
+        actorUserId: args.attackerId,
+        actorDisplayName: attacker.displayName,
+        actorCaste: attacker.caste,
+        targetUserId: defenderId,
+        targetDisplayName: defender.displayName,
+        tileId: args.targetTileId,
+        outcome: result.outcome,
+      },
+      now
+    );
+    if (
+      attacker.stats.tilesHeld < 1000 &&
+      attackerStats.tilesHeld >= 1000
+    ) {
+      logCommunityEventInTx(
+        tx,
+        db,
+        {
+          kind: "milestone_1k_tiles",
+          actorUserId: args.attackerId,
+          actorDisplayName: attacker.displayName,
+          actorCaste: attacker.caste,
+        },
+        now
+      );
+    }
 
     const attack: GameAttack = {
       id: attackId,

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -547,3 +547,51 @@ export interface CombatResult {
     forgeScoutsBonusApplied?: boolean;
   };
 }
+
+
+// =====================================================================
+// Community feed + chat
+// =====================================================================
+
+/** Events surfaced in the dashboard's CommunityPanel activity feed. */
+export type CommunityEventKind =
+  | "player_join"
+  | "caste_pick"
+  | "caste_change"
+  | "attack"
+  | "milestone_1k_tiles";
+
+/** Single entry in the `game_community_events` log. Denormalized so the
+ *  feed renderer never needs to join against game_players. */
+export interface CommunityEvent {
+  id: string;
+  kind: CommunityEventKind;
+  createdAt: Timestamp | Date;
+  /** Player who performed the action. */
+  actorUserId: string;
+  actorDisplayName: string;
+  actorCaste: Caste | null;
+  // Attack-specific fields
+  targetUserId?: string;
+  targetDisplayName?: string;
+  tileId?: string;
+  outcome?: AttackOutcome;
+  // Caste-change-specific fields
+  fromCaste?: Caste;
+  toCaste?: Caste;
+}
+
+/** Single message in the `game_community_messages` collection. */
+export interface CommunityMessage {
+  id: string;
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  body: string;
+  createdAt: Timestamp | Date;
+  /** Set when the message has been soft-deleted (by the author or an
+   *  admin). The chat renderer hides deleted messages by default. */
+  deletedAt?: Timestamp | Date;
+  /** True when the deletion was performed by an admin. */
+  deletedByAdmin?: boolean;
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -108,7 +108,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (185 endpoints)
+## API (189 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -198,6 +198,10 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     POST   /api/game/build [Yes] — Build units on a tile
     POST   /api/game/build/bulk [Yes] — Execute a bulk build plan across tiles
     POST   /api/game/caste/change [Yes] — Switch castes (one-time, after reaching 1000 tiles)
+    GET    /api/game/community/chat [Yes] — Recent community chat messages
+    POST   /api/game/community/chat [Yes] — Post a chat message (rate-limited: 10 / 60s per user)
+    DELETE /api/game/community/chat/{messageId} [Yes] — Delete a chat message (own or admin)
+    GET    /api/game/community/feed [Yes] — Recent community events (player joins, caste picks, attacks)
     POST   /api/game/distribute/bulk [Yes] — Distribute one land type across multiple tiles
     GET    /api/game/eligibility [Yes] — Get the current user's game eligibility state
     POST   /api/game/explore [Yes] — Frontier-explore one or more new tiles


### PR DESCRIPTION
## Summary
Adds a collapsible community section at the bottom of `/game` with a 50-entry activity feed (left) and a global chat board (right). Manual refresh — no realtime listener (per your call).

## Activity feed
Five event kinds, all denormalized at write-time so the renderer needs zero joins:
- `player_join` — wired into `createPlayerWithSpawnServer`
- `caste_pick` — wired into `chooseCasteServer`
- `caste_change` — wired into `changeCasteServer` (carries from/to caste)
- `attack` — wired into `attackTileServer` (with outcome)
- `milestone_1k_tiles` — emitted when `tilesHeld` crosses 1,000

## Chat
- `POST /api/game/community/chat` rate-limited to 10/60s per user (Upstash, with in-memory fallback). 500-char body cap.
- Soft-delete by author or admin; sets `deletedAt` + `deletedByAdmin` for audit.
- Optimistic prepend on send. ⌘/Ctrl + Enter to post.

## What changed
- `lib/game/community.ts` — NEW event/message helpers + queries.
- `lib/game/data-server.ts` — 4 hook insertions + 2 new collections in COLLECTIONS dict.
- `lib/game/types.ts` — `CommunityEvent` + `CommunityMessage` types.
- `lib/api-schemas/game.ts` — 4 new ts-rest entries (`getCommunityFeed`, `getCommunityChat`, `postCommunityChat`, `deleteCommunityChat`).
- `app/api/game/community/{feed,chat,chat/[messageId]}/route.ts` — NEW.
- `app/game/_components/dashboard/CommunityPanel.tsx` — NEW collapsible 2-col panel.
- `app/game/_components/dashboard/DashboardView.tsx` — mount the panel after DashboardReports.
- `config/firebase/firestore.rules` — auth-read, admin-only-write rules for both collections.
- `lib/account-deletion/registry.ts` — classify both collections as user-owned (fieldEqualsUid) so right-to-delete sweeps them.

## Cost note
With manual refresh + 30s CDN cache on the feed, expected new Firestore reads per active player per week: ~10–30 (one feed + one chat fetch per dashboard expansion). Writes scale with actions (1 event write per attack/caste pick/etc., +1 per message posted).

## Test plan
- [x] Typecheck + lint clean
- [x] 1,789 / 1,789 jest tests pass
- [x] `npm run build` clean
- [x] `check:route-contracts` clean (4 new contracts registered)
- [ ] Smoke on prod: expand the panel, verify feed loads + chat loads. Post a message; verify it appears + you can delete your own.
- [ ] Trigger an attack from a test player; verify the event appears in the feed after a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)