### PR TITLE
feat(pydata-2026): LLM-score every submission before merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,3 +35,34 @@ Skip a branch if `git log --oneline origin/develop..origin/<branch>` shows commi
 `maintainer-application` is intentionally excluded — it accumulates application PRs reviewed asynchronously, not bulk-promoted.
 
 When a new core branch is added (next cohort, next event), add it to the list above so the next pass picks it up.
+
+## PyData submission merge checklist
+
+Every PR into `pydata-2026-submissions` is a hackathon entry — it must be scored by the LLM judge before it lands, and the score is what feeds the "Best Submission" ranking and the AI-judge badge on each card on the event page. **Do not merge a PyData submission PR before `score.json` exists in the submission folder.**
+
+For each PR targeting `pydata-2026-submissions`:
+
+1. **Check it out locally.**
+   ```bash
+   gh pr checkout <pr-number>
+   ```
+2. **Review for the standard rules** (no Moderna branding, no secrets, folder is the contributor's GitHub handle, `submission.ipynb` + `meta.json` present). See `pydata-2026-submissions/README.md`.
+3. **Run the LLM scorer.** This calls Claude with the hackathon rubric and writes `score.json` (score 1-10 + rationale + model + scoredAt) into the submission folder:
+   ```bash
+   ANTHROPIC_API_KEY=... npx tsx scripts/score-pydata-submission.ts --handle <gh-handle>
+   ```
+   Re-score with `--force` only if the contributor pushed new commits after the first score. The rubric and "competition datasets" list are defined inline in the script; update them there when the event rules change.
+4. **Commit `score.json` onto the PR branch** (DCO sign-off required like any other commit):
+   ```bash
+   git add pydata-2026-submissions/<gh-handle>/score.json
+   git commit -s -m "judge(pydata-2026): score <gh-handle> submission"
+   git push
+   ```
+   The score lives with the submission so the event page can render the AI-judge badge and so the ranking is auditable in the merge commit.
+5. **Merge the PR** into `pydata-2026-submissions` (squash is fine — the score commit is small and self-contained).
+6. **Bulk-promote** the submission branch into `develop` per the normal flow when batching is done.
+
+Notes:
+- `score.json` is **maintainer-authored**, not contributor-authored. Reject any PR that includes a `score.json` written by the contributor — they don't get to score themselves.
+- If `ANTHROPIC_API_KEY` isn't available locally, you can run the scorer against the merged folder later, but score every submission before announcing winners — the "Best Submission" prize is decided from these scores.
+- A PyData submission without `score.json` will still render on the event page (the badge just won't appear), but it is **ineligible for "Best Submission"** until scored.

--- a/app/events/cursor-boston-pydata-2026/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/page.tsx
@@ -455,6 +455,22 @@ function SubmissionCard({ submission }: { submission: PyDataSubmission }) {
         </ul>
       ) : null}
 
+      {submission.score ? (
+        <div className="mt-4 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 dark:border-emerald-400/20 dark:bg-emerald-400/5">
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
+              AI judge score
+            </span>
+            <span className="font-mono text-sm font-semibold tabular-nums text-emerald-700 dark:text-emerald-400">
+              {submission.score.score}/10
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+            {submission.score.rationale}
+          </p>
+        </div>
+      ) : null}
+
       {submission.collaborators.length > 0 ? (
         <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
           With:{" "}

--- a/lib/pydata-submissions.ts
+++ b/lib/pydata-submissions.ts
@@ -30,14 +30,27 @@ export const PYDATA_SUBMISSIONS_REPO_URL =
 
 const NOTEBOOK_FILENAME = "submission.ipynb";
 const META_FILENAME = "meta.json";
+const SCORE_FILENAME = "score.json";
 const MAX_TITLE = 120;
 const MAX_DESCRIPTION = 500;
 const MAX_TAGS = 6;
 const MAX_COLLABORATORS = 10;
+const MAX_RATIONALE = 1000;
 
 export interface PyDataSubmissionCollaborator {
   displayName: string;
   githubHandle: string | null;
+}
+
+export interface PyDataSubmissionScore {
+  /** Integer 1-10 from the LLM judge. */
+  score: number;
+  /** Short justification from the judge. */
+  rationale: string;
+  /** Model name that produced the score (e.g. `claude-opus-4-7`). */
+  model: string;
+  /** ISO timestamp of when the score was written. */
+  scoredAt: string;
 }
 
 export interface PyDataSubmission {
@@ -51,6 +64,12 @@ export interface PyDataSubmission {
   notebookUrl: string;
   /** GitHub URL pointing at the submission folder. */
   folderUrl: string;
+  /**
+   * Hackathon judge score. Maintainer-authored via
+   * `scripts/score-pydata-submission.ts` and committed as `score.json`
+   * before the PR is merged. Absent if not yet scored.
+   */
+  score: PyDataSubmissionScore | null;
 }
 
 function clampString(s: unknown, max: number): string {
@@ -109,9 +128,31 @@ function readMeta(folderPath: string): unknown {
   }
 }
 
+function readScore(folderPath: string): PyDataSubmissionScore | null {
+  const scorePath = path.join(folderPath, SCORE_FILENAME);
+  if (!fs.existsSync(scorePath)) return null;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(fs.readFileSync(scorePath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return null;
+  }
+  const score = Number(parsed.score);
+  if (!Number.isFinite(score) || score < 1 || score > 10) return null;
+  const rationale = clampString(parsed.rationale, MAX_RATIONALE);
+  if (!rationale) return null;
+  const model = clampString(parsed.model, 80) || "unknown";
+  const scoredAt = clampString(parsed.scoredAt, 40) || "";
+  return { score, rationale, model, scoredAt };
+}
+
 function buildSubmission(
   handleDir: string,
-  meta: Record<string, unknown>
+  meta: Record<string, unknown>,
+  score: PyDataSubmissionScore | null
 ): PyDataSubmission | null {
   const title = clampString(meta.title, MAX_TITLE);
   const description = clampString(meta.description, MAX_DESCRIPTION);
@@ -130,6 +171,7 @@ function buildSubmission(
     collaborators,
     notebookUrl: `${PYDATA_SUBMISSIONS_REPO_URL}/blob/main/${PYDATA_SUBMISSIONS_DIR}/${handleDir}/${NOTEBOOK_FILENAME}`,
     folderUrl: `${PYDATA_SUBMISSIONS_REPO_URL}/tree/main/${PYDATA_SUBMISSIONS_DIR}/${handleDir}`,
+    score,
   };
 }
 
@@ -175,7 +217,12 @@ export function getPyDataSubmissions(): PyDataSubmission[] {
       continue;
     }
 
-    const submission = buildSubmission(handleDir, meta as Record<string, unknown>);
+    const score = readScore(folderPath);
+    const submission = buildSubmission(
+      handleDir,
+      meta as Record<string, unknown>,
+      score
+    );
     if (!submission) {
       console.warn(
         `[pydata-submissions] ${handleDir}: ${META_FILENAME} missing required fields, skipping`

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "send-contact-list-email": "tsx scripts/send-contact-list-email.ts",
     "ai-evaluate": "tsx scripts/ai-evaluate-submissions.ts",
     "ai-evaluate:apply-json": "tsx scripts/apply-ai-scores-from-json.ts",
+    "score-pydata": "tsx scripts/score-pydata-submission.ts",
     "distribute-credits": "tsx scripts/distribute-cursor-credits.ts",
     "seed-luma-registrants": "tsx scripts/seed-luma-registrants.ts",
     "generate-contributors": "bash scripts/generate-contributors.sh",

--- a/pydata-2026-submissions/README.md
+++ b/pydata-2026-submissions/README.md
@@ -75,13 +75,20 @@ reads this directory at build time and renders a card per merged submission.
 
 1. A maintainer reviews the PR for the rules above (no branding leak, no
    secrets, file structure correct).
-2. PR gets merged into the `pydata-2026-submissions` branch.
-3. When the maintainer is ready (likely batched, end-of-night or next
+2. **The maintainer runs the LLM judge** against your notebook and commits
+   a `score.json` (score 1-10 + rationale + model) into your folder. This
+   is the "black box" judge that decides the **Best Submission** winners.
+   You don't add `score.json` yourself — any PR that ships one will be
+   rejected.
+3. PR gets merged into the `pydata-2026-submissions` branch.
+4. When the maintainer is ready (likely batched, end-of-night or next
    morning), `pydata-2026-submissions` is merged into `develop`, then
-   `develop` into `main`. Vercel deploys main → your card goes live.
-4. Your submission shows up on the event page. Other attendees can browse
+   `develop` into `main`. Vercel deploys main → your card (with score
+   badge) goes live.
+5. Your submission shows up on the event page. Other attendees can browse
    it; the notebook itself is rendered by GitHub's built-in `.ipynb`
    viewer.
 
 If anything's off, the maintainer will leave PR comments and you can push
-fixes to the same branch.
+fixes to the same branch. If you push new commits after a score lands, the
+maintainer will re-score before merging.

--- a/scripts/score-pydata-submission.ts
+++ b/scripts/score-pydata-submission.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * PyData × Cursor Boston (May 13, 2026) — LLM scorer for hackathon submissions.
+ *
+ * Reads a `pydata-2026-submissions/<handle>/` folder, calls Claude with the
+ * hackathon rubric, and writes `score.json` into the same folder. The score
+ * file is what the event page renders on each card and what the maintainers
+ * use to rank "Best Submission" entries.
+ *
+ * Usage:
+ *   npx tsx scripts/score-pydata-submission.ts --handle <gh-handle>
+ *   npx tsx scripts/score-pydata-submission.ts --all
+ *   npx tsx scripts/score-pydata-submission.ts --handle alice --force   # re-score
+ *   npx tsx scripts/score-pydata-submission.ts --all --skip-existing
+ *
+ * Requires: ANTHROPIC_API_KEY
+ *
+ * The merge checklist for maintainers lives in CLAUDE.md
+ * ("PyData submission merge checklist") — score.json must be committed onto
+ * the submission branch before the PR is merged.
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import Anthropic from "@anthropic-ai/sdk";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  PYDATA_SUBMISSIONS_DIR,
+} from "../lib/pydata-submissions";
+
+const MODEL = "claude-opus-4-7";
+const SCORE_FILENAME = "score.json";
+const NOTEBOOK_FILENAME = "submission.ipynb";
+const META_FILENAME = "meta.json";
+const MAX_NOTEBOOK_CHARS = 30_000;
+
+const COMPETITION_DATASETS = [
+  "FLIP2: Expanding Protein Fitness Landscape Benchmarks",
+  "ProteinGym",
+  "1000 Genomes Project",
+  "GTEx Datasets",
+  "ERA5 Reanalysis (Copernicus)",
+  "NOAA Climate Data Online Datasets",
+  "LeRobot Datasets (Hugging Face)",
+  "UCI Wall-Following Robot Navigation",
+  "UCI Bank Marketing",
+  "Kaggle Marketing Campaign Datasets",
+  "UCI Online Retail",
+  "Retailrocket E-commerce Dataset (Kaggle)",
+  "Analyze Boston (City of Boston Open Data)",
+  "MBTA Open Data",
+];
+
+const RUBRIC = `You are the AI "black box" judge for the Cursor Boston × PyData hackathon (May 13, 2026 at Moderna HQ).
+
+## Challenge
+Attendees had one evening to use Cursor and Marimo to build a notebook that uncovers **one compelling insight** from one of the competition datasets below. The brief: "One notebook. One insight. Make it interesting."
+
+## Competition datasets (at least one must be used)
+${COMPETITION_DATASETS.map((d) => `- ${d}`).join("\n")}
+
+External / non-competition datasets disqualify the submission for "Best Submission".
+
+## Evaluation Criteria — score holistically 1-10
+
+1. **Insight clarity & sharpness** — Is there a single, clearly articulated finding? Diffuse "here is some EDA" notebooks score lower; a sharp, specific insight stated up front scores higher.
+2. **Dataset eligibility & engagement** — Uses ≥1 competition dataset. Surface-level "read CSV, plot histogram" scores lower; thoughtful, dataset-aware analysis scores higher. If no competition dataset is used, score must be ≤3.
+3. **Evidence & rigor** — Does the analysis actually support the claimed insight? Sensible methodology, no obvious leakage / sampling errors, reproducible code.
+4. **Narrative & data storytelling** — Setup → exploration → finding → significance. Reader can follow the argument. Marimo's reactive surface used purposefully (not just as a Jupyter substitute).
+5. **Interest / "make it interesting"** — Is the insight surprising, contrarian, actionable, or genuinely useful? Generic charts of well-known trends score lower; novel framings score higher.
+
+## Scoring guide
+- 1-2: Empty / broken / off-topic / no competition dataset used
+- 3-4: Minimal analysis, generic finding, weak evidence
+- 5-6: Solid exploratory work, reasonable finding, but unremarkable
+- 7-8: Clear sharp insight, well-supported, good narrative
+- 9-10: Exceptional — surprising or actionable insight, rigorous evidence, polished storytelling
+
+## Important notes
+- Judge fairly for a single-evening event. Don't expect production polish.
+- A missing or broken notebook is an automatic 1.
+- Be honest and differentiate. Not every submission deserves a 7.
+- The "insight" must be in the notebook itself, not just in the meta description.
+
+Respond with ONLY a JSON object (no markdown fencing, no prose around it):
+{"score": <integer 1-10>, "rationale": "<2-4 sentence justification calling out the specific insight, the dataset, and the main strength/weakness>"}`;
+
+interface ScoreFile {
+  score: number;
+  rationale: string;
+  model: string;
+  scoredAt: string;
+  scorerVersion: number;
+}
+
+const SCORER_VERSION = 1;
+
+function parseArgs(argv: string[]) {
+  const handleIdx = argv.indexOf("--handle");
+  const handle =
+    handleIdx >= 0 ? argv[handleIdx + 1]?.trim().toLowerCase() ?? null : null;
+  const all = argv.includes("--all");
+  const force = argv.includes("--force");
+  const skipExisting = argv.includes("--skip-existing");
+
+  if (!handle && !all) {
+    console.error("Specify --handle <gh-handle> or --all");
+    process.exit(1);
+  }
+  if (handle && all) {
+    console.error("Specify only one of --handle or --all");
+    process.exit(1);
+  }
+  return { handle, all, force, skipExisting };
+}
+
+interface NotebookCell {
+  cell_type?: string;
+  source?: string | string[];
+}
+
+function cellSourceToString(source: NotebookCell["source"]): string {
+  if (typeof source === "string") return source;
+  if (Array.isArray(source)) return source.join("");
+  return "";
+}
+
+function extractNotebookText(notebookPath: string): string {
+  const raw = fs.readFileSync(notebookPath, "utf8");
+  let parsed: { cells?: NotebookCell[] };
+  try {
+    parsed = JSON.parse(raw) as { cells?: NotebookCell[] };
+  } catch {
+    return raw.slice(0, MAX_NOTEBOOK_CHARS);
+  }
+
+  const cells = Array.isArray(parsed.cells) ? parsed.cells : [];
+  const parts: string[] = [];
+  for (const cell of cells) {
+    const text = cellSourceToString(cell.source).trim();
+    if (!text) continue;
+    const kind = cell.cell_type === "markdown" ? "MD" : "CODE";
+    parts.push(`--- ${kind} ---\n${text}`);
+  }
+  const joined = parts.join("\n\n");
+  if (joined.length <= MAX_NOTEBOOK_CHARS) return joined;
+  const head = Math.floor(MAX_NOTEBOOK_CHARS * 0.7);
+  const tail = MAX_NOTEBOOK_CHARS - head - 50;
+  return (
+    joined.slice(0, head) +
+    "\n\n…[truncated middle]…\n\n" +
+    joined.slice(joined.length - tail)
+  );
+}
+
+interface ScoreResult {
+  score: number;
+  rationale: string;
+}
+
+async function scoreSubmission(
+  client: Anthropic,
+  handle: string,
+  folderPath: string
+): Promise<ScoreResult> {
+  const notebookPath = path.join(folderPath, NOTEBOOK_FILENAME);
+  const metaPath = path.join(folderPath, META_FILENAME);
+
+  if (!fs.existsSync(notebookPath)) {
+    throw new Error(`${handle}: missing ${NOTEBOOK_FILENAME}`);
+  }
+
+  const meta = fs.existsSync(metaPath)
+    ? fs.readFileSync(metaPath, "utf8")
+    : "(missing meta.json)";
+  const notebook = extractNotebookText(notebookPath);
+
+  const context = [
+    `## Submission: ${handle}`,
+    `\n### meta.json\n${meta}`,
+    `\n### submission.ipynb (cells extracted)\n${notebook}`,
+  ].join("\n");
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: 500,
+    messages: [{ role: "user", content: `${RUBRIC}\n\n---\n\n${context}` }],
+  });
+
+  const text =
+    response.content[0]?.type === "text" ? response.content[0].text : "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) throw new Error(`Could not parse model response: ${text}`);
+  const parsed = JSON.parse(jsonMatch[0]) as {
+    score?: unknown;
+    rationale?: unknown;
+  };
+  const score = Number(parsed.score);
+  const rationale = String(parsed.rationale ?? "").trim();
+  if (!Number.isInteger(score) || score < 1 || score > 10) {
+    throw new Error(`Invalid score: ${String(parsed.score)}`);
+  }
+  if (!rationale) throw new Error("Empty rationale");
+  return { score, rationale };
+}
+
+function writeScoreFile(folderPath: string, result: ScoreResult): string {
+  const out: ScoreFile = {
+    score: result.score,
+    rationale: result.rationale,
+    model: MODEL,
+    scoredAt: new Date().toISOString(),
+    scorerVersion: SCORER_VERSION,
+  };
+  const scorePath = path.join(folderPath, SCORE_FILENAME);
+  fs.writeFileSync(scorePath, JSON.stringify(out, null, 2) + "\n");
+  return scorePath;
+}
+
+function hasExistingScore(folderPath: string): boolean {
+  return fs.existsSync(path.join(folderPath, SCORE_FILENAME));
+}
+
+function listHandles(rootDir: string): string[] {
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  const handles: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+    handles.push(entry.name);
+  }
+  handles.sort();
+  return handles;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("ANTHROPIC_API_KEY is required.");
+    process.exit(1);
+  }
+
+  const rootDir = path.join(process.cwd(), PYDATA_SUBMISSIONS_DIR);
+  if (!fs.existsSync(rootDir)) {
+    console.error(`Directory not found: ${rootDir}`);
+    process.exit(1);
+  }
+
+  const handles = args.all ? listHandles(rootDir) : [args.handle!];
+  if (handles.length === 0) {
+    console.log("No submissions to score.");
+    return;
+  }
+
+  const client = new Anthropic();
+
+  for (const handle of handles) {
+    const folderPath = path.join(rootDir, handle);
+    if (!fs.existsSync(folderPath)) {
+      console.error(`${handle}: folder not found, skipping`);
+      continue;
+    }
+
+    if (hasExistingScore(folderPath) && !args.force) {
+      if (args.skipExisting || args.all) {
+        console.log(`${handle}: score.json already exists, skipping (use --force to re-score)`);
+        continue;
+      }
+      console.error(
+        `${handle}: score.json already exists. Use --force to overwrite.`
+      );
+      process.exit(1);
+    }
+
+    console.log(`Scoring ${handle}…`);
+    try {
+      const result = await scoreSubmission(client, handle, folderPath);
+      const scorePath = writeScoreFile(folderPath, result);
+      console.log(`  ${result.score}/10 — ${result.rationale}`);
+      console.log(`  wrote ${path.relative(process.cwd(), scorePath)}`);
+    } catch (e) {
+      console.error(
+        `  failed: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/score-pydata-submission.ts` — calls Claude with the PyData × Cursor Boston hackathon rubric and writes `score.json` (score 1-10 + rationale + model + scoredAt) into the submission folder.
- Adds a "PyData submission merge checklist" to `CLAUDE.md` — maintainers must run the scorer and commit `score.json` (signed-off) onto the PR branch **before** merging.
- Extends `lib/pydata-submissions.ts` and the event page card to render an "AI judge score" badge when `score.json` is present.
- Updates `pydata-2026-submissions/README.md` so attendees know the maintainer authors `score.json` and they shouldn't ship one themselves.
- Adds `npm run score-pydata` wrapper.

The scorer rubric is built from the event brief — five holistic 1-10 criteria (insight clarity, dataset eligibility/engagement, evidence, narrative, interest), with the competition-dataset list inlined and the "no external datasets" eligibility encoded as a score-cap rule.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [ ] Dry-run the scorer against a sample submission folder once one lands
- [ ] Verify the badge renders on the event page when `score.json` is present
- [ ] Verify cards without `score.json` render unchanged