### PR TITLE
refactor(game): move caste lore into the catalog

### DIFF
--- a/app/game/setup/_components/CastePickCard.tsx
+++ b/app/game/setup/_components/CastePickCard.tsx
@@ -59,10 +59,7 @@ export function CastePickCard({ caste, busy, onChoose }: Props) {
         </div>
       </div>
 
-      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed mb-2">
-        {presentation.lore}
-      </p>
-      <CatalogLore entry={profile} className="mb-3" />
+      <CatalogLore entry={profile} className="mb-3 text-sm leading-relaxed" />
 
       <div className="grid grid-cols-3 gap-2 text-xs mb-3">
         <Stat

--- a/app/game/setup/_lib/constants.ts
+++ b/app/game/setup/_lib/constants.ts
@@ -10,43 +10,34 @@ export const CASTES: Caste[] = ["white", "blue", "black", "red", "green"];
 
 export const DISTRIBUTABLE: LandType[] = ["military", "food", "magic"];
 
-// Caste accent + lore text shown on the caste-pick card. Lore is intentionally
-// short (1 paragraph), matches the in-game restraint, and avoids real-world
-// references. Edit here when retuning caste identity; keep tone aligned with
-// docs/generals/LORE.md.
+// Caste swatch + tagline shown on the caste-pick card. The longer lore
+// paragraph lives on `CasteProfile.lore` in lib/game/content/castes.ts so
+// it sits next to the mechanical caste data (and renders via CatalogLore
+// like every other catalog entry). Edit lore there; edit swatch/tagline
+// here. Keep tone aligned with docs/generals/LORE.md.
 export const CASTE_PRESENTATION: Record<
   Caste,
-  { swatch: string; tagline: string; lore: string }
+  { swatch: string; tagline: string }
 > = {
   white: {
     swatch: "#e5e7eb",
     tagline: "Light · order · the long defense",
-    lore:
-      "White moves slowly and remembers everything. Their banners are old, their drills older, and their pikemen will hold a road for as many days as the road needs holding. Sanctuaries glow on the hilltops at dusk; the priests do not explain how.",
   },
   blue: {
     swatch: "#60a5fa",
     tagline: "Water · sky · the patient tide",
-    lore:
-      "Blue plays the long economy. Their captains are astronomers, their air corps moves on currents no scout can chart, and their production magic refills granaries through a winter no one can quite remember surviving. They win wars that began three seasons ago.",
   },
   black: {
     swatch: "#a78bfa",
     tagline: "Death · blood · the cost paid forward",
-    lore:
-      "Black armies are quiet at the edges and loud in the middle. Their reavers are bone-armored and tireless; their blood-tide spells fall on a battlefield like a price already settled. They take towns by walking through them. They keep no prisoners they can spare.",
   },
   red: {
     swatch: "#f87171",
     tagline: "Fire · forge · the short hot sentence",
-    lore:
-      "Red wars are decided in three days or three minutes. Their siege foundries turn out trebuchets that smell of pitch and bone-glue; their pyre-mortars throw heat that cracks stone. Their defenses are thin because their generals do not intend to need them.",
   },
   green: {
     swatch: "#4ade80",
     tagline: "Wood · growth · the held line",
-    lore:
-      "Green takes ground and keeps it. Their wardens build deeper than other castes, and their tiles hold more soldiers per acre because the soldiers eat from the land they stand on. Their air is weak; they don't intend to leave the ground.",
   },
 };
 

--- a/lib/game/content/castes.ts
+++ b/lib/game/content/castes.ts
@@ -38,6 +38,8 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       attrition: 0.85,
     },
     supplyMultiplier: 1.25,
+    lore:
+      "White moves slowly and remembers everything. Their banners are old, their drills older, and their pikemen will hold a road for as many days as the road needs holding. Sanctuaries glow on the hilltops at dusk; the priests do not explain how.",
   },
   blue: {
     caste: "blue",
@@ -53,6 +55,8 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       attrition: 1.05,
     },
     supplyMultiplier: 0.75,
+    lore:
+      "Blue plays the long economy. Their captains are astronomers, their air corps moves on currents no scout can chart, and their production magic refills granaries through a winter no one can quite remember surviving. They win wars that began three seasons ago.",
   },
   black: {
     caste: "black",
@@ -68,6 +72,8 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       attrition: 1.30,
     },
     supplyMultiplier: 0.5,
+    lore:
+      "Black armies are quiet at the edges and loud in the middle. Their reavers are bone-armored and tireless; their blood-tide spells fall on a battlefield like a price already settled. They take towns by walking through them. They keep no prisoners they can spare.",
   },
   red: {
     caste: "red",
@@ -83,6 +89,8 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       attrition: 1.00,
     },
     supplyMultiplier: 1.0,
+    lore:
+      "Red wars are decided in three days or three minutes. Their siege foundries turn out trebuchets that smell of pitch and bone-glue; their pyre-mortars throw heat that cracks stone. Their defenses are thin because their generals do not intend to need them.",
   },
   green: {
     caste: "green",
@@ -98,6 +106,8 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       attrition: 0.85,
     },
     supplyMultiplier: 1.5,
+    lore:
+      "Green takes ground and keeps it. Their wardens build deeper than other castes, and their tiles hold more soldiers per acre because the soldiers eat from the land they stand on. Their air is weak; they don't intend to leave the ground.",
   },
 };
 


### PR DESCRIPTION
Single-commit release.

## PRs / commits included

- `0184975` refactor(game): move caste lore into the catalog — @Ludwitt

## What this does

Consolidates caste lore into a single source. `CasteProfile.lore` was added in the original plumbing commit but never populated; the real lore strings lived in `CASTE_PRESENTATION` (a UI constants file), and CastePickCard ended up rendering both — the real paragraph, then a "No lore yet." placeholder right beneath it. Now:

- The five caste lore strings live on `CASTE_PROFILES.lore` in `lib/game/content/castes.ts`, sitting next to the caste's mechanical data — same pattern as every other catalog entry.
- `CASTE_PRESENTATION` keeps swatch + tagline only (genuine UI-display concerns).
- `CastePickCard` renders caste lore via the same `<CatalogLore>` component used everywhere else, so the placeholder fallback fires correctly if any caste's lore is cleared.

No content changes — same five paragraphs, new home.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` (touched files) — clean
- [ ] Post-deploy: visit `/game/setup` and confirm each caste card shows its lore exactly once (no duplicate paragraph, no "No lore yet." placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)