### PR TITLE
release: second maintainer onboarded (@bradAGI)

### DIFF
--- a/.github/ACTIVE_ISSUES.md
+++ b/.github/ACTIVE_ISSUES.md
@@ -20,7 +20,6 @@ Work that's in flight on `develop` or being delivered to a submission branch.
 Committed direction for the next minor release, but not yet started.
 
 - **v0.2 — Enhanced Member Profiles & Social Integration** — richer profile pages, social-graph features
-- **Maintainer recruitment** — fill the second maintainer seat ([MAINTAINERS.md](../MAINTAINERS.md#were-recruiting-a-second-maintainer))
 - **Test coverage lift** — raise Jest thresholds toward 75% statements / 65% branches (targeted API-route handlers + game data layer first)
 
 ## Future — vision

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,56 @@
 # CODEOWNERS - Defines code owners for automatic review requests
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Listing two owners on a line makes either eligible to review; GitHub will
+# auto-request review from at least one when a PR opens. Where one maintainer
+# is the primary reviewer for an area, only that handle is listed.
 
 # Default owners for everything in the repo
-* @rogerSuperBuilderAlpha
+*                            @rogerSuperBuilderAlpha @bradAGI
 
 # Frontend components
-/app/ @rogerSuperBuilderAlpha
-/components/ @rogerSuperBuilderAlpha
+/app/                        @rogerSuperBuilderAlpha @bradAGI
+/components/                 @rogerSuperBuilderAlpha @bradAGI
 
 # Core library code
-/lib/ @rogerSuperBuilderAlpha
+/lib/                        @rogerSuperBuilderAlpha @bradAGI
+
+# Security-adjacent and sanitization (Brad primary — establishes his
+# pre-application work on safe JSON parsing across API routes,
+# Firestore doc-id sanitization, and CSP hardening)
+/lib/middleware.ts           @bradAGI @rogerSuperBuilderAlpha
+/lib/sanitize.ts             @bradAGI @rogerSuperBuilderAlpha
+/lib/rate-limit.ts           @bradAGI @rogerSuperBuilderAlpha
+/lib/rate-limit-server.ts    @bradAGI @rogerSuperBuilderAlpha
+/lib/upstash-rate-limit.ts   @bradAGI @rogerSuperBuilderAlpha
+
+# Game subsystem — Roger primary
+/lib/game/                   @rogerSuperBuilderAlpha @bradAGI
+/app/game/                   @rogerSuperBuilderAlpha @bradAGI
 
 # Configuration and infrastructure
-/config/ @rogerSuperBuilderAlpha
-/.github/ @rogerSuperBuilderAlpha
-/docker/ @rogerSuperBuilderAlpha
+/config/                     @rogerSuperBuilderAlpha @bradAGI
+
+# .github root configuration — Roger primary
+/.github/                    @rogerSuperBuilderAlpha @bradAGI
+
+# CI / release workflows (Brad primary — the test-coverage and bundle-size
+# work he did pre-application touched these)
+/.github/workflows/          @bradAGI @rogerSuperBuilderAlpha
+
+# Docker — Roger primary
+/docker/                     @rogerSuperBuilderAlpha @bradAGI
+
+# Test surface (Brad primary — established expertise: 952 tests added
+# pre-application, plus the OSS-readiness lift in May 2026)
+/__tests__/                  @bradAGI @rogerSuperBuilderAlpha
+/e2e/                        @bradAGI @rogerSuperBuilderAlpha
 
 # Documentation
-*.md @rogerSuperBuilderAlpha
-/docs/ @rogerSuperBuilderAlpha
+*.md                         @rogerSuperBuilderAlpha @bradAGI
+/docs/                       @rogerSuperBuilderAlpha @bradAGI
+
+# Governance docs (Roger primary — Project Lead authority)
+/MAINTAINERS.md              @rogerSuperBuilderAlpha
+/.github/GOVERNANCE.md       @rogerSuperBuilderAlpha
+/.github/CODEOWNERS          @rogerSuperBuilderAlpha

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,14 +5,9 @@
 | Name | GitHub | Role | Since |
 |------|--------|------|-------|
 | Roger Hunt | [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) | Project Lead | 2026-01-27 |
+| Brad Egan  | [@bradAGI](https://github.com/bradAGI) | Maintainer | 2026-05-13 |
 
 The full role definitions, decision-making process, and code-review tiers live in [`.github/GOVERNANCE.md`](.github/GOVERNANCE.md).
-
-## We're recruiting a second maintainer
-
-Cursor Boston currently runs on a single maintainer, which is fragile for an active community project. **We are actively recruiting a second maintainer** to share review, release, and triage responsibilities.
-
-If you've been contributing regularly and want to step into a maintainer role, see **[Becoming a maintainer](#becoming-a-maintainer)** below. The path is public — you don't need to wait to be tapped on the shoulder.
 
 ## Becoming a maintainer
 
@@ -25,7 +20,7 @@ Both paths use the same evaluation criteria (sustained contributions, code-revie
 
 ## CODEOWNERS and area ownership
 
-[`.github/CODEOWNERS`](.github/CODEOWNERS) currently routes every path to `@rogerSuperBuilderAlpha` (the only maintainer). When a second maintainer is added, the file will be split by area — frontend, library code, infrastructure, docs — so review responsibility is shared cleanly. The split is intentionally deferred until there are two people to share it.
+[`.github/CODEOWNERS`](.github/CODEOWNERS) now lists both maintainers as default owners, with Brad as the primary reviewer for the test surface (`__tests__/`), CI/release workflows (`.github/workflows/`), and the security-adjacent middleware (`lib/middleware.ts`, `lib/sanitize.ts`) — the areas he established expertise in through the test-coverage and security-hardening work that preceded his application. Roger remains primary on governance docs, README/marketing copy, and the game subsystem.
 
 ## Day-to-day
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ CRON_SECRET=your-secret RATE_LIMIT_CLEANUP_BATCH_SIZE=200 RATE_LIMIT_CLEANUP_MAX
 
 See the full roadmap — including active development, planned work, and where to find issues to pick up — in **[`.github/ACTIVE_ISSUES.md`](.github/ACTIVE_ISSUES.md)**.
 
-We're also **recruiting a second maintainer** — see [MAINTAINERS.md](MAINTAINERS.md#were-recruiting-a-second-maintainer) if you're interested.
+Maintained by **[@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha)** (Project Lead) and **[@bradAGI](https://github.com/bradAGI)** (Maintainer) — see [MAINTAINERS.md](MAINTAINERS.md) for area ownership.
 
 ---
 


### PR DESCRIPTION
## Summary
Promotes the @bradAGI maintainer-onboarding from develop to main. Fills the second maintainer seat per GOVERNANCE.md Path B (public self-nomination), splits CODEOWNERS by area, and removes the now-stale "recruiting" callouts.

## PRs included
- #832 — docs(governance): onboard @bradAGI as the second maintainer — @rogerSuperBuilderAlpha

## Credit
Thanks @bradAGI for the 54 PRs of pre-application work (test coverage 14% → 43%, security hardening, CI improvements) that made this a clear decision. Thanks @rogerSuperBuilderAlpha as Project Lead for the GOVERNANCE.md Path B that made the public path possible.

## Test plan
- [x] All PR-level checks passed on #832
- [x] CODEOWNERS file parses correctly
- [ ] After deploy: a new PR touching `__tests__/` should auto-request @bradAGI as reviewer
- [ ] After deploy: MAINTAINERS.md table renders both maintainers on github.com

## Notes
- Bypasses DCO topology via `--admin` per the documented release workflow.
- 3 other standing applications (@nebullii, @AaronGrace978, @sreekar-ss) remain on the maintainer-application branch for separate per-application decisions later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)