### PR TITLE
release: attack-spell crash fix + artifact UX overhaul

### DIFF
--- a/app/api/game/artifacts/route.ts
+++ b/app/api/game/artifacts/route.ts
@@ -49,6 +49,8 @@ export async function GET(request: NextRequest) {
               description: def.description,
               flavorOnFind: def.flavorOnFind,
               baseStrength: def.baseStrength,
+              lore: def.lore,
+              imageUrl: def.imageUrl,
             }
           : null,
       };

--- a/app/game/artifacts/page.tsx
+++ b/app/game/artifacts/page.tsx
@@ -14,6 +14,8 @@ import type {
   ArtifactType,
   GameArtifact,
 } from "@/lib/game/types";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { CatalogLore } from "@/app/game/_components/CatalogLore";
 
 interface InventoryArtifact extends GameArtifact {
   definition: {
@@ -22,6 +24,8 @@ interface InventoryArtifact extends GameArtifact {
     description: string;
     flavorOnFind: string;
     baseStrength: number;
+    lore?: string;
+    imageUrl?: string;
   } | null;
 }
 
@@ -298,20 +302,37 @@ export default function ArtifactsInventoryPage() {
                           RARITY_COLORS[a.rarity]
                         } ${a.used ? "opacity-50" : ""}`}
                       >
-                        <div className="flex items-baseline justify-between mb-1">
-                          <h3 className="font-semibold">
-                            {a.definition?.name ?? a.definitionId}
-                          </h3>
-                          <span className="text-xs text-neutral-500 capitalize ml-2">
-                            {a.type}
-                          </span>
+                        <div className="flex gap-3 mb-2">
+                          <CatalogImage
+                            entry={a.definition ?? { name: a.definitionId }}
+                            size="md"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-baseline justify-between gap-2">
+                              <h3 className="font-semibold truncate">
+                                {a.definition?.name ?? a.definitionId}
+                              </h3>
+                              <span className="text-xs text-neutral-500 capitalize shrink-0">
+                                {a.type}
+                              </span>
+                            </div>
+                            {a.definition && (
+                              <p className="text-xs text-neutral-600 dark:text-neutral-400 mt-1">
+                                {a.definition.description}
+                              </p>
+                            )}
+                          </div>
                         </div>
                         {a.definition && (
                           <>
-                            <p className="text-xs text-neutral-600 dark:text-neutral-400 mb-2">
-                              {a.definition.description}
-                            </p>
+                            <CatalogLore
+                              entry={a.definition}
+                              className="text-xs mb-2"
+                            />
                             <p className="text-xs italic text-neutral-500 mb-2">
+                              <span className="not-italic text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500 mr-1">
+                                Found:
+                              </span>
                               {a.definition.flavorOnFind}
                             </p>
                             <div className="text-xs text-neutral-500 mb-3">

--- a/app/game/threats/_components/BattleSimPanel.tsx
+++ b/app/game/threats/_components/BattleSimPanel.tsx
@@ -8,7 +8,12 @@
 
 import { useState } from "react";
 import { SPELLS_BY_ID } from "@/lib/game/content";
-import type { SpellDefinition, UnitStack } from "@/lib/game/types";
+import type {
+  ArtifactDefinition,
+  GameArtifact,
+  SpellDefinition,
+  UnitStack,
+} from "@/lib/game/types";
 import type { AttackPreview } from "../_lib/use-attack-preview";
 import { CatalogImage } from "@/app/game/_components/CatalogImage";
 import { CatalogLore } from "@/app/game/_components/CatalogLore";
@@ -64,6 +69,18 @@ export interface BattleSimPanelProps {
     turnCost: number;
     disabledReason: string | null;
   };
+  // Expandable artifact-use picker. Lets the player spend a relevant
+  // offensive/intel artifact from within the attack flow rather than
+  // hunting for it in a separate panel — these are one-time-use items
+  // whose effects fold into the very next attack.
+  useArtifact?: {
+    artifacts: ReadonlyArray<{
+      artifact: GameArtifact;
+      definition: ArtifactDefinition | null;
+    }>;
+    onUse: (artifactId: string) => void;
+    disabledReason: string | null;
+  };
 }
 
 function totalUnits(s: UnitStack): number {
@@ -93,6 +110,7 @@ export function BattleSimPanel({
   siege,
   flyover,
   castSpell,
+  useArtifact,
   selectedOffenseSpell,
 }: BattleSimPanelProps) {
   return (
@@ -139,6 +157,7 @@ export function BattleSimPanel({
           siege={siege}
           flyover={flyover}
           castSpell={castSpell}
+          useArtifact={useArtifact}
         />
       </div>
     </div>
@@ -375,6 +394,7 @@ function ActionButtonStrip({
   siege,
   flyover,
   castSpell,
+  useArtifact,
 }: {
   disabled?: boolean;
   busy?: boolean;
@@ -382,8 +402,10 @@ function ActionButtonStrip({
   siege?: BattleSimPanelProps["siege"];
   flyover?: BattleSimPanelProps["flyover"];
   castSpell?: BattleSimPanelProps["castSpell"];
+  useArtifact?: BattleSimPanelProps["useArtifact"];
 }) {
   const [castOpen, setCastOpen] = useState(false);
+  const [artifactOpen, setArtifactOpen] = useState(false);
 
   const wholePanelDisabledReason = disabled
     ? "Preview disabled — pre-actions unavailable."
@@ -436,6 +458,20 @@ function ActionButtonStrip({
         `Pick a siege/disarm/attrition spell · ${castSpell.turnCost} turns`,
     });
   }
+  if (useArtifact && useArtifact.artifacts.length > 0) {
+    const reason = wholePanelDisabledReason ?? useArtifact.disabledReason;
+    buttons.push({
+      key: "artifact",
+      label: `Artifact (${useArtifact.artifacts.length}) ${
+        artifactOpen ? "▾" : "▸"
+      }`,
+      onClick: reason ? undefined : () => setArtifactOpen((o) => !o),
+      disabled: reason !== null,
+      title:
+        reason ??
+        `Spend a one-time artifact whose effect rolls into your next attack`,
+    });
+  }
   if (buttons.length === 0) {
     return (
       <div className="flex flex-wrap gap-2 pt-1">
@@ -485,6 +521,85 @@ function ActionButtonStrip({
           onAfterCast={() => setCastOpen(false)}
         />
       )}
+      {artifactOpen && useArtifact && (
+        <UseArtifactPicker
+          useArtifact={useArtifact}
+          wholePanelDisabledReason={wholePanelDisabledReason}
+          onAfterUse={() => setArtifactOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function UseArtifactPicker({
+  useArtifact,
+  wholePanelDisabledReason,
+  onAfterUse,
+}: {
+  useArtifact: NonNullable<BattleSimPanelProps["useArtifact"]>;
+  wholePanelDisabledReason: string | null;
+  onAfterUse: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
+      <div className="px-3 py-1.5 border-b border-neutral-200 dark:border-neutral-800 text-[10px] uppercase tracking-wide text-neutral-500">
+        Spend an artifact · one-time use · effect rolls into your next attack
+      </div>
+      <ul className="divide-y divide-neutral-100 dark:divide-neutral-900">
+        {useArtifact.artifacts.map((entry) => {
+          const blocked = wholePanelDisabledReason !== null;
+          const def = entry.definition;
+          const kindLabel =
+            def?.type === "offense"
+              ? "⚔ Offense"
+              : def?.type === "intel"
+                ? "🔎 Intel"
+                : def?.type === "defense"
+                  ? "🛡 Defense"
+                  : "✨ Artifact";
+          return (
+            <li key={entry.artifact.id}>
+              <button
+                type="button"
+                disabled={blocked}
+                title={wholePanelDisabledReason ?? def?.description ?? entry.artifact.definitionId}
+                onClick={() => {
+                  if (blocked) return;
+                  useArtifact.onUse(entry.artifact.id);
+                  onAfterUse();
+                }}
+                className={`w-full flex items-center gap-3 px-3 py-2 text-left text-[11px] transition-colors ${
+                  blocked
+                    ? "text-neutral-400 dark:text-neutral-600 cursor-not-allowed"
+                    : "hover:bg-neutral-100 dark:hover:bg-neutral-900"
+                }`}
+              >
+                <CatalogImage
+                  entry={def ?? { name: entry.artifact.definitionId }}
+                  size="sm"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline gap-2">
+                    <span className="font-medium shrink-0">{kindLabel}</span>
+                    <span className="truncate">
+                      · {def?.name ?? entry.artifact.definitionId}
+                    </span>
+                    <span className="ml-auto font-mono text-neutral-500 shrink-0 capitalize">
+                      {entry.artifact.rarity}
+                    </span>
+                  </div>
+                  {def?.description ? (
+                    <p className="text-[10px] text-neutral-500 dark:text-neutral-400 mt-0.5 line-clamp-2">
+                      {def.description}
+                    </p>
+                  ) : null}
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/app/game/threats/_components/BattleSimPanel.tsx
+++ b/app/game/threats/_components/BattleSimPanel.tsx
@@ -10,11 +10,25 @@ import { useState } from "react";
 import { SPELLS_BY_ID } from "@/lib/game/content";
 import type { SpellDefinition, UnitStack } from "@/lib/game/types";
 import type { AttackPreview } from "../_lib/use-attack-preview";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { CatalogLore } from "@/app/game/_components/CatalogLore";
 
 export interface BattleSimPanelProps {
   preview: AttackPreview | null;
   loading: boolean;
   error: string | null;
+  /**
+   * The offense spell the player currently has staged for the attack (the
+   * value of the offense-spell `<select>` in ThreatRow). When set, the
+   * panel renders a "Selected offense spell" block with the spell's full
+   * description, lore, and expected attack-power boost so the player can
+   * see what they're committing to before they swing.
+   */
+  selectedOffenseSpell?: {
+    spell: SpellDefinition;
+    /** Midpoint-dice attack-power boost (already caste/magic-multiplied). */
+    expectedMagnitude: number;
+  } | null;
   // True when the calling row has determined the attack is structurally
   // impossible (e.g. enemy shielded). The panel renders a muted "preview
   // unavailable" state instead of stale numbers.
@@ -79,6 +93,7 @@ export function BattleSimPanel({
   siege,
   flyover,
   castSpell,
+  selectedOffenseSpell,
 }: BattleSimPanelProps) {
   return (
     <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50/50 dark:bg-neutral-900/30 my-3">
@@ -109,6 +124,13 @@ export function BattleSimPanel({
         ) : (
           <PreviewBody preview={preview} stale={loading} />
         )}
+
+        {selectedOffenseSpell ? (
+          <SelectedOffenseSpellBlock
+            spell={selectedOffenseSpell.spell}
+            expectedMagnitude={selectedOffenseSpell.expectedMagnitude}
+          />
+        ) : null}
 
         <ActionButtonStrip
           disabled={disabled}
@@ -213,6 +235,37 @@ function PreviewBody({
       {/* Tile-type modifiers — only show when non-neutral. Same vocab as
           BattleReport so post-attack and pre-attack copy match. */}
       <PreviewModifiers preview={preview} />
+    </div>
+  );
+}
+
+function SelectedOffenseSpellBlock({
+  spell,
+  expectedMagnitude,
+}: {
+  spell: SpellDefinition;
+  expectedMagnitude: number;
+}) {
+  return (
+    <div className="rounded-md border border-amber-200 dark:border-amber-900 bg-amber-50/50 dark:bg-amber-950/20 p-3 flex gap-3">
+      <CatalogImage entry={spell} size="sm" />
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="font-semibold text-[11px] uppercase tracking-wide text-amber-700 dark:text-amber-300">
+            Offense spell · T{spell.tier} {spell.name}
+          </span>
+          <span className="font-mono text-[11px] text-amber-700 dark:text-amber-300 shrink-0">
+            ~+{Math.round(expectedMagnitude)} atk power
+          </span>
+        </div>
+        <p className="text-xs text-neutral-700 dark:text-neutral-300 leading-relaxed">
+          {spell.description}
+        </p>
+        <CatalogLore entry={spell} className="text-xs" />
+        <p className="text-[10px] text-neutral-500">
+          Cost +5 turns · midpoint dice 1.0× (actual roll 0.5–1.5×)
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -139,10 +139,50 @@ export function ThreatRow(props: ThreatRowProps) {
     entry.bestSource;
 
   const myCaste = player.caste;
+  // Show only spells the player has actually unlocked (tilesHeld gate).
+  // Turn-budget is a per-attack check applied by `attackDisabledReason` once
+  // a spell is selected, so we keep visibility broad enough that the player
+  // still sees freshly-unlocked spells even with a low turn count.
   const offenseSpells = useMemo<SpellDefinition[]>(
-    () => (myCaste ? getSpellsForCasteAndType(myCaste, "offense") : []),
-    [myCaste]
+    () =>
+      myCaste
+        ? getSpellsForCasteAndType(myCaste, "offense").filter(
+            (s) => player.stats.tilesHeld >= s.minTilesRequired
+          )
+        : [],
+    [myCaste, player.stats.tilesHeld]
   );
+  // Compute expected midpoint magnitude (flat attack-power add) per spell so
+  // the option label can preview the effect and the BattleSimPanel can show
+  // the selected spell's full description+lore inline.
+  const offenseSpellPreviews = useMemo(() => {
+    if (!myCaste) return new Map<string, number>();
+    const out = new Map<string, number>();
+    for (const s of offenseSpells) {
+      out.set(
+        s.id,
+        realizedSpellMagnitude({
+          baseStrength: s.baseStrength,
+          caste: s.caste,
+          spellType: s.type,
+          magicLandCount: myMagicLandCount,
+          activeUpgrades: player.activeUpgrades ?? {},
+          dice: 1.0,
+        })
+      );
+    }
+    return out;
+  }, [myCaste, offenseSpells, myMagicLandCount, player.activeUpgrades]);
+  const selectedOffenseSpell: SpellDefinition | null = useMemo(
+    () =>
+      offenseSpellId
+        ? offenseSpells.find((s) => s.id === offenseSpellId) ?? null
+        : null,
+    [offenseSpellId, offenseSpells]
+  );
+  const selectedOffenseExpected: number | null = selectedOffenseSpell
+    ? offenseSpellPreviews.get(selectedOffenseSpell.id) ?? null
+    : null;
   const defenseSpells = useMemo<SpellDefinition[]>(
     () => (myCaste ? getSpellsForCasteAndType(myCaste, "defense") : []),
     [myCaste]
@@ -182,7 +222,11 @@ export function ThreatRow(props: ThreatRowProps) {
 
   const enemyShielded = entry.enemyOwner?.shielded ?? false;
   const sentTotal = ground + siege + air;
-  const attackTurnCost = 1 + (offenseSpellId ? 5 : 0);
+  // Drive the turn-cost off the effective id (computed below) so a stale
+  // selection whose spell no longer resolves doesn't quote the wrong cost.
+  // Forward-reference is fine: effectiveOffenseSpellId is derived directly
+  // from selectedOffenseSpell which is already memoized above.
+  const attackTurnCost = 1 + (selectedOffenseSpell ? 5 : 0);
   const attackDisabledReason = (() => {
     if (enemyShielded) return "Enemy shielded";
     if (sentTotal === 0) return "No units selected";
@@ -205,11 +249,19 @@ export function ThreatRow(props: ThreatRowProps) {
   // preview refetches even when the form fields haven't changed — those
   // actions mutate server-side intel-effects that the projection reads.
   const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
+
+  // The "effective" id we send to the preview and attack APIs. If the
+  // staged offenseSpellId no longer resolves to a castable spell (e.g.
+  // tilesHeld dropped below its minTilesRequired since selection), fall
+  // back to none. Derived at use rather than via a cleanup effect so we
+  // don't trigger a cascading render.
+  const effectiveOffenseSpellId = selectedOffenseSpell ? selectedOffenseSpell.id : null;
+
   const attackPreview = useAttackPreview({
     sourceTileId: source.tileId,
     targetTileId: entry.enemyTile.tileId,
     units: { ground, siege, air },
-    offenseSpellId: offenseSpellId || null,
+    offenseSpellId: effectiveOffenseSpellId,
     disabled: previewDisabled,
     refreshKey: previewRefreshKey,
   });
@@ -221,7 +273,7 @@ export function ThreatRow(props: ThreatRowProps) {
       sourceTileId: source.tileId,
       targetTileId: entry.enemyTile.tileId,
       units: { ground, siege, air },
-      offenseSpellId: offenseSpellId || null,
+      offenseSpellId: effectiveOffenseSpellId,
     });
     if (res) {
       // If we have full combat detail + report + post-combat tile, render
@@ -485,11 +537,18 @@ export function ThreatRow(props: ThreatRowProps) {
               className="w-full px-2 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
             >
               <option value="">— none —</option>
-              {offenseSpells.map((s) => (
-                <option key={s.id} value={s.id}>
-                  T{s.tier} {s.name}
-                </option>
-              ))}
+              {offenseSpells.map((s) => {
+                const expected = offenseSpellPreviews.get(s.id);
+                const fx =
+                  expected !== undefined
+                    ? ` · ~+${Math.round(expected)} atk power`
+                    : "";
+                return (
+                  <option key={s.id} value={s.id}>
+                    T{s.tier} {s.name}{fx}
+                  </option>
+                );
+              })}
             </select>
           </label>
         </div>
@@ -511,6 +570,14 @@ export function ThreatRow(props: ThreatRowProps) {
       {/* ─── Battle simulation panel (live projection) ───────────────────── */}
       <div className="mx-4">
         <BattleSimPanel
+          selectedOffenseSpell={
+            selectedOffenseSpell
+              ? {
+                  spell: selectedOffenseSpell,
+                  expectedMagnitude: selectedOffenseExpected ?? 0,
+                }
+              : null
+          }
           preview={attackPreview.preview}
           loading={attackPreview.loading}
           error={attackPreview.error}

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -578,6 +578,19 @@ export function ThreatRow(props: ThreatRowProps) {
                 }
               : null
           }
+          useArtifact={{
+            artifacts: [...offensiveArtifacts, ...intelArtifacts].map((a) => ({
+              artifact: a,
+              definition: ARTIFACTS_BY_ID.get(a.definitionId) ?? null,
+            })),
+            onUse: (artifactId) => {
+              const a = [...offensiveArtifacts, ...intelArtifacts].find(
+                (x) => x.id === artifactId
+              );
+              if (a) void handleUseArtifact(a, entry.enemyTile.tileId);
+            },
+            disabledReason: busy ? "Busy" : null,
+          }}
           preview={attackPreview.preview}
           loading={attackPreview.loading}
           error={attackPreview.error}
@@ -738,9 +751,10 @@ export function ThreatRow(props: ThreatRowProps) {
                     onClick={() => handleUseArtifact(a, entry.enemyTile.tileId)}
                     disabled={busy}
                     title={def?.description ?? a.definitionId}
-                    className="px-3 py-1.5 text-xs rounded border border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30 disabled:opacity-50"
+                    className="flex items-center gap-2 px-2 py-1.5 text-xs rounded border border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30 disabled:opacity-50"
                   >
-                    Use {def?.name ?? a.definitionId}
+                    <CatalogImage entry={def ?? { name: a.definitionId }} size="xs" />
+                    <span>Use {def?.name ?? a.definitionId}</span>
                   </button>
                 );
               })}
@@ -750,9 +764,12 @@ export function ThreatRow(props: ThreatRowProps) {
           {/* Offensive artifacts (used on enemy tile) */}
           {offensiveArtifacts.length > 0 && (
             <section>
-              <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
-                Offensive artifacts (on enemy)
+              <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-1">
+                Offensive artifacts (on enemy) · one-time use
               </h3>
+              <p className="text-[11px] text-neutral-500 mb-2">
+                Spent before your attack — the bonus applies to your next swing.
+              </p>
               <div className="flex flex-wrap gap-2">
                 {offensiveArtifacts.map((a) => {
                   const def = ARTIFACTS_BY_ID.get(a.definitionId);
@@ -764,9 +781,10 @@ export function ThreatRow(props: ThreatRowProps) {
                       }
                       disabled={busy}
                       title={def?.description ?? a.definitionId}
-                      className="px-3 py-1.5 text-xs rounded border border-red-300 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-50"
+                      className="flex items-center gap-2 px-2 py-1.5 text-xs rounded border border-red-300 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-50"
                     >
-                      Use {def?.name ?? a.definitionId}
+                      <CatalogImage entry={def ?? { name: a.definitionId }} size="xs" />
+                      <span>Use {def?.name ?? a.definitionId}</span>
                     </button>
                   );
                 })}
@@ -819,7 +837,7 @@ export function ThreatRow(props: ThreatRowProps) {
               {defensiveArtifacts.length > 0 && (
                 <div>
                   <p className="text-xs text-neutral-500 mb-1">
-                    Defense artifacts (on source)
+                    Defense artifacts (on source) · one-time use
                   </p>
                   <div className="flex flex-wrap gap-2">
                     {defensiveArtifacts.map((a) => {
@@ -830,9 +848,10 @@ export function ThreatRow(props: ThreatRowProps) {
                           onClick={() => handleUseArtifact(a, source.tileId)}
                           disabled={busy}
                           title={def?.description ?? a.definitionId}
-                          className="px-3 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
+                          className="flex items-center gap-2 px-2 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
                         >
-                          Use {def?.name ?? a.definitionId}
+                          <CatalogImage entry={def ?? { name: a.definitionId }} size="xs" />
+                          <span>Use {def?.name ?? a.definitionId}</span>
                         </button>
                       );
                     })}

--- a/app/game/threats/_lib/use-attack-preview.ts
+++ b/app/game/threats/_lib/use-attack-preview.ts
@@ -112,14 +112,26 @@ export function useAttackPreview(args: PreviewArgs): PreviewState {
               : {}),
           }),
         });
+        // The error shape from apiError() is { message, code }, not a bare
+        // string — render flow used to drop the object straight into state
+        // and React would throw "Objects are not valid as a React child"
+        // when the message rendered. Extract .message defensively (still
+        // handle a string fallback in case some upstream returns one).
         const data = (await res.json()) as
           | (AttackPreview & { success: true })
-          | { success: false; error: string };
+          | {
+              success: false;
+              error: string | { message?: string; code?: string };
+            };
         // Stale-result guard: if a newer request fired while we waited,
         // discard this response.
         if (cancelled || myReqId !== reqIdRef.current) return;
         if (!data.success) {
-          setState({ preview: null, loading: false, error: data.error });
+          const errMsg =
+            typeof data.error === "string"
+              ? data.error
+              : (data.error?.message ?? "Preview failed");
+          setState({ preview: null, loading: false, error: errMsg });
           return;
         }
         setState({

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -215,7 +215,7 @@ export function OwnTilePanel({
               No unused defense artifacts in inventory.
             </p>
           ) : (
-            <div className="flex flex-wrap gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               {defensiveArtifacts.map((a) => {
                 const def = ARTIFACTS_BY_ID.get(a.definitionId);
                 return (
@@ -224,9 +224,17 @@ export function OwnTilePanel({
                     onClick={() => onUseArtifact(a.id)}
                     disabled={busy || tile.type === "unrevealed"}
                     title={def?.description ?? a.definitionId}
-                    className="px-3 py-1.5 text-sm border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50"
+                    className="flex items-start gap-2 p-2 text-left text-sm border border-blue-300 dark:border-blue-700 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50"
                   >
-                    Use {def?.name ?? a.definitionId}
+                    <CatalogImage entry={def ?? { name: a.definitionId }} size="sm" />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium truncate">
+                        Use {def?.name ?? a.definitionId}
+                      </div>
+                      <div className="text-[11px] text-neutral-600 dark:text-neutral-400 line-clamp-2 mt-0.5">
+                        {def?.description ?? ""}
+                      </div>
+                    </div>
                   </button>
                 );
               })}
@@ -327,7 +335,10 @@ export function EnemyTilePanel({
         <h2 className="text-sm font-semibold uppercase tracking-wide text-red-700 dark:text-red-300">
           Offensive artifacts
         </h2>
-        <div className="flex flex-wrap gap-2">
+        <p className="text-xs text-red-700/70 dark:text-red-300/70">
+          One-time use. The bonus consumes on your next attack.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           {offensiveArtifacts.map((a) => {
             const def = ARTIFACTS_BY_ID.get(a.definitionId);
             return (
@@ -336,9 +347,17 @@ export function EnemyTilePanel({
                 onClick={() => onUseArtifact(a.id)}
                 disabled={busy}
                 title={def?.description ?? a.definitionId}
-                className="px-3 py-1.5 text-sm border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
+                className="flex items-start gap-2 p-2 text-left text-sm border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
               >
-                Use {def?.name ?? a.definitionId}
+                <CatalogImage entry={def ?? { name: a.definitionId }} size="sm" />
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium truncate">
+                    Use {def?.name ?? a.definitionId}
+                  </div>
+                  <div className="text-[11px] text-neutral-600 dark:text-neutral-400 line-clamp-2 mt-0.5">
+                    {def?.description ?? ""}
+                  </div>
+                </div>
               </button>
             );
           })}
@@ -352,7 +371,10 @@ export function EnemyTilePanel({
         <h2 className="text-sm font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300">
           Intel artifacts
         </h2>
-        <div className="flex flex-wrap gap-2">
+        <p className="text-xs text-violet-700/70 dark:text-violet-300/70">
+          One-time use. Reveals intel on this tile when spent.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           {intelArtifacts.map((a) => {
             const def = ARTIFACTS_BY_ID.get(a.definitionId);
             return (
@@ -361,9 +383,17 @@ export function EnemyTilePanel({
                 onClick={() => onUseArtifact(a.id)}
                 disabled={busy}
                 title={def?.description ?? a.definitionId}
-                className="px-3 py-1.5 text-sm border border-violet-300 dark:border-violet-700 rounded-lg hover:bg-violet-100 dark:hover:bg-violet-900/30 transition-colors disabled:opacity-50"
+                className="flex items-start gap-2 p-2 text-left text-sm border border-violet-300 dark:border-violet-700 rounded-lg hover:bg-violet-100 dark:hover:bg-violet-900/30 transition-colors disabled:opacity-50"
               >
-                Use {def?.name ?? a.definitionId}
+                <CatalogImage entry={def ?? { name: a.definitionId }} size="sm" />
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium truncate">
+                    Use {def?.name ?? a.definitionId}
+                  </div>
+                  <div className="text-[11px] text-neutral-600 dark:text-neutral-400 line-clamp-2 mt-0.5">
+                    {def?.description ?? ""}
+                  </div>
+                </div>
               </button>
             );
           })}

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -12,6 +12,7 @@ import {
   ARTIFACTS_BY_ID,
   getUnitForCasteAndType,
 } from "@/lib/game/content";
+import { realizedSpellMagnitude } from "@/lib/game/combat";
 import { CatalogImage } from "@/app/game/_components/CatalogImage";
 import type {
   GameArtifact,
@@ -270,9 +271,22 @@ export function EnemyTilePanel({
   const targetBorders = new Set(neighborTileIds(tile.q, tile.r));
   const myBorders = ownedTiles.filter((t) => targetBorders.has(t.tileId));
   const myCaste = player.caste;
+  // Only show offense spells the player has actually unlocked (tilesHeld
+  // gate). Picking an unusable spell would 400 from the server and isn't a
+  // meaningful choice — better to hide them outright. Turn-budget is still
+  // handled by the disabled-attack reasoning below.
   const offenseSpells = myCaste
-    ? ALL_SPELLS.filter((s) => s.caste === myCaste && s.type === "offense")
+    ? ALL_SPELLS.filter(
+        (s) =>
+          s.caste === myCaste &&
+          s.type === "offense" &&
+          player.stats.tilesHeld >= s.minTilesRequired
+      )
     : [];
+  // Magic-land count drives spell scaling. PlayerStats doesn't store it
+  // directly, so we count it off the player's owned tiles. Cheap (the
+  // attack panel already has ownedTiles in scope).
+  const playerMagicLandCount = ownedTiles.filter((t) => t.type === "magic").length;
   const intelSpell = myCaste
     ? ALL_SPELLS.find((s) => s.caste === myCaste && s.type === "intel")
     : null;
@@ -452,11 +466,21 @@ export function EnemyTilePanel({
             className="mt-1 block w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
           >
             <option value="">— none —</option>
-            {offenseSpells.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.name}
-              </option>
-            ))}
+            {offenseSpells.map((s) => {
+              const expected = realizedSpellMagnitude({
+                baseStrength: s.baseStrength,
+                caste: s.caste,
+                spellType: s.type,
+                magicLandCount: playerMagicLandCount,
+                activeUpgrades: player.activeUpgrades ?? {},
+                dice: 1.0,
+              });
+              return (
+                <option key={s.id} value={s.id}>
+                  T{s.tier} {s.name} · ~+{Math.round(expected)} atk power
+                </option>
+              );
+            })}
           </select>
         </label>
 

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -380,6 +380,13 @@ export interface ArtifactDefinition {
   // For type === "intel": how deep the reveal goes when the artifact is spent
   // on a target tile. Ignored otherwise.
   intelDepth?: IntelDepth;
+  /** Long-form flavor / lore that stays visible on the artifact's catalog
+   *  card. Different from `flavorOnFind` (one-time discovery copy). UI falls
+   *  back to "No lore yet." when absent. */
+  lore?: string;
+  /** Path or URL to illustrative art. UI falls back to /logo.svg when absent.
+   *  Convention: /game/artifacts/<id>.png (e.g. "/game/artifacts/rare-stormglass-ward.png"). */
+  imageUrl?: string;
 }
 
 // Persisted, time-bounded combat effects produced by intel spells and


### PR DESCRIPTION
Two-commit release: a crash fix that's been live for a couple of hours on develop, plus the artifact UX pass.

## PRs / commits included

- `2acb062` feat(game): artifact UX overhaul — lore/imageUrl, prominent images, in-attack picker — @Ludwitt
- `9eca573` fix(game): attack-spell crash + filter to castable + preview spell effects — @Ludwitt

## What's in here

**Crash fix (`9eca573`):** Picking an offense spell during an attack used to crash the threats page. Root cause: `useAttackPreview` cast the error response as a string, but `apiError()` actually returns `{ message, code }` — React threw "Objects are not valid as a React child" when rendering it. Defensively extract `.message`. Also filtered the offense-spell `<select>` to only spells the player has unlocked, and added a midpoint-dice expected effect summary (`~+18 atk power`) on each option label plus a full selected-spell detail block in the battle simulation panel.

**Artifact UX (`2acb062`):**
- Added `lore` + `imageUrl` to `ArtifactDefinition` (parity with the other catalogs). `flavorOnFind` stays as discovery-time copy.
- `/game/artifacts` inventory cards now lead with a 64px image; lore + flavorOnFind stacked underneath.
- Every in-attack artifact button (offense/intel on enemy, defense on own tile, ThreatRow surfaces) now shows a 32px image + name + 2-line description preview instead of a tiny text-only button.
- BattleSimPanel got a new "Artifact (N) ▸" action next to spy/siege/flyover/cast — opens an inline picker with image + kind badge + rarity + description for every relevant artifact. One click consumes it via the existing `/api/game/artifact/use` flow; the effect rolls into the next attack through `preCastOffenseBonus` (offense) or the intel reveal pipeline (intel).
- Deferred: in-combat artifact effects (mid-`resolveAttack` mechanics) — flagged in the commit body, follow-up PR.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` (touched files) — clean
- [x] `check-route-contracts.js` — 158/0-debt
- [x] Dev-server smoke: `/game`, `/game/threats`, `/game/artifacts` all 200 with no compile errors
- [ ] Post-deploy: confirm the attack-spell crash is gone (pick a tier-locked spell — should now be hidden) and the BattleSim "Artifact ▸" picker opens with images + descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)