### PR TITLE
release: third maintainer onboarded (@nebullii)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,19 @@
 # CODEOWNERS - Defines code owners for automatic review requests
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
-# Listing two owners on a line makes either eligible to review; GitHub will
-# auto-request review from at least one when a PR opens. Where one maintainer
-# is the primary reviewer for an area, only that handle is listed.
+# Listing multiple owners on a line makes any of them eligible to review;
+# GitHub will auto-request review from at least one when a PR opens. Where
+# a maintainer is the primary reviewer for an area, their handle is listed first.
 
 # Default owners for everything in the repo
-*                            @rogerSuperBuilderAlpha @bradAGI
+*                            @rogerSuperBuilderAlpha @bradAGI @nebullii
 
-# Frontend components
-/app/                        @rogerSuperBuilderAlpha @bradAGI
-/components/                 @rogerSuperBuilderAlpha @bradAGI
+# Frontend components (Neha co-primary — feed/map/ui work)
+/app/                        @rogerSuperBuilderAlpha @bradAGI @nebullii
+/components/                 @nebullii @rogerSuperBuilderAlpha @bradAGI
 
 # Core library code
-/lib/                        @rogerSuperBuilderAlpha @bradAGI
+/lib/                        @rogerSuperBuilderAlpha @bradAGI @nebullii
 
 # Security-adjacent and sanitization (Brad primary — establishes his
 # pre-application work on safe JSON parsing across API routes,
@@ -24,15 +24,24 @@
 /lib/rate-limit-server.ts    @bradAGI @rogerSuperBuilderAlpha
 /lib/upstash-rate-limit.ts   @bradAGI @rogerSuperBuilderAlpha
 
+# Analytics dashboard (Neha primary — shipped PR #155, closes feature #81)
+/app/analytics/              @nebullii @rogerSuperBuilderAlpha
+/app/api/analytics/          @nebullii @rogerSuperBuilderAlpha
+
+# Realtime live sessions (Neha primary — shipped PR #213)
+/app/live/                   @nebullii @rogerSuperBuilderAlpha
+/app/api/live/               @nebullii @rogerSuperBuilderAlpha
+/lib/live-sessions/          @nebullii @rogerSuperBuilderAlpha
+
 # Game subsystem — Roger primary
-/lib/game/                   @rogerSuperBuilderAlpha @bradAGI
-/app/game/                   @rogerSuperBuilderAlpha @bradAGI
+/lib/game/                   @rogerSuperBuilderAlpha @bradAGI @nebullii
+/app/game/                   @rogerSuperBuilderAlpha @bradAGI @nebullii
 
 # Configuration and infrastructure
-/config/                     @rogerSuperBuilderAlpha @bradAGI
+/config/                     @rogerSuperBuilderAlpha @bradAGI @nebullii
 
 # .github root configuration — Roger primary
-/.github/                    @rogerSuperBuilderAlpha @bradAGI
+/.github/                    @rogerSuperBuilderAlpha @bradAGI @nebullii
 
 # CI / release workflows (Brad primary — the test-coverage and bundle-size
 # work he did pre-application touched these)
@@ -43,12 +52,12 @@
 
 # Test surface (Brad primary — established expertise: 952 tests added
 # pre-application, plus the OSS-readiness lift in May 2026)
-/__tests__/                  @bradAGI @rogerSuperBuilderAlpha
-/e2e/                        @bradAGI @rogerSuperBuilderAlpha
+/__tests__/                  @bradAGI @rogerSuperBuilderAlpha @nebullii
+/e2e/                        @bradAGI @rogerSuperBuilderAlpha @nebullii
 
 # Documentation
-*.md                         @rogerSuperBuilderAlpha @bradAGI
-/docs/                       @rogerSuperBuilderAlpha @bradAGI
+*.md                         @rogerSuperBuilderAlpha @bradAGI @nebullii
+/docs/                       @rogerSuperBuilderAlpha @bradAGI @nebullii
 
 # Governance docs (Roger primary — Project Lead authority)
 /MAINTAINERS.md              @rogerSuperBuilderAlpha

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,9 @@
 
 | Name | GitHub | Role | Since |
 |------|--------|------|-------|
-| Roger Hunt | [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) | Project Lead | 2026-01-27 |
-| Brad Egan  | [@bradAGI](https://github.com/bradAGI) | Maintainer | 2026-05-13 |
+| Roger Hunt      | [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) | Project Lead | 2026-01-27 |
+| Brad Egan       | [@bradAGI](https://github.com/bradAGI) | Maintainer | 2026-05-13 |
+| Neha Chaudhari  | [@nebullii](https://github.com/nebullii) | Maintainer | 2026-05-13 |
 
 The full role definitions, decision-making process, and code-review tiers live in [`.github/GOVERNANCE.md`](.github/GOVERNANCE.md).
 
@@ -20,7 +21,11 @@ Both paths use the same evaluation criteria (sustained contributions, code-revie
 
 ## CODEOWNERS and area ownership
 
-[`.github/CODEOWNERS`](.github/CODEOWNERS) now lists both maintainers as default owners, with Brad as the primary reviewer for the test surface (`__tests__/`), CI/release workflows (`.github/workflows/`), and the security-adjacent middleware (`lib/middleware.ts`, `lib/sanitize.ts`) — the areas he established expertise in through the test-coverage and security-hardening work that preceded his application. Roger remains primary on governance docs, README/marketing copy, and the game subsystem.
+[`.github/CODEOWNERS`](.github/CODEOWNERS) lists all three maintainers as default owners. Per-area primaries:
+
+- **Brad** — test surface (`__tests__/`, `e2e/`), CI/release workflows (`.github/workflows/`), and security-adjacent middleware (`lib/middleware.ts`, `lib/sanitize.ts`, rate-limit modules) — the areas he established expertise in through the test-coverage and security-hardening work that preceded his application.
+- **Neha** — analytics dashboard (`app/analytics/`, `app/api/analytics/`), realtime lightning-talk sessions (`app/live/`, `app/api/live/`, `lib/live-sessions/`), and the feed/map UI components — the two feature projects she shipped (#155, #213) plus the UI surface she's iterated on.
+- **Roger** — governance docs (MAINTAINERS.md, GOVERNANCE.md, CODEOWNERS), README/marketing copy, and the game subsystem.
 
 ## Day-to-day
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ CRON_SECRET=your-secret RATE_LIMIT_CLEANUP_BATCH_SIZE=200 RATE_LIMIT_CLEANUP_MAX
 
 See the full roadmap — including active development, planned work, and where to find issues to pick up — in **[`.github/ACTIVE_ISSUES.md`](.github/ACTIVE_ISSUES.md)**.
 
-Maintained by **[@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha)** (Project Lead) and **[@bradAGI](https://github.com/bradAGI)** (Maintainer) — see [MAINTAINERS.md](MAINTAINERS.md) for area ownership.
+Maintained by **[@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha)** (Project Lead), **[@bradAGI](https://github.com/bradAGI)** (Maintainer), and **[@nebullii](https://github.com/nebullii)** (Maintainer) — see [MAINTAINERS.md](MAINTAINERS.md) for area ownership.
 
 ---
 


### PR DESCRIPTION
## Summary
Promotes the @nebullii maintainer-onboarding from develop to main. Fills the third maintainer seat per GOVERNANCE.md Path B (public self-nomination), splits CODEOWNERS to give her primary ownership on analytics + realtime sessions (her shipped features), and updates the README maintainers credit line.

## PRs included
- #834 — docs(governance): onboard @nebullii as the third maintainer — @rogerSuperBuilderAlpha

## Credit
Thanks @nebullii for the 10 PRs of pre-application work, especially the two major feature deliveries — the public community analytics dashboard (#155, closes feature project #81) and the realtime lightning talk sessions (#213). Thanks @rogerSuperBuilderAlpha as Project Lead for the decision.

## Maintainer team is now 3
- @rogerSuperBuilderAlpha (Project Lead, since 2026-01-27)
- @bradAGI (Maintainer, since 2026-05-13)
- @nebullii (Maintainer, since 2026-05-13)

## Test plan
- [x] All PR-level checks passed on #834
- [x] CODEOWNERS file parses correctly
- [ ] After deploy: PR touching `app/analytics/` or `app/live/` auto-requests @nebullii

## Notes
- Bypasses DCO topology via `--admin` per the documented release workflow.
- 2 other standing applications (@AaronGrace978, @sreekar-ss) remain on the maintainer-application branch for separate per-application decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)