### PR TITLE
release: develop → main (governance refresh + OSS-review action items)

### DIFF
--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -42,11 +42,7 @@ Maintainers are contributors who have demonstrated a sustained commitment to the
 - Ensuring code quality and consistency
 - Enforcing the Code of Conduct
 
-**Current Maintainers:**
-
-| Name | GitHub | Role |
-|------|--------|------|
-| Roger | [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) | Project Lead |
+**Current Maintainers:** the canonical roster — including names, GitHub handles, role tier, and per-area ownership — lives in [`MAINTAINERS.md`](../MAINTAINERS.md). This document describes the *rules* maintainers operate under; the roster file describes *who* the maintainers are at any given moment.
 
 #### Becoming a Maintainer
 
@@ -128,16 +124,6 @@ For decisions where consensus cannot be reached:
 4. Decisions require a simple majority
 5. The Project Lead may break ties
 
-### When there is only one maintainer
-
-While the maintainer team has a **single** person with merge rights (see the table above):
-
-- **Majority votes** described elsewhere in this document are decided by that maintainer (or by the Project Lead if they are the same person).
-- **Major changes** that call for two maintainer approvals should still get **community review time** (e.g. open PR, request feedback on Discord) before merge; the Project Lead approves when satisfied.
-- **Governance changes** that require “a majority of maintainers” require **Project Lead approval** plus the usual PR and comment period.
-
-When additional maintainers are added, this section no longer applies and normal multi-maintainer rules apply.
-
 ### Emergency Decisions
 
 In urgent situations (security vulnerabilities, Code of Conduct violations, critical bugs), maintainers may act without full consensus:
@@ -149,13 +135,28 @@ In urgent situations (security vulnerabilities, Code of Conduct violations, crit
 
 ## Code Review
 
-All code changes require review before merging:
+All code changes require review before merging.
 
-- **Minor changes** (typos, docs, small fixes): One maintainer approval
-- **Standard changes** (features, bug fixes): One maintainer approval, 24-hour waiting period for objections
-- **Major changes** (architecture, breaking changes): Two maintainer approvals, 72-hour waiting period
+### Tiers
 
-The author of a PR cannot approve their own changes. However, maintainers may merge their own PRs after receiving the required approvals.
+- **Minor changes** (typos, docs, small fixes): One maintainer approval.
+- **Standard changes** (features, bug fixes): One maintainer approval, 24-hour waiting period for objections.
+- **Major changes** (architecture, breaking changes): Two maintainer approvals, 72-hour waiting period.
+
+### No self-approval
+
+The author of a PR cannot approve their own changes. A maintainer may merge their own PR **only after** another maintainer has submitted a GitHub "Approve" review on that PR. This rule applies to every PR, including governance/docs PRs and including the Project Lead.
+
+This is enforced procedurally (maintainers are expected to follow it) and observably (GitHub's review history on each PR is the audit trail). If the maintainer team observes that the rule is being skipped in practice, the next governance update should move enforcement to a required-status-check on the branch protection rules.
+
+### Exception: solo-emergency merges
+
+If only one maintainer is reachable and the change is urgent (security patch, production outage), that maintainer may merge without a second reviewer. The merged PR must then be:
+
+1. Linked in `#maintainers` on Discord with the reason for the exception.
+2. Reviewed retroactively by a second maintainer within 7 days; any issues found are fixed via a follow-up PR.
+
+This exception exists so the rule never blocks a security fix, not as a routine path.
 
 ## Releases
 

--- a/.github/MAINTAINER_APPLICATION_TEMPLATE.md
+++ b/.github/MAINTAINER_APPLICATION_TEMPLATE.md
@@ -79,9 +79,17 @@ Optional — anything we should know that the template didn't cover.
 
 1. **Acknowledgement** within ~3 days: a maintainer responds to confirm the application is in review.
 2. **Review** within ~2 weeks: maintainers evaluate against the criteria in [GOVERNANCE.md](GOVERNANCE.md#becoming-a-maintainer) (sustained contributions, codebase understanding, review judgment, community fit).
-3. **Decision** posted in the PR. Three possible outcomes:
-   - **Accepted** — PR merged, you're invited to the maintainer team, [MAINTAINERS.md](../MAINTAINERS.md) updated, [CODEOWNERS](CODEOWNERS) split by area.
+3. **Decision** posted in the application PR. Three possible outcomes:
+   - **Accepted** — your application PR is merged on the `maintainer-application` branch. A maintainer then opens a separate `onboard/<your-handle>-maintainer` PR against `develop` with the governance update (your row added to [MAINTAINERS.md](../MAINTAINERS.md), area assignment in [CODEOWNERS](CODEOWNERS), entry in [CHANGELOG.md](../CHANGELOG.md)). When that PR merges, you are invited to the maintainer team and granted repo access.
    - **Deferred** — feedback on what additional contribution would make the case stronger; you're welcome to update and re-request review later.
    - **Declined** — feedback on why; the PR is closed but you remain welcome as a contributor.
 
 There's no penalty for applying. The worst case is useful feedback on where to focus next.
+
+### Audit trail
+
+To trace any maintainer's onboarding after the fact:
+
+- Their **application** is on the `maintainer-application` branch as a merged PR titled `Maintainer application: <handle>`.
+- Their **governance update** is on `develop`/`main` as a merged PR from `onboard/<handle>-maintainer`.
+- The pair is the canonical record of consent and process.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -19,8 +19,9 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 Preferred options (pick one):
 
-1. **GitHub private vulnerability reporting** (if available on the repository) — use the **Report a vulnerability** link on the **Security** tab. This opens a private thread with maintainers.
-2. **Email:** **security@cursorboston.com**
+1. **GitHub private vulnerability reporting** (recommended) — use the **Report a vulnerability** link on the [**Security** tab](https://github.com/rogerSuperBuilderAlpha/cursor-boston/security/advisories/new). This opens a private thread visible to every maintainer and is the fastest path to a fix. It does not depend on email forwarding being configured.
+2. **Email:** **security@cursorboston.com** (forwards to the maintainer team).
+3. **Fallback:** if you don't get an acknowledgement within 48 hours via either channel, please email **hello@cursorboston.com** with the subject line beginning `[security]` so it lands in the same triage queue used by the rest of the maintainer team. This fallback exists so a misrouted security@ message never delays a disclosure.
 
 For machine-readable disclosure routing, see [`public/.well-known/security.txt`](../public/.well-known/security.txt) (served at `https://cursorboston.com/.well-known/security.txt` in production).
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Run type check
         run: npm run type-check
 
+      - name: Check API.md is up-to-date with contracts
+        # Regenerate openapi.json and docs/API.md from the ts-rest contracts.
+        # docs/API.md is checked into git; openapi.json is a build artifact.
+        # If either contract changed without regenerating the docs, fail loud
+        # so the PR author runs `npm run generate:openapi && npm run generate:api-md`.
+        run: |
+          npm run generate:openapi
+          npm run generate:api-md
+          if ! git diff --exit-code -- docs/API.md; then
+            echo "::error::docs/API.md is out of date. Run 'npm run generate:openapi && npm run generate:api-md' and commit the result."
+            exit 1
+          fi
+
   security:
     name: Security Scanning
     runs-on: ubuntu-latest

--- a/.github/workflows/firestore-deploy.yml
+++ b/.github/workflows/firestore-deploy.yml
@@ -45,9 +45,9 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
 
       - name: Validate firestore.indexes.json parses
         run: node -e "JSON.parse(require('fs').readFileSync('config/firebase/firestore.indexes.json','utf8'))"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,6 +31,9 @@ jobs:
           days-before-close: 14
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: 'good first issue,help wanted,security,accessibility'
-          exempt-pr-labels: 'security'
-          exempt-all-milestones: true
+          exempt-issue-labels: 'good first issue,help wanted,security,accessibility,pinned'
+          exempt-pr-labels: 'security,pinned'
+          # Blanket milestone exemption was removed: an ancient milestoned
+          # issue should not be permanently insulated from triage. Use the
+          # `pinned` label on the rare items that genuinely shouldn't go
+          # stale (long-term tracking issues, ongoing initiatives).

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -12,7 +12,7 @@ jobs:
   update-contributors:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # full history for git log
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,6 +37,11 @@ path = '''(?i)(credit|referral).*\.(csv|tsv|txt|json)$'''
 # the April 2026 incident slipped through because the prior `docs/`
 # allowlist suppressed scans on every file under docs/, including the
 # CSV that held the leaked codes.
+#
+# Audit cadence: any change to this list (especially new path entries)
+# should be justified in the PR description. Broad allowlists are how
+# the April 2026 incident happened — keep this list as narrow as
+# practical, and prefer per-rule exceptions over path exemptions.
 [allowlist]
 paths = [
   '''\.env\.local\.example''',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] — targeting 0.2.0
+
+Tracks work accumulated since the v0.1.0 tag (2026-01-27). The next tagged release will be cut from this section.
 
 ### Added
 
+- Three additional maintainers onboarded (Brad Egan, Neha Chaudhari, Aaron Grace) — see [`MAINTAINERS.md`](MAINTAINERS.md) for area ownership
 - `docs/VERCEL.md` — production-only Vercel policy and dashboard checklist
 - `NOTICE` file for project copyright and SPDX identifier
-- `MAINTAINERS.md` entry point linking to governance and release docs
+- `MAINTAINERS.md` canonical maintainer roster with per-area ownership
 - `docs/README.md` documentation index
 - `docs/RELEASING.md` maintainer release runbook
 - `docs/SUPPLY_CHAIN.md` overview of security and dependency automation
+- `docs/OPENSOURCE_REVIEW.md` + `docs/REVIEW_ACTION_PLAN.md` — published OSS health review and 12-week action plan
+- `docs/SECURITY_OPERATIONS.md` rotation cadence and runbook
 - `public/.well-known/security.txt` for standardized security contact discovery
-- GitHub Actions: DCO check, Dependency Review, OpenSSF Scorecard
+- GitHub Actions: DCO check, Dependency Review, OpenSSF Scorecard, Firestore-deploy-on-push-to-main
 - `.github/ISSUE_TEMPLATE/config.yml` with contact links (Discord, security policy, dev guide)
+- Per-area `CODEOWNERS` split across the four maintainers
+- Rate-limit hardening on the unauthenticated `/api/auth/resolve-email` endpoint
+- API.md drift guard in CI (fails the build if generated OpenAPI docs diverge from checked-in `docs/API.md`)
 
 ### Changed
 
@@ -30,7 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docker**: base image updated to **Node 22** to match `.nvmrc`
 - **package.json**: `license` set to `GPL-3.0-only`; `engines.node` set to `>=22.0.0`
 - **Docs**: beginner guide (`docs/GET_STARTED.md`) uses feature branches and correct push instructions; support docs no longer reference disabled GitHub Discussions
-- **Security policy**: documents GitHub private vulnerability reporting alongside email
+- **Security policy**: documents GitHub private vulnerability reporting alongside email; clarifies fallback contact if the dedicated security inbox doesn't acknowledge within 48h
+- **Governance**: removed the now-obsolete "when there is only one maintainer" section; documented the no-self-approval rule explicitly and added a solo-emergency-merge exception path
+- **CI hygiene**: `postinstall` no longer auto-installs Playwright Chromium in CI environments (the e2e job has its own cache + install)
+- **Stale workflow**: narrowed `exempt-all-milestones` so ancient milestoned issues can still be triaged
+- **Action SHA pins**: aligned `actions/checkout` and `actions/setup-node` across workflows
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ graph TB
 
     subgraph Vercel["Vercel"]
         Pages["Pages & Layouts<br/>(SSR / Static)"]
-        API["API Routes<br/>(63 endpoints)"]
+        API["API Routes<br/>(160+ endpoints)"]
         MW["Middleware<br/>(CSRF, Rate Limit, Logging)"]
     end
 
@@ -144,7 +144,7 @@ Each feature is **fully isolated** — new routes, new Firestore collections, no
 - [Submission branches](docs/SUBMISSION_BRANCHES.md) - When to PR against `develop` vs. a long-lived submission branch
 - [Support](.github/SUPPORT.md) - Where to ask questions (Discord, issues, email)
 - [Governance](.github/GOVERNANCE.md) - Roles, decisions, and maintainer process
-- [Maintainers](MAINTAINERS.md) - Pointer to governance and releases
+- [Maintainers](MAINTAINERS.md) - Current roster and per-area ownership
 - [GitHub Issues](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues) - Browse and claim open tasks
 - [Code of Conduct](.github/CODE_OF_CONDUCT.md) - Our community standards
 - [Security Policy](.github/SECURITY.md) - How to report security vulnerabilities
@@ -154,6 +154,7 @@ Each feature is **fully isolated** — new routes, new Firestore collections, no
 - [Changelog](CHANGELOG.md) - Version history
 - [Vercel deployments](docs/VERCEL.md) - Production-only deploys (PRs do not trigger Vercel builds)
 - [API Reference](docs/API.md) - Full list of API endpoints
+- [LICENSE](LICENSE) and [NOTICE](NOTICE) - GPL-3.0 license terms and project attributions
 
 ---
 

--- a/app/api/auth/resolve-email/route.ts
+++ b/app/api/auth/resolve-email/route.ts
@@ -8,8 +8,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
 import { parseRequestBody } from "@/lib/api-response";
 import { authContract } from "@/lib/api-schemas/auth";
+import { withRateLimitMiddleware } from "@/lib/middleware";
 
-export async function POST(request: NextRequest) {
+// Strict per-IP rate limit: this endpoint reveals whether an email maps to
+// an account, so it is an enumeration vector. Legitimate users hit it once
+// during sign-in; a brute-force enumeration of common addresses would burn
+// through this budget within seconds.
+const RATE_LIMIT = {
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  maxRequests: 10,
+};
+
+async function handler(request: NextRequest): Promise<NextResponse> {
   try {
     const bodyOrError = await parseRequestBody(request);
     if (bodyOrError instanceof NextResponse) return bodyOrError;
@@ -89,3 +99,5 @@ export async function POST(request: NextRequest) {
     );
   }
 }
+
+export const POST = withRateLimitMiddleware(RATE_LIMIT, handler);

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -115,6 +115,29 @@ These require `FIREBASE_SERVICE_ACCOUNT_JSON` in `.env.local`:
 | `npm run backfill-merge-credit` | Backfill contributor merge credits (see `docs/CONTRIBUTOR_MERGE_CREDIT_BACKFILL.md`) |
 | `npm run send-hack-a-sprint-emails` | Send hackathon event emails (see `docs/HACK_A_SPRINT_2026_OPS.md`) |
 
+### Categories of script in `scripts/`
+
+The `scripts/` directory holds ~90 files. Most are not part of the day-to-day developer loop. Use this guide to know which are which.
+
+**Supported (referenced from `package.json` scripts):** anything wired up in `package.json` under `scripts` is a supported entry point. Run them via `npm run <name>`, not by invoking the file directly — the `package.json` wrapper sets the right `tsx` flags. The current supported set: `dev`, `build`, `test`, `test:rules`, `test:e2e`, `lint`, `type-check`, `validate-env`, `generate:openapi`, `generate:api-md`, `generate:llms-txt`, `check:route-contracts`, `seed-hackathon-teams`, `check-members-db`, `rate-limit-cleanup`, `rebuild-snapshots`, `backfill-merge-credit`, `send-hack-a-sprint-emails`, `sync-event-contacts`, `send-contact-list-email`, `ai-evaluate`, `ai-evaluate:apply-json`, `score-pydata`, `distribute-credits`, `seed-luma-registrants`, `generate-contributors`, `add:gpl-headers`, `analyze`.
+
+**Maintainer ops scripts (invoked directly with `tsx`):** files prefixed `send-`, `sync-`, `seed-`, `set-cohort-`, `admit-`, `audit-`, `freeze-`, `rank-`, `count-`, `list-`, `export-`, `treasure-hunt-`, `admin-grant-`, `build-hack-a-sprint-`, `firestore-reads-metrics`, `suppress-mailgun-bounces`. These are operational one-shots used to run cohorts, send broadcast emails, audit game state, or freeze rankings. They are kept in the tree so the ops work is reviewable and replayable, but they are not part of the normal contributor loop. Most assume `FIREBASE_SERVICE_ACCOUNT_JSON` in `.env.local` and many will only do the right thing when run by a maintainer with the right context. **If you're a contributor, you almost certainly don't need to run any of these.**
+
+**Internal analysis (prefixed `_`):** files starting with `_` (e.g. `_analysis-pull-gcp-metrics.ts`, `_merge-pydata-website-luma.ts`) are throwaway analysis scripts kept for reproducibility. They may be deleted at any time. Don't depend on them from other code.
+
+**Helpers (`scripts/_lib/`, `scripts/data/`):** shared modules used by the scripts above. Not entry points.
+
+**CI/workflow helpers:**
+- `add-gpl-headers.js` — runs in pre-commit to keep GPL headers in place
+- `check-route-contracts.js` — runs in `prebuild` to fail the build if an API route lacks a ts-rest contract
+- `generate-openapi.ts`, `generate-api-md.ts`, `generate-llms-txt.js` — regenerate `openapi.json`, `docs/API.md`, and `public/llms.txt` during `prebuild`
+- `validate-env.ts` — fails the build if required env vars are missing or placeholder
+- `validate-hack-a-sprint-submission-pr.cjs` — runs in the hack-a-sprint submission validation workflow
+- `vercel-ignore-build.sh` — the `ignoreCommand` used by `vercel.json` to skip non-production builds
+- `generate-contributors.sh` — runs in the `update-contributors` workflow on push to main
+
+If a script is missing from this list, treat it as maintainer-internal and ask before running it.
+
 ---
 
 ## Pre-commit Hooks

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "check:route-contracts": "node scripts/check-route-contracts.js",
     "prebuild": "npm run validate-env && npm run generate:openapi && npm run generate:api-md && npm run generate:llms-txt && npm run check:route-contracts",
     "prepare": "husky install",
-    "postinstall": "PLAYWRIGHT_BROWSERS_PATH=0 playwright install chromium || true",
+    "postinstall": "node scripts/maybe-install-playwright.js",
     "add:gpl-headers": "node scripts/add-gpl-headers.js",
     "analyze": "ANALYZE=true next build"
   },

--- a/scripts/maybe-install-playwright.js
+++ b/scripts/maybe-install-playwright.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/*
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// Runs after `npm install`. Installs the Playwright Chromium binary for local
+// developers so `npm run test:e2e` works without a manual `playwright install`
+// step. Skipped in CI (the e2e workflow caches the browser separately) and
+// when the contributor opts out with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1.
+//
+// Failures here are non-fatal — Playwright is only required for e2e tests, so
+// a missing browser must never block a regular `npm install`.
+
+"use strict";
+
+const SKIP_ENV_KEYS = [
+  "CI",
+  "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD",
+  "PLAYWRIGHT_SKIP_BROWSER_GC",
+];
+
+function shouldSkip() {
+  for (const key of SKIP_ENV_KEYS) {
+    const value = process.env[key];
+    if (value && value !== "0" && value.toLowerCase() !== "false") {
+      return key;
+    }
+  }
+  return null;
+}
+
+const skipReason = shouldSkip();
+if (skipReason) {
+  console.log(
+    `[postinstall] Skipping Playwright Chromium install (${skipReason} is set).`
+  );
+  process.exit(0);
+}
+
+const { spawnSync } = require("node:child_process");
+const result = spawnSync("npx", ["playwright", "install", "chromium"], {
+  stdio: "inherit",
+  env: { ...process.env, PLAYWRIGHT_BROWSERS_PATH: "0" },
+});
+
+if (result.error || (typeof result.status === "number" && result.status !== 0)) {
+  console.log(
+    "[postinstall] Playwright Chromium install did not complete cleanly. " +
+      "This is non-fatal; run `npm run test:e2e:install` before running e2e tests."
+  );
+}


### PR DESCRIPTION
## Summary

Ships the OSS-review action-item work from 2026-05-13 to main:

1. **`fix(auth)`** — rate-limit `/api/auth/resolve-email` (10 req/15 min per IP) to close an email enumeration vector. Unauthenticated callers can no longer brute-force valid emails.
2. **`docs(governance)`** — refresh of the governance and contributor-facing docs to match the May 2026 4-maintainer reality:
   - `GOVERNANCE.md`: removes the obsolete "when only one maintainer" section; canonical roster now lives in `MAINTAINERS.md`; documents the no-self-approval rule explicitly with a solo-emergency exception.
   - `SECURITY.md`: GitHub private vulnerability reporting promoted as the recommended path; `hello@` fallback added if `security@` doesn't acknowledge within 48h.
   - `MAINTAINER_APPLICATION_TEMPLATE.md`: documents the actual two-PR flow (`maintainer-application` branch → `onboard/<handle>-maintainer` PR) for auditability.
   - `README.md`: stale "63 endpoints" → "160+"; LICENSE + NOTICE now linked.
   - `CHANGELOG.md`: Unreleased section labeled as targeting 0.2.0 with the May 2026 work listed.
   - `docs/DEVELOPMENT.md`: new `scripts/` categorization guide (supported / maintainer-ops / internal-analysis / CI helpers).
   - `.gitleaks.toml`: maintenance-cadence comment on the allowlist (root cause of the April 2026 incident was a too-broad path exemption).
3. **`ci`** — supply-chain and DX hardening:
   - Postinstall replaced with `scripts/maybe-install-playwright.js`: skips Chromium download under `CI=true` or `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`, eliminating wasted CI work and surprise installs for forks.
   - `stale.yml`: removed blanket `exempt-all-milestones`; old milestoned issues can be triaged again. Use `pinned` label for the rare items that should be insulated.
   - `ci.yml`: new step regenerates `docs/API.md` from contracts and fails the build on drift, so the human-readable API docs cannot diverge from the ts-rest contracts.
   - `firestore-deploy.yml` + `update-contributors.yml`: aligned `actions/checkout` + `actions/setup-node` SHA pins with the rest of the workflows.

## Commits included

| SHA | Author | Description |
|-----|--------|-------------|
| 93126b9 | @rogerSuperBuilderAlpha | `fix(auth)`: rate-limit /api/auth/resolve-email |
| ebda8b0 | @rogerSuperBuilderAlpha | `docs(governance)`: refresh for 4-maintainer reality |
| 0b46b2f | @rogerSuperBuilderAlpha | `ci`: postinstall gating, stale narrowing, API.md drift guard, SHA alignment |

All three commits were authored directly on `develop` against this release window. No external contributor PRs are in this batch.

## Validation

- `npm run type-check` clean
- `npm run generate:openapi && npm run generate:api-md` produce zero diff against the committed `docs/API.md` — drift guard will pass on first run
- `CI=true node scripts/maybe-install-playwright.js` confirmed it skips correctly
- `/api/auth/resolve-email` route still type-checks with the middleware wrapper

## Test plan

- [ ] CI green on the merge commit (lint-and-typecheck includes the new API.md drift guard)
- [ ] First push to `main` triggers the Firestore-deploy workflow only if the rules/indexes changed — they did not in this batch, so the workflow should be skipped
- [ ] Fast-forward the contributor submission branches (`c1w*-submission`, `pydata-2026-submissions`, `game-contributions`) per `CLAUDE.md`