### PR TITLE
fix(cohort): add ts-rest contract for withdraw route

### DIFF
--- a/app/api/summer-cohort/withdraw/route.ts
+++ b/app/api/summer-cohort/withdraw/route.ts
@@ -10,6 +10,7 @@ import { getAdminDb } from "@/lib/firebase-admin";
 import { verifyWithdrawToken } from "@/lib/unsubscribe-token";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { isValidCohortId, SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
+import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,9 +33,18 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const email = request.nextUrl.searchParams.get("email")?.toLowerCase().trim();
-  const cohortId = request.nextUrl.searchParams.get("cohortId")?.trim();
-  const token = request.nextUrl.searchParams.get("token")?.trim();
+  const parsedQuery = summerCohortContract.withdraw.query.safeParse({
+    email: request.nextUrl.searchParams.get("email") ?? undefined,
+    cohortId: request.nextUrl.searchParams.get("cohortId") ?? undefined,
+    token: request.nextUrl.searchParams.get("token") ?? undefined,
+  });
+  const email = parsedQuery.success
+    ? parsedQuery.data.email?.toLowerCase().trim()
+    : undefined;
+  const cohortId = parsedQuery.success
+    ? parsedQuery.data.cohortId?.trim()
+    : undefined;
+  const token = parsedQuery.success ? parsedQuery.data.token?.trim() : undefined;
 
   if (!email || !cohortId || !token) {
     return NextResponse.redirect(

--- a/lib/api-schemas/summer-cohort.ts
+++ b/lib/api-schemas/summer-cohort.ts
@@ -56,6 +56,14 @@ const AdminApplicationsQuery = z.object({
   status: z.enum(["pending", "admitted", "rejected", "waitlist"]).optional(),
 });
 
+const WithdrawQuery = z.object({
+  email: z.string().optional(),
+  cohortId: z.string().optional(),
+  token: z.string().optional(),
+});
+
+const RedirectResponse = z.object({}).optional();
+
 const AdminIntakeAggregatesQuery = z.object({
   cohort: z.string().min(1).max(64).optional(),
 });
@@ -91,6 +99,14 @@ export const summerCohortContract = c.router(
       body: z.object({}).optional(),
       responses: { 200: PassthroughOk, 401: ApiErrorSchema, 500: ApiErrorSchema },
       metadata: { errorCodes: ["UNAUTHORIZED", "SERVER_ERROR"] as const },
+    },
+    withdraw: {
+      method: "GET",
+      path: "/api/summer-cohort/withdraw",
+      summary: "One-click cohort withdrawal (HMAC token in query)",
+      query: WithdrawQuery,
+      responses: { 302: RedirectResponse },
+      metadata: { errorCodes: [] as const },
     },
     intakeSurveyGet: {
       method: "GET",


### PR DESCRIPTION
## Summary
Follow-up to PR #786 — that release failed the prod build because the new `app/api/summer-cohort/withdraw/route.ts` didn't have a ts-rest contract entry, which `check-route-contracts.js` flat-rejects. This adds the contract entry and wires the route to validate query params through it (same pattern as the unsubscribe route).

## Included commits
- `a430433` fix(cohort): add ts-rest contract for /api/summer-cohort/withdraw

🤖 Generated with [Claude Code](https://claude.com/claude-code)