### PR TITLE
perf(game): compact per-tile encoding shrinks world snapshot ~70%

### DIFF
--- a/__tests__/app/game/parse-world-snapshot.test.ts
+++ b/__tests__/app/game/parse-world-snapshot.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Timestamp } from "firebase/firestore";
+import { parseSnapshotDoc } from "@/app/game/_lib/parse-world-snapshot";
+import type { MapTile } from "@/lib/game/types";
+import { compactTile } from "@/lib/game/world-snapshot-codec";
+
+describe("parseSnapshotDoc", () => {
+  const sampleTile: MapTile = {
+    tileId: "3_-2",
+    q: 3,
+    r: -2,
+    type: "military",
+    ownerId: "user_alpha",
+    units: { ground: 12, siege: 0, air: 0 },
+    armedDefenseSpellId: null,
+  };
+
+  const sampleOwner = {
+    userId: "user_alpha",
+    displayName: "Alpha",
+    caste: "white" as const,
+    shielded: false,
+    isNpc: false,
+  };
+
+  describe("schemaVersion 2 (compactTiles)", () => {
+    it("decodes compactTiles back into MapTile[]", () => {
+      const out = parseSnapshotDoc({
+        schemaVersion: 2,
+        compactTiles: [compactTile(sampleTile)],
+        owners: [sampleOwner],
+        generatedAt: "2026-05-12T12:00:00.000Z",
+        tileCount: 1,
+        ownerCount: 1,
+      });
+      expect(out.tiles).toEqual([sampleTile]);
+      expect(out.owners).toEqual([sampleOwner]);
+      expect(out.generatedAt).toBe("2026-05-12T12:00:00.000Z");
+      expect(out.tileCount).toBe(1);
+      expect(out.ownerCount).toBe(1);
+    });
+  });
+
+  describe("schemaVersion 1 (legacy tiles)", () => {
+    it("uses tiles directly when compactTiles is absent", () => {
+      const out = parseSnapshotDoc({
+        tiles: [sampleTile],
+        owners: [sampleOwner],
+        generatedAt: "2026-05-08T00:00:00.000Z",
+        tileCount: 1,
+        ownerCount: 1,
+      });
+      expect(out.tiles).toEqual([sampleTile]);
+    });
+
+    it("prefers v2 compactTiles when both fields are present", () => {
+      const v2Tile: MapTile = { ...sampleTile, q: 99, r: 99, tileId: "99_99" };
+      const out = parseSnapshotDoc({
+        compactTiles: [compactTile(v2Tile)],
+        tiles: [sampleTile], // should be ignored
+        owners: [sampleOwner],
+        generatedAt: "2026-05-12T12:00:00.000Z",
+        tileCount: 1,
+        ownerCount: 1,
+      });
+      expect(out.tiles).toEqual([v2Tile]);
+    });
+  });
+
+  describe("generatedAt coercion", () => {
+    it("accepts a Firestore Timestamp", () => {
+      const ts = Timestamp.fromDate(new Date("2026-05-10T12:00:00.000Z"));
+      const out = parseSnapshotDoc({
+        compactTiles: [],
+        owners: [],
+        generatedAt: ts,
+        tileCount: 0,
+        ownerCount: 0,
+      });
+      expect(out.generatedAt).toBe("2026-05-10T12:00:00.000Z");
+    });
+
+    it("accepts a plain Date", () => {
+      const out = parseSnapshotDoc({
+        compactTiles: [],
+        owners: [],
+        generatedAt: new Date("2026-05-09T12:00:00.000Z"),
+        tileCount: 0,
+        ownerCount: 0,
+      });
+      expect(out.generatedAt).toBe("2026-05-09T12:00:00.000Z");
+    });
+
+    it("accepts an ISO string", () => {
+      const out = parseSnapshotDoc({
+        compactTiles: [],
+        owners: [],
+        generatedAt: "2026-05-08T12:00:00.000Z",
+        tileCount: 0,
+        ownerCount: 0,
+      });
+      expect(out.generatedAt).toBe("2026-05-08T12:00:00.000Z");
+    });
+
+    it("falls back to now when generatedAt is missing", () => {
+      const before = Date.now();
+      const out = parseSnapshotDoc({
+        compactTiles: [],
+        owners: [],
+        tileCount: 0,
+        ownerCount: 0,
+      });
+      const parsed = Date.parse(out.generatedAt);
+      expect(parsed).toBeGreaterThanOrEqual(before);
+      expect(parsed).toBeLessThanOrEqual(Date.now() + 100);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("returns empty arrays when neither tiles nor compactTiles is present", () => {
+      const out = parseSnapshotDoc({
+        owners: [],
+        generatedAt: "2026-05-12T12:00:00.000Z",
+      });
+      expect(out.tiles).toEqual([]);
+      expect(out.tileCount).toBe(0);
+    });
+
+    it("treats missing owners as empty", () => {
+      const out = parseSnapshotDoc({
+        compactTiles: [],
+        generatedAt: "2026-05-12T12:00:00.000Z",
+      });
+      expect(out.owners).toEqual([]);
+      expect(out.ownerCount).toBe(0);
+    });
+
+    it("derives counts from arrays when count fields are missing", () => {
+      const out = parseSnapshotDoc({
+        compactTiles: [compactTile(sampleTile), compactTile({ ...sampleTile, q: 4 })],
+        owners: [sampleOwner],
+        generatedAt: "2026-05-12T12:00:00.000Z",
+      });
+      expect(out.tileCount).toBe(2);
+      expect(out.ownerCount).toBe(1);
+    });
+  });
+});

--- a/__tests__/lib/game/world-snapshot-codec.test.ts
+++ b/__tests__/lib/game/world-snapshot-codec.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { MapTile } from "@/lib/game/types";
+import {
+  compactTile,
+  expandTile,
+  WORLD_SNAPSHOT_SCHEMA_VERSION,
+} from "@/lib/game/world-snapshot-codec";
+
+describe("world-snapshot codec", () => {
+  it("schema version is 2", () => {
+    expect(WORLD_SNAPSHOT_SCHEMA_VERSION).toBe(2);
+  });
+
+  describe("round-trip", () => {
+    const cases: Array<{ name: string; tile: MapTile }> = [
+      {
+        name: "empty unrevealed tile (the common case)",
+        tile: {
+          tileId: "5_-3",
+          q: 5,
+          r: -3,
+          type: "unrevealed",
+          ownerId: null,
+          units: { ground: 0, siege: 0, air: 0 },
+          armedDefenseSpellId: null,
+        },
+      },
+      {
+        name: "owned military tile with mixed units",
+        tile: {
+          tileId: "0_0",
+          q: 0,
+          r: 0,
+          type: "military",
+          ownerId: "user_abc123",
+          units: { ground: 50, siege: 10, air: 0 },
+          armedDefenseSpellId: null,
+        },
+      },
+      {
+        name: "tile with a defense spell armed",
+        tile: {
+          tileId: "-7_4",
+          q: -7,
+          r: 4,
+          type: "magic",
+          ownerId: "user_def456",
+          units: { ground: 0, siege: 0, air: 5 },
+          armedDefenseSpellId: "white_t3_shield",
+        },
+      },
+      {
+        name: "all five LandType values",
+        tile: {
+          tileId: "1_1",
+          q: 1,
+          r: 1,
+          type: "food",
+          ownerId: null,
+          units: { ground: 0, siege: 0, air: 0 },
+          armedDefenseSpellId: null,
+        },
+      },
+    ];
+
+    it.each(cases)("$name round-trips", ({ tile }) => {
+      expect(expandTile(compactTile(tile))).toEqual(tile);
+    });
+  });
+
+  describe("size win", () => {
+    // The whole point of v2: the on-wire form is much smaller. Lock that
+    // win in with a coarse byte-budget assertion. If a future change
+    // accidentally puffs the encoding back up, this test will catch it.
+    it("the empty-tile common case is < 30 bytes JSON", () => {
+      const empty: MapTile = {
+        tileId: "5_-3",
+        q: 5,
+        r: -3,
+        type: "unrevealed",
+        ownerId: null,
+        units: { ground: 0, siege: 0, air: 0 },
+        armedDefenseSpellId: null,
+      };
+      const v1Bytes = JSON.stringify(empty).length;
+      const v2Bytes = JSON.stringify(compactTile(empty)).length;
+      expect(v2Bytes).toBeLessThan(30);
+      // Sanity check: at least 4× smaller for the common case.
+      expect(v1Bytes / v2Bytes).toBeGreaterThan(4);
+    });
+
+    it("a populated map saves >50% on the tiles array", () => {
+      // Mostly-empty world with ~5% of tiles owned/populated — a rough
+      // proxy for the live world today.
+      const tiles: MapTile[] = [];
+      for (let i = 0; i < 1000; i++) {
+        const owned = i % 20 === 0;
+        tiles.push({
+          tileId: `${i}_0`,
+          q: i,
+          r: 0,
+          type: owned ? "military" : "unrevealed",
+          ownerId: owned ? "user_abcdef123456" : null,
+          units: owned ? { ground: 25, siege: 0, air: 0 } : { ground: 0, siege: 0, air: 0 },
+          armedDefenseSpellId: null,
+        });
+      }
+      const v1 = JSON.stringify(tiles).length;
+      const v2 = JSON.stringify(tiles.map(compactTile)).length;
+      expect(v2 / v1).toBeLessThan(0.5);
+    });
+  });
+
+  describe("error handling", () => {
+    it("rejects an unknown LandType on encode", () => {
+      const bad = { ...mkTile(), type: "swamp" as unknown as MapTile["type"] };
+      expect(() => compactTile(bad)).toThrow(/Unknown LandType/);
+    });
+
+    it("rejects an unknown type code on decode", () => {
+      expect(() => expandTile({ q: 0, r: 0, t: "z" })).toThrow(/Unknown CompactTile type code/);
+    });
+
+    it("decodes missing optional fields to defaults", () => {
+      const tile = expandTile({ q: 4, r: -2, t: "u" });
+      expect(tile).toEqual({
+        tileId: "4_-2",
+        q: 4,
+        r: -2,
+        type: "unrevealed",
+        ownerId: null,
+        units: { ground: 0, siege: 0, air: 0 },
+        armedDefenseSpellId: null,
+      });
+    });
+  });
+});
+
+function mkTile(): MapTile {
+  return {
+    tileId: "0_0",
+    q: 0,
+    r: 0,
+    type: "unrevealed",
+    ownerId: null,
+    units: { ground: 0, siege: 0, air: 0 },
+    armedDefenseSpellId: null,
+  };
+}

--- a/app/game/_lib/parse-world-snapshot.ts
+++ b/app/game/_lib/parse-world-snapshot.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// Pure parser for a snapshot doc as delivered by the Firestore Web SDK
+// (`onSnapshot` data payload). Lives in its own file so it's testable
+// without React or the SDK transport. The hook in
+// `use-world-snapshot-listener.ts` is a thin wrapper around this.
+
+import { Timestamp } from "firebase/firestore";
+import type { Caste, MapTile } from "@/lib/game/types";
+import {
+  expandTile,
+  type CompactTile,
+} from "@/lib/game/world-snapshot-codec";
+
+export interface ClientWorldSnapshotOwner {
+  userId: string;
+  displayName: string;
+  caste: Caste | null;
+  shielded: boolean;
+  isNpc: boolean;
+}
+
+export interface ClientWorldSnapshot {
+  tiles: MapTile[];
+  owners: ClientWorldSnapshotOwner[];
+  generatedAt: string;
+  tileCount: number;
+  ownerCount: number;
+}
+
+/**
+ * Decode a snapshot doc payload. Handles both schema versions:
+ *   - v2 (current writer): tiles in `compactTiles[]`, decoded via expandTile.
+ *   - v1 (legacy): tiles in `tiles[]`, used as-is.
+ *
+ * Tolerates malformed input by returning empty arrays — the listener
+ * surfaces parser errors via React state instead of throwing.
+ */
+export function parseSnapshotDoc(
+  data: Record<string, unknown>
+): ClientWorldSnapshot {
+  const generatedAtRaw = data.generatedAt;
+  let generatedAt: string;
+  if (generatedAtRaw instanceof Timestamp) {
+    generatedAt = generatedAtRaw.toDate().toISOString();
+  } else if (generatedAtRaw instanceof Date) {
+    generatedAt = generatedAtRaw.toISOString();
+  } else if (typeof generatedAtRaw === "string") {
+    generatedAt = generatedAtRaw;
+  } else {
+    generatedAt = new Date().toISOString();
+  }
+  // v2 docs store `compactTiles`; v1 docs store `tiles`. Either is OK.
+  let tiles: MapTile[];
+  if (Array.isArray(data.compactTiles)) {
+    tiles = (data.compactTiles as CompactTile[]).map(expandTile);
+  } else if (Array.isArray(data.tiles)) {
+    tiles = data.tiles as MapTile[];
+  } else {
+    tiles = [];
+  }
+  const owners = Array.isArray(data.owners)
+    ? (data.owners as ClientWorldSnapshotOwner[])
+    : [];
+  return {
+    tiles,
+    owners,
+    generatedAt,
+    tileCount: typeof data.tileCount === "number" ? data.tileCount : tiles.length,
+    ownerCount:
+      typeof data.ownerCount === "number" ? data.ownerCount : owners.length,
+  };
+}

--- a/app/game/_lib/use-world-snapshot-listener.ts
+++ b/app/game/_lib/use-world-snapshot-listener.ts
@@ -6,31 +6,18 @@
 
 "use client";
 
-import { doc, onSnapshot, Timestamp } from "firebase/firestore";
+import { doc, onSnapshot } from "firebase/firestore";
 import { useEffect, useRef, useState } from "react";
 import { db as firestoreDb } from "@/lib/firebase";
-import type { Caste, MapTile } from "@/lib/game/types";
+import {
+  parseSnapshotDoc,
+  type ClientWorldSnapshot,
+  type ClientWorldSnapshotOwner,
+} from "./parse-world-snapshot";
 
-// Mirrors WorldSnapshot in lib/game/world-snapshot.ts (which we can't
-// import here because it pulls firebase-admin). When the snapshot doc is
-// read by the client SDK, Firestore Timestamps stay as Timestamp
-// instances; we coerce to ISO strings on parse so the rest of the UI
-// treats it as plain JSON.
-export interface ClientWorldSnapshotOwner {
-  userId: string;
-  displayName: string;
-  caste: Caste | null;
-  shielded: boolean;
-  isNpc: boolean;
-}
-
-export interface ClientWorldSnapshot {
-  tiles: MapTile[];
-  owners: ClientWorldSnapshotOwner[];
-  generatedAt: string;
-  tileCount: number;
-  ownerCount: number;
-}
+// Re-export the snapshot types so existing callers that pull these from
+// the listener module keep working.
+export type { ClientWorldSnapshot, ClientWorldSnapshotOwner };
 
 // Detach from the live listener when the tab is hidden OR the user has
 // been idle for this long. Firestore bills 1 read per delivered change,
@@ -60,32 +47,6 @@ export interface WorldSnapshotListenerState {
   /** Last error observed from the listener (e.g. permission denied
    *  before sign-in). Cleared on a successful delivery. */
   error: string | null;
-}
-
-function parseSnapshotDoc(data: Record<string, unknown>): ClientWorldSnapshot {
-  const generatedAtRaw = data.generatedAt;
-  let generatedAt: string;
-  if (generatedAtRaw instanceof Timestamp) {
-    generatedAt = generatedAtRaw.toDate().toISOString();
-  } else if (generatedAtRaw instanceof Date) {
-    generatedAt = generatedAtRaw.toISOString();
-  } else if (typeof generatedAtRaw === "string") {
-    generatedAt = generatedAtRaw;
-  } else {
-    generatedAt = new Date().toISOString();
-  }
-  const tiles = Array.isArray(data.tiles) ? (data.tiles as MapTile[]) : [];
-  const owners = Array.isArray(data.owners)
-    ? (data.owners as ClientWorldSnapshotOwner[])
-    : [];
-  return {
-    tiles,
-    owners,
-    generatedAt,
-    tileCount: typeof data.tileCount === "number" ? data.tileCount : tiles.length,
-    ownerCount:
-      typeof data.ownerCount === "number" ? data.ownerCount : owners.length,
-  };
 }
 
 /**

--- a/lib/game/world-snapshot-codec.ts
+++ b/lib/game/world-snapshot-codec.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// Pure encode/decode helpers for the world-snapshot doc shape. Lives in
+// its own file (no firebase-admin dependency) so both the server-only
+// writer in `world-snapshot.ts` and the client listener in
+// `app/game/_lib/use-world-snapshot-listener.ts` can share one codec.
+
+import type { LandType, MapTile } from "./types";
+import { tileIdFromAxial } from "./world-gen";
+
+// Bumped when on-disk shape changes. Reader code should accept any version
+// it knows how to decode; v2 (current) reads compactTiles, v1 (legacy)
+// read tiles. Doc-shape rollbacks would require deploying a reader that
+// understands both — same pattern as today's reader.
+export const WORLD_SNAPSHOT_SCHEMA_VERSION = 2;
+
+// Single-character codes for LandType. The on-wire form pays a per-tile
+// price for the type string in 4,000+ array entries; trimming "unrevealed"
+// (10 chars) → "u" (1 char) shaves ~5–9 bytes per tile.
+const TYPE_TO_CODE: Record<LandType, string> = {
+  unrevealed: "u",
+  unassigned: "x",
+  military: "m",
+  food: "f",
+  magic: "g",
+};
+const CODE_TO_TYPE: Record<string, LandType> = {
+  u: "unrevealed",
+  x: "unassigned",
+  m: "military",
+  f: "food",
+  g: "magic",
+};
+
+/**
+ * On-wire form of a MapTile inside a v2 snapshot doc. All fields except
+ * q, r, t are omitted when at their zero/null default — most map tiles are
+ * "unrevealed empty", which compresses from ~140 B to ~22 B per entry.
+ *
+ * Layout choices favor readability over absolute density: short keys + omit
+ * defaults. Estimate at current scale (4,419 tiles, mostly empty):
+ *   v1 (`MapTile[]`):       ~660 KB
+ *   v2 (`CompactTile[]`):   ~200 KB  (~70% reduction)
+ */
+export interface CompactTile {
+  q: number;
+  r: number;
+  /** LandType code — see TYPE_TO_CODE. */
+  t: string;
+  /** Owner userId. Omitted when null (unowned). */
+  o?: string;
+  /** Ground units. Omitted when 0. */
+  g?: number;
+  /** Siege units. Omitted when 0. */
+  s?: number;
+  /** Air units. Omitted when 0. */
+  a?: number;
+  /** Armed defense spell id. Omitted when null. */
+  d?: string;
+}
+
+/** Encode a MapTile into its compact form. Pure. */
+export function compactTile(tile: MapTile): CompactTile {
+  const code = TYPE_TO_CODE[tile.type];
+  if (!code) throw new Error(`Unknown LandType: ${tile.type}`);
+  const c: CompactTile = { q: tile.q, r: tile.r, t: code };
+  if (tile.ownerId) c.o = tile.ownerId;
+  // tile.units may be undefined on legacy docs that predate the field.
+  if (tile.units?.ground) c.g = tile.units.ground;
+  if (tile.units?.siege) c.s = tile.units.siege;
+  if (tile.units?.air) c.a = tile.units.air;
+  if (tile.armedDefenseSpellId) c.d = tile.armedDefenseSpellId;
+  return c;
+}
+
+/** Decode a CompactTile back into a MapTile. Pure. */
+export function expandTile(c: CompactTile): MapTile {
+  const type = CODE_TO_TYPE[c.t];
+  if (!type) throw new Error(`Unknown CompactTile type code: ${c.t}`);
+  return {
+    tileId: tileIdFromAxial(c.q, c.r),
+    q: c.q,
+    r: c.r,
+    type,
+    ownerId: c.o ?? null,
+    units: { ground: c.g ?? 0, siege: c.s ?? 0, air: c.a ?? 0 },
+    armedDefenseSpellId: c.d ?? null,
+  };
+}

--- a/lib/game/world-snapshot.ts
+++ b/lib/game/world-snapshot.ts
@@ -24,7 +24,22 @@ import { getAdminDb } from "@/lib/firebase-admin";
 import { logger } from "@/lib/logger";
 import { isShieldActive } from "./turns";
 import type { Caste, GamePlayer, MapTile } from "./types";
+import {
+  compactTile,
+  expandTile,
+  WORLD_SNAPSHOT_SCHEMA_VERSION,
+  type CompactTile,
+} from "./world-snapshot-codec";
 import { neighborTileIds } from "./world-gen";
+
+// Re-export the codec so existing callers that pull these from
+// `world-snapshot` keep working.
+export {
+  compactTile,
+  expandTile,
+  WORLD_SNAPSHOT_SCHEMA_VERSION,
+} from "./world-snapshot-codec";
+export type { CompactTile } from "./world-snapshot-codec";
 
 export const WORLD_SNAPSHOT_COLLECTION = "game_world_snapshots";
 export const WORLD_SNAPSHOT_DOC = "latest";
@@ -54,8 +69,15 @@ export interface WorldSnapshot {
   ownerCount: number;
 }
 
+// On-disk form. v2 stores `compactTiles`; v1 stored `tiles`. The reader
+// detects format via `schemaVersion` (defaulting to v1 for legacy docs)
+// and decodes accordingly.
 interface StoredWorldSnapshot {
-  tiles: MapTile[];
+  schemaVersion?: number;
+  // v2 (current writer always emits this):
+  compactTiles?: CompactTile[];
+  // v1 (still readable; written until the first v2 rebuild lands):
+  tiles?: MapTile[];
   owners: WorldSnapshotOwner[];
   generatedAt: FirebaseFirestore.Timestamp | Date;
   expiresAt: FirebaseFirestore.Timestamp | Date;
@@ -201,7 +223,8 @@ export async function rebuildWorldSnapshotServer(
 
   const snapshot = await computeWorldSnapshot(db, now);
   const stored: StoredWorldSnapshot = {
-    tiles: snapshot.tiles,
+    schemaVersion: WORLD_SNAPSHOT_SCHEMA_VERSION,
+    compactTiles: snapshot.tiles.map(compactTile),
     owners: snapshot.owners,
     generatedAt: now,
     expiresAt: new Date(now.getTime() + WORLD_SNAPSHOT_TTL_MS),
@@ -218,6 +241,7 @@ export async function rebuildWorldSnapshotServer(
   const bytes = JSON.stringify(stored).length;
 
   logger.info("Game world snapshot rebuilt", {
+    schemaVersion: WORLD_SNAPSHOT_SCHEMA_VERSION,
     tileCount: snapshot.tileCount,
     ownerCount: snapshot.ownerCount,
     approxBytes: bytes,
@@ -246,7 +270,16 @@ export async function readWorldSnapshotServer(): Promise<{
   if (!doc.exists) return null;
 
   const data = doc.data() as StoredWorldSnapshot | undefined;
-  if (!data || !Array.isArray(data.tiles) || !Array.isArray(data.owners)) {
+  if (!data || !Array.isArray(data.owners)) return null;
+
+  // Decode tiles from whichever format is present. v2 docs store
+  // `compactTiles`; legacy v1 docs store `tiles` directly. Either is OK.
+  let tiles: MapTile[];
+  if (Array.isArray(data.compactTiles)) {
+    tiles = data.compactTiles.map(expandTile);
+  } else if (Array.isArray(data.tiles)) {
+    tiles = data.tiles;
+  } else {
     return null;
   }
 
@@ -261,10 +294,10 @@ export async function readWorldSnapshotServer(): Promise<{
 
   return {
     snapshot: {
-      tiles: data.tiles,
+      tiles,
       owners: data.owners,
       generatedAt: generatedAt.toISOString(),
-      tileCount: data.tileCount ?? data.tiles.length,
+      tileCount: data.tileCount ?? tiles.length,
       ownerCount: data.ownerCount ?? data.owners.length,
     },
     isStale: Date.now() >= expiresAt.getTime(),
@@ -337,9 +370,11 @@ export function deriveMyMapFromSnapshot(
   return { myTiles, borderTiles, owners };
 }
 
-// Future work: when the world grows past ~12K tiles the snapshot doc will
-// approach Firestore's 1MB hard limit. Shard by `tileId.charCodeAt(0) % N`
-// into `game_world_snapshots/shard-{n}` and fan-out reads. Owners stay
-// unsharded (player count grows much slower than tile count). The reader
-// API can stay the same — `readWorldSnapshotServer` just gets all shards
-// in parallel.
+// Future work: schemaVersion 2 (compact per-tile encoding) brought the doc
+// from ~660 KB → ~200 KB at 4,419 tiles. The next ceiling is still the
+// Firestore 1MB single-doc limit — at the v2 size that's ~25K tiles, but
+// past ~15K worth pre-emptively sharding. Plan: hash by
+// `tileId.charCodeAt(0) % N` into `game_world_snapshots/shard-{n}` and
+// fan-out reads. Owners stay unsharded (player count grows much slower
+// than tile count). The reader API can stay the same —
+// `readWorldSnapshotServer` just gets all shards in parallel and concats.


### PR DESCRIPTION
## Summary

- Shrinks `game_world_snapshots/latest` from **~660 KB → ~200 KB** at current scale (4,419 tiles, mostly empty), pulling capacity headroom from **68% → ~20%** of Firestore's 1 MB single-doc limit. Buys ~3× tile growth before sharding becomes necessary.
- New pure codec at `lib/game/world-snapshot-codec.ts`: single-char `LandType` codes (`u`/`x`/`m`/`f`/`g`) and omitted zero/null fields per tile. Empty tile JSON drops from ~140 B → ~22 B.
- Reader handles both v2 (`compactTiles[]`) and v1 (`tiles[]`) so a rollback degrades to the existing legacy live-query path instead of crashing.
- Same shared codec on the client listener (`use-world-snapshot-listener.ts`).

Context: phase A of the scaling plan that came out of the [10-day GCP/Firebase usage analysis](../tree/develop/scripts/data/analysis-2026-05-12) (May 2–12). Phase B (hash-sharding into 4 shards) is deferred to a follow-up PR.

## Test plan

- [x] `npx jest --config config/jest.config.js __tests__/lib/game/world-snapshot-codec.test.ts` (10 codec round-trip + size-budget tests)
- [x] Full suite: 170 suites / 1,805 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [ ] Post-deploy: confirm one cron rebuild logs `schemaVersion: 2` and `approxBytes` ≈ 200K (down from ~680K)
- [ ] Post-deploy: open `/game` in browser, confirm map renders identically to current

## Rollback safety

The reader is dual-version. If we revert this PR after a v2 doc has been written, the old reader sees `tiles` field absent on the doc and the existing `if (!Array.isArray(data.tiles)) return null;` branch falls through to the legacy `getAllMapTilesServer` / `getAllOwnerSummariesServer` live-query path. Slow but correct — no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)