### PR TITLE
release: pydata-2026 registration close + CSV export tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,7 @@ docs/*referral*/
 *referral*.csv
 *.credits.csv
 *.referrals.csv
+
+# Event-registration exports — contain attendee PII (email, phone). Live
+# in scripts/data/ as a working dir for one-shot exports; never commit.
+scripts/data/*-registrations-*.csv

--- a/app/api/events/pydata-2026/registration/route.ts
+++ b/app/api/events/pydata-2026/registration/route.ts
@@ -11,6 +11,7 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import { logger } from "@/lib/logger";
 import {
+  PYDATA_2026_REGISTRATION_OPEN,
   PYDATA_2026_REGISTRATIONS_COLLECTION,
   validatePydataRegistration,
   type PydataRegistration,
@@ -76,6 +77,20 @@ async function handleGet(request: NextRequest) {
 }
 
 async function handlePost(request: NextRequest) {
+  // Door list is locked once we've handed the CSV to Moderna. Block
+  // both new sign-ups and edits to existing rows so the snapshot we
+  // sent matches what stays in Firestore. The withdraw route stays
+  // open — people freeing up slots is fine.
+  if (!PYDATA_2026_REGISTRATION_OPEN) {
+    return NextResponse.json(
+      {
+        error: "Registration closed",
+        message:
+          "Registration for the May 13 PyData × Cursor Boston event is closed. The badge list has been sent to Moderna. If you need to update your details or cancel, email hello@cursorboston.com.",
+      },
+      { status: 410 }
+    );
+  }
   const user = await getVerifiedUser(request);
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/events/cursor-boston-pydata-2026/register/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/register/page.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import {
   PYDATA_2026_CAPACITY,
   PYDATA_2026_EVENT_SLUG,
+  PYDATA_2026_REGISTRATION_OPEN,
   PYDATA_2026_REGISTRATION_PATH,
   type PydataRegistration,
 } from "@/lib/pydata-2026";
@@ -196,7 +197,7 @@ export default function PyDataRegisterPage() {
           don&apos;t match.
         </p>
 
-        {!registration ? <ProcessExplainer /> : null}
+        {!registration && PYDATA_2026_REGISTRATION_OPEN ? <ProcessExplainer /> : null}
 
         <div className="mt-10">
           {authLoading || loading ? (
@@ -207,6 +208,8 @@ export default function PyDataRegisterPage() {
             <SignInGate />
           ) : registration ? (
             <AwaitingBadge registration={registration} onEdit={() => setRegistration(null)} />
+          ) : !PYDATA_2026_REGISTRATION_OPEN ? (
+            <RegistrationClosed />
           ) : (
             <RegistrationForm
               form={form}
@@ -498,6 +501,31 @@ function ProcessExplainer() {
         </ul>
       </div>
     </section>
+  );
+}
+
+function RegistrationClosed() {
+  return (
+    <div className="rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+      <h2 className="text-xl font-semibold tracking-tight">
+        Registration is closed
+      </h2>
+      <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
+        We&apos;ve sent the door list to Moderna and the badge cap is locked.
+        New sign-ups can no longer be added for the May 13 event.
+      </p>
+      <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
+        If you registered earlier, your details are already on the list — sign
+        in to see your status. If you need to change anything or cancel, email{" "}
+        <a
+          href="mailto:hello@cursorboston.com"
+          className="underline font-medium"
+        >
+          hello@cursorboston.com
+        </a>
+        .
+      </p>
+    </div>
   );
 }
 

--- a/lib/pydata-2026.ts
+++ b/lib/pydata-2026.ts
@@ -21,6 +21,18 @@ export const PYDATA_2026_REGISTRATION_PATH = `/events/${PYDATA_2026_EVENT_SLUG}/
 export const PYDATA_2026_REGISTRATIONS_COLLECTION = "pydataHack2026Registrations";
 
 /**
+ * Hard switch on the registration form. Set to `false` once we've sent
+ * the badge CSV to Moderna — at that point the door list is locked, no
+ * more new sign-ups or edits should land in the snapshot we already
+ * handed off. Existing registrants can still see their AwaitingBadge
+ * card and the `withdraw` route remains open so people can free up
+ * slots if they can't make it.
+ *
+ * Flipped to false on 2026-05-12 ahead of the May 13 event.
+ */
+export const PYDATA_2026_REGISTRATION_OPEN = false;
+
+/**
  * Event name written into eventContacts.eventNames by the Luma sync scripts
  * (sync-event-contacts.ts derives this from the CSV filename). Lookups for
  * "is this email on the pydata Luma list?" must match this string exactly.

--- a/scripts/export-pydata-registrations.ts
+++ b/scripts/export-pydata-registrations.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-shot: export all PyData 2026 site registrations to CSV.
+ *
+ * Output columns (in this order):
+ *   First Name, Last Name, Email, Phone, Organization, Status,
+ *   Registered At (ISO UTC), Updated At (ISO UTC), UID
+ *
+ * Rows are ordered by createdAt ascending — same order Moderna's badge
+ * cap (PYDATA_2026_CAPACITY) is applied in.
+ *
+ * Usage:
+ *   npx tsx scripts/export-pydata-registrations.ts
+ *   npx tsx scripts/export-pydata-registrations.ts --out=/tmp/pydata.csv
+ *   npx tsx scripts/export-pydata-registrations.ts --include-cancelled
+ *
+ * Default output path: scripts/data/pydata-2026-registrations-<YYYY-MM-DD>.csv
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { initializeApp, cert, getApps } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { loadEnvConfig } from "@next/env";
+import {
+  PYDATA_2026_REGISTRATIONS_COLLECTION,
+  type PydataRegistrationStatus,
+} from "../lib/pydata-2026";
+
+loadEnvConfig(process.cwd());
+
+interface CliArgs {
+  outPath: string;
+  includeCancelled: boolean;
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2);
+  const includeCancelled = args.includes("--include-cancelled");
+  const outArg = args.find((a) => a.startsWith("--out="));
+  const today = new Date().toISOString().slice(0, 10);
+  const defaultOut = path.join(
+    process.cwd(),
+    `scripts/data/pydata-2026-registrations-${today}.csv`
+  );
+  return {
+    outPath: outArg ? outArg.slice("--out=".length) : defaultOut,
+    includeCancelled,
+  };
+}
+
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const s = String(value);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function tsToIso(value: unknown): string {
+  if (value instanceof Timestamp) return value.toDate().toISOString();
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") return new Date(value).toISOString();
+  return "";
+}
+
+function tsToMs(value: unknown): number {
+  if (value instanceof Timestamp) return value.toMillis();
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number") return value;
+  return 0;
+}
+
+async function main(): Promise<void> {
+  const { outPath, includeCancelled } = parseArgs();
+  const json = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  if (!json) throw new Error("missing FIREBASE_SERVICE_ACCOUNT_JSON");
+  const credentials = JSON.parse(json);
+  if (!getApps().length) {
+    initializeApp({ credential: cert(credentials), projectId: credentials.project_id });
+  }
+  const db = getFirestore();
+
+  const snap = await db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).get();
+  const rows = snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      uid: d.id,
+      firstName: typeof data.firstName === "string" ? data.firstName : "",
+      lastName: typeof data.lastName === "string" ? data.lastName : "",
+      email: typeof data.email === "string" ? data.email : "",
+      phone: typeof data.phone === "string" ? data.phone : "",
+      organization: typeof data.organization === "string" ? data.organization : "",
+      status: (typeof data.status === "string" ? data.status : "awaiting-badge") as PydataRegistrationStatus,
+      createdAtMs: tsToMs(data.createdAt),
+      createdAtIso: tsToIso(data.createdAt),
+      updatedAtIso: tsToIso(data.updatedAt) || tsToIso(data.createdAt),
+    };
+  });
+
+  const filtered = includeCancelled
+    ? rows
+    : rows.filter((r) => r.status !== "cancelled");
+
+  filtered.sort((a, b) => a.createdAtMs - b.createdAtMs);
+
+  const header = [
+    "First Name",
+    "Last Name",
+    "Email",
+    "Phone",
+    "Organization",
+    "Status",
+    "Registered At",
+    "Updated At",
+    "UID",
+  ];
+  const lines = [header.map(csvEscape).join(",")];
+  for (const r of filtered) {
+    lines.push(
+      [
+        r.firstName,
+        r.lastName,
+        r.email,
+        r.phone,
+        r.organization,
+        r.status,
+        r.createdAtIso,
+        r.updatedAtIso,
+        r.uid,
+      ]
+        .map(csvEscape)
+        .join(",")
+    );
+  }
+
+  mkdirSync(path.dirname(outPath), { recursive: true });
+  writeFileSync(outPath, lines.join("\n") + "\n", "utf8");
+
+  const byStatus: Record<string, number> = {};
+  for (const r of filtered) byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+  const cancelledCount = rows.length - filtered.length;
+
+  console.log(`Wrote ${outPath}`);
+  console.log(`Total rows in CSV: ${filtered.length}`);
+  console.log(`By status:`, byStatus);
+  if (!includeCancelled && cancelledCount > 0) {
+    console.log(`(excluded ${cancelledCount} cancelled — pass --include-cancelled to include)`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Includes

- **#815** — feat(pydata-2026): close registration + add CSV export tool — @rogerSuperBuilderAlpha

## Highlights

- Locks the door list ahead of the May 13 PyData × Cursor Boston event at Moderna. New \`PYDATA_2026_REGISTRATION_OPEN\` constant (set to \`false\`); registration POST returns 410 Gone; the register page swaps the form for a "Registration is closed" card. Existing registrants still see their AwaitingBadge view; the withdraw route stays open so people who can't make it can still free up slots.
- New \`scripts/export-pydata-registrations.ts\` for re-exporting the CSV anytime (sorted by createdAt to match Moderna's badge cap ordering).
- \`scripts/data/*-registrations-*.csv\` now gitignored — attendee PII shouldn't land in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)