### PR TITLE
release: game/threats attack-tab redesign + caste-lore refactor + docs sync

### DIFF
--- a/app/game/threats/_components/ArmyPanel.tsx
+++ b/app/game/threats/_components/ArmyPanel.tsx
@@ -1,0 +1,197 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import {
+  ALL_BUILDINGS,
+  ALL_UNITS,
+  UPGRADES_BY_ID,
+} from "@/lib/game/content";
+import { getActiveUpgrades } from "@/lib/game/upgrades";
+import type {
+  BuildingDefinition,
+  Caste,
+  GamePlayer,
+  UnitDefinition,
+  UpgradeDefinition,
+} from "@/lib/game/types";
+
+export interface ArmyPanelProps {
+  player: GamePlayer;
+}
+
+interface UnitRow {
+  unit: UnitDefinition;
+  upgrade: UpgradeDefinition | null;
+}
+interface BuildingRow {
+  building: BuildingDefinition;
+  upgrade: UpgradeDefinition | null;
+}
+
+/**
+ * Top-of-page reference card on the Threats list. Shows the player's
+ * caste, their three unit profiles (ground / siege / air) with whichever
+ * caste-specific upgrade is active on each, and the three caste buildings
+ * (military / food / magic) with the same. Lets the player see at a
+ * glance what their army's actually carrying before they commit to a
+ * matchup — no need to round-trip to /game/upgrades.
+ *
+ * Units and buildings whose upgrade slot is empty render with a dimmed
+ * "no upgrade picked" badge linking the player to /game/upgrades.
+ */
+export function ArmyPanel(props: ArmyPanelProps) {
+  const { player } = props;
+  const [open, setOpen] = useState(true);
+
+  const rows = useMemo(() => {
+    if (!player.caste) {
+      return { units: [], buildings: [] };
+    }
+    return computeRows(player.caste, getActiveUpgrades(player));
+  }, [player]);
+
+  if (!player.caste) return null;
+
+  return (
+    <section className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full px-4 py-2 flex items-baseline justify-between text-left hover:bg-neutral-50 dark:hover:bg-neutral-900/40"
+        aria-expanded={open}
+      >
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold tracking-wide uppercase text-neutral-700 dark:text-neutral-200">
+            🪖 Your army
+          </h2>
+          <span className="text-[10px] text-neutral-500 capitalize">
+            · {player.caste} caste
+          </span>
+        </div>
+        <span className="text-xs text-neutral-500">{open ? "▾" : "▸"}</span>
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4 pt-1 space-y-3">
+          <Group label="Units" rows={rows.units} kind="unit" />
+          <Group
+            label="Tiles & buildings"
+            rows={rows.buildings}
+            kind="building"
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Group({
+  label,
+  rows,
+  kind,
+}: {
+  label: string;
+  rows: ReadonlyArray<UnitRow | BuildingRow>;
+  kind: "unit" | "building";
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="space-y-1.5">
+      <h3 className="text-[11px] uppercase tracking-wide text-neutral-500">
+        {label}
+      </h3>
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {rows.map((row) => (
+          <Card key={kind === "unit" ? (row as UnitRow).unit.id : (row as BuildingRow).building.id} row={row} kind={kind} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  row,
+  kind,
+}: {
+  row: UnitRow | BuildingRow;
+  kind: "unit" | "building";
+}) {
+  const base = kind === "unit" ? (row as UnitRow).unit : (row as BuildingRow).building;
+  const upgrade = row.upgrade;
+  const subtitle =
+    kind === "unit"
+      ? `${(row as UnitRow).unit.type}`
+      : `${(row as BuildingRow).building.landType}`;
+  // When an upgrade is picked, show its art + name; otherwise show the
+  // base unit/building art so the row still has a visual.
+  const display = upgrade ?? base;
+  const tone = upgrade
+    ? "border-emerald-300 dark:border-emerald-800 bg-emerald-50/40 dark:bg-emerald-950/10"
+    : "border-neutral-200 dark:border-neutral-800";
+  return (
+    <div
+      className={`flex items-start gap-2 p-2 rounded-md border ${tone}`}
+      title={upgrade?.description ?? base.description}
+    >
+      <CatalogImage entry={display} size="sm" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-xs font-medium truncate">{base.name}</span>
+          <span className="text-[10px] uppercase tracking-wide text-neutral-500 shrink-0">
+            {subtitle}
+          </span>
+        </div>
+        {upgrade ? (
+          <p className="text-[11px] text-emerald-700 dark:text-emerald-300 mt-0.5 truncate">
+            ⚙ {upgrade.name}
+          </p>
+        ) : (
+          <p className="text-[11px] text-neutral-500 italic mt-0.5">
+            no upgrade picked
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function computeRows(
+  caste: Caste,
+  active: Record<string, string>
+): { units: UnitRow[]; buildings: BuildingRow[] } {
+  const units: UnitRow[] = ALL_UNITS.filter((u) => u.caste === caste)
+    .sort(unitSort)
+    .map((u) => ({
+      unit: u,
+      upgrade: lookupUpgrade(active[u.id]),
+    }));
+  const buildings: BuildingRow[] = ALL_BUILDINGS.filter((b) => b.caste === caste)
+    .sort(buildingSort)
+    .map((b) => ({
+      building: b,
+      upgrade: lookupUpgrade(active[b.id]),
+    }));
+  return { units, buildings };
+}
+
+function lookupUpgrade(upgradeId: string | undefined): UpgradeDefinition | null {
+  if (!upgradeId) return null;
+  return UPGRADES_BY_ID.get(upgradeId) ?? null;
+}
+
+function unitSort(a: UnitDefinition, b: UnitDefinition): number {
+  const order = { ground: 0, siege: 1, air: 2 } as const;
+  return order[a.type] - order[b.type];
+}
+
+function buildingSort(a: BuildingDefinition, b: BuildingDefinition): number {
+  const order: Record<string, number> = { military: 0, food: 1, magic: 2 };
+  return (order[a.landType] ?? 99) - (order[b.landType] ?? 99);
+}

--- a/app/game/threats/_components/BattleSimPanel.tsx
+++ b/app/game/threats/_components/BattleSimPanel.tsx
@@ -6,7 +6,6 @@
 
 "use client";
 
-import { useState } from "react";
 import { SPELLS_BY_ID } from "@/lib/game/content";
 import type { SpellDefinition, UnitStack } from "@/lib/game/types";
 import type { AttackPreview } from "../_lib/use-attack-preview";
@@ -17,6 +16,11 @@ export interface BattleSimPanelProps {
   preview: AttackPreview | null;
   loading: boolean;
   error: string | null;
+  // True when the calling row has determined the attack is structurally
+  // impossible (e.g. enemy shielded). The panel renders a muted "preview
+  // unavailable" state instead of stale numbers.
+  disabled?: boolean;
+  disabledReason?: string;
   /**
    * The offense spell the player currently has staged for the attack (the
    * value of the offense-spell `<select>` in ThreatRow). When set, the
@@ -29,48 +33,14 @@ export interface BattleSimPanelProps {
     /** Midpoint-dice attack-power boost (already caste/magic-multiplied). */
     expectedMagnitude: number;
   } | null;
-  // True when the calling row has determined the attack is structurally
-  // impossible (e.g. enemy shielded). The panel renders a muted "preview
-  // unavailable" state instead of stale numbers.
-  disabled?: boolean;
-  disabledReason?: string;
-  // Action handlers. Each is independently optional — Phase 4 will wire
-  // onCastSpell after Phase 3's spy/siege/flyover ship. Disabled reasons
-  // come pre-computed from the parent (turn budget, unit availability,
-  // shield, busy) so the panel just renders.
-  busy?: boolean;
-  spy?: { onClick: () => void; turnCost: number; disabledReason: string | null };
-  siege?: { onClick: () => void; turnCost: number; disabledReason: string | null };
-  flyover?: {
-    onClick: () => void;
-    turnCost: number;
-    disabledReason: string | null;
-    airUnits: number;
-  };
-  // Expandable spell-cast picker. The player sees three options (siege /
-  // disarm / attrition) populated by the parent. Clicking the parent
-  // button toggles the picker; clicking a spell row fires onCast.
-  castSpell?: {
-    spells: ReadonlyArray<{
-      spell: SpellDefinition;
-      // Pre-computed midpoint magnitude (dice=1.0) so the picker can
-      // show the player what to expect on average.
-      expectedMagnitude: number;
-      // Already-disabled tooltip if the player can't cast this spell
-      // (turn budget, tile minimum, etc.). null = clickable.
-      disabledReason: string | null;
-    }>;
-    onCast: (spellId: string) => void;
-    turnCost: number;
-    disabledReason: string | null;
-  };
 }
 
-// Artifacts are deliberately NOT surfaced inside this panel. They're
-// one-time pre-attack items and live in the dedicated "Offensive / Intel /
-// Defense artifacts" sections outside the attack form, so a click never
-// happens "inside the attack" and the consumed-vs-staged distinction stays
-// unambiguous.
+// Pre-attack actions (spy / siege / flyover / cast spell) live in the new
+// BoostPanel — this component is a pure projection now. Artifacts also live
+// outside this panel (BoostPanel for offense+intel, ManageSourcePanel for
+// defense) so the "Selected offense spell" block is the only action-adjacent
+// element here, and even that's a *display* of the picker upstream, not a
+// click target.
 
 function totalUnits(s: UnitStack): number {
   return s.ground + s.siege + s.air;
@@ -82,11 +52,10 @@ function fmtStack(s: UnitStack): string {
 
 /**
  * Inline live battle simulation panel for the ThreatRow attack form.
- * Renders the projected combat outcome (midpoint RNG, no commitment) plus
- * a strip of pre-attack action buttons.
+ * Renders the projected combat outcome (midpoint RNG, no commitment).
  *
- * V1: read-only — the action buttons are present but disabled with a
- * "Coming soon" tooltip. Phases 3 and 4 wire them up.
+ * Pure-preview: contains no action buttons. Pre-attack actions live in
+ * the sibling BoostPanel; source-side actions live in ManageSourcePanel.
  */
 export function BattleSimPanel({
   preview,
@@ -94,18 +63,13 @@ export function BattleSimPanel({
   error,
   disabled,
   disabledReason,
-  busy,
-  spy,
-  siege,
-  flyover,
-  castSpell,
   selectedOffenseSpell,
 }: BattleSimPanelProps) {
   return (
-    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50/50 dark:bg-neutral-900/30 my-3">
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50/50 dark:bg-neutral-900/30">
       <div className="flex items-baseline justify-between px-3 py-2 border-b border-neutral-200 dark:border-neutral-800">
         <h4 className="font-semibold uppercase tracking-wide text-[11px] text-neutral-600 dark:text-neutral-300">
-          Battle simulation
+          📊 Projected outcome
         </h4>
         <span className="text-[10px] text-neutral-500">
           midpoint projection · no turns spent
@@ -137,15 +101,6 @@ export function BattleSimPanel({
             expectedMagnitude={selectedOffenseSpell.expectedMagnitude}
           />
         ) : null}
-
-        <ActionButtonStrip
-          disabled={disabled}
-          busy={busy}
-          spy={spy}
-          siege={siege}
-          flyover={flyover}
-          castSpell={castSpell}
-        />
       </div>
     </div>
   );
@@ -238,8 +193,6 @@ function PreviewBody({
         </div>
       )}
 
-      {/* Tile-type modifiers — only show when non-neutral. Same vocab as
-          BattleReport so post-attack and pre-attack copy match. */}
       <PreviewModifiers preview={preview} />
     </div>
   );
@@ -364,202 +317,4 @@ function buildActivePreps(effects: AttackPreview["effects"]): {
     });
   }
   return out;
-}
-
-interface ActionButton {
-  key: string;
-  label: string;
-  onClick?: () => void;
-  disabled: boolean;
-  title: string;
-}
-
-function ActionButtonStrip({
-  disabled,
-  busy,
-  spy,
-  siege,
-  flyover,
-  castSpell,
-}: {
-  disabled?: boolean;
-  busy?: boolean;
-  spy?: BattleSimPanelProps["spy"];
-  siege?: BattleSimPanelProps["siege"];
-  flyover?: BattleSimPanelProps["flyover"];
-  castSpell?: BattleSimPanelProps["castSpell"];
-}) {
-  const [castOpen, setCastOpen] = useState(false);
-
-  const wholePanelDisabledReason = disabled
-    ? "Preview disabled — pre-actions unavailable."
-    : busy
-      ? "Another action is in progress…"
-      : null;
-
-  const buttons: ActionButton[] = [];
-  if (spy) {
-    const reason = wholePanelDisabledReason ?? spy.disabledReason;
-    buttons.push({
-      key: "spy",
-      label: `Spy +${spy.turnCost}T`,
-      onClick: reason ? undefined : spy.onClick,
-      disabled: reason !== null,
-      title: reason ?? `Cast intel spell · ${spy.turnCost} turns`,
-    });
-  }
-  if (siege) {
-    const reason = wholePanelDisabledReason ?? siege.disabledReason;
-    buttons.push({
-      key: "siege",
-      label: `Siege +${siege.turnCost}T`,
-      onClick: reason ? undefined : siege.onClick,
-      disabled: reason !== null,
-      title: reason ?? `Soften standing defense · ${siege.turnCost} turns`,
-    });
-  }
-  if (flyover) {
-    const reason = wholePanelDisabledReason ?? flyover.disabledReason;
-    buttons.push({
-      key: "flyover",
-      label: `Flyover (${flyover.airUnits}a) +${flyover.turnCost}T`,
-      onClick: reason ? undefined : flyover.onClick,
-      disabled: reason !== null,
-      title:
-        reason ??
-        `Send ${flyover.airUnits} air to attrit defenders · 2× attacker losses · ${flyover.turnCost} turn`,
-    });
-  }
-  if (castSpell) {
-    const reason = wholePanelDisabledReason ?? castSpell.disabledReason;
-    buttons.push({
-      key: "cast",
-      label: `Cast +${castSpell.turnCost}T ${castOpen ? "▾" : "▸"}`,
-      onClick: reason ? undefined : () => setCastOpen((o) => !o),
-      disabled: reason !== null,
-      title:
-        reason ??
-        `Pick a siege/disarm/attrition spell · ${castSpell.turnCost} turns`,
-    });
-  }
-  if (buttons.length === 0) {
-    return (
-      <div className="flex flex-wrap gap-2 pt-1">
-        {[
-          { label: "Spy +5T", note: "Not wired" },
-          { label: "Siege +5T", note: "Not wired" },
-          { label: "Flyover ▸", note: "Not wired" },
-          { label: "Cast ▸", note: "Not wired" },
-        ].map((b) => (
-          <button
-            key={b.label}
-            type="button"
-            disabled
-            title={b.note}
-            className="px-3 py-1 text-[11px] rounded border border-neutral-200 dark:border-neutral-800 text-neutral-400 dark:text-neutral-600 bg-neutral-50 dark:bg-neutral-900/40 cursor-not-allowed"
-          >
-            {b.label}
-          </button>
-        ))}
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap gap-2 pt-1">
-        {buttons.map((b) => (
-          <button
-            key={b.key}
-            type="button"
-            onClick={b.onClick}
-            disabled={b.disabled}
-            title={b.title}
-            className={`px-3 py-1 text-[11px] rounded border transition-colors ${
-              b.disabled
-                ? "border-neutral-200 dark:border-neutral-800 text-neutral-400 dark:text-neutral-600 bg-neutral-50 dark:bg-neutral-900/40 cursor-not-allowed"
-                : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-700 dark:text-neutral-300"
-            }`}
-          >
-            {b.label}
-          </button>
-        ))}
-      </div>
-      {castOpen && castSpell && (
-        <CastSpellPicker
-          castSpell={castSpell}
-          wholePanelDisabledReason={wholePanelDisabledReason}
-          onAfterCast={() => setCastOpen(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-function CastSpellPicker({
-  castSpell,
-  wholePanelDisabledReason,
-  onAfterCast,
-}: {
-  castSpell: NonNullable<BattleSimPanelProps["castSpell"]>;
-  wholePanelDisabledReason: string | null;
-  onAfterCast: () => void;
-}) {
-  function fmtMagnitude(spell: SpellDefinition, expected: number): string {
-    if (spell.type === "siege") {
-      return `~−${(expected * 100).toFixed(0)}% standing floor`;
-    }
-    if (spell.type === "disarm") {
-      return `~${(Math.min(1, expected) * 100).toFixed(0)}% disarm`;
-    }
-    if (spell.type === "attrition") {
-      return `~${Math.round(expected)} enemies lost`;
-    }
-    return "";
-  }
-  return (
-    <div className="rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
-      <div className="px-3 py-1.5 border-b border-neutral-200 dark:border-neutral-800 text-[10px] uppercase tracking-wide text-neutral-500">
-        Choose spell · {castSpell.turnCost} turns each · dice 0.5–1.5×
-      </div>
-      <ul className="divide-y divide-neutral-100 dark:divide-neutral-900">
-        {castSpell.spells.map((entry) => {
-          const reason = wholePanelDisabledReason ?? entry.disabledReason;
-          const blocked = reason !== null;
-          const labelKind =
-            entry.spell.type === "siege"
-              ? "🏰 Siege"
-              : entry.spell.type === "disarm"
-                ? "✨ Disarm"
-                : "☠ Attrition";
-          return (
-            <li key={entry.spell.id}>
-              <button
-                type="button"
-                disabled={blocked}
-                title={reason ?? "Cast this spell on the target"}
-                onClick={() => {
-                  if (blocked) return;
-                  castSpell.onCast(entry.spell.id);
-                  onAfterCast();
-                }}
-                className={`w-full flex items-center justify-between gap-3 px-3 py-2 text-left text-[11px] transition-colors ${
-                  blocked
-                    ? "text-neutral-400 dark:text-neutral-600 cursor-not-allowed"
-                    : "hover:bg-neutral-100 dark:hover:bg-neutral-900"
-                }`}
-              >
-                <span className="flex items-baseline gap-2 min-w-0">
-                  <span className="font-medium shrink-0">{labelKind}</span>
-                  <span className="truncate">· {entry.spell.name}</span>
-                </span>
-                <span className="font-mono text-neutral-500 shrink-0">
-                  {fmtMagnitude(entry.spell, entry.expectedMagnitude)}
-                </span>
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
 }

--- a/app/game/threats/_components/BoostPanel.tsx
+++ b/app/game/threats/_components/BoostPanel.tsx
@@ -1,0 +1,399 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import type {
+  ArtifactDefinition,
+  GameArtifact,
+  SpellDefinition,
+} from "@/lib/game/types";
+
+type TabId = "artifact" | "spy" | "siege" | "flyover";
+
+export interface BoostPanelProps {
+  busy?: boolean;
+
+  /** Artifacts the player can spend before this attack. Each row carries
+   *  both the instance + its definition so the picker can render image,
+   *  name, rarity, description. Buckets are kept separate so we can
+   *  surface "intel" under the Spy tab and "offense" under Artifacts. */
+  offensiveArtifacts: ReadonlyArray<{
+    artifact: GameArtifact;
+    definition: ArtifactDefinition | null;
+  }>;
+  intelArtifacts: ReadonlyArray<{
+    artifact: GameArtifact;
+    definition: ArtifactDefinition | null;
+  }>;
+  /** The artifact id currently *queued* for the upcoming attack. Empty
+   *  string means nothing queued. The parent owns this state and clears
+   *  it once the attack actually fires (consuming the artifact). */
+  queuedArtifactId: string;
+  /** Toggles which offensive artifact is queued. Click the same card
+   *  again to clear. Queuing does NOT consume the artifact — the
+   *  consumption only happens when the parent fires the attack. */
+  onQueueArtifact: (artifactId: string) => void;
+  /** Intel-tab artifacts (under Spy intel) are reveals — they fire
+   *  immediately because the player needs the info before deciding to
+   *  attack. Distinct path from queueable offensive artifacts. */
+  onUseIntelArtifact: (artifactId: string) => void;
+
+  /** Spy intel spell (single-spell action, distinct from intel artifacts). */
+  spy?: {
+    spell: SpellDefinition;
+    onClick: () => void;
+    disabledReason: string | null;
+  };
+
+  /** Pre-attack siege action — reduces the enemy tile's standing defense. */
+  siege?: {
+    onClick: () => void;
+    turnCost: number;
+    disabledReason: string | null;
+  };
+
+  /** Alternate air-only attack that attrits defenders without committing
+   *  the rest of the army. Air units available on the source tile drive
+   *  whether this is castable. */
+  flyover?: {
+    onClick: () => void;
+    turnCost: number;
+    airUnits: number;
+    disabledReason: string | null;
+  };
+}
+
+/**
+ * Unified "boost your odds" panel. Replaces three older pieces — the
+ * action button strip inside BattleSimPanel, the offensive-artifact grid,
+ * and the intel-artifact grid — with a single tabbed picker. Each tab
+ * is only surfaced when there's actually something castable inside,
+ * so a row with no spy spell + no air units + no spells doesn't render
+ * a wall of empty buttons.
+ */
+export function BoostPanel(props: BoostPanelProps) {
+  const tabs = buildTabList(props);
+  const [active, setActive] = useState<TabId | null>(tabs[0]?.id ?? null);
+
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  const current = tabs.find((t) => t.id === active) ?? tabs[0];
+
+  return (
+    <section className="rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50/40 dark:bg-amber-950/10 overflow-hidden h-full flex flex-col">
+      <header className="px-3 py-2 border-b border-amber-200 dark:border-amber-900 flex items-baseline justify-between shrink-0">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+          ✨ Boost your odds
+        </h3>
+        <span className="text-[10px] text-amber-700/60 dark:text-amber-300/60">
+          optional · spent before the attack
+        </span>
+      </header>
+
+      <div className="flex flex-wrap gap-1 px-2 pt-2 border-b border-amber-200/60 dark:border-amber-900/60 shrink-0">
+        {tabs.map((tab) => {
+          const isActive = current?.id === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActive(tab.id)}
+              className={`px-3 py-1 text-xs rounded-t-md font-medium transition-colors ${
+                isActive
+                  ? "bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 border-x border-t border-amber-200 dark:border-amber-900"
+                  : "text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+              }`}
+            >
+              {tab.label}
+              {tab.badge !== undefined && (
+                <span className="ml-1.5 text-[10px] text-neutral-400">
+                  {tab.badge}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="px-3 py-3 flex-1">
+        {current?.id === "artifact" && (
+          <ArtifactTab
+            artifacts={props.offensiveArtifacts}
+            busy={props.busy}
+            mode="queue"
+            selectedId={props.queuedArtifactId}
+            onSelect={props.onQueueArtifact}
+            emptyLabel="No offensive artifacts in your inventory."
+            kindLabel="Offensive"
+            accent="red"
+          />
+        )}
+        {current?.id === "spy" && (
+          <SpyTab
+            spy={props.spy}
+            intelArtifacts={props.intelArtifacts}
+            busy={props.busy}
+            onUseArtifact={props.onUseIntelArtifact}
+          />
+        )}
+        {current?.id === "siege" && props.siege && (
+          <SimpleActionTab
+            label={`Siege (+${props.siege.turnCost}T)`}
+            description="Reduce the enemy tile's standing defense floor before your next swing. Stacks with offensive spells."
+            onClick={props.siege.onClick}
+            disabledReason={props.siege.disabledReason}
+            busy={props.busy}
+            tone="amber"
+          />
+        )}
+        {current?.id === "flyover" && props.flyover && (
+          <SimpleActionTab
+            label={`Flyover (${props.flyover.airUnits}a, +${props.flyover.turnCost}T)`}
+            description={`Send your ${props.flyover.airUnits} air units to attrit the defenders without committing your ground/siege. Attacker losses are 2× by design.`}
+            onClick={props.flyover.onClick}
+            disabledReason={props.flyover.disabledReason}
+            busy={props.busy}
+            tone="sky"
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+interface Tab {
+  id: TabId;
+  label: string;
+  badge?: number | string;
+}
+
+function buildTabList(props: BoostPanelProps): Tab[] {
+  const list: Tab[] = [];
+  if (props.offensiveArtifacts.length > 0) {
+    list.push({
+      id: "artifact",
+      label: "Artifacts",
+      badge: props.offensiveArtifacts.length,
+    });
+  }
+  if (props.spy || props.intelArtifacts.length > 0) {
+    const badge =
+      (props.spy ? 1 : 0) + props.intelArtifacts.length;
+    list.push({
+      id: "spy",
+      label: "Spy intel",
+      badge: badge > 0 ? badge : undefined,
+    });
+  }
+  if (props.siege) {
+    list.push({ id: "siege", label: "Siege" });
+  }
+  if (props.flyover && props.flyover.airUnits > 0) {
+    list.push({ id: "flyover", label: "Flyover" });
+  }
+  return list;
+}
+
+/**
+ * Artifact grid. Two modes:
+ *   - `mode="queue"` — clicking toggles `selectedId`; the artifact is
+ *     NOT consumed until the parent fires the attack. Used for the
+ *     offensive Artifacts tab.
+ *   - `mode="use"`  — clicking fires `onSelect` once as an immediate
+ *     server action (the parent calls the use-artifact API). Used for
+ *     intel artifacts under the Spy tab — those reveal info now.
+ */
+function ArtifactTab({
+  artifacts,
+  busy,
+  mode,
+  selectedId,
+  onSelect,
+  emptyLabel,
+  kindLabel,
+  accent,
+}: {
+  artifacts: ReadonlyArray<{
+    artifact: GameArtifact;
+    definition: ArtifactDefinition | null;
+  }>;
+  busy?: boolean;
+  mode: "queue" | "use";
+  selectedId?: string;
+  onSelect: (artifactId: string) => void;
+  emptyLabel: string;
+  kindLabel: string;
+  accent: "red" | "violet";
+}) {
+  if (artifacts.length === 0) {
+    return <p className="text-xs text-neutral-500 italic">{emptyLabel}</p>;
+  }
+  const baseTone =
+    accent === "red"
+      ? "border-red-300 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30"
+      : "border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30";
+  const selectedTone =
+    accent === "red"
+      ? "border-red-400 bg-red-50 dark:bg-red-950/40 ring-1 ring-red-400/60"
+      : "border-violet-400 bg-violet-50 dark:bg-violet-950/40 ring-1 ring-violet-400/60";
+  const blurb =
+    mode === "queue"
+      ? "Queue one — the bonus consumes when you click Attack."
+      : "One-time use — fires immediately and reveals intel.";
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] text-neutral-600 dark:text-neutral-400">
+        {blurb}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {artifacts.map(({ artifact, definition }) => {
+          const isSelected = mode === "queue" && selectedId === artifact.id;
+          return (
+            <button
+              key={artifact.id}
+              type="button"
+              disabled={busy}
+              // In queue mode, clicking the already-selected card clears
+              // the selection. In use mode, every click fires once.
+              onClick={() =>
+                onSelect(mode === "queue" && isSelected ? "" : artifact.id)
+              }
+              title={definition?.description ?? artifact.definitionId}
+              className={`flex items-start gap-2 p-2 text-left text-xs border rounded-md transition-colors disabled:opacity-50 ${
+                isSelected ? selectedTone : baseTone
+              }`}
+            >
+              <CatalogImage entry={definition ?? { name: artifact.definitionId }} size="sm" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-medium truncate">
+                    {definition?.name ?? artifact.definitionId}
+                  </span>
+                  <span className="text-[10px] capitalize text-neutral-500 shrink-0">
+                    {isSelected ? "queued" : `${kindLabel} · ${artifact.rarity}`}
+                  </span>
+                </div>
+                {definition?.description && (
+                  <p className="text-[11px] text-neutral-600 dark:text-neutral-400 mt-0.5 line-clamp-2">
+                    {definition.description}
+                  </p>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SpyTab({
+  spy,
+  intelArtifacts,
+  busy,
+  onUseArtifact,
+}: {
+  spy: BoostPanelProps["spy"];
+  intelArtifacts: BoostPanelProps["intelArtifacts"];
+  busy?: boolean;
+  onUseArtifact: (id: string) => void;
+}) {
+  const empty = !spy && intelArtifacts.length === 0;
+  if (empty) {
+    return (
+      <p className="text-xs text-neutral-500 italic">
+        No caste intel spell or intel artifacts available.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {spy && (
+        <div>
+          <p className="text-[11px] text-neutral-600 dark:text-neutral-400 mb-1.5">
+            Cast your caste intel spell on the enemy tile.
+          </p>
+          <button
+            type="button"
+            disabled={busy || spy.disabledReason !== null}
+            title={spy.disabledReason ?? spy.spell.description}
+            onClick={spy.onClick}
+            className="flex items-start gap-2 p-2 text-left text-xs border rounded-md border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30 disabled:opacity-50 w-full"
+          >
+            <CatalogImage entry={spy.spell} size="sm" />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-medium">
+                  🔎 Spy · T{spy.spell.tier} {spy.spell.name}
+                </span>
+                <span className="text-[10px] text-violet-700 dark:text-violet-300 shrink-0">
+                  +{spy.spell.turnCost}T
+                </span>
+              </div>
+              <p className="text-[11px] text-neutral-600 dark:text-neutral-400 mt-0.5 line-clamp-2">
+                {spy.spell.description}
+              </p>
+            </div>
+          </button>
+        </div>
+      )}
+      {intelArtifacts.length > 0 && (
+        <ArtifactTab
+          artifacts={intelArtifacts}
+          busy={busy}
+          mode="use"
+          onSelect={onUseArtifact}
+          emptyLabel=""
+          kindLabel="Intel"
+          accent="violet"
+        />
+      )}
+    </div>
+  );
+}
+
+function SimpleActionTab({
+  label,
+  description,
+  onClick,
+  disabledReason,
+  busy,
+  tone,
+}: {
+  label: string;
+  description: string;
+  onClick: () => void;
+  disabledReason: string | null;
+  busy?: boolean;
+  tone: "amber" | "sky";
+}) {
+  const cls =
+    tone === "amber"
+      ? "border-amber-300 dark:border-amber-800 hover:bg-amber-50 dark:hover:bg-amber-950/30"
+      : "border-sky-300 dark:border-sky-800 hover:bg-sky-50 dark:hover:bg-sky-950/30";
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-neutral-700 dark:text-neutral-300">{description}</p>
+      <button
+        type="button"
+        disabled={busy || disabledReason !== null}
+        title={disabledReason ?? label}
+        onClick={onClick}
+        className={`px-4 py-2 text-sm font-medium border rounded-md transition-colors disabled:opacity-50 ${cls}`}
+      >
+        {label}
+      </button>
+      {disabledReason && (
+        <p className="text-[11px] text-neutral-500">{disabledReason}</p>
+      )}
+    </div>
+  );
+}

--- a/app/game/threats/_components/ChangeSourceModal.tsx
+++ b/app/game/threats/_components/ChangeSourceModal.tsx
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { buildingForCasteAndLand } from "@/lib/game/content";
+import type { Caste, MapTile } from "@/lib/game/types";
+
+export interface ChangeSourceModalProps {
+  candidates: ReadonlyArray<MapTile>;
+  myCaste: Caste;
+  /** Tile id of the currently-selected source — highlighted in the list
+   *  so the player can tell at a glance what they're swapping away from. */
+  currentSourceId: string;
+  /** Tile id of the strongest source per threats-derive — gets a badge so
+   *  the player knows the default pick was load-bearing. */
+  bestSourceId: string;
+  /** Enemy tile id, for context in the modal header. */
+  targetTileId: string;
+  onSelect: (tileId: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * Modal picker for the Attack tab's source tile. Lists every player tile
+ * that borders the enemy and lets the player pick a different launch
+ * point — same card shape as SourceTileCard so the swap is visually
+ * obvious.
+ *
+ * Closes on backdrop click, ESC, or after a selection lands.
+ */
+export function ChangeSourceModal(props: ChangeSourceModalProps) {
+  const {
+    candidates,
+    myCaste,
+    currentSourceId,
+    bestSourceId,
+    targetTileId,
+    onSelect,
+    onClose,
+  } = props;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
+      <div
+        className="bg-white dark:bg-neutral-900 rounded-lg shadow-xl max-w-xl w-full max-h-[80vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-700 dark:text-neutral-200">
+              Choose source tile
+            </h2>
+            <p className="text-xs text-neutral-500 mt-0.5">
+              {candidates.length} of your tiles border{" "}
+              <span className="font-mono">{targetTileId}</span>. Pick which
+              one swings.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-200 text-lg leading-none"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="p-3 space-y-2">
+          {candidates.map((tile) => {
+            const isCurrent = tile.tileId === currentSourceId;
+            const isBest = tile.tileId === bestSourceId;
+            const building =
+              tile.type !== "unassigned"
+                ? buildingForCasteAndLand(myCaste, tile.type)
+                : undefined;
+            const totalUnits =
+              tile.units.ground + tile.units.siege + tile.units.air;
+            return (
+              <button
+                key={tile.tileId}
+                type="button"
+                onClick={() => {
+                  onSelect(tile.tileId);
+                  onClose();
+                }}
+                className={`w-full text-left flex items-stretch gap-3 px-3 py-2 rounded-md border transition-colors ${
+                  isCurrent
+                    ? "border-emerald-400 bg-emerald-50 dark:bg-emerald-950/40 ring-1 ring-emerald-400/50"
+                    : "border-neutral-200 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-900/40"
+                }`}
+              >
+                <div className="shrink-0 flex items-center">
+                  <CatalogImage
+                    entry={building ?? { name: tile.type }}
+                    size="md"
+                    className="rounded-md"
+                  />
+                </div>
+                <div className="min-w-0 flex-1 flex flex-col justify-center gap-0.5">
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <span className="font-mono font-semibold text-sm text-neutral-800 dark:text-neutral-100">
+                      {tile.tileId}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+                      {tile.type}
+                    </span>
+                    {isBest && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">
+                        ✨ best
+                      </span>
+                    )}
+                    {isCurrent && !isBest && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300">
+                        current
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-[11px] text-neutral-500 font-mono">
+                    G{tile.units.ground} · S{tile.units.siege} · A
+                    {tile.units.air}
+                    {totalUnits > 0 && (
+                      <span className="ml-2 text-neutral-400">
+                        ({totalUnits} total)
+                      </span>
+                    )}
+                  </div>
+                  {building && (
+                    <div className="text-[11px] text-neutral-600 dark:text-neutral-400 truncate">
+                      {building.name}
+                    </div>
+                  )}
+                </div>
+                <div className="shrink-0 flex items-center text-neutral-400 group-hover:text-neutral-600">
+                  →
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/game/threats/_components/ManageSourcePanel.tsx
+++ b/app/game/threats/_components/ManageSourcePanel.tsx
@@ -1,0 +1,258 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { unitsPerCycleForLand } from "@/app/game/recruit/_lib/constants";
+import type {
+  ArtifactDefinition,
+  GameArtifact,
+  GamePlayer,
+  LandType,
+  MapTile,
+  SpellDefinition,
+  UnitType,
+} from "@/lib/game/types";
+
+const LAND_TYPES: { type: LandType; label: string }[] = [
+  { type: "military", label: "Military" },
+  { type: "food", label: "Food" },
+  { type: "magic", label: "Magic" },
+  { type: "unassigned", label: "Unassigned" },
+];
+
+const UNIT_TYPES: UnitType[] = ["ground", "siege", "air"];
+
+export interface ManageSourcePanelProps {
+  source: MapTile;
+  player: GamePlayer;
+  busy?: boolean;
+
+  defenseSpells: ReadonlyArray<SpellDefinition>;
+  defensiveArtifacts: ReadonlyArray<{
+    artifact: GameArtifact;
+    definition: ArtifactDefinition | null;
+  }>;
+
+  onAssign: (type: LandType) => void;
+  onRecruit: (type: UnitType) => void;
+  onArmDefenseSpell: (spellId: string) => void;
+  onUseDefensiveArtifact: (artifactId: string) => void;
+}
+
+/**
+ * Defense tab content for a ThreatRow: every action that beefs up the
+ * source tile. Always expanded (no disclosure) — when the player picks
+ * this tab they want every defense lever in front of them.
+ *
+ * Sections, top → bottom: source summary, assign land type, recruit
+ * units, arm defense spell, defense artifacts. Each section gates
+ * itself by player resources and skips empty inventories.
+ */
+export function ManageSourcePanel(props: ManageSourcePanelProps) {
+  const {
+    source,
+    player,
+    busy,
+    defenseSpells,
+    defensiveArtifacts,
+    onAssign,
+    onRecruit,
+    onArmDefenseSpell,
+    onUseDefensiveArtifact,
+  } = props;
+
+  const yieldPerCycle = unitsPerCycleForLand(source.type);
+
+  return (
+    <div className="space-y-4 text-xs">
+      {/* Source summary — single line at top so the player always knows
+          which of their tiles they're configuring. */}
+      <div className="flex items-baseline justify-between gap-2 px-3 py-2 rounded-md bg-neutral-50 dark:bg-neutral-900/40 border border-neutral-200 dark:border-neutral-800">
+        <span className="font-mono font-semibold text-neutral-700 dark:text-neutral-200">
+          {source.tileId}
+        </span>
+        <span className="text-neutral-500 capitalize">{source.type}</span>
+        <span className="font-mono text-neutral-500">
+          G{source.units.ground} S{source.units.siege} A{source.units.air}
+        </span>
+      </div>
+
+      {/* Assign tile type */}
+      <Section
+        title="Assign tile type"
+        meta="1 turn"
+        description="Change what this tile produces. Military recruits ground/siege/air; food and magic feed kingdom-wide bonuses."
+      >
+        <div className="flex flex-wrap gap-1.5">
+          {LAND_TYPES.map((a) => {
+            const isCurrent = source.type === a.type;
+            const cantSpend = player.turnsRemaining < 1;
+            const reason = isCurrent
+              ? `Already ${a.label.toLowerCase()}`
+              : cantSpend
+                ? "Need 1 turn"
+                : null;
+            return (
+              <button
+                key={a.type}
+                onClick={() => onAssign(a.type)}
+                disabled={busy || reason !== null}
+                title={reason ?? `Set source to ${a.label.toLowerCase()}`}
+                className={`px-3 py-1.5 rounded border text-sm ${
+                  isCurrent
+                    ? "border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300"
+                    : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                } disabled:opacity-50`}
+              >
+                {a.label}
+              </button>
+            );
+          })}
+        </div>
+      </Section>
+
+      {/* Recruit */}
+      <Section
+        title="Recruit units"
+        meta="5 turns each"
+        description={
+          yieldPerCycle > 0
+            ? `+${yieldPerCycle} of the chosen unit type per cycle on this tile.`
+            : "This tile cannot recruit until you assign it a land type above."
+        }
+      >
+        <div className="flex flex-wrap gap-1.5">
+          {UNIT_TYPES.map((u) => {
+            const reason =
+              yieldPerCycle <= 0
+                ? "Assign a land type first"
+                : player.turnsRemaining < 5
+                  ? "Need 5 turns"
+                  : null;
+            return (
+              <button
+                key={u}
+                onClick={() => onRecruit(u)}
+                disabled={busy || reason !== null}
+                title={reason ?? `Recruit +${yieldPerCycle} ${u} on source`}
+                className="px-3 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 capitalize text-sm"
+              >
+                +{yieldPerCycle || 10} {u}
+              </button>
+            );
+          })}
+        </div>
+      </Section>
+
+      {/* Arm defense spell */}
+      {defenseSpells.length > 0 && (
+        <Section
+          title="Arm a defense spell"
+          meta="5 turns · triggers when attacked"
+          description="Stage one of your caste's defense spells on this tile. It auto-casts the moment an enemy attacks."
+        >
+          <div className="flex flex-wrap gap-1.5">
+            {defenseSpells.map((s) => {
+              const reason =
+                source.armedDefenseSpellId === s.id
+                  ? "Already armed"
+                  : player.turnsRemaining < 5
+                    ? "Need 5 turns"
+                    : player.stats.tilesHeld < s.minTilesRequired
+                      ? `Need ${s.minTilesRequired} tiles`
+                      : null;
+              const armed = source.armedDefenseSpellId === s.id;
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => onArmDefenseSpell(s.id)}
+                  disabled={busy || reason !== null}
+                  title={reason ?? s.description}
+                  className={`flex items-center gap-2 px-2.5 py-1.5 rounded border ${
+                    armed
+                      ? "border-blue-400 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200"
+                      : "border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30"
+                  } disabled:opacity-50 text-sm`}
+                >
+                  <CatalogImage entry={s} size="xs" />
+                  <span>
+                    T{s.tier} {s.name}
+                  </span>
+                  {armed && (
+                    <span className="text-[10px] uppercase tracking-wide opacity-70">
+                      armed
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </Section>
+      )}
+
+      {/* Defense artifacts */}
+      {defensiveArtifacts.length > 0 && (
+        <Section
+          title="Defense artifacts"
+          meta="one-time use"
+          description="Bind a defensive artifact to this tile. The bonus consumes the next time you're attacked."
+        >
+          <div className="flex flex-wrap gap-1.5">
+            {defensiveArtifacts.map(({ artifact, definition }) => (
+              <button
+                key={artifact.id}
+                type="button"
+                disabled={busy}
+                onClick={() => onUseDefensiveArtifact(artifact.id)}
+                title={definition?.description ?? artifact.definitionId}
+                className="flex items-center gap-2 px-2.5 py-1.5 rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50 text-sm"
+              >
+                <CatalogImage
+                  entry={definition ?? { name: artifact.definitionId }}
+                  size="xs"
+                />
+                <span>{definition?.name ?? artifact.definitionId}</span>
+              </button>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  meta,
+  description,
+  children,
+}: {
+  title: string;
+  meta?: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-1.5">
+      <header className="flex items-baseline gap-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-700 dark:text-neutral-200">
+          {title}
+        </h4>
+        {meta && (
+          <span className="text-[10px] text-neutral-500">· {meta}</span>
+        )}
+      </header>
+      {description && (
+        <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
+          {description}
+        </p>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/app/game/threats/_components/SourceTileCard.tsx
+++ b/app/game/threats/_components/SourceTileCard.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { buildingForCasteAndLand } from "@/lib/game/content";
+import type { Caste, MapTile } from "@/lib/game/types";
+
+export interface SourceTileCardProps {
+  source: MapTile;
+  myCaste: Caste;
+  candidateCount: number;
+  isBest: boolean;
+  onOpenPicker: () => void;
+}
+
+/**
+ * Inline "source tile" card sized to match the height of the G/S/A
+ * input + recruit-button column to its right. Compact two-line layout:
+ * row 1 = tile id + land type + badges, row 2 = unit counts. A
+ * "⚙ Change (N)" pill on the right opens the source picker when the
+ * player has more than one candidate tile bordering this enemy.
+ */
+export function SourceTileCard(props: SourceTileCardProps) {
+  const { source, myCaste, candidateCount, isBest, onOpenPicker } = props;
+  const building =
+    source.type !== "unassigned"
+      ? buildingForCasteAndLand(myCaste, source.type)
+      : undefined;
+  const totalUnits =
+    source.units.ground + source.units.siege + source.units.air;
+  return (
+    <div className="rounded-md border border-emerald-300/70 dark:border-emerald-900 bg-emerald-50/40 dark:bg-emerald-950/10 px-2.5 py-1.5 h-full flex items-center gap-2.5 min-h-0">
+      <CatalogImage
+        entry={building ?? { name: source.type }}
+        size="sm"
+        className="rounded shrink-0"
+      />
+      <div className="min-w-0 flex-1 leading-tight">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <span className="font-mono font-semibold text-sm text-neutral-800 dark:text-neutral-100">
+            {source.tileId}
+          </span>
+          <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+            {building?.name ?? source.type}
+          </span>
+          {isBest && (
+            <span className="text-[10px] px-1.5 py-px rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">
+              ✨ best
+            </span>
+          )}
+        </div>
+        <div className="text-[11px] text-neutral-500 font-mono mt-0.5">
+          G{source.units.ground} · S{source.units.siege} · A{source.units.air}
+          {totalUnits > 0 && (
+            <span className="ml-1.5 text-neutral-400">({totalUnits})</span>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onOpenPicker}
+        disabled={candidateCount <= 1}
+        title={
+          candidateCount <= 1
+            ? "Only one of your tiles borders this enemy."
+            : `Pick a different source (${candidateCount} candidates)`
+        }
+        className="shrink-0 px-2.5 py-1 text-[11px] rounded-md border border-emerald-300 dark:border-emerald-800 text-emerald-700 dark:text-emerald-200 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+      >
+        ⚙ Change
+        {candidateCount > 1 && (
+          <span className="ml-1 opacity-70">({candidateCount})</span>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/app/game/threats/_components/SpellPicker.tsx
+++ b/app/game/threats/_components/SpellPicker.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import type { SpellDefinition } from "@/lib/game/types";
+
+export interface SpellPickerProps {
+  spells: ReadonlyArray<SpellDefinition>;
+  /** Map of spellId → expected magnitude midpoint (atk-power add) for label. */
+  expectedById: ReadonlyMap<string, number>;
+  selectedSpellId: string;
+  onSelect: (spellId: string) => void;
+}
+
+/**
+ * Card-style offensive spell picker. Renders the player's castable
+ * offense spells as visual cards — image + name + tier + expected effect
+ * + flavor — and a "no spell" card at the front so the player can opt
+ * out without digging in a dropdown. The selected card glows red to
+ * mirror the artifact-pick styling in BoostPanel.
+ *
+ * Lives in its own box (parent renders the section header) so it can
+ * sit alongside the projected-outcome panel without competing for
+ * vertical space inside the attack form.
+ */
+export function SpellPicker(props: SpellPickerProps) {
+  const { spells, expectedById, selectedSpellId, onSelect } = props;
+  return (
+    <section className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/40 dark:bg-red-950/10 overflow-hidden h-full flex flex-col">
+      <header className="px-3 py-2 border-b border-red-200 dark:border-red-900 flex items-baseline justify-between shrink-0">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-300">
+          🪄 Offensive spell
+        </h3>
+        <span className="text-[10px] text-red-700/60 dark:text-red-300/60">
+          optional · +5t when cast with the attack
+        </span>
+      </header>
+
+      <div className="px-3 py-3 flex-1">
+        {spells.length === 0 ? (
+          <p className="text-xs italic text-neutral-500">
+            No offensive spells unlocked yet.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <NoneCard
+              selected={selectedSpellId === ""}
+              onSelect={() => onSelect("")}
+            />
+            {spells.map((s) => {
+              const expected = expectedById.get(s.id);
+              const isSelected = selectedSpellId === s.id;
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => onSelect(isSelected ? "" : s.id)}
+                  title={s.description}
+                  className={`flex items-start gap-2 p-2 text-left text-xs border rounded-md transition-colors ${
+                    isSelected
+                      ? "border-red-400 bg-red-50 dark:bg-red-950/40 ring-1 ring-red-400/60"
+                      : "border-red-300 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30"
+                  }`}
+                >
+                  <CatalogImage entry={s} size="sm" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="font-medium truncate">
+                        T{s.tier} {s.name}
+                      </span>
+                      {expected !== undefined && (
+                        <span className="text-[10px] text-red-700 dark:text-red-300 shrink-0">
+                          ~+{Math.round(expected)} atk
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-neutral-600 dark:text-neutral-400 mt-0.5 line-clamp-2">
+                      {s.description}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function NoneCard({
+  selected,
+  onSelect,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex items-center gap-2 p-2 text-left text-xs border rounded-md transition-colors ${
+        selected
+          ? "border-neutral-500 bg-neutral-100 dark:bg-neutral-900/40 ring-1 ring-neutral-400/60"
+          : "border-dashed border-neutral-300 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-900/30"
+      }`}
+    >
+      <span className="w-8 h-8 rounded-md bg-neutral-200 dark:bg-neutral-800 flex items-center justify-center text-neutral-500 text-base shrink-0">
+        ∅
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-medium">No spell</div>
+        <p className="text-[11px] text-neutral-500">
+          Save 5 turns — swing on raw force.
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -7,8 +7,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { unitsPerCycleForLand } from "@/app/game/recruit/_lib/constants";
 import { ARTIFACTS_BY_ID, getSpellsForCasteAndType } from "@/lib/game/content";
-import { CatalogImage } from "@/app/game/_components/CatalogImage";
 import { realizedSpellMagnitude } from "@/lib/game/combat";
 import type {
   CombatResult,
@@ -21,25 +21,25 @@ import type {
   TurnReport,
   UnitType,
 } from "@/lib/game/types";
-import { unitsPerCycleForLand } from "@/app/game/recruit/_lib/constants";
 import type { ThreatEntry } from "../_lib/threats-derive";
 import { useAttackPreview } from "../_lib/use-attack-preview";
 import { BattleReport } from "./BattleReport";
 import { BattleSimPanel } from "./BattleSimPanel";
-
-const UNIT_TYPES: UnitType[] = ["ground", "siege", "air"];
-const LAND_TYPES: { type: LandType; label: string }[] = [
-  { type: "military", label: "Military" },
-  { type: "food", label: "Food" },
-  { type: "magic", label: "Magic" },
-  { type: "unassigned", label: "Unassigned" },
-];
+import { BoostPanel } from "./BoostPanel";
+import { ChangeSourceModal } from "./ChangeSourceModal";
+import { ManageSourcePanel } from "./ManageSourcePanel";
+import { SourceTileCard } from "./SourceTileCard";
+import { SpellPicker } from "./SpellPicker";
 
 export interface ThreatRowProps {
   entry: ThreatEntry;
   player: GamePlayer;
   artifacts: ReadonlyArray<GameArtifact>;
   busy: boolean;
+  /** Open the row's full attack flow on first render. Top-N rows by
+   *  advantage are auto-expanded by the page; the rest stay collapsed
+   *  to keep the list scannable. User can still toggle manually. */
+  defaultExpanded?: boolean;
   // Count of the player's magic-land tiles. Drives the magic multiplier
   // in the spell-cast picker's expected-magnitude readout. Passed from
   // the page so the row doesn't need the full tile list.
@@ -116,9 +116,16 @@ export interface ThreatRowProps {
  * that will 4xx out — the row tells them up-front why it's not allowed.
  */
 export function ThreatRow(props: ThreatRowProps) {
-  const { entry, player, artifacts, busy, myMagicLandCount } = props;
-  const [expanded, setExpanded] = useState(false);
+  const { entry, player, artifacts, busy, myMagicLandCount, defaultExpanded } =
+    props;
+  const [expanded, setExpanded] = useState(defaultExpanded ?? false);
+  const [activeTab, setActiveTab] = useState<"attack" | "defense">("attack");
   const [sourceTileId, setSourceTileId] = useState(entry.bestSource.tileId);
+  const [sourcePickerOpen, setSourcePickerOpen] = useState(false);
+  // Offensive artifact queued for this swing. The artifact is NOT
+  // consumed until handleAttack fires — clicking the card just stages
+  // it (visual ring), and clicking the same card again clears it.
+  const [queuedArtifactId, setQueuedArtifactId] = useState<string>("");
   const [ground, setGround] = useState(0);
   const [siege, setSiege] = useState(0);
   const [air, setAir] = useState(0);
@@ -180,32 +187,8 @@ export function ThreatRow(props: ThreatRowProps) {
         : null,
     [offenseSpellId, offenseSpells]
   );
-  const selectedOffenseExpected: number | null = selectedOffenseSpell
-    ? offenseSpellPreviews.get(selectedOffenseSpell.id) ?? null
-    : null;
   const defenseSpells = useMemo<SpellDefinition[]>(
     () => (myCaste ? getSpellsForCasteAndType(myCaste, "defense") : []),
-    [myCaste]
-  );
-  const siegeSpell = useMemo<SpellDefinition | null>(
-    () =>
-      myCaste
-        ? getSpellsForCasteAndType(myCaste, "siege")[0] ?? null
-        : null,
-    [myCaste]
-  );
-  const disarmSpell = useMemo<SpellDefinition | null>(
-    () =>
-      myCaste
-        ? getSpellsForCasteAndType(myCaste, "disarm")[0] ?? null
-        : null,
-    [myCaste]
-  );
-  const attritionSpell = useMemo<SpellDefinition | null>(
-    () =>
-      myCaste
-        ? getSpellsForCasteAndType(myCaste, "attrition")[0] ?? null
-        : null,
     [myCaste]
   );
   const intelSpell = useMemo<SpellDefinition | null>(
@@ -269,6 +252,21 @@ export function ThreatRow(props: ThreatRowProps) {
   async function handleAttack() {
     setToast(null);
     setBattle(null);
+    // Consume a queued artifact (if any) before the swing fires. We
+    // await so the server-side intel/offense effect is in place by the
+    // time the attack resolves. If the use-artifact call fails, abort —
+    // the user shouldn't lose units to a half-applied bonus.
+    if (queuedArtifactId) {
+      const a = artifacts.find((x) => x.id === queuedArtifactId);
+      if (a) {
+        const useRes = await props.onUseArtifact(
+          a.id,
+          entry.enemyTile.tileId
+        );
+        if (!useRes) return;
+        if (useRes.intelReport) setIntelReport(useRes.intelReport);
+      }
+    }
     const res = await props.onAttack({
       sourceTileId: source.tileId,
       targetTileId: entry.enemyTile.tileId,
@@ -291,6 +289,7 @@ export function ThreatRow(props: ThreatRowProps) {
       setGround(0);
       setSiege(0);
       setAir(0);
+      setQueuedArtifactId("");
       if (res.intelReport) setIntelReport(res.intelReport);
     }
   }
@@ -355,19 +354,6 @@ export function ThreatRow(props: ThreatRowProps) {
     }
   }
 
-  async function handleCastSpellFromPanel(spellId: string) {
-    setToast(null);
-    const res = await props.onCastSpell(
-      spellId,
-      source.tileId,
-      entry.enemyTile.tileId
-    );
-    if (res) {
-      setToast(res.reportSummary || "Spell cast");
-      setPreviewRefreshKey((k) => k + 1);
-    }
-  }
-
   async function handleFlyoverFromPanel() {
     setToast(null);
     setBattle(null);
@@ -406,24 +392,29 @@ export function ThreatRow(props: ThreatRowProps) {
         ? "text-amber-600 dark:text-amber-400"
         : "text-red-600 dark:text-red-400";
 
+  const recentOutcomes =
+    Boolean(battle) || Boolean(toast) || Boolean(intelReport);
+
   return (
     <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 overflow-hidden">
-      {/* ─── Compact summary line ─────────────────────────────────────────── */}
-      <div className="px-4 py-3 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-sm">
-        <button
-          onClick={() => setExpanded((v) => !v)}
-          className="text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-200"
-          aria-expanded={expanded}
-          aria-label={expanded ? "Collapse" : "Expand"}
-        >
+      {/* ── Summary line: click the chevron to expand the full attack flow ─ */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full px-4 py-3 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-sm text-left hover:bg-neutral-50 dark:hover:bg-neutral-900/40"
+        aria-expanded={expanded}
+        aria-label={expanded ? "Collapse row" : "Expand row"}
+      >
+        <span className="text-neutral-500 shrink-0">
           {expanded ? "▾" : "▸"}
-        </button>
+        </span>
         <span className="font-mono font-semibold">{entry.enemyTile.tileId}</span>
         <span className="text-neutral-600 dark:text-neutral-300">
           {enemyName} · {enemyCasteLabel}
         </span>
         <span className="font-mono text-xs text-neutral-500">
-          G{entry.enemyTile.units.ground} S{entry.enemyTile.units.siege} A{entry.enemyTile.units.air}
+          G{entry.enemyTile.units.ground} S{entry.enemyTile.units.siege} A
+          {entry.enemyTile.units.air}
         </span>
         {enemyShielded && (
           <span className="px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 text-xs">
@@ -433,441 +424,350 @@ export function ThreatRow(props: ThreatRowProps) {
         <span className={`font-semibold ${advantageTone}`}>
           adv {advantageLabel}
         </span>
-      </div>
+        {!expanded && (
+          <span className="ml-auto text-xs text-neutral-500">
+            Plan attack →
+          </span>
+        )}
+      </button>
 
-      {/* ─── Source prep strip — always visible (assign + recruit) ──────── */}
-      <div className="px-4 pb-2 space-y-1.5">
-        {/* Assign land type */}
-        <div className="flex flex-wrap items-center gap-1.5 text-xs">
-          <span className="text-neutral-500 mr-1">Assign source · 1t:</span>
-          {LAND_TYPES.map((a) => {
-            const isCurrent = source.type === a.type;
-            const cantSpend = player.turnsRemaining < 1;
-            const reason = isCurrent
-              ? `Already ${a.label.toLowerCase()}`
-              : cantSpend
-                ? "Need 1 turn"
-                : null;
-            return (
-              <button
-                key={a.type}
-                onClick={() => handleAssign(a.type)}
-                disabled={busy || reason !== null}
-                title={reason ?? `Set source to ${a.label.toLowerCase()}`}
-                className={`px-2 py-1 rounded border ${
-                  isCurrent
-                    ? "border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300"
-                    : "border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-                } disabled:opacity-50`}
-              >
-                {a.label}
-              </button>
-            );
-          })}
-        </div>
-        {/* Recruit — military/food/magic recruit at different rates;
-            unrevealed/unassigned can't recruit (must assign first). */}
-        <div className="flex flex-wrap items-center gap-1.5 text-xs">
-          <span className="text-neutral-500 mr-1">Recruit · 5t:</span>
-          {UNIT_TYPES.map((u) => {
-            const yieldPerCycle = unitsPerCycleForLand(source.type);
-            const reason =
-              yieldPerCycle <= 0
-                ? "Tile cannot recruit — assign land type first"
+      {expanded && (
+        <div className="border-t border-neutral-200 dark:border-neutral-800">
+          {/* Row-level mode tabs — Attack (plan/launch the strike) vs.
+              Defense (beef up the source tile). Picking the right mode
+              up front keeps each tab clean and focused. */}
+          <div className="flex gap-1 px-3 pt-3" role="tablist">
+            <TabButton
+              active={activeTab === "attack"}
+              tone="red"
+              onClick={() => setActiveTab("attack")}
+            >
+              ⚔️ Attack
+            </TabButton>
+            <TabButton
+              active={activeTab === "defense"}
+              tone="blue"
+              onClick={() => setActiveTab("defense")}
+            >
+              🛡 Defense
+            </TabButton>
+          </div>
+
+          {activeTab === "attack" && (() => {
+            const recruitYield = unitsPerCycleForLand(source.type);
+            const recruitDisabledReason =
+              recruitYield <= 0
+                ? "Assign a land type to this tile first (Defense tab)"
                 : player.turnsRemaining < 5
-                  ? "Need 5 turns"
+                  ? `Need 5 turns (you have ${player.turnsRemaining})`
                   : null;
             return (
-              <button
-                key={u}
-                onClick={() => handleRecruit(u)}
-                disabled={busy || reason !== null}
-                title={
-                  reason ?? `Recruit +${yieldPerCycle} ${u} on source`
-                }
-                className="px-2 py-1 rounded border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-50 capitalize"
-              >
-                +{yieldPerCycle || 10} {u}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* ─── Inline attack form (visible always) ─────────────────────────── */}
-      <div className="px-4 pb-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
-        <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto_auto_minmax(0,1fr)] items-end">
-          <label className="text-xs">
-            <span className="text-neutral-500 block mb-0.5">Source</span>
-            <select
-              value={sourceTileId}
-              onChange={(e) => setSourceTileId(e.target.value)}
-              className="w-full px-2 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
-            >
-              {entry.candidateSources.map((t) => (
-                <option key={t.tileId} value={t.tileId}>
-                  {t.tileId} ({t.type}) — G{t.units.ground} S{t.units.siege} A{t.units.air}
-                </option>
-              ))}
-            </select>
-          </label>
-          <UnitInput
-            label={`G/${source.units.ground}`}
-            value={ground}
-            max={source.units.ground}
-            onChange={setGround}
-          />
-          <UnitInput
-            label={`S/${source.units.siege}`}
-            value={siege}
-            max={source.units.siege}
-            onChange={setSiege}
-          />
-          <UnitInput
-            label={`A/${source.units.air}`}
-            value={air}
-            max={source.units.air}
-            onChange={setAir}
-          />
-          <label className="text-xs">
-            <span className="text-neutral-500 block mb-0.5">Spell (+5t)</span>
-            <select
-              value={offenseSpellId}
-              onChange={(e) => setOffenseSpellId(e.target.value)}
-              className="w-full px-2 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
-            >
-              <option value="">— none —</option>
-              {offenseSpells.map((s) => {
-                const expected = offenseSpellPreviews.get(s.id);
-                const fx =
-                  expected !== undefined
-                    ? ` · ~+${Math.round(expected)} atk power`
-                    : "";
-                return (
-                  <option key={s.id} value={s.id}>
-                    T{s.tier} {s.name}{fx}
-                  </option>
-                );
-              })}
-            </select>
-          </label>
-        </div>
-        <button
-          onClick={handleAttack}
-          disabled={busy || attackDisabledReason !== null}
-          title={attackDisabledReason ?? `Costs ${attackTurnCost} turns`}
-          className="px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-500 transition-colors disabled:opacity-50"
-        >
-          Attack ({attackTurnCost}t)
-        </button>
-      </div>
-      {attackDisabledReason && (
-        <div className="px-4 pb-2 text-xs text-neutral-500">
-          Attack disabled: {attackDisabledReason}.
-        </div>
-      )}
-
-      {/* ─── Battle simulation panel (live projection) ───────────────────── */}
-      <div className="mx-4">
-        <BattleSimPanel
-          selectedOffenseSpell={
-            selectedOffenseSpell
-              ? {
-                  spell: selectedOffenseSpell,
-                  expectedMagnitude: selectedOffenseExpected ?? 0,
-                }
-              : null
-          }
-          preview={attackPreview.preview}
-          loading={attackPreview.loading}
-          error={attackPreview.error}
-          disabled={previewDisabled}
-          disabledReason={
-            previewDisabled
-              ? enemyShielded
-                ? "Enemy is shielded — no preview while shielded."
-                : "Not in play phase — preview unavailable."
-              : undefined
-          }
-          busy={busy}
-          spy={
-            intelSpell
-              ? {
-                  onClick: () => void handleCastIntel(),
-                  turnCost: intelSpell.turnCost,
-                  disabledReason:
-                    player.turnsRemaining < intelSpell.turnCost
-                      ? `Need ${intelSpell.turnCost} turns (you have ${player.turnsRemaining})`
-                      : null,
-                }
-              : undefined
-          }
-          siege={{
-            onClick: () => void handleSiegeFromPanel(),
-            turnCost: 5,
-            disabledReason:
-              player.turnsRemaining < 5
-                ? `Need 5 turns (you have ${player.turnsRemaining})`
-                : null,
-          }}
-          flyover={{
-            onClick: () => void handleFlyoverFromPanel(),
-            turnCost: 1,
-            airUnits: air,
-            disabledReason: (() => {
-              if (air <= 0) return "Set air units in the form first";
-              if (air > source.units.air)
-                return `Source has only ${source.units.air} air`;
-              if (player.turnsRemaining < 1)
-                return `Need 1 turn (you have ${player.turnsRemaining})`;
-              return null;
-            })(),
-          }}
-          castSpell={(() => {
-            // Build the picker entries for the player's caste-specific
-            // tier-1 spells of the new kinds. Expected magnitude uses
-            // dice=1.0 (midpoint of [0.5, 1.5]) so the player sees the
-            // average outcome before the actual roll.
-            const ownedMagic = myMagicLandCount;
-            const turnCost = 5;
-            const baseDisabled =
-              player.turnsRemaining < turnCost
-                ? `Need ${turnCost} turns (you have ${player.turnsRemaining})`
-                : null;
-            const candidates: SpellDefinition[] = [
-              siegeSpell,
-              disarmSpell,
-              attritionSpell,
-            ].filter((s): s is SpellDefinition => s !== null);
-            return {
-              spells: candidates.map((s) => {
-                const expected = realizedSpellMagnitude({
-                  baseStrength: s.baseStrength,
-                  caste: s.caste,
-                  spellType: s.type,
-                  magicLandCount: ownedMagic,
-                  activeUpgrades: player.activeUpgrades ?? {},
-                  dice: 1.0,
-                });
-                let entryDisabled = baseDisabled;
-                if (
-                  !entryDisabled &&
-                  player.stats.tilesHeld < s.minTilesRequired
-                ) {
-                  entryDisabled = `Need ${s.minTilesRequired} tiles held (you have ${player.stats.tilesHeld})`;
-                }
-                return {
-                  spell: s,
-                  expectedMagnitude: expected,
-                  disabledReason: entryDisabled,
-                };
-              }),
-              onCast: (spellId) => void handleCastSpellFromPanel(spellId),
-              turnCost,
-              disabledReason:
-                candidates.length === 0
-                  ? "No castable spells for your caste"
-                  : baseDisabled,
-            };
-          })()}
-        />
-      </div>
-
-      {/* ─── Battle report (full structured readout after an attack) ─────── */}
-      {battle && (
-        <div className="mx-4 mb-3">
-          <BattleReport
-            combat={battle.combat}
-            report={battle.report}
-            targetTile={battle.targetTile}
-            onDismiss={() => setBattle(null)}
-          />
-        </div>
-      )}
-
-      {/* ─── Toast (one-line result for non-attack actions) ──────────────── */}
-      {toast && (
-        <div className="mx-4 mb-3 px-3 py-2 rounded bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900 text-xs text-emerald-800 dark:text-emerald-200 flex items-center justify-between gap-2">
-          <span>{toast}</span>
-          <button
-            onClick={() => setToast(null)}
-            className="text-emerald-600 dark:text-emerald-400 hover:text-emerald-900 dark:hover:text-emerald-200"
-          >
-            ✕
-          </button>
-        </div>
-      )}
-
-      {/* ─── Intel report (rendered when populated by spy / intel artifact) ─ */}
-      {intelReport && (
-        <div className="mx-4 mb-3">
-          <ThreatIntelPanel
-            report={intelReport}
-            onDismiss={() => setIntelReport(null)}
-          />
-        </div>
-      )}
-
-      {/* ─── Expanded action panels ──────────────────────────────────────── */}
-      {expanded && (
-        <div className="border-t border-neutral-200 dark:border-neutral-800 px-4 py-3 space-y-4">
-          {/* Spy + intel artifacts */}
-          <section>
-            <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
-              Spy / intel
-            </h3>
-            <div className="flex flex-wrap gap-2">
-              {intelSpell && (
-                <SpyButton
-                  spell={intelSpell}
-                  player={player}
-                  busy={busy}
-                  onCast={handleCastIntel}
-                />
-              )}
-              {intelArtifacts.length === 0 && !intelSpell && (
-                <p className="text-xs text-neutral-500">
-                  No caste intel spell or intel artifacts available.
-                </p>
-              )}
-              {intelArtifacts.map((a) => {
-                const def = ARTIFACTS_BY_ID.get(a.definitionId);
-                return (
-                  <button
-                    key={a.id}
-                    onClick={() => handleUseArtifact(a, entry.enemyTile.tileId)}
-                    disabled={busy}
-                    title={def?.description ?? a.definitionId}
-                    className="flex items-center gap-2 px-2 py-1.5 text-xs rounded border border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30 disabled:opacity-50"
+            <div className="px-4 py-3 space-y-4">
+              {/* Row 1 — source tile card on the left + three unit columns
+                  (input over +N recruit button) on the right. Labels
+                  ("G/20" etc.) sit ABOVE the box stack so the source-tile
+                  card and the input-over-button stack share the same
+                  height beneath the label row. */}
+              <div className="grid gap-3 grid-cols-[minmax(0,1fr)_auto_auto_auto] items-stretch">
+                {/* Source column — invisible label-height spacer above
+                    the card so the card aligns with the unit input
+                    boxes, not the labels. */}
+                <div className="flex flex-col">
+                  <span
+                    aria-hidden="true"
+                    className="text-xs mb-1 invisible select-none"
                   >
-                    <CatalogImage entry={def ?? { name: a.definitionId }} size="xs" />
-                    <span>Use {def?.name ?? a.definitionId}</span>
-                  </button>
-                );
-              })}
-            </div>
-          </section>
-
-          {/* Offensive artifacts (used on enemy tile) */}
-          {offensiveArtifacts.length > 0 && (
-            <section>
-              <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-1">
-                Offensive artifacts (on enemy) · one-time use
-              </h3>
-              <p className="text-[11px] text-neutral-500 mb-2">
-                Spent before your attack — the bonus applies to your next swing.
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {offensiveArtifacts.map((a) => {
-                  const def = ARTIFACTS_BY_ID.get(a.definitionId);
-                  return (
-                    <button
-                      key={a.id}
-                      onClick={() =>
-                        handleUseArtifact(a, entry.enemyTile.tileId)
-                      }
-                      disabled={busy}
-                      title={def?.description ?? a.definitionId}
-                      className="flex items-center gap-2 px-2 py-1.5 text-xs rounded border border-red-300 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-50"
-                    >
-                      <CatalogImage entry={def ?? { name: a.definitionId }} size="xs" />
-                      <span>Use {def?.name ?? a.definitionId}</span>
-                    </button>
-                  );
-                })}
+                    ·
+                  </span>
+                  {myCaste && (
+                    <div className="flex-1">
+                      <SourceTileCard
+                        source={source}
+                        myCaste={myCaste}
+                        candidateCount={entry.candidateSources.length}
+                        isBest={source.tileId === entry.bestSource.tileId}
+                        onOpenPicker={() => setSourcePickerOpen(true)}
+                      />
+                    </div>
+                  )}
+                </div>
+                <UnitWithRecruit
+                  label={`G/${source.units.ground}`}
+                  value={ground}
+                  max={source.units.ground}
+                  onChange={setGround}
+                  recruitYield={recruitYield}
+                  recruitDisabledReason={recruitDisabledReason}
+                  busy={busy}
+                  onRecruit={() => void handleRecruit("ground")}
+                />
+                <UnitWithRecruit
+                  label={`S/${source.units.siege}`}
+                  value={siege}
+                  max={source.units.siege}
+                  onChange={setSiege}
+                  recruitYield={recruitYield}
+                  recruitDisabledReason={recruitDisabledReason}
+                  busy={busy}
+                  onRecruit={() => void handleRecruit("siege")}
+                />
+                <UnitWithRecruit
+                  label={`A/${source.units.air}`}
+                  value={air}
+                  max={source.units.air}
+                  onChange={setAir}
+                  recruitYield={recruitYield}
+                  recruitDisabledReason={recruitDisabledReason}
+                  busy={busy}
+                  onRecruit={() => void handleRecruit("air")}
+                />
               </div>
-            </section>
+
+              {/* Row 2 — Boost (left) | Spell picker (right). Both are
+                  "optional modifiers" on the swing, so pairing them visually
+                  reinforces that they're the player's tuning levers. The
+                  grid stretches both boxes to the same height. */}
+              <div className="grid gap-4 lg:grid-cols-2 items-stretch">
+                <BoostPanel
+                  busy={busy}
+                  offensiveArtifacts={offensiveArtifacts.map((a) => ({
+                    artifact: a,
+                    definition: ARTIFACTS_BY_ID.get(a.definitionId) ?? null,
+                  }))}
+                  intelArtifacts={intelArtifacts.map((a) => ({
+                    artifact: a,
+                    definition: ARTIFACTS_BY_ID.get(a.definitionId) ?? null,
+                  }))}
+                  queuedArtifactId={queuedArtifactId}
+                  onQueueArtifact={(id) => setQueuedArtifactId(id)}
+                  onUseIntelArtifact={(artifactId) => {
+                    const a = artifacts.find((x) => x.id === artifactId);
+                    if (a) void handleUseArtifact(a, entry.enemyTile.tileId);
+                  }}
+                  spy={
+                    intelSpell
+                      ? {
+                          spell: intelSpell,
+                          onClick: () => void handleCastIntel(),
+                          disabledReason:
+                            player.turnsRemaining < intelSpell.turnCost
+                              ? `Need ${intelSpell.turnCost} turns (you have ${player.turnsRemaining})`
+                              : player.stats.tilesHeld < intelSpell.minTilesRequired
+                                ? `Need ${intelSpell.minTilesRequired} tiles held`
+                                : null,
+                        }
+                      : undefined
+                  }
+                  siege={{
+                    onClick: () => void handleSiegeFromPanel(),
+                    turnCost: 5,
+                    disabledReason:
+                      player.turnsRemaining < 5
+                        ? `Need 5 turns (you have ${player.turnsRemaining})`
+                        : null,
+                  }}
+                  flyover={{
+                    onClick: () => void handleFlyoverFromPanel(),
+                    turnCost: 1,
+                    airUnits: air,
+                    disabledReason: (() => {
+                      if (air <= 0) return "Set air units in the form first";
+                      if (air > source.units.air)
+                        return `Source has only ${source.units.air} air`;
+                      if (player.turnsRemaining < 1)
+                        return `Need 1 turn (you have ${player.turnsRemaining})`;
+                      return null;
+                    })(),
+                  }}
+                />
+                <SpellPicker
+                  spells={offenseSpells}
+                  expectedById={offenseSpellPreviews}
+                  selectedSpellId={offenseSpellId}
+                  onSelect={setOffenseSpellId}
+                />
+              </div>
+
+              {/* Row 3 — Projected outcome (left) + big Attack call-to-action
+                  (right). The CTA mirrors the projection's height so the
+                  player's eye lands on it the moment they're happy with the
+                  preview. */}
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)] items-stretch">
+                <BattleSimPanel
+                  selectedOffenseSpell={null}
+                  preview={attackPreview.preview}
+                  loading={attackPreview.loading}
+                  error={attackPreview.error}
+                  disabled={previewDisabled}
+                  disabledReason={
+                    previewDisabled
+                      ? enemyShielded
+                        ? "Enemy is shielded — no preview while shielded."
+                        : "Not in play phase — preview unavailable."
+                      : undefined
+                  }
+                />
+                <button
+                  onClick={handleAttack}
+                  disabled={busy || attackDisabledReason !== null}
+                  title={attackDisabledReason ?? `Costs ${attackTurnCost} turns`}
+                  className="rounded-lg bg-red-600 hover:bg-red-500 text-white font-bold transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex flex-col items-center justify-center gap-2 p-6 min-h-[180px]"
+                >
+                  <span className="text-3xl leading-none">⚔️</span>
+                  <span className="text-xl tracking-wide">ATTACK</span>
+                  <span className="text-sm font-medium opacity-80">
+                    {attackTurnCost} turn{attackTurnCost === 1 ? "" : "s"}
+                  </span>
+                  {attackDisabledReason && (
+                    <span className="text-[11px] font-normal opacity-90 text-center px-2 mt-1">
+                      {attackDisabledReason}
+                    </span>
+                  )}
+                </button>
+              </div>
+            </div>
+            );
+          })()}
+
+          {sourcePickerOpen && myCaste && (
+            <ChangeSourceModal
+              candidates={entry.candidateSources}
+              myCaste={myCaste}
+              currentSourceId={source.tileId}
+              bestSourceId={entry.bestSource.tileId}
+              targetTileId={entry.enemyTile.tileId}
+              onSelect={(id) => setSourceTileId(id)}
+              onClose={() => setSourcePickerOpen(false)}
+            />
           )}
 
-          {/* Manage source tile — defense-side only.
-              Assign + recruit live in the always-visible strip up top. */}
-          <section>
-            <h3 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
-              Defend source · {source.tileId} ({source.type})
-            </h3>
-
-            <div className="space-y-3">
-              {/* Arm defense spell */}
-              {defenseSpells.length > 0 && (
-                <div>
-                  <p className="text-xs text-neutral-500 mb-1">
-                    Arm defense spell — 5 turns
-                  </p>
-                  <div className="flex flex-wrap gap-2">
-                    {defenseSpells.map((s) => {
-                      const reason =
-                        source.armedDefenseSpellId === s.id
-                          ? "Already armed"
-                          : player.turnsRemaining < 5
-                            ? "Need 5 turns"
-                            : player.stats.tilesHeld < s.minTilesRequired
-                              ? `Need ${s.minTilesRequired} tiles`
-                              : null;
-                      return (
-                        <button
-                          key={s.id}
-                          onClick={() => handleArm(s.id)}
-                          disabled={busy || reason !== null}
-                          title={reason ?? s.description}
-                          className="flex items-center gap-2 px-3 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
-                        >
-                          <CatalogImage entry={s} size="xs" />
-                          <span>T{s.tier} {s.name}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-
-              {/* Defense artifacts (on source tile) */}
-              {defensiveArtifacts.length > 0 && (
-                <div>
-                  <p className="text-xs text-neutral-500 mb-1">
-                    Defense artifacts (on source) · one-time use
-                  </p>
-                  <div className="flex flex-wrap gap-2">
-                    {defensiveArtifacts.map((a) => {
-                      const def = ARTIFACTS_BY_ID.get(a.definitionId);
-                      return (
-                        <button
-                          key={a.id}
-                          onClick={() => handleUseArtifact(a, source.tileId)}
-                          disabled={busy}
-                          title={def?.description ?? a.definitionId}
-                          className="flex items-center gap-2 px-2 py-1.5 text-xs rounded border border-blue-300 dark:border-blue-800 hover:bg-blue-50 dark:hover:bg-blue-950/30 disabled:opacity-50"
-                        >
-                          <CatalogImage entry={def ?? { name: a.definitionId }} size="xs" />
-                          <span>Use {def?.name ?? a.definitionId}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
+          {activeTab === "defense" && (
+            <div className="px-4 py-3">
+              <ManageSourcePanel
+                source={source}
+                player={player}
+                busy={busy}
+                defenseSpells={defenseSpells}
+                defensiveArtifacts={defensiveArtifacts.map((a) => ({
+                  artifact: a,
+                  definition: ARTIFACTS_BY_ID.get(a.definitionId) ?? null,
+                }))}
+                onAssign={(t) => void handleAssign(t)}
+                onRecruit={(u) => void handleRecruit(u)}
+                onArmDefenseSpell={(spellId) => void handleArm(spellId)}
+                onUseDefensiveArtifact={(artifactId) => {
+                  const a = artifacts.find((x) => x.id === artifactId);
+                  if (a) void handleUseArtifact(a, source.tileId);
+                }}
+              />
             </div>
-          </section>
+          )}
+
+          {/* ── RECENT OUTCOMES (full-width, below the tab content) ─────── */}
+          {recentOutcomes && (
+            <section className="px-4 py-3 space-y-2 border-t border-neutral-100 dark:border-neutral-900/60">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                Recent outcomes
+              </h3>
+              {battle && (
+                <BattleReport
+                  combat={battle.combat}
+                  report={battle.report}
+                  targetTile={battle.targetTile}
+                  onDismiss={() => setBattle(null)}
+                />
+              )}
+              {intelReport && (
+                <ThreatIntelPanel
+                  report={intelReport}
+                  onDismiss={() => setIntelReport(null)}
+                />
+              )}
+              {toast && (
+                <div className="px-3 py-2 rounded bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900 text-xs text-emerald-800 dark:text-emerald-200 flex items-center justify-between gap-2">
+                  <span>{toast}</span>
+                  <button
+                    onClick={() => setToast(null)}
+                    className="text-emerald-600 dark:text-emerald-400 hover:text-emerald-900 dark:hover:text-emerald-200"
+                  >
+                    ✕
+                  </button>
+                </div>
+              )}
+            </section>
+          )}
         </div>
       )}
     </div>
   );
 }
 
-function UnitInput({
+function TabButton({
+  active,
+  tone,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  tone: "red" | "blue";
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const activeCls =
+    tone === "red"
+      ? "border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-200"
+      : "border-blue-300 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-200";
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`px-4 py-1.5 text-sm font-semibold rounded-t-md border-x border-t -mb-px transition-colors ${
+        active
+          ? activeCls
+          : "border-transparent text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function UnitWithRecruit({
   label,
   value,
   max,
   onChange,
+  recruitYield,
+  recruitDisabledReason,
+  busy,
+  onRecruit,
 }: {
   label: string;
   value: number;
   max: number;
   onChange: (n: number) => void;
+  recruitYield: number;
+  recruitDisabledReason: string | null;
+  busy: boolean;
+  onRecruit: () => void;
 }) {
+  // When recruitYield is 0 the source tile can't actually produce that unit
+  // (no land type assigned). Show "+10" so the column width stays
+  // consistent, but disable the button — the tooltip carries the why.
+  const buttonLabel = recruitYield > 0 ? `+${recruitYield}` : "+10";
+  const inputId = `units-${label.replace(/[^a-z0-9]/gi, "-")}`;
   return (
-    <label className="text-xs">
-      <span className="text-neutral-500 block mb-0.5">{label}</span>
+    <div className="flex flex-col w-24">
+      <label
+        htmlFor={inputId}
+        className="text-xs text-neutral-500 mb-1 truncate"
+      >
+        {label}
+      </label>
       <input
+        id={inputId}
         type="number"
         min={0}
         max={max}
@@ -876,38 +776,18 @@ function UnitInput({
           const n = Number.parseInt(e.target.value, 10);
           onChange(Number.isFinite(n) ? Math.max(0, Math.min(max, n)) : 0);
         }}
-        className="w-20 px-2 py-1.5 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-sm"
+        className="w-full px-3 py-2 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-base font-medium"
       />
-    </label>
-  );
-}
-
-function SpyButton({
-  spell,
-  player,
-  busy,
-  onCast,
-}: {
-  spell: SpellDefinition;
-  player: GamePlayer;
-  busy: boolean;
-  onCast: () => void;
-}) {
-  const reason =
-    player.turnsRemaining < spell.turnCost
-      ? `Need ${spell.turnCost} turns`
-      : player.stats.tilesHeld < spell.minTilesRequired
-        ? `Need ${spell.minTilesRequired} tiles`
-        : null;
-  return (
-    <button
-      onClick={onCast}
-      disabled={busy || reason !== null}
-      title={reason ?? spell.description}
-      className="px-3 py-1.5 text-xs rounded border border-violet-300 dark:border-violet-800 hover:bg-violet-50 dark:hover:bg-violet-950/30 disabled:opacity-50"
-    >
-      Spy: {spell.name} ({spell.turnCost}t)
-    </button>
+      <button
+        type="button"
+        onClick={onRecruit}
+        disabled={busy || recruitDisabledReason !== null}
+        title={recruitDisabledReason ?? `Recruit ${buttonLabel} on this tile (5 turns)`}
+        className="mt-1 w-full px-3 py-2 text-sm rounded border border-emerald-400 dark:border-emerald-800 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 disabled:opacity-40 disabled:cursor-not-allowed font-medium"
+      >
+        {buttonLabel} · 5t
+      </button>
+    </div>
   );
 }
 

--- a/app/game/threats/page.tsx
+++ b/app/game/threats/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import { SignedOutLanding } from "../_components/dashboard/SignedOutLanding";
 import { useDashboardData } from "../_lib/use-dashboard-data";
+import { ArmyPanel } from "./_components/ArmyPanel";
 import { ThreatRow } from "./_components/ThreatRow";
 import { deriveThreatEntries } from "./_lib/threats-derive";
 
@@ -167,6 +168,8 @@ export default function ThreatsPage() {
         </div>
       )}
 
+      <ArmyPanel player={player} />
+
       {visibleEntries.length === 0 ? (
         <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-6 text-center text-sm text-neutral-500">
           {entries.length === 0
@@ -175,13 +178,18 @@ export default function ThreatsPage() {
         </div>
       ) : (
         <div className="space-y-3">
-          {visibleEntries.map((entry) => (
+          {visibleEntries.map((entry, idx) => (
             <ThreatRow
               key={entry.enemyTile.tileId}
               entry={entry}
               player={player}
               artifacts={artifacts}
               busy={busy}
+              // Auto-expand the top-3 ranked threats so the user lands in
+              // the canonical attack flow without an extra click on the
+              // matchups they're most likely to act on. Lower-ranked rows
+              // stay collapsed to keep the page scannable.
+              defaultExpanded={idx < 3}
               onAttack={withBusy(handleAttack)}
               onCastIntelSpell={withBusy(handleCastIntelSpell)}
               onUseArtifact={withBusy(handleUseArtifact)}

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/lib/game/content";
 import { realizedSpellMagnitude } from "@/lib/game/combat";
 import { CatalogImage } from "@/app/game/_components/CatalogImage";
+import { BattleSimPanel } from "@/app/game/threats/_components/BattleSimPanel";
+import { useAttackPreview } from "@/app/game/threats/_lib/use-attack-preview";
 import type {
   GameArtifact,
   GamePlayer,
@@ -329,6 +331,31 @@ export function EnemyTilePanel({
     player.phase === "play" &&
     player.turnsRemaining >= 1 + (offenseSpellId ? 5 : 0);
 
+  // Live battle simulation — same hook the threats-page uses. Renders below
+  // the attack form so the modal and the threats page give the same answer
+  // for the same matchup. Preview disabled when the matchup is structurally
+  // impossible (no source, wrong phase) since the server would reject it.
+  const selectedOffense = offenseSpells.find((s) => s.id === offenseSpellId) ?? null;
+  const selectedOffenseExpected = selectedOffense
+    ? realizedSpellMagnitude({
+        baseStrength: selectedOffense.baseStrength,
+        caste: selectedOffense.caste,
+        spellType: selectedOffense.type,
+        magicLandCount: playerMagicLandCount,
+        activeUpgrades: player.activeUpgrades ?? {},
+        dice: 1.0,
+      })
+    : null;
+  const previewDisabled =
+    !source || player.phase !== "play" || sentTotal === 0;
+  const attackPreview = useAttackPreview({
+    sourceTileId: source?.tileId ?? "",
+    targetTileId: tile.tileId,
+    units: { ground, siege, air },
+    offenseSpellId: selectedOffense ? selectedOffense.id : null,
+    disabled: previewDisabled,
+  });
+
   const offenseArtifactSection =
     onUseArtifact && offensiveArtifacts.length > 0 ? (
       <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/20 p-4 space-y-2">
@@ -528,6 +555,31 @@ export function EnemyTilePanel({
           {busy ? "Resolving…" : `Send ${sentTotal} units (cost ${1 + (offenseSpellId ? 5 : 0)} turns)`}
         </button>
       </div>
+
+      {/* Live battle simulation — parity with the threats-page experience. */}
+      <BattleSimPanel
+        preview={attackPreview.preview}
+        loading={attackPreview.loading}
+        error={attackPreview.error}
+        disabled={previewDisabled}
+        disabledReason={
+          !source
+            ? "Pick a source tile first."
+            : player.phase !== "play"
+              ? "Not in play phase — preview unavailable."
+              : sentTotal === 0
+                ? "Set unit counts to see a projection."
+                : undefined
+        }
+        selectedOffenseSpell={
+          selectedOffense
+            ? {
+                spell: selectedOffense,
+                expectedMagnitude: selectedOffenseExpected ?? 0,
+              }
+            : null
+        }
+      />
 
       {offenseArtifactSection}
       {spySection}

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**155 paths, 189 operations across 31 areas.**
+**158 paths, 192 operations across 31 areas.**
 
 ---
 
@@ -124,6 +124,7 @@ _Coworking sessions and PyData 2026 ticketing._
 | GET | `/api/events/pydata-2026/luma-status` | No | Whether the current user appears on the PyData Luma guest list |
 | GET | `/api/events/pydata-2026/registration` | Yes | Get the current user's PyData 2026 registration (if any) |
 | POST | `/api/events/pydata-2026/registration` | Yes | Create or update the current user's PyData 2026 registration |
+| POST | `/api/events/pydata-2026/withdraw` | No | Two-step PyData withdrawal: confirmation page POSTs here with HMAC token |
 
 ## Game
 
@@ -406,8 +407,10 @@ _Talk-submission moderation queue._
 | DELETE | `/api/summer-cohort/apply` | Yes | Withdraw the current user's summer-cohort application |
 | GET | `/api/summer-cohort/apply` | Yes | Get the current user's summer-cohort application + counts |
 | POST | `/api/summer-cohort/apply` | Yes | Create or update the current user's summer-cohort application |
+| POST | `/api/summer-cohort/confirm-dev-env` | Yes | Cohort 1 admit confirms dev environment is set up (Node + Git + IDE) |
 | GET | `/api/summer-cohort/intake-survey` | Yes | Get the current user's intake-survey response |
 | POST | `/api/summer-cohort/intake-survey` | Yes | Submit (or re-submit) the intake survey |
 | GET | `/api/summer-cohort/submissions/{weekId}` | No | Public read of merged submissions on a vote-format week |
 | GET | `/api/summer-cohort/votes` | No | Aggregate vote counts for a vote-format week |
 | POST | `/api/summer-cohort/votes` | Yes | Toggle the current user's vote for a submission |
+| GET | `/api/summer-cohort/withdraw` | No | One-click cohort withdrawal (HMAC token in query) |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -32,6 +32,7 @@ Licensed GPL-3.0-only.
     /cfp
     /code-of-conduct
     /cohort-ai
+    /cohort-withdraw
     /cookbook
     /cookies
     /disclaimer
@@ -83,6 +84,7 @@ Licensed GPL-3.0-only.
     /partners
     /privacy
     /profile
+    /pydata-withdraw
     /questions
     /questions/[questionId]
     /questions/ask
@@ -108,7 +110,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (189 endpoints)
+## API (192 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -185,6 +187,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     GET    /api/events/pydata-2026/luma-status — Whether the current user appears on the PyData Luma guest list
     GET    /api/events/pydata-2026/registration [Yes] — Get the current user's PyData 2026 registration (if any)
     POST   /api/events/pydata-2026/registration [Yes] — Create or update the current user's PyData 2026 registration
+    POST   /api/events/pydata-2026/withdraw — Two-step PyData withdrawal: confirmation page POSTs here with HMAC token
 
 ### Game
 
@@ -389,11 +392,13 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     DELETE /api/summer-cohort/apply [Yes] — Withdraw the current user's summer-cohort application
     GET    /api/summer-cohort/apply [Yes] — Get the current user's summer-cohort application + counts
     POST   /api/summer-cohort/apply [Yes] — Create or update the current user's summer-cohort application
+    POST   /api/summer-cohort/confirm-dev-env [Yes] — Cohort 1 admit confirms dev environment is set up (Node + Git + IDE)
     GET    /api/summer-cohort/intake-survey [Yes] — Get the current user's intake-survey response
     POST   /api/summer-cohort/intake-survey [Yes] — Submit (or re-submit) the intake survey
     GET    /api/summer-cohort/submissions/{weekId} — Public read of merged submissions on a vote-format week
     GET    /api/summer-cohort/votes — Aggregate vote counts for a vote-format week
     POST   /api/summer-cohort/votes [Yes] — Toggle the current user's vote for a submission
+    GET    /api/summer-cohort/withdraw — One-click cohort withdrawal (HMAC token in query)
 
 ## Error Format
 


### PR DESCRIPTION
## Summary

Release develop → main with three changes:

- **feat(game/threats):** Attack-tab redesign — `ArmyPanel` reference at the top, designed source-tile card with picker modal, side-by-side Boost + Spell-picker boxes, queued offensive artifacts, big ATTACK CTA, Defense tab for source-tile management. (56151ad)
- **refactor(game):** Move caste lore into the catalog. (0184975)
- **chore(docs):** Regenerate `API.md` + `llms.txt` for previously-added cohort/PyData routes. (0d55bfb)

## Contributors

- Ludwitt — all three commits

## Test plan

- [x] Local prod build succeeds
- [ ] `/game/threats` renders Army panel + expanded rows with Attack/Defense tabs
- [ ] Offensive artifact stays queued until Attack fires (not consumed on click)
- [ ] Source-tile change modal opens when multiple sources border the enemy
- [ ] Spell + Boost boxes render at equal height; +N recruit buttons function

🤖 Generated with [Claude Code](https://claude.com/claude-code)