### PR TITLE
feat(cohort): dev-env confirmation modal + tonight's kickoff reminder

### DIFF
--- a/app/api/summer-cohort/apply/route.ts
+++ b/app/api/summer-cohort/apply/route.ts
@@ -34,6 +34,7 @@ function serializeApplication(
 ) {
   const createdAt = data.createdAt;
   const updatedAt = data.updatedAt;
+  const devEnvAt = data.cohort1DevEnvConfirmedAt;
   return {
     userId: data.userId ?? null,
     email: data.email ?? null,
@@ -46,6 +47,10 @@ function serializeApplication(
     wantsToPresent:
       typeof data.wantsToPresent === "boolean" ? data.wantsToPresent : null,
     mayImmersionRsvped: extras.mayImmersionRsvped,
+    cohort1DevEnvConfirmedAt:
+      devEnvAt && typeof (devEnvAt as { toMillis?: () => number }).toMillis === "function"
+        ? (devEnvAt as { toMillis: () => number }).toMillis()
+        : null,
     createdAt:
       createdAt && typeof (createdAt as { toMillis?: () => number }).toMillis === "function"
         ? (createdAt as { toMillis: () => number }).toMillis()

--- a/app/api/summer-cohort/confirm-dev-env/route.ts
+++ b/app/api/summer-cohort/confirm-dev-env/route.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import { logger } from "@/lib/logger";
+import { SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
+import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
+
+// @contracts: summerCohortContract.confirmDevEnv
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/summer-cohort/confirm-dev-env
+ *
+ * Auth-required. Stamps `cohort1DevEnvConfirmedAt` on the current user's
+ * cohort application. Gated to admitted Cohort 1 applicants — the readiness
+ * modal already hides the affordance from anyone else, but we re-check here
+ * so the API can't be poked from a stale tab.
+ *
+ * Idempotent: re-stamps the timestamp on every call. The modal closes once
+ * the timestamp is non-null, so re-clicks have no UX consequence.
+ */
+async function handlePost(request: NextRequest) {
+  // Touch the imported contract so the import isn't tree-shaken in any
+  // tooling that scans the source. The body is empty by contract.
+  void summerCohortContract.confirmDevEnv;
+
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json(
+      { error: "Server not configured" },
+      { status: 500 }
+    );
+  }
+
+  const appRef = db.collection(SUMMER_COHORT_COLLECTION).doc(user.uid);
+  const appSnap = await appRef.get();
+  if (!appSnap.exists) {
+    return NextResponse.json(
+      { error: "No application on file" },
+      { status: 403 }
+    );
+  }
+  const app = appSnap.data() || {};
+  const status = typeof app.status === "string" ? app.status : "pending";
+  const cohorts = Array.isArray(app.cohorts) ? (app.cohorts as string[]) : [];
+  if (status !== "admitted" || !cohorts.includes("cohort-1")) {
+    return NextResponse.json(
+      { error: "Only admitted Cohort 1 applicants can confirm dev env" },
+      { status: 403 }
+    );
+  }
+
+  await appRef.update({
+    cohort1DevEnvConfirmedAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  // Re-read so we can return the resolved server timestamp as millis.
+  const refreshed = await appRef.get();
+  const data = refreshed.data() || {};
+  const stamp = data.cohort1DevEnvConfirmedAt;
+  const millis =
+    stamp && typeof (stamp as { toMillis?: () => number }).toMillis === "function"
+      ? (stamp as { toMillis: () => number }).toMillis()
+      : Date.now();
+
+  logger.info("[summer-cohort/confirm-dev-env] confirmed", {
+    uid: user.uid,
+    at: millis,
+  });
+
+  return NextResponse.json({ ok: true, cohort1DevEnvConfirmedAt: millis });
+}
+
+export const POST = withMiddleware(rateLimitConfigs.standard, handlePost);

--- a/app/summer-cohort/_components/SetupReadinessModal.tsx
+++ b/app/summer-cohort/_components/SetupReadinessModal.tsx
@@ -24,10 +24,22 @@ interface SetupReadinessModalProps {
   needsGithub: boolean;
   /** Intake survey not yet submitted — displayed only, never triggers pop. */
   needsSurvey: boolean;
+  /**
+   * Cohort 1 admit hasn't self-attested their dev environment is ready
+   * (Node + Git + Cursor / Claude Code). Triggers the modal to pop and
+   * surfaces a single "Yes, I'm ready" button.
+   */
+  needsDevEnvConfirm: boolean;
   onConnectDiscord: () => void;
   onConnectGithub: () => void;
   /** Closes the modal and switches the page to the intake-survey tab. */
   onGoToSurvey: () => void;
+  /**
+   * POST /api/summer-cohort/confirm-dev-env, then refresh the application.
+   * Should resolve once the timestamp is persisted so the row can flip to
+   * "done" without a full page reload.
+   */
+  onConfirmDevEnv: () => Promise<void>;
 }
 
 /**
@@ -40,13 +52,29 @@ export function SetupReadinessModal({
   needsDiscord,
   needsGithub,
   needsSurvey,
+  needsDevEnvConfirm,
   onConnectDiscord,
   onConnectGithub,
   onGoToSurvey,
+  onConfirmDevEnv,
 }: SetupReadinessModalProps) {
-  const shouldOpen = needsDiscord || needsGithub;
+  const shouldOpen = needsDiscord || needsGithub || needsDevEnvConfirm;
   const [isOpen, setIsOpen] = useState(false);
+  const [devEnvSubmitting, setDevEnvSubmitting] = useState(false);
+  const [devEnvError, setDevEnvError] = useState<string | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const handleConfirmDevEnv = useCallback(async () => {
+    setDevEnvSubmitting(true);
+    setDevEnvError(null);
+    try {
+      await onConfirmDevEnv();
+    } catch {
+      setDevEnvError("Couldn't save. Try again in a moment.");
+    } finally {
+      setDevEnvSubmitting(false);
+    }
+  }, [onConfirmDevEnv]);
 
   // Open whenever the trigger condition becomes true. We only auto-open on
   // the rising edge so that closing the modal doesn't immediately re-open it
@@ -118,11 +146,11 @@ export function SetupReadinessModal({
           id="setup-readiness-title"
           className="pr-8 text-xl font-bold text-white md:text-2xl"
         >
-          Cohort 1 kicks off Mon, May 11 — let&apos;s get you ready
+          Cohort 1 kicks off TONIGHT at 6pm EST — final readiness check
         </h2>
         <p className="mt-2 text-sm text-neutral-400">
-          A few quick checks before kickoff. Knock these out now and you can
-          show up Monday focused on the work, not the setup.
+          Knock these out before 6pm so kickoff is about the work, not
+          logistics.
         </p>
 
         <ul className="mt-5 space-y-2">
@@ -150,17 +178,34 @@ export function SetupReadinessModal({
               handleClose();
             }}
           />
+          <StatusRow
+            label="Dev environment ready (Node + Git + Cursor or Claude Code)"
+            done={!needsDevEnvConfirm}
+            doneCopy="Confirmed — you're all set for kickoff."
+            actionLabel={devEnvSubmitting ? "Saving…" : "Yes, I'm ready"}
+            onAction={handleConfirmDevEnv}
+            actionDisabled={devEnvSubmitting}
+          />
         </ul>
+
+        {devEnvError ? (
+          <p className="mt-3 text-xs text-red-300" role="alert">
+            {devEnvError}
+          </p>
+        ) : null}
 
         <div className="mt-5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 p-4">
           <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-300">
             <Laptop className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
-            On your laptop
+            Haven&apos;t installed Node, Git, or an IDE yet?
           </div>
           <p className="mt-1.5 text-sm text-neutral-200">
-            Install <strong>Node</strong>, <strong>Git</strong>, and{" "}
-            <strong>Cursor</strong> (or Claude Code) before Monday. The full
-            walkthrough is at <span className="font-mono">ludwitt.com/alc</span>.
+            Not required, but <strong>highly</strong> encouraged today —
+            tonight&apos;s kickoff is at 6pm EST. The 20-minute walkthrough at{" "}
+            <span className="font-mono">ludwitt.com/alc</span> covers Node,
+            Git, and <strong>Cursor</strong> (or <strong>Claude Code</strong>)
+            end-to-end so you don&apos;t spend kickoff debugging install
+            issues.
           </p>
           <a
             href={ALC_URL}
@@ -190,6 +235,7 @@ interface StatusRowProps {
   doneCopy: string;
   actionLabel: string;
   onAction: () => void;
+  actionDisabled?: boolean;
 }
 
 function StatusRow({
@@ -198,6 +244,7 @@ function StatusRow({
   doneCopy,
   actionLabel,
   onAction,
+  actionDisabled,
 }: StatusRowProps) {
   return (
     <li
@@ -230,7 +277,8 @@ function StatusRow({
         <button
           type="button"
           onClick={onAction}
-          className="shrink-0 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-amber-950 transition-colors hover:bg-amber-400"
+          disabled={actionDisabled}
+          className="shrink-0 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-amber-950 transition-colors hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {actionLabel}
         </button>

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -56,6 +56,8 @@ interface ApplicationDto {
   isLocal: boolean | null;
   wantsToPresent: boolean | null;
   mayImmersionRsvped: boolean;
+  /** Server timestamp (ms) of when the user self-attested dev env ready. */
+  cohort1DevEnvConfirmedAt: number | null;
   createdAt: number | null;
   updatedAt: number | null;
 }
@@ -797,9 +799,39 @@ function SummerCohortPageInner() {
           needsDiscord={!discord.discordInfo}
           needsGithub={!github.githubInfo?.login}
           needsSurvey={intakeStatus === "incomplete"}
+          needsDevEnvConfirm={
+            (application?.cohort1DevEnvConfirmedAt ?? null) === null
+          }
           onConnectDiscord={discord.connect}
           onConnectGithub={github.connect}
           onGoToSurvey={() => setActiveTab("intake-survey")}
+          onConfirmDevEnv={async () => {
+            if (!user) return;
+            const token = await user.getIdToken();
+            const res = await fetch("/api/summer-cohort/confirm-dev-env", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+              },
+              body: "{}",
+            });
+            if (!res.ok) {
+              throw new Error("confirm_dev_env_failed");
+            }
+            const json = (await res.json()) as {
+              ok: true;
+              cohort1DevEnvConfirmedAt: number;
+            };
+            setApplication((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    cohort1DevEnvConfirmedAt: json.cohort1DevEnvConfirmedAt,
+                  }
+                : prev
+            );
+          }}
         />
       ) : null}
       <header className="mb-8">

--- a/lib/api-schemas/summer-cohort.ts
+++ b/lib/api-schemas/summer-cohort.ts
@@ -62,6 +62,16 @@ const WithdrawQuery = z.object({
   token: z.string().optional(),
 });
 
+// No body — auth identifies the user; the endpoint just stamps a timestamp.
+const ConfirmDevEnvBody = z.object({}).openapi("SummerCohortConfirmDevEnvBody");
+
+const ConfirmDevEnvResponse = z
+  .object({
+    ok: z.literal(true),
+    cohort1DevEnvConfirmedAt: z.number().int().nonnegative(),
+  })
+  .openapi("SummerCohortConfirmDevEnvResponse");
+
 const RedirectResponse = z.object({}).optional();
 
 const AdminIntakeAggregatesQuery = z.object({
@@ -107,6 +117,22 @@ export const summerCohortContract = c.router(
       query: WithdrawQuery,
       responses: { 302: RedirectResponse },
       metadata: { errorCodes: [] as const },
+    },
+    confirmDevEnv: {
+      method: "POST",
+      path: "/api/summer-cohort/confirm-dev-env",
+      summary:
+        "Cohort 1 admit confirms dev environment is set up (Node + Git + IDE)",
+      body: ConfirmDevEnvBody,
+      responses: {
+        200: ConfirmDevEnvResponse,
+        401: ApiErrorSchema,
+        403: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "FORBIDDEN", "SERVER_ERROR"] as const,
+      },
     },
     intakeSurveyGet: {
       method: "GET",

--- a/scripts/send-cohort1-dev-env-check.ts
+++ b/scripts/send-cohort1-dev-env-check.ts
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Same-day reminder to admitted Cohort 1 applicants who haven't yet
+ * confirmed their dev environment is set up (Node + Git + Cursor or
+ * Claude Code). Sent the morning of kickoff so they have time to install
+ * before the 6pm EST Zoom.
+ *
+ * Recipients = admitted cohort-1 AND cohort1DevEnvConfirmedAt is unset.
+ * The cohort page's SetupReadinessModal will pop on next visit and let
+ * them flip the confirmation with one click.
+ *
+ * Idempotent via `cohort1DevEnvCheckEmailedAt` on the application doc.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-dev-env-check.ts --dry-run
+ *   npx tsx scripts/send-cohort1-dev-env-check.ts --send
+ *   npx tsx scripts/send-cohort1-dev-env-check.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const ALC_URL = "https://ludwitt.com/alc";
+const STAMP_FIELD = "cohort1DevEnvCheckEmailedAt";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject =
+    "Cohort 1 kicks off TONIGHT 6pm EST — confirm your dev setup on the cohort page";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Tonight at 6pm EST is your Cohort 1 kickoff Zoom.</strong> One last thing to lock in before then.</p>
+
+<p>Head to the cohort page and you&apos;ll see a quick readiness modal — confirm your dev environment is set up:</p>
+
+<ul style="padding-left:20px;margin-top:8px;">
+  <li style="margin-bottom:4px;"><strong>Node</strong> installed</li>
+  <li style="margin-bottom:4px;"><strong>Git</strong> installed</li>
+  <li style="margin-bottom:4px;"><strong>Cursor</strong> (or <strong>Claude Code</strong>) installed</li>
+</ul>
+
+<p style="margin-top:16px;">It&apos;s a single &quot;Yes, I&apos;m ready&quot; button — takes 5 seconds — and it helps us know who needs help before kickoff vs. who&apos;s ready to roll.</p>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<h3 style="margin-top:32px;margin-bottom:8px;color:#065f46;font-size:16px;">Haven&apos;t installed any of those yet?</h3>
+<p style="margin-top:0;">Not required, but <strong>highly highly</strong> encouraged to take care of this today if you haven&apos;t. There&apos;s a 20-minute walkthrough at <a href="${ALC_URL}"><strong>ludwitt.com/alc</strong></a> that covers Node, Git, and Cursor end-to-end. Run through it now and you&apos;ll show up to kickoff actually ready to build, instead of stuck on installs.</p>
+
+<p>
+  <a href="${ALC_URL}" style="display:inline-block;background:#fff;color:#065f46;border:1px solid #065f46;padding:8px 16px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">
+    Open the walkthrough at ludwitt.com/alc
+  </a>
+</p>
+
+<p style="margin-top:24px;">See you tonight at 6.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<h3 style="margin-top:32px;margin-bottom:8px;color:#b91c1c;font-size:16px;">Can&apos;t make tonight?</h3>
+<p style="margin:0 0 12px 0;">If your plans changed and you can&apos;t join, please withdraw so your spot goes to the waitlist:</p>
+<p style="margin:0 0 24px 0;">
+  <a href="${escapeHtml(withdrawUrl)}" style="display:inline-block;background:#fff;color:#b91c1c;border:1px solid #b91c1c;padding:8px 16px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">
+    Withdraw from Cohort 1
+  </a>
+</p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> (different from withdrawing).
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Tonight at 6pm EST is your Cohort 1 kickoff Zoom. One last thing to lock in before then.
+
+Head to the cohort page and you'll see a quick readiness modal — confirm your dev environment is set up:
+
+  • Node installed
+  • Git installed
+  • Cursor (or Claude Code) installed
+
+It's a single "Yes, I'm ready" button — takes 5 seconds — and it helps us know who needs help before kickoff vs. who's ready to roll.
+
+  → ${COHORT_URL}
+
+
+HAVEN'T INSTALLED ANY OF THOSE YET?
+
+Not required, but HIGHLY HIGHLY encouraged to take care of this today if you haven't. There's a 20-minute walkthrough at ludwitt.com/alc that covers Node, Git, and Cursor end-to-end. Run through it now and you'll show up to kickoff actually ready to build, instead of stuck on installs.
+
+  → ${ALC_URL}
+
+
+See you tonight at 6.
+
+— Roger
+roger@cursorboston.com
+
+
+CAN'T MAKE TONIGHT?
+
+If your plans changed and you can't join, please withdraw so your spot goes to the waitlist:
+${withdrawUrl}
+
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe (different from withdrawing): ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+  if (!dryRun) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log("Loading summerCohortApplications…");
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyConfirmed = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      cohort1DevEnvConfirmedAt?: unknown;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (d.cohort1DevEnvConfirmedAt) {
+      skippedAlreadyConfirmed++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(`\nEligible recipients (cohort-1 admit + dev env unconfirmed): ${recipients.length}`);
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — already confirmed dev env: ${skippedAlreadyConfirmed}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n--- TEXT preview ---\n${text}\n--- end ---`);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Same-day push for Cohort 1's 6pm EST kickoff tonight.

## What's in here

- **Modal upgrade**: `SetupReadinessModal` now surfaces a 4th row — "Dev environment ready (Node + Git + Cursor or Claude Code)". Pops for any admitted cohort-1 applicant whose `cohort1DevEnvConfirmedAt` is unset. One-click attest.
- **New API**: `POST /api/summer-cohort/confirm-dev-env` (auth-required, admitted cohort-1 only) stamps the timestamp; ts-rest contract entry added.
- **GET /apply** now serializes `cohort1DevEnvConfirmedAt` so the page can decide whether to pop without an extra round-trip.
- **Email**: `scripts/send-cohort1-dev-env-check.ts` — 102 eligible recipients (admitted cohort-1, dev env unconfirmed). Subject "Cohort 1 kicks off TONIGHT 6pm EST — confirm your dev setup on the cohort page". Heavily promotes ludwitt.com/alc for anyone who hasn't installed yet. Idempotent via `cohort1DevEnvCheckEmailedAt`.

Direct commits on develop: 9b8cd5a — @Ludwitt

## Test plan
- [x] Type-check (`npm run type-check`) — clean
- [x] Route-contracts check — clean (158 routes, 0 debt)
- [x] Lint on touched files — clean
- [x] Email dry-run — 102 eligible, sample renders correctly
- [ ] After deploy: smoke-test confirm-dev-env API (401 unauthed, 200 authed admit, modal flips row to done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)