### PR TITLE
release: game catalog lore + imageUrl plumbing

### DIFF
--- a/app/game/_components/CatalogImage.tsx
+++ b/app/game/_components/CatalogImage.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { cn } from "@/lib/utils";
+import {
+  getCatalogImageSrc,
+  hasCatalogImage,
+} from "@/lib/game/content/display";
+
+type Size = "xs" | "sm" | "md" | "lg" | "xl";
+
+const SIZE_PX: Record<Size, number> = {
+  xs: 24,
+  sm: 32,
+  md: 64,
+  lg: 128,
+  xl: 192,
+};
+
+interface CatalogImageProps {
+  /** Any catalog entry that may carry imageUrl + name. */
+  entry: { imageUrl?: string | null; name?: string };
+  /** Visual size; pins both width + height so layout doesn't shift. */
+  size?: Size;
+  /** Override the alt text. Defaults to entry.name. */
+  alt?: string;
+  /** Extra classes — appended to the defaults (rounded, opacity-50 on fallback). */
+  className?: string;
+}
+
+/**
+ * Renders a catalog entry's illustration with a graceful fallback to the
+ * project logo at half opacity when no `imageUrl` is set yet. Plain `<img>`
+ * (no `next/image`) to match the game pages' existing pattern and avoid
+ * forcing every contributor to update `next.config.js` domains when adding
+ * external-host images later.
+ */
+export function CatalogImage({
+  entry,
+  size = "sm",
+  alt,
+  className,
+}: CatalogImageProps) {
+  const src = getCatalogImageSrc(entry);
+  const isFallback = !hasCatalogImage(entry);
+  const px = SIZE_PX[size];
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- matches existing game-page pattern; see plan doc
+    <img
+      src={src}
+      alt={alt ?? entry.name ?? ""}
+      width={px}
+      height={px}
+      loading="lazy"
+      className={cn(
+        "rounded-md shrink-0 object-cover",
+        isFallback && "opacity-50",
+        className,
+      )}
+    />
+  );
+}

--- a/app/game/_components/CatalogLore.tsx
+++ b/app/game/_components/CatalogLore.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { cn } from "@/lib/utils";
+import {
+  getCatalogLore,
+  hasCatalogLore,
+} from "@/lib/game/content/display";
+
+interface CatalogLoreProps {
+  /** Any catalog entry that may carry a lore field. */
+  entry: { lore?: string | null };
+  /** Extra classes appended to the defaults. */
+  className?: string;
+}
+
+/**
+ * Renders a catalog entry's long-form lore. Falls back to a faded "No lore
+ * yet." placeholder so the visual indicates a real-but-empty slot rather
+ * than a missing UI element. Styling distinguishes placeholder (italic,
+ * muted) from real lore (regular weight, primary copy color).
+ */
+export function CatalogLore({ entry, className }: CatalogLoreProps) {
+  const text = getCatalogLore(entry);
+  const isPlaceholder = !hasCatalogLore(entry);
+  return (
+    <p
+      className={cn(
+        "text-sm leading-relaxed",
+        isPlaceholder
+          ? "italic text-neutral-500 dark:text-neutral-500"
+          : "text-neutral-700 dark:text-neutral-300",
+        className,
+      )}
+    >
+      {text}
+    </p>
+  );
+}

--- a/app/game/setup/_components/CastePickCard.tsx
+++ b/app/game/setup/_components/CastePickCard.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/lib/game/content";
 import type { Caste } from "@/lib/game/types";
 import { CASTE_PRESENTATION } from "../_lib/constants";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { CatalogLore } from "@/app/game/_components/CatalogLore";
 
 interface Props {
   caste: Caste;
@@ -42,19 +44,25 @@ export function CastePickCard({ caste, busy, onChoose }: Props) {
 
   return (
     <div className="border border-neutral-200 dark:border-neutral-800 rounded-lg p-4 bg-white dark:bg-neutral-950 flex flex-col">
-      <div className="flex items-center gap-3 mb-2">
-        <span
-          aria-hidden="true"
-          className="inline-block w-4 h-4 rounded-full border border-neutral-300 dark:border-neutral-700"
-          style={{ background: presentation.swatch }}
-        />
-        <h3 className="text-lg font-semibold capitalize">{caste}</h3>
-        <span className="text-xs text-neutral-500">{presentation.tagline}</span>
+      <div className="flex items-start gap-3 mb-3">
+        <CatalogImage entry={{ ...profile, name: caste }} size="md" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              aria-hidden="true"
+              className="inline-block w-4 h-4 rounded-full border border-neutral-300 dark:border-neutral-700"
+              style={{ background: presentation.swatch }}
+            />
+            <h3 className="text-lg font-semibold capitalize">{caste}</h3>
+          </div>
+          <span className="text-xs text-neutral-500">{presentation.tagline}</span>
+        </div>
       </div>
 
-      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed mb-3">
+      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed mb-2">
         {presentation.lore}
       </p>
+      <CatalogLore entry={profile} className="mb-3" />
 
       <div className="grid grid-cols-3 gap-2 text-xs mb-3">
         <Stat
@@ -113,11 +121,17 @@ export function CastePickCard({ caste, busy, onChoose }: Props) {
               currently come from the artifact pool and from production spells.
             </p>
           ) : (
-            <ul className="space-y-1">
+            <ul className="space-y-2">
               {buildings.map((b) => (
-                <li key={b.id} className="text-xs">
-                  <span className="font-medium">{b.name}</span>
-                  <span className="text-neutral-500"> — {b.description}</span>
+                <li key={b.id} className="text-xs flex gap-2">
+                  <CatalogImage entry={b} size="xs" />
+                  <div className="min-w-0 flex-1">
+                    <div>
+                      <span className="font-medium">{b.name}</span>
+                      <span className="text-neutral-500"> — {b.description}</span>
+                    </div>
+                    <CatalogLore entry={b} className="text-xs mt-0.5" />
+                  </div>
                 </li>
               ))}
             </ul>
@@ -155,18 +169,22 @@ function UnitLine({
   bonus: number;
 }) {
   return (
-    <div className="border border-neutral-200 dark:border-neutral-800 rounded p-2">
-      <div className="flex items-baseline justify-between">
-        <span className="font-medium">{unit.name}</span>
-        <span className="text-[10px] uppercase tracking-wide text-neutral-500">
-          {unit.type} · ×{bonus.toFixed(2)}
-        </span>
-      </div>
-      <div className="text-xs text-neutral-500 mt-0.5">
-        ATK {unit.attack} · DEF {unit.defense} · HP {unit.hp}
-      </div>
-      <div className="text-xs text-neutral-600 dark:text-neutral-400 italic mt-1">
-        {unit.description}
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded p-2 flex gap-2">
+      <CatalogImage entry={unit} size="sm" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between">
+          <span className="font-medium">{unit.name}</span>
+          <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+            {unit.type} · ×{bonus.toFixed(2)}
+          </span>
+        </div>
+        <div className="text-xs text-neutral-500 mt-0.5">
+          ATK {unit.attack} · DEF {unit.defense} · HP {unit.hp}
+        </div>
+        <div className="text-xs text-neutral-600 dark:text-neutral-400 italic mt-1">
+          {unit.description}
+        </div>
+        <CatalogLore entry={unit} className="text-xs mt-1" />
       </div>
     </div>
   );
@@ -182,18 +200,22 @@ function SpellLine({
   bonus: number;
 }) {
   return (
-    <div className="border border-neutral-200 dark:border-neutral-800 rounded p-2">
-      <div className="flex items-baseline justify-between">
-        <span className="font-medium">{spell.name}</span>
-        <span className="text-[10px] uppercase tracking-wide text-neutral-500">
-          {slot} · ×{bonus.toFixed(2)}
-        </span>
-      </div>
-      <div className="text-xs text-neutral-500 mt-0.5">
-        Base strength {spell.baseStrength}
-      </div>
-      <div className="text-xs text-neutral-600 dark:text-neutral-400 italic mt-1">
-        {spell.description}
+    <div className="border border-neutral-200 dark:border-neutral-800 rounded p-2 flex gap-2">
+      <CatalogImage entry={spell} size="sm" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between">
+          <span className="font-medium">{spell.name}</span>
+          <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+            {slot} · ×{bonus.toFixed(2)}
+          </span>
+        </div>
+        <div className="text-xs text-neutral-500 mt-0.5">
+          Base strength {spell.baseStrength}
+        </div>
+        <div className="text-xs text-neutral-600 dark:text-neutral-400 italic mt-1">
+          {spell.description}
+        </div>
+        <CatalogLore entry={spell} className="text-xs mt-1" />
       </div>
     </div>
   );

--- a/app/game/spells/_components/SpellCell.tsx
+++ b/app/game/spells/_components/SpellCell.tsx
@@ -12,6 +12,8 @@ import type {
   SpellDefinition,
   SpellType,
 } from "@/lib/game/types";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { CatalogLore } from "@/app/game/_components/CatalogLore";
 import { TYPE_LABEL } from "../_lib/constants";
 import { DefenseControls } from "./spell-cell/DefenseControls";
 import { OffenseHint } from "./spell-cell/OffenseHint";
@@ -95,15 +97,21 @@ export function SpellCell(props: Props) {
 
   return (
     <div className="p-4 flex flex-col gap-3 min-h-[8rem]">
-      <div className="flex items-baseline justify-between gap-2">
-        <h3 className="font-semibold text-sm">{spell.name}</h3>
-        <span className="text-[10px] uppercase tracking-wide text-neutral-500 shrink-0">
-          {TYPE_LABEL[column]}
-        </span>
+      <div className="flex items-start gap-3">
+        <CatalogImage entry={spell} size="sm" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline justify-between gap-2">
+            <h3 className="font-semibold text-sm">{spell.name}</h3>
+            <span className="text-[10px] uppercase tracking-wide text-neutral-500 shrink-0">
+              {TYPE_LABEL[column]}
+            </span>
+          </div>
+          <p className="text-xs text-neutral-600 dark:text-neutral-400 leading-relaxed mt-1">
+            {spell.description}
+          </p>
+        </div>
       </div>
-      <p className="text-xs text-neutral-600 dark:text-neutral-400 leading-relaxed flex-1">
-        {spell.description}
-      </p>
+      <CatalogLore entry={spell} className="text-xs flex-1" />
       <div className="text-[11px] text-neutral-500">
         Strength <strong>{spell.baseStrength}</strong> · cost{" "}
         <strong>{spell.turnCost}t</strong>

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -8,6 +8,7 @@
 
 import { useMemo, useState } from "react";
 import { ARTIFACTS_BY_ID, getSpellsForCasteAndType } from "@/lib/game/content";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
 import { realizedSpellMagnitude } from "@/lib/game/combat";
 import type {
   CombatResult,
@@ -736,9 +737,10 @@ export function ThreatRow(props: ThreatRowProps) {
                           onClick={() => handleArm(s.id)}
                           disabled={busy || reason !== null}
                           title={reason ?? s.description}
-                          className="px-3 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
+                          className="flex items-center gap-2 px-3 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
                         >
-                          T{s.tier} {s.name}
+                          <CatalogImage entry={s} size="xs" />
+                          <span>T{s.tier} {s.name}</span>
                         </button>
                       );
                     })}

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -7,7 +7,12 @@
 "use client";
 
 import { useState } from "react";
-import { ALL_SPELLS, ARTIFACTS_BY_ID } from "@/lib/game/content";
+import {
+  ALL_SPELLS,
+  ARTIFACTS_BY_ID,
+  getUnitForCasteAndType,
+} from "@/lib/game/content";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
 import type {
   GameArtifact,
   GamePlayer,
@@ -140,16 +145,25 @@ export function OwnTilePanel({
           </p>
         ) : (
           <div className="flex flex-wrap gap-2">
-            {UNIT_TYPES.map((u) => (
-              <button
-                key={u}
-                onClick={() => onBuild(u)}
-                disabled={busy || !canBuild}
-                className="px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors capitalize disabled:opacity-50"
-              >
-                +10 {u}
-              </button>
-            ))}
+            {UNIT_TYPES.map((u) => {
+              const unit = player.caste
+                ? getUnitForCasteAndType(player.caste, u)
+                : null;
+              return (
+                <button
+                  key={u}
+                  onClick={() => onBuild(u)}
+                  disabled={busy || !canBuild}
+                  className="flex items-center gap-2 px-4 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors disabled:opacity-50"
+                  title={unit?.description ?? u}
+                >
+                  {unit ? <CatalogImage entry={unit} size="xs" /> : null}
+                  <span className="capitalize">
+                    +10 {unit?.name ?? u}
+                  </span>
+                </button>
+              );
+            })}
           </div>
         )}
       </section>
@@ -176,10 +190,11 @@ export function OwnTilePanel({
                   player.turnsRemaining < 5 ||
                   tile.armedDefenseSpellId === s.id
                 }
-                className="px-3 py-1.5 text-sm border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50"
+                className="flex items-center gap-2 px-3 py-1.5 text-sm border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50"
                 title={s.description}
               >
-                {s.name}
+                <CatalogImage entry={s} size="xs" />
+                <span>{s.name}</span>
               </button>
             ))}
           </div>

--- a/app/game/upgrades/page.tsx
+++ b/app/game/upgrades/page.tsx
@@ -14,6 +14,8 @@ import {
   ALL_UNITS,
   ALL_UPGRADES,
 } from "@/lib/game/content";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { CatalogLore } from "@/app/game/_components/CatalogLore";
 import type {
   BuildingDefinition,
   Caste,
@@ -341,15 +343,21 @@ function UpgradeRow({
                   : "border-neutral-200 dark:border-neutral-800"
               }`}
             >
-              <div className="flex items-baseline justify-between mb-1">
-                <span className="font-medium">{opt.name}</span>
-                <span className="text-[10px] uppercase tracking-wide text-neutral-500">
-                  Option {opt.optionIndex}
-                </span>
+              <div className="flex items-start gap-2 mb-2">
+                <CatalogImage entry={opt} size="sm" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline justify-between mb-1">
+                    <span className="font-medium">{opt.name}</span>
+                    <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+                      Option {opt.optionIndex}
+                    </span>
+                  </div>
+                  <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                    {opt.description}
+                  </p>
+                </div>
               </div>
-              <p className="text-xs text-neutral-600 dark:text-neutral-400 mb-2">
-                {opt.description}
-              </p>
+              <CatalogLore entry={opt} className="text-xs mb-2" />
               {effects && (
                 <p className="text-xs text-emerald-700 dark:text-emerald-400 mb-2 font-mono">
                   {effects}

--- a/lib/game/content/display.ts
+++ b/lib/game/content/display.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Display helpers for game catalog entries (spells, units, upgrades, castes,
+ * buildings). Each catalog entry may carry optional `lore` and `imageUrl`
+ * fields. These helpers normalize the access so render surfaces don't each
+ * re-implement the fallback rules.
+ *
+ * Pure / dependency-free — safe to import from both server and client code.
+ */
+
+/** Logo used when a catalog entry has no `imageUrl` yet. */
+export const FALLBACK_LOGO_SRC = "/logo.svg";
+
+/** Placeholder copy used when a catalog entry has no `lore` yet. */
+export const LORE_PLACEHOLDER = "No lore yet.";
+
+interface ImageBearing {
+  imageUrl?: string | null;
+}
+
+interface LoreBearing {
+  lore?: string | null;
+}
+
+/** Resolve the src to render for a catalog entry — real `imageUrl` if set,
+ *  otherwise the project logo. */
+export function getCatalogImageSrc(entry: ImageBearing | null | undefined): string {
+  const url = entry?.imageUrl?.trim();
+  return url ? url : FALLBACK_LOGO_SRC;
+}
+
+/** True when the entry carries real art (used to dim the fallback state). */
+export function hasCatalogImage(entry: ImageBearing | null | undefined): boolean {
+  return Boolean(entry?.imageUrl?.trim());
+}
+
+/** Resolve the lore text to render — the entry's `lore` if set, otherwise
+ *  the placeholder string. Always returns a non-empty string. */
+export function getCatalogLore(entry: LoreBearing | null | undefined): string {
+  const text = entry?.lore?.trim();
+  return text ? text : LORE_PLACEHOLDER;
+}
+
+/** True when the entry carries real lore (used to style the placeholder
+ *  state distinctly). */
+export function hasCatalogLore(entry: LoreBearing | null | undefined): boolean {
+  return Boolean(entry?.lore?.trim());
+}

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -57,6 +57,11 @@ export interface UnitDefinition {
   defense: number;
   hp: number;
   description: string;
+  /** Long-form flavor / lore. UI falls back to "No lore yet." when absent. */
+  lore?: string;
+  /** Path or URL to illustrative art. UI falls back to /logo.svg when absent.
+   *  Convention: /game/units/<id>.png (e.g. "/game/units/white-ground-pikeman.png"). */
+  imageUrl?: string;
 }
 
 export type SpellTier = 1 | 2 | 3 | 4 | 5;
@@ -80,6 +85,11 @@ export interface SpellDefinition {
   turnCost: number;
   // For type === "intel": which reveal scope the spy spell delivers.
   intelScope?: IntelSpellScope;
+  /** Long-form flavor / lore. UI falls back to "No lore yet." when absent. */
+  lore?: string;
+  /** Path or URL to illustrative art. UI falls back to /logo.svg when absent.
+   *  Convention: /game/spells/<id>.png (e.g. "/game/spells/white-offense-smite.png"). */
+  imageUrl?: string;
 }
 
 export interface BuildingDefinition {
@@ -92,6 +102,11 @@ export interface BuildingDefinition {
   description: string;
   capacityBonus?: number;
   unitTypeAffinity?: { type: UnitType; multiplier: number };
+  /** Long-form flavor / lore. UI falls back to "No lore yet." when absent. */
+  lore?: string;
+  /** Path or URL to illustrative art. UI falls back to /logo.svg when absent.
+   *  Convention: /game/buildings/<id>.png (e.g. "/game/buildings/white-military.png"). */
+  imageUrl?: string;
 }
 
 // ──── v2: Unit & building upgrades ────
@@ -136,6 +151,11 @@ export interface UpgradeDefinition {
   // Set on the optionIndex-4 air-unit upgrades only; identifies which
   // caste-flavored intel passive this upgrade provides.
   intelPassive?: AirIntelPassive;
+  /** Long-form flavor / lore. UI falls back to "No lore yet." when absent. */
+  lore?: string;
+  /** Path or URL to illustrative art. UI falls back to /logo.svg when absent.
+   *  Convention: /game/upgrades/<id>.png (e.g. "/game/upgrades/white-ground-pikeman-upgrade-1.png"). */
+  imageUrl?: string;
 }
 
 export interface CasteProfile {
@@ -148,6 +168,11 @@ export interface CasteProfile {
   // it stacks on top of base defense. Green/White lean concentrated; Blue/Black
   // are comfortable spread.
   supplyMultiplier: number;
+  /** Long-form flavor / lore. UI falls back to "No lore yet." when absent. */
+  lore?: string;
+  /** Path or URL to illustrative art. UI falls back to /logo.svg when absent.
+   *  Convention: /game/castes/<caste>.png (e.g. "/game/castes/white.png"). */
+  imageUrl?: string;
 }
 
 export interface UnitStack {


### PR DESCRIPTION
Single-commit release.

## PRs / commits included

- `a577a70` feat(game): wire lore + imageUrl plumbing for spell/unit/upgrade/caste/building catalogs — @Ludwitt

## What this does

Adds optional `lore?: string` + `imageUrl?: string` to all five game-content catalog interfaces (UnitDefinition, SpellDefinition, BuildingDefinition, UpgradeDefinition, CasteProfile) plus the rendering plumbing to display them with graceful fallbacks (logo at half opacity for missing images, "No lore yet." in italic-muted for missing lore).

No content is added in this PR — every catalog entry continues to render the existing description plus the fallback states. Contributors can now drop lore strings and PNGs (in `public/game/<catalog>/<id>.png`) into the repo one entry at a time without touching code.

Render surfaces wired: SpellCell, CastePickCard (caste header + each unit/spell/building line), upgrades page (option cards), tile-action-panels (build-units + defense-spell-arm buttons), ThreatRow (defense-spell-arm). Native `<select>` spell pickers in attack/bulk-recruit panels are left untouched — `<option>` can't render HTML.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` (touched files) — clean
- [x] `check-route-contracts.js` — 158 routes, 0 debt (no API changes)
- [x] Dev server smoke: `/` and `/game` both return HTTP 200 with no compile errors
- [ ] Post-deploy: visit `/game/spells`, `/game/setup`, `/game/upgrades` and confirm the fallback logo + "No lore yet." render correctly on every entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)