### PR TITLE
release: cohort modal expansion + designer onboarding + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Project instructions for Claude
+
+Conventions and behaviors that apply to every session in this repo.
+
+## Firestore rules + indexes — run on every commit
+
+**Before every commit, run the Firestore rules tests and validate the indexes file.** A broken rule or a malformed index spec ships silently otherwise — both files are referenced by `firebase.json` but neither has a build-time check. The Firestore emulator is the only way to catch a regression locally before CI.
+
+What to run:
+
+```bash
+# Rules: full emulator-backed test suite (covers config/firebase/firestore.rules)
+npm run test:rules
+
+# Indexes: parseable JSON + matches the deployed schema shape
+node -e "JSON.parse(require('fs').readFileSync('config/firebase/firestore.indexes.json','utf8'))"
+```
+
+If either fails, fix the underlying issue before committing — don't bypass with `--no-verify`.
+
+Notes:
+- `npm run test:rules` boots the Firestore emulator; it can take 20–30 s. That's acceptable cost on every commit; the failure mode it prevents (broken security rules in prod) is much worse.
+- The rules file lives at `config/firebase/firestore.rules`; indexes at `config/firebase/firestore.indexes.json`. Both are wired through `firebase.json` at the repo root.
+- CI also runs the "Firestore rules tests" check on every PR; the local pre-commit run is the early warning so we don't push a broken branch.
+- **Prerequisite: Java.** The Firestore emulator needs a JRE. If `java -version` fails, install one (`brew install --cask temurin` on macOS) before relying on the local rules tests. If Java is unavailable in the environment, validate the indexes JSON at minimum and rely on the CI "Firestore rules tests" check as the backstop — note this gap explicitly when committing.

--- a/__tests__/components/SummerCohortModal.test.tsx
+++ b/__tests__/components/SummerCohortModal.test.tsx
@@ -1,10 +1,33 @@
-import { act, render, screen } from "@testing-library/react";
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import SummerCohortModal from "@/components/SummerCohortModal";
+
 import {
   SUMMER_COHORT_LOCALSTORAGE_KEY,
   SUMMER_COHORT_OPEN_EVENT,
 } from "@/lib/summer-cohort";
+
+// Mock the AuthContext + usePathname BEFORE importing the modal so the
+// modal sees the mock instead of pulling in firebase at module-load time.
+const mockUseAuth = jest.fn();
+const mockUsePathname = jest.fn();
+
+jest.mock("@/contexts/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  usePathname: () => mockUsePathname(),
+}));
+
+import SummerCohortModal from "@/components/SummerCohortModal";
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -29,11 +52,15 @@ describe("SummerCohortModal", () => {
     localStorageMock.clear();
     localStorageMock.getItem.mockClear();
     localStorageMock.setItem.mockClear();
+    mockUseAuth.mockReset();
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    mockUsePathname.mockReset();
+    mockUsePathname.mockReturnValue("/");
   });
 
-  it("auto-opens on first visit (no localStorage flag for today)", () => {
+  it("auto-opens on first visit (no localStorage flag for today)", async () => {
     render(<SummerCohortModal />);
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(
       screen.getByText("Cursor Boston Summer Cohort")
     ).toBeInTheDocument();
@@ -46,19 +73,106 @@ describe("SummerCohortModal", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("renders both cohort date rows and the Apply button", () => {
+  it("does not auto-open on suppressed pathnames (/summer-cohort)", () => {
+    mockUsePathname.mockReturnValue("/summer-cohort");
     render(<SummerCohortModal />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not auto-open on /contribute/game-art", () => {
+    mockUsePathname.mockReturnValue("/contribute/game-art");
+    render(<SummerCohortModal />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders both cohort rows; cohort 1 marked Closed", async () => {
+    render(<SummerCohortModal />);
+    await screen.findByRole("dialog");
     expect(screen.getByText("Cohort 1")).toBeInTheDocument();
     expect(screen.getByText("Cohort 2")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /apply/i })).toHaveAttribute(
-      "href",
-      "/summer-cohort"
-    );
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+  });
+
+  it("default CTA is Apply → /summer-cohort for signed-out users", async () => {
+    render(<SummerCohortModal />);
+    await screen.findByRole("dialog");
+    const cta = screen.getByRole("link", { name: /^apply/i });
+    expect(cta).toHaveAttribute("href", "/summer-cohort");
+  });
+
+  it("includes the May 26 immersion link as an external link", async () => {
+    render(<SummerCohortModal />);
+    await screen.findByRole("dialog");
+    const link = screen.getByRole("link", {
+      name: /Hult \/ Cursor Boston immersion/i,
+    });
+    expect(link).toHaveAttribute("href", expect.stringContaining("luma.com"));
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("includes the designer-contribute internal link", async () => {
+    render(<SummerCohortModal />);
+    await screen.findByRole("dialog");
+    const link = screen.getByRole("link", {
+      name: /Contribute art to the game/i,
+    });
+    expect(link).toHaveAttribute("href", "/contribute/game-art");
+  });
+
+  it("swaps CTA to View-your-cohort when the user has already applied", async () => {
+    const fakeUser = {
+      getIdToken: jest.fn().mockResolvedValue("fake-token"),
+    } as unknown as {
+      getIdToken: () => Promise<string>;
+    };
+    mockUseAuth.mockReturnValue({ user: fakeUser, loading: false });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ application: { userId: "u1" } }),
+    });
+    // @ts-expect-error - assigning a mock to the global fetch in the test env
+    global.fetch = fetchMock;
+
+    render(<SummerCohortModal />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /View your cohort/i })
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("link", { name: /View your cohort/i })
+    ).toHaveAttribute("href", "/summer-cohort");
+  });
+
+  it("keeps Apply CTA when fetch returns no application", async () => {
+    const fakeUser = {
+      getIdToken: jest.fn().mockResolvedValue("fake-token"),
+    } as unknown as {
+      getIdToken: () => Promise<string>;
+    };
+    mockUseAuth.mockReturnValue({ user: fakeUser, loading: false });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ application: null }),
+    });
+    // @ts-expect-error - assigning a mock to the global fetch in the test env
+    global.fetch = fetchMock;
+
+    render(<SummerCohortModal />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /^apply/i })
+      ).toBeInTheDocument();
+    });
   });
 
   it("closes and writes today's date on close", async () => {
     const user = userEvent.setup();
     render(<SummerCohortModal />);
+    await screen.findByRole("dialog");
     await user.click(
       screen.getByRole("button", { name: /close summer cohort/i })
     );
@@ -72,6 +186,7 @@ describe("SummerCohortModal", () => {
   it("closes when Maybe later is clicked", async () => {
     const user = userEvent.setup();
     render(<SummerCohortModal />);
+    await screen.findByRole("dialog");
     await user.click(screen.getByText("Maybe later"));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
@@ -79,12 +194,12 @@ describe("SummerCohortModal", () => {
   it("closes on Escape key", async () => {
     const user = userEvent.setup();
     render(<SummerCohortModal />);
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await screen.findByRole("dialog");
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("re-opens on the open-summer-cohort-modal custom event", () => {
+  it("re-opens on the open-summer-cohort-modal custom event", async () => {
     const today = new Date().toISOString().slice(0, 10);
     localStorageMock.getItem.mockReturnValueOnce(today);
     render(<SummerCohortModal />);
@@ -95,9 +210,9 @@ describe("SummerCohortModal", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
-  it("has aria-modal and aria-labelledby on the dialog", () => {
+  it("has aria-modal and aria-labelledby on the dialog", async () => {
     render(<SummerCohortModal />);
-    const dialog = screen.getByRole("dialog");
+    const dialog = await screen.findByRole("dialog");
     expect(dialog).toHaveAttribute("aria-modal", "true");
     expect(dialog).toHaveAttribute("aria-labelledby", "summer-cohort-title");
   });

--- a/app/contribute/game-art/page.tsx
+++ b/app/contribute/game-art/page.tsx
@@ -1,0 +1,344 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getRepoUrl } from "@/lib/github-edit-link";
+
+export const metadata: Metadata = {
+  title: "Add art to the game · Cursor Boston",
+  description:
+    "How designers can contribute artwork for the Cursor Boston game — units, spells, castes, buildings, upgrades, and artifacts — and open a pull request.",
+};
+
+const REPO = getRepoUrl();
+const CATALOG_BROWSE_BASE = `${REPO}/tree/develop/lib/game/content`;
+const PUBLIC_BROWSE_BASE = `${REPO}/tree/develop/public/game`;
+
+interface Category {
+  key: string;
+  label: string;
+  /** Path relative to /public where PNGs live. */
+  publicPath: string;
+  /** Folder under lib/game/content that holds the catalog source-of-truth. */
+  catalogPath: string;
+  /** Naming pattern (concrete examples below). */
+  pattern: string;
+  examples: string[];
+}
+
+const CATEGORIES: Category[] = [
+  {
+    key: "castes",
+    label: "Castes",
+    publicPath: "/public/game/castes/",
+    catalogPath: "lib/game/content/castes.ts",
+    pattern: "<caste>.png",
+    examples: ["white.png", "blue.png", "green.png", "red.png", "black.png"],
+  },
+  {
+    key: "units",
+    label: "Units",
+    publicPath: "/public/game/units/",
+    catalogPath: "lib/game/content/units/",
+    pattern: "<id>.png  (where id is `<caste>-<type>-<name>`)",
+    examples: [
+      "white-ground-pikeman.png",
+      "blue-air-sky-reader.png",
+      "green-ground-warden.png",
+      "red-air-phoenix-talon.png",
+      "black-siege-bone-hurler.png",
+    ],
+  },
+  {
+    key: "spells",
+    label: "Spells",
+    publicPath: "/public/game/spells/",
+    catalogPath: "lib/game/content/spells/",
+    pattern: "<id>.png  (where id is `<caste>-<school>-<name>`)",
+    examples: [
+      "white-offense-smite.png",
+      "blue-defense-arcane-veil.png",
+      "black-attrition-bone-fever.png",
+      "red-production-forge-blessing.png",
+      "green-disarm-binding-roots.png",
+    ],
+  },
+  {
+    key: "buildings",
+    label: "Buildings",
+    publicPath: "/public/game/buildings/",
+    catalogPath: "lib/game/content/buildings/",
+    pattern: "<id>.png  (typically `<caste>-<kind>` or shared `<kind>`)",
+    examples: ["white-military.png", "blue-magic.png", "green-food.png"],
+  },
+  {
+    key: "upgrades",
+    label: "Upgrades",
+    publicPath: "/public/game/upgrades/",
+    catalogPath: "lib/game/content/upgrades/",
+    pattern: "<id>.png  (matches the upgrade target id + tier)",
+    examples: ["white-ground-pikeman-upgrade-1.png"],
+  },
+  {
+    key: "artifacts",
+    label: "Artifacts",
+    publicPath: "/public/game/artifacts/",
+    catalogPath: "lib/game/content/artifacts/",
+    pattern: "<id>.png  (matches the artifact id from the catalog)",
+    examples: ["rare-stormglass-ward.png"],
+  },
+];
+
+export default function ContributeGameArtPage() {
+  return (
+    <main className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <div className="mx-auto max-w-3xl px-6 py-12 md:py-16">
+        <nav className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+          <Link href="/" className="hover:text-emerald-600 dark:hover:text-emerald-400">
+            Home
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-neutral-700 dark:text-neutral-300">
+            Contribute game art
+          </span>
+        </nav>
+
+        <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+          Add art to the Cursor Boston game
+        </h1>
+        <p className="mt-4 text-base text-neutral-600 dark:text-neutral-400">
+          The game catalog has slots for hundreds of images — units, spells,
+          buildings, upgrades, castes, and artifacts. Most ship today without
+          art and fall back to a placeholder logo. <strong>Your PR replaces the
+          placeholder for every player on the next page load.</strong> No code
+          changes needed; the catalogs already wire each entry&apos;s image by
+          convention. Drop a PNG in the right folder with the matching
+          filename and you&apos;re done.
+        </p>
+
+        <Section id="what-we-need" title="What we need">
+          <p className="text-sm text-neutral-700 dark:text-neutral-300">
+            Each catalog entry has an <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs dark:bg-neutral-800">id</code>. The
+            UI looks for <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs dark:bg-neutral-800">/game/&lt;category&gt;/&lt;id&gt;.png</code> in
+            the <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs dark:bg-neutral-800">public/</code> tree. Match the id exactly
+            and the image is automatically picked up — there&apos;s nothing to
+            register or import.
+          </p>
+
+          <ul className="mt-6 space-y-5">
+            {CATEGORIES.map((c) => (
+              <li
+                key={c.key}
+                className="rounded-lg border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900"
+              >
+                <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+                  <h3 className="text-lg font-semibold">{c.label}</h3>
+                  <code className="text-xs text-neutral-500">
+                    {c.publicPath}
+                  </code>
+                </div>
+                <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+                  Filename: <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">{c.pattern}</code>
+                </p>
+                <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                  Examples:{" "}
+                  {c.examples.map((e, i) => (
+                    <span key={e}>
+                      <code className="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">
+                        {e}
+                      </code>
+                      {i < c.examples.length - 1 ? ", " : ""}
+                    </span>
+                  ))}
+                </p>
+                <p className="mt-3 text-xs">
+                  <a
+                    href={`${CATALOG_BROWSE_BASE}/${c.catalogPath.replace(
+                      /^lib\/game\/content\//,
+                      ""
+                    )}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+                  >
+                    Browse the {c.label.toLowerCase()} catalog on GitHub →
+                  </a>
+                </p>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        <Section id="style-notes" title="Style notes">
+          <ul className="mt-2 list-disc space-y-2 pl-5 text-sm text-neutral-700 dark:text-neutral-300">
+            <li>
+              <strong>Format:</strong> PNG with transparent background. The
+              UI composites your image over various card backgrounds.
+            </li>
+            <li>
+              <strong>Square aspect ratio.</strong> Most game UI surfaces
+              render images in a square slot. Suggested working size is
+              512×512 or 1024×1024; the UI will downscale.
+            </li>
+            <li>
+              <strong>Caste palette.</strong> Match the existing caste color
+              language where it makes sense — white reads as paladin /
+              cathedral, blue as arcane, green as druidic / wild, red as
+              forge / fire, black as shadow / undead. Stylistic riffs are
+              welcome; you don&apos;t have to mimic any one reference.
+            </li>
+            <li>
+              <strong>Readable at small sizes.</strong> Cards render at
+              ~80–120 px in many places; avoid tiny details that disappear.
+            </li>
+            <li>
+              <strong>License.</strong> The repo is GPL-3.0. By submitting a
+              PR you certify the work is yours (or compatibly licensed) and
+              you&apos;re fine with it shipping under the project license.
+              See <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">LICENSE</code> at the repo root.
+            </li>
+          </ul>
+        </Section>
+
+        <Section id="how-to-pr" title="How to submit a PR">
+          <ol className="mt-2 list-decimal space-y-3 pl-5 text-sm text-neutral-700 dark:text-neutral-300">
+            <li>
+              Fork{" "}
+              <a
+                href={REPO}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+              >
+                rogerSuperBuilderAlpha/cursor-boston
+              </a>{" "}
+              and clone your fork locally.
+            </li>
+            <li>
+              Create a branch with a designer-friendly name, e.g.{" "}
+              <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">art/your-handle-white-ground-set</code>.
+            </li>
+            <li>
+              Drop your PNGs into the matching{" "}
+              <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">public/game/&lt;category&gt;/</code>{" "}
+              folder. The folder may not exist yet — go ahead and create it
+              if needed. Each filename must exactly match the catalog{" "}
+              <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">id</code>{" "}
+              with a <code>.png</code> extension. (See the GitHub links above
+              for the catalog ids.)
+            </li>
+            <li>
+              Commit with a sign-off (the project requires DCO):{" "}
+              <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">git commit -s -m &quot;feat(game/art): add white ground unit set&quot;</code>.
+            </li>
+            <li>
+              Push and open a PR against{" "}
+              <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">develop</code>. Drop a couple of preview
+              thumbnails in the PR description so reviewers can eyeball the
+              set without checking out the branch.
+            </li>
+          </ol>
+
+          <div className="mt-5 rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-amber-900 dark:bg-amber-500/10 dark:text-amber-200">
+            <p className="font-semibold">Submit in batches when you can</p>
+            <p className="mt-1">
+              A full caste set (e.g. all 9 white units + a few spells) is
+              easier to review than a single one-off. Open a draft PR early
+              if you want feedback on naming or palette before you polish a
+              batch.
+            </p>
+          </div>
+
+          <p className="mt-5 text-sm text-neutral-700 dark:text-neutral-300">
+            Full code-contribution flow (DCO sign-off, commit message
+            conventions, what to expect on review) lives in{" "}
+            <a
+              href={`${REPO}/blob/develop/docs/FIRST_CONTRIBUTION.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+            >
+              docs/FIRST_CONTRIBUTION.md
+            </a>{" "}
+            — same rules apply to art PRs.
+          </p>
+        </Section>
+
+        <Section id="what-happens-next" title="What happens when your art lands">
+          <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+            Once your PR merges, the next time a player opens the recruit,
+            spells, threats, attack, or community panels they&apos;ll see your
+            artwork instead of the placeholder logo. There&apos;s no cache
+            bust or migration step — the catalog already references{" "}
+            <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">/game/&lt;category&gt;/&lt;id&gt;.png</code>{" "}
+            for every entry; your file just fills in the slot.
+          </p>
+          <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
+            You&apos;ll show up in{" "}
+            <Link
+              href="/contributors"
+              className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+            >
+              CONTRIBUTORS
+            </Link>{" "}
+            once your PR merges.
+          </p>
+        </Section>
+
+        <Section id="questions" title="Questions?">
+          <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+            Open an issue on the{" "}
+            <a
+              href={`${REPO}/issues/new`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+            >
+              repo
+            </a>{" "}
+            or email{" "}
+            <a
+              href="mailto:hello@cursorboston.com"
+              className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+            >
+              hello@cursorboston.com
+            </a>
+            . Browse what&apos;s already in{" "}
+            <a
+              href={PUBLIC_BROWSE_BASE}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+            >
+              public/game/
+            </a>{" "}
+            to see what&apos;s already covered.
+          </p>
+        </Section>
+      </div>
+    </main>
+  );
+}
+
+function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mt-12">
+      <h2 className="text-xl font-semibold tracking-tight md:text-2xl">
+        {title}
+      </h2>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}

--- a/app/game/_components/dashboard/DashboardView.tsx
+++ b/app/game/_components/dashboard/DashboardView.tsx
@@ -33,6 +33,7 @@ import { NavGrid } from "./NavGrid";
 import { DashboardReports } from "./DashboardReports";
 import { CasteChangeCard } from "./CasteChangeCard";
 import { CommunityPanel } from "./CommunityPanel";
+import { DesignersWantedCard } from "./DesignersWantedCard";
 import { OnboardingWizard } from "../onboarding/OnboardingWizard";
 import type { GamePlayer } from "@/lib/game/types";
 
@@ -163,6 +164,8 @@ export function DashboardView({ player, data }: DashboardViewProps) {
           user={data.user}
           onRefresh={data.refresh}
         />
+
+        <DesignersWantedCard />
 
         <HeroCard
           turnsRemaining={player.turnsRemaining}

--- a/app/game/_components/dashboard/DesignersWantedCard.tsx
+++ b/app/game/_components/dashboard/DesignersWantedCard.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+
+/**
+ * Top-of-dashboard invitation for designers to contribute art to the
+ * game catalog. Renders unconditionally (no auth or per-player gate)
+ * since most catalog entries still ship without art and a designer
+ * landing here is exactly who we want to convert.
+ *
+ * Visual style is intentionally distinct from the status-alert banners
+ * (eligibility = amber/emerald, caste-change = neutral) — violet reads
+ * as a friendly invitation rather than something the player needs to
+ * resolve.
+ */
+export function DesignersWantedCard() {
+  return (
+    <div
+      className="mb-6 rounded-lg border border-violet-300/60 bg-violet-50 dark:border-violet-700/40 dark:bg-violet-950/30 p-4"
+      role="region"
+      aria-label="Designers wanted"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-violet-900 dark:text-violet-100">
+            🎨 Designers wanted — help us bring the game to life
+          </p>
+          <p className="mt-1 text-sm text-violet-800/90 dark:text-violet-200/90">
+            Most units, spells, and buildings still ship without art. If you
+            can draw, your work goes straight into the catalog and into every
+            player&apos;s game on the next page load.
+          </p>
+        </div>
+        <Link
+          href="/contribute/game-art"
+          className="inline-flex shrink-0 items-center justify-center gap-2 rounded-md bg-violet-600 px-3.5 py-2 text-sm font-semibold text-white hover:bg-violet-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2 focus-visible:ring-offset-violet-50 dark:focus-visible:ring-offset-violet-950"
+        >
+          Read the contributor guide
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/SummerCohortModal.tsx
+++ b/components/SummerCohortModal.tsx
@@ -8,39 +8,110 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
 import {
   SUMMER_COHORTS,
+  SUMMER_COHORT_IMMERSION,
   SUMMER_COHORT_LOCALSTORAGE_KEY,
   SUMMER_COHORT_OPEN_EVENT,
   SUMMER_COHORT_RETURN_TO,
+  SUMMER_COHORT_VIEW_TO,
 } from "@/lib/summer-cohort";
 
 function todayKey(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+// Pages that already cover the modal's content — don't auto-pop on top of
+// them. Manual dispatch of SUMMER_COHORT_OPEN_EVENT still works.
+const SUPPRESS_AUTO_OPEN_PREFIXES = ["/summer-cohort", "/contribute/game-art"];
+
+// Cap the wait for the "have you applied?" fetch before opening anyway.
+// Keeps the modal snappy if the API is slow; the CTA defaults to "Apply".
+const APPLIED_FETCH_TIMEOUT_MS = 600;
+
 export default function SummerCohortModal() {
+  const { user, loading: authLoading } = useAuth();
+  const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
+  // null = not yet known; true/false = resolved.
+  const [hasApplied, setHasApplied] = useState<boolean | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  // Prevent double-resolves from racing each other.
+  const appliedResolvedRef = useRef(false);
 
+  // Auto-open gate: localStorage + pathname + applied-state lookup.
   useEffect(() => {
+    if (authLoading) return;
+    let lastShown: string | null = null;
     try {
-      const lastShown = localStorage.getItem(SUMMER_COHORT_LOCALSTORAGE_KEY);
-      if (lastShown !== todayKey()) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing with localStorage on mount
-        setIsOpen(true);
-      }
+      lastShown = localStorage.getItem(SUMMER_COHORT_LOCALSTORAGE_KEY);
     } catch {
-      /* localStorage unavailable; skip auto-open */
+      // localStorage unavailable; skip auto-open entirely
+      return;
     }
-  }, []);
+    if (lastShown === todayKey()) return;
+    if (
+      pathname &&
+      SUPPRESS_AUTO_OPEN_PREFIXES.some((p) => pathname.startsWith(p))
+    ) {
+      return;
+    }
 
+    let cancelled = false;
+    const resolveApplied = (value: boolean | null) => {
+      if (cancelled || appliedResolvedRef.current) return;
+      appliedResolvedRef.current = true;
+      setHasApplied(value);
+      setIsOpen(true);
+    };
+
+    if (!user) {
+      resolveApplied(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    // Race the apply-status fetch against a short timeout so a slow API
+    // can't delay the modal indefinitely.
+    const timer = setTimeout(() => resolveApplied(false), APPLIED_FETCH_TIMEOUT_MS);
+    (async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/summer-cohort/apply", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          resolveApplied(false);
+          return;
+        }
+        const json = (await res.json()) as { application?: unknown | null };
+        resolveApplied(json.application != null);
+      } catch {
+        resolveApplied(false);
+      } finally {
+        clearTimeout(timer);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [authLoading, user, pathname]);
+
+  // Manual open via custom event — bypasses every gate.
   useEffect(() => {
-    const handleOpen = () => setIsOpen(true);
+    const handleOpen = () => {
+      if (hasApplied === null) setHasApplied(false);
+      setIsOpen(true);
+    };
     window.addEventListener(SUMMER_COHORT_OPEN_EVENT, handleOpen);
     return () => window.removeEventListener(SUMMER_COHORT_OPEN_EVENT, handleOpen);
-  }, []);
+  }, [hasApplied]);
 
   useEffect(() => {
     if (isOpen) {
@@ -75,6 +146,9 @@ export default function SummerCohortModal() {
 
   if (!isOpen) return null;
 
+  const ctaHref = hasApplied ? SUMMER_COHORT_VIEW_TO : SUMMER_COHORT_RETURN_TO;
+  const ctaLabel = hasApplied ? "View your cohort" : "Apply";
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
@@ -90,7 +164,7 @@ export default function SummerCohortModal() {
 
       <div
         ref={modalRef}
-        className="relative bg-neutral-900 border border-neutral-800 rounded-2xl p-6 md:p-8 max-w-md w-full shadow-2xl"
+        className="relative bg-neutral-900 border border-neutral-800 rounded-2xl p-6 md:p-8 max-w-md w-full shadow-2xl max-h-[90vh] overflow-y-auto"
       >
         <button
           ref={closeButtonRef}
@@ -146,27 +220,49 @@ export default function SummerCohortModal() {
           </p>
 
           <ul className="space-y-2 mb-6 text-left">
-            {SUMMER_COHORTS.map((cohort) => (
-              <li
-                key={cohort.id}
-                className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-neutral-800/60 border border-neutral-800"
-              >
-                <span className="text-sm font-semibold text-white">
-                  {cohort.label}
-                </span>
-                <span className="text-xs text-neutral-300">
-                  {cohort.startLabel} – {cohort.endLabel}
-                </span>
-              </li>
-            ))}
+            {SUMMER_COHORTS.map((cohort) => {
+              const closed = cohort.signupsClosed === true;
+              return (
+                <li
+                  key={cohort.id}
+                  className={`flex items-center justify-between gap-3 px-4 py-3 rounded-lg border ${
+                    closed
+                      ? "bg-neutral-900/40 border-neutral-800 opacity-70"
+                      : "bg-neutral-800/60 border-neutral-700"
+                  }`}
+                >
+                  <span
+                    className={`text-sm font-semibold ${
+                      closed ? "text-neutral-400" : "text-white"
+                    }`}
+                  >
+                    {cohort.label}
+                  </span>
+                  <span className="flex items-center gap-2">
+                    <span
+                      className={`text-xs ${
+                        closed ? "text-neutral-500" : "text-neutral-300"
+                      }`}
+                    >
+                      {cohort.startLabel} – {cohort.endLabel}
+                    </span>
+                    {closed ? (
+                      <span className="text-[10px] uppercase tracking-wide font-semibold px-2 py-0.5 rounded-full border border-neutral-700 text-neutral-400">
+                        Closed
+                      </span>
+                    ) : null}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
 
           <Link
-            href={SUMMER_COHORT_RETURN_TO}
+            href={ctaHref}
             onClick={handleClose}
             className="flex items-center justify-center gap-2 w-full px-4 py-3 bg-emerald-500 text-white rounded-lg font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
           >
-            Apply
+            {ctaLabel}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="16"
@@ -182,6 +278,70 @@ export default function SummerCohortModal() {
               <path d="M5 12h14M13 5l7 7-7 7" />
             </svg>
           </Link>
+
+          <div className="mt-5 space-y-2 text-left">
+            <a
+              href={SUMMER_COHORT_IMMERSION.lumaUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleClose}
+              className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-neutral-800 bg-neutral-800/40 hover:bg-neutral-800/70 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+            >
+              <span className="min-w-0">
+                <span className="block text-xs uppercase tracking-wide text-emerald-400 font-semibold">
+                  {SUMMER_COHORT_IMMERSION.label}
+                </span>
+                <span className="block text-sm text-white truncate">
+                  {SUMMER_COHORT_IMMERSION.title}
+                </span>
+              </span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-neutral-400 shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M7 17L17 7M7 7h10v10" />
+              </svg>
+            </a>
+
+            <Link
+              href="/contribute/game-art"
+              onClick={handleClose}
+              className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-neutral-800 bg-neutral-800/40 hover:bg-neutral-800/70 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+            >
+              <span className="min-w-0">
+                <span className="block text-xs uppercase tracking-wide text-violet-300 font-semibold">
+                  Designers
+                </span>
+                <span className="block text-sm text-white truncate">
+                  Contribute art to the game
+                </span>
+              </span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-neutral-400 shrink-0"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14M13 5l7 7-7 7" />
+              </svg>
+            </Link>
+          </div>
 
           <button
             onClick={handleClose}

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -15,6 +15,9 @@ export const SUMMER_COHORT_NOTIFY_EMAIL = "roger@cursorboston.com";
 export const SUMMER_COHORT_LOCALSTORAGE_KEY =
   "cursor-boston-summer-cohort-modal-shown-date";
 export const SUMMER_COHORT_RETURN_TO = "/summer-cohort";
+/** CTA target for users who already submitted an application — same page,
+ *  which surfaces their existing application status and cohort details. */
+export const SUMMER_COHORT_VIEW_TO = "/summer-cohort";
 export const SUMMER_COHORT_OPEN_EVENT = "open-summer-cohort-modal";
 
 export type SummerCohortId = "cohort-1" | "cohort-2";
@@ -27,6 +30,10 @@ export interface SummerCohort {
   startLabel: string;
   endLabel: string;
   graduationLabel: string;
+  /** True once we've stopped accepting new applications for this cohort.
+   *  The intro modal greys the row out and shows a "Closed" pill; the
+   *  Apply CTA targets the next still-open cohort. */
+  signupsClosed?: boolean;
 }
 
 export const SUMMER_COHORTS: readonly SummerCohort[] = [
@@ -38,6 +45,7 @@ export const SUMMER_COHORTS: readonly SummerCohort[] = [
     startLabel: "Mon, May 11",
     endLabel: "Fri, Jun 19",
     graduationLabel: "Graduation: Fri, Jun 19",
+    signupsClosed: true,
   },
   {
     id: "cohort-2",


### PR DESCRIPTION
## Includes

- **#817** — feat(cohort/game): expand intro modal + designer onboarding flow + CLAUDE.md — @rogerSuperBuilderAlpha

## Highlights

- **Modal**: cohort 1 marked closed (muted row + "Closed" pill); cohort 2 keeps emphasis. New "View your cohort" CTA swap when the user already has an application (detected via `useAuth()` + `GET /api/summer-cohort/apply`, gated behind a 600 ms timeout). Two new secondary rows: external link to the May 26 Hult immersion Luma RSVP and an internal link to the new designer guide. `usePathname()` suppresses auto-open on `/summer-cohort` and `/contribute/game-art`.
- **Game dashboard**: new top-of-page "Designers wanted" card (violet) inviting designers to contribute art. Rendered between `CasteChangeCard` and `HeroCard`.
- **Designer guide** at `/contribute/game-art`: per-category `public/` paths and filename conventions (castes, units, spells, buildings, upgrades, artifacts) with example IDs from the live catalogs, style notes, and the PR flow (fork, branch naming, DCO `-s` sign-off, link out to `docs/FIRST_CONTRIBUTION.md`).
- **CLAUDE.md** (new at repo root): codifies the project rule that Claude runs `npm run test:rules` + validates `firestore.indexes.json` before every commit. Documents the Java prerequisite and the CI backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)