### PR TITLE
release: cohort-1 lockdown — close signups, withdraw flow, admit tooling

### DIFF
--- a/__tests__/app/api/summer-cohort/apply.test.ts
+++ b/__tests__/app/api/summer-cohort/apply.test.ts
@@ -178,7 +178,7 @@ describe("POST /api/summer-cohort/apply", () => {
           email: "applicant@example.com",
           name: "Test Applicant",
           phone: "555-1234",
-          cohorts: ["cohort-1", "cohort-2"],
+          cohorts: ["cohort-2"],
           siteId: "cursor-boston",
           status: "pending",
           isLocal: true,
@@ -192,7 +192,7 @@ describe("POST /api/summer-cohort/apply", () => {
             name: "Test Applicant",
             email: "applicant@example.com",
             phone: "555-1234",
-            cohorts: ["cohort-1", "cohort-2"],
+            cohorts: ["cohort-2"],
             createdAt: { toMillis: () => Date.now() },
           }),
         },
@@ -204,7 +204,7 @@ describe("POST /api/summer-cohort/apply", () => {
         ...validBody,
         name: "Test Applicant",
         phone: "555-1234",
-        cohorts: ["cohort-1", "cohort-2", "cohort-1"], // dedupe
+        cohorts: ["cohort-2", "cohort-2"], // dedupe
         isLocal: true,
         wantsToPresent: true,
       })
@@ -216,6 +216,51 @@ describe("POST /api/summer-cohort/apply", () => {
     // Wait a microtask so the fire-and-forget email has a chance to dispatch.
     await new Promise((r) => setTimeout(r, 10));
     expect(mockSendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects new cohort-1 applications with 403 (signups closed)", async () => {
+    mockDocGet.mockResolvedValueOnce({ exists: false });
+    const res = await POST(
+      makePost({
+        ...validBody,
+        cohorts: ["cohort-1"],
+      })
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/Cohort 1 applications are closed/);
+    expect(mockDocSet).not.toHaveBeenCalled();
+  });
+
+  it("lets existing cohort-1 applicants edit their record", async () => {
+    mockDocGet
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ cohorts: ["cohort-1"] }),
+      })
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          userId: "user-123",
+          email: "applicant@example.com",
+          name: "Existing C1",
+          phone: "555-0000",
+          cohorts: ["cohort-1"],
+          siteId: "cursor-boston",
+          status: "admitted",
+          isLocal: true,
+          wantsToPresent: true,
+        }),
+      });
+    const res = await POST(
+      makePost({
+        ...validBody,
+        name: "Existing C1",
+        phone: "555-0000",
+        cohorts: ["cohort-1"],
+      })
+    );
+    expect(res.status).toBe(200);
   });
 
   it("updates existing application without sending notification email", async () => {

--- a/app/api/summer-cohort/apply/route.ts
+++ b/app/api/summer-cohort/apply/route.ts
@@ -207,6 +207,25 @@ async function handlePost(request: NextRequest) {
   try {
     const ref = db.collection(SUMMER_COHORT_COLLECTION).doc(user.uid);
     const existing = await ref.get();
+    // Cohort 1 signups are closed (kickoff is Mon May 11). New applicants
+    // cannot include cohort-1; existing applicants who already opted into
+    // cohort-1 can keep editing their record (phone, etc.) without losing it.
+    const wantsCohort1 = cohorts.includes("cohort-1");
+    const alreadyHadCohort1 = existing.exists
+      ? Array.isArray((existing.data() as { cohorts?: SummerCohortId[] }).cohorts) &&
+        ((existing.data() as { cohorts?: SummerCohortId[] }).cohorts ?? []).includes(
+          "cohort-1"
+        )
+      : false;
+    if (wantsCohort1 && !alreadyHadCohort1) {
+      return NextResponse.json(
+        {
+          error:
+            "Cohort 1 applications are closed — kickoff is Mon May 11. Cohort 2 is still open.",
+        },
+        { status: 403 }
+      );
+    }
     const baseFields = {
       userId: user.uid,
       email: user.email,

--- a/app/api/summer-cohort/withdraw/route.ts
+++ b/app/api/summer-cohort/withdraw/route.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { verifyWithdrawToken } from "@/lib/unsubscribe-token";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { isValidCohortId, SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE = { windowMs: 15 * 60 * 1000, maxRequests: 20 };
+
+/**
+ * GET /api/summer-cohort/withdraw?email=...&cohortId=...&token=...
+ *
+ * Validates the HMAC token and marks the application as withdrawn in Firestore,
+ * then redirects to a confirmation page. Mirrors the unsubscribe route shape
+ * but writes to summerCohortApplications instead of eventContacts.
+ */
+export async function GET(request: NextRequest) {
+  const clientId = getClientIdentifier(request as unknown as Request);
+  const rateResult = checkRateLimit(`cohort-withdraw:${clientId}`, RATE);
+  if (!rateResult.success) {
+    return NextResponse.redirect(
+      new URL("/cohort-withdraw?status=rate-limited", request.url)
+    );
+  }
+
+  const email = request.nextUrl.searchParams.get("email")?.toLowerCase().trim();
+  const cohortId = request.nextUrl.searchParams.get("cohortId")?.trim();
+  const token = request.nextUrl.searchParams.get("token")?.trim();
+
+  if (!email || !cohortId || !token) {
+    return NextResponse.redirect(
+      new URL("/cohort-withdraw?status=invalid", request.url)
+    );
+  }
+
+  if (!isValidCohortId(cohortId)) {
+    return NextResponse.redirect(
+      new URL("/cohort-withdraw?status=invalid", request.url)
+    );
+  }
+
+  if (!/^[a-f0-9]{64}$/i.test(token)) {
+    return NextResponse.redirect(
+      new URL("/cohort-withdraw?status=invalid", request.url)
+    );
+  }
+
+  if (!verifyWithdrawToken(email, cohortId, token)) {
+    return NextResponse.redirect(
+      new URL("/cohort-withdraw?status=invalid", request.url)
+    );
+  }
+
+  try {
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.redirect(
+        new URL("/cohort-withdraw?status=error", request.url)
+      );
+    }
+
+    const snap = await db
+      .collection(SUMMER_COHORT_COLLECTION)
+      .where("email", "==", email)
+      .limit(1)
+      .get();
+
+    if (snap.empty) {
+      // Don't leak existence — same success page either way.
+      return NextResponse.redirect(
+        new URL("/cohort-withdraw?status=success", request.url)
+      );
+    }
+
+    await snap.docs[0].ref.update({
+      status: "withdrawn",
+      statusUpdatedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    return NextResponse.redirect(
+      new URL("/cohort-withdraw?status=success", request.url)
+    );
+  } catch {
+    return NextResponse.redirect(
+      new URL("/cohort-withdraw?status=error", request.url)
+    );
+  }
+}

--- a/app/cohort-withdraw/page.tsx
+++ b/app/cohort-withdraw/page.tsx
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Cohort 1 withdrawal - Cursor Boston",
+  description: "Confirm your withdrawal from Cursor Boston Cohort 1.",
+};
+
+export default async function CohortWithdrawPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const { status } = await searchParams;
+
+  return (
+    <div className="flex flex-col">
+      <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="max-w-xl mx-auto text-center">
+          {status === "success" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                You&apos;ve withdrawn from Cohort 1
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                Your spot will be freed up for the waitlist. If this was a
+                mistake or you change your mind, email{" "}
+                <a
+                  href="mailto:roger@cursorboston.com"
+                  className="underline"
+                >
+                  roger@cursorboston.com
+                </a>{" "}
+                — we can put you back in.
+              </p>
+            </>
+          )}
+          {status === "invalid" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Invalid link
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                This withdrawal link is invalid or has been tampered with. If
+                you meant to withdraw, email{" "}
+                <a
+                  href="mailto:roger@cursorboston.com"
+                  className="underline"
+                >
+                  roger@cursorboston.com
+                </a>{" "}
+                directly.
+              </p>
+            </>
+          )}
+          {status === "rate-limited" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Too many requests
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                Please wait a few minutes and try again.
+              </p>
+            </>
+          )}
+          {status === "error" && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Something went wrong
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                We couldn&apos;t process your withdrawal. Please try again or
+                email{" "}
+                <a
+                  href="mailto:roger@cursorboston.com"
+                  className="underline"
+                >
+                  roger@cursorboston.com
+                </a>
+                .
+              </p>
+            </>
+          )}
+          {!status && (
+            <>
+              <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                Cohort 1 withdrawal
+              </h1>
+              <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+                Use the link in your email to withdraw from Cohort 1.
+              </p>
+            </>
+          )}
+          <Link
+            href="/"
+            className="text-sm text-neutral-500 hover:text-foreground transition-colors"
+          >
+            &larr; Back to cursorboston.com
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -54,7 +54,8 @@ export type SummerCohortStatus =
   | "pending"
   | "admitted"
   | "rejected"
-  | "waitlist";
+  | "waitlist"
+  | "withdrawn";
 
 export interface SummerCohortApplication {
   userId: string;
@@ -162,8 +163,10 @@ export const SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER =
 export const SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER =
   "https://discord.gg/PLACEHOLDER";
 
-/** Hard cap on Cohort 1 admits. Auto-admit-on-PR-merge respects this. */
-export const SUMMER_COHORT_C1_CAP = 100;
+/** Hard cap on Cohort 1 admits. Auto-admit-on-PR-merge respects this.
+ *  Bumped 2026-05-10 when we admitted everyone who applied to lock the roster
+ *  before the May 11 kickoff. */
+export const SUMMER_COHORT_C1_CAP = 200;
 
 /** PR-merge auto-admit deadline.
  *  Pending Cohort 1 applicants who get a PR merged into the community repo

--- a/lib/unsubscribe-token.ts
+++ b/lib/unsubscribe-token.ts
@@ -35,3 +35,33 @@ export function buildUnsubscribeUrl(email: string): string {
   const token = generateUnsubscribeToken(email);
   return `${origin}/api/notifications/unsubscribe?email=${encodeURIComponent(email)}&token=${token}`;
 }
+
+// HMAC namespace prefix so a withdraw token can never be replayed against the
+// unsubscribe endpoint (or vice-versa) even though both share the same secret.
+const WITHDRAW_NS = "withdraw-cohort";
+
+export function generateWithdrawToken(email: string, cohortId: string): string {
+  return createHmac("sha256", SECRET)
+    .update(`${WITHDRAW_NS}:${cohortId}:${email.toLowerCase().trim()}`)
+    .digest("hex");
+}
+
+export function verifyWithdrawToken(
+  email: string,
+  cohortId: string,
+  token: string
+): boolean {
+  return generateWithdrawToken(email, cohortId) === token;
+}
+
+export function buildWithdrawUrl(email: string, cohortId: string): string {
+  const origin =
+    (process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com").replace(
+      /\/$/,
+      ""
+    );
+  const token = generateWithdrawToken(email, cohortId);
+  return `${origin}/api/summer-cohort/withdraw?email=${encodeURIComponent(
+    email
+  )}&cohortId=${encodeURIComponent(cohortId)}&token=${token}`;
+}

--- a/scripts/admit-all-cohort1-pending.ts
+++ b/scripts/admit-all-cohort1-pending.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Bulk-admit every Cohort 1 application that isn't already admitted or
+ * withdrawn. Includes pending, waitlist, AND rejected — the user explicitly
+ * chose "everyone except withdrawn" semantics on 2026-05-10 to lock the
+ * roster before the May 11 kickoff.
+ *
+ * Idempotent: re-running is a no-op for already-admitted docs.
+ *
+ * Usage:
+ *   npx tsx scripts/admit-all-cohort1-pending.ts --dry-run
+ *   npx tsx scripts/admit-all-cohort1-pending.ts --apply
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+interface Candidate {
+  applicationId: string;
+  email: string;
+  name: string;
+  status: string;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const apply = process.argv.includes("--apply");
+  if (!dryRun && !apply) {
+    console.error("Pass --dry-run or --apply.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const snap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const candidates: Candidate[] = [];
+  let scanned = 0;
+  let alreadyAdmitted = 0;
+  let withdrawn = 0;
+  let notCohort1 = 0;
+  const breakdown: Record<string, number> = {};
+
+  for (const doc of snap.docs) {
+    scanned++;
+    const d = doc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      notCohort1++;
+      continue;
+    }
+    const status = d.status ?? "pending";
+    if (status === "admitted") {
+      alreadyAdmitted++;
+      continue;
+    }
+    if (status === "withdrawn") {
+      withdrawn++;
+      continue;
+    }
+    breakdown[status] = (breakdown[status] ?? 0) + 1;
+    candidates.push({
+      applicationId: doc.id,
+      email: (d.email ?? "").trim(),
+      name: (d.name ?? "").trim(),
+      status,
+    });
+  }
+
+  console.log(`Scanned: ${scanned}`);
+  console.log(`Not cohort-1: ${notCohort1}`);
+  console.log(`Already admitted: ${alreadyAdmitted}`);
+  console.log(`Already withdrawn (skipped): ${withdrawn}`);
+  console.log(`To be admitted: ${candidates.length}`);
+  console.log(`  Breakdown of from-statuses:`, breakdown);
+
+  if (candidates.length > 0) {
+    console.log("\nFirst 10 candidates:");
+    for (const c of candidates.slice(0, 10)) {
+      console.log(`  ${c.status.padEnd(10)}  ${c.email.padEnd(40)}  ${c.name}`);
+    }
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no writes made.");
+    return;
+  }
+
+  let admitted = 0;
+  let failed = 0;
+  for (const c of candidates) {
+    try {
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(c.applicationId).update({
+        status: "admitted",
+        admittedAt: FieldValue.serverTimestamp(),
+        admittedVia: "bulk-may10",
+        statusUpdatedAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      admitted++;
+    } catch (e) {
+      failed++;
+      console.error(`Failed to admit ${c.email}:`, e);
+    }
+  }
+  console.log(`\nDone. Admitted ${admitted}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-status-update.ts
+++ b/scripts/send-cohort1-status-update.ts
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Cohort 1 — Sunday-evening status email sent the day before kickoff.
+ * Personalized checklist (Discord, GitHub, intake survey), CTA to the
+ * onboarding walkthrough at ludwitt.com/alc, heads-up that 3 emails are
+ * coming Mon May 11 before the 6pm EST kickoff Zoom, and a one-click
+ * "Withdraw from Cohort 1" link for anyone no longer participating.
+ *
+ * Idempotent via `cohort1StatusUpdateEmailedAt` on the application doc.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-status-update.ts --dry-run
+ *   npx tsx scripts/send-cohort1-status-update.ts --send
+ *   npx tsx scripts/send-cohort1-status-update.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+import { SUMMER_COHORT_INTAKE_COLLECTION } from "../lib/summer-cohort-intake";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const ALC_URL = "https://ludwitt.com/alc";
+const STAMP_FIELD = "cohort1StatusUpdateEmailedAt";
+
+interface Recipient {
+  applicationId: string;
+  userId: string;
+  email: string;
+  name: string;
+  firstName: string;
+  hasDiscord: boolean;
+  hasGithub: boolean;
+  hasSurvey: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function row({
+  done,
+  label,
+  todoCopy,
+  doneCopy,
+}: {
+  done: boolean;
+  label: string;
+  todoCopy: string;
+  doneCopy: string;
+}): string {
+  if (done) {
+    return `<li style="margin-bottom:6px;"><strong>✅ ${escapeHtml(label)}</strong> — ${escapeHtml(doneCopy)}</li>`;
+  }
+  return `<li style="margin-bottom:6px;"><strong>⚠️ ${escapeHtml(label)}</strong> — ${escapeHtml(todoCopy)}</li>`;
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Cohort 1 starts tomorrow at 6pm EST — your status + 3 emails coming";
+
+  const items = [
+    row({
+      done: r.hasDiscord,
+      label: "Connect Discord",
+      todoCopy:
+        "Without Discord you can't see the cohort channel. One click on the cohort page handles it.",
+      doneCopy: "Connected — you've been added to the cohort-1 channel.",
+    }),
+    row({
+      done: r.hasGithub,
+      label: "Connect GitHub",
+      todoCopy:
+        "We use GitHub to count your weekly PRs against the cohort milestones.",
+      doneCopy: "Connected — your PRs will count.",
+    }),
+    row({
+      done: r.hasSurvey,
+      label: "Intake survey (~5 min)",
+      todoCopy:
+        "Tells us what tracks fit you. If you haven't done it, knock it out tonight.",
+      doneCopy: "Submitted. Thanks!",
+    }),
+  ].join("");
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Cohort 1 kicks off <strong>tomorrow — Mon, May 11 at 6pm EST</strong> on the kickoff Zoom. The roster is now locked; you're in.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Your status</h3>
+<ul style="padding-left:20px;">${items}</ul>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">If you haven't done the local-machine setup yet</h3>
+<p>Walk through the 20-minute onboarding tonight so Monday isn't spent wrestling with Node / Git / Cursor:</p>
+<p>
+  <a href="${ALC_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open ludwitt.com/alc →
+  </a>
+</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">What's coming tomorrow</h3>
+<p>I'll send <strong>three emails before kickoff</strong> on Monday:</p>
+<ol style="padding-left:20px;">
+  <li>Final logistics + Zoom link</li>
+  <li>Week-1 PM-tool brief (what you're building Mon–Fri)</li>
+  <li>Discord channel layout + how we'll run the cohort comms</li>
+</ol>
+<p>Watch your inbox during the day so nothing surprises you at 6pm.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Cohort page</h3>
+<p>One-click access to Discord, GitHub, and the intake survey:</p>
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#7c3aed;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<h3 style="margin-top:32px;margin-bottom:8px;color:#b91c1c;">Not joining anymore?</h3>
+<p>Life happens. If you're no longer participating, please <strong>withdraw now</strong> so I can free your spot for the waitlist:</p>
+<p>
+  <a href="${escapeHtml(withdrawUrl)}" style="display:inline-block;background:#fff;color:#b91c1c;border:1px solid #b91c1c;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Withdraw from Cohort 1
+  </a>
+</p>
+<p style="font-size:14px;color:#6b7280;">One click; no confirmation page. You'll land on a "you've been withdrawn" page. This removes you from the cohort entirely — different from the unsubscribe link below, which only stops emails.</p>
+
+<p style="margin-top:32px;">See you tomorrow.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you applied to Cohort 1 of the Cursor Boston summer cohort.<br/>
+Don't want any emails from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a> (different from withdrawing — this just stops emails, doesn't remove you from the cohort).
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.firstName?.trim() || "there"},
+
+Cohort 1 kicks off tomorrow — Mon, May 11 at 6pm EST — on the kickoff Zoom. The roster is now locked; you're in.
+
+YOUR STATUS
+
+  ${r.hasDiscord ? "[✓]" : "[ ]"} Connect Discord — ${r.hasDiscord ? "Connected; you've been added to the cohort-1 channel." : "Without Discord you can't see the cohort channel."}
+  ${r.hasGithub ? "[✓]" : "[ ]"} Connect GitHub — ${r.hasGithub ? "Connected; your PRs will count." : "We use GitHub to count your weekly PRs."}
+  ${r.hasSurvey ? "[✓]" : "[ ]"} Intake survey (~5 min) — ${r.hasSurvey ? "Submitted. Thanks!" : "Knock it out tonight."}
+
+IF YOU HAVEN'T DONE THE LOCAL-MACHINE SETUP
+Walk through the 20-minute onboarding tonight: ${ALC_URL}
+
+WHAT'S COMING TOMORROW
+Three emails before the 6pm kickoff:
+  1. Final logistics + Zoom link
+  2. Week-1 PM-tool brief
+  3. Discord channel layout
+
+COHORT PAGE
+One-click access to Discord, GitHub, intake survey: ${COHORT_URL}
+
+NOT JOINING ANYMORE?
+If you're no longer participating, please withdraw so I can free your spot:
+${withdrawUrl}
+
+One click; no confirmation page. This removes you from the cohort entirely — different from unsubscribing, which only stops emails.
+
+See you tomorrow.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you applied to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails (different from withdrawing): ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log("Loading cohort-1 admits + intake survey responses + users...");
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const intakeSnap = await db.collection(SUMMER_COHORT_INTAKE_COLLECTION).get();
+  const intakeEmailSet = new Set<string>();
+  for (const doc of intakeSnap.docs) {
+    const d = doc.data() as { email?: string };
+    if (d.email) intakeEmailSet.add(d.email.toLowerCase().trim());
+  }
+
+  const recipients: Recipient[] = [];
+  let skippedNotAdmitted = 0;
+  let skippedNotCohort1 = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoUserId = 0;
+  let skippedNoEmail = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      userId?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.userId) {
+      skippedNoUserId++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const userSnap = await db.collection("users").doc(d.userId).get();
+    const u = userSnap.exists
+      ? (userSnap.data() as {
+          discord?: { id?: string };
+          github?: { login?: string };
+        })
+      : null;
+    const hasDiscord = !!u?.discord?.id;
+    const hasGithub = !!u?.github?.login;
+    const hasSurvey = intakeEmailSet.has(d.email.toLowerCase().trim());
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      userId: d.userId,
+      email: d.email.trim(),
+      name,
+      firstName,
+      hasDiscord,
+      hasGithub,
+      hasSurvey,
+    });
+  }
+
+  console.log(`Eligible recipients: ${recipients.length}`);
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no userId: ${skippedNoUserId}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed: ${skippedAlreadyEmailed}`);
+  // Status histogram
+  let allDone = 0;
+  let missingDiscord = 0;
+  let missingGithub = 0;
+  let missingSurvey = 0;
+  for (const r of recipients) {
+    if (r.hasDiscord && r.hasGithub && r.hasSurvey) allDone++;
+    if (!r.hasDiscord) missingDiscord++;
+    if (!r.hasGithub) missingGithub++;
+    if (!r.hasSurvey) missingSurvey++;
+  }
+  console.log(
+    `Status: fully-set-up=${allDone}, missing-discord=${missingDiscord}, missing-github=${missingGithub}, missing-survey=${missingSurvey}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(
+        `Status: discord=${sample.hasDiscord}, github=${sample.hasGithub}, survey=${sample.hasSurvey}`
+      );
+      console.log("\n--- HTML preview (first 2500 chars) ---");
+      console.log(html.slice(0, 2500));
+      console.log("\n--- Text preview (first 2000 chars) ---");
+      console.log(text.slice(0, 2000));
+    }
+    console.log(`\nWould send to ${recipients.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Locks the cohort-1 roster the night before the May 11 6pm EST kickoff:
- 403 any new cohort-1 application; existing cohort-1 applicants can still edit their record (phone, etc.).
- New `GET /api/summer-cohort/withdraw` HMAC-token route + `/cohort-withdraw` landing page so the status email can ship a one-click withdraw link.
- Adds `"withdrawn"` to `SummerCohortStatus` and bumps `SUMMER_COHORT_C1_CAP` to 200 to fit the post-bulk-admit roster.
- Two scripts: `admit-all-cohort1-pending.ts` (idempotent bulk-admit) and `send-cohort1-status-update.ts` (personalized Discord/GitHub/intake checklist + 3-emails-tomorrow heads-up + withdraw CTA).

## Included commits
- `57e3062` feat(cohort): close cohort-1 signups, add withdraw flow, admit + status-email tooling

## Contributors
- @Ludwitt — single-commit release

## Why now
Kickoff is Mon May 11 at 6pm EST. The roster needs to be final tonight so I can send tomorrow's three pre-kickoff emails to a stable list, and any last-minute applicants can no longer slip in.

## Test plan
- [x] Jest: 18/18 cohort apply tests pass (added 2 for the new gate, modified 1 to use cohort-2 for the success path).
- [x] Type check clean.
- [ ] After deploy: hit POST `/api/summer-cohort/apply` with `{cohorts: ["cohort-1"]}` from a test account → expect 403.
- [ ] After deploy: visit a generated `/api/summer-cohort/withdraw?email=...&cohortId=cohort-1&token=...` URL → redirect to `/cohort-withdraw?status=success`.
- [ ] Run `admit-all-cohort1-pending.ts --dry-run` then `--apply`; verify with `count-cohort.ts`.
- [ ] Run `send-cohort1-status-update.ts --dry-run`; eyeball preview; then `--send`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)