### PR TITLE
chore: commit leftover operational scripts from May 10

### DIFF
--- a/scripts/admin-grant-100-this-week.ts
+++ b/scripts/admin-grant-100-this-week.ts
@@ -1,0 +1,51 @@
+/**
+ * One-shot: directly grant +100 turns to every real player for the current
+ * week, bypassing the broken cron. Sets lastWeeklyGrantWeekStart so the
+ * cron treats this week as already-granted (no double-grant if it later
+ * fires).
+ *
+ * Idempotent: re-running for the same week is a no-op for already-granted
+ * players.
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { weekStartIsoForRollover } from "../lib/game/turns";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) { console.error("no db"); process.exit(1); }
+  const now = new Date();
+  const wkStart = weekStartIsoForRollover(now);
+  const snap = await db.collection("game_players").get();
+  const results: Array<{ name: string; before: number; after: number }> = [];
+  let skippedAlreadyGranted = 0;
+  let grantedNpc = 0;
+  for (const doc of snap.docs) {
+    const d = doc.data() as {
+      isNpc?: boolean;
+      displayName?: string;
+      turnsRemaining?: number;
+      lastWeeklyGrantWeekStart?: string;
+    };
+    if (d.lastWeeklyGrantWeekStart === wkStart) { skippedAlreadyGranted++; continue; }
+    if (d.isNpc === true) grantedNpc++;
+    const before = d.turnsRemaining ?? 0;
+    const after = before + 100;
+    await db.collection("game_players").doc(doc.id).update({
+      turnsRemaining: after,
+      lastWeeklyGrantWeekStart: wkStart,
+      lastWeeklyGrantAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    results.push({ name: d.displayName || "(unnamed)", before, after });
+  }
+  console.log(JSON.stringify({
+    wkStart,
+    granted: results.length,
+    grantedNpc,
+    skippedAlreadyGranted,
+  }, null, 2));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/run-npc-weekly-now.ts
+++ b/scripts/run-npc-weekly-now.ts
@@ -1,0 +1,48 @@
+/**
+ * One-shot: roll back the admin pre-grant on NPCs (so the gate in
+ * runNpcWeeklyServer doesn't skip them), then run the NPC weekly behavior
+ * for the current week. Net effect on NPC turns is identical to the cron
+ * having run normally; they'll get +100 and then spend most of it.
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { runNpcWeeklyServer } from "../lib/game/npc-weekly";
+import { weekStartIsoForRollover } from "../lib/game/turns";
+
+async function main() {
+  const db = getAdminDb();
+  if (!db) { console.error("no db"); process.exit(1); }
+  const wkStart = weekStartIsoForRollover(new Date());
+  const snap = await db.collection("game_players").get();
+  let rolledBack = 0;
+  for (const doc of snap.docs) {
+    const d = doc.data() as {
+      isNpc?: boolean;
+      turnsRemaining?: number;
+      lastWeeklyGrantWeekStart?: string;
+    };
+    if (d.isNpc !== true) continue;
+    if (d.lastWeeklyGrantWeekStart !== wkStart) continue;
+    await db.collection("game_players").doc(doc.id).update({
+      turnsRemaining: Math.max(0, (d.turnsRemaining ?? 0) - 100),
+      lastWeeklyGrantWeekStart: FieldValue.delete(),
+      lastWeeklyGrantAt: FieldValue.delete(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    rolledBack++;
+  }
+  console.log(`Rolled back admin pre-grant on ${rolledBack} NPCs.`);
+
+  console.log("Running NPC weekly behavior...");
+  const summary = await runNpcWeeklyServer({});
+  console.log(JSON.stringify({
+    weekStartIso: summary.weekStartIso,
+    scanned: summary.scanned,
+    granted: summary.granted,
+    skippedAlreadyGranted: summary.skippedAlreadyGranted,
+    totals: summary.totals,
+  }, null, 2));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/send-cohort1-finalize-reminder.ts
+++ b/scripts/send-cohort1-finalize-reminder.ts
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Cohort 1 finalize reminder — pre-kickoff Saturday email to admits who
+ * STILL have at least one of:
+ *   - Discord not connected (cannot see the cohort channel)
+ *   - GitHub not connected
+ *   - Intake survey not submitted
+ *
+ * Single primary CTA: connect Discord. Lists the other open items
+ * inline so they're not surprised on Monday. Tightly scoped — we
+ * already sent the status email today; this is a "kickoff is in 2
+ * days, please finish setup" follow-up to the people who still owe
+ * something.
+ *
+ * Idempotent via `cohort1FinalizeReminderEmailedAt` on the application
+ * doc.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-finalize-reminder.ts --dry-run
+ *   npx tsx scripts/send-cohort1-finalize-reminder.ts --send
+ *   npx tsx scripts/send-cohort1-finalize-reminder.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+import { SUMMER_COHORT_INTAKE_COLLECTION } from "../lib/summer-cohort-intake";
+
+const COHORT_URL = "https://www.cursorboston.com/summer-cohort";
+const ALC_URL = "https://ludwitt.com/alc";
+const STAMP_FIELD = "cohort1FinalizeReminderEmailedAt";
+
+interface Recipient {
+  applicationId: string;
+  userId: string;
+  email: string;
+  name: string;
+  firstName: string;
+  needsDiscord: boolean;
+  needsGithub: boolean;
+  needsSurvey: boolean;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function row({
+  done,
+  label,
+  todoCopy,
+  doneCopy,
+}: {
+  done: boolean;
+  label: string;
+  todoCopy: string;
+  doneCopy: string;
+}): string {
+  if (done) {
+    return `<li><strong>✅ ${escapeHtml(label)}</strong> — ${escapeHtml(doneCopy)}</li>`;
+  }
+  return `<li><strong>⚠️ ${escapeHtml(label)}</strong> — ${escapeHtml(todoCopy)}</li>`;
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = "Cohort 1 starts Monday — finish your setup (2 minutes)";
+
+  const items = [
+    row({
+      done: !r.needsDiscord,
+      label: "Connect Discord",
+      todoCopy:
+        "Without Discord you can't see the cohort channel. One click on the cohort page handles it.",
+      doneCopy: "Connected — you've been added to the cohort-1 channel.",
+    }),
+    row({
+      done: !r.needsGithub,
+      label: "Connect GitHub",
+      todoCopy:
+        "We use GitHub to count your weekly PRs against the cohort milestones.",
+      doneCopy: "Connected — your PRs will count.",
+    }),
+    row({
+      done: !r.needsSurvey,
+      label: "Intake survey (~5 min)",
+      todoCopy:
+        "Tells us what tracks fit you. Surveys after Monday lose their priority.",
+      doneCopy: "Submitted. Thanks!",
+    }),
+  ].join("");
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Cohort 1 kicks off <strong>Monday, May 11</strong> — two days from now. You're admitted, but our records show you still have at least one open item from your setup. None of these take more than a couple minutes; please knock them out today or tomorrow so Monday isn't spent on logistics.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Your status</h3>
+<ul>${items}</ul>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">One-click finalize</h3>
+<p>Visit the cohort page — it has direct buttons for everything you need:</p>
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<p style="font-size:14px;color:#6b7280;">If you're new to the local-machine setup (Node, Git, Cursor), there's also a 20-minute walkthrough at <a href="${ALC_URL}">ludwitt.com/alc</a> — worth it before Monday.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">If you're not joining anymore</h3>
+<p>That's fine — just reply with "withdrawing" and we'll free up the spot for the waitlist. No hard feelings.</p>
+
+<p>See you Monday.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you applied to Cohort 1 of the Cursor Boston summer cohort.<br/>
+Don't want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.firstName?.trim() || "there"},
+
+Cohort 1 kicks off Monday, May 11 — two days from now. You're admitted, but our records show you still have at least one open item from your setup. None of these take more than a couple minutes; please knock them out today or tomorrow so Monday isn't spent on logistics.
+
+YOUR STATUS
+
+  ${r.needsDiscord ? "[ ]" : "[✓]"} Connect Discord — ${r.needsDiscord ? "Without Discord you can't see the cohort channel." : "Connected; you've been added to the cohort-1 channel."}
+  ${r.needsGithub ? "[ ]" : "[✓]"} Connect GitHub — ${r.needsGithub ? "We use GitHub to count your weekly PRs." : "Connected; your PRs will count."}
+  ${r.needsSurvey ? "[ ]" : "[✓]"} Intake survey (~5 min) — ${r.needsSurvey ? "Tells us what tracks fit you." : "Submitted. Thanks!"}
+
+ONE-CLICK FINALIZE
+  ${COHORT_URL}
+
+If you're new to the local-machine setup (Node, Git, Cursor), there's also a walkthrough at ${ALC_URL}.
+
+IF YOU'RE NOT JOINING ANYMORE
+Just reply with "withdrawing" and we'll free up the spot.
+
+See you Monday.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you applied to Cohort 1 of the Cursor Boston summer cohort.
+Don't want to hear from us? ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log("Loading cohort-1 admits…");
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  // Pre-load intake-survey rows by email so we can flag survey status
+  // without N round-trips. The collection is small (≲ 200 rows).
+  const intakeSnap = await db.collection(SUMMER_COHORT_INTAKE_COLLECTION).get();
+  const intakeEmailSet = new Set<string>();
+  for (const doc of intakeSnap.docs) {
+    const d = doc.data() as { email?: string };
+    if (d.email) intakeEmailSet.add(d.email.toLowerCase().trim());
+  }
+
+  const recipients: Recipient[] = [];
+  let skippedAlreadyEmailed = 0;
+  let skippedNotAdmitted = 0;
+  let skippedFinished = 0;
+  let skippedNoUserId = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      userId?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (!d.userId) {
+      skippedNoUserId++;
+      continue;
+    }
+    const userSnap = await db.collection("users").doc(d.userId).get();
+    const u = userSnap.exists
+      ? (userSnap.data() as {
+          discord?: { id?: string; username?: string };
+          github?: { login?: string };
+        })
+      : null;
+    const needsDiscord = !u?.discord?.id;
+    const needsGithub = !u?.github?.login;
+    const needsSurvey = !intakeEmailSet.has(
+      (d.email ?? "").toLowerCase().trim()
+    );
+
+    if (!needsDiscord && !needsGithub && !needsSurvey) {
+      skippedFinished++;
+      continue;
+    }
+
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      userId: d.userId,
+      email: (d.email ?? "").trim(),
+      name,
+      firstName,
+      needsDiscord,
+      needsGithub,
+      needsSurvey,
+    });
+  }
+
+  console.log(`Eligible (have at least one open item): ${recipients.length}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — fully finished: ${skippedFinished}`);
+  console.log(`Skipped — no userId on application: ${skippedNoUserId}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(
+        `Status: discord=${!sample.needsDiscord}, github=${!sample.needsGithub}, survey=${!sample.needsSurvey}`
+      );
+      console.log("\n--- HTML preview (first 1500 chars) ---");
+      console.log(html.slice(0, 1500));
+      console.log("\n--- Text preview (first 1500 chars) ---");
+      console.log(text.slice(0, 1500));
+    }
+    console.log(`\nWould send to ${recipients.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      // Stamp idempotency flag.
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-game-jumpstart-300.ts
+++ b/scripts/send-game-jumpstart-300.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * /game jumpstart — emails Cohort 1 admits who have NOT yet created a
+ * /game player, telling them they have a 300-turn starting bucket and a
+ * brand-new first-run wizard waiting at /game.
+ *
+ * Idempotent via `gameJumpstartEmailedAt` on the application doc.
+ *
+ * Usage:
+ *   npx tsx scripts/send-game-jumpstart-300.ts --dry-run
+ *   npx tsx scripts/send-game-jumpstart-300.ts --send
+ *   npx tsx scripts/send-game-jumpstart-300.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const GAME_URL = "https://cursorboston.com/game";
+const STAMP_FIELD = "gameJumpstartEmailedAt";
+
+interface Recipient {
+  applicationId: string;
+  userId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = "Your /game general is waiting — 300 turns to get started";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>You're admitted to Cohort 1 but haven't fired up <strong>/game</strong> yet — and the rest of the cohort is already racking up territory and PRs against it. Time to claim your general.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">What's waiting for you</h3>
+<ul style="padding-left:20px;">
+  <li><strong>300 turns</strong> in your starting bucket — enough to clear setup (claim 25 lands, pick a caste) and still have a substantial pool for early recruiting and your first attacks.</li>
+  <li><strong>Brand-new first-run wizard</strong> we just shipped — walks you through tile distribution, caste selection, and your first moves so you don't have to read the docs to get going.</li>
+  <li><strong>+100 turns every Sunday</strong> on top of whatever you've banked, as long as you merged a PR that week. No cap on banking — hoarders win.</li>
+</ul>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Why play it</h3>
+<p>The whole point: it's a real persistent web game built inside the same repo we use for everything else. Recruit units, run threats, cast spells, climb the leaderboard. And if you spot something you'd want different — a new spell, a tile-type tweak, a UI fix — <strong>open a PR</strong>. Contributions to /game are exactly the kind of work this cohort is here to do.</p>
+
+<p>
+  <a href="${GAME_URL}" style="display:inline-block;background:#7c3aed;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Start playing →
+  </a>
+</p>
+
+<p style="font-size:14px;color:#6b7280;">10 minutes is all the wizard needs. Most of the cohort is in the <code>distribute</code> or <code>play</code> phase already — catch up before the leaderboard locks in.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you're an admitted member of Cursor Boston Cohort 1.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.firstName?.trim() || "there"},
+
+You're admitted to Cohort 1 but haven't fired up /game yet — and the rest of the cohort is already racking up territory and PRs against it. Time to claim your general.
+
+WHAT'S WAITING FOR YOU
+  • 300 turns in your starting bucket — enough to clear setup (claim 25 lands, pick a caste) and still have a substantial pool for early recruiting and your first attacks.
+  • Brand-new first-run wizard we just shipped — walks you through tile distribution, caste selection, and your first moves.
+  • +100 turns every Sunday on top of whatever you've banked, as long as you merged a PR that week. No cap on banking — hoarders win.
+
+WHY PLAY IT
+The whole point: it's a real persistent web game built inside the same repo we use for everything else. Recruit units, run threats, cast spells, climb the leaderboard. And if you spot something you'd want different — a new spell, a tile-type tweak, a UI fix — open a PR. Contributions to /game are exactly the kind of work this cohort is here to do.
+
+Start playing: ${GAME_URL}
+
+10 minutes is all the wizard needs.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're an admitted member of Cursor Boston Cohort 1.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log("Loading cohort-1 admits + existing players...");
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const playersSnap = await db.collection("game_players").get();
+  const playerUserIds = new Set<string>();
+  for (const p of playersSnap.docs) {
+    const d = p.data() as { isNpc?: boolean };
+    if (d.isNpc !== true) playerUserIds.add(p.id);
+  }
+
+  const recipients: Recipient[] = [];
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyPlaying = 0;
+  let skippedNoUserId = 0;
+  let skippedNoEmail = 0;
+  let skippedAlreadyEmailed = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      userId?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.userId) {
+      skippedNoUserId++;
+      continue;
+    }
+    if (playerUserIds.has(d.userId)) {
+      skippedAlreadyPlaying++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      userId: d.userId,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(`Eligible (admitted, not playing, not yet emailed): ${recipients.length}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — already playing: ${skippedAlreadyPlaying}`);
+  console.log(`Skipped — no userId: ${skippedNoUserId}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed: ${skippedAlreadyEmailed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview (first 1800 chars) ---");
+      console.log(html.slice(0, 1800));
+      console.log("\n--- Text preview (first 1800 chars) ---");
+      console.log(text.slice(0, 1800));
+    }
+    console.log(`\nWould send to ${recipients.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      if (sent % 25 === 0) console.log(`  Progress: ${sent}/${recipients.length}`);
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-game-weekly-100.ts
+++ b/scripts/send-game-weekly-100.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Weekly turn-grant notification — emails real (non-NPC) /game players
+ * after the Sunday rollover lands their +100 turns. Personalizes with
+ * caste + current balance.
+ *
+ * Idempotent via `weekly100EmailWeekStart` on the player doc; re-running
+ * the same week is a no-op for anyone already emailed.
+ *
+ * Usage:
+ *   npx tsx scripts/send-game-weekly-100.ts --dry-run
+ *   npx tsx scripts/send-game-weekly-100.ts --send
+ *   npx tsx scripts/send-game-weekly-100.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { weekStartIsoForRollover } from "../lib/game/turns";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const GAME_URL = "https://cursorboston.com/game";
+const STAMP_FIELD = "weekly100EmailWeekStart";
+
+interface Recipient {
+  userId: string;
+  email: string;
+  firstName: string;
+  displayName: string;
+  caste: string | null;
+  turnsRemaining: number;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "general");
+  const general = escapeHtml(r.displayName?.trim() || "your general");
+  const balance = r.turnsRemaining;
+  const casteLine = r.caste ? `Your ${escapeHtml(r.caste)} caste is ready for the week.` : "";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = `+100 turns just landed on ${general}`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Sunday rollover went through — <strong>${general} just got +100 turns</strong>. ${casteLine}</p>
+
+<p>Your current bucket: <strong>${balance} turns</strong>.</p>
+
+<p>The grant <em>adds</em> to whatever you'd banked, so hoarders win. There's no cap. Spend them on recruiting, attacks, spells, exploration — whatever moves you up the leaderboard before next Sunday's refill.</p>
+
+<p>
+  <a href="${GAME_URL}" style="display:inline-block;background:#7c3aed;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open /game →
+  </a>
+</p>
+
+<p style="font-size:14px;color:#6b7280;">Reminder: weekly grants only fire if you merged a PR in the prior 7 days. If you want next Sunday's 100, ship something this week — even a tiny PR to /game counts.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you have an active general at cursorboston.com/game.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.firstName?.trim() || "general"},
+
+Sunday rollover went through — ${r.displayName?.trim() || "your general"} just got +100 turns.${r.caste ? ` Your ${r.caste} caste is ready for the week.` : ""}
+
+Your current bucket: ${balance} turns.
+
+The grant adds to whatever you'd banked, so hoarders win. There's no cap. Spend them on recruiting, attacks, spells, exploration — whatever moves you up the leaderboard before next Sunday's refill.
+
+Open /game: ${GAME_URL}
+
+Reminder: weekly grants only fire if you merged a PR in the prior 7 days. If you want next Sunday's 100, ship something this week.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you have an active general at cursorboston.com/game.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const wkStart = weekStartIsoForRollover(new Date());
+  console.log(`Week start: ${wkStart}`);
+  console.log("Loading real players...");
+  const playersSnap = await db.collection("game_players").get();
+
+  // Build userId → email lookup from cohort applications
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const emailByUserId = new Map<string, string>();
+  for (const doc of appsSnap.docs) {
+    const d = doc.data() as { userId?: string; email?: string };
+    if (d.userId && d.email) emailByUserId.set(d.userId, d.email.trim());
+  }
+
+  const recipients: Recipient[] = [];
+  let skippedNpc = 0;
+  let skippedNoGrant = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of playersSnap.docs) {
+    const d = doc.data() as {
+      isNpc?: boolean;
+      displayName?: string;
+      caste?: string | null;
+      turnsRemaining?: number;
+      lastWeeklyGrantWeekStart?: string;
+      [STAMP_FIELD]?: string;
+    };
+    if (d.isNpc === true) {
+      skippedNpc++;
+      continue;
+    }
+    if (d.lastWeeklyGrantWeekStart !== wkStart) {
+      skippedNoGrant++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD] === wkStart) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const email = emailByUserId.get(doc.id);
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    const displayName = (d.displayName || "").trim() || "your general";
+    const firstName = displayName.split(" ")[0] || "general";
+    recipients.push({
+      userId: doc.id,
+      email,
+      firstName,
+      displayName,
+      caste: d.caste ?? null,
+      turnsRemaining: d.turnsRemaining ?? 0,
+    });
+  }
+
+  console.log(`Eligible (granted this week, not yet emailed): ${recipients.length}`);
+  console.log(`Skipped — NPC: ${skippedNpc}`);
+  console.log(`Skipped — no grant this week: ${skippedNoGrant}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}=${wkStart}): ${skippedAlreadyEmailed}`);
+  console.log(`Skipped — no email on cohort application: ${skippedNoEmail}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview (first 1500 chars) ---");
+      console.log(html.slice(0, 1500));
+      console.log("\n--- Text preview (first 1500 chars) ---");
+      console.log(text.slice(0, 1500));
+    }
+    console.log(`\nWould send to ${recipients.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection("game_players")
+        .doc(r.userId)
+        .update({ [STAMP_FIELD]: wkStart, updatedAt: FieldValue.serverTimestamp() });
+      sent++;
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Single-commit release that adds the five operational scripts used during the May 10 game-grant + cohort lockdown push. Script-only — no runtime code touched, no behavior change.

## Included commits
- `e389ae3` chore(scripts): commit leftover one-shots from May 10 game-grant + cohort run

## Contributors
- @Ludwitt — single-commit release

## Test plan
- [x] No app-runtime files touched; type check + tests unaffected.
- [x] Each script was already executed successfully against prod during the May 10 push; committing here for reproducibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)