### PR TITLE
release: develop → main (PyData close-out + game/cohort May 10-11 batch)

### DIFF
--- a/app/api/events/pydata-2026/withdraw/route.ts
+++ b/app/api/events/pydata-2026/withdraw/route.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  PYDATA_2026_REGISTRATIONS_COLLECTION,
+  type PydataRegistrationStatus,
+} from "@/lib/pydata-2026";
+import { verifyPydataWithdrawToken } from "@/lib/unsubscribe-token";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE = { windowMs: 15 * 60 * 1000, maxRequests: 20 };
+
+/**
+ * POST /api/events/pydata-2026/withdraw
+ *
+ * Form-encoded body: { email, token }
+ *
+ * Confirmation page at /pydata-withdraw posts here after the user clicks
+ * "Yes, withdraw me". Validates the HMAC token (namespaced "withdraw-pydata-2026"),
+ * marks the PyData registration as cancelled, then 303-redirects back to the
+ * confirmation page with a status query param.
+ *
+ * Two-step (page → POST) by design — the email link lands on a confirmation
+ * UI rather than auto-withdrawing on first click. This avoids accidental
+ * withdrawals from email-client link-previews.
+ */
+export async function POST(request: NextRequest) {
+  const clientId = getClientIdentifier(request as unknown as Request);
+  const rateResult = checkRateLimit(`pydata-withdraw:${clientId}`, RATE);
+  if (!rateResult.success) {
+    return NextResponse.redirect(
+      new URL("/pydata-withdraw?status=rate-limited", request.url),
+      303
+    );
+  }
+
+  let email: string | undefined;
+  let token: string | undefined;
+  try {
+    const form = await request.formData();
+    const rawEmail = form.get("email");
+    const rawToken = form.get("token");
+    email = typeof rawEmail === "string" ? rawEmail.toLowerCase().trim() : undefined;
+    token = typeof rawToken === "string" ? rawToken.trim() : undefined;
+  } catch {
+    return NextResponse.redirect(
+      new URL("/pydata-withdraw?status=invalid", request.url),
+      303
+    );
+  }
+
+  if (!email || !token) {
+    return NextResponse.redirect(
+      new URL("/pydata-withdraw?status=invalid", request.url),
+      303
+    );
+  }
+
+  if (!/^[a-f0-9]{64}$/i.test(token)) {
+    return NextResponse.redirect(
+      new URL("/pydata-withdraw?status=invalid", request.url),
+      303
+    );
+  }
+
+  if (!verifyPydataWithdrawToken(email, token)) {
+    return NextResponse.redirect(
+      new URL("/pydata-withdraw?status=invalid", request.url),
+      303
+    );
+  }
+
+  try {
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.redirect(
+        new URL("/pydata-withdraw?status=error", request.url),
+        303
+      );
+    }
+
+    const snap = await db
+      .collection(PYDATA_2026_REGISTRATIONS_COLLECTION)
+      .where("email", "==", email)
+      .limit(1)
+      .get();
+
+    if (snap.empty) {
+      // Don't leak existence — same success page either way.
+      return NextResponse.redirect(
+        new URL("/pydata-withdraw?status=success", request.url),
+        303
+      );
+    }
+
+    const cancelled: PydataRegistrationStatus = "cancelled";
+    await snap.docs[0]!.ref.update({
+      status: cancelled,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    return NextResponse.redirect(
+      new URL("/pydata-withdraw?status=success", request.url),
+      303
+    );
+  } catch {
+    return NextResponse.redirect(
+      new URL("/pydata-withdraw?status=error", request.url),
+      303
+    );
+  }
+}

--- a/app/pydata-withdraw/page.tsx
+++ b/app/pydata-withdraw/page.tsx
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+
+import { verifyPydataWithdrawToken } from "@/lib/unsubscribe-token";
+
+export const metadata: Metadata = {
+  title: "PyData May 13 withdrawal - Cursor Boston",
+  description: "Confirm your withdrawal from the May 13 PyData Data Science Hack.",
+};
+
+export const dynamic = "force-dynamic";
+
+// Mask the local part of an email for display so a forwarded link doesn't leak
+// the recipient's full address — keep enough chars to recognize your own.
+function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return email;
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  if (local.length <= 3) return local[0] + "***" + domain;
+  return local.slice(0, 2) + "***" + local.slice(-1) + domain;
+}
+
+export default async function PydataWithdrawPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string; email?: string; token?: string }>;
+}) {
+  const { status, email: rawEmail, token } = await searchParams;
+  const email = rawEmail?.toLowerCase().trim() ?? "";
+
+  if (status === "success") {
+    return (
+      <Shell>
+        <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+          You&apos;ve withdrawn from PyData May 13
+        </h1>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+          Thanks for letting us know — we&apos;ll release your seat to someone on
+          the waitlist. If this was a mistake, email{" "}
+          <a href="mailto:roger@cursorboston.com" className="underline">
+            roger@cursorboston.com
+          </a>{" "}
+          and we&apos;ll put you back in if there&apos;s still room.
+        </p>
+        <BackLink />
+      </Shell>
+    );
+  }
+
+  if (status === "invalid") {
+    return (
+      <Shell>
+        <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+          Invalid link
+        </h1>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+          This withdrawal link is invalid or has been tampered with. If you
+          meant to withdraw, email{" "}
+          <a href="mailto:roger@cursorboston.com" className="underline">
+            roger@cursorboston.com
+          </a>{" "}
+          directly.
+        </p>
+        <BackLink />
+      </Shell>
+    );
+  }
+
+  if (status === "rate-limited") {
+    return (
+      <Shell>
+        <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+          Too many requests
+        </h1>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+          Please wait a few minutes and try again.
+        </p>
+        <BackLink />
+      </Shell>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <Shell>
+        <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+          Something went wrong
+        </h1>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+          We couldn&apos;t process your withdrawal. Please try again or email{" "}
+          <a href="mailto:roger@cursorboston.com" className="underline">
+            roger@cursorboston.com
+          </a>
+          .
+        </p>
+        <BackLink />
+      </Shell>
+    );
+  }
+
+  // Default state: confirmation. Verify signature before rendering the
+  // "Confirm withdrawal" button — bad tokens look identical to status=invalid.
+  if (!email || !token || !verifyPydataWithdrawToken(email, token)) {
+    return (
+      <Shell>
+        <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+          Invalid link
+        </h1>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+          This withdrawal link is invalid or has been tampered with. If you
+          meant to withdraw, email{" "}
+          <a href="mailto:roger@cursorboston.com" className="underline">
+            roger@cursorboston.com
+          </a>{" "}
+          directly.
+        </p>
+        <BackLink />
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+        Withdraw from PyData May 13?
+      </h1>
+      <p className="text-neutral-600 dark:text-neutral-400 mb-2">
+        You&apos;re about to withdraw{" "}
+        <span className="font-medium text-foreground">{maskEmail(email)}</span>{" "}
+        from the Cursor Boston × PyData Data Science Hack on Wednesday, May 13
+        at Moderna HQ.
+      </p>
+      <p className="text-neutral-600 dark:text-neutral-400 mb-8">
+        We&apos;ll mark your seat as available and give it to someone on the
+        waitlist. This can&apos;t be undone with one click — if you change your
+        mind, email{" "}
+        <a href="mailto:roger@cursorboston.com" className="underline">
+          roger@cursorboston.com
+        </a>
+        .
+      </p>
+      <form
+        method="POST"
+        action="/api/events/pydata-2026/withdraw"
+        className="flex flex-col sm:flex-row gap-3 items-center justify-center"
+      >
+        <input type="hidden" name="email" value={email} />
+        <input type="hidden" name="token" value={token} />
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-md bg-red-600 px-6 py-3 text-sm font-semibold text-white hover:bg-red-700 transition-colors"
+        >
+          Yes, withdraw me
+        </button>
+        <Link
+          href="/events/cursor-boston-pydata-2026/register"
+          className="inline-flex items-center justify-center rounded-md border border-neutral-300 dark:border-neutral-700 bg-transparent px-6 py-3 text-sm font-semibold text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+        >
+          Never mind, keep my spot
+        </Link>
+      </form>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col">
+      <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="max-w-xl mx-auto text-center">{children}</div>
+      </section>
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/"
+      className="text-sm text-neutral-500 hover:text-foreground transition-colors"
+    >
+      &larr; Back to cursorboston.com
+    </Link>
+  );
+}

--- a/lib/api-schemas/events.ts
+++ b/lib/api-schemas/events.ts
@@ -50,6 +50,15 @@ const PydataRegistrationBody = z
   })
   .openapi("PydataRegistrationBody");
 
+const PydataWithdrawBody = z
+  .object({
+    email: z.string().min(1),
+    token: z.string().min(1),
+  })
+  .openapi("PydataWithdrawBody");
+
+const PydataWithdrawRedirect = z.object({}).optional();
+
 // ──────────────────── Response schemas ────────────────────
 
 const EligibilityResponse = z
@@ -237,6 +246,16 @@ export const eventsContract = c.router(
           "SERVER_ERROR",
         ] as const,
       },
+    },
+    pydataWithdraw: {
+      method: "POST",
+      path: "/api/events/pydata-2026/withdraw",
+      summary:
+        "Two-step PyData withdrawal: confirmation page POSTs here with HMAC token",
+      contentType: "application/x-www-form-urlencoded",
+      body: PydataWithdrawBody,
+      responses: { 303: PydataWithdrawRedirect },
+      metadata: { errorCodes: [] as const },
     },
   },
   { pathPrefix: "", strictStatusCodes: true }

--- a/lib/unsubscribe-token.ts
+++ b/lib/unsubscribe-token.ts
@@ -65,3 +65,29 @@ export function buildWithdrawUrl(email: string, cohortId: string): string {
     email
   )}&cohortId=${encodeURIComponent(cohortId)}&token=${token}`;
 }
+
+// Distinct namespace for the PyData May 13 withdraw flow so a token issued for
+// PyData cannot be replayed against the cohort withdraw endpoint (or vice-versa).
+const PYDATA_WITHDRAW_NS = "withdraw-pydata-2026";
+
+export function generatePydataWithdrawToken(email: string): string {
+  return createHmac("sha256", SECRET)
+    .update(`${PYDATA_WITHDRAW_NS}:${email.toLowerCase().trim()}`)
+    .digest("hex");
+}
+
+export function verifyPydataWithdrawToken(email: string, token: string): boolean {
+  return generatePydataWithdrawToken(email) === token;
+}
+
+// Builds the confirmation PAGE URL (not the API URL). The page renders an
+// "Are you sure?" form that POSTs to /api/events/pydata-2026/withdraw.
+export function buildPydataWithdrawUrl(email: string): string {
+  const origin =
+    (process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com").replace(
+      /\/$/,
+      ""
+    );
+  const token = generatePydataWithdrawToken(email);
+  return `${origin}/pydata-withdraw?email=${encodeURIComponent(email)}&token=${token}`;
+}

--- a/scripts/send-pydata-luma-only-urgent.ts
+++ b/scripts/send-pydata-luma-only-urgent.ts
@@ -1,0 +1,464 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * URGENT email to people on the PyData May 13 Luma list who have NOT yet
+ * registered on cursorboston.com. The website (Firestore
+ * pydataHack2026Registrations) is the source of truth Moderna receives, so
+ * Luma-only RSVPs will be turned away at security.
+ *
+ * No withdraw button here (per user direction) — the goal is to push them
+ * onto the website while seats remain, not let them slip off the list.
+ *
+ * Dynamic cohort footer matches the website-reminder script:
+ *   - cohort-1 admit       → "tonight 6pm kickoff" reminder
+ *   - any other applicant  → "you're signed up" acknowledgement
+ *   - no application       → invite to Cohort 2
+ *
+ * Idempotent via `pydataLumaOnlyUrgentEmailedAt` on the eventContacts doc.
+ *
+ * Usage:
+ *   npx tsx scripts/send-pydata-luma-only-urgent.ts --dry-run --csv "<path>"
+ *   npx tsx scripts/send-pydata-luma-only-urgent.ts --send    --csv "<path>"
+ *   npx tsx scripts/send-pydata-luma-only-urgent.ts --send    --csv "<path>" --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { readFileSync } from "fs";
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { PYDATA_2026_REGISTRATIONS_COLLECTION } from "../lib/pydata-2026";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const REGISTER_URL =
+  "https://cursorboston.com/events/cursor-boston-pydata-2026/register";
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const GAME_URL = "https://cursorboston.com/game";
+const EVENT_CONTACTS_COLLECTION = "eventContacts";
+const STAMP_FIELD = "pydataLumaOnlyUrgentEmailedAt";
+
+type FooterVariant = "cohort1-kickoff" | "applied-other" | "invite-cohort2";
+
+interface CohortInfo {
+  status: string;
+  cohorts: string[];
+}
+
+interface CsvRow {
+  email: string;
+  firstName: string;
+  lastName: string;
+  approvalStatus: string;
+}
+
+interface Recipient {
+  email: string;
+  firstName: string;
+  cohort: CohortInfo | null;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function parseCsv(content: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      /* skip */
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((cell) => cell.length > 0)) rows.push(row);
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  const out: Record<string, string>[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const line = rows[r]!;
+    const obj: Record<string, string> = {};
+    for (let j = 0; j < header.length; j++) obj[header[j]!] = (line[j] ?? "").trim();
+    out.push(obj);
+  }
+  return out;
+}
+
+function chooseFooterVariant(cohort: CohortInfo | null): FooterVariant {
+  if (!cohort) return "invite-cohort2";
+  if (cohort.status === "admitted" && cohort.cohorts.includes("cohort-1")) {
+    return "cohort1-kickoff";
+  }
+  return "applied-other";
+}
+
+function buildFooterHtml(variant: FooterVariant, cohort: CohortInfo | null): string {
+  if (variant === "cohort1-kickoff") {
+    return `<div style="margin-top:28px;padding:14px 16px;background:#ecfdf5;border:1px solid #10b981;border-radius:8px;">
+  <p style="margin:0;color:#065f46;"><strong>🎯 Tonight at 6pm EST — Cohort 1 kickoff Zoom.</strong> The link is on your cohort dashboard. <a href="${COHORT_URL}" style="color:#065f46;text-decoration:underline;">Open it now</a>. See you there.</p>
+</div>`;
+  }
+  if (variant === "applied-other") {
+    const which = cohort?.cohorts.includes("cohort-2") ? "Cohort 2" : "the summer cohort";
+    return `<div style="margin-top:28px;padding:14px 16px;background:#f3f4f6;border:1px solid #d1d5db;border-radius:8px;">
+  <p style="margin:0;color:#374151;">You&apos;re signed up for <strong>${which}</strong>. We&apos;ll be in touch with next steps soon. <a href="${COHORT_URL}" style="color:#374151;text-decoration:underline;">Cohort page</a>.</p>
+</div>`;
+  }
+  return `<div style="margin-top:28px;padding:14px 16px;background:#eff6ff;border:1px solid #3b82f6;border-radius:8px;">
+  <p style="margin:0;color:#1e40af;"><strong>Cohort 1 just closed</strong> — but Cohort 2 applications are open. If you want in: <a href="${COHORT_URL}" style="color:#1e40af;text-decoration:underline;"><strong>Apply for Cohort 2</strong></a>.</p>
+</div>`;
+}
+
+function buildFooterText(variant: FooterVariant, cohort: CohortInfo | null): string {
+  if (variant === "cohort1-kickoff") {
+    return `\n🎯 TONIGHT AT 6PM EST — COHORT 1 KICKOFF ZOOM.\nThe link is on your cohort dashboard: ${COHORT_URL}\nSee you there.\n`;
+  }
+  if (variant === "applied-other") {
+    const which = cohort?.cohorts.includes("cohort-2") ? "Cohort 2" : "the summer cohort";
+    return `\nYou're signed up for ${which}. We'll be in touch with next steps soon.\nCohort page: ${COHORT_URL}\n`;
+  }
+  return `\nCohort 1 just closed — but Cohort 2 applications are open.\nIf you want in, apply here: ${COHORT_URL}\n`;
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const firstName = r.firstName?.trim() || "there";
+  const firstHtml = escapeHtml(firstName);
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const variant = chooseFooterVariant(r.cohort);
+  const footerHtml = buildFooterHtml(variant, r.cohort);
+  const footerText = buildFooterText(variant, r.cohort);
+
+  const subject =
+    "URGENT — register on cursorboston.com or you won't be admitted to PyData May 13";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${firstHtml},</p>
+
+<p>You&apos;re on the <strong>Luma list</strong> for the Cursor Boston × PyData Data Science Hack on <strong>Wednesday, May 13 at Moderna HQ</strong> — but <strong>we don&apos;t have a website registration from you yet.</strong></p>
+
+<div style="margin:20px 0;padding:16px;background:#fee2e2;border-left:4px solid #dc2626;border-radius:4px;">
+  <p style="margin:0;"><strong>The website registration on cursorboston.com is what Moderna actually uses for badge access.</strong> Luma RSVPs <strong>do not</strong> get you in the door. If you don&apos;t register on the website, you will be turned away at security.</p>
+</div>
+
+<p><strong>Register now — takes 30 seconds:</strong></p>
+<p>
+  <a href="${REGISTER_URL}" style="display:inline-block;background:#dc2626;color:#fff;padding:14px 28px;border-radius:8px;text-decoration:none;font-weight:700;font-size:16px;">
+    Register on cursorboston.com →
+  </a>
+</p>
+
+<div style="margin-top:20px;padding:14px 16px;background:#fef3c7;border:1px solid #f59e0b;border-radius:6px;">
+  <p style="margin:0;"><strong>Heads-up:</strong> the first + last name you enter <strong>must match your driver&apos;s license / passport exactly</strong>, or Moderna security will turn you away.</p>
+</div>
+
+<p style="margin-top:20px;">We&apos;re close to the 150-seat cap and Moderna closes their list 48 hours before the event. Don&apos;t wait — register now.</p>
+
+<p>See you Wednesday (assuming you register today).</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+${footerHtml}
+
+<p style="margin-top:24px;font-size:14px;color:#6b7280;"><strong>P.S.</strong> — Try <a href="${GAME_URL}" style="color:#6b7280;"><code>/game</code></a>, our Cursor Boston strategy game. Claim hexes, build armies, weekly turn grants. <a href="${GAME_URL}" style="color:#6b7280;">cursorboston.com/game</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you RSVP&apos;d on Luma for the May 13 PyData hack.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstName},
+
+You're on the LUMA LIST for the Cursor Boston × PyData Data Science Hack on Wednesday, May 13 at Moderna HQ — but we don't have a website registration from you yet.
+
+🚨 THE WEBSITE REGISTRATION ON CURSORBOSTON.COM IS WHAT MODERNA ACTUALLY USES FOR BADGE ACCESS.
+   Luma RSVPs DO NOT get you in the door. If you don't register on the website, you will be turned away at security.
+
+REGISTER NOW — TAKES 30 SECONDS:
+${REGISTER_URL}
+
+⚠️  HEADS-UP: the first + last name you enter MUST MATCH your driver's license / passport EXACTLY, or Moderna security will turn you away.
+
+We're close to the 150-seat cap and Moderna closes their list 48 hours before the event. Don't wait — register now.
+
+See you Wednesday (assuming you register today).
+
+— Roger
+roger@cursorboston.com
+
+${footerText}
+
+P.S. — Try /game, our Cursor Boston strategy game. Claim hexes, build armies, weekly turn grants.
+${GAME_URL}
+
+
+---
+You're receiving this because you RSVP'd on Luma for the May 13 PyData hack.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function parseArgs(argv: string[]) {
+  const dryRun = argv.includes("--dry-run");
+  const send = argv.includes("--send");
+  const force = argv.includes("--force");
+  const csvIdx = argv.indexOf("--csv");
+  const csvPath = csvIdx >= 0 ? argv[csvIdx + 1] : undefined;
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (!csvPath) {
+    console.error("Missing --csv <path>");
+    process.exit(1);
+  }
+  return { dryRun, force, csvPath };
+}
+
+async function main(): Promise<void> {
+  const { dryRun, force, csvPath } = parseArgs(process.argv.slice(2));
+
+  if (!dryRun) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // Parse Luma CSV
+  const raw = readFileSync(csvPath, "utf8");
+  const cleaned = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  const rows = parseCsv(cleaned);
+  console.log(`Loaded ${rows.length} rows from CSV`);
+
+  const csvRows: CsvRow[] = [];
+  const csvSeen = new Set<string>();
+  let csvSkippedNotApproved = 0;
+  let csvSkippedNoEmail = 0;
+  let csvSkippedDup = 0;
+  for (const r of rows) {
+    const email = (r.email || "").trim().toLowerCase();
+    if (!email) {
+      csvSkippedNoEmail++;
+      continue;
+    }
+    const status = (r.approval_status || "").trim().toLowerCase();
+    if (status !== "approved") {
+      csvSkippedNotApproved++;
+      continue;
+    }
+    if (csvSeen.has(email)) {
+      csvSkippedDup++;
+      continue;
+    }
+    csvSeen.add(email);
+    csvRows.push({
+      email,
+      firstName: r.first_name || "",
+      lastName: r.last_name || "",
+      approvalStatus: status,
+    });
+  }
+  console.log(
+    `Luma approved (deduped): ${csvRows.length} | skipped: ${csvSkippedNotApproved} not-approved, ${csvSkippedNoEmail} no-email, ${csvSkippedDup} duplicate`
+  );
+
+  // Pull all PyData website registrations to filter out
+  console.log("Loading pydataHack2026Registrations to filter…");
+  const regsSnap = await db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).get();
+  const registeredEmails = new Set<string>();
+  for (const doc of regsSnap.docs) {
+    const d = doc.data() as { email?: string; status?: string };
+    if (!d.email) continue;
+    // Skip cancelled regs — if you cancelled your website reg, we still treat
+    // you as Luma-only and nudge you back if you came back via Luma.
+    if (d.status === "cancelled") continue;
+    registeredEmails.add(d.email.toLowerCase().trim());
+  }
+  console.log(`Active website registrations: ${registeredEmails.size}`);
+
+  // Build cohort lookup map
+  console.log("Loading summerCohortApplications…");
+  const cohortSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const cohortByEmail = new Map<string, CohortInfo>();
+  for (const doc of cohortSnap.docs) {
+    const d = doc.data() as {
+      email?: string;
+      status?: string;
+      cohorts?: string[];
+    };
+    if (!d.email) continue;
+    const key = d.email.toLowerCase().trim();
+    if (!key) continue;
+    cohortByEmail.set(key, {
+      status: d.status ?? "",
+      cohorts: Array.isArray(d.cohorts) ? d.cohorts : [],
+    });
+  }
+  console.log(`Cohort applications indexed: ${cohortByEmail.size}`);
+
+  // Pull idempotency stamps from eventContacts (in one scan rather than 215 reads)
+  const stampedSet = new Set<string>();
+  if (!force) {
+    console.log("Loading eventContacts idempotency stamps…");
+    const ecSnap = await db.collection(EVENT_CONTACTS_COLLECTION).get();
+    for (const doc of ecSnap.docs) {
+      const d = doc.data() as Record<string, unknown>;
+      if (d[STAMP_FIELD]) stampedSet.add(doc.id);
+    }
+    console.log(`Already-emailed contacts: ${stampedSet.size}`);
+  }
+
+  // Filter to Luma-only + un-emailed
+  const recipients: Recipient[] = [];
+  let skippedRegistered = 0;
+  let skippedAlreadyEmailed = 0;
+  for (const row of csvRows) {
+    if (registeredEmails.has(row.email)) {
+      skippedRegistered++;
+      continue;
+    }
+    if (!force && stampedSet.has(row.email)) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    recipients.push({
+      email: row.email,
+      firstName: row.firstName,
+      cohort: cohortByEmail.get(row.email) ?? null,
+    });
+  }
+
+  // Footer breakdown
+  let cohort1 = 0;
+  let appliedOther = 0;
+  let invite = 0;
+  for (const r of recipients) {
+    const v = chooseFooterVariant(r.cohort);
+    if (v === "cohort1-kickoff") cohort1++;
+    else if (v === "applied-other") appliedOther++;
+    else invite++;
+  }
+
+  console.log(`\nEligible (Luma-only, not-yet-registered): ${recipients.length}`);
+  console.log(`  cohort-1 kickoff variant: ${cohort1}`);
+  console.log(`  already-applied variant: ${appliedOther}`);
+  console.log(`  invite-to-cohort-2 variant: ${invite}`);
+  console.log(`Skipped — already website-registered: ${skippedRegistered}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const samples: Recipient[] = [];
+    const seenVariants = new Set<FooterVariant>();
+    for (const r of recipients) {
+      const v = chooseFooterVariant(r.cohort);
+      if (!seenVariants.has(v)) {
+        seenVariants.add(v);
+        samples.push(r);
+      }
+      if (samples.length >= 3) break;
+    }
+    for (const sample of samples) {
+      const { subject, text } = buildEmail(sample);
+      console.log(
+        `\n=== sample (variant: ${chooseFooterVariant(sample.cohort)}) ===`
+      );
+      console.log(`To: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`--- TEXT preview ---`);
+      console.log(text);
+      console.log(`--- end ---`);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      // Stamp idempotency on eventContacts (doc ID is the lowercased email).
+      // Merge in case the contact doc doesn't exist yet (rare — should be
+      // synced from CSV first — but harmless if it creates a sparse doc).
+      await db
+        .collection(EVENT_CONTACTS_COLLECTION)
+        .doc(r.email)
+        .set({ [STAMP_FIELD]: FieldValue.serverTimestamp() }, { merge: true });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-pydata-website-reg-reminder.ts
+++ b/scripts/send-pydata-website-reg-reminder.ts
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Pre-event reminder to PyData May 13 website registrants:
+ *   1. Verify the first + last name on the registration matches their photo ID
+ *      (Moderna ID-checks at the door; mismatches get turned away).
+ *   2. Offer a one-click withdraw button if they can't come — landing on a
+ *      confirmation page (not auto-withdraw), so accidental clicks don't
+ *      release seats.
+ *
+ * Footer is dynamic per recipient based on summerCohortApplications:
+ *   - cohort-1 admit       → "tonight 6pm kickoff" reminder
+ *   - any other applicant  → "you're signed up" acknowledgement
+ *   - no application       → invite to Cohort 2 (Cohort 1 is closed)
+ *
+ * Includes a P.S. promoting /game.
+ *
+ * Idempotent via `pydataNameVerifyReminderEmailedAt` on the registration doc.
+ *
+ * Usage:
+ *   npx tsx scripts/send-pydata-website-reg-reminder.ts --dry-run
+ *   npx tsx scripts/send-pydata-website-reg-reminder.ts --send
+ *   npx tsx scripts/send-pydata-website-reg-reminder.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import {
+  buildUnsubscribeUrl,
+  buildPydataWithdrawUrl,
+} from "../lib/unsubscribe-token";
+import { PYDATA_2026_REGISTRATIONS_COLLECTION } from "../lib/pydata-2026";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const REGISTER_URL =
+  "https://cursorboston.com/events/cursor-boston-pydata-2026/register";
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const GAME_URL = "https://cursorboston.com/game";
+const STAMP_FIELD = "pydataNameVerifyReminderEmailedAt";
+
+type FooterVariant = "cohort1-kickoff" | "applied-other" | "invite-cohort2";
+
+interface CohortInfo {
+  status: string;
+  cohorts: string[];
+}
+
+interface Recipient {
+  docId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  cohort: CohortInfo | null;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function chooseFooterVariant(cohort: CohortInfo | null): FooterVariant {
+  if (!cohort) return "invite-cohort2";
+  if (cohort.status === "admitted" && cohort.cohorts.includes("cohort-1")) {
+    return "cohort1-kickoff";
+  }
+  return "applied-other";
+}
+
+function buildFooterHtml(variant: FooterVariant, cohort: CohortInfo | null): string {
+  if (variant === "cohort1-kickoff") {
+    return `<div style="margin-top:28px;padding:14px 16px;background:#ecfdf5;border:1px solid #10b981;border-radius:8px;">
+  <p style="margin:0;color:#065f46;"><strong>🎯 Tonight at 6pm EST — Cohort 1 kickoff Zoom.</strong> The link is on your cohort dashboard. <a href="${COHORT_URL}" style="color:#065f46;text-decoration:underline;">Open it now</a>. See you there.</p>
+</div>`;
+  }
+  if (variant === "applied-other") {
+    const which = cohort?.cohorts.includes("cohort-2") ? "Cohort 2" : "the summer cohort";
+    return `<div style="margin-top:28px;padding:14px 16px;background:#f3f4f6;border:1px solid #d1d5db;border-radius:8px;">
+  <p style="margin:0;color:#374151;">You&apos;re signed up for <strong>${which}</strong>. We&apos;ll be in touch with next steps soon. <a href="${COHORT_URL}" style="color:#374151;text-decoration:underline;">Cohort page</a>.</p>
+</div>`;
+  }
+  return `<div style="margin-top:28px;padding:14px 16px;background:#eff6ff;border:1px solid #3b82f6;border-radius:8px;">
+  <p style="margin:0;color:#1e40af;"><strong>Cohort 1 just closed</strong> — but Cohort 2 applications are open. If you want in: <a href="${COHORT_URL}" style="color:#1e40af;text-decoration:underline;"><strong>Apply for Cohort 2</strong></a>.</p>
+</div>`;
+}
+
+function buildFooterText(variant: FooterVariant, cohort: CohortInfo | null): string {
+  if (variant === "cohort1-kickoff") {
+    return `\n🎯 TONIGHT AT 6PM EST — COHORT 1 KICKOFF ZOOM.\nThe link is on your cohort dashboard: ${COHORT_URL}\nSee you there.\n`;
+  }
+  if (variant === "applied-other") {
+    const which = cohort?.cohorts.includes("cohort-2") ? "Cohort 2" : "the summer cohort";
+    return `\nYou're signed up for ${which}. We'll be in touch with next steps soon.\nCohort page: ${COHORT_URL}\n`;
+  }
+  return `\nCohort 1 just closed — but Cohort 2 applications are open.\nIf you want in, apply here: ${COHORT_URL}\n`;
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const firstName = r.firstName?.trim() || "there";
+  const firstHtml = escapeHtml(firstName);
+  const lastNameHtml = escapeHtml(r.lastName?.trim() || "");
+  const emailHtml = escapeHtml(r.email);
+
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildPydataWithdrawUrl(r.email);
+
+  const variant = chooseFooterVariant(r.cohort);
+  const footerHtml = buildFooterHtml(variant, r.cohort);
+  const footerText = buildFooterText(variant, r.cohort);
+
+  const subject =
+    "PyData May 13 — verify the name on your registration matches your photo ID";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${firstHtml},</p>
+
+<p>You&apos;re registered for the <strong>Cursor Boston × PyData Data Science Hack</strong> on <strong>Wednesday, May 13, 6:30 PM</strong> at Moderna HQ (325 Binney St, Cambridge). One critical thing before the event:</p>
+
+<div style="margin:20px 0;padding:16px;background:#fef3c7;border-left:4px solid #f59e0b;border-radius:4px;">
+  <p style="margin:0;"><strong>Moderna security checks every attendee&apos;s photo ID against the badge list.</strong> The first + last name on your registration <strong>must match your driver&apos;s license / passport exactly</strong>. If they don&apos;t match, you will be turned away at the door.</p>
+</div>
+
+<p>Your current registration on file:</p>
+<p style="margin:8px 0 0 0;padding:12px 16px;background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;font-family:ui-monospace,SFMono-Regular,monospace;font-size:14px;">
+  <strong>${firstHtml} ${lastNameHtml}</strong><br/>
+  ${emailHtml}
+</p>
+
+<p style="margin-top:20px;">If that does <strong>not</strong> match the name on your photo ID, please update it now (takes 30 seconds):</p>
+<p>
+  <a href="${REGISTER_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Edit my registration →
+  </a>
+</p>
+
+<h3 style="margin-top:32px;margin-bottom:8px;color:#b91c1c;font-size:16px;">Can&apos;t make it anymore?</h3>
+<p style="margin:0 0 12px 0;">We&apos;re close to the 150-seat cap. If you can&apos;t come, please withdraw so someone on the waitlist can take your spot. (You&apos;ll land on a confirmation page — no accidental clicks.)</p>
+<p style="margin:0 0 24px 0;">
+  <a href="${escapeHtml(withdrawUrl)}" style="display:inline-block;background:#fff;color:#b91c1c;border:1px solid #b91c1c;padding:8px 16px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">
+    Withdraw from May 13
+  </a>
+</p>
+
+<p>See you Wednesday.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+${footerHtml}
+
+<p style="margin-top:24px;font-size:14px;color:#6b7280;"><strong>P.S.</strong> — Try <a href="${GAME_URL}" style="color:#6b7280;"><code>/game</code></a>, our Cursor Boston strategy game. Claim hexes, build armies, weekly turn grants. <a href="${GAME_URL}" style="color:#6b7280;">cursorboston.com/game</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you registered for the May 13 PyData hack on cursorboston.com.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> (different from withdrawing from the event).
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstName},
+
+You're registered for the Cursor Boston × PyData Data Science Hack on Wednesday, May 13, 6:30 PM at Moderna HQ (325 Binney St, Cambridge). One critical thing before the event:
+
+⚠️  MODERNA SECURITY CHECKS EVERY ATTENDEE'S PHOTO ID AGAINST THE BADGE LIST.
+    The first + last name on your registration MUST MATCH your driver's license / passport EXACTLY. If they don't match, you will be turned away at the door.
+
+Your current registration on file:
+  ${r.firstName?.trim()} ${r.lastName?.trim()}
+  ${r.email}
+
+If that does NOT match the name on your photo ID, please update it now (takes 30 seconds):
+${REGISTER_URL}
+
+
+CAN'T MAKE IT ANYMORE?
+
+We're close to the 150-seat cap. If you can't come, please withdraw so someone on the waitlist can take your spot. (You'll land on a confirmation page — no accidental clicks.)
+
+${withdrawUrl}
+
+
+See you Wednesday.
+
+— Roger
+roger@cursorboston.com
+
+${footerText}
+
+P.S. — Try /game, our Cursor Boston strategy game. Claim hexes, build armies, weekly turn grants.
+${GAME_URL}
+
+
+---
+You're receiving this because you registered for the May 13 PyData hack on cursorboston.com.
+Unsubscribe (different from withdrawing from the event): ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // Build cohort lookup map (email lowercased → status + cohorts)
+  console.log("Loading summerCohortApplications…");
+  const cohortSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const cohortByEmail = new Map<string, CohortInfo>();
+  for (const doc of cohortSnap.docs) {
+    const d = doc.data() as {
+      email?: string;
+      status?: string;
+      cohorts?: string[];
+    };
+    if (!d.email) continue;
+    const key = d.email.toLowerCase().trim();
+    if (!key) continue;
+    cohortByEmail.set(key, {
+      status: d.status ?? "",
+      cohorts: Array.isArray(d.cohorts) ? d.cohorts : [],
+    });
+  }
+  console.log(`Cohort applications indexed: ${cohortByEmail.size}`);
+
+  console.log("Loading pydataHack2026Registrations…");
+  const regsSnap = await db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).get();
+  console.log(`Total registrations: ${regsSnap.size}`);
+
+  const recipients: Recipient[] = [];
+  let skippedCancelled = 0;
+  let skippedNoEmail = 0;
+  let skippedAlreadyEmailed = 0;
+
+  for (const regDoc of regsSnap.docs) {
+    const d = regDoc.data() as {
+      email?: string;
+      firstName?: string;
+      lastName?: string;
+      status?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (d.status === "cancelled") {
+      skippedCancelled++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const emailKey = d.email.toLowerCase().trim();
+    recipients.push({
+      docId: regDoc.id,
+      email: d.email.trim(),
+      firstName: d.firstName ?? "",
+      lastName: d.lastName ?? "",
+      cohort: cohortByEmail.get(emailKey) ?? null,
+    });
+  }
+
+  // Footer breakdown for sanity
+  let cohort1 = 0;
+  let appliedOther = 0;
+  let invite = 0;
+  for (const r of recipients) {
+    const v = chooseFooterVariant(r.cohort);
+    if (v === "cohort1-kickoff") cohort1++;
+    else if (v === "applied-other") appliedOther++;
+    else invite++;
+  }
+
+  console.log(`\nEligible recipients: ${recipients.length}`);
+  console.log(`  cohort-1 kickoff variant: ${cohort1}`);
+  console.log(`  already-applied variant: ${appliedOther}`);
+  console.log(`  invite-to-cohort-2 variant: ${invite}`);
+  console.log(`Skipped — cancelled: ${skippedCancelled}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const samples: Recipient[] = [];
+    const seenVariants = new Set<FooterVariant>();
+    for (const r of recipients) {
+      const v = chooseFooterVariant(r.cohort);
+      if (!seenVariants.has(v)) {
+        seenVariants.add(v);
+        samples.push(r);
+      }
+      if (samples.length >= 3) break;
+    }
+    for (const sample of samples) {
+      const { subject, text } = buildEmail(sample);
+      console.log(
+        `\n=== sample (variant: ${chooseFooterVariant(sample.cohort)}) ===`
+      );
+      console.log(`To: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`--- TEXT preview ---`);
+      console.log(text);
+      console.log(`--- end ---`);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(PYDATA_2026_REGISTRATIONS_COLLECTION)
+        .doc(r.docId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Cuts develop to main ahead of the PyData May 13 event so the new withdraw page + API are live before close-out emails go out.

## Highlights

- **PyData May 13 close-out** (new in this release): two-step withdraw flow at `/pydata-withdraw` + `/api/events/pydata-2026/withdraw`, plus two one-shot email scripts (website-reg name-verify reminder + Luma-only urgent register prompt). Both emails carry a per-recipient cohort footer (cohort-1 admits → tonight's 6pm kickoff reminder; cohort-2 / other → acknowledgement; non-applicants → invite to Cohort 2) and a `/game` P.S.
- **Cohort 1 close-out tooling**: signups closed, withdraw flow, admit + status-email tooling, ts-rest contract for `/api/summer-cohort/withdraw`.
- **Game**: community feed + chat panel on dashboard, onboarding wizard, 1000-tile caste switch, real-time world map, Humans/NPCs audience filter, single-surface Threats hub, weekly turn-grant fix.

## PRs included

- #763 feat(game): single-surface Threats action hub at /game/threats — @rogerSuperBuilderAlpha
- #765 feat(game): inline tile prep + structured battle readout on threats page — @rogerSuperBuilderAlpha
- #769 feat(game): battle sim, tile-type mechanics, leaderboard filter — @rogerSuperBuilderAlpha
- #770 feat(cohort): readiness modal, setup + game tabs, status email — @rogerSuperBuilderAlpha
- #773 fix(game): accept null offenseSpellId on /api/game/attack — @rogerSuperBuilderAlpha
- #775 fix(game): 'Defender had' label after capture + recruit on food/magic tiles from threats — @rogerSuperBuilderAlpha
- #777 feat(game): Humans/NPCs audience filter on world map — @rogerSuperBuilderAlpha
- #779 feat(game): real-time world map + gated snapshot rebuilds — @rogerSuperBuilderAlpha
- #781 feat(game): first-run onboarding wizard + 1000-tile caste switch — @rogerSuperBuilderAlpha
- #783 feat(game): community feed + chat panel on dashboard — @rogerSuperBuilderAlpha

## Direct commits on develop (no PR)

- 2ef1416 feat(pydata): close-out comms + two-step withdraw flow for May 13 — @Ludwitt
- e389ae3 chore(scripts): commit leftover one-shots from May 10 game-grant + cohort run — @Ludwitt
- a430433 fix(cohort): add ts-rest contract for /api/summer-cohort/withdraw — @Ludwitt
- 57e3062 feat(cohort): close cohort-1 signups, add withdraw flow, admit + status-email tooling — @Ludwitt
- 05de2c7 fix(game): weekly turn grant adds 100 instead of replacing bucket — @Ludwitt
- b14b992 docs: regen API.md + llms.txt for new endpoints — @Ludwitt
- 98768ec fix(admin): wire ts-rest contracts for summer-cohort admin routes — @Ludwitt
- dab47e9 feat(admin): summer cohort dashboard with email-gated access — @Ludwitt

## Test plan
- [x] Typecheck (`npm run type-check`) — clean
- [x] PyData scripts dry-run cleanly (111 + 111 recipients, footer variants distribute as expected)
- [ ] After deploy: smoke-test `/pydata-withdraw?email=...&token=...` (renders confirmation), POST `/api/events/pydata-2026/withdraw` (303 → status=success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)