### PR TITLE
release: auto-deploy Firestore rules + indexes on push to main

### DIFF
--- a/.github/workflows/firestore-deploy.yml
+++ b/.github/workflows/firestore-deploy.yml
@@ -1,0 +1,77 @@
+name: Deploy Firestore rules + indexes
+
+# Auto-deploys `config/firebase/firestore.rules` and
+# `config/firebase/firestore.indexes.json` whenever main moves and either
+# file (or `firebase.json`) changed. Vercel handles the Next.js app on
+# the same push; this workflow handles the Firebase side.
+#
+# Manual trigger via workflow_dispatch is also wired so a maintainer can
+# re-run a deploy without pushing a new commit (useful after editing a
+# rule directly in the Firebase console and pulling the change down).
+#
+# Required repo secret:
+#   FIREBASE_SERVICE_ACCOUNT_JSON — full JSON for a service account on
+#     the cursor-boston project with the
+#     `roles/firebaserules.admin` and `roles/datastore.indexAdmin`
+#     roles (or broader `roles/firebase.admin`).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'config/firebase/firestore.rules'
+      - 'config/firebase/firestore.indexes.json'
+      - 'firebase.json'
+      - '.github/workflows/firestore-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize deploys per-ref. A queued second push waits for the first
+  # to land instead of racing the Firebase API.
+  group: firestore-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: firebase deploy --only firestore:rules,firestore:indexes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Validate firestore.indexes.json parses
+        run: node -e "JSON.parse(require('fs').readFileSync('config/firebase/firestore.indexes.json','utf8'))"
+
+      - name: Write service-account credentials to a temp file
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FIREBASE_SERVICE_ACCOUNT_JSON:-}" ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT_JSON secret is not set on this repo"
+            exit 1
+          fi
+          umask 077
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/sa.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
+
+      - name: Deploy Firestore rules + indexes
+        run: |
+          npx --yes firebase-tools@15 deploy \
+            --only firestore:rules,firestore:indexes \
+            --project cursor-boston \
+            --non-interactive
+
+      - name: Cleanup credentials
+        if: always()
+        run: rm -f "$RUNNER_TEMP/sa.json"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,8 @@
 
 Conventions and behaviors that apply to every session in this repo.
 
-## Firestore rules + indexes — verify before every commit
+## Firestore rules + indexes deploy automatically on push to main
 
-The Firestore security rules (`config/firebase/firestore.rules`) and composite-index spec (`config/firebase/firestore.indexes.json`) ship without a build-time check. A broken file shows up only at deploy time or when a query starts failing in prod. So before every commit:
+`config/firebase/firestore.rules` and `config/firebase/firestore.indexes.json` are deployed by `.github/workflows/firestore-deploy.yml` whenever main moves and either file (or `firebase.json`) changed. **Don't `firebase deploy` these by hand.** If a manual re-deploy is needed (e.g. after editing in the Firebase console and pulling the change down), trigger the `Deploy Firestore rules + indexes` workflow via `workflow_dispatch` instead.
 
-1. **Validate the indexes JSON parses.** Cheap, no dependencies:
-   ```bash
-   node -e "JSON.parse(require('fs').readFileSync('config/firebase/firestore.indexes.json','utf8'))"
-   ```
-2. **If the commit touches `firestore.rules` or `firestore.indexes.json`, the CI "Firestore rules tests" check is the gate** — don't merge a PR where that check is failing. The check runs `npm run test:rules` against the Firestore emulator in cloud CI, where the dependencies it needs (a JRE for the emulator) are already provisioned.
-3. **If you're actively editing `firestore.rules` and want a local emulator run,** that's `npm run test:rules`. It needs Java on the path. Don't install Java just to satisfy this rule — only set up the local emulator if you're doing real rules work and want the fast feedback loop. For everything else, the CI check is the source of truth.
-
-No `--no-verify` bypasses on commits that touch these files.
+The workflow validates that `firestore.indexes.json` parses before deploying. The Firestore emulator isn't run on every commit — that's a heavyweight check (needs Java) and CI's "Firestore rules tests" job already covers it on every PR.


### PR DESCRIPTION
## Includes

- **#821** — ci(firestore): auto-deploy rules + indexes on push to main — @rogerSuperBuilderAlpha

Adds `.github/workflows/firestore-deploy.yml` which fires on push to main (or `workflow_dispatch`) when `firestore.rules`, `firestore.indexes.json`, or `firebase.json` change, and runs `firebase deploy --only firestore:rules,firestore:indexes` via the new `FIREBASE_SERVICE_ACCOUNT_JSON` repo secret.

CLAUDE.md collapsed to one paragraph: don't deploy rules/indexes by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)