### PR TITLE
release: regenerated API.md + llms.txt for pydata access route

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**158 paths, 192 operations across 31 areas.**
+**159 paths, 193 operations across 31 areas.**
 
 ---
 
@@ -119,6 +119,7 @@ _Coworking sessions and PyData 2026 ticketing._
 | DELETE | `/api/events/{eventId}/coworking/register` | Yes | Cancel the current user's coworking registration |
 | POST | `/api/events/{eventId}/coworking/register` | Yes | Register for a coworking session in an event |
 | GET | `/api/events/{eventId}/coworking/slots` | No | List coworking sessions with availability for an event |
+| GET | `/api/events/pydata-2026/access` | No | Whether the signed-in user is on the 150-person PyData 2026 door list |
 | GET | `/api/events/pydata-2026/admin/list` | Yes | Admin: paginated PyData 2026 registrations with cap-vs-waitlist |
 | GET | `/api/events/pydata-2026/capacity` | No | Public PyData 2026 capacity / claimed / remaining counts |
 | GET | `/api/events/pydata-2026/luma-status` | No | Whether the current user appears on the PyData Luma guest list |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -33,12 +33,14 @@ Licensed GPL-3.0-only.
     /code-of-conduct
     /cohort-ai
     /cohort-withdraw
+    /contribute/game-art
     /cookbook
     /cookies
     /disclaimer
     /ecosystem
     /events
     /events/[slug]
+    /events/cursor-boston-pydata-2026
     /events/cursor-boston-pydata-2026/admin
     /events/cursor-boston-pydata-2026/register
     /events/request
@@ -110,7 +112,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (192 endpoints)
+## API (193 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -182,6 +184,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     DELETE /api/events/{eventId}/coworking/register [Yes] — Cancel the current user's coworking registration
     POST   /api/events/{eventId}/coworking/register [Yes] — Register for a coworking session in an event
     GET    /api/events/{eventId}/coworking/slots — List coworking sessions with availability for an event
+    GET    /api/events/pydata-2026/access — Whether the signed-in user is on the 150-person PyData 2026 door list
     GET    /api/events/pydata-2026/admin/list [Yes] — Admin: paginated PyData 2026 registrations with cap-vs-waitlist
     GET    /api/events/pydata-2026/capacity — Public PyData 2026 capacity / claimed / remaining counts
     GET    /api/events/pydata-2026/luma-status — Whether the current user appears on the PyData Luma guest list


### PR DESCRIPTION
## Summary
Promotes one commit from develop to main — the mechanical regeneration of the public API docs to include the `/api/events/pydata-2026/access` route (already running in production but missing from `docs/API.md` and `public/llms.txt` until now).

## Commits included
- `906a172` chore(docs): regenerate API.md + llms.txt — @rogerSuperBuilderAlpha

## Credit
Thanks @rogerSuperBuilderAlpha.

## Test plan
- [x] No code changes — generated docs only
- [x] Diff matches the actual route surface (verified by `npm run build` regenerator output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)