### PR TITLE
docs(governance): onboard @AaronGrace978 as Community Maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,14 @@
 # a maintainer is the primary reviewer for an area, their handle is listed first.
 
 # Default owners for everything in the repo
-*                            @rogerSuperBuilderAlpha @bradAGI @nebullii
+*                            @rogerSuperBuilderAlpha @bradAGI @nebullii @AaronGrace978
 
 # Frontend components (Neha co-primary — feed/map/ui work)
-/app/                        @rogerSuperBuilderAlpha @bradAGI @nebullii
+/app/                        @rogerSuperBuilderAlpha @bradAGI @nebullii @AaronGrace978
 /components/                 @nebullii @rogerSuperBuilderAlpha @bradAGI
+
+# Footer + branding-adjacent assets (Aaron primary — shipped #506 X/LinkedIn)
+/components/Footer.tsx       @AaronGrace978 @rogerSuperBuilderAlpha
 
 # Core library code
 /lib/                        @rogerSuperBuilderAlpha @bradAGI @nebullii
@@ -33,6 +36,9 @@
 /app/api/live/               @nebullii @rogerSuperBuilderAlpha
 /lib/live-sessions/          @nebullii @rogerSuperBuilderAlpha
 
+# Partners / external-facing pages (Aaron primary — CMO-track surface)
+/app/partners/               @AaronGrace978 @rogerSuperBuilderAlpha
+
 # Game subsystem — Roger primary
 /lib/game/                   @rogerSuperBuilderAlpha @bradAGI @nebullii
 /app/game/                   @rogerSuperBuilderAlpha @bradAGI @nebullii
@@ -41,7 +47,7 @@
 /config/                     @rogerSuperBuilderAlpha @bradAGI @nebullii
 
 # .github root configuration — Roger primary
-/.github/                    @rogerSuperBuilderAlpha @bradAGI @nebullii
+/.github/                    @rogerSuperBuilderAlpha @bradAGI @nebullii @AaronGrace978
 
 # CI / release workflows (Brad primary — the test-coverage and bundle-size
 # work he did pre-application touched these)
@@ -56,8 +62,12 @@
 /e2e/                        @bradAGI @rogerSuperBuilderAlpha @nebullii
 
 # Documentation
-*.md                         @rogerSuperBuilderAlpha @bradAGI @nebullii
-/docs/                       @rogerSuperBuilderAlpha @bradAGI @nebullii
+*.md                         @rogerSuperBuilderAlpha @bradAGI @nebullii @AaronGrace978
+/docs/                       @rogerSuperBuilderAlpha @bradAGI @nebullii @AaronGrace978
+
+# Welcoming / first-touch docs (Aaron primary — community/contributor onboarding)
+/docs/GET_STARTED.md         @AaronGrace978 @rogerSuperBuilderAlpha
+/docs/FIRST_CONTRIBUTION.md  @AaronGrace978 @rogerSuperBuilderAlpha
 
 # Governance docs (Roger primary — Project Lead authority)
 /MAINTAINERS.md              @rogerSuperBuilderAlpha

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@
 | Roger Hunt      | [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) | Project Lead | 2026-01-27 |
 | Brad Egan       | [@bradAGI](https://github.com/bradAGI) | Maintainer | 2026-05-13 |
 | Neha Chaudhari  | [@nebullii](https://github.com/nebullii) | Maintainer | 2026-05-13 |
+| Aaron Grace     | [@AaronGrace978](https://github.com/AaronGrace978) | Community Maintainer | 2026-05-13 |
 
 The full role definitions, decision-making process, and code-review tiers live in [`.github/GOVERNANCE.md`](.github/GOVERNANCE.md).
 
@@ -21,11 +22,16 @@ Both paths use the same evaluation criteria (sustained contributions, code-revie
 
 ## CODEOWNERS and area ownership
 
-[`.github/CODEOWNERS`](.github/CODEOWNERS) lists all three maintainers as default owners. Per-area primaries:
+[`.github/CODEOWNERS`](.github/CODEOWNERS) lists all four maintainers as default owners. Per-area primaries:
 
 - **Brad** — test surface (`__tests__/`, `e2e/`), CI/release workflows (`.github/workflows/`), and security-adjacent middleware (`lib/middleware.ts`, `lib/sanitize.ts`, rate-limit modules) — the areas he established expertise in through the test-coverage and security-hardening work that preceded his application.
 - **Neha** — analytics dashboard (`app/analytics/`, `app/api/analytics/`), realtime lightning-talk sessions (`app/live/`, `app/api/live/`, `lib/live-sessions/`), and the feed/map UI components — the two feature projects she shipped (#155, #213) plus the UI surface she's iterated on.
-- **Roger** — governance docs (MAINTAINERS.md, GOVERNANCE.md, CODEOWNERS), README/marketing copy, and the game subsystem.
+- **Aaron** — community/marketing-facing surface: the footer (`components/Footer.tsx` — which he shipped in #506), partner-facing pages (`app/partners/`), and the welcoming-tier docs (`docs/GET_STARTED.md`, `docs/FIRST_CONTRIBUTION.md`) — aligned with his self-described CMO-style role. Default reviewer everywhere else; expects to develop additional primary areas in the role.
+- **Roger** — governance docs (MAINTAINERS.md, GOVERNANCE.md, CODEOWNERS), and the game subsystem.
+
+### Community Maintainer track
+
+Aaron holds the **Community Maintainer** title rather than the standard Maintainer title — a track for maintainers whose value to the project is principally in welcoming, contributor support, and external-facing surface rather than deep code review. The decision-making weight is the same (one maintainer = one approval), but the expected day-to-day differs: triage and contributor-support questions, marketing-adjacent docs, and the welcoming pages, rather than deep code review on `lib/` or `app/api/`. The track may evolve into a standard Maintainer role as the codebase familiarity grows.
 
 ## Day-to-day
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ CRON_SECRET=your-secret RATE_LIMIT_CLEANUP_BATCH_SIZE=200 RATE_LIMIT_CLEANUP_MAX
 
 See the full roadmap — including active development, planned work, and where to find issues to pick up — in **[`.github/ACTIVE_ISSUES.md`](.github/ACTIVE_ISSUES.md)**.
 
-Maintained by **[@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha)** (Project Lead), **[@bradAGI](https://github.com/bradAGI)** (Maintainer), and **[@nebullii](https://github.com/nebullii)** (Maintainer) — see [MAINTAINERS.md](MAINTAINERS.md) for area ownership.
+Maintained by **[@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha)** (Project Lead), **[@bradAGI](https://github.com/bradAGI)** (Maintainer), **[@nebullii](https://github.com/nebullii)** (Maintainer), and **[@AaronGrace978](https://github.com/AaronGrace978)** (Community Maintainer) — see [MAINTAINERS.md](MAINTAINERS.md) for area ownership.
 
 ---
 


### PR DESCRIPTION
## Summary
Accepts @AaronGrace978's standing maintainer application into a new **Community Maintainer** track. Updates MAINTAINERS.md, .github/CODEOWNERS, and README.md.

## Why a new track

Aaron is stepping in as Cursor Boston's CMO. His application is explicit about being "newer to the formal maintainer title" and emphasizes welcoming, contributor support, and external comms over deep code review. Three reasonable responses to that profile were: accept as standard Maintainer (overstates the code signal), defer (penalizes a real community contribution), or **define a Community Maintainer track that captures the actual shape** of the contribution. This PR takes the third path.

The Community Maintainer track:
- Same decision weight as Maintainer (one approval = one approval)
- Different day-to-day expectation: triage, contributor support, welcoming docs, marketing-adjacent surface — not deep `lib/` or `app/api/` review
- Can evolve to standard Maintainer as codebase familiarity grows

## CODEOWNERS scope

Aaron is **primary** only on areas where he's shown demonstrated interest:
- `components/Footer.tsx` — he shipped #506 (X/LinkedIn footer)
- `app/partners/` — external-facing surface
- `docs/GET_STARTED.md` + `docs/FIRST_CONTRIBUTION.md` — contributor onboarding

He's a **default** owner everywhere else (so he gets visibility on all PRs) but no other code-area primaries.

## Maintainer team is now 4
- @rogerSuperBuilderAlpha — Project Lead
- @bradAGI — Maintainer (primary: tests, CI, security middleware)
- @nebullii — Maintainer (primary: analytics, live sessions, components)
- @AaronGrace978 — Community Maintainer (primary: footer, partners, welcoming docs)

## Remaining application

@sreekar-ss is still on the maintainer-application branch. Open decision.

## Test plan
- [x] CODEOWNERS syntax parses
- [ ] After merge: PR touching `components/Footer.tsx` or `app/partners/` auto-requests @AaronGrace978
- [ ] After merge: README + MAINTAINERS.md render the 4-person team

🤖 Generated with [Claude Code](https://claude.com/claude-code)