### PR TITLE
fix(avatars): standardize null-safe user photo rendering via Avatar

### DIFF
--- a/__tests__/components/ui/Avatar.test.tsx
+++ b/__tests__/components/ui/Avatar.test.tsx
@@ -89,4 +89,23 @@ describe("Avatar", () => {
     render(<Avatar email="test@x.com" />);
     expect(screen.getByRole("img", { name: "test@x.com" })).toBeInTheDocument();
   });
+
+  it("accepts a numeric size for the image render path", () => {
+    render(<Avatar src="/photo.jpg" name="Alice" size={40} />);
+    const img = screen.getByAltText("Alice");
+    expect(img).toHaveAttribute("width", "40");
+    expect(img).toHaveAttribute("height", "40");
+    expect(img).toHaveStyle({ width: "40px", height: "40px" });
+  });
+
+  it("accepts a numeric size for the fallback render path", () => {
+    const { container } = render(<Avatar name="Alice" size={24} />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el).toHaveStyle({ width: "24px", height: "24px" });
+  });
+
+  it("renders fallback when src is null", () => {
+    render(<Avatar src={null} name="Alice Baker" />);
+    expect(screen.getByText("AB")).toBeInTheDocument();
+  });
 });

--- a/app/hackathons/pool/page.tsx
+++ b/app/hackathons/pool/page.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useState, useCallback, Suspense } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { useSearchParams } from "next/navigation";
 import {
   collection,
@@ -92,15 +92,6 @@ interface JoinRequest {
   teamId: string;
   status: string;
   createdAt: Timestamp | { toDate: () => Date };
-}
-
-function getInitials(name: string | null | undefined): string {
-  if (name) {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-    return name[0].toUpperCase();
-  }
-  return "?";
 }
 
 function HackathonsPoolPageContent() {
@@ -241,6 +232,7 @@ function HackathonsPoolPageContent() {
 
   useEffect(() => {
     if (authLoading || !user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- finalize loading state once auth resolves to signed-out
       if (!authLoading && !user) setLoading(false);
       return;
     }
@@ -475,19 +467,12 @@ function HackathonsPoolPageContent() {
                   className="flex items-center justify-between gap-3 py-2 border-b border-neutral-800 last:border-0"
                 >
                   <div className="flex items-center gap-2.5 min-w-0">
-                    {u.photoURL ? (
-                      <Image
-                        src={u.photoURL}
-                        alt={u.displayName || "User"}
-                        width={36}
-                        height={36}
-                        className="rounded-full object-cover shrink-0"
-                      />
-                    ) : (
-                      <div className="w-9 h-9 rounded-full bg-neutral-800 flex items-center justify-center text-white text-sm font-semibold shrink-0">
-                        {getInitials(u.displayName)}
-                      </div>
-                    )}
+                    <Avatar
+                      src={u.photoURL}
+                      name={u.displayName}
+                      size={36}
+                      className="shrink-0"
+                    />
                     <div className="min-w-0">
                       <p className="text-white font-medium text-sm truncate">{u.displayName || "Anonymous"}</p>
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-neutral-500 text-xs">
@@ -584,19 +569,11 @@ function HackathonsPoolPageContent() {
                               key={idx}
                               className="flex items-center gap-1 text-neutral-400 text-xs"
                             >
-                              {slot.profile.photoURL ? (
-                                <Image
-                                  src={slot.profile.photoURL}
-                                  alt={slot.profile.displayName || "Member"}
-                                  width={20}
-                                  height={20}
-                                  className="rounded-full object-cover"
-                                />
-                              ) : (
-                                <div className="w-5 h-5 rounded-full bg-neutral-700 flex items-center justify-center text-white text-[10px] font-medium">
-                                  {getInitials(slot.profile.displayName)}
-                                </div>
-                              )}
+                              <Avatar
+                                src={slot.profile.photoURL}
+                                name={slot.profile.displayName}
+                                size={20}
+                              />
                               <span className="truncate max-w-[70px]">
                                 {slot.profile.displayName || "Anonymous"}
                               </span>

--- a/app/hackathons/team/page.tsx
+++ b/app/hackathons/team/page.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useState, useCallback, Suspense } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { useSearchParams } from "next/navigation";
 import { doc, updateDoc, Timestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
@@ -63,15 +63,6 @@ interface Submission {
   cutoffAt?: Date | { toISOString: () => string };
   disqualified?: boolean;
   disqualifiedReason?: string;
-}
-
-function getInitials(name: string | null | undefined): string {
-  if (name) {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-    return name[0].toUpperCase();
-  }
-  return "?";
 }
 
 function HackathonsTeamPageContent() {
@@ -194,6 +185,7 @@ function HackathonsTeamPageContent() {
 
   useEffect(() => {
     if (authLoading || !user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- finalize loading state once auth resolves to signed-out
       if (!authLoading && !user) setLoading(false);
       return;
     }
@@ -451,19 +443,11 @@ function HackathonsTeamPageContent() {
                 const profile = memberProfiles[uid];
                 return (
                   <li key={uid} className="flex items-center gap-3 py-2">
-                    {profile?.photoURL ? (
-                      <Image
-                        src={profile.photoURL}
-                        alt={profile.displayName || "Member"}
-                        width={40}
-                        height={40}
-                        className="rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="w-10 h-10 rounded-full bg-neutral-800 flex items-center justify-center text-white font-semibold">
-                        {getInitials(profile?.displayName)}
-                      </div>
-                    )}
+                    <Avatar
+                      src={profile?.photoURL}
+                      name={profile?.displayName}
+                      size={40}
+                    />
                     <div>
                       <p className="text-white font-medium">{profile?.displayName || "Anonymous"}</p>
                       {uid === user.uid && <span className="text-neutral-500 text-sm">(you)</span>}

--- a/app/hackathons/teams/page.tsx
+++ b/app/hackathons/teams/page.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useState, useCallback, Suspense } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { useSearchParams } from "next/navigation";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
@@ -31,15 +31,6 @@ interface PublicUser {
   uid: string;
   displayName: string | null;
   photoURL: string | null;
-}
-
-function getInitials(name: string | null | undefined): string {
-  if (name) {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-    return name[0].toUpperCase();
-  }
-  return "?";
 }
 
 function isPlaceholderId(id: string): boolean {
@@ -123,6 +114,7 @@ function TeamsPageContent() {
 
   useEffect(() => {
     if (authLoading) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
     fetchData();
   }, [authLoading, fetchData]);
 
@@ -256,19 +248,11 @@ function TeamsPageContent() {
                                 key={idx}
                                 className="flex items-center gap-1.5 text-neutral-300 text-sm"
                               >
-                                {slot.profile.photoURL ? (
-                                  <Image
-                                    src={slot.profile.photoURL}
-                                    alt={slot.profile.displayName || "Member"}
-                                    width={24}
-                                    height={24}
-                                    className="rounded-full object-cover"
-                                  />
-                                ) : (
-                                  <div className="w-6 h-6 rounded-full bg-neutral-700 flex items-center justify-center text-white text-xs font-medium">
-                                    {getInitials(slot.profile.displayName)}
-                                  </div>
-                                )}
+                                <Avatar
+                                  src={slot.profile.photoURL}
+                                  name={slot.profile.displayName}
+                                  size={24}
+                                />
                                 <span className="truncate max-w-[100px]">
                                   {slot.profile.displayName || "Anonymous"}
                                 </span>
@@ -371,19 +355,11 @@ function TeamsPageContent() {
                                 key={idx}
                                 className="flex items-center gap-1.5 text-neutral-400 text-sm"
                               >
-                                {slot.profile.photoURL ? (
-                                  <Image
-                                    src={slot.profile.photoURL}
-                                    alt={slot.profile.displayName || "Member"}
-                                    width={22}
-                                    height={22}
-                                    className="rounded-full object-cover"
-                                  />
-                                ) : (
-                                  <div className="w-[22px] h-[22px] rounded-full bg-neutral-700 flex items-center justify-center text-white text-xs font-medium">
-                                    {getInitials(slot.profile.displayName)}
-                                  </div>
-                                )}
+                                <Avatar
+                                  src={slot.profile.photoURL}
+                                  name={slot.profile.displayName}
+                                  size={22}
+                                />
                                 <span className="truncate max-w-[90px]">
                                   {slot.profile.displayName || "Anonymous"}
                                 </span>

--- a/app/mentorship/page.tsx
+++ b/app/mentorship/page.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { doc, getDoc } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { getMentorshipProfile } from "@/lib/mentorship/data";
@@ -267,21 +267,12 @@ function MatchCard({
     <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6 flex flex-col">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          {userProfile?.photoURL ? (
-            <Image
-              src={userProfile.photoURL}
-              alt={userProfile.displayName || "User"}
-              width={48}
-              height={48}
-              className="w-12 h-12 rounded-full object-cover"
-            />
-          ) : (
-            <div className="w-12 h-12 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center shrink-0">
-              <span className="text-neutral-500 font-medium">
-                {userProfile?.displayName?.[0]?.toUpperCase() || "?"}
-              </span>
-            </div>
-          )}
+          <Avatar
+            src={userProfile?.photoURL}
+            name={userProfile?.displayName}
+            size={48}
+            className="shrink-0"
+          />
           <div>
             <h3 className="font-semibold">{userProfile?.displayName || "Anonymous"}</h3>
             <div className="flex items-center gap-2 mt-1">

--- a/app/pair/[sessionId]/page.tsx
+++ b/app/pair/[sessionId]/page.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { doc, getDoc, updateDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import type { PairSession, SessionNotes } from "@/lib/pair-programming/types";
@@ -235,21 +235,11 @@ export default function SessionDetailPage() {
           {/* Partner Info */}
           {otherUser && (
             <div className="flex items-center gap-4 mb-6 p-4 bg-neutral-50 dark:bg-neutral-800 rounded-lg">
-              {otherUser.photoURL ? (
-                <Image
-                  src={otherUser.photoURL}
-                  alt={otherUser.displayName || "Partner"}
-                  width={64}
-                  height={64}
-                  className="w-16 h-16 rounded-full"
-                />
-              ) : (
-                <div className="w-16 h-16 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
-                  <span className="text-2xl text-neutral-500">
-                    {otherUser.displayName?.[0]?.toUpperCase() || "?"}
-                  </span>
-                </div>
-              )}
+              <Avatar
+                src={otherUser.photoURL}
+                name={otherUser.displayName}
+                size={64}
+              />
               <div>
                 <h3 className="font-semibold text-lg">
                   {otherUser.displayName || "Anonymous User"}

--- a/app/pair/page.tsx
+++ b/app/pair/page.tsx
@@ -16,7 +16,7 @@ import type {
   SessionType,
   AvailabilityWindow,
 } from "@/lib/pair-programming/types";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { getPairProfile, getAllActiveProfiles } from "@/lib/pair-programming/data";
 import { getTopMatches } from "@/lib/pair-programming/matching";
 import { doc, getDoc } from "firebase/firestore";
@@ -297,21 +297,11 @@ function MatchCard({
     <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          {userProfile?.photoURL ? (
-            <Image
-              src={userProfile.photoURL}
-              alt={userProfile.displayName || "User"}
-              width={48}
-              height={48}
-              className="w-12 h-12 rounded-full"
-            />
-          ) : (
-            <div className="w-12 h-12 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
-              <span className="text-neutral-500">
-                {userProfile?.displayName?.[0]?.toUpperCase() || "?"}
-              </span>
-            </div>
-          )}
+          <Avatar
+            src={userProfile?.photoURL}
+            name={userProfile?.displayName}
+            size={48}
+          />
           <div>
             <h3 className="font-semibold">
               {userProfile?.displayName || "Anonymous User"}

--- a/app/pair/requests/page.tsx
+++ b/app/pair/requests/page.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { useRouter } from "next/navigation";
 import type { PairRequest, SessionType } from "@/lib/pair-programming/types";
 import { doc, getDoc } from "firebase/firestore";
@@ -241,21 +241,11 @@ function RequestCard({
   return (
     <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 p-6">
       <div className="flex items-start gap-4">
-        {otherUser?.photoURL ? (
-          <Image
-            src={otherUser.photoURL}
-            alt={otherUser.displayName || "User"}
-            width={48}
-            height={48}
-            className="w-12 h-12 rounded-full"
-          />
-        ) : (
-          <div className="w-12 h-12 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
-            <span className="text-neutral-500">
-              {otherUser?.displayName?.[0]?.toUpperCase() || "?"}
-            </span>
-          </div>
-        )}
+        <Avatar
+          src={otherUser?.photoURL}
+          name={otherUser?.displayName}
+          size={48}
+        />
         <div className="flex-1">
           <div className="flex items-center justify-between mb-2">
             <h3 className="font-semibold">

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -9,23 +9,22 @@
 import { useState } from "react";
 import Image from "next/image";
 
+type SizePreset = "sm" | "md" | "lg" | "xl";
+
 interface AvatarProps {
   src?: string | null;
   name?: string | null;
   email?: string | null;
-  size?: "sm" | "md" | "lg" | "xl";
+  size?: SizePreset | number;
   className?: string;
 }
 
-// Generate a consistent color based on a string
 function stringToColor(str: string): string {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
     hash = str.charCodeAt(i) + ((hash << 5) - hash);
   }
-
-  // Generate vibrant colors in the emerald/teal/cyan range
-  const hue = Math.abs(hash % 60) + 140; // 140-200 range (cyan to green)
+  const hue = Math.abs(hash % 60) + 140;
   return `hsl(${hue}, 70%, 45%)`;
 }
 
@@ -54,19 +53,39 @@ function getInitials(
   return "?";
 }
 
-const sizeClasses = {
-  sm: "w-8 h-8 text-sm",
-  md: "w-12 h-12 text-lg",
-  lg: "w-16 h-16 text-2xl",
-  xl: "w-24 h-24 text-3xl",
+const presetSizes: Record<SizePreset, { px: number; box: string; text: string }> = {
+  sm: { px: 32, box: "w-8 h-8", text: "text-sm" },
+  md: { px: 48, box: "w-12 h-12", text: "text-lg" },
+  lg: { px: 64, box: "w-16 h-16", text: "text-2xl" },
+  xl: { px: 96, box: "w-24 h-24", text: "text-3xl" },
 };
 
-const imageSizes = {
-  sm: 32,
-  md: 48,
-  lg: 64,
-  xl: 96,
-};
+function textClassForPx(px: number): string {
+  if (px <= 24) return "text-[10px]";
+  if (px <= 32) return "text-xs";
+  if (px <= 44) return "text-sm";
+  if (px <= 60) return "text-lg";
+  if (px <= 80) return "text-2xl";
+  return "text-3xl";
+}
+
+function resolveSize(size: SizePreset | number): {
+  px: number;
+  boxClass: string;
+  textClass: string;
+  boxStyle?: { width: number; height: number };
+} {
+  if (typeof size === "number") {
+    return {
+      px: size,
+      boxClass: "",
+      textClass: textClassForPx(size),
+      boxStyle: { width: size, height: size },
+    };
+  }
+  const preset = presetSizes[size];
+  return { px: preset.px, boxClass: preset.box, textClass: preset.text };
+}
 
 export default function Avatar({
   src,
@@ -76,6 +95,7 @@ export default function Avatar({
   className = "",
 }: AvatarProps) {
   const [imgError, setImgError] = useState(false);
+  const { px, boxClass, textClass, boxStyle } = resolveSize(size);
   const identifier = email || name || "user";
   const initials = getInitials(name, email);
   const gradient = getGradient(identifier);
@@ -85,9 +105,10 @@ export default function Avatar({
       <Image
         src={src}
         alt={name || "Profile"}
-        width={imageSizes[size]}
-        height={imageSizes[size]}
-        className={`rounded-full object-cover ${sizeClasses[size].split(" ").slice(0, 2).join(" ")} ${className}`}
+        width={px}
+        height={px}
+        className={`rounded-full object-cover ${boxClass} ${className}`.trim()}
+        style={boxStyle}
         onError={() => setImgError(true)}
       />
     );
@@ -97,8 +118,8 @@ export default function Avatar({
     <div
       role="img"
       aria-label={name || email || "User avatar"}
-      className={`${sizeClasses[size]} rounded-full flex items-center justify-center font-semibold text-white shadow-inner ${className}`}
-      style={{ background: gradient }}
+      className={`${boxClass} ${textClass} rounded-full flex items-center justify-center font-semibold text-white shadow-inner ${className}`.trim()}
+      style={{ ...boxStyle, background: gradient }}
     >
       {initials}
     </div>

--- a/components/ProfileRequirementsModal.tsx
+++ b/components/ProfileRequirementsModal.tsx
@@ -9,7 +9,7 @@
 import { useState, useEffect, useCallback, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import Link from "next/link";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
 
 export type RequirementType =
@@ -116,6 +116,7 @@ export default function ProfileRequirementsModal({
 
   useEffect(() => {
     if (isOpen && user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- show spinner while fetch-on-open completes
       setLoading(true);
       fetchProfile();
     }
@@ -454,33 +455,11 @@ export default function ProfileRequirementsModal({
         <div className="p-6 border-b border-neutral-800">
           <div className="flex items-start justify-between">
             <div className="flex items-center gap-3">
-              {profile?.photoURL ? (
-                <Image
-                  src={profile.photoURL}
-                  alt="Profile"
-                  width={48}
-                  height={48}
-                  className="rounded-full"
-                />
-              ) : (
-                <div className="w-12 h-12 bg-neutral-800 rounded-full flex items-center justify-center">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="24"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="text-neutral-500"
-                  >
-                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-                    <circle cx="12" cy="7" r="4" />
-                  </svg>
-                </div>
-              )}
+              <Avatar
+                src={profile?.photoURL}
+                name={profile?.displayName}
+                size={48}
+              />
               <div>
                 <h2 id="profile-requirements-title" className="text-xl font-bold text-white">{title}</h2>
                 <p className="text-sm text-neutral-400">{description}</p>

--- a/components/events/CoworkingSlots.tsx
+++ b/components/events/CoworkingSlots.tsx
@@ -8,7 +8,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import ProfileRequirementsModal from "@/components/ProfileRequirementsModal";
 
 interface Attendee {
@@ -410,19 +410,11 @@ export default function CoworkingSlots({ eventId }: CoworkingSlotsProps) {
                         key={index}
                         className="flex items-center gap-2 px-3 py-1.5 bg-neutral-800 rounded-full"
                       >
-                        {attendee.photoUrl ? (
-                          <Image
-                            src={attendee.photoUrl}
-                            alt={attendee.displayName}
-                            width={20}
-                            height={20}
-                            className="rounded-full"
-                          />
-                        ) : (
-                          <div className="w-5 h-5 bg-neutral-700 rounded-full flex items-center justify-center text-xs text-neutral-400">
-                            {attendee.displayName.charAt(0).toUpperCase()}
-                          </div>
-                        )}
+                        <Avatar
+                          src={attendee.photoUrl}
+                          name={attendee.displayName}
+                          size={20}
+                        />
                         <span className="text-sm text-neutral-300">
                           {attendee.displayName}
                         </span>

--- a/components/feed/MessageCard.tsx
+++ b/components/feed/MessageCard.tsx
@@ -7,9 +7,9 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import type { Message, ReactionType } from "@/types/feed";
-import { getInitials, formatRelativeDate } from "@/lib/utils";
+import { formatRelativeDate } from "@/lib/utils";
 import { ReplyCard } from "./ReplyCard";
 import { ReportMessageMenu } from "./ReportMessageMenu";
 
@@ -95,19 +95,12 @@ export function MessageCard({
           aria-label={`View ${message.authorName}'s profile`}
           className="shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 rounded-full"
         >
-          {message.authorPhoto ? (
-            <Image
-              src={message.authorPhoto}
-              alt={message.authorName}
-              width={40}
-              height={40}
-              className="rounded-full object-cover hover:opacity-80 transition-opacity"
-            />
-          ) : (
-            <div className="w-10 h-10 rounded-full bg-neutral-200 dark:bg-neutral-800 flex items-center justify-center text-neutral-700 dark:text-white font-semibold hover:bg-neutral-300 dark:hover:bg-neutral-700 transition-colors">
-              {getInitials(message.authorName)}
-            </div>
-          )}
+          <Avatar
+            src={message.authorPhoto}
+            name={message.authorName}
+            size={40}
+            className="hover:opacity-80 transition-opacity"
+          />
         </button>
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between gap-2">

--- a/components/feed/PostComposer.tsx
+++ b/components/feed/PostComposer.tsx
@@ -6,10 +6,9 @@
 
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { User } from "firebase/auth";
-import { getInitials } from "@/lib/utils";
+import Avatar from "@/components/Avatar";
 
 interface PostComposerProps {
   user: User | null;
@@ -55,19 +54,12 @@ export function PostComposer({
     <div className="bg-white dark:bg-neutral-900 rounded-xl p-4 border border-neutral-200 dark:border-neutral-800 mb-6">
       <div className="flex gap-3">
         <div className="shrink-0">
-          {user.photoURL ? (
-            <Image
-              src={user.photoURL}
-              alt={user.displayName || "You"}
-              width={40}
-              height={40}
-              className="w-10 h-10 rounded-full object-cover"
-            />
-          ) : (
-            <div className="w-10 h-10 rounded-full bg-neutral-200 dark:bg-neutral-800 flex items-center justify-center text-neutral-700 dark:text-white font-semibold">
-              {getInitials(user.displayName || user.email)}
-            </div>
-          )}
+          <Avatar
+            src={user.photoURL}
+            name={user.displayName}
+            email={user.email}
+            size={40}
+          />
         </div>
         <div className="flex-1">
           <textarea

--- a/components/feed/ReplyCard.tsx
+++ b/components/feed/ReplyCard.tsx
@@ -7,9 +7,9 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import type { Message, ReactionType } from "@/types/feed";
-import { getInitials, formatRelativeDate } from "@/lib/utils";
+import { formatRelativeDate } from "@/lib/utils";
 
 interface ReplyCardProps {
   reply: Message;
@@ -35,19 +35,12 @@ export function ReplyCard({
   return (
     <div className="bg-neutral-100 dark:bg-neutral-800/50 rounded-lg p-3">
       <div className="flex items-start gap-2">
-        {reply.authorPhoto ? (
-          <Image
-            src={reply.authorPhoto}
-            alt={reply.authorName}
-            width={28}
-            height={28}
-            className="rounded-full object-cover shrink-0"
-          />
-        ) : (
-          <div className="w-7 h-7 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center text-neutral-700 dark:text-white text-xs font-semibold shrink-0">
-            {getInitials(reply.authorName)}
-          </div>
-        )}
+        <Avatar
+          src={reply.authorPhoto}
+          name={reply.authorName}
+          size={28}
+          className="shrink-0"
+        />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <span className="font-medium text-neutral-900 dark:text-white text-sm">{reply.authorName}</span>

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -4,9 +4,8 @@
  * See LICENSE file for details.
  */
 
-import Image from "next/image";
+import Avatar from "@/components/Avatar";
 import type { PublicMember } from "@/types/members";
-import { getInitials } from "@/lib/utils";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
 import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
 import { evaluateBadgeEligibility } from "@/lib/badges/eligibility";
@@ -63,30 +62,26 @@ export function MemberCard({ member }: MemberCardProps) {
       {/* Header */}
       <div className="flex items-start gap-4 mb-4">
         <div className="relative shrink-0">
-          {member.photoURL ? (
-            <Image
-              src={member.photoURL}
-              alt={member.displayName || "Member"}
-              width={56}
-              height={56}
-              className="rounded-full object-cover"
-            />
-          ) : (
-            <div className={`w-14 h-14 rounded-full flex items-center justify-center text-foreground font-semibold text-lg ${
-              isAgent ? "bg-purple-900/50" : "bg-neutral-100 dark:bg-neutral-800"
-            }`}>
-              {isAgent ? (
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                  <rect x="3" y="11" width="18" height="10" rx="2" />
-                  <circle cx="12" cy="5" r="2" />
-                  <path d="M12 7v4" />
-                  <circle cx="8" cy="16" r="1" fill="currentColor" />
-                  <circle cx="16" cy="16" r="1" fill="currentColor" />
-                </svg>
-              ) : (
-                getInitials(member.displayName)
-              )}
+          {isAgent && !member.photoURL ? (
+            <div
+              role="img"
+              aria-label={member.displayName || "Agent"}
+              className="w-14 h-14 rounded-full flex items-center justify-center text-foreground bg-purple-900/50"
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <rect x="3" y="11" width="18" height="10" rx="2" />
+                <circle cx="12" cy="5" r="2" />
+                <path d="M12 7v4" />
+                <circle cx="8" cy="16" r="1" fill="currentColor" />
+                <circle cx="16" cy="16" r="1" fill="currentColor" />
+              </svg>
             </div>
+          ) : (
+            <Avatar
+              src={member.photoURL}
+              name={member.displayName}
+              size={56}
+            />
           )}
         </div>
         <div className="flex-1 min-w-0">


### PR DESCRIPTION
Closes #584.

## What changed

User photo URL rendering was inconsistent across the app: every site had its own bespoke null-fallback (different sizes, different `getInitials` helpers, no image-load-error handling). The existing `Avatar` component already handles all of this centrally — this PR standardizes on it.

### Avatar component (`components/Avatar.tsx`)
- Extended `size` prop to accept a numeric (px) value alongside the existing `sm`/`md`/`lg`/`xl` presets. Backward-compatible — every existing call site uses a preset and still does.
- Added 3 unit tests for the numeric size path and explicit `src={null}`.

### Migrated 15 sites
All previously had `{x.photoURL ? <Image .../> : <div>bespoke fallback</div>}` patterns. Sizes ranged from 20–64 px, none of which matched a preset — hence the numeric `size` extension.

| File | Site | px |
|---|---|---|
| `components/feed/MessageCard.tsx` | post author avatar | 40 |
| `components/feed/ReplyCard.tsx` | reply author avatar | 28 |
| `components/feed/PostComposer.tsx` | composer self avatar | 40 |
| `components/members/MemberCard.tsx` | member card (keeps agent bot icon for no-photo agents) | 56 |
| `components/ProfileRequirementsModal.tsx` | profile header | 48 |
| `components/events/CoworkingSlots.tsx` | attendee chip | 20 |
| `app/mentorship/page.tsx` | match card | 48 |
| `app/pair/page.tsx` | partner card | 48 |
| `app/pair/requests/page.tsx` | request card | 48 |
| `app/pair/[sessionId]/page.tsx` | session partner | 64 |
| `app/hackathons/team/page.tsx` | team member row | 40 |
| `app/hackathons/teams/page.tsx` | team rosters (x2) | 22, 24 |
| `app/hackathons/pool/page.tsx` | pool members + team rosters (x2) | 20, 36 |

### Why this is the right fix
Issue #584 mentions "Add explicit null checks before Image components" — but the audit revealed every site already had a null guard. The real problem was **inconsistency**: 7 different `getInitials` implementations, none using `Avatar`'s image-load-error fallback, varying styles per surface. Moving everything through `Avatar` is the only change that actually delivers consistency.

### Acceptance criteria
- [x] No unguarded photo access (15 sites audited, all already guarded — now also handle image load errors)
- [x] Fallback avatar shown when null (via `Avatar`'s gradient + initials)
- [x] TypeScript strict mode satisfied (Avatar's `src?: string | null` matches every call site)

### Out of scope (intentional)
- `app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx` uses raw `<img>` with an eslint-disable comment explaining "avatar URLs come from arbitrary OAuth providers, not the configured Next image domain list" — left as-is to respect that deliberate choice. (`next.config.js` does allow Google + GitHub avatar domains, so this could be migrated in a follow-up if desired.)

### Side cleanups
- Removed 4 dead local `getInitials` helpers and dead `Image` imports in migrated files.
- Added `eslint-disable-next-line react-hooks/set-state-in-effect` on 4 pre-existing warnings on lines I touched files (matches the existing disable pattern used in 27 other files — pre-existing, not introduced here).

## Test plan
- [ ] `npm test -- __tests__/components/ui/Avatar.test.tsx` — 15 tests pass (12 existing + 3 new)
- [ ] `npm test -- __tests__/components/feed __tests__/components/members` — touched components green
- [ ] Visit `/members`, `/pair`, `/mentorship`, `/hackathons/team`, `/hackathons/teams`, `/hackathons/pool` with both signed-in (photo) and synthetic null-photo state — all fallbacks render correctly
- [ ] Mobile + dark mode look correct

Net diff: **+173 / -291** (15 files).
