### PR TITLE
release: ci dep bumps (dependency-review-action 5.0.0, cosign-installer 4.1.2)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign release artifacts
         env:


### PR DESCRIPTION
## Summary

Release develop → main. Two CI workflow dependency bumps from Dependabot, no application code changes.

## Included PRs

- #799 — ci(deps): bump sigstore/cosign-installer from 3.9.1 to 4.1.2 — @dependabot
- #800 — ci(deps): bump actions/dependency-review-action from 4.9.0 to 5.0.0 — @dependabot

## Test plan

- [x] Both PRs squash-merged to develop
- [x] All non-coverage CI checks green on both PRs (lint, security, E2E, firestore-rules, DCO, Vercel)
- [ ] Coverage threshold known-failing on develop (pre-existing, unrelated to these workflow-only changes) — admin merge