### PR TITLE
revert(game): pull artifact picker out of BattleSimPanel

### DIFF
--- a/app/game/threats/_components/BattleSimPanel.tsx
+++ b/app/game/threats/_components/BattleSimPanel.tsx
@@ -8,12 +8,7 @@
 
 import { useState } from "react";
 import { SPELLS_BY_ID } from "@/lib/game/content";
-import type {
-  ArtifactDefinition,
-  GameArtifact,
-  SpellDefinition,
-  UnitStack,
-} from "@/lib/game/types";
+import type { SpellDefinition, UnitStack } from "@/lib/game/types";
 import type { AttackPreview } from "../_lib/use-attack-preview";
 import { CatalogImage } from "@/app/game/_components/CatalogImage";
 import { CatalogLore } from "@/app/game/_components/CatalogLore";
@@ -69,19 +64,13 @@ export interface BattleSimPanelProps {
     turnCost: number;
     disabledReason: string | null;
   };
-  // Expandable artifact-use picker. Lets the player spend a relevant
-  // offensive/intel artifact from within the attack flow rather than
-  // hunting for it in a separate panel — these are one-time-use items
-  // whose effects fold into the very next attack.
-  useArtifact?: {
-    artifacts: ReadonlyArray<{
-      artifact: GameArtifact;
-      definition: ArtifactDefinition | null;
-    }>;
-    onUse: (artifactId: string) => void;
-    disabledReason: string | null;
-  };
 }
+
+// Artifacts are deliberately NOT surfaced inside this panel. They're
+// one-time pre-attack items and live in the dedicated "Offensive / Intel /
+// Defense artifacts" sections outside the attack form, so a click never
+// happens "inside the attack" and the consumed-vs-staged distinction stays
+// unambiguous.
 
 function totalUnits(s: UnitStack): number {
   return s.ground + s.siege + s.air;
@@ -110,7 +99,6 @@ export function BattleSimPanel({
   siege,
   flyover,
   castSpell,
-  useArtifact,
   selectedOffenseSpell,
 }: BattleSimPanelProps) {
   return (
@@ -157,7 +145,6 @@ export function BattleSimPanel({
           siege={siege}
           flyover={flyover}
           castSpell={castSpell}
-          useArtifact={useArtifact}
         />
       </div>
     </div>
@@ -394,7 +381,6 @@ function ActionButtonStrip({
   siege,
   flyover,
   castSpell,
-  useArtifact,
 }: {
   disabled?: boolean;
   busy?: boolean;
@@ -402,10 +388,8 @@ function ActionButtonStrip({
   siege?: BattleSimPanelProps["siege"];
   flyover?: BattleSimPanelProps["flyover"];
   castSpell?: BattleSimPanelProps["castSpell"];
-  useArtifact?: BattleSimPanelProps["useArtifact"];
 }) {
   const [castOpen, setCastOpen] = useState(false);
-  const [artifactOpen, setArtifactOpen] = useState(false);
 
   const wholePanelDisabledReason = disabled
     ? "Preview disabled — pre-actions unavailable."
@@ -458,20 +442,6 @@ function ActionButtonStrip({
         `Pick a siege/disarm/attrition spell · ${castSpell.turnCost} turns`,
     });
   }
-  if (useArtifact && useArtifact.artifacts.length > 0) {
-    const reason = wholePanelDisabledReason ?? useArtifact.disabledReason;
-    buttons.push({
-      key: "artifact",
-      label: `Artifact (${useArtifact.artifacts.length}) ${
-        artifactOpen ? "▾" : "▸"
-      }`,
-      onClick: reason ? undefined : () => setArtifactOpen((o) => !o),
-      disabled: reason !== null,
-      title:
-        reason ??
-        `Spend a one-time artifact whose effect rolls into your next attack`,
-    });
-  }
   if (buttons.length === 0) {
     return (
       <div className="flex flex-wrap gap-2 pt-1">
@@ -521,85 +491,6 @@ function ActionButtonStrip({
           onAfterCast={() => setCastOpen(false)}
         />
       )}
-      {artifactOpen && useArtifact && (
-        <UseArtifactPicker
-          useArtifact={useArtifact}
-          wholePanelDisabledReason={wholePanelDisabledReason}
-          onAfterUse={() => setArtifactOpen(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-function UseArtifactPicker({
-  useArtifact,
-  wholePanelDisabledReason,
-  onAfterUse,
-}: {
-  useArtifact: NonNullable<BattleSimPanelProps["useArtifact"]>;
-  wholePanelDisabledReason: string | null;
-  onAfterUse: () => void;
-}) {
-  return (
-    <div className="rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
-      <div className="px-3 py-1.5 border-b border-neutral-200 dark:border-neutral-800 text-[10px] uppercase tracking-wide text-neutral-500">
-        Spend an artifact · one-time use · effect rolls into your next attack
-      </div>
-      <ul className="divide-y divide-neutral-100 dark:divide-neutral-900">
-        {useArtifact.artifacts.map((entry) => {
-          const blocked = wholePanelDisabledReason !== null;
-          const def = entry.definition;
-          const kindLabel =
-            def?.type === "offense"
-              ? "⚔ Offense"
-              : def?.type === "intel"
-                ? "🔎 Intel"
-                : def?.type === "defense"
-                  ? "🛡 Defense"
-                  : "✨ Artifact";
-          return (
-            <li key={entry.artifact.id}>
-              <button
-                type="button"
-                disabled={blocked}
-                title={wholePanelDisabledReason ?? def?.description ?? entry.artifact.definitionId}
-                onClick={() => {
-                  if (blocked) return;
-                  useArtifact.onUse(entry.artifact.id);
-                  onAfterUse();
-                }}
-                className={`w-full flex items-center gap-3 px-3 py-2 text-left text-[11px] transition-colors ${
-                  blocked
-                    ? "text-neutral-400 dark:text-neutral-600 cursor-not-allowed"
-                    : "hover:bg-neutral-100 dark:hover:bg-neutral-900"
-                }`}
-              >
-                <CatalogImage
-                  entry={def ?? { name: entry.artifact.definitionId }}
-                  size="sm"
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-baseline gap-2">
-                    <span className="font-medium shrink-0">{kindLabel}</span>
-                    <span className="truncate">
-                      · {def?.name ?? entry.artifact.definitionId}
-                    </span>
-                    <span className="ml-auto font-mono text-neutral-500 shrink-0 capitalize">
-                      {entry.artifact.rarity}
-                    </span>
-                  </div>
-                  {def?.description ? (
-                    <p className="text-[10px] text-neutral-500 dark:text-neutral-400 mt-0.5 line-clamp-2">
-                      {def.description}
-                    </p>
-                  ) : null}
-                </div>
-              </button>
-            </li>
-          );
-        })}
-      </ul>
     </div>
   );
 }

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -578,19 +578,6 @@ export function ThreatRow(props: ThreatRowProps) {
                 }
               : null
           }
-          useArtifact={{
-            artifacts: [...offensiveArtifacts, ...intelArtifacts].map((a) => ({
-              artifact: a,
-              definition: ARTIFACTS_BY_ID.get(a.definitionId) ?? null,
-            })),
-            onUse: (artifactId) => {
-              const a = [...offensiveArtifacts, ...intelArtifacts].find(
-                (x) => x.id === artifactId
-              );
-              if (a) void handleUseArtifact(a, entry.enemyTile.tileId);
-            },
-            disabledReason: busy ? "Busy" : null,
-          }}
           preview={attackPreview.preview}
           loading={attackPreview.loading}
           error={attackPreview.error}


### PR DESCRIPTION
Single-commit revert release.

## PRs / commits included

- `3a20850` revert(game): pull artifact picker out of BattleSimPanel — @Ludwitt

## What this does

Removes the artifact-use picker I added to BattleSimPanel in the previous release. Artifacts are pre-attack items by design — surfacing them inside the attack form blurred the line (a click inside the "attack staging" UI would consume the artifact instantly, which was the wrong mental model).

Artifact use now happens exclusively from the dedicated pre-attack sections (Offensive / Intel artifacts on the enemy panel, Defense artifacts on the source-tile panel). Those still have the image + 2-line description treatment from the prior commit so they're easy to spot.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` (touched files) — clean
- [ ] Post-deploy: confirm BattleSimPanel no longer shows an "Artifact ▸" button; confirm the dedicated artifact sections still render with images + descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)