### PR TITLE
release: develop → main — grant fix + recent /game features

### DIFF
--- a/__tests__/lib/game/turns.test.ts
+++ b/__tests__/lib/game/turns.test.ts
@@ -205,11 +205,17 @@ describe("shouldGrantWeeklyTurns + applyWeeklyGrant", () => {
     expect(shouldGrantWeeklyTurns(granted, true, "2026-05-10")).toBe(true);
   });
 
-  it("applyWeeklyGrant resets turnsRemaining to 100 (no rollover)", () => {
+  it("applyWeeklyGrant adds WEEKLY_TURN_GRANT to turnsRemaining (banks rollover)", () => {
     const partial: GamePlayer = { ...p(), turnsRemaining: 30 };
     const granted = applyWeeklyGrant(partial, "2026-05-03");
-    expect(granted.turnsRemaining).toBe(WEEKLY_TURN_GRANT);
+    expect(granted.turnsRemaining).toBe(30 + WEEKLY_TURN_GRANT);
     expect(granted.lastWeeklyGrantWeekStart).toBe("2026-05-03");
+  });
+
+  it("applyWeeklyGrant adds even when bucket is full (no cap)", () => {
+    const flush: GamePlayer = { ...p(), turnsRemaining: 300 };
+    const granted = applyWeeklyGrant(flush, "2026-05-03");
+    expect(granted.turnsRemaining).toBe(300 + WEEKLY_TURN_GRANT);
   });
 });
 

--- a/lib/game/turns.ts
+++ b/lib/game/turns.ts
@@ -12,7 +12,7 @@ export const WEEKLY_TURN_GRANT = 100;
 // Initial bucket granted at spawn. Larger than the weekly grant so a fresh
 // general can clear setup (assign 25 lands, pick a caste) and still have a
 // substantial pool for early recruiting / first attacks before the next
-// Sunday rollover refills the bucket.
+// Sunday rollover tops up the bucket.
 export const STARTING_TURN_GRANT = 300;
 export const SHIELD_DURATION_WEEKS = 3;
 export const SHIELD_TURN_THRESHOLD = 300;
@@ -200,6 +200,8 @@ export function shouldGrantWeeklyTurns(
   return true;
 }
 
+// Adds WEEKLY_TURN_GRANT on top of any unspent turns — banking is rewarded,
+// not penalized. A player who hoarded 300 going into the rollover ends at 400.
 export function applyWeeklyGrant(
   player: GamePlayer,
   weekStartIso: string,
@@ -207,7 +209,7 @@ export function applyWeeklyGrant(
 ): GamePlayer {
   return {
     ...player,
-    turnsRemaining: WEEKLY_TURN_GRANT,
+    turnsRemaining: player.turnsRemaining + WEEKLY_TURN_GRANT,
     lastWeeklyGrantAt: now,
     lastWeeklyGrantWeekStart: weekStartIso,
     updatedAt: now,

--- a/scripts/audit-turns.ts
+++ b/scripts/audit-turns.ts
@@ -1,0 +1,51 @@
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+import { getAdminDb } from "../lib/firebase-admin";
+import { weekStartIsoForRollover } from "../lib/game/turns";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) { console.error("Firebase Admin not configured."); process.exit(1); }
+  const snap = await db.collection("game_players").get();
+  const now = new Date();
+  const currentWeekIso = weekStartIsoForRollover(now);
+  const rows: Array<Record<string, unknown>> = [];
+  let realTotal = 0;
+  let grantedThisWeek = 0;
+  let notGrantedThisWeek = 0;
+  let neverGranted = 0;
+  let stillStarting = 0;
+  for (const doc of snap.docs) {
+    const d = doc.data() as {
+      isNpc?: boolean; displayName?: string; phase?: string;
+      turnsRemaining?: number; turnsSpentTotal?: number;
+      lastWeeklyGrantWeekStart?: string;
+    };
+    if (d.isNpc === true) continue;
+    realTotal++;
+    const granted = d.lastWeeklyGrantWeekStart === currentWeekIso;
+    if (granted) grantedThisWeek++;
+    else notGrantedThisWeek++;
+    if (!d.lastWeeklyGrantWeekStart) neverGranted++;
+    if ((d.turnsSpentTotal ?? 0) === 0 && (d.turnsRemaining ?? 0) === 300) stillStarting++;
+    rows.push({
+      name: d.displayName || "(unnamed)",
+      phase: d.phase,
+      remaining: d.turnsRemaining,
+      spent: d.turnsSpentTotal,
+      lastGrantWeek: d.lastWeeklyGrantWeekStart ?? null,
+      grantedCurrentWeek: granted,
+    });
+  }
+  rows.sort((a, b) => Number(b.remaining ?? 0) - Number(a.remaining ?? 0));
+  console.log(JSON.stringify({
+    currentWeekIso,
+    realTotal,
+    grantedThisWeek,
+    notGrantedThisWeek,
+    neverGranted,
+    stillAtStartingBucket: stillStarting,
+    rows,
+  }, null, 2));
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
Ships the weekly turn-grant fix (today's bug — rollover was replacing balances with 100 instead of adding 100) along with the 12 game/admin commits that have accumulated on develop since the last release.

## Included commits
- `05de2c7` fix(game): weekly turn grant adds 100 instead of replacing bucket
- `f1e7e8b` feat(game): community feed + chat panel on dashboard (#783)
- `3a886c2` feat(game): first-run onboarding wizard + 1000-tile caste switch (#781)
- `044324f` feat(game): real-time world map + smart-gated snapshot rebuilds (#779)
- `894ffad` feat(game): Humans/NPCs audience filter on world map (#777)
- `023e955` fix(game): correct 'Defender had' label + open recruit to all tile types on threats (#775)
- `1884950` fix(game): accept null offenseSpellId on /api/game/attack (#773)
- `b14b992` docs: regen API.md + llms.txt for new endpoints
- `1580655` feat(cohort): readiness modal, setup + game tabs, status email (#770)
- `e7c5785` feat(game): battle sim, tile-type mechanics, leaderboard filter (#769)
- `98768ec` fix(admin): wire ts-rest contracts for summer-cohort admin routes
- `dab47e9` feat(admin): summer cohort dashboard with email-gated access
- `5fc4faa` feat(game): inline tile prep + structured battle readout on threats page (#765)

## Contributors
- @Ludwitt — all 13 commits

## Why now
The cron rotation also rotated the rollover secret; this deploy will pick up the new `GAME_ROLLOVER_SECRET` env var (already set in Vercel + GH Actions) so today's failed rollover can be re-triggered. Without the merge, today's rollover would run the OLD math (replace bucket with 100), penalizing players who banked turns.

## Test plan
- [x] `lib/game/turns.ts` change covered by `__tests__/lib/game/turns.test.ts` (35/35 pass locally)
- [ ] Verify Vercel prod deploy goes green
- [ ] Re-trigger `game-weekly-rollover.yml` + `game-npc-weekly.yml`
- [ ] `npx tsx scripts/audit-turns.ts` — every real player should have `lastGrantWeek=2026-05-10`, balance bumped by exactly 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)