### PR TITLE
release: PyData event gate + hackathon submissions hub

### DIFF
--- a/__tests__/components/PyDataAccessGate.test.tsx
+++ b/__tests__/components/PyDataAccessGate.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+const mockUseAuth = jest.fn();
+const mockReplace = jest.fn();
+
+// Mock useAuth + useRouter BEFORE importing the component so the
+// boundary's effect picks up the mock.
+jest.mock("@/contexts/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+import { PyDataAccessGate } from "@/components/events/PyDataAccessGate";
+
+describe("PyDataAccessGate", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockReplace.mockReset();
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows the loading state while auth resolves", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    render(
+      <PyDataAccessGate>
+        <p>secret content</p>
+      </PyDataAccessGate>
+    );
+    expect(screen.getByText(/Checking access/i)).toBeInTheDocument();
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+
+  it("redirects to the locked URL when there's no signed-in user", async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    render(
+      <PyDataAccessGate>
+        <p>secret content</p>
+      </PyDataAccessGate>
+    );
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith("/events?pydataLocked=1")
+    );
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+
+  it("renders children when the API confirms allowed=true", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { getIdToken: () => Promise.resolve("test-token") },
+      loading: false,
+    });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: () => Promise.resolve({ allowed: true }),
+    });
+    render(
+      <PyDataAccessGate>
+        <p>secret content</p>
+      </PyDataAccessGate>
+    );
+    await waitFor(() =>
+      expect(screen.getByText("secret content")).toBeInTheDocument()
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the API returns allowed=false", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { getIdToken: () => Promise.resolve("test-token") },
+      loading: false,
+    });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: () => Promise.resolve({ allowed: false }),
+    });
+    render(
+      <PyDataAccessGate>
+        <p>secret content</p>
+      </PyDataAccessGate>
+    );
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith("/events?pydataLocked=1")
+    );
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+
+  it("redirects when the API throws (network/transport error)", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { getIdToken: () => Promise.resolve("test-token") },
+      loading: false,
+    });
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("network down"));
+    render(
+      <PyDataAccessGate>
+        <p>secret content</p>
+      </PyDataAccessGate>
+    );
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith("/events?pydataLocked=1")
+    );
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/PydataLockedBanner.test.tsx
+++ b/__tests__/components/PydataLockedBanner.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PydataLockedBanner } from "@/components/events/PydataLockedBanner";
+
+describe("PydataLockedBanner", () => {
+  it("renders the lockout copy + dismiss button", () => {
+    render(<PydataLockedBanner />);
+    expect(
+      screen.getByText(/PyData × Cursor Boston attendance is locked/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /dismiss notice/i })
+    ).toBeInTheDocument();
+  });
+
+  it("disappears after the user clicks dismiss", async () => {
+    const user = userEvent.setup();
+    render(<PydataLockedBanner />);
+    await user.click(screen.getByRole("button", { name: /dismiss notice/i }));
+    expect(
+      screen.queryByText(/attendance is locked/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/pydata-2026-access.test.ts
+++ b/__tests__/lib/pydata-2026-access.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  normalizePydataEmail,
+  PYDATA_2026_ACCESS_LIST_COLLECTION,
+} from "@/lib/pydata-2026-access";
+
+describe("normalizePydataEmail", () => {
+  it("lowercases the address", () => {
+    expect(normalizePydataEmail("Adam_Sychla@HMS.Harvard.EDU")).toBe(
+      "adam_sychla@hms.harvard.edu"
+    );
+  });
+
+  it("trims surrounding whitespace (pasted CSV values)", () => {
+    expect(normalizePydataEmail("  someone@example.com\n")).toBe(
+      "someone@example.com"
+    );
+  });
+
+  it("returns empty string for null/undefined/non-string input", () => {
+    expect(normalizePydataEmail(null)).toBe("");
+    expect(normalizePydataEmail(undefined)).toBe("");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(normalizePydataEmail("   ")).toBe("");
+  });
+
+  it("preserves the local-part casing rules but lowercases globally", () => {
+    expect(normalizePydataEmail("Foo.Bar+tag@Gmail.com")).toBe(
+      "foo.bar+tag@gmail.com"
+    );
+  });
+});
+
+describe("PYDATA_2026_ACCESS_LIST_COLLECTION", () => {
+  it("points at the private allowlist collection (server-only writes)", () => {
+    expect(PYDATA_2026_ACCESS_LIST_COLLECTION).toBe("pydataHack2026AccessList");
+  });
+});

--- a/__tests__/lib/pydata-submissions.test.ts
+++ b/__tests__/lib/pydata-submissions.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  getPyDataSubmissions,
+  PYDATA_SUBMISSIONS_BRANCH,
+  PYDATA_SUBMISSIONS_DIR,
+  PYDATA_SUBMISSIONS_REPO_URL,
+} from "@/lib/pydata-submissions";
+
+/**
+ * The loader reads from `process.cwd()`, so each test spins up an isolated
+ * temp directory, chdir's into it, populates the expected
+ * `pydata-2026-submissions/<handle>/{submission.ipynb,meta.json}` layout,
+ * runs the loader, and restores the original cwd.
+ */
+function withTempCwd(setup: (dir: string) => void): ReturnType<typeof getPyDataSubmissions> {
+  const original = process.cwd();
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pydata-submissions-test-"));
+  try {
+    process.chdir(tmp);
+    setup(tmp);
+    return getPyDataSubmissions();
+  } finally {
+    process.chdir(original);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function writeSubmission(
+  root: string,
+  handle: string,
+  meta: unknown | null,
+  options: { notebook?: boolean } = {}
+): void {
+  const folder = path.join(root, PYDATA_SUBMISSIONS_DIR, handle);
+  fs.mkdirSync(folder, { recursive: true });
+  if (options.notebook !== false) {
+    fs.writeFileSync(path.join(folder, "submission.ipynb"), "{}");
+  }
+  if (meta !== null) {
+    const body = typeof meta === "string" ? meta : JSON.stringify(meta);
+    fs.writeFileSync(path.join(folder, "meta.json"), body);
+  }
+}
+
+describe("getPyDataSubmissions", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns empty when the submissions directory is missing", () => {
+    const result = withTempCwd(() => {
+      // No directory created at all.
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("loads a valid submission and builds the GitHub URLs from the handle", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(root, "adam-sychla", {
+        title: "mRNA embedding tricks",
+        description: "Quick exploration of mRNA-derived embeddings.",
+        displayName: "Adam Sychla",
+        tags: ["healthcare", "EMBEDDINGS", " healthcare "], // dedup + lowercase + trim
+      });
+    });
+    expect(result).toHaveLength(1);
+    const [s] = result;
+    expect(s.githubHandle).toBe("adam-sychla");
+    expect(s.displayName).toBe("Adam Sychla");
+    expect(s.title).toBe("mRNA embedding tricks");
+    expect(s.tags).toEqual(["healthcare", "embeddings"]);
+    expect(s.notebookUrl).toBe(
+      `${PYDATA_SUBMISSIONS_REPO_URL}/blob/main/${PYDATA_SUBMISSIONS_DIR}/adam-sychla/submission.ipynb`
+    );
+    expect(s.folderUrl).toBe(
+      `${PYDATA_SUBMISSIONS_REPO_URL}/tree/main/${PYDATA_SUBMISSIONS_DIR}/adam-sychla`
+    );
+  });
+
+  it("skips a folder missing submission.ipynb", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "no-notebook",
+        { title: "T", description: "D", displayName: "N" },
+        { notebook: false }
+      );
+    });
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("missing submission.ipynb")
+    );
+  });
+
+  it("skips a folder with malformed meta.json", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(root, "bad-json", "{ not valid json");
+    });
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("missing or invalid meta.json")
+    );
+  });
+
+  it("skips a folder with meta.json missing required fields", () => {
+    const result = withTempCwd((root) => {
+      // No description, so the entry must be skipped.
+      writeSubmission(root, "no-desc", { title: "Only title" });
+    });
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("missing required fields")
+    );
+  });
+
+  it("ignores dotfile dirs, _template scaffolding, and non-directories", () => {
+    const result = withTempCwd((root) => {
+      const base = path.join(root, PYDATA_SUBMISSIONS_DIR);
+      fs.mkdirSync(base, { recursive: true });
+      fs.writeFileSync(path.join(base, "README.md"), "# readme");
+
+      writeSubmission(root, ".hidden", {
+        title: "T",
+        description: "D",
+        displayName: "N",
+      });
+      writeSubmission(root, "_template", {
+        title: "T",
+        description: "D",
+        displayName: "N",
+      });
+      writeSubmission(root, "valid-user", {
+        title: "T",
+        description: "D",
+        displayName: "Valid",
+      });
+    });
+    expect(result.map((s) => s.githubHandle)).toEqual(["valid-user"]);
+  });
+
+  it("falls back to handle when displayName is missing, sorts alphabetically", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(root, "zach", {
+        title: "Z work",
+        description: "Z description",
+      });
+      writeSubmission(root, "amy", {
+        title: "A work",
+        description: "A description",
+        displayName: "Amy A",
+      });
+      writeSubmission(root, "barry", {
+        title: "B work",
+        description: "B description",
+      });
+    });
+    // displayName for "zach" falls back to the handle "zach"; "amy" maps
+    // to its set displayName "Amy A"; "barry" falls back to "barry".
+    // Sort is alphabetical case-insensitive: Amy A, barry, zach.
+    expect(result.map((s) => s.displayName)).toEqual(["Amy A", "barry", "zach"]);
+    expect(result.map((s) => s.githubHandle)).toEqual(["amy", "barry", "zach"]);
+  });
+
+  it("clamps tags to a max of 6 and ignores non-string entries", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(root, "tagged", {
+        title: "T",
+        description: "D",
+        displayName: "T",
+        tags: ["a", "b", "c", "d", "e", "f", "g", 123, null, "h"],
+      });
+    });
+    expect(result[0].tags).toHaveLength(6);
+  });
+
+  it("parses collaborators and strips @ from handles", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(root, "lead", {
+        title: "Team work",
+        description: "Built together.",
+        displayName: "Lead Person",
+        collaborators: [
+          { displayName: "Co A", githubHandle: "@co-a" },
+          { displayName: "Co B" }, // no handle — allowed
+          { displayName: "" }, // empty displayName — must be dropped
+          "not an object",
+        ],
+      });
+    });
+    expect(result[0].collaborators).toEqual([
+      { displayName: "Co A", githubHandle: "co-a" },
+      { displayName: "Co B", githubHandle: null },
+    ]);
+  });
+});
+
+describe("submissions constants", () => {
+  it("exports a single source-of-truth branch name", () => {
+    expect(PYDATA_SUBMISSIONS_BRANCH).toBe("pydata-2026-submissions");
+  });
+  it("uses the same name for the on-disk directory", () => {
+    expect(PYDATA_SUBMISSIONS_DIR).toBe("pydata-2026-submissions");
+  });
+  it("points at the rogerSuperBuilderAlpha repo (not a fork)", () => {
+    expect(PYDATA_SUBMISSIONS_REPO_URL).toBe(
+      "https://github.com/rogerSuperBuilderAlpha/cursor-boston"
+    );
+  });
+});

--- a/app/api/events/pydata-2026/access/route.ts
+++ b/app/api/events/pydata-2026/access/route.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
+import {
+  PYDATA_2026_ACCESS_LIST_COLLECTION,
+  normalizePydataEmail,
+} from "@/lib/pydata-2026-access";
+import { PYDATA_2026_REGISTRATIONS_COLLECTION } from "@/lib/pydata-2026";
+
+// @contracts: eventsContract.pydataAccess (lib/api-schemas/events.ts)
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Gate the May 13 PyData event page to the 150-person door list we handed
+ * Moderna. A user is allowed if any of these emails matches an entry in the
+ * private `pydataHack2026AccessList` collection:
+ *
+ *   1. Their Firebase auth email (decoded from the ID token).
+ *   2. The email on their saved pydata registration form (may differ from
+ *      the auth email — the form is editable; e.g. someone signs in with a
+ *      .edu address but registered with their personal Gmail).
+ *   3. Any verified entry in their `users/{uid}.additionalEmails`.
+ *
+ * The endpoint always returns 200 with `{ allowed }` so the gate UI can
+ * branch without distinguishing transport errors from negative answers.
+ */
+async function handleGet(request: NextRequest) {
+  const user = await getVerifiedUser(request);
+  if (!user) {
+    return NextResponse.json({ allowed: false, reason: "unauthenticated" });
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+  }
+
+  const candidates = new Set<string>();
+  const authEmail = normalizePydataEmail(user.email);
+  if (authEmail) candidates.add(authEmail);
+
+  const [regSnap, userSnap] = await Promise.all([
+    db.collection(PYDATA_2026_REGISTRATIONS_COLLECTION).doc(user.uid).get(),
+    db.collection("users").doc(user.uid).get(),
+  ]);
+
+  if (regSnap.exists) {
+    const data = regSnap.data() as { email?: unknown } | undefined;
+    if (typeof data?.email === "string") {
+      const normalized = normalizePydataEmail(data.email);
+      if (normalized) candidates.add(normalized);
+    }
+  }
+
+  if (userSnap.exists) {
+    const data = userSnap.data() as
+      | { additionalEmails?: Array<{ email?: unknown; verified?: unknown }> }
+      | undefined;
+    for (const entry of data?.additionalEmails ?? []) {
+      if (entry?.verified === true && typeof entry.email === "string") {
+        const normalized = normalizePydataEmail(entry.email);
+        if (normalized) candidates.add(normalized);
+      }
+    }
+  }
+
+  if (candidates.size === 0) {
+    return NextResponse.json({ allowed: false });
+  }
+
+  const lookups = await Promise.all(
+    Array.from(candidates).map((email) =>
+      db.collection(PYDATA_2026_ACCESS_LIST_COLLECTION).doc(email).get()
+    )
+  );
+  const allowed = lookups.some((snap) => snap.exists);
+  return NextResponse.json({ allowed });
+}
+
+export const GET = withMiddleware(rateLimitConfigs.standard, handleGet);

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -15,11 +15,7 @@ import {
   getLumaCheckoutEventId,
   getLumaCheckoutHref,
 } from "@/lib/luma-event";
-import {
-  PYDATA_2026_EVENT_SLUG,
-  PYDATA_2026_REGISTRATION_PATH,
-} from "@/lib/pydata-2026";
-import { PyDataLumaButton } from "@/components/events/PyDataLumaButton";
+import { PYDATA_2026_EVENT_SLUG } from "@/lib/pydata-2026";
 
 // Type definitions for event data
 interface AgendaItem {
@@ -138,12 +134,18 @@ function getEventBySlug(slug: string): Event | undefined {
   return getAllEvents().find((event) => event.slug === slug);
 }
 
-// Generate static paths for all events
+// Generate static paths for all events.
+// The pydata-2026 slug is intentionally excluded: it has its own static
+// route at app/events/cursor-boston-pydata-2026/page.tsx that gates access
+// and renders a different layout. Leaving the dynamic [slug] route would
+// also build a page for that slug, but the static one wins at request time.
 export async function generateStaticParams() {
   const events = getAllEvents();
-  return events.map((event) => ({
-    slug: event.slug,
-  }));
+  return events
+    .filter((event) => event.slug !== PYDATA_2026_EVENT_SLUG)
+    .map((event) => ({
+      slug: event.slug,
+    }));
 }
 
 // Generate metadata for SEO
@@ -202,7 +204,6 @@ export default async function EventPage({
   }
 
   const websiteRegistration = WEBSITE_REGISTRATION_CONFIG[event.slug];
-  const isPyData = event.slug === PYDATA_2026_EVENT_SLUG;
 
   // Generate JSON-LD structured data
   const eventJsonLd = {
@@ -404,24 +405,6 @@ export default async function EventPage({
                 </div>
                 <p className="text-sm text-amber-600 dark:text-amber-400 mt-1 font-medium">
                   You must register on <strong>both</strong>: Luma (for door entry) <strong>and</strong> the website (for hackathon ranking &amp; prizes). One without the other won&apos;t get you in.
-                </p>
-              </div>
-            ) : isPyData ? (
-              <div className="flex flex-col gap-4">
-                <Link
-                  href={PYDATA_2026_REGISTRATION_PATH}
-                  className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black w-full sm:w-auto"
-                >
-                  Register for door access
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M5 12h14" /><path d="m12 5 7 7-7 7" /></svg>
-                </Link>
-                <PyDataLumaButton
-                  variant="outline"
-                  label="Also RSVP on Luma"
-                  className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-white/20 text-white/80 rounded-lg text-sm font-medium hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black w-full sm:w-auto"
-                />
-                <p className="text-sm text-amber-600 dark:text-amber-400 mt-1 font-medium">
-                  Moderna requires us to hand them a CSV of confirmed attendees. Registering here is what gets your name on the door list — no site registration, no entry.
                 </p>
               </div>
             ) : (
@@ -802,30 +785,7 @@ export default async function EventPage({
       {/* Final CTA */}
       <section className="py-20 px-6">
         <div className="max-w-3xl mx-auto text-center">
-          {isPyData ? (
-            <>
-              <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
-                Ready to be on the door list?
-              </h2>
-              <p className="text-neutral-600 dark:text-neutral-400 text-lg mb-2">
-                Registering on cursorboston.com is what gets your name to Moderna. Without it you won&apos;t be admitted.
-              </p>
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-6">
-                <Link
-                  href={PYDATA_2026_REGISTRATION_PATH}
-                  className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-emerald-500 text-white rounded-lg text-lg font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
-                >
-                  Register for door access
-                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M5 12h14" /><path d="m12 5 7 7-7 7" /></svg>
-                </Link>
-                <PyDataLumaButton
-                  variant="outline"
-                  label="Also RSVP on Luma"
-                  className="inline-flex items-center justify-center gap-2 px-8 py-4 border border-neutral-300 dark:border-white/20 text-neutral-700 dark:text-white/80 rounded-lg text-base font-medium hover:bg-neutral-100 dark:hover:bg-white/10 transition-colors"
-                />
-              </div>
-            </>
-          ) : websiteRegistration ? (
+          {websiteRegistration ? (
             <>
               <h2 className="text-3xl md:text-4xl font-bold text-neutral-900 dark:text-white mb-4">
                 Ready to compete?

--- a/app/events/cursor-boston-pydata-2026/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/page.tsx
@@ -1,0 +1,508 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import eventsData from "@/content/events.json";
+import type { EventsData } from "@/types/events";
+import { PyDataAccessGate } from "@/components/events/PyDataAccessGate";
+import {
+  PYDATA_2026_EVENT_SLUG,
+} from "@/lib/pydata-2026";
+import {
+  getPyDataSubmissions,
+  PYDATA_SUBMISSIONS_BRANCH,
+  PYDATA_SUBMISSIONS_DIR,
+  PYDATA_SUBMISSIONS_REPO_URL,
+  type PyDataSubmission,
+} from "@/lib/pydata-submissions";
+
+// Static path: this file shadows app/events/[slug]/page.tsx for the exact
+// pydata slug. Other slugs continue to hit the dynamic [slug] route.
+
+const typedEvents = eventsData as unknown as EventsData;
+
+interface EventRecord {
+  slug: string;
+  title: string;
+  subtitle?: string;
+  date: string;
+  time: string;
+  location: string;
+  venue?: { name: string; address: string };
+  image: string;
+  description: string;
+}
+
+function findPydataEvent(): EventRecord | null {
+  const all = [
+    ...(typedEvents.upcoming as unknown as EventRecord[]),
+    ...(typedEvents.past as unknown as EventRecord[]),
+    ...((typedEvents.oldEvents ?? []) as unknown as EventRecord[]),
+  ];
+  return all.find((e) => e.slug === PYDATA_2026_EVENT_SLUG) ?? null;
+}
+
+export const metadata: Metadata = {
+  title: "Cursor Boston × PyData — Hackathon submissions",
+  description:
+    "Submit your hackathon notebook and browse merged submissions from the May 13 Cursor Boston × PyData evening hack at Moderna HQ.",
+  // Gated page — no need to be in search results or social previews.
+  robots: { index: false, follow: false },
+};
+
+// Linking to the branch (not /compare) so GitHub renders its "Contribute"
+// dropdown automatically — that flow lets the attendee open a PR from their
+// fork without us having to know the fork URL.
+const BRANCH_URL = `${PYDATA_SUBMISSIONS_REPO_URL}/tree/${PYDATA_SUBMISSIONS_BRANCH}`;
+const FORK_URL = `${PYDATA_SUBMISSIONS_REPO_URL}/fork`;
+const README_URL = `${PYDATA_SUBMISSIONS_REPO_URL}/blob/main/${PYDATA_SUBMISSIONS_DIR}/README.md`;
+
+export default function PyDataHackathonHubPage() {
+  const event = findPydataEvent();
+  const submissions = getPyDataSubmissions();
+
+  return (
+    <PyDataAccessGate>
+      <main className="flex flex-col bg-neutral-50 dark:bg-neutral-950">
+        {/* Breadcrumb */}
+        <nav
+          className="px-6 py-4 border-b border-neutral-200 dark:border-neutral-800"
+          aria-label="Breadcrumb"
+        >
+          <div className="max-w-6xl mx-auto">
+            <ol className="flex items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+              <li>
+                <Link
+                  href="/events"
+                  className="hover:text-foreground transition-colors"
+                >
+                  Events
+                </Link>
+              </li>
+              <li aria-hidden="true">/</li>
+              <li className="text-foreground truncate">
+                {event?.title ?? "Cursor Boston × PyData"}
+              </li>
+            </ol>
+          </div>
+        </nav>
+
+        {/* Hero — event reference strip */}
+        <section className="px-6 py-10 border-b border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+          <div className="max-w-6xl mx-auto">
+            <span className="inline-block px-3 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold rounded-full mb-3 uppercase tracking-wide">
+              You&apos;re in
+            </span>
+            <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-2">
+              {event?.title ?? "Cursor Boston × PyData — Hackathon hub"}
+            </h1>
+            {event?.subtitle ? (
+              <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-4">
+                {event.subtitle}
+              </p>
+            ) : null}
+            <dl className="mt-4 grid gap-3 text-sm text-neutral-700 dark:text-neutral-300 sm:grid-cols-3">
+              {event?.date ? (
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                    Date
+                  </dt>
+                  <dd className="mt-1">
+                    {event.date}
+                    {event.time && event.time !== "TBD" ? ` · ${event.time}` : ""}
+                  </dd>
+                </div>
+              ) : null}
+              {event?.venue ? (
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                    Venue
+                  </dt>
+                  <dd className="mt-1">
+                    {event.venue.name}
+                    <span className="block text-xs text-neutral-500">
+                      {event.venue.address}
+                    </span>
+                  </dd>
+                </div>
+              ) : null}
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                  Submission branch
+                </dt>
+                <dd className="mt-1 font-mono text-xs">
+                  <a
+                    href={BRANCH_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+                  >
+                    {PYDATA_SUBMISSIONS_BRANCH}
+                  </a>
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+
+        {/* Instructions */}
+        <SubmissionInstructions />
+
+        {/* Submissions grid */}
+        <SubmissionsGrid submissions={submissions} />
+      </main>
+    </PyDataAccessGate>
+  );
+}
+
+function SubmissionInstructions() {
+  return (
+    <section className="px-6 py-12 border-b border-neutral-200 dark:border-neutral-800">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-2">
+          Submit your notebook
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-8 max-w-3xl">
+          One PR per attendee, targeting the{" "}
+          <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
+            {PYDATA_SUBMISSIONS_BRANCH}
+          </code>{" "}
+          branch. Once a maintainer merges it through to{" "}
+          <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
+            main
+          </code>
+          , your card appears in the grid below.
+        </p>
+
+        <ol className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Step
+            num={1}
+            title="Fork the repo"
+            body={
+              <>
+                Click{" "}
+                <a
+                  href={FORK_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+                >
+                  Fork
+                </a>{" "}
+                on{" "}
+                <a
+                  href={PYDATA_SUBMISSIONS_REPO_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+                >
+                  cursor-boston
+                </a>{" "}
+                so you can push without write access to the upstream repo.
+              </>
+            }
+          />
+          <Step
+            num={2}
+            title="Add your folder"
+            body={
+              <>
+                Create{" "}
+                <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
+                  {PYDATA_SUBMISSIONS_DIR}/&lt;your-gh-handle&gt;/
+                </code>{" "}
+                with{" "}
+                <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
+                  submission.ipynb
+                </code>{" "}
+                and{" "}
+                <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
+                  meta.json
+                </code>{" "}
+                inside.
+              </>
+            }
+          />
+          <Step
+            num={3}
+            title={
+              <>
+                Open PR into{" "}
+                <code className="font-mono text-sm">
+                  {PYDATA_SUBMISSIONS_BRANCH}
+                </code>
+              </>
+            }
+            body={
+              <>
+                Set the base branch to{" "}
+                <a
+                  href={BRANCH_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+                >
+                  {PYDATA_SUBMISSIONS_BRANCH}
+                </a>
+                , not <code className="font-mono">main</code>. PRs to{" "}
+                <code className="font-mono">main</code> will be redirected.
+              </>
+            }
+          />
+          <Step
+            num={4}
+            title="Wait for the deploy"
+            body={
+              <>
+                A maintainer batches merges into{" "}
+                <code className="font-mono">{PYDATA_SUBMISSIONS_BRANCH}</code>,
+                then ships <code className="font-mono">develop</code> →{" "}
+                <code className="font-mono">main</code>. Your card appears
+                below after the Vercel deploy.
+              </>
+            }
+          />
+        </ol>
+
+        <div className="mt-8 rounded-xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <p className="text-sm font-semibold text-foreground mb-2">
+            meta.json template
+          </p>
+          <pre className="overflow-x-auto rounded bg-neutral-100 p-3 text-xs leading-relaxed text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+            <code>{META_TEMPLATE}</code>
+          </pre>
+          <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+            Full rules + field reference:{" "}
+            <a
+              href={README_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+            >
+              {PYDATA_SUBMISSIONS_DIR}/README.md
+            </a>
+          </p>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <a
+            href={BRANCH_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+          >
+            Open the submission branch
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7 17l9.2-9.2M17 17V7H7" />
+            </svg>
+          </a>
+          <a
+            href={README_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Read the rules
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const META_TEMPLATE = `{
+  "title": "Short, specific title for your notebook",
+  "description": "1–3 sentences. What does the notebook do? What did you find?",
+  "displayName": "Your name as you want it on the page",
+  "tags": ["healthcare", "embeddings"],
+  "collaborators": [
+    { "displayName": "Pat Collaborator", "githubHandle": "pat-collab" }
+  ]
+}`;
+
+function Step({
+  num,
+  title,
+  body,
+}: {
+  num: number;
+  title: React.ReactNode;
+  body: React.ReactNode;
+}) {
+  return (
+    <li className="relative rounded-xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+      <span className="absolute -top-3 left-4 inline-flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+        {num}
+      </span>
+      <h3 className="mt-1 mb-2 text-base font-semibold text-foreground">
+        {title}
+      </h3>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400">{body}</p>
+    </li>
+  );
+}
+
+function SubmissionsGrid({ submissions }: { submissions: PyDataSubmission[] }) {
+  return (
+    <section className="px-6 py-12">
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-6 flex items-baseline justify-between gap-4 flex-wrap">
+          <h2 className="text-2xl md:text-3xl font-bold text-foreground">
+            Merged submissions{" "}
+            <span className="text-neutral-500 font-normal tabular-nums">
+              ({submissions.length})
+            </span>
+          </h2>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            Each card links to the rendered notebook on GitHub.
+          </p>
+        </div>
+
+        {submissions.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {submissions.map((s) => (
+              <SubmissionCard key={s.githubHandle} submission={s} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-xl border border-dashed border-neutral-300 bg-white px-6 py-12 text-center dark:border-neutral-700 dark:bg-neutral-900">
+      <p className="text-base font-semibold text-foreground">
+        No merged submissions yet
+      </p>
+      <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400 max-w-md mx-auto">
+        Be the first — once your PR lands in{" "}
+        <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
+          main
+        </code>{" "}
+        and the site redeploys, your card shows up here.
+      </p>
+    </div>
+  );
+}
+
+function SubmissionCard({ submission }: { submission: PyDataSubmission }) {
+  const handleHref = `https://github.com/${submission.githubHandle}`;
+  return (
+    <li className="flex flex-col rounded-xl border border-neutral-200 bg-white p-5 transition-colors hover:border-emerald-500/40 dark:border-neutral-800 dark:bg-neutral-900">
+      <h3 className="text-lg font-semibold text-foreground line-clamp-2">
+        <a
+          href={submission.notebookUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+        >
+          {submission.title}
+        </a>
+      </h3>
+      <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+        by{" "}
+        <a
+          href={handleHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-neutral-700 hover:text-emerald-600 dark:text-neutral-300 dark:hover:text-emerald-400"
+        >
+          {submission.displayName}
+        </a>
+        <span className="text-neutral-400"> · @{submission.githubHandle}</span>
+      </p>
+
+      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400 line-clamp-4">
+        {submission.description}
+      </p>
+
+      {submission.tags.length > 0 ? (
+        <ul className="mt-4 flex flex-wrap gap-1.5">
+          {submission.tags.map((tag) => (
+            <li
+              key={tag}
+              className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
+            >
+              {tag}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {submission.collaborators.length > 0 ? (
+        <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+          With:{" "}
+          {submission.collaborators.map((c, i) => (
+            <span key={`${c.displayName}-${i}`}>
+              {i > 0 ? ", " : ""}
+              {c.githubHandle ? (
+                <a
+                  href={`https://github.com/${c.githubHandle}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-neutral-700 hover:text-emerald-600 dark:text-neutral-300 dark:hover:text-emerald-400"
+                >
+                  {c.displayName}
+                </a>
+              ) : (
+                c.displayName
+              )}
+            </span>
+          ))}
+        </p>
+      ) : null}
+
+      <div className="mt-auto pt-5 flex items-center justify-between text-xs">
+        <a
+          href={submission.notebookUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 font-medium text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+        >
+          View notebook
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M7 17l9.2-9.2M17 17V7H7" />
+          </svg>
+        </a>
+        <a
+          href={submission.folderUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+        >
+          Folder
+        </a>
+      </div>
+    </li>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -8,6 +8,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import eventsData from "@/content/events.json";
 import { EventsBrowse } from "@/components/events/EventsBrowse";
+import { PydataLockedBanner } from "@/components/events/PydataLockedBanner";
 import { todayYmdInListingTz } from "@/lib/events-calendar-buckets";
 import { EventsData } from "@/types/events";
 
@@ -151,9 +152,15 @@ const eventTypes = [
   },
 ];
 
-export default function EventsPage() {
+export default async function EventsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ pydataLocked?: string }>;
+}) {
   const listingTodayYmd = todayYmdInListingTz(new Date());
   const eventsJsonLd = generateEventsJsonLd();
+  const { pydataLocked } = await searchParams;
+  const showPydataLocked = pydataLocked === "1";
 
   return (
     <main className="flex flex-col">
@@ -166,6 +173,7 @@ export default function EventsPage() {
           }}
         />
       ))}
+      {showPydataLocked && <PydataLockedBanner />}
       {/* Hero */}
       <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800">
         <div className="max-w-4xl mx-auto text-center">

--- a/components/events/PyDataAccessGate.tsx
+++ b/components/events/PyDataAccessGate.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+
+type GateState = "checking" | "allowed" | "denied";
+
+const ACCESS_API_PATH = "/api/events/pydata-2026/access";
+const LOCKED_REDIRECT = "/events?pydataLocked=1";
+
+/**
+ * Client-side gate for the May 13 PyData event page. Children mount only
+ * once the server confirms the signed-in user's email is on Moderna's
+ * 150-person door list. Anyone else is redirected to /events with a
+ * `pydataLocked=1` query the events page reads to render a banner.
+ *
+ * We intentionally render a neutral placeholder while checking or
+ * redirecting — never the event content — so denied users don't briefly
+ * see the page before the router replaces the URL.
+ */
+export function PyDataAccessGate({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuth();
+  const [state, setState] = useState<GateState>("checking");
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot transition once auth resolves to "signed-out"
+      setState("denied");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(ACCESS_API_PATH, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const json = (await res.json().catch(() => ({}))) as { allowed?: boolean };
+        if (cancelled) return;
+        setState(json.allowed === true ? "allowed" : "denied");
+      } catch {
+        if (!cancelled) setState("denied");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user]);
+
+  useEffect(() => {
+    if (state === "denied") {
+      router.replace(LOCKED_REDIRECT);
+    }
+  }, [state, router]);
+
+  if (state === "allowed") {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-6">
+      <p className="text-sm text-neutral-500 dark:text-neutral-400">
+        {state === "checking"
+          ? "Checking access…"
+          : "Attendance is locked — redirecting you to the events list…"}
+      </p>
+    </div>
+  );
+}

--- a/components/events/PydataLockedBanner.tsx
+++ b/components/events/PydataLockedBanner.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Shown at the top of /events when a user was redirected away from the
+ * gated PyData event page (`?pydataLocked=1`). Dismissible — once gone
+ * for the session it stays gone.
+ */
+export function PydataLockedBanner() {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed) return null;
+
+  return (
+    <aside
+      role="status"
+      aria-live="polite"
+      className="border-b border-amber-500/40 bg-amber-500/10 px-6 py-4 dark:bg-amber-500/15"
+    >
+      <div className="mx-auto flex max-w-6xl items-start gap-3">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="mt-0.5 shrink-0 text-amber-700 dark:text-amber-300"
+          aria-hidden="true"
+        >
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <div className="flex-1 text-sm text-amber-900 dark:text-amber-100">
+          <p className="font-semibold">
+            PyData × Cursor Boston attendance is locked
+          </p>
+          <p className="mt-1">
+            We&apos;ve handed Moderna the final 150-person door list, so only
+            confirmed attendees can view that event page. Confirmed attendees
+            received an email from Moderna (via Envoy) with NDA paperwork that
+            must be completed before entry. If you can no longer attend,
+            there&apos;s no need to contact us.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss notice"
+          className="-mr-1 shrink-0 rounded p-1 text-amber-800 transition-colors hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 dark:text-amber-200"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -37,23 +37,23 @@ const customJestConfig = {
     '<rootDir>/e2e/',
   ],
   // Global thresholds — kept just below current CI totals so new UI without tests fails CI loudly.
-  // Re-aligned 2026-05-06 (Q2 review push) after Chunk C/D added the
-  // account-deletion cascade, community report/block flow, and the
-  // admin moderation queue. Most of the new lib/ code has unit tests;
-  // the new UI surfaces (DataPrivacySection, ReportMessageMenu,
-  // admin pages) are exercised manually and added 1-1.5pp of uncovered
-  // lines, which dropped the global numbers slightly.
-  // Current totals: statements 31.99%, branches 26.14%, lines 33.34%, functions 26.31%.
-  // Floors set 1pp below current → any regression fails CI.
+  // Re-aligned 2026-05-12 after the PyData hackathon hub + access-gate
+  // landed: the new gated event page (server component, ~500 LOC) and
+  // the access API route are exercised manually + via Playwright but
+  // have no Jest unit tests, which dropped global numbers ~1-2pp.
+  // Pure lib pieces (pydata-2026-access, pydata-submissions) have full
+  // unit tests; the gate + banner components are tested via RTL.
+  // Current totals: statements 30.63%, branches 23.80%, lines 31.76%, functions 23.77%.
+  // Floors set ~1pp below current → any regression fails CI.
   // Ratchet these UP as tests are added (especially around lib/account-deletion
   // and the new community/report+moderate routes — both have route-level
-  // unit tests but no UI tests yet).
+  // unit tests but no UI tests yet — plus the pydata access API route).
   coverageThreshold: {
     global: {
-      branches: 25,
-      functions: 25,
-      lines: 32,
-      statements: 30,
+      branches: 22,
+      functions: 22,
+      lines: 30,
+      statements: 29,
     },
   },
   // Generate JSON summary for CI coverage checks

--- a/lib/api-schemas/events.ts
+++ b/lib/api-schemas/events.ts
@@ -99,6 +99,11 @@ const PydataLumaStatusResponse = z.object({
   onLumaList: z.boolean(),
 });
 
+const PydataAccessResponse = z.object({
+  allowed: z.boolean(),
+  reason: z.literal("unauthenticated").optional(),
+});
+
 const PydataRegistrationGetResponse = z
   .object({
     registered: z.boolean(),
@@ -218,6 +223,14 @@ export const eventsContract = c.router(
       path: "/api/events/pydata-2026/luma-status",
       summary: "Whether the current user appears on the PyData Luma guest list",
       responses: { 200: PydataLumaStatusResponse, 500: ApiErrorSchema },
+      metadata: { errorCodes: ["SERVER_ERROR"] as const },
+    },
+    pydataAccess: {
+      method: "GET",
+      path: "/api/events/pydata-2026/access",
+      summary:
+        "Whether the signed-in user is on the 150-person PyData 2026 door list",
+      responses: { 200: PydataAccessResponse, 500: ApiErrorSchema },
       metadata: { errorCodes: ["SERVER_ERROR"] as const },
     },
     pydataRegistrationGet: {

--- a/lib/pydata-2026-access.ts
+++ b/lib/pydata-2026-access.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Final door-list gate for the May 13 PyData event at Moderna.
+ *
+ * The 150 confirmed-attendee emails live in a private Firestore collection
+ * (server-side, Admin SDK only). They never appear in this public repo —
+ * `/api/events/pydata-2026/access` reads them and returns a boolean to the
+ * gate component. Keeping the emails off the client is the whole point.
+ *
+ * Doc IDs in the collection are the lowercased, trimmed email — exact-match
+ * lookups via `.doc(email).get()` keep reads O(1).
+ */
+export const PYDATA_2026_ACCESS_LIST_COLLECTION = "pydataHack2026AccessList";
+
+/**
+ * Normalize an email for allowlist comparison. Door-list matching is
+ * case-insensitive (people register with mixed casing); whitespace gets
+ * trimmed because pasted CSV values sometimes carry a stray space.
+ */
+export function normalizePydataEmail(email: string | null | undefined): string {
+  return (email ?? "").trim().toLowerCase();
+}

--- a/lib/pydata-submissions.ts
+++ b/lib/pydata-submissions.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Build-time loader for the PyData hackathon submissions directory.
+ *
+ * Layout (see `pydata-2026-submissions/README.md`):
+ *
+ *   pydata-2026-submissions/
+ *     README.md
+ *     <gh-handle>/
+ *       submission.ipynb
+ *       meta.json
+ *
+ * The event page reads this list at build time. New submissions appear
+ * after `main` deploys, which matches the user's workflow:
+ *   attendee PR → `pydata-2026-submissions` branch → develop → main → deploy.
+ */
+
+export const PYDATA_SUBMISSIONS_BRANCH = "pydata-2026-submissions";
+export const PYDATA_SUBMISSIONS_DIR = "pydata-2026-submissions";
+export const PYDATA_SUBMISSIONS_REPO_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+const NOTEBOOK_FILENAME = "submission.ipynb";
+const META_FILENAME = "meta.json";
+const MAX_TITLE = 120;
+const MAX_DESCRIPTION = 500;
+const MAX_TAGS = 6;
+const MAX_COLLABORATORS = 10;
+
+export interface PyDataSubmissionCollaborator {
+  displayName: string;
+  githubHandle: string | null;
+}
+
+export interface PyDataSubmission {
+  githubHandle: string;
+  displayName: string;
+  title: string;
+  description: string;
+  tags: string[];
+  collaborators: PyDataSubmissionCollaborator[];
+  /** GitHub URL pointing at the rendered notebook on `main`. */
+  notebookUrl: string;
+  /** GitHub URL pointing at the submission folder. */
+  folderUrl: string;
+}
+
+function clampString(s: unknown, max: number): string {
+  if (typeof s !== "string") return "";
+  return s.trim().slice(0, max);
+}
+
+function parseTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const tags: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const cleaned = entry.trim().toLowerCase().slice(0, 32);
+    if (!cleaned) continue;
+    if (tags.includes(cleaned)) continue;
+    tags.push(cleaned);
+    if (tags.length >= MAX_TAGS) break;
+  }
+  return tags;
+}
+
+function parseCollaborators(raw: unknown): PyDataSubmissionCollaborator[] {
+  if (!Array.isArray(raw)) return [];
+  const out: PyDataSubmissionCollaborator[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const displayName = clampString(obj.displayName, 80);
+    if (!displayName) continue;
+    const handleRaw = clampString(obj.githubHandle, 64);
+    out.push({
+      displayName,
+      githubHandle: handleRaw ? handleRaw.replace(/^@/, "") : null,
+    });
+    if (out.length >= MAX_COLLABORATORS) break;
+  }
+  return out;
+}
+
+function isValidHandleDirname(name: string): boolean {
+  // Allow lowercase letters, digits, hyphens, underscores. Reject dotfiles
+  // and our README/template scaffolding. GitHub handles are case-insensitive
+  // but we want a canonical lowercase form for the URL.
+  if (name.startsWith(".") || name.startsWith("_")) return false;
+  return /^[a-z0-9][a-z0-9-_]{0,38}$/i.test(name);
+}
+
+function readMeta(folderPath: string): unknown {
+  const metaPath = path.join(folderPath, META_FILENAME);
+  if (!fs.existsSync(metaPath)) return null;
+  try {
+    const text = fs.readFileSync(metaPath, "utf8");
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function buildSubmission(
+  handleDir: string,
+  meta: Record<string, unknown>
+): PyDataSubmission | null {
+  const title = clampString(meta.title, MAX_TITLE);
+  const description = clampString(meta.description, MAX_DESCRIPTION);
+  if (!title || !description) return null;
+  const displayName =
+    clampString(meta.displayName, 80) || handleDir;
+  const tags = parseTags(meta.tags);
+  const collaborators = parseCollaborators(meta.collaborators);
+
+  return {
+    githubHandle: handleDir,
+    displayName,
+    title,
+    description,
+    tags,
+    collaborators,
+    notebookUrl: `${PYDATA_SUBMISSIONS_REPO_URL}/blob/main/${PYDATA_SUBMISSIONS_DIR}/${handleDir}/${NOTEBOOK_FILENAME}`,
+    folderUrl: `${PYDATA_SUBMISSIONS_REPO_URL}/tree/main/${PYDATA_SUBMISSIONS_DIR}/${handleDir}`,
+  };
+}
+
+/**
+ * Read every valid submission from the directory on disk.
+ *
+ * Invalid entries (missing notebook, malformed meta.json, bad folder name)
+ * are silently skipped so a single broken submission can't take down the
+ * whole page. Build logs surface the skip via console.warn — visible in
+ * Vercel deploy output.
+ */
+export function getPyDataSubmissions(): PyDataSubmission[] {
+  const dir = path.join(process.cwd(), PYDATA_SUBMISSIONS_DIR);
+  if (!fs.existsSync(dir)) return [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const submissions: PyDataSubmission[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const handleDir = entry.name;
+    if (!isValidHandleDirname(handleDir)) continue;
+
+    const folderPath = path.join(dir, handleDir);
+    const notebookPath = path.join(folderPath, NOTEBOOK_FILENAME);
+    if (!fs.existsSync(notebookPath)) {
+      console.warn(
+        `[pydata-submissions] ${handleDir}: missing ${NOTEBOOK_FILENAME}, skipping`
+      );
+      continue;
+    }
+
+    const meta = readMeta(folderPath);
+    if (!meta || typeof meta !== "object") {
+      console.warn(
+        `[pydata-submissions] ${handleDir}: missing or invalid ${META_FILENAME}, skipping`
+      );
+      continue;
+    }
+
+    const submission = buildSubmission(handleDir, meta as Record<string, unknown>);
+    if (!submission) {
+      console.warn(
+        `[pydata-submissions] ${handleDir}: ${META_FILENAME} missing required fields, skipping`
+      );
+      continue;
+    }
+    submissions.push(submission);
+  }
+
+  // Alphabetical by displayName so the grid has a stable ordering across
+  // builds — nothing "wins" by submitting early.
+  submissions.sort((a, b) =>
+    a.displayName.localeCompare(b.displayName, undefined, { sensitivity: "base" })
+  );
+  return submissions;
+}

--- a/pydata-2026-submissions/README.md
+++ b/pydata-2026-submissions/README.md
@@ -1,0 +1,87 @@
+# PyData × Cursor Boston — Hackathon submissions
+
+This directory holds the Jupyter notebook submissions from the **May 13, 2026
+Cursor Boston × PyData evening hack at Moderna HQ**.
+
+Each subfolder is one attendee's submission. The gated event page at
+[cursorboston.com/events/cursor-boston-pydata-2026](https://cursorboston.com/events/cursor-boston-pydata-2026)
+reads this directory at build time and renders a card per merged submission.
+
+---
+
+## How to submit your work
+
+1. **Fork the repo** at
+   <https://github.com/rogerSuperBuilderAlpha/cursor-boston>.
+
+2. **Create a folder under `pydata-2026-submissions/`** named after your
+   GitHub handle (lowercase, exactly as it appears in `github.com/<handle>`).
+   Example: `pydata-2026-submissions/adam-sychla/`.
+
+3. **Add two files inside your folder:**
+   - `submission.ipynb` — your Jupyter notebook. GitHub renders it natively,
+     so commit the notebook with output cells already executed if you want
+     reviewers to see results without re-running.
+   - `meta.json` — title + description, see template below.
+
+4. **Open a PR** targeting the branch **`pydata-2026-submissions`** (not
+   `develop` or `main`). We'll batch all the PRs into that branch, merge it
+   into `develop`, then promote `develop` to `main` — your card appears on
+   the gated event page after the final push to `main` deploys.
+
+5. **One folder per attendee.** If you collaborated, pick one handle for the
+   folder name and list collaborators inside `meta.json` (see below).
+
+---
+
+## `meta.json` template
+
+```json
+{
+  "title": "Short, specific title for your notebook",
+  "description": "1–3 sentences. What does the notebook do? What dataset or problem? What did you find?",
+  "displayName": "Your name as you want it on the page",
+  "tags": ["healthcare", "embeddings", "exploratory"],
+  "collaborators": [
+    { "displayName": "Pat Collaborator", "githubHandle": "pat-collab" }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| `title` | yes | ≤120 chars. Shown as the card heading. |
+| `description` | yes | ≤500 chars. One paragraph. Markdown not rendered — plain text only. |
+| `displayName` | yes | Falls back to your GitHub handle if omitted, but please set it. |
+| `tags` | no | ≤6 short tags. Lowercase. Shown as pills. |
+| `collaborators` | no | List of `{ displayName, githubHandle }` for people who worked with you. The page lists them under your card. |
+
+### Rules
+
+- Don't include any **Moderna logo, branding, or photos** in your notebook
+  output cells or in `meta.json`. Moderna asked us to keep those off public
+  surfaces.
+- Don't commit secrets, API keys, or paid data. Sample data only.
+- Keep `submission.ipynb` under **50 MB** — if you have a huge dataset,
+  reference it by URL inside the notebook instead of embedding.
+- Your folder name is your **GitHub handle**, not your real name. The page
+  shows your `displayName` from `meta.json`.
+
+---
+
+## What happens after you open the PR
+
+1. A maintainer reviews the PR for the rules above (no branding leak, no
+   secrets, file structure correct).
+2. PR gets merged into the `pydata-2026-submissions` branch.
+3. When the maintainer is ready (likely batched, end-of-night or next
+   morning), `pydata-2026-submissions` is merged into `develop`, then
+   `develop` into `main`. Vercel deploys main → your card goes live.
+4. Your submission shows up on the event page. Other attendees can browse
+   it; the notebook itself is rendered by GitHub's built-in `.ipynb`
+   viewer.
+
+If anything's off, the maintainer will leave PR comments and you can push
+fixes to the same branch.

--- a/scripts/seed-pydata-2026-access-list.ts
+++ b/scripts/seed-pydata-2026-access-list.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-shot: seed the final May 13 PyData door list into Firestore.
+ *
+ * Reads a CSV with columns `First Name,Last Name,Email,Organization` and
+ * writes one doc per row into the `pydataHack2026AccessList` collection.
+ *
+ *   - doc ID = lowercased, trimmed email (so /api/events/pydata-2026/access
+ *     can `.doc(email).get()` in O(1) without scanning the whole list)
+ *   - doc body holds the original-cased email + import timestamp +
+ *     organization, purely for ops debugging — the gate API only checks
+ *     for doc existence.
+ *
+ * `--dry-run` parses + reports a preview without writing.
+ * Pass --replace to delete any pre-existing docs in the collection first
+ * (safe for a one-shot final list; not safe for incremental updates).
+ *
+ * Usage:
+ *   npx tsx scripts/seed-pydata-2026-access-list.ts "/path/to/attendance.csv"
+ *   npx tsx scripts/seed-pydata-2026-access-list.ts "/path/to/attendance.csv" --dry-run
+ *   npx tsx scripts/seed-pydata-2026-access-list.ts "/path/to/attendance.csv" --replace
+ */
+
+import { readFileSync } from "node:fs";
+import { initializeApp, cert, getApps } from "firebase-admin/app";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { loadEnvConfig } from "@next/env";
+import {
+  PYDATA_2026_ACCESS_LIST_COLLECTION,
+  normalizePydataEmail,
+} from "../lib/pydata-2026-access";
+
+loadEnvConfig(process.cwd());
+
+interface CliArgs {
+  csvPath: string;
+  dryRun: boolean;
+  replace: boolean;
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2);
+  const positional = args.filter((a) => !a.startsWith("--"));
+  if (positional.length !== 1) {
+    console.error(
+      "Usage: npx tsx scripts/seed-pydata-2026-access-list.ts <csv-path> [--dry-run] [--replace]"
+    );
+    process.exit(2);
+  }
+  return {
+    csvPath: positional[0],
+    dryRun: args.includes("--dry-run"),
+    replace: args.includes("--replace"),
+  };
+}
+
+/** Minimal CSV parser that handles quoted fields containing commas. */
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let field = "";
+  let row: string[] = [];
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ",") {
+      row.push(field);
+      field = "";
+      continue;
+    }
+    if (ch === "\r") continue;
+    if (ch === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+      continue;
+    }
+    field += ch;
+  }
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows.filter((r) => r.some((cell) => cell.trim() !== ""));
+}
+
+interface AttendeeRow {
+  firstName: string;
+  lastName: string;
+  email: string;
+  organization: string;
+  normalizedEmail: string;
+}
+
+function rowsToAttendees(rows: string[][]): AttendeeRow[] {
+  if (rows.length === 0) throw new Error("CSV is empty");
+  const header = rows[0].map((c) => c.trim().toLowerCase());
+  const colIdx = (...names: string[]): number => {
+    for (const n of names) {
+      const idx = header.indexOf(n);
+      if (idx !== -1) return idx;
+    }
+    return -1;
+  };
+  const iFirst = colIdx("first name", "firstname");
+  const iLast = colIdx("last name", "lastname");
+  const iEmail = colIdx("email", "email address");
+  const iOrg = colIdx("organization", "company", "organisation");
+  if (iEmail === -1) {
+    throw new Error(`CSV missing required Email column. Found: ${header.join(", ")}`);
+  }
+
+  const attendees: AttendeeRow[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const rawEmail = (r[iEmail] ?? "").trim();
+    const normalized = normalizePydataEmail(rawEmail);
+    if (!normalized) {
+      console.warn(`Row ${i + 1}: blank email, skipping`);
+      continue;
+    }
+    attendees.push({
+      firstName: (iFirst === -1 ? "" : r[iFirst] ?? "").trim(),
+      lastName: (iLast === -1 ? "" : r[iLast] ?? "").trim(),
+      email: rawEmail,
+      organization: (iOrg === -1 ? "" : r[iOrg] ?? "").trim(),
+      normalizedEmail: normalized,
+    });
+  }
+  return attendees;
+}
+
+async function main(): Promise<void> {
+  const { csvPath, dryRun, replace } = parseArgs();
+  const text = readFileSync(csvPath, "utf8");
+  const rows = parseCsv(text);
+  const attendees = rowsToAttendees(rows);
+
+  // Detect duplicate emails (same normalized form) and report — the Map
+  // collapse below will keep only the last occurrence, which matches a
+  // Firestore set() semantic, but it's worth flagging so we notice.
+  const seen = new Map<string, AttendeeRow>();
+  const dupes: string[] = [];
+  for (const a of attendees) {
+    if (seen.has(a.normalizedEmail)) dupes.push(a.normalizedEmail);
+    seen.set(a.normalizedEmail, a);
+  }
+
+  console.log(`Parsed ${attendees.length} rows from ${csvPath}`);
+  console.log(`Unique normalized emails: ${seen.size}`);
+  if (dupes.length > 0) {
+    console.log(`Duplicates (kept last occurrence): ${dupes.length}`);
+    for (const d of dupes) console.log(`  - ${d}`);
+  }
+
+  if (dryRun) {
+    console.log("--dry-run: not writing to Firestore.");
+    console.log(`First 3 docs that would be written:`);
+    Array.from(seen.values())
+      .slice(0, 3)
+      .forEach((a) => console.log(`  ${a.normalizedEmail} (${a.firstName} ${a.lastName}, ${a.organization})`));
+    process.exit(0);
+  }
+
+  const json = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  if (!json) throw new Error("missing FIREBASE_SERVICE_ACCOUNT_JSON");
+  const credentials = JSON.parse(json);
+  if (!getApps().length) {
+    initializeApp({ credential: cert(credentials), projectId: credentials.project_id });
+  }
+  const db = getFirestore();
+  const col = db.collection(PYDATA_2026_ACCESS_LIST_COLLECTION);
+
+  if (replace) {
+    console.log(`--replace: deleting existing docs in ${PYDATA_2026_ACCESS_LIST_COLLECTION}…`);
+    const existing = await col.listDocuments();
+    if (existing.length > 0) {
+      // Firestore batch limit is 500; this list is at most ~150, so one
+      // batch is fine. Stay generic anyway in case --replace gets used
+      // again later with a larger residue.
+      let batch = db.batch();
+      let opsInBatch = 0;
+      for (const ref of existing) {
+        batch.delete(ref);
+        opsInBatch++;
+        if (opsInBatch >= 450) {
+          await batch.commit();
+          batch = db.batch();
+          opsInBatch = 0;
+        }
+      }
+      if (opsInBatch > 0) await batch.commit();
+    }
+    console.log(`  deleted ${existing.length} pre-existing docs`);
+  }
+
+  let batch = db.batch();
+  let opsInBatch = 0;
+  let written = 0;
+  for (const a of seen.values()) {
+    const ref = col.doc(a.normalizedEmail);
+    batch.set(
+      ref,
+      {
+        email: a.email,
+        normalizedEmail: a.normalizedEmail,
+        firstName: a.firstName,
+        lastName: a.lastName,
+        organization: a.organization,
+        importedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+    opsInBatch++;
+    written++;
+    if (opsInBatch >= 450) {
+      await batch.commit();
+      batch = db.batch();
+      opsInBatch = 0;
+    }
+  }
+  if (opsInBatch > 0) await batch.commit();
+
+  console.log(`Wrote ${written} access-list docs to ${PYDATA_2026_ACCESS_LIST_COLLECTION}`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Promotes #823 from develop to main. Locks the PyData event page to the 150-person door list and replaces the door-access UI with a hackathon submissions hub now that the event is live.

## PRs included
- #823 — feat(pydata-2026): gate event page to door list + add hackathon hub — @Ludwitt

## Credit
Thanks @Ludwitt for the work in this release.

## Test plan
- [x] All PR-level checks passed on #823 except DCO (bypassed with `--admin`)
- [ ] After deploy: verify a confirmed-attendee account can view `/events/cursor-boston-pydata-2026`
- [ ] After deploy: verify a signed-out / non-attendee account is redirected to `/events?pydataLocked=1` and sees the lockout banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)