### PR TITLE
Release: BASE+SUPER combat redesign

### DIFF
--- a/__tests__/app/game/parse-world-snapshot.test.ts
+++ b/__tests__/app/game/parse-world-snapshot.test.ts
@@ -17,6 +17,7 @@ describe("parseSnapshotDoc", () => {
     type: "military",
     ownerId: "user_alpha",
     units: { ground: 12, siege: 0, air: 0 },
+    baseUnits: { ground: 22, siege: 8, air: 5 },
     armedDefenseSpellId: null,
   };
 

--- a/__tests__/lib/game/combat.test.ts
+++ b/__tests__/lib/game/combat.test.ts
@@ -6,6 +6,11 @@
 
 import {
   applyFlyoverModifiers,
+  attributeAttackerLosses,
+  attributeDefenderLosses,
+  BASE_CAPTURE_RETENTION,
+  BASE_DURABILITY_MULT,
+  baseUnitsTarget,
   computeSupplyMultiplier,
   computeTileCapacity,
   distributeUnitKills,
@@ -1427,5 +1432,291 @@ describe("distributeUnitKills", () => {
   it("handles killCount equal to total — kills everyone", () => {
     const k = distributeUnitKills(stack(7, 11, 13), 31);
     expect(k).toEqual(stack(7, 11, 13));
+  });
+});
+
+// ─── BASE + SUPER combat (2026-05-13 rework) ─────────────────────────────
+// These tests pin down the behavioral expectations of the BASE-units
+// redesign: every tile defends with intrinsic militia even when SUPER is
+// empty, near-equal fights tip into stalemate instead of an exact-tie dead
+// branch, the loss curve is decisiveness-keyed, captures retain a fraction
+// of BASE, and the SUPER/BASE attribution at the server layer absorbs
+// damage from SUPER first.
+
+describe("resolveAttack — BASE units defense", () => {
+  it("empty SUPER but full BASE garrison can repel a small attacker", () => {
+    // 10 ground vs a tile with no recruited units but a full military
+    // garrison (22/8/5 composite, BASE_DURABILITY_MULT-tougher than SUPER).
+    // The attacker is outnumbered ~3.5×; we expect the outcome to skew
+    // toward repelled (not always — RNG can swing it — but the *intent*
+    // is that an empty tile is not free real estate).
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({ caste: "red", units: stack(10, 0, 0), unitsAlive: 100 }),
+      defaultDefender({
+        caste: "white",
+        unitsOnTile: stack(22, 8, 5), // composite stack = base only
+        baseUnitsOnTile: stack(22, 8, 5),
+        unitsAlive: 35,
+      }),
+      tile,
+      makeSeededRng("empty-tile-base")
+    );
+    // The decisive-capture path is no longer guaranteed — the defender
+    // brought ~35 BASE units against 10 attackers and should hold or stalemate.
+    expect(["repelled", "stalemate", "captured"]).toContain(result.outcome);
+    // Whichever way the dice fell, the defender pre-attack stack must
+    // surface the BASE garrison.
+    expect(result.defenderBasePreAttack).toEqual(stack(22, 8, 5));
+  });
+});
+
+describe("resolveAttack — stalemate band", () => {
+  it("returns stalemate when finalAttack/finalDefense is within ±8%", () => {
+    // Construct attacker and defender with similar power. We can't fully
+    // control RNG ratios, but we can search across seeds and confirm the
+    // band fires sometimes (and never with a 0/609 freq like the old code).
+    const tile = defaultTile(2000);
+    let stalemateCount = 0;
+    for (let seed = 0; seed < 60; seed++) {
+      const result = resolveAttack(
+        defaultAttacker({ caste: "white", units: stack(50, 50, 50) }),
+        defaultDefender({
+          caste: "white",
+          unitsOnTile: stack(50, 50, 50),
+        }),
+        tile,
+        makeSeededRng(`stalemate-${seed}`)
+      );
+      if (result.outcome === "stalemate") stalemateCount++;
+    }
+    // Old code: 0 stalemates ever. New code: a few per 60 seeds is plenty.
+    expect(stalemateCount).toBeGreaterThan(0);
+  });
+
+  it("stalemate causes both sides to take partial losses", () => {
+    // Force a stalemate by mirroring composition + caste; pick a seed
+    // that lands in the band.
+    const tile = defaultTile(2000);
+    let stalemate: CombatResult | null = null;
+    for (let seed = 0; seed < 100 && !stalemate; seed++) {
+      const r = resolveAttack(
+        defaultAttacker({ caste: "white", units: stack(50, 50, 50) }),
+        defaultDefender({
+          caste: "white",
+          unitsOnTile: stack(50, 50, 50),
+        }),
+        tile,
+        makeSeededRng(`stalemate-losses-${seed}`)
+      );
+      if (r.outcome === "stalemate") stalemate = r;
+    }
+    expect(stalemate).not.toBeNull();
+    const atkTotal =
+      stalemate!.attackerLosses.ground +
+      stalemate!.attackerLosses.siege +
+      stalemate!.attackerLosses.air;
+    const defTotal =
+      stalemate!.defenderLosses.ground +
+      stalemate!.defenderLosses.siege +
+      stalemate!.defenderLosses.air;
+    // Stalemate band: attacker ~50% loss, defender ~40% loss on a ~150 stack.
+    expect(atkTotal).toBeGreaterThan(0);
+    expect(defTotal).toBeGreaterThan(0);
+    // Neither side wiped (stalemate, not a one-sided wipe).
+    expect(atkTotal).toBeLessThan(150);
+    expect(defTotal).toBeLessThan(150);
+  });
+});
+
+describe("resolveAttack — decisiveness-keyed loss curves", () => {
+  it("decisive capture: attacker loses < 20% on a 2× edge", () => {
+    // Heavy attacker advantage: 500/500/500 vs 50/50/50 (~10× power).
+    // Decisive capture means the attacker doesn't bleed out.
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        units: stack(500, 500, 500),
+        unitsAlive: 5000,
+      }),
+      defaultDefender({
+        caste: "white",
+        unitsOnTile: stack(50, 50, 50),
+      }),
+      tile,
+      makeSeededRng("decisive-capture")
+    );
+    expect(result.outcome).toBe("captured");
+    const sent = result.unitsDeployed;
+    const sentTotal = sent.ground + sent.siege + sent.air;
+    const lost =
+      result.attackerLosses.ground +
+      result.attackerLosses.siege +
+      result.attackerLosses.air;
+    expect(lost / sentTotal).toBeLessThan(0.2);
+    expect(result.lossCurveTag).toBe("decisive-capture");
+  });
+
+  it("decisive repel: attacker loses > 60% on a heavy underdog roll", () => {
+    // Attacker is heavily outclassed. Old curve would wipe 99.7%; new
+    // curve should bleed them, but not vaporize unless extremely lopsided.
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        units: stack(5, 5, 5),
+        unitsAlive: 15,
+      }),
+      defaultDefender({
+        caste: "white",
+        unitsOnTile: stack(300, 300, 300),
+        unitsAlive: 1000,
+      }),
+      tile,
+      makeSeededRng("decisive-repel")
+    );
+    expect(result.outcome).toBe("repelled");
+    const sent = result.unitsDeployed;
+    const sentTotal = sent.ground + sent.siege + sent.air;
+    const lost =
+      result.attackerLosses.ground +
+      result.attackerLosses.siege +
+      result.attackerLosses.air;
+    expect(lost / sentTotal).toBeGreaterThan(0.6);
+    expect(result.lossCurveTag).toBe("decisive-repel");
+  });
+
+  it("exposes finalAttack and finalDefense for the BattleReport", () => {
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker(),
+      defaultDefender(),
+      tile,
+      makeSeededRng("expose-power")
+    );
+    expect(result.finalAttack).toBeGreaterThan(0);
+    expect(result.finalDefense).toBeGreaterThan(0);
+    // The pre-attack stack mirrors what the caller passed as unitsOnTile.
+    expect(result.defenderUnitsPreAttack).toEqual(stack(50, 50, 50));
+  });
+});
+
+describe("attributeDefenderLosses — SUPER-first split", () => {
+  it("SUPER absorbs damage before BASE bleeds", () => {
+    const out = attributeDefenderLosses({
+      superBefore: stack(20, 0, 0),
+      baseBefore: stack(10, 0, 0),
+      totalLosses: stack(15, 0, 0),
+      outcome: "repelled",
+      captureBaseRetentionFactor: 1,
+    });
+    expect(out.superLost).toEqual(stack(15, 0, 0));
+    expect(out.baseLost).toEqual(stack(0, 0, 0));
+    expect(out.newSuper).toEqual(stack(5, 0, 0));
+    expect(out.newBase).toEqual(stack(10, 0, 0));
+  });
+
+  it("BASE picks up overflow when SUPER is exhausted", () => {
+    // 25 damage, only 20 SUPER → 5 overflow → BASE durability soaks
+    // ~5/1.30 ≈ 4 BASE killed.
+    const out = attributeDefenderLosses({
+      superBefore: stack(20, 0, 0),
+      baseBefore: stack(10, 0, 0),
+      totalLosses: stack(25, 0, 0),
+      outcome: "repelled",
+      captureBaseRetentionFactor: 1,
+    });
+    expect(out.superLost.ground).toBe(20);
+    expect(out.baseLost.ground).toBe(Math.round(5 / BASE_DURABILITY_MULT));
+    expect(out.newSuper).toEqual(stack(0, 0, 0));
+    expect(out.newBase.ground).toBe(10 - out.baseLost.ground);
+  });
+
+  it("on capture, SUPER is wiped and BASE retained at the factor", () => {
+    const out = attributeDefenderLosses({
+      superBefore: stack(8, 4, 2),
+      baseBefore: stack(40, 16, 8),
+      // Curve losses are ignored on capture — server uses wiped+retained.
+      totalLosses: stack(2, 1, 0),
+      outcome: "captured",
+      captureBaseRetentionFactor: BASE_CAPTURE_RETENTION,
+    });
+    expect(out.newSuper).toEqual(stack(0, 0, 0));
+    expect(out.newBase).toEqual(
+      stack(
+        Math.floor(40 * BASE_CAPTURE_RETENTION),
+        Math.floor(16 * BASE_CAPTURE_RETENTION),
+        Math.floor(8 * BASE_CAPTURE_RETENTION)
+      )
+    );
+  });
+});
+
+describe("attributeAttackerLosses — proportional split", () => {
+  it("losses go entirely to SUPER when no BASE was conscripted", () => {
+    const out = attributeAttackerLosses({
+      superSent: stack(10, 5, 0),
+      baseSent: stack(0, 0, 0),
+      totalLosses: stack(3, 2, 0),
+    });
+    expect(out.superLost).toEqual(stack(3, 2, 0));
+    expect(out.baseLost).toEqual(stack(0, 0, 0));
+  });
+
+  it("splits proportionally when SUPER + BASE were both deployed", () => {
+    // 80% SUPER, 20% BASE → ~80% of losses come from SUPER.
+    const out = attributeAttackerLosses({
+      superSent: stack(80, 0, 0),
+      baseSent: stack(20, 0, 0),
+      totalLosses: stack(10, 0, 0),
+    });
+    expect(out.superLost.ground + out.baseLost.ground).toBe(10);
+    expect(out.superLost.ground).toBeGreaterThanOrEqual(7);
+    expect(out.baseLost.ground).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("baseUnitsTarget — caste + land profiles", () => {
+  it("unowned tile gets the raw land seed (no caste mult, no entrenchment)", () => {
+    const u = baseUnitsTarget({ landType: "military", caste: null });
+    // LAND_TYPE_BASE.military = { ground: 22, siege: 8, air: 5 }
+    expect(u).toEqual(stack(22, 8, 5));
+  });
+
+  it("red caste boosts ground/siege over white baseline", () => {
+    const red = baseUnitsTarget({ landType: "military", caste: "red" });
+    const white = baseUnitsTarget({ landType: "military", caste: "white" });
+    expect(red.ground).toBeGreaterThanOrEqual(white.ground);
+    expect(red.siege).toBeGreaterThanOrEqual(white.siege);
+  });
+
+  it("unrevealed tile gets zero BASE", () => {
+    expect(
+      baseUnitsTarget({ landType: "unrevealed", caste: "red" })
+    ).toEqual(stack(0, 0, 0));
+  });
+});
+
+describe("resolveAttack — BASE retention on capture", () => {
+  it("surfaces captureBaseRetentionFactor < 1 on capture", () => {
+    const tile = defaultTile(2000);
+    const result = resolveAttack(
+      defaultAttacker({
+        caste: "red",
+        units: stack(500, 500, 500),
+        unitsAlive: 5000,
+      }),
+      defaultDefender({
+        caste: "white",
+        unitsOnTile: stack(10, 10, 10),
+        baseUnitsOnTile: stack(10, 10, 10),
+      }),
+      tile,
+      makeSeededRng("retention-cap")
+    );
+    expect(result.outcome).toBe("captured");
+    expect(result.captureBaseRetentionFactor).toBeLessThan(1);
+    expect(result.captureBaseRetentionFactor).toBeGreaterThan(0);
   });
 });

--- a/__tests__/lib/game/data-server.test.ts
+++ b/__tests__/lib/game/data-server.test.ts
@@ -252,10 +252,25 @@ describe("getOwnedTilesServer", () => {
     jest.clearAllMocks();
   });
 
-  it("returns an empty array when the player owns no tiles", async () => {
-    const get = jest.fn().mockResolvedValue({ docs: [] });
+  // After the BASE+SUPER redesign, getOwnedTilesServer also fetches the
+  // owner's player doc for lazy-regen and may fire-and-forget tile updates.
+  // The mock builder below stubs both paths so the unit tests stay tight.
+  function buildOwnedTilesMockDb(tileDocs: Array<{ data: () => unknown }>) {
+    const get = jest.fn().mockResolvedValue({ docs: tileDocs });
     const where = jest.fn().mockReturnValue({ get });
-    const db: any = { collection: jest.fn(() => ({ where })) };
+    const tileDoc = jest.fn(() => ({ update: jest.fn().mockResolvedValue(undefined) }));
+    const playerDoc = jest.fn(() => ({
+      get: jest.fn().mockResolvedValue({ exists: false, data: () => undefined }),
+    }));
+    const collection = jest.fn((name: string) => {
+      if (name === "game_players") return { doc: playerDoc };
+      return { where, doc: tileDoc };
+    });
+    return { db: { collection } as any, where };
+  }
+
+  it("returns an empty array when the player owns no tiles", async () => {
+    const { db, where } = buildOwnedTilesMockDb([]);
     mockAdminDb.mockReturnValue(db);
     const result = await getOwnedTilesServer("u1");
     expect(result).toEqual([]);
@@ -267,9 +282,7 @@ describe("getOwnedTilesServer", () => {
       { data: () => ({ tileId: "t1", ownerId: "u1", q: 0, r: 0, type: "military" }) },
       { data: () => ({ tileId: "t2", ownerId: "u1", q: 1, r: 0, type: "food" }) },
     ];
-    const get = jest.fn().mockResolvedValue({ docs });
-    const where = jest.fn().mockReturnValue({ get });
-    const db: any = { collection: jest.fn(() => ({ where })) };
+    const { db } = buildOwnedTilesMockDb(docs);
     mockAdminDb.mockReturnValue(db);
     const result = await getOwnedTilesServer("u1");
     expect(result).toHaveLength(2);

--- a/__tests__/lib/game/world-snapshot-codec.test.ts
+++ b/__tests__/lib/game/world-snapshot-codec.test.ts
@@ -12,8 +12,8 @@ import {
 } from "@/lib/game/world-snapshot-codec";
 
 describe("world-snapshot codec", () => {
-  it("schema version is 2", () => {
-    expect(WORLD_SNAPSHOT_SCHEMA_VERSION).toBe(2);
+  it("schema version is 3", () => {
+    expect(WORLD_SNAPSHOT_SCHEMA_VERSION).toBe(3);
   });
 
   describe("round-trip", () => {
@@ -27,6 +27,7 @@ describe("world-snapshot codec", () => {
           type: "unrevealed",
           ownerId: null,
           units: { ground: 0, siege: 0, air: 0 },
+          baseUnits: { ground: 0, siege: 0, air: 0 },
           armedDefenseSpellId: null,
         },
       },
@@ -39,6 +40,7 @@ describe("world-snapshot codec", () => {
           type: "military",
           ownerId: "user_abc123",
           units: { ground: 50, siege: 10, air: 0 },
+          baseUnits: { ground: 22, siege: 8, air: 5 },
           armedDefenseSpellId: null,
         },
       },
@@ -51,6 +53,7 @@ describe("world-snapshot codec", () => {
           type: "magic",
           ownerId: "user_def456",
           units: { ground: 0, siege: 0, air: 5 },
+          baseUnits: { ground: 8, siege: 2, air: 15 },
           armedDefenseSpellId: "white_t3_shield",
         },
       },
@@ -63,6 +66,7 @@ describe("world-snapshot codec", () => {
           type: "food",
           ownerId: null,
           units: { ground: 0, siege: 0, air: 0 },
+          baseUnits: { ground: 0, siege: 0, air: 0 },
           armedDefenseSpellId: null,
         },
       },
@@ -85,6 +89,7 @@ describe("world-snapshot codec", () => {
         type: "unrevealed",
         ownerId: null,
         units: { ground: 0, siege: 0, air: 0 },
+        baseUnits: { ground: 0, siege: 0, air: 0 },
         armedDefenseSpellId: null,
       };
       const v1Bytes = JSON.stringify(empty).length;
@@ -107,6 +112,9 @@ describe("world-snapshot codec", () => {
           type: owned ? "military" : "unrevealed",
           ownerId: owned ? "user_abcdef123456" : null,
           units: owned ? { ground: 25, siege: 0, air: 0 } : { ground: 0, siege: 0, air: 0 },
+          baseUnits: owned
+            ? { ground: 22, siege: 8, air: 5 }
+            : { ground: 0, siege: 0, air: 0 },
           armedDefenseSpellId: null,
         });
       }
@@ -135,8 +143,17 @@ describe("world-snapshot codec", () => {
         type: "unrevealed",
         ownerId: null,
         units: { ground: 0, siege: 0, air: 0 },
+        baseUnits: { ground: 0, siege: 0, air: 0 },
         armedDefenseSpellId: null,
       });
+    });
+
+    it("decodes a v2 doc (no bg/bs/ba fields) with baseUnits=0", () => {
+      // Backwards-compat smoke: pre-v3 docs never wrote bg/bs/ba. v3 readers
+      // must tolerate their absence so rolling deploys don't choke.
+      const tile = expandTile({ q: 0, r: 0, t: "m", g: 50, s: 10 });
+      expect(tile.units).toEqual({ ground: 50, siege: 10, air: 0 });
+      expect(tile.baseUnits).toEqual({ ground: 0, siege: 0, air: 0 });
     });
   });
 });

--- a/app/game/threats/_components/BattleReport.tsx
+++ b/app/game/threats/_components/BattleReport.tsx
@@ -37,14 +37,6 @@ function totalUnits(stack: UnitStack): number {
   return stack.ground + stack.siege + stack.air;
 }
 
-function addStacks(a: UnitStack, b: UnitStack): UnitStack {
-  return {
-    ground: a.ground + b.ground,
-    siege: a.siege + b.siege,
-    air: a.air + b.air,
-  };
-}
-
 function fmtRoll(n: number): string {
   return `${n.toFixed(2)}×`;
 }
@@ -67,15 +59,51 @@ export function BattleReport({
   targetTile,
   onDismiss,
 }: BattleReportProps) {
-  const defenderPreAttack =
-    combat.outcome === "captured"
-      ? combat.defenderLosses
-      : addStacks(targetTile.units, combat.defenderLosses);
+  // BASE+SUPER: defenderUnitsPreAttack is the composite stack (garrison +
+  // reinforcements) the defender held entering combat. Surfaced by
+  // resolveAttack so we don't have to back-derive from post-attack state.
+  // Optional-with-fallback so older test fixtures + legacy CombatResult
+  // shapes still render: on captures the targetTile now belongs to the
+  // attacker so `defenderLosses` alone reconstructs the pre-attack stack;
+  // on repels/stalemates we add surviving units to lost ones.
+  const defenderPreAttack: UnitStack =
+    combat.defenderUnitsPreAttack ??
+    (combat.outcome === "captured"
+      ? { ...combat.defenderLosses }
+      : {
+          ground: targetTile.units.ground + combat.defenderLosses.ground,
+          siege: targetTile.units.siege + combat.defenderLosses.siege,
+          air: targetTile.units.air + combat.defenderLosses.air,
+        });
+  const defenderBasePreAttack: UnitStack = combat.defenderBasePreAttack ?? {
+    ground: 0,
+    siege: 0,
+    air: 0,
+  };
   const sent = combat.unitsDeployed;
   const sentTotal = totalUnits(sent);
   const defenderHadTotal = totalUnits(defenderPreAttack);
   const attackerLost = combat.attackerLosses;
   const defenderLost = combat.defenderLosses;
+
+  // Decisiveness label for the banner sub-title. Maps the lossCurveTag from
+  // combat to player-facing prose.
+  const decisivenessLabel = (() => {
+    switch (combat.lossCurveTag) {
+      case "decisive-capture":
+        return "Decisive";
+      case "close-capture":
+        return "Narrow";
+      case "stalemate":
+        return "Stalemate";
+      case "close-repel":
+        return "Pyrrhic loss";
+      case "decisive-repel":
+        return "Crushed";
+      default:
+        return null;
+    }
+  })();
 
   const banner = (() => {
     if (combat.outcome === "captured") {
@@ -184,6 +212,11 @@ export function BattleReport({
       <div className="flex items-baseline justify-between px-3 py-2">
         <h3 className="font-semibold uppercase tracking-wide text-xs">
           {banner.label}
+          {decisivenessLabel && (
+            <span className="normal-case font-semibold ml-2 opacity-90">
+              · {decisivenessLabel}
+            </span>
+          )}
           <span className="text-neutral-500 normal-case font-normal ml-2">
             · {report.cost} turn{report.cost === 1 ? "" : "s"} spent
           </span>
@@ -215,6 +248,37 @@ export function BattleReport({
               {defenderPreAttack.air}
             </span>
             <span className="text-neutral-500">({defenderHadTotal} total)</span>
+            {totalUnits(defenderBasePreAttack) > 0 && (
+              <>
+                <span className="text-neutral-500">↳ garrison</span>
+                <span className="text-neutral-500 italic">
+                  G{defenderBasePreAttack.ground} · S
+                  {defenderBasePreAttack.siege} · A
+                  {defenderBasePreAttack.air}
+                </span>
+                <span className="text-neutral-500 italic">
+                  ({totalUnits(defenderBasePreAttack)} base)
+                </span>
+              </>
+            )}
+            {totalUnits(defenderBasePreAttack) > 0 &&
+              defenderHadTotal - totalUnits(defenderBasePreAttack) > 0 && (
+                <>
+                  <span className="text-neutral-500">↳ reinforcements</span>
+                  <span className="text-neutral-500 italic">
+                    G
+                    {defenderPreAttack.ground - defenderBasePreAttack.ground}
+                    {" · "}S
+                    {defenderPreAttack.siege - defenderBasePreAttack.siege}
+                    {" · "}A
+                    {defenderPreAttack.air - defenderBasePreAttack.air}
+                  </span>
+                  <span className="text-neutral-500 italic">
+                    ({defenderHadTotal - totalUnits(defenderBasePreAttack)}{" "}
+                    recruited)
+                  </span>
+                </>
+              )}
           </div>
         </section>
 

--- a/app/game/threats/_components/BattleSimPanel.tsx
+++ b/app/game/threats/_components/BattleSimPanel.tsx
@@ -173,7 +173,20 @@ function PreviewBody({
         <div className="col-span-2">
           <span className="text-neutral-500">Defender on tile · </span>
           <span className="font-mono">
-            {fmtStack(target.units)} ({totalUnits(target.units)})
+            {fmtStack({
+              ground:
+                target.units.ground + (target.baseUnits?.ground ?? 0),
+              siege:
+                target.units.siege + (target.baseUnits?.siege ?? 0),
+              air: target.units.air + (target.baseUnits?.air ?? 0),
+            })}
+            {" "}
+            (
+            {totalUnits(target.units) +
+              (target.baseUnits?.ground ?? 0) +
+              (target.baseUnits?.siege ?? 0) +
+              (target.baseUnits?.air ?? 0)}
+            )
           </span>
         </div>
       </div>

--- a/app/game/threats/_components/ManageSourcePanel.tsx
+++ b/app/game/threats/_components/ManageSourcePanel.tsx
@@ -78,7 +78,9 @@ export function ManageSourcePanel(props: ManageSourcePanelProps) {
         </span>
         <span className="text-neutral-500 capitalize">{source.type}</span>
         <span className="font-mono text-neutral-500">
-          G{source.units.ground} S{source.units.siege} A{source.units.air}
+          G{source.units.ground + (source.baseUnits?.ground ?? 0)} S
+          {source.units.siege + (source.baseUnits?.siege ?? 0)} A
+          {source.units.air + (source.baseUnits?.air ?? 0)}
         </span>
       </div>
 

--- a/app/game/threats/_components/SourceTileCard.tsx
+++ b/app/game/threats/_components/SourceTileCard.tsx
@@ -31,8 +31,13 @@ export function SourceTileCard(props: SourceTileCardProps) {
     source.type !== "unassigned"
       ? buildingForCasteAndLand(myCaste, source.type)
       : undefined;
-  const totalUnits =
-    source.units.ground + source.units.siege + source.units.air;
+  // BASE+SUPER: source card reflects the full deployable pool — garrison +
+  // recruited — since the attack form drafts from both.
+  const sourceBase = source.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+  const totalGround = source.units.ground + sourceBase.ground;
+  const totalSiege = source.units.siege + sourceBase.siege;
+  const totalAir = source.units.air + sourceBase.air;
+  const totalUnits = totalGround + totalSiege + totalAir;
   return (
     <div className="rounded-md border border-emerald-300/70 dark:border-emerald-900 bg-emerald-50/40 dark:bg-emerald-950/10 px-2.5 py-1.5 h-full flex items-center gap-2.5 min-h-0">
       <CatalogImage
@@ -55,7 +60,7 @@ export function SourceTileCard(props: SourceTileCardProps) {
           )}
         </div>
         <div className="text-[11px] text-neutral-500 font-mono mt-0.5">
-          G{source.units.ground} · S{source.units.siege} · A{source.units.air}
+          G{totalGround} · S{totalSiege} · A{totalAir}
           {totalUnits > 0 && (
             <span className="ml-1.5 text-neutral-400">({totalUnits})</span>
           )}

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -23,7 +23,6 @@ import type {
 } from "@/lib/game/types";
 import type { ThreatEntry } from "../_lib/threats-derive";
 import { useAttackPreview } from "../_lib/use-attack-preview";
-import { BattleReport } from "./BattleReport";
 import { BattleSimPanel } from "./BattleSimPanel";
 import { BoostPanel } from "./BoostPanel";
 import { ChangeSourceModal } from "./ChangeSourceModal";
@@ -57,6 +56,15 @@ export interface ThreatRowProps {
     report: TurnReport | null;
     targetTile: GameTile | null;
   } | null>;
+  /** Bubble a resolved attack/flyover up to the page so it can render the
+   *  battle modal. Kept at the page level so the result survives this row
+   *  unmounting (e.g. on a successful capture, the enemy tile drops out of
+   *  the threats list and the row disappears mid-read). */
+  onBattleResolved: (data: {
+    combat: CombatResult;
+    report: TurnReport;
+    targetTile: GameTile;
+  }) => void;
   onCastIntelSpell: (
     spellId: string,
     targetTileId: string
@@ -132,14 +140,6 @@ export function ThreatRow(props: ThreatRowProps) {
   const [offenseSpellId, setOffenseSpellId] = useState<string>("");
   const [toast, setToast] = useState<string | null>(null);
   const [intelReport, setIntelReport] = useState<IntelReport | null>(null);
-  // Structured battle readout shown after an attack lands. Replaces the
-  // plain toast for attack actions; non-attack actions (recruit, arm, etc.)
-  // still use the toast.
-  const [battle, setBattle] = useState<{
-    combat: CombatResult;
-    report: TurnReport;
-    targetTile: GameTile;
-  } | null>(null);
 
   const source =
     entry.candidateSources.find((t) => t.tileId === sourceTileId) ??
@@ -210,12 +210,22 @@ export function ThreatRow(props: ThreatRowProps) {
   // Forward-reference is fine: effectiveOffenseSpellId is derived directly
   // from selectedOffenseSpell which is already memoized above.
   const attackTurnCost = 1 + (selectedOffenseSpell ? 5 : 0);
+  // BASE+SUPER: deployable per type = SUPER (recruited) + BASE (garrison
+  // conscriptable). Slider max + validation key off the composite.
+  const sourceBaseStack = source.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+  const sourceDeployableGround = source.units.ground + sourceBaseStack.ground;
+  const sourceDeployableSiege = source.units.siege + sourceBaseStack.siege;
+  const sourceDeployableAir = source.units.air + sourceBaseStack.air;
+
   const attackDisabledReason = (() => {
     if (enemyShielded) return "Enemy shielded";
     if (sentTotal === 0) return "No units selected";
-    if (ground > source.units.ground) return `Source has only ${source.units.ground} ground`;
-    if (siege > source.units.siege) return `Source has only ${source.units.siege} siege`;
-    if (air > source.units.air) return `Source has only ${source.units.air} air`;
+    if (ground > sourceDeployableGround)
+      return `Source has only ${sourceDeployableGround} ground`;
+    if (siege > sourceDeployableSiege)
+      return `Source has only ${sourceDeployableSiege} siege`;
+    if (air > sourceDeployableAir)
+      return `Source has only ${sourceDeployableAir} air`;
     if (player.turnsRemaining < attackTurnCost)
       return `Need ${attackTurnCost} turns (you have ${player.turnsRemaining})`;
     if (player.phase !== "play") return "Not in play phase";
@@ -251,7 +261,6 @@ export function ThreatRow(props: ThreatRowProps) {
 
   async function handleAttack() {
     setToast(null);
-    setBattle(null);
     // Consume a queued artifact (if any) before the swing fires. We
     // await so the server-side intel/offense effect is in place by the
     // time the attack resolves. If the use-artifact call fails, abort —
@@ -274,11 +283,12 @@ export function ThreatRow(props: ThreatRowProps) {
       offenseSpellId: effectiveOffenseSpellId,
     });
     if (res) {
-      // If we have full combat detail + report + post-combat tile, render
-      // the structured battle card. Otherwise (older server response) fall
-      // back to a one-line toast.
+      // Full combat detail → hand it to the page so the result modal
+      // renders even if this row unmounts (captured tiles drop out of
+      // the threat list). Otherwise (older server response) fall back
+      // to a one-line toast in this row.
       if (res.combat && res.report && res.targetTile) {
-        setBattle({
+        props.onBattleResolved({
           combat: res.combat,
           report: res.report,
           targetTile: res.targetTile,
@@ -356,7 +366,6 @@ export function ThreatRow(props: ThreatRowProps) {
 
   async function handleFlyoverFromPanel() {
     setToast(null);
-    setBattle(null);
     const res = await props.onFlyover(source.tileId, entry.enemyTile.tileId, {
       ground: 0,
       siege: 0,
@@ -364,7 +373,7 @@ export function ThreatRow(props: ThreatRowProps) {
     });
     if (res) {
       if (res.combat && res.report && res.targetTile) {
-        setBattle({
+        props.onBattleResolved({
           combat: res.combat,
           report: res.report,
           targetTile: res.targetTile,
@@ -392,8 +401,7 @@ export function ThreatRow(props: ThreatRowProps) {
         ? "text-amber-600 dark:text-amber-400"
         : "text-red-600 dark:text-red-400";
 
-  const recentOutcomes =
-    Boolean(battle) || Boolean(toast) || Boolean(intelReport);
+  const recentOutcomes = Boolean(toast) || Boolean(intelReport);
 
   return (
     <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 overflow-hidden">
@@ -413,8 +421,14 @@ export function ThreatRow(props: ThreatRowProps) {
           {enemyName} · {enemyCasteLabel}
         </span>
         <span className="font-mono text-xs text-neutral-500">
-          G{entry.enemyTile.units.ground} S{entry.enemyTile.units.siege} A
-          {entry.enemyTile.units.air}
+          G
+          {entry.enemyTile.units.ground +
+            (entry.enemyTile.baseUnits?.ground ?? 0)}
+          {" "}S
+          {entry.enemyTile.units.siege +
+            (entry.enemyTile.baseUnits?.siege ?? 0)}
+          {" "}A
+          {entry.enemyTile.units.air + (entry.enemyTile.baseUnits?.air ?? 0)}
         </span>
         {enemyShielded && (
           <span className="px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 text-xs">
@@ -492,9 +506,9 @@ export function ThreatRow(props: ThreatRowProps) {
                   )}
                 </div>
                 <UnitWithRecruit
-                  label={`G/${source.units.ground}`}
+                  label={`G/${sourceDeployableGround}`}
                   value={ground}
-                  max={source.units.ground}
+                  max={sourceDeployableGround}
                   onChange={setGround}
                   recruitYield={recruitYield}
                   recruitDisabledReason={recruitDisabledReason}
@@ -502,9 +516,9 @@ export function ThreatRow(props: ThreatRowProps) {
                   onRecruit={() => void handleRecruit("ground")}
                 />
                 <UnitWithRecruit
-                  label={`S/${source.units.siege}`}
+                  label={`S/${sourceDeployableSiege}`}
                   value={siege}
-                  max={source.units.siege}
+                  max={sourceDeployableSiege}
                   onChange={setSiege}
                   recruitYield={recruitYield}
                   recruitDisabledReason={recruitDisabledReason}
@@ -512,9 +526,9 @@ export function ThreatRow(props: ThreatRowProps) {
                   onRecruit={() => void handleRecruit("siege")}
                 />
                 <UnitWithRecruit
-                  label={`A/${source.units.air}`}
+                  label={`A/${sourceDeployableAir}`}
                   value={air}
-                  max={source.units.air}
+                  max={sourceDeployableAir}
                   onChange={setAir}
                   recruitYield={recruitYield}
                   recruitDisabledReason={recruitDisabledReason}
@@ -572,8 +586,8 @@ export function ThreatRow(props: ThreatRowProps) {
                     airUnits: air,
                     disabledReason: (() => {
                       if (air <= 0) return "Set air units in the form first";
-                      if (air > source.units.air)
-                        return `Source has only ${source.units.air} air`;
+                      if (air > sourceDeployableAir)
+                        return `Source has only ${sourceDeployableAir} air`;
                       if (player.turnsRemaining < 1)
                         return `Need 1 turn (you have ${player.turnsRemaining})`;
                       return null;
@@ -669,14 +683,6 @@ export function ThreatRow(props: ThreatRowProps) {
               <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
                 Recent outcomes
               </h3>
-              {battle && (
-                <BattleReport
-                  combat={battle.combat}
-                  report={battle.report}
-                  targetTile={battle.targetTile}
-                  onDismiss={() => setBattle(null)}
-                />
-              )}
               {intelReport && (
                 <ThreatIntelPanel
                   report={intelReport}

--- a/app/game/threats/_lib/threats-derive.ts
+++ b/app/game/threats/_lib/threats-derive.ts
@@ -40,7 +40,18 @@ export interface ThreatEntry {
 }
 
 function totalUnits(tile: MapTile): number {
-  return tile.units.ground + tile.units.siege + tile.units.air;
+  // BASE+SUPER: displayed totals always sum the intrinsic garrison with
+  // recruited reinforcements. Threat-derivation, advantage scoring, and
+  // every consumer downstream uses this composite count.
+  const baseUnits = tile.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+  return (
+    tile.units.ground +
+    tile.units.siege +
+    tile.units.air +
+    baseUnits.ground +
+    baseUnits.siege +
+    baseUnits.air
+  );
 }
 
 /**

--- a/app/game/threats/page.tsx
+++ b/app/game/threats/page.tsx
@@ -8,9 +8,15 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import type {
+  CombatResult,
+  GameTile,
+  TurnReport,
+} from "@/lib/game/types";
 import { SignedOutLanding } from "../_components/dashboard/SignedOutLanding";
 import { useDashboardData } from "../_lib/use-dashboard-data";
 import { ArmyPanel } from "./_components/ArmyPanel";
+import { BattleReport } from "./_components/BattleReport";
 import { ThreatRow } from "./_components/ThreatRow";
 import { deriveThreatEntries } from "./_lib/threats-derive";
 
@@ -56,6 +62,14 @@ export default function ThreatsPage() {
   const [hideShielded, setHideShielded] = useState(true);
   const [hideOverwhelming, setHideOverwhelming] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Lifted out of ThreatRow so a successful capture (which unmounts the
+  // attacked row) doesn't yank the result away mid-read. The modal stays
+  // up until the user clicks Close, then they move on to the next threat.
+  const [battleResult, setBattleResult] = useState<{
+    combat: CombatResult;
+    report: TurnReport;
+    targetTile: GameTile;
+  } | null>(null);
 
   const entries = useMemo(() => {
     if (!user || !player) return [];
@@ -199,9 +213,40 @@ export default function ThreatsPage() {
               onSiege={withBusy(handleSiege)}
               onFlyover={withBusy(handleFlyover)}
               onCastSpell={withBusy(handleCastSpell)}
+              onBattleResolved={setBattleResult}
               myMagicLandCount={myMagicLandCount}
             />
           ))}
+        </div>
+      )}
+
+      {battleResult && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Battle result"
+          onClick={() => setBattleResult(null)}
+        >
+          <div
+            className="w-full max-w-2xl max-h-[90vh] overflow-y-auto space-y-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <BattleReport
+              combat={battleResult.combat}
+              report={battleResult.report}
+              targetTile={battleResult.targetTile}
+              onDismiss={() => setBattleResult(null)}
+            />
+            <button
+              type="button"
+              onClick={() => setBattleResult(null)}
+              autoFocus
+              className="w-full px-4 py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-semibold text-base shadow-lg"
+            >
+              Close
+            </button>
+          </div>
         </div>
       )}
     </main>

--- a/app/game/tiles/_components/TileHexagon.tsx
+++ b/app/game/tiles/_components/TileHexagon.tsx
@@ -55,7 +55,16 @@ export function TileHexagon({
   const strokeWidth = isOwn ? 1.5 : isForeign ? 3.5 : 2.25;
   const text = TYPE_TEXT[t.type];
   const armed = !!t.armedDefenseSpellId;
-  const totalUnits = t.units.ground + t.units.siege + t.units.air;
+  // BASE+SUPER: hex visual intensity reflects total defender force, not
+  // just recruited units. An undefended military tile with 45 BASE should
+  // look as armed as one with 45 SUPER.
+  const totalUnits =
+    t.units.ground +
+    t.units.siege +
+    t.units.air +
+    (t.baseUnits?.ground ?? 0) +
+    (t.baseUnits?.siege ?? 0) +
+    (t.baseUnits?.air ?? 0);
   // Filter dimming still applies, but the muddy 0.6 wash on foreign tiles
   // is gone — the bright fill carries the visual weight on its own.
   const opacity = matched ? 1 : 0.12;

--- a/app/game/tiles/_components/TileHoverCard.tsx
+++ b/app/game/tiles/_components/TileHoverCard.tsx
@@ -23,9 +23,20 @@ export function TileHoverCard({ hovered, hoveredOwner, isOwnTile }: Props) {
         <span className="capitalize text-neutral-500">{hovered.type}</span>
       </div>
       <div className="text-neutral-600 dark:text-neutral-400">
-        G {hovered.units.ground} · S {hovered.units.siege} · A{" "}
-        {hovered.units.air}
+        G {hovered.units.ground + (hovered.baseUnits?.ground ?? 0)} · S{" "}
+        {hovered.units.siege + (hovered.baseUnits?.siege ?? 0)} · A{" "}
+        {hovered.units.air + (hovered.baseUnits?.air ?? 0)}
       </div>
+      {hovered.baseUnits &&
+        hovered.baseUnits.ground +
+          hovered.baseUnits.siege +
+          hovered.baseUnits.air >
+          0 && (
+          <div className="text-neutral-500 italic text-[11px] mt-0.5">
+            ↳ garrison: {hovered.baseUnits.ground}G/{hovered.baseUnits.siege}S/
+            {hovered.baseUnits.air}A
+          </div>
+        )}
       {hovered.armedDefenseSpellId && (
         <div className="text-blue-600 dark:text-blue-400 mt-1">
           Armed: {hovered.armedDefenseSpellId}

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -486,34 +486,48 @@ export function EnemyTilePanel({
             onChange={(e) => setSourceTileId(e.target.value)}
             className="mt-1 block w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
           >
-            {myBorders.map((t) => (
-              <option key={t.tileId} value={t.tileId}>
-                {t.tileId} — G{t.units.ground} S{t.units.siege} A{t.units.air}
-              </option>
-            ))}
+            {myBorders.map((t) => {
+              const tb = t.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+              return (
+                <option key={t.tileId} value={t.tileId}>
+                  {t.tileId} — G{t.units.ground + tb.ground} S
+                  {t.units.siege + tb.siege} A{t.units.air + tb.air}
+                </option>
+              );
+            })}
           </select>
         </label>
 
-        <div className="grid grid-cols-3 gap-3">
-          <UnitInput
-            label={`Ground / ${source?.units.ground ?? 0}`}
-            value={ground}
-            max={source?.units.ground ?? 0}
-            onChange={setGround}
-          />
-          <UnitInput
-            label={`Siege / ${source?.units.siege ?? 0}`}
-            value={siege}
-            max={source?.units.siege ?? 0}
-            onChange={setSiege}
-          />
-          <UnitInput
-            label={`Air / ${source?.units.air ?? 0}`}
-            value={air}
-            max={source?.units.air ?? 0}
-            onChange={setAir}
-          />
-        </div>
+        {(() => {
+          // BASE+SUPER: deployable per type = SUPER + BASE.
+          const sb =
+            source?.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+          const maxGround = (source?.units.ground ?? 0) + sb.ground;
+          const maxSiege = (source?.units.siege ?? 0) + sb.siege;
+          const maxAir = (source?.units.air ?? 0) + sb.air;
+          return (
+            <div className="grid grid-cols-3 gap-3">
+              <UnitInput
+                label={`Ground / ${maxGround}`}
+                value={ground}
+                max={maxGround}
+                onChange={setGround}
+              />
+              <UnitInput
+                label={`Siege / ${maxSiege}`}
+                value={siege}
+                max={maxSiege}
+                onChange={setSiege}
+              />
+              <UnitInput
+                label={`Air / ${maxAir}`}
+                value={air}
+                max={maxAir}
+                onChange={setAir}
+              />
+            </div>
+          );
+        })()}
 
         <label className="block text-sm font-medium">
           Offense spell (optional, +5 turns)

--- a/lib/game/combat.ts
+++ b/lib/game/combat.ts
@@ -17,6 +17,7 @@ import {
   magicMultiplierBonusFromUpgrades,
 } from "./upgrades";
 import type {
+  ActiveProductionSpell,
   AirIntelPassive,
   AttackOutcome,
   Caste,
@@ -24,7 +25,9 @@ import type {
   CombatDefenderInput,
   CombatResult,
   CombatTileInput,
+  IntrinsicTileBuff,
   LandType,
+  LossCurveTag,
   SpellTier,
   SpellType,
   UnitStack,
@@ -99,6 +102,71 @@ export const STANDING_DEFENSE_FRACTION: Record<LandType, number> = {
 // have their contribution multiplied by this factor. Stacks
 // multiplicatively on top of the existing magicMultiplier(magicLandCount).
 export const MAGIC_TILE_SPELL_MULT = 1.25;
+
+// ──── BASE + SUPER combat (May 2026) ─────────────────────────────────────
+// Per-tile intrinsic garrison ("BASE") that fights regardless of recruitment.
+// LAND_TYPE_BASE is the seed count by tile type; CASTE_BASE_PROFILE scales
+// per-type counts by the owner's caste; intrinsic buffs / upgrades / active
+// production spells / entrenchment all stack on top via baseUnitsTarget().
+//
+// Design intent: a fresh undefended military tile resists ~35 effective
+// units; a food tile ~23; an unassigned frontier tile ~15. BASE-vs-BASE
+// favors the defender (target-land mult, supply, intel) so SUPER recruitment
+// is the offensive tipping point. See PLAN at
+// /Users/ludwitt/.claude/plans/write-up-a-plan-federated-babbage.md.
+export const LAND_TYPE_BASE: Record<LandType, UnitStack> = {
+  unrevealed: { ground: 0, siege: 0, air: 0 },
+  unassigned: { ground: 12, siege: 0, air: 3 },
+  military: { ground: 22, siege: 8, air: 5 },
+  food: { ground: 18, siege: 0, air: 5 },
+  magic: { ground: 8, siege: 2, air: 15 },
+};
+
+// Caste flavor on BASE COUNTS. Per-unit STAT bonuses are handled by the
+// existing `getCasteProfile(caste).unitTypeBonuses` chain in
+// compositionPower, so we don't duplicate stat tuning here.
+export const CASTE_BASE_PROFILE: Record<Caste, Record<UnitType, number>> = {
+  red:   { ground: 1.25, siege: 1.10, air: 0.90 },
+  white: { ground: 1.10, siege: 1.00, air: 1.00 },
+  black: { ground: 1.00, siege: 0.90, air: 1.10 },
+  green: { ground: 1.15, siege: 1.05, air: 1.05 },
+  blue:  { ground: 0.95, siege: 1.00, air: 1.30 },
+};
+
+// BASE units are entrenched militia — harder to kill per unit than SUPER. In
+// loss attribution we route incoming damage through SUPER first, then any
+// overflow into BASE divided by this multiplier. So a 10-HP BASE force tanks
+// damage like a 13-HP force from the attacker's perspective.
+export const BASE_DURABILITY_MULT = 1.30;
+
+// On capture, the new owner inherits this fraction of the prior owner's
+// BASE as a residual garrison. The rest is killed / scattered during the
+// occupation. The new owner's caste regens this back toward its own target.
+export const BASE_CAPTURE_RETENTION = 0.25;
+
+// Closeness band for stalemates. If |finalAttack/finalDefense - 1| is below
+// this, the outcome is "stalemate" — both sides take partial losses, tile
+// stays with defender. 0.08 ⇒ roughly 8% closeness window, expected to
+// produce 8–15% stalemates on the historical force-ratio distribution.
+export const STALEMATE_BAND = 0.08;
+
+// Lazy regen rate per wall-clock hour. Tile heals toward its current
+// baseUnitsTarget at this rate (split across unit types proportional to
+// where BASE is most under-target). Food / magic / unassigned regenerate
+// slowly; military tiles refill at a faster cadence.
+export const LAND_TYPE_BASE_REGEN_PER_HOUR: Record<LandType, number> = {
+  unrevealed: 0,
+  unassigned: 0.5,
+  military: 2,
+  food: 1,
+  magic: 1,
+};
+
+// Tile entrenchment ramp — long-held tiles develop fortifications, store
+// rooms, and trained militia. Capped so a month-old kingdom doesn't become
+// invulnerable.
+export const ENTRENCHMENT_WEEKLY_BONUS = 0.05;
+export const ENTRENCHMENT_MAX_BONUS = 0.25;
 
 const UNDERDOG_SIZE_RATIO = 0.5;
 const UNDERDOG_DEFENSE_BONUS = 0.25;
@@ -251,6 +319,332 @@ export function unitCapFromFoodLands(foodLandCount: number): number {
   return Math.round(5 * upToFifty + 2.5 * above);
 }
 
+// ──── BASE garrison helpers ──────────────────────────────────────────────
+
+function toMs(t: Date | { toMillis?: () => number; seconds?: number } | undefined): number {
+  if (!t) return 0;
+  if (t instanceof Date) return t.getTime();
+  const ts = t as { toMillis?: () => number; seconds?: number };
+  if (typeof ts.toMillis === "function") return ts.toMillis();
+  if (typeof ts.seconds === "number") return ts.seconds * 1000;
+  return 0;
+}
+
+/**
+ * Target BASE units for a tile under its current configuration. The result
+ * is what BASE will regenerate toward; it does NOT mutate the tile. All
+ * configurable levers feed in:
+ *   - tile type (LAND_TYPE_BASE seed)
+ *   - owner caste (CASTE_BASE_PROFILE per-type count multiplier)
+ *   - per-tile intrinsicBuffs (artifact-stamped, with optional expiry)
+ *   - tile age (entrenchment up to ENTRENCHMENT_MAX_BONUS)
+ *   - active production spells (boost via casteSpellTypeBonus.production)
+ *
+ * Unowned tiles (caste=null) get the LAND_TYPE_BASE seed only — no caste
+ * mults, no entrenchment, no spells. This makes frontier tiles harder than
+ * developed tiles, but not free territory.
+ */
+export function baseUnitsTarget(args: {
+  landType: LandType;
+  caste: Caste | null;
+  upgradeIds?: readonly string[];
+  intrinsicBuffs?: ReadonlyArray<IntrinsicTileBuff>;
+  createdAt?: Date | { toMillis?: () => number; seconds?: number };
+  activeUpgrades?: Record<string, string>;
+  productionSpellsActive?: ReadonlyArray<ActiveProductionSpell>;
+  now?: Date;
+}): UnitStack {
+  const seed = LAND_TYPE_BASE[args.landType];
+  if (!seed || seed.ground + seed.siege + seed.air === 0) {
+    return { ground: 0, siege: 0, air: 0 };
+  }
+
+  // Caste flavor on counts. Unowned tiles get the bare seed.
+  const casteMult = args.caste ? CASTE_BASE_PROFILE[args.caste] : null;
+
+  // Entrenchment ramp from tile age. Caps at ENTRENCHMENT_MAX_BONUS after
+  // ENTRENCHMENT_MAX_BONUS / ENTRENCHMENT_WEEKLY_BONUS weeks (currently
+  // ~5 weeks). Unowned tiles skip entrenchment so freshly-revealed frontier
+  // doesn't pretend to be ancient.
+  let entrenchment = 0;
+  if (args.caste && args.createdAt) {
+    const now = (args.now ?? new Date()).getTime();
+    const ageMs = Math.max(0, now - toMs(args.createdAt));
+    const weeks = ageMs / (7 * 24 * 60 * 60 * 1000);
+    entrenchment = Math.min(
+      ENTRENCHMENT_MAX_BONUS,
+      weeks * ENTRENCHMENT_WEEKLY_BONUS
+    );
+  }
+
+  // Active intrinsic buffs — sum flat baseCountBonus across non-expired
+  // entries. Stat bonuses on the buffs are applied at combat-time via
+  // compositionPower, not here (this function only returns counts).
+  const buffBonus: UnitStack = { ground: 0, siege: 0, air: 0 };
+  if (args.intrinsicBuffs && args.intrinsicBuffs.length > 0) {
+    const nowMs = (args.now ?? new Date()).getTime();
+    for (const b of args.intrinsicBuffs) {
+      if (b.expiresAt && toMs(b.expiresAt) <= nowMs) continue;
+      if (!b.baseCountBonus) continue;
+      buffBonus.ground += b.baseCountBonus.ground ?? 0;
+      buffBonus.siege += b.baseCountBonus.siege ?? 0;
+      buffBonus.air += b.baseCountBonus.air ?? 0;
+    }
+  }
+
+  // Production-spell boost. Mirrors the cap formula's spell-bonus shape:
+  // active production spells nudge BASE counts up by a fraction tied to the
+  // caste's production-spell-type bonus. Implementation kept conservative —
+  // a +5% per active spell, capped at +25%.
+  let spellMult = 1;
+  if (args.caste && args.productionSpellsActive && args.productionSpellsActive.length > 0) {
+    const profile = getCasteProfile(args.caste);
+    const productionBonus = profile.spellTypeBonuses.production ?? 1;
+    // Count active spells (caller is expected to have filtered expired ones,
+    // but defend against stale entries anyway).
+    const activeCount = args.productionSpellsActive.length;
+    spellMult = Math.min(1.25, 1 + 0.05 * activeCount * productionBonus);
+  }
+
+  // Per-tile building upgrades. The existing `buildingCapacityBonus` chain
+  // doesn't tune base counts, so we just sum bonuses from buildings whose
+  // definitions declare a baseUnitCountBonus when one is added in the
+  // future. For now this is a no-op pass-through.
+  // (left intentionally minimal; future BUILDINGS_BY_ID entries can add bonuses)
+
+  const result: UnitStack = {
+    ground: 0,
+    siege: 0,
+    air: 0,
+  };
+  for (const t of UNIT_TYPES) {
+    const seedCount = seed[t];
+    if (seedCount === 0 && buffBonus[t] === 0) {
+      result[t] = 0;
+      continue;
+    }
+    const casteFactor = casteMult ? casteMult[t] : 1;
+    const raw =
+      (seedCount * casteFactor + buffBonus[t]) *
+      spellMult *
+      (1 + entrenchment);
+    result[t] = Math.max(0, Math.round(raw));
+  }
+  return result;
+}
+
+/**
+ * Step the tile's BASE units toward its target. Returns the new baseUnits,
+ * the updated baseRegenedAt timestamp, and the delta count so callers can
+ * decide whether to write to Firestore. Caller is responsible for picking
+ * regen rate from LAND_TYPE_BASE_REGEN_PER_HOUR.
+ *
+ * Regen distributes across unit types proportional to where BASE is most
+ * under-target (so a tile that has air but no ground regenerates ground
+ * first). Doesn't overshoot — clamps at target.
+ */
+export function applyBaseRegen(args: {
+  currentBase: UnitStack;
+  target: UnitStack;
+  landType: LandType;
+  baseRegenedAt: Date | { toMillis?: () => number; seconds?: number };
+  now: Date;
+}): { baseUnits: UnitStack; baseRegenedAt: Date; deltaUnits: number } {
+  const rate = LAND_TYPE_BASE_REGEN_PER_HOUR[args.landType];
+  const since = toMs(args.baseRegenedAt);
+  const nowMs = args.now.getTime();
+  const hours = Math.max(0, (nowMs - since) / (60 * 60 * 1000));
+  if (rate <= 0 || hours <= 0) {
+    return {
+      baseUnits: { ...args.currentBase },
+      baseRegenedAt: args.now,
+      deltaUnits: 0,
+    };
+  }
+
+  let toAdd = Math.floor(rate * hours);
+  if (toAdd <= 0) {
+    return {
+      baseUnits: { ...args.currentBase },
+      baseRegenedAt: args.now,
+      deltaUnits: 0,
+    };
+  }
+
+  // Compute per-type deficits. If everything is at target, no regen.
+  const deficits: Record<UnitType, number> = {
+    ground: Math.max(0, args.target.ground - args.currentBase.ground),
+    siege: Math.max(0, args.target.siege - args.currentBase.siege),
+    air: Math.max(0, args.target.air - args.currentBase.air),
+  };
+  const totalDeficit = deficits.ground + deficits.siege + deficits.air;
+  if (totalDeficit === 0) {
+    return {
+      baseUnits: { ...args.currentBase },
+      baseRegenedAt: args.now,
+      deltaUnits: 0,
+    };
+  }
+  toAdd = Math.min(toAdd, totalDeficit);
+
+  // Distribute proportional to deficit; remainder goes to ground.
+  const next: UnitStack = { ...args.currentBase };
+  let addedSoFar = 0;
+  for (const t of UNIT_TYPES) {
+    if (deficits[t] === 0) continue;
+    const share = Math.floor((deficits[t] / totalDeficit) * toAdd);
+    const apply = Math.min(share, deficits[t]);
+    next[t] += apply;
+    addedSoFar += apply;
+  }
+  // Any rounding remainder — prioritize whichever type still has deficit.
+  let remainder = toAdd - addedSoFar;
+  if (remainder > 0) {
+    for (const t of UNIT_TYPES) {
+      if (remainder === 0) break;
+      const stillDeficit = args.target[t] - next[t];
+      if (stillDeficit <= 0) continue;
+      const apply = Math.min(remainder, stillDeficit);
+      next[t] += apply;
+      remainder -= apply;
+    }
+  }
+
+  return {
+    baseUnits: next,
+    baseRegenedAt: args.now,
+    deltaUnits: toAdd,
+  };
+}
+
+/**
+ * Split incoming defender losses across SUPER (recruited) and BASE
+ * (intrinsic). SUPER absorbs damage first — it's the deployed army taking
+ * the front-line role. BASE only bleeds when SUPER is exhausted; its
+ * effective HP is multiplied by BASE_DURABILITY_MULT because militia
+ * defending entrenched positions takes less damage per unit.
+ *
+ * On capture, the standard curve does its work, but BASE additionally
+ * survives at BASE_CAPTURE_RETENTION (default 25%) — the new owner inherits
+ * a residual garrison that regenerates back up under their caste profile.
+ */
+export function attributeDefenderLosses(args: {
+  superBefore: UnitStack;
+  baseBefore: UnitStack;
+  totalLosses: UnitStack;
+  outcome: AttackOutcome;
+  captureBaseRetentionFactor: number;
+}): {
+  superLost: UnitStack;
+  baseLost: UnitStack;
+  newSuper: UnitStack;
+  newBase: UnitStack;
+} {
+  const superLost: UnitStack = { ground: 0, siege: 0, air: 0 };
+  const baseLost: UnitStack = { ground: 0, siege: 0, air: 0 };
+
+  for (const t of UNIT_TYPES) {
+    const dmg = args.totalLosses[t];
+    if (dmg <= 0) continue;
+    const superAvail = args.superBefore[t];
+    const fromSuper = Math.min(dmg, superAvail);
+    superLost[t] = fromSuper;
+    const overflow = dmg - fromSuper;
+    if (overflow > 0) {
+      // Overflow takes from BASE, but durability soaks part of it.
+      const reducedOverflow = overflow / BASE_DURABILITY_MULT;
+      baseLost[t] = Math.min(args.baseBefore[t], Math.round(reducedOverflow));
+    }
+  }
+
+  const newSuper: UnitStack = {
+    ground: Math.max(0, args.superBefore.ground - superLost.ground),
+    siege: Math.max(0, args.superBefore.siege - superLost.siege),
+    air: Math.max(0, args.superBefore.air - superLost.air),
+  };
+  let newBase: UnitStack = {
+    ground: Math.max(0, args.baseBefore.ground - baseLost.ground),
+    siege: Math.max(0, args.baseBefore.siege - baseLost.siege),
+    air: Math.max(0, args.baseBefore.air - baseLost.air),
+  };
+
+  if (args.outcome === "captured") {
+    // On capture, SUPER is wiped entirely (overrides the curve — losing the
+    // tile means the deployed army is destroyed or captured), and BASE is
+    // cut to the retention factor. The new owner inherits the residual.
+    const wipedSuper: UnitStack = {
+      ground: args.superBefore.ground,
+      siege: args.superBefore.siege,
+      air: args.superBefore.air,
+    };
+    const retention = Math.max(0, Math.min(1, args.captureBaseRetentionFactor));
+    const retainedBase: UnitStack = {
+      ground: Math.floor(args.baseBefore.ground * retention),
+      siege: Math.floor(args.baseBefore.siege * retention),
+      air: Math.floor(args.baseBefore.air * retention),
+    };
+    return {
+      superLost: wipedSuper,
+      baseLost: {
+        ground: args.baseBefore.ground - retainedBase.ground,
+        siege: args.baseBefore.siege - retainedBase.siege,
+        air: args.baseBefore.air - retainedBase.air,
+      },
+      newSuper: { ground: 0, siege: 0, air: 0 },
+      newBase: retainedBase,
+    };
+  }
+
+  return { superLost, baseLost, newSuper, newBase };
+}
+
+/**
+ * Split attacker losses across the SUPER and BASE units that were
+ * conscripted into the attack. Apportions per-type proportional to what
+ * was sent from each pool, so an attack drawing 80% from SUPER and 20%
+ * from BASE distributes losses similarly.
+ */
+export function attributeAttackerLosses(args: {
+  superSent: UnitStack;
+  baseSent: UnitStack;
+  totalLosses: UnitStack;
+}): {
+  superLost: UnitStack;
+  baseLost: UnitStack;
+} {
+  const superLost: UnitStack = { ground: 0, siege: 0, air: 0 };
+  const baseLost: UnitStack = { ground: 0, siege: 0, air: 0 };
+  for (const t of UNIT_TYPES) {
+    const lostT = args.totalLosses[t];
+    if (lostT <= 0) continue;
+    const superSentT = args.superSent[t];
+    const baseSentT = args.baseSent[t];
+    const totalSentT = superSentT + baseSentT;
+    if (totalSentT === 0) continue;
+    // Proportional split. Round SUPER first so any rounding error goes to
+    // BASE (which is more elastic since it regenerates).
+    const fromSuper = Math.min(
+      superSentT,
+      Math.round(lostT * (superSentT / totalSentT))
+    );
+    const fromBase = Math.min(baseSentT, lostT - fromSuper);
+    superLost[t] = fromSuper;
+    baseLost[t] = fromBase;
+  }
+  return { superLost, baseLost };
+}
+
+// Helper for callers that have a UnitStack and need to know whether it's
+// empty — handy because pieces of code outside combat.ts will start needing
+// to sum SUPER+BASE.
+export function addStacks(a: UnitStack, b: UnitStack): UnitStack {
+  return {
+    ground: a.ground + b.ground,
+    siege: a.siege + b.siege,
+    air: a.air + b.air,
+  };
+}
+
 export function computeTileCapacity(
   landType: LandType,
   caste: Caste | null,
@@ -331,21 +725,6 @@ function applyLossFraction(units: UnitStack, fraction: number): UnitStack {
     siege: Math.min(units.siege, Math.floor(units.siege * f)),
     air: Math.min(units.air, Math.floor(units.air * f)),
   };
-}
-
-function totalHpForStack(
-  units: UnitStack,
-  caste: Caste,
-  activeUpgrades: Record<string, string> = {}
-): number {
-  const profile = getCasteProfile(caste);
-  let total = 0;
-  for (const t of UNIT_TYPES) {
-    const def = getUnitForCasteAndType(caste, t);
-    const stats = effectiveUnitStats(def, activeUpgrades);
-    total += units[t] * stats.hp * profile.unitTypeBonuses[t];
-  }
-  return total;
 }
 
 // One-sided power computation. mode = "attack" pulls each unit's `attack` stat;
@@ -491,6 +870,15 @@ export function resolveAttack(
       preCastOffenseApplied: 0,
       rng: { attackerRoll: 0, defenderRoll: 0 },
       appliedSpells,
+      // BASE+SUPER fields — trivial repel, no force engaged.
+      finalAttack: 0,
+      finalDefense: 0,
+      defenderUnitsPreAttack: { ...defender.unitsOnTile },
+      defenderBasePreAttack:
+        defender.baseUnitsOnTile ?? { ground: 0, siege: 0, air: 0 },
+      decisiveness: 1,
+      lossCurveTag: "decisive-repel",
+      captureBaseRetentionFactor: 1,
     };
   }
 
@@ -643,25 +1031,64 @@ export function resolveAttack(
   const finalAttack = attackPower * attackerRoll;
   const finalDefense = defensePower * defenderRoll;
 
+  // Closeness band: when finalAttack and finalDefense are within
+  // ±STALEMATE_BAND of each other, the engagement is a stalemate — both
+  // sides bleed, tile stays with defender. Replaces the dead `===` branch
+  // that never fired with floats + RNG.
+  const ratio = finalDefense > 0 ? finalAttack / finalDefense : Infinity;
+  const closeness = Math.abs(ratio - 1);
   let outcome: AttackOutcome;
-  if (finalAttack > finalDefense) outcome = "captured";
-  else if (finalDefense > finalAttack) outcome = "repelled";
-  else outcome = "stalemate";
+  if (closeness < STALEMATE_BAND) {
+    outcome = "stalemate";
+  } else if (ratio > 1) {
+    outcome = "captured";
+  } else {
+    outcome = "repelled";
+  }
 
-  const attackerHp = totalHpForStack(deployed, attacker.caste, attackerUpgrades);
-  const defenderHp = totalHpForStack(
+  // Decisiveness in log2 of ratio — symmetric scale where ±1 is a 2× edge,
+  // ±2 is a 4× edge. Drives the loss curves below and the BattleReport
+  // "Decisive / Close / Pyrrhic" label.
+  const d = ratio === 0 ? -Infinity : ratio === Infinity ? Infinity : Math.log2(ratio);
+
+  // Decisiveness-keyed loss fractions. Replaces the symmetric
+  // `lossFrac = opposingPower / ownHp` which produced near-total wipes on
+  // any imbalance. The curves smooth toward "decisive winner loses ~5–15%,
+  // decisive loser loses 90–95%; close fights split losses more evenly."
+  let attackerLossFrac: number;
+  let defenderLossFrac: number;
+  let lossCurveTag: LossCurveTag;
+  if (outcome === "stalemate") {
+    attackerLossFrac = 0.5;
+    defenderLossFrac = 0.4;
+    lossCurveTag = "stalemate";
+  } else if (outcome === "captured") {
+    // d > 0. Saturated forms keep the high-end clamps reasonable.
+    attackerLossFrac = clamp01(0.5 - 0.2 * d);
+    defenderLossFrac = clamp01(0.65 + 0.15 * d);
+    lossCurveTag = d >= 1 ? "decisive-capture" : "close-capture";
+  } else {
+    // outcome === "repelled". d < 0; flip sign to compute magnitudes.
+    const magnitude = -d;
+    attackerLossFrac = clamp01(0.6 + 0.2 * magnitude);
+    defenderLossFrac = clamp01(0.3 - 0.15 * magnitude);
+    lossCurveTag = magnitude >= 1 ? "decisive-repel" : "close-repel";
+  }
+  // Floor non-zero losses so a "close" outcome doesn't collapse to zero
+  // through rounding.
+  if (outcome === "captured" && attackerLossFrac < 0.05) attackerLossFrac = 0.05;
+  if (outcome === "repelled" && defenderLossFrac > 0 && defenderLossFrac < 0.05)
+    defenderLossFrac = 0.05;
+
+  const attackerLosses = applyLossFraction(deployed, attackerLossFrac);
+  const defenderLosses = applyLossFraction(
     defender.unitsOnTile,
-    defender.caste,
-    defenderUpgrades
+    defenderLossFrac
   );
-  const attackerLossFrac = attackerHp > 0 ? finalDefense / attackerHp : 0;
-  const defenderLossFrac = defenderHp > 0 ? finalAttack / defenderHp : 0;
-
-  let attackerLosses = applyLossFraction(deployed, attackerLossFrac);
-  let defenderLosses =
-    outcome === "captured"
-      ? { ...defender.unitsOnTile }
-      : applyLossFraction(defender.unitsOnTile, defenderLossFrac);
+  // Note: the prior "capture wipes all defenders" override is intentionally
+  // gone. Loss attribution + SUPER-wipe semantics are now a server concern
+  // (see attributeDefenderLosses); this function returns the raw
+  // curve-based losses for the composite stack.
 
   let airIntel: CombatResult["airIntel"];
   if (airIntelPassive) {
@@ -683,6 +1110,13 @@ export function resolveAttack(
     // it stitches the post-resolve report.
   }
 
+  // Surface the closeness for the BattleReport "Decisive / Close / Pyrrhic"
+  // label. BASE retention only kicks in on capture; otherwise leave at 1
+  // (the curve-based defender losses do the work for non-captures).
+  const decisiveness = closeness;
+  const captureBaseRetentionFactor =
+    outcome === "captured" ? BASE_CAPTURE_RETENTION : 1;
+
   return {
     outcome,
     unitsDeployed: deployed,
@@ -703,6 +1137,14 @@ export function resolveAttack(
     preCastOffenseApplied,
     rng: { attackerRoll, defenderRoll },
     appliedSpells,
+    finalAttack,
+    finalDefense,
+    defenderUnitsPreAttack: { ...defender.unitsOnTile },
+    defenderBasePreAttack:
+      defender.baseUnitsOnTile ?? { ground: 0, siege: 0, air: 0 },
+    decisiveness,
+    lossCurveTag,
+    captureBaseRetentionFactor,
     ...(airIntel ? { airIntel } : {}),
   };
 }

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -5,10 +5,14 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { Firestore, Transaction } from "firebase-admin/firestore";
+import type { Firestore, Timestamp, Transaction } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import {
+  applyBaseRegen,
   applyFlyoverModifiers,
+  attributeAttackerLosses,
+  attributeDefenderLosses,
+  baseUnitsTarget,
   computeTileCapacity,
   distributeUnitKills,
   makeSeededRng,
@@ -399,7 +403,92 @@ export async function getOwnedTilesServer(userId: string): Promise<GameTile[]> {
     .collection(COLLECTIONS.TILES)
     .where("ownerId", "==", userId)
     .get();
-  return snap.docs.map((d) => d.data() as GameTile);
+  const playerSnap = await db.collection(COLLECTIONS.PLAYERS).doc(userId).get();
+  const player = playerSnap.exists ? (playerSnap.data() as GamePlayer) : null;
+  const tiles = snap.docs.map((d) => d.data() as GameTile);
+  return applyLazyRegenBatch(tiles, player, new Date());
+}
+
+// In-memory + fire-and-forget Firestore writeback of BASE regen across a
+// batch of tiles. Returns the regenerated tiles. Writes only fire for tiles
+// where the BASE delta is non-zero (avoids write storms on read-heavy paths).
+// The writes are not awaited — the caller's response uses the in-memory
+// regen result; the next request reads the persisted values.
+function applyLazyRegenBatch(
+  tiles: GameTile[],
+  player: GamePlayer | null,
+  now: Date
+): GameTile[] {
+  const db = adminDbOrThrow();
+  const out: GameTile[] = [];
+  for (const t of tiles) {
+    out.push(applyLazyRegen(t, player, now, db));
+  }
+  return out;
+}
+
+function applyLazyRegen(
+  tile: GameTile,
+  player: GamePlayer | null,
+  now: Date,
+  db: Firestore
+): GameTile {
+  if (!tile.ownerId) return tile;
+  const currentBase = tile.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+  const target = baseUnitsTarget({
+    landType: tile.type,
+    caste: player?.caste ?? null,
+    upgradeIds: tile.upgradeIds,
+    intrinsicBuffs: tile.intrinsicBuffs,
+    createdAt:
+      tile.createdAt instanceof Date
+        ? tile.createdAt
+        : typeof (tile.createdAt as Timestamp | undefined)?.toDate === "function"
+          ? (tile.createdAt as Timestamp).toDate()
+          : undefined,
+    activeUpgrades: player?.activeUpgrades ?? {},
+    productionSpellsActive: player?.productionSpellsActive,
+    now,
+  });
+  const baseRegenedAt =
+    tile.baseRegenedAt instanceof Date
+      ? tile.baseRegenedAt
+      : typeof (tile.baseRegenedAt as Timestamp | undefined)?.toDate ===
+          "function"
+        ? (tile.baseRegenedAt as Timestamp).toDate()
+        : tile.createdAt instanceof Date
+          ? tile.createdAt
+          : typeof (tile.createdAt as Timestamp | undefined)?.toDate ===
+              "function"
+            ? (tile.createdAt as Timestamp).toDate()
+            : now;
+  const result = applyBaseRegen({
+    currentBase,
+    target,
+    landType: tile.type,
+    baseRegenedAt,
+    now,
+  });
+  if (result.deltaUnits <= 0) return tile;
+  // Fire-and-forget Firestore writeback. Failures are logged inside the
+  // surrounding logger; we don't await so the read path stays snappy.
+  db.collection(COLLECTIONS.TILES)
+    .doc(tile.tileId)
+    .update({
+      baseUnits: result.baseUnits,
+      baseRegenedAt: result.baseRegenedAt,
+    })
+    .catch((e) => {
+      logger.warn("applyLazyRegen writeback failed", {
+        tileId: tile.tileId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    });
+  return {
+    ...tile,
+    baseUnits: result.baseUnits,
+    baseRegenedAt: result.baseRegenedAt,
+  };
 }
 
 // Lightweight tile fetch — uses Firestore's select() to only pull the fields
@@ -413,7 +502,16 @@ export async function getOwnedMapTilesServer(
   const snap = await db
     .collection(COLLECTIONS.TILES)
     .where("ownerId", "==", userId)
-    .select("tileId", "q", "r", "type", "ownerId", "units", "armedDefenseSpellId")
+    .select(
+      "tileId",
+      "q",
+      "r",
+      "type",
+      "ownerId",
+      "units",
+      "baseUnits",
+      "armedDefenseSpellId"
+    )
     .get();
   return snap.docs.map((d) => {
     const data = d.data();
@@ -424,6 +522,7 @@ export async function getOwnedMapTilesServer(
       type: data.type,
       ownerId: data.ownerId ?? null,
       units: data.units,
+      baseUnits: data.baseUnits ?? { ground: 0, siege: 0, air: 0 },
       armedDefenseSpellId: data.armedDefenseSpellId ?? null,
     } as MapTile;
   });
@@ -437,7 +536,16 @@ export async function getAllMapTilesServer(): Promise<MapTile[]> {
   const db = adminDbOrThrow();
   const snap = await db
     .collection(COLLECTIONS.TILES)
-    .select("tileId", "q", "r", "type", "ownerId", "units", "armedDefenseSpellId")
+    .select(
+      "tileId",
+      "q",
+      "r",
+      "type",
+      "ownerId",
+      "units",
+      "baseUnits",
+      "armedDefenseSpellId"
+    )
     .get();
   return snap.docs.map((d) => {
     const data = d.data();
@@ -448,6 +556,7 @@ export async function getAllMapTilesServer(): Promise<MapTile[]> {
       type: data.type,
       ownerId: data.ownerId ?? null,
       units: data.units,
+      baseUnits: data.baseUnits ?? { ground: 0, siege: 0, air: 0 },
       armedDefenseSpellId: data.armedDefenseSpellId ?? null,
     } as MapTile;
   });
@@ -476,7 +585,16 @@ export async function getMapTilesInBoundsServer(bounds: {
     .collection(COLLECTIONS.TILES)
     .where("q", ">=", bounds.qMin)
     .where("q", "<=", bounds.qMax)
-    .select("tileId", "q", "r", "type", "ownerId", "units", "armedDefenseSpellId")
+    .select(
+      "tileId",
+      "q",
+      "r",
+      "type",
+      "ownerId",
+      "units",
+      "baseUnits",
+      "armedDefenseSpellId"
+    )
     .limit(VIEWPORT_TILE_LIMIT + 1)
     .get();
   if (snap.size > VIEWPORT_TILE_LIMIT) {
@@ -496,6 +614,7 @@ export async function getMapTilesInBoundsServer(bounds: {
       type: data.type,
       ownerId: data.ownerId ?? null,
       units: data.units,
+      baseUnits: data.baseUnits ?? { ground: 0, siege: 0, air: 0 },
       armedDefenseSpellId: data.armedDefenseSpellId ?? null,
     } as MapTile);
   }
@@ -571,6 +690,7 @@ export async function getMyMapServer(
         type: data.type,
         ownerId: data.ownerId,
         units: data.units,
+        baseUnits: data.baseUnits ?? { ground: 0, siege: 0, air: 0 },
         armedDefenseSpellId: data.armedDefenseSpellId ?? null,
       });
       enemyOwnerIds.add(data.ownerId);
@@ -633,7 +753,15 @@ export async function getAllOwnerSummariesServer(
 export async function getTileServer(tileId: string): Promise<GameTile | null> {
   const db = adminDbOrThrow();
   const snap = await db.collection(COLLECTIONS.TILES).doc(tileId).get();
-  return snap.exists ? (snap.data() as GameTile) : null;
+  if (!snap.exists) return null;
+  const tile = snap.data() as GameTile;
+  if (!tile.ownerId) return tile;
+  const playerSnap = await db
+    .collection(COLLECTIONS.PLAYERS)
+    .doc(tile.ownerId)
+    .get();
+  const player = playerSnap.exists ? (playerSnap.data() as GamePlayer) : null;
+  return applyLazyRegen(tile, player, new Date(), db);
 }
 
 // v2 — new players spawn with 25 already-revealed unassigned tiles, skipping
@@ -742,6 +870,11 @@ export async function createPlayerWithSpawnServer(
         type: "unrevealed" as LandType,
         level: 0,
         units: { ground: 0, siege: 0, air: 0 },
+        // BASE garrison stays zero on unrevealed; exploreNextTileServer
+        // seeds it the moment the tile flips to unassigned.
+        baseUnits: { ground: 0, siege: 0, air: 0 },
+        baseRegenedAt: now,
+        intrinsicBuffs: [],
         armedDefenseSpellId: null,
         neighborTileIds: neighborTileIds(q, r),
         upgradeIds: [],
@@ -837,9 +970,31 @@ export async function exploreNextTileServer(
     );
     const artifact = rolled?.definition ?? null;
 
+    // Seed BASE garrison the moment the tile flips out of unrevealed —
+    // unassigned tiles get the LAND_TYPE_BASE seed scaled by caste, which
+    // ensures every revealed tile has a real defensive floor.
+    const exploreCreatedAt: Date | undefined =
+      tile.createdAt instanceof Date
+        ? tile.createdAt
+        : typeof (tile.createdAt as Timestamp | undefined)?.toDate === "function"
+          ? (tile.createdAt as Timestamp).toDate()
+          : undefined;
+    const initialBaseUnits = baseUnitsTarget({
+      landType: "unassigned",
+      caste: player.caste,
+      upgradeIds: tile.upgradeIds,
+      intrinsicBuffs: tile.intrinsicBuffs,
+      createdAt: exploreCreatedAt,
+      activeUpgrades: player.activeUpgrades ?? {},
+      productionSpellsActive: player.productionSpellsActive,
+      now,
+    });
+
     tx.update(tileRef, {
       type: "unassigned" as LandType,
       revealedAt: now,
+      baseUnits: initialBaseUnits,
+      baseRegenedAt: now,
       updatedAt: now,
     });
     tx.update(playerRef, {
@@ -853,6 +1008,8 @@ export async function exploreNextTileServer(
     const updatedTile: GameTile = {
       ...tile,
       type: "unassigned",
+      baseUnits: initialBaseUnits,
+      baseRegenedAt: now,
       revealedAt: now,
       updatedAt: now,
     };
@@ -953,7 +1110,53 @@ export async function distributeTileServer(
     );
     const artifact = rolled?.definition ?? null;
 
-    tx.update(tileRef, { type, updatedAt: now });
+    // Re-seed BASE garrison toward the new land type's target. We don't
+    // snap to the new target instantly; the existing baseUnits stay (the
+    // militia don't disappear when you re-zone), but we update
+    // baseRegenedAt so the next regen tick aims at the new type's target.
+    // Exception: if the tile is being re-typed away from a developed
+    // type back to unassigned, leave baseUnits alone and let lazy regen
+    // decay it (a future enhancement; for now no decay).
+    const createdAtDate: Date | undefined =
+      tile.createdAt instanceof Date
+        ? tile.createdAt
+        : typeof (tile.createdAt as Timestamp | undefined)?.toDate === "function"
+          ? (tile.createdAt as Timestamp).toDate()
+          : undefined;
+    const newBaseTarget = baseUnitsTarget({
+      landType: type,
+      caste: player.caste,
+      upgradeIds: tile.upgradeIds,
+      intrinsicBuffs: tile.intrinsicBuffs,
+      createdAt: createdAtDate,
+      activeUpgrades: player.activeUpgrades ?? {},
+      productionSpellsActive: player.productionSpellsActive,
+      now,
+    });
+    // If existing baseUnits is below the new target, jump to halfway —
+    // distribute-as-promotion shouldn't be an instant-full-garrison cheat.
+    const currentBase = tile.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+    const seededBase = {
+      ground: Math.max(
+        currentBase.ground,
+        Math.floor((currentBase.ground + newBaseTarget.ground) / 2)
+      ),
+      siege: Math.max(
+        currentBase.siege,
+        Math.floor((currentBase.siege + newBaseTarget.siege) / 2)
+      ),
+      air: Math.max(
+        currentBase.air,
+        Math.floor((currentBase.air + newBaseTarget.air) / 2)
+      ),
+    };
+
+    tx.update(tileRef, {
+      type,
+      baseUnits: seededBase,
+      baseRegenedAt: now,
+      updatedAt: now,
+    });
     tx.update(playerRef, {
       turnsRemaining: player.turnsRemaining - 1,
       turnsSpentTotal,
@@ -975,7 +1178,13 @@ export async function distributeTileServer(
         turnsSpentTotal,
         updatedAt: now,
       },
-      tile: { ...tile, type, updatedAt: now },
+      tile: {
+        ...tile,
+        type,
+        baseUnits: seededBase,
+        baseRegenedAt: now,
+        updatedAt: now,
+      },
       report,
       artifact: rolled?.doc ?? null,
     };
@@ -2193,9 +2402,26 @@ export async function attackTileServer(args: {
         attacker.turnsRemaining
       );
     }
-    if (!stackHasAtLeast(source.units, args.units)) {
+    // BASE+SUPER: source's deployable pool is units (SUPER) + baseUnits (BASE).
+    // We draw from SUPER first per type; any overflow conscripts from BASE.
+    const sourceBase: UnitStack =
+      source.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+    const targetBase: UnitStack =
+      target.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+    const sourceDeployable = addStack(source.units, sourceBase);
+    if (!stackHasAtLeast(sourceDeployable, args.units)) {
       throw new GameInsufficientUnitsError();
     }
+    const superSent: UnitStack = {
+      ground: Math.min(args.units.ground, source.units.ground),
+      siege: Math.min(args.units.siege, source.units.siege),
+      air: Math.min(args.units.air, source.units.air),
+    };
+    const baseSent: UnitStack = {
+      ground: args.units.ground - superSent.ground,
+      siege: args.units.siege - superSent.siege,
+      air: args.units.air - superSent.air,
+    };
 
     const defenderActiveUpgrades = defender.activeUpgrades ?? {};
     const attackerActiveUpgrades = attacker.activeUpgrades ?? {};
@@ -2205,12 +2431,16 @@ export async function attackTileServer(args: {
       target.upgradeIds,
       defenderActiveUpgrades
     );
+    // Capacity check is against SUPER on tile only — BASE is intrinsic and
+    // doesn't compete for cap (food-cap math doesn't include militia).
     const defenderTotalOnTile = sumStack(target.units);
     const availableSpace = Math.max(0, tileCapacity - defenderTotalOnTile);
     const sentTotal = sumStack(args.units);
     if (sentTotal > availableSpace) {
       throw new GameTileFullError(availableSpace, sentTotal);
     }
+    // Composite defender stack for combat — base+super fight together.
+    const defenderComposite = addStack(target.units, targetBase);
 
     // Read the 6 neighbor tiles to compute supply. Hex coords are immutable,
     // so deriving IDs from (q, r) is canonical even if neighborTileIds drifts.
@@ -2250,7 +2480,8 @@ export async function attackTileServer(args: {
       },
       {
         caste: defender.caste,
-        unitsOnTile: target.units,
+        unitsOnTile: defenderComposite,
+        baseUnitsOnTile: targetBase,
         armedDefenseSpellId: target.armedDefenseSpellId,
         magicLandCount: 0,
         unitsAlive: defender.stats.unitsAlive,
@@ -2279,11 +2510,39 @@ export async function attackTileServer(args: {
       });
     }
 
-    const survivors = subtractStack(result.unitsDeployed, result.attackerLosses);
-    const sourceAfterDispatch = subtractStack(source.units, args.units);
+    // BASE+SUPER loss attribution. Split combat losses back into the
+    // pools they came from so each tile's units / baseUnits stay coherent.
+    const attackerLossSplit = attributeAttackerLosses({
+      superSent,
+      baseSent,
+      totalLosses: result.attackerLosses,
+    });
+    const defenderLossSplit = attributeDefenderLosses({
+      superBefore: target.units,
+      baseBefore: targetBase,
+      totalLosses: result.defenderLosses,
+      outcome: result.outcome,
+      captureBaseRetentionFactor: result.captureBaseRetentionFactor,
+    });
+
+    const superSurvivors: UnitStack = {
+      ground: superSent.ground - attackerLossSplit.superLost.ground,
+      siege: superSent.siege - attackerLossSplit.superLost.siege,
+      air: superSent.air - attackerLossSplit.superLost.air,
+    };
+    const baseSurvivors: UnitStack = {
+      ground: baseSent.ground - attackerLossSplit.baseLost.ground,
+      siege: baseSent.siege - attackerLossSplit.baseLost.siege,
+      air: baseSent.air - attackerLossSplit.baseLost.air,
+    };
+
+    const sourceUnitsAfterDispatch = subtractStack(source.units, superSent);
+    const sourceBaseAfterDispatch = subtractStack(sourceBase, baseSent);
 
     let updatedSourceUnits: UnitStack;
+    let updatedSourceBase: UnitStack;
     let updatedTargetUnits: UnitStack;
+    let updatedTargetBase: UnitStack;
     let updatedTargetOwner: string | null = target.ownerId;
     let updatedTargetType: LandType = target.type;
     let updatedTargetLevel: number = target.level;
@@ -2292,18 +2551,28 @@ export async function attackTileServer(args: {
 
     if (result.outcome === "captured") {
       captured = true;
-      updatedSourceUnits = sourceAfterDispatch;
-      updatedTargetUnits = survivors;
+      // Source: sent units are gone (no return on capture).
+      updatedSourceUnits = sourceUnitsAfterDispatch;
+      updatedSourceBase = sourceBaseAfterDispatch;
+      // Target: SUPER survivors occupy as new SUPER; BASE survivors fold
+      // into the residual defender BASE that survived the capture.
+      updatedTargetUnits = superSurvivors;
+      updatedTargetBase = addStack(defenderLossSplit.newBase, baseSurvivors);
       updatedTargetOwner = args.attackerId;
       updatedTargetLevel = 0;
       updatedTargetUpgrades = [];
     } else {
-      updatedSourceUnits = addStack(sourceAfterDispatch, survivors);
-      updatedTargetUnits = subtractStack(target.units, result.defenderLosses);
+      // Survivors return home; defender keeps post-curve base+super.
+      updatedSourceUnits = addStack(sourceUnitsAfterDispatch, superSurvivors);
+      updatedSourceBase = addStack(sourceBaseAfterDispatch, baseSurvivors);
+      updatedTargetUnits = defenderLossSplit.newSuper;
+      updatedTargetBase = defenderLossSplit.newBase;
     }
 
-    const attackerLossesTotal = sumStack(result.attackerLosses);
-    const defenderLossesTotal = sumStack(result.defenderLosses);
+    // unitsAlive tracks SUPER only (food-cap-bound). BASE losses don't hit
+    // the player-level stat.
+    const attackerSuperLostTotal = sumStack(attackerLossSplit.superLost);
+    const defenderSuperLostTotal = sumStack(defenderLossSplit.superLost);
 
     const attackerTurnsSpentTotal = attacker.turnsSpentTotal + turnCost;
     const rolled = rollAndStageArtifact(
@@ -2316,9 +2585,17 @@ export async function attackTileServer(args: {
     );
     const artifact = rolled?.definition ?? null;
 
-    tx.update(sourceRef, { units: updatedSourceUnits, updatedAt: now });
+    tx.update(sourceRef, {
+      units: updatedSourceUnits,
+      baseUnits: updatedSourceBase,
+      updatedAt: now,
+    });
     tx.update(targetRef, {
       units: updatedTargetUnits,
+      baseUnits: updatedTargetBase,
+      // On capture, baseRegenedAt resets so the new owner's caste regens
+      // the residual militia from now.
+      baseRegenedAt: captured ? now : (target.baseRegenedAt ?? now),
       ownerId: updatedTargetOwner,
       type: updatedTargetType,
       level: updatedTargetLevel,
@@ -2330,13 +2607,13 @@ export async function attackTileServer(args: {
 
     const attackerStats = {
       ...attacker.stats,
-      unitsAlive: Math.max(0, attacker.stats.unitsAlive - attackerLossesTotal),
+      unitsAlive: Math.max(0, attacker.stats.unitsAlive - attackerSuperLostTotal),
       attacksWon: attacker.stats.attacksWon + (captured ? 1 : 0),
       tilesHeld: attacker.stats.tilesHeld + (captured ? 1 : 0),
     };
     const defenderStats = {
       ...defender.stats,
-      unitsAlive: Math.max(0, defender.stats.unitsAlive - defenderLossesTotal),
+      unitsAlive: Math.max(0, defender.stats.unitsAlive - defenderSuperLostTotal),
       attacksLost: defender.stats.attacksLost + (captured ? 1 : 0),
       tilesHeld: Math.max(0, defender.stats.tilesHeld - (captured ? 1 : 0)),
     };
@@ -2423,10 +2700,17 @@ export async function attackTileServer(args: {
         updatedAt: now,
       },
       defenderPlayer: { ...defender, stats: defenderStats, updatedAt: now },
-      sourceTile: { ...source, units: updatedSourceUnits, updatedAt: now },
+      sourceTile: {
+        ...source,
+        units: updatedSourceUnits,
+        baseUnits: updatedSourceBase,
+        updatedAt: now,
+      },
       targetTile: {
         ...target,
         units: updatedTargetUnits,
+        baseUnits: updatedTargetBase,
+        baseRegenedAt: captured ? now : (target.baseRegenedAt ?? now),
         ownerId: updatedTargetOwner,
         type: updatedTargetType,
         level: updatedTargetLevel,
@@ -2640,15 +2924,20 @@ export async function attackPreviewServer(args: {
   // result is identical across previews and players can't fish for outcomes.
   const midpointRng = (): number => 0.5;
 
-  // Clamp requested units to what's actually on the source tile so the
-  // projection reflects what the player could actually deploy. The real
-  // attack call rejects over-spec; here we soft-clamp instead so the panel
-  // stays useful while a player tweaks numbers.
+  // Clamp requested units to source SUPER + BASE so the projection
+  // reflects everything the player could deploy (the real attack call
+  // drafts BASE into the send pool).
+  const sourceBase: UnitStack =
+    source.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+  const targetBase: UnitStack =
+    target.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+  const sourceDeployable = addStack(source.units, sourceBase);
   const clampedUnits: UnitStack = {
-    ground: Math.min(args.units.ground, source.units.ground),
-    siege: Math.min(args.units.siege, source.units.siege),
-    air: Math.min(args.units.air, source.units.air),
+    ground: Math.min(args.units.ground, sourceDeployable.ground),
+    siege: Math.min(args.units.siege, sourceDeployable.siege),
+    air: Math.min(args.units.air, sourceDeployable.air),
   };
+  const defenderComposite = addStack(target.units, targetBase);
 
   const combat = resolveAttack(
     {
@@ -2664,7 +2953,8 @@ export async function attackPreviewServer(args: {
     },
     {
       caste: defender.caste,
-      unitsOnTile: target.units,
+      unitsOnTile: defenderComposite,
+      baseUnitsOnTile: targetBase,
       armedDefenseSpellId: target.armedDefenseSpellId,
       magicLandCount: 0,
       unitsAlive: defender.stats.unitsAlive,
@@ -2930,9 +3220,25 @@ export async function flyoverTileServer(args: {
         attacker.turnsRemaining
       );
     }
-    if (!stackHasAtLeast(source.units, args.units)) {
+    // BASE+SUPER: same draft semantics as attackTileServer.
+    const sourceBase: UnitStack =
+      source.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+    const targetBase: UnitStack =
+      target.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+    const sourceDeployable = addStack(source.units, sourceBase);
+    if (!stackHasAtLeast(sourceDeployable, args.units)) {
       throw new GameInsufficientUnitsError();
     }
+    const superSent: UnitStack = {
+      ground: Math.min(args.units.ground, source.units.ground),
+      siege: Math.min(args.units.siege, source.units.siege),
+      air: Math.min(args.units.air, source.units.air),
+    };
+    const baseSent: UnitStack = {
+      ground: args.units.ground - superSent.ground,
+      siege: args.units.siege - superSent.siege,
+      air: args.units.air - superSent.air,
+    };
 
     const defenderActiveUpgrades = defender.activeUpgrades ?? {};
     const attackerActiveUpgrades = attacker.activeUpgrades ?? {};
@@ -2957,6 +3263,7 @@ export async function flyoverTileServer(args: {
       friendlyNeighbors.push({ landType: t.type });
     }
 
+    const defenderComposite = addStack(target.units, targetBase);
     const flyoverId = randomUUID();
     const baseCombat = resolveAttack(
       {
@@ -2971,7 +3278,8 @@ export async function flyoverTileServer(args: {
       },
       {
         caste: defender.caste,
-        unitsOnTile: target.units,
+        unitsOnTile: defenderComposite,
+        baseUnitsOnTile: targetBase,
         armedDefenseSpellId: target.armedDefenseSpellId,
         magicLandCount: 0,
         unitsAlive: defender.stats.unitsAlive,
@@ -2993,31 +3301,65 @@ export async function flyoverTileServer(args: {
     // applyFlyoverModifiers so it's covered by combat tests.
     const combat = applyFlyoverModifiers(baseCombat);
 
-    // Commit unit deltas. Source loses what was sent + the doubled losses
-    // never came back; survivors return.
-    const attackerLossesTotal = sumStack(combat.attackerLosses);
-    const defenderLossesTotal = sumStack(combat.defenderLosses);
-    const survivors = subtractStack(combat.unitsDeployed, combat.attackerLosses);
-    const sourceAfterDispatch = subtractStack(source.units, args.units);
-    const updatedSourceUnits = addStack(sourceAfterDispatch, survivors);
-    const updatedTargetUnits = subtractStack(target.units, combat.defenderLosses);
+    // BASE+SUPER loss attribution (no capture branch — flyover always repels).
+    const attackerLossSplit = attributeAttackerLosses({
+      superSent,
+      baseSent,
+      totalLosses: combat.attackerLosses,
+    });
+    const defenderLossSplit = attributeDefenderLosses({
+      superBefore: target.units,
+      baseBefore: targetBase,
+      totalLosses: combat.defenderLosses,
+      outcome: combat.outcome,
+      captureBaseRetentionFactor: combat.captureBaseRetentionFactor,
+    });
+
+    const superSurvivors: UnitStack = {
+      ground: superSent.ground - attackerLossSplit.superLost.ground,
+      siege: superSent.siege - attackerLossSplit.superLost.siege,
+      air: superSent.air - attackerLossSplit.superLost.air,
+    };
+    const baseSurvivors: UnitStack = {
+      ground: baseSent.ground - attackerLossSplit.baseLost.ground,
+      siege: baseSent.siege - attackerLossSplit.baseLost.siege,
+      air: baseSent.air - attackerLossSplit.baseLost.air,
+    };
+    const updatedSourceUnits = addStack(
+      subtractStack(source.units, superSent),
+      superSurvivors
+    );
+    const updatedSourceBase = addStack(
+      subtractStack(sourceBase, baseSent),
+      baseSurvivors
+    );
+    const updatedTargetUnits = defenderLossSplit.newSuper;
+    const updatedTargetBase = defenderLossSplit.newBase;
+
+    const attackerSuperLostTotal = sumStack(attackerLossSplit.superLost);
+    const defenderSuperLostTotal = sumStack(defenderLossSplit.superLost);
 
     const turnsSpentTotal = attacker.turnsSpentTotal + turnCost;
 
-    tx.update(sourceRef, { units: updatedSourceUnits, updatedAt: now });
+    tx.update(sourceRef, {
+      units: updatedSourceUnits,
+      baseUnits: updatedSourceBase,
+      updatedAt: now,
+    });
     tx.update(targetRef, {
       units: updatedTargetUnits,
+      baseUnits: updatedTargetBase,
       lastAttackedAt: now,
       updatedAt: now,
     });
 
     const attackerStats = {
       ...attacker.stats,
-      unitsAlive: Math.max(0, attacker.stats.unitsAlive - attackerLossesTotal),
+      unitsAlive: Math.max(0, attacker.stats.unitsAlive - attackerSuperLostTotal),
     };
     const defenderStats = {
       ...defender.stats,
-      unitsAlive: Math.max(0, defender.stats.unitsAlive - defenderLossesTotal),
+      unitsAlive: Math.max(0, defender.stats.unitsAlive - defenderSuperLostTotal),
     };
 
     tx.update(attackerRef, {
@@ -3046,8 +3388,19 @@ export async function flyoverTileServer(args: {
         stats: attackerStats,
         updatedAt: now,
       },
-      sourceTile: { ...source, units: updatedSourceUnits, updatedAt: now },
-      targetTile: { ...target, units: updatedTargetUnits, lastAttackedAt: now, updatedAt: now },
+      sourceTile: {
+        ...source,
+        units: updatedSourceUnits,
+        baseUnits: updatedSourceBase,
+        updatedAt: now,
+      },
+      targetTile: {
+        ...target,
+        units: updatedTargetUnits,
+        baseUnits: updatedTargetBase,
+        lastAttackedAt: now,
+        updatedAt: now,
+      },
       report,
       combat,
     };
@@ -3940,6 +4293,15 @@ export async function frontierExploreServer(
     );
     const artifact = rolled?.definition ?? null;
 
+    const initialBaseUnits = baseUnitsTarget({
+      landType: "unassigned",
+      caste: player.caste,
+      upgradeIds: [],
+      createdAt: now,
+      activeUpgrades: player.activeUpgrades ?? {},
+      productionSpellsActive: player.productionSpellsActive,
+      now,
+    });
     const tile: GameTile = {
       tileId: sample.tileId,
       q: sample.tile.q,
@@ -3948,6 +4310,9 @@ export async function frontierExploreServer(
       type: "unassigned",
       level: 0,
       units: { ground: 0, siege: 0, air: 0 },
+      baseUnits: initialBaseUnits,
+      baseRegenedAt: now,
+      intrinsicBuffs: [],
       armedDefenseSpellId: null,
       neighborTileIds: neighborTileIds(sample.tile.q, sample.tile.r),
       upgradeIds: [],
@@ -4220,6 +4585,15 @@ export async function farExpeditionExploreServer(
     );
     const artifact = rolled?.definition ?? null;
 
+    const initialBaseUnits = baseUnitsTarget({
+      landType: "unassigned",
+      caste: player.caste,
+      upgradeIds: [],
+      createdAt: now,
+      activeUpgrades: player.activeUpgrades ?? {},
+      productionSpellsActive: player.productionSpellsActive,
+      now,
+    });
     const tile: GameTile = {
       tileId,
       q: dropCoord.q,
@@ -4228,6 +4602,9 @@ export async function farExpeditionExploreServer(
       type: "unassigned",
       level: 0,
       units: { ground: 0, siege: 0, air: 0 },
+      baseUnits: initialBaseUnits,
+      baseRegenedAt: now,
+      intrinsicBuffs: [],
       armedDefenseSpellId: null,
       neighborTileIds: neighborTileIds(dropCoord.q, dropCoord.r),
       upgradeIds: [],
@@ -4613,6 +4990,15 @@ export async function bulkFrontierExploreServer(
       const artifact = rolled?.definition ?? null;
       if (rolled) artifacts.push(rolled.doc);
 
+      const initialBaseUnits = baseUnitsTarget({
+        landType: "unassigned",
+        caste: player.caste,
+        upgradeIds: [],
+        createdAt: now,
+        activeUpgrades: player.activeUpgrades ?? {},
+        productionSpellsActive: player.productionSpellsActive,
+        now,
+      });
       const tile: GameTile = {
         tileId: sample.tileId,
         q: sample.tile.q,
@@ -4621,6 +5007,9 @@ export async function bulkFrontierExploreServer(
         type: "unassigned",
         level: 0,
         units: { ground: 0, siege: 0, air: 0 },
+        baseUnits: initialBaseUnits,
+        baseRegenedAt: now,
+        intrinsicBuffs: [],
         armedDefenseSpellId: null,
         neighborTileIds: neighborTileIds(sample.tile.q, sample.tile.r),
         upgradeIds: [],

--- a/lib/game/npc-weekly.ts
+++ b/lib/game/npc-weekly.ts
@@ -192,7 +192,16 @@ function findAttackCandidates(
 ): AttackCandidate[] {
   const candidates: AttackCandidate[] = [];
   for (const src of ctx.myMilitary) {
-    if (sumStack(src.units) < 5) continue;
+    // BASE+SUPER: NPCs can draft from both pools, so the candidate filter
+    // includes baseUnits in the deployable count. A tile with 0 SUPER and
+    // 22 BASE ground is now a viable source for raids.
+    const srcBase = src.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+    const srcDeployable = {
+      ground: src.units.ground + srcBase.ground,
+      siege: src.units.siege + srcBase.siege,
+      air: src.units.air + srcBase.air,
+    };
+    if (sumStack(srcDeployable) < 5) continue;
     for (const neighborId of src.neighborTileIds) {
       const target = world.npcTilesById.get(neighborId);
       if (!target) continue;
@@ -212,7 +221,7 @@ function findAttackCandidates(
         sourceTileId: src.tileId,
         targetTileId: target.tileId,
         defenderId: target.ownerId!,
-        sourceUnits: { ...src.units },
+        sourceUnits: srcDeployable,
         targetCapacity: open,
       });
     }

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -236,6 +236,21 @@ export interface GameTile {
   type: LandType;
   level: number;
   units: UnitStack;
+  // Intrinsic garrison ("BASE"): militia that lives on the tile regardless of
+  // recruitment. Composes with `units` (SUPER) in combat — defenders fight with
+  // base+super, attackers can draw from base+super at the source. Regenerates
+  // toward a per-tile target over wall-clock time (see baseRegenedAt).
+  // Optional for legacy docs predating the v3 schema; readers coalesce to
+  // {0,0,0} until the backfill stamps in real values.
+  baseUnits?: UnitStack;
+  // Wall-clock timestamp of the last applyBaseRegen tick. Lazy regen reads
+  // (now - baseRegenedAt) and steps baseUnits toward its target. Optional for
+  // legacy docs; coalesce to createdAt when missing.
+  baseRegenedAt?: Timestamp | Date;
+  // Tile-permanent buffs stamped by artifacts. Each entry can modify
+  // baseUnits count or per-unit stats on this tile only. Expires when
+  // expiresAt < now (null = permanent).
+  intrinsicBuffs?: IntrinsicTileBuff[];
   armedDefenseSpellId: string | null;
   neighborTileIds: string[];
   upgradeIds: string[];
@@ -251,6 +266,24 @@ export interface GameTile {
   updatedAt: Timestamp | Date;
 }
 
+// Stamped onto a tile by intrinsic-buff artifacts. baseUnitsTarget() folds
+// these in. The shape is forward-compat: future artifacts can introduce new
+// modifier types (e.g. defenseStatBonus) without breaking the schema.
+export interface IntrinsicTileBuff {
+  artifactId: string;
+  appliedAt: Timestamp | Date;
+  // Flat add to base unit counts. Stacks additively with other buffs.
+  baseCountBonus?: Partial<UnitStack>;
+  // Multiplicative bonus to per-unit defense stat on this tile. Stacks
+  // multiplicatively with other buffs and with caste profile defense.
+  defenseStatBonus?: number;
+  // Multiplicative bonus to per-unit attack stat on this tile. Stacks
+  // multiplicatively with other buffs and with caste profile attack.
+  attackStatBonus?: number;
+  // null / absent = permanent.
+  expiresAt?: Timestamp | Date;
+}
+
 // Lightweight projection of GameTile for map-fetch payloads. Strips
 // neighborTileIds (~6 strings × N tiles), upgradeIds, level, and timestamps
 // — fields the dashboard/hex-map/recruit/spells pages don't use. Tile detail
@@ -262,6 +295,10 @@ export interface MapTile {
   type: LandType;
   ownerId: string | null;
   units: UnitStack;
+  // Garrison (BASE) counts, included so map tooltips and the threat list can
+  // render correct totals. Optional for v2-snapshot back-compat — coalesce to
+  // {0,0,0} when absent.
+  baseUnits?: UnitStack;
   armedDefenseSpellId: string | null;
 }
 
@@ -311,7 +348,15 @@ export interface CombatAttackerInput {
 
 export interface CombatDefenderInput {
   caste: Caste;
+  // Composite stack (BASE garrison + SUPER reinforcements) entering combat.
+  // resolveAttack treats this as a single defender force; the server is
+  // responsible for splitting losses back into the underlying pools.
   unitsOnTile: UnitStack;
+  // BASE portion of `unitsOnTile`. Echoed onto CombatResult so the
+  // BattleReport can render "X garrison + Y reinforcements" without
+  // re-querying. Optional for legacy callers; absent ⇒ treat as 0
+  // (whole stack rendered as reinforcements).
+  baseUnitsOnTile?: UnitStack;
   armedDefenseSpellId: string | null;
   magicLandCount: number;
   unitsAlive: number;
@@ -578,7 +623,44 @@ export interface CombatResult {
     weakFace?: UnitType;
     forgeScoutsBonusApplied?: boolean;
   };
+  // BASE+SUPER combat additions ────────────────────────────────────────────
+  // finalAttack / finalDefense (the post-RNG values used to determine
+  // outcome). Surfaced so the loss-attribution helpers don't have to
+  // re-derive them and so the UI can show the closeness of the fight.
+  finalAttack: number;
+  finalDefense: number;
+  // Composite defender stack (BASE + SUPER) entering combat. Surfaced so the
+  // BattleReport can render "Defender had X" without back-deriving from
+  // post-attack tile state (which on capture is now the attacker's survivors,
+  // not the defender's losses).
+  defenderUnitsPreAttack: UnitStack;
+  // BASE portion of defenderUnitsPreAttack. The remainder is SUPER. Lets the
+  // BattleReport render "X garrison + Y reinforcements" without coupling to
+  // the server's post-attack tile state. Absent if the caller didn't supply
+  // baseUnitsOnTile in the defender input.
+  defenderBasePreAttack: UnitStack;
+  // |ratio - 1| where ratio = finalAttack / finalDefense. 0 = perfectly even,
+  // 1 = 2× one side. Drives the "Decisive / Close / Pyrrhic" labels in the
+  // BattleReport modal.
+  decisiveness: number;
+  // Human-readable tag for the loss curve that applied. One of:
+  //   "decisive-capture" | "close-capture" | "stalemate" | "close-repel" | "decisive-repel"
+  // The UI uses this for the outcome banner; combat math uses the same tag
+  // internally to scale losses.
+  lossCurveTag: LossCurveTag;
+  // Fraction of the defender's pre-attack BASE that survives capture
+  // (0..1). The server multiplies target.baseUnits by this on capture; the
+  // new owner inherits a small garrison rather than starting at zero. 1 for
+  // non-captured outcomes (BASE losses then come from the curve).
+  captureBaseRetentionFactor: number;
 }
+
+export type LossCurveTag =
+  | "decisive-capture"
+  | "close-capture"
+  | "stalemate"
+  | "close-repel"
+  | "decisive-repel";
 
 
 // =====================================================================

--- a/lib/game/world-snapshot-codec.ts
+++ b/lib/game/world-snapshot-codec.ts
@@ -13,10 +13,11 @@ import type { LandType, MapTile } from "./types";
 import { tileIdFromAxial } from "./world-gen";
 
 // Bumped when on-disk shape changes. Reader code should accept any version
-// it knows how to decode; v2 (current) reads compactTiles, v1 (legacy)
-// read tiles. Doc-shape rollbacks would require deploying a reader that
-// understands both — same pattern as today's reader.
-export const WORLD_SNAPSHOT_SCHEMA_VERSION = 2;
+// it knows how to decode; v3 (current) adds BASE-unit garrison fields
+// (bg/bs/ba) alongside the SUPER-unit fields (g/s/a). v2 omitted them; v1
+// stored the entire MapTile uncompressed. v3 readers default missing
+// baseUnits to {0,0,0}, so a v2 doc still decodes cleanly during rollout.
+export const WORLD_SNAPSHOT_SCHEMA_VERSION = 3;
 
 // Single-character codes for LandType. The on-wire form pays a per-tile
 // price for the type string in 4,000+ array entries; trimming "unrevealed"
@@ -53,12 +54,18 @@ export interface CompactTile {
   t: string;
   /** Owner userId. Omitted when null (unowned). */
   o?: string;
-  /** Ground units. Omitted when 0. */
+  /** Ground units (SUPER, recruited). Omitted when 0. */
   g?: number;
-  /** Siege units. Omitted when 0. */
+  /** Siege units (SUPER, recruited). Omitted when 0. */
   s?: number;
-  /** Air units. Omitted when 0. */
+  /** Air units (SUPER, recruited). Omitted when 0. */
   a?: number;
+  /** Ground BASE units (intrinsic garrison). Omitted when 0. v3+. */
+  bg?: number;
+  /** Siege BASE units (intrinsic garrison). Omitted when 0. v3+. */
+  bs?: number;
+  /** Air BASE units (intrinsic garrison). Omitted when 0. v3+. */
+  ba?: number;
   /** Armed defense spell id. Omitted when null. */
   d?: string;
 }
@@ -73,6 +80,10 @@ export function compactTile(tile: MapTile): CompactTile {
   if (tile.units?.ground) c.g = tile.units.ground;
   if (tile.units?.siege) c.s = tile.units.siege;
   if (tile.units?.air) c.a = tile.units.air;
+  // tile.baseUnits is optional pre-backfill; encode only non-zero entries.
+  if (tile.baseUnits?.ground) c.bg = tile.baseUnits.ground;
+  if (tile.baseUnits?.siege) c.bs = tile.baseUnits.siege;
+  if (tile.baseUnits?.air) c.ba = tile.baseUnits.air;
   if (tile.armedDefenseSpellId) c.d = tile.armedDefenseSpellId;
   return c;
 }
@@ -88,6 +99,9 @@ export function expandTile(c: CompactTile): MapTile {
     type,
     ownerId: c.o ?? null,
     units: { ground: c.g ?? 0, siege: c.s ?? 0, air: c.a ?? 0 },
+    // v2 docs predate BASE units → default to {0,0,0} so the client still
+    // renders cleanly until the next rebuild stamps real values.
+    baseUnits: { ground: c.bg ?? 0, siege: c.bs ?? 0, air: c.ba ?? 0 },
     armedDefenseSpellId: c.d ?? null,
   };
 }

--- a/lib/game/world-snapshot.ts
+++ b/lib/game/world-snapshot.ts
@@ -96,7 +96,16 @@ export async function computeWorldSnapshot(
   const [tilesSnap, playersSnap] = await Promise.all([
     db
       .collection("game_tiles")
-      .select("tileId", "q", "r", "type", "ownerId", "units", "armedDefenseSpellId")
+      .select(
+        "tileId",
+        "q",
+        "r",
+        "type",
+        "ownerId",
+        "units",
+        "baseUnits",
+        "armedDefenseSpellId"
+      )
       .get(),
     db
       .collection("game_players")
@@ -121,6 +130,9 @@ export async function computeWorldSnapshot(
       type: data.type,
       ownerId: data.ownerId ?? null,
       units: data.units,
+      // baseUnits is post-backfill (2026-05-13); tiles still missing it
+      // render as zero-base until the next read triggers lazy regen.
+      baseUnits: data.baseUnits ?? { ground: 0, siege: 0, air: 0 },
       armedDefenseSpellId: data.armedDefenseSpellId ?? null,
     };
   });

--- a/scripts/_debug-battle-stats.ts
+++ b/scripts/_debug-battle-stats.ts
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Read-only battle analytics. Pulls every doc from game_attacks and
+ * surfaces the stats we'll want before tuning combat mechanics:
+ *   - Overall outcome distribution (captured / repelled / stalemate)
+ *   - Attacker-win % by force-ratio bucket (does sending 2× units feel
+ *     decisive? are coin flips happening at 1×? are 5×+ ever upset?)
+ *   - Bloodiness: average attacker/defender loss as % of units committed
+ *   - Caste matchup matrix (attacker caste → win % vs each defender caste)
+ *   - NPC↔NPC vs NPC↔human vs human↔human breakdowns
+ *   - Spell + modifier prevalence
+ *   - Recent-vs-all comparison (today's blitz vs full history)
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import type { Caste, GameAttack, GamePlayer, UnitStack } from "../lib/game/types";
+
+const CASTES: Caste[] = ["black", "red", "white", "green", "blue"];
+
+function sumStack(s: UnitStack | undefined | null): number {
+  if (!s) return 0;
+  return (s.ground ?? 0) + (s.siege ?? 0) + (s.air ?? 0);
+}
+
+function toMs(t: GameAttack["createdAt"]): number {
+  if (!t) return 0;
+  if (t instanceof Date) return t.getTime();
+  // Firestore Timestamp shape
+  const ts = t as { toMillis?: () => number; seconds?: number };
+  if (typeof ts.toMillis === "function") return ts.toMillis();
+  if (typeof ts.seconds === "number") return ts.seconds * 1000;
+  return 0;
+}
+
+async function main(): Promise<void> {
+  const db = getAdminDb();
+  if (!db) throw new Error("no db");
+
+  // Load players first so we can label by NPC/human and grab caste backstop.
+  const playersSnap = await db.collection("game_players").get();
+  const isNpc = new Map<string, boolean>();
+  const nameByUid = new Map<string, string>();
+  for (const d of playersSnap.docs) {
+    const p = d.data() as GamePlayer & { isNpc?: boolean };
+    isNpc.set(d.id, p.isNpc === true);
+    nameByUid.set(d.id, p.displayName ?? d.id.slice(0, 6));
+  }
+
+  const attacksSnap = await db.collection("game_attacks").get();
+  const attacks: GameAttack[] = attacksSnap.docs.map((d) => ({
+    id: d.id,
+    ...(d.data() as GameAttack),
+  }));
+  attacks.sort((a, b) => toMs(a.createdAt) - toMs(b.createdAt));
+
+  if (attacks.length === 0) {
+    console.log("No attacks recorded yet.");
+    return;
+  }
+
+  console.log(`=== Battle Analytics — ${attacks.length} total attacks ===\n`);
+
+  // ── Time range
+  const firstMs = toMs(attacks[0].createdAt);
+  const lastMs = toMs(attacks[attacks.length - 1].createdAt);
+  console.log(
+    `First: ${new Date(firstMs).toISOString()}  Last: ${new Date(lastMs).toISOString()}`
+  );
+
+  // ── Overall outcome distribution
+  const outcomeCount = { captured: 0, repelled: 0, stalemate: 0 };
+  for (const a of attacks) outcomeCount[a.outcome]++;
+  const pct = (n: number) => ((100 * n) / attacks.length).toFixed(1);
+  console.log("\n── Overall outcomes");
+  console.log(
+    `  captured:  ${String(outcomeCount.captured).padStart(5)}  ${pct(outcomeCount.captured)}%`
+  );
+  console.log(
+    `  repelled:  ${String(outcomeCount.repelled).padStart(5)}  ${pct(outcomeCount.repelled)}%`
+  );
+  console.log(
+    `  stalemate: ${String(outcomeCount.stalemate).padStart(5)}  ${pct(outcomeCount.stalemate)}%`
+  );
+
+  // ── Attacker-side counts: NPC vs Human
+  const buckets = {
+    npcVsNpc: { total: 0, captured: 0, repelled: 0, stalemate: 0 },
+    npcVsHuman: { total: 0, captured: 0, repelled: 0, stalemate: 0 },
+    humanVsNpc: { total: 0, captured: 0, repelled: 0, stalemate: 0 },
+    humanVsHuman: { total: 0, captured: 0, repelled: 0, stalemate: 0 },
+  };
+  for (const a of attacks) {
+    const aIsNpc = isNpc.get(a.attackerId) ?? false;
+    const dIsNpc = isNpc.get(a.defenderId) ?? false;
+    const key = aIsNpc
+      ? dIsNpc
+        ? "npcVsNpc"
+        : "npcVsHuman"
+      : dIsNpc
+        ? "humanVsNpc"
+        : "humanVsHuman";
+    buckets[key].total++;
+    buckets[key][a.outcome]++;
+  }
+  console.log("\n── NPC vs Human (attacker→defender)");
+  for (const [k, b] of Object.entries(buckets)) {
+    if (b.total === 0) continue;
+    const winRate = ((100 * b.captured) / b.total).toFixed(1);
+    console.log(
+      `  ${k.padEnd(14)}: ${String(b.total).padStart(5)} attacks · cap=${b.captured} rep=${b.repelled} sta=${b.stalemate} · attacker-win ${winRate}%`
+    );
+  }
+
+  // ── Force-ratio bucket vs outcome
+  // Ratio = units sent / (defender units on the tile at moment of attack).
+  // We approximate "defender units" from defenderLosses + (we don't have
+  // post-tile state here, just GameAttack record). Best estimate: defender
+  // had at least `unitsLostDefender` units, and on capture they had exactly
+  // that many; on repel they had more but we can't recover the exact figure
+  // from the attack doc. Use unitsLostDefender as the floor.
+  console.log(
+    "\n── Force-ratio (units-sent / defender-units-lost) vs outcome"
+  );
+  const ratioBuckets = [
+    { label: "≤0.5×  (outnumbered 2:1+)", min: 0, max: 0.5 },
+    { label: "0.5–0.9× (underdog)", min: 0.5, max: 0.9 },
+    { label: "0.9–1.1× (even)", min: 0.9, max: 1.1 },
+    { label: "1.1–2×  (favored)", min: 1.1, max: 2.0 },
+    { label: "2–5×   (overwhelming)", min: 2.0, max: 5.0 },
+    { label: "5×+    (steamroll)", min: 5.0, max: Infinity },
+  ];
+  const ratioRows = ratioBuckets.map((b) => ({
+    ...b,
+    total: 0,
+    captured: 0,
+    repelled: 0,
+    stalemate: 0,
+  }));
+  let undefRatio = 0;
+  for (const a of attacks) {
+    const sent = sumStack(a.unitsSent);
+    const defLost = sumStack(a.unitsLostDefender);
+    if (defLost === 0) {
+      undefRatio++;
+      continue;
+    }
+    const r = sent / defLost;
+    for (const row of ratioRows) {
+      if (r >= row.min && r < row.max) {
+        row.total++;
+        row[a.outcome]++;
+        break;
+      }
+    }
+  }
+  for (const r of ratioRows) {
+    if (r.total === 0) continue;
+    const winRate = ((100 * r.captured) / r.total).toFixed(1);
+    console.log(
+      `  ${r.label.padEnd(28)}: n=${String(r.total).padStart(5)} cap=${r.captured} rep=${r.repelled} · win ${winRate}%`
+    );
+  }
+  if (undefRatio > 0) {
+    console.log(
+      `  (skipped ${undefRatio} attacks where defenderLost=0 — empty-tile claims or instant repels)`
+    );
+  }
+
+  // ── Bloodiness: average attacker loss / sent, defender loss / lost
+  console.log("\n── Bloodiness (per-outcome averages)");
+  for (const outcome of ["captured", "repelled", "stalemate"] as const) {
+    const subset = attacks.filter((a) => a.outcome === outcome);
+    if (subset.length === 0) continue;
+    let aLostPctSum = 0;
+    let aLostCount = 0;
+    let dLostSum = 0;
+    let sentSum = 0;
+    let aLostSum = 0;
+    for (const a of subset) {
+      const sent = sumStack(a.unitsSent);
+      const aLost = sumStack(a.unitsLostAttacker);
+      const dLost = sumStack(a.unitsLostDefender);
+      sentSum += sent;
+      aLostSum += aLost;
+      dLostSum += dLost;
+      if (sent > 0) {
+        aLostPctSum += aLost / sent;
+        aLostCount++;
+      }
+    }
+    const avgAttackerLossPct = aLostCount > 0 ? (100 * aLostPctSum) / aLostCount : 0;
+    console.log(
+      `  ${outcome.padEnd(10)}: n=${String(subset.length).padStart(5)}  ` +
+        `avg sent=${(sentSum / subset.length).toFixed(1)}  ` +
+        `avg attacker-lost=${(aLostSum / subset.length).toFixed(1)} (${avgAttackerLossPct.toFixed(1)}% of sent)  ` +
+        `avg defender-lost=${(dLostSum / subset.length).toFixed(1)}`
+    );
+  }
+
+  // ── Caste matchup matrix (attacker → defender win %)
+  console.log("\n── Caste matchup: attacker-win % (rows=attacker, cols=defender, n in parens)");
+  const matrix = new Map<string, { total: number; cap: number }>();
+  for (const a of attacks) {
+    if (!a.casteAttacker || !a.casteDefender) continue;
+    const k = `${a.casteAttacker}|${a.casteDefender}`;
+    const cur = matrix.get(k) ?? { total: 0, cap: 0 };
+    cur.total++;
+    if (a.outcome === "captured") cur.cap++;
+    matrix.set(k, cur);
+  }
+  const headerCells = CASTES.map((c) => c.padStart(11));
+  console.log(`            ${headerCells.join(" ")}`);
+  for (const atk of CASTES) {
+    const cells: string[] = [];
+    for (const def of CASTES) {
+      const cell = matrix.get(`${atk}|${def}`);
+      if (!cell || cell.total === 0) {
+        cells.push("       —   ");
+      } else {
+        const wr = ((100 * cell.cap) / cell.total).toFixed(0);
+        cells.push(`${wr}% (n=${cell.total})`.padStart(11));
+      }
+    }
+    console.log(`  ${atk.padEnd(9)} ${cells.join(" ")}`);
+  }
+
+  // ── Spell prevalence
+  let withOffense = 0;
+  let withDefense = 0;
+  const offenseById = new Map<string, number>();
+  const defenseById = new Map<string, number>();
+  for (const a of attacks) {
+    if (a.offenseSpellId) {
+      withOffense++;
+      offenseById.set(a.offenseSpellId, (offenseById.get(a.offenseSpellId) ?? 0) + 1);
+    }
+    if (a.defenseSpellId) {
+      withDefense++;
+      defenseById.set(a.defenseSpellId, (defenseById.get(a.defenseSpellId) ?? 0) + 1);
+    }
+  }
+  console.log("\n── Spell prevalence");
+  console.log(`  with offense spell: ${withOffense}  (${pct(withOffense)}%)`);
+  console.log(`  with defense spell: ${withDefense}  (${pct(withDefense)}%)`);
+  if (offenseById.size > 0) {
+    console.log("  offense spells used:");
+    for (const [id, n] of [...offenseById.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${id.padEnd(30)} ${n}`);
+    }
+  }
+  if (defenseById.size > 0) {
+    console.log("  defense spells triggered:");
+    for (const [id, n] of [...defenseById.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${id.padEnd(30)} ${n}`);
+    }
+  }
+
+  // ── Top attackers
+  console.log("\n── Top 10 attackers (by attack count)");
+  const byAttacker = new Map<string, { total: number; cap: number; rep: number }>();
+  for (const a of attacks) {
+    const cur = byAttacker.get(a.attackerId) ?? { total: 0, cap: 0, rep: 0 };
+    cur.total++;
+    if (a.outcome === "captured") cur.cap++;
+    else if (a.outcome === "repelled") cur.rep++;
+    byAttacker.set(a.attackerId, cur);
+  }
+  const sortedAttackers = [...byAttacker.entries()].sort((a, b) => b[1].total - a[1].total);
+  for (const [uid, s] of sortedAttackers.slice(0, 10)) {
+    const tag = isNpc.get(uid) ? "[NPC]" : "[hum]";
+    const wr = ((100 * s.cap) / s.total).toFixed(0);
+    console.log(
+      `  ${tag} ${(nameByUid.get(uid) ?? uid).padEnd(28)} n=${String(s.total).padStart(4)}  cap=${s.cap} rep=${s.rep}  win ${wr}%`
+    );
+  }
+
+  // ── Top defenders (most attacked)
+  console.log("\n── Top 10 defenders (most attacked)");
+  const byDefender = new Map<string, { total: number; lost: number; held: number }>();
+  for (const a of attacks) {
+    const cur = byDefender.get(a.defenderId) ?? { total: 0, lost: 0, held: 0 };
+    cur.total++;
+    if (a.outcome === "captured") cur.lost++;
+    else if (a.outcome === "repelled") cur.held++;
+    byDefender.set(a.defenderId, cur);
+  }
+  const sortedDefenders = [...byDefender.entries()].sort((a, b) => b[1].total - a[1].total);
+  for (const [uid, s] of sortedDefenders.slice(0, 10)) {
+    const tag = isNpc.get(uid) ? "[NPC]" : "[hum]";
+    const lossRate = ((100 * s.lost) / s.total).toFixed(0);
+    console.log(
+      `  ${tag} ${(nameByUid.get(uid) ?? uid).padEnd(28)} attacked=${String(s.total).padStart(4)}  tiles-lost=${s.lost}  held=${s.held}  loss-rate ${lossRate}%`
+    );
+  }
+
+  // ── Today's blitz subset vs full history
+  // Today started ~2026-05-13 00:00 UTC.
+  const todayStart = new Date("2026-05-13T00:00:00Z").getTime();
+  const todayAttacks = attacks.filter((a) => toMs(a.createdAt) >= todayStart);
+  if (todayAttacks.length > 0 && todayAttacks.length < attacks.length) {
+    console.log(`\n── Today's subset (${todayAttacks.length}/${attacks.length} attacks since 2026-05-13)`);
+    const t = { captured: 0, repelled: 0, stalemate: 0 };
+    for (const a of todayAttacks) t[a.outcome]++;
+    const tPct = (n: number) => ((100 * n) / todayAttacks.length).toFixed(1);
+    console.log(`  captured ${t.captured} (${tPct(t.captured)}%)  repelled ${t.repelled} (${tPct(t.repelled)}%)  stalemate ${t.stalemate} (${tPct(t.stalemate)}%)`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_debug-npc-adjacency.ts
+++ b/scripts/_debug-npc-adjacency.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Throwaway diagnostic: for every NPC tile, count neighbor ownership
+ * buckets (self / other NPC / human / unowned / missing). Tells us
+ * whether NPCs are geographically able to attack anyone at all.
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import type { GamePlayer, GameTile } from "../lib/game/types";
+
+async function main(): Promise<void> {
+  const db = getAdminDb();
+  if (!db) throw new Error("no db");
+
+  const playersSnap = await db.collection("game_players").get();
+  const isNpc = new Map<string, boolean>();
+  const displayByUid = new Map<string, string>();
+  for (const d of playersSnap.docs) {
+    const p = d.data() as GamePlayer & { isNpc?: boolean };
+    isNpc.set(d.id, p.isNpc === true);
+    displayByUid.set(d.id, p.displayName ?? d.id.slice(0, 6));
+  }
+
+  const tilesSnap = await db.collection("game_tiles").get();
+  const tilesById = new Map<string, GameTile>();
+  for (const d of tilesSnap.docs) tilesById.set(d.id, d.data() as GameTile);
+
+  let npcTileCount = 0;
+  let npcMilitaryTileCount = 0;
+  let neighborsSelf = 0;
+  let neighborsOtherNpc = 0;
+  let neighborsHuman = 0;
+  let neighborsUnowned = 0;
+  let neighborsMissing = 0;
+
+  // Per-NPC: count military tiles with at least one other-NPC neighbor.
+  const perNpc = new Map<
+    string,
+    { militaryTiles: number; militaryBorderingOtherNpc: number; sampleBorder?: string }
+  >();
+
+  for (const t of tilesById.values()) {
+    if (!t.ownerId || !isNpc.get(t.ownerId)) continue;
+    npcTileCount += 1;
+    if (t.type !== "military") continue;
+    npcMilitaryTileCount += 1;
+
+    const stats = perNpc.get(t.ownerId) ?? {
+      militaryTiles: 0,
+      militaryBorderingOtherNpc: 0,
+    };
+    stats.militaryTiles += 1;
+
+    let bordersOtherNpc = false;
+    for (const nid of t.neighborTileIds ?? []) {
+      const n = tilesById.get(nid);
+      if (!n) {
+        neighborsMissing += 1;
+        continue;
+      }
+      if (!n.ownerId) {
+        neighborsUnowned += 1;
+        continue;
+      }
+      if (n.ownerId === t.ownerId) {
+        neighborsSelf += 1;
+        continue;
+      }
+      if (isNpc.get(n.ownerId)) {
+        neighborsOtherNpc += 1;
+        bordersOtherNpc = true;
+        if (!stats.sampleBorder) {
+          stats.sampleBorder = `${t.tileId}→${n.tileId} (${displayByUid.get(n.ownerId)})`;
+        }
+      } else {
+        neighborsHuman += 1;
+      }
+    }
+    if (bordersOtherNpc) stats.militaryBorderingOtherNpc += 1;
+    perNpc.set(t.ownerId, stats);
+  }
+
+  console.log("=== NPC adjacency diagnostic ===");
+  console.log(`NPC tiles total: ${npcTileCount}, military: ${npcMilitaryTileCount}`);
+  console.log("Neighbor ownership buckets across all NPC-military tiles:");
+  console.log(`  same owner (self): ${neighborsSelf}`);
+  console.log(`  other NPC:         ${neighborsOtherNpc}`);
+  console.log(`  human:             ${neighborsHuman}`);
+  console.log(`  unowned:           ${neighborsUnowned}`);
+  console.log(`  missing tile:      ${neighborsMissing}`);
+  console.log();
+  console.log("Per-NPC summary (any military tile bordering another NPC?):");
+  let npcsWithBorders = 0;
+  for (const [uid, s] of [...perNpc.entries()].sort()) {
+    const flag = s.militaryBorderingOtherNpc > 0 ? "YES" : "no ";
+    if (s.militaryBorderingOtherNpc > 0) npcsWithBorders += 1;
+    console.log(
+      `  [${flag}] ${(displayByUid.get(uid) ?? uid).padEnd(28)} ` +
+        `mil=${s.militaryTiles} borderingOtherNpc=${s.militaryBorderingOtherNpc}` +
+        (s.sampleBorder ? `  e.g. ${s.sampleBorder}` : "")
+    );
+  }
+  console.log(`\nTotal NPCs with at least one NPC-vs-NPC military border: ${npcsWithBorders}/${perNpc.size}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/_debug-npc-turns.ts
+++ b/scripts/_debug-npc-turns.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Throwaway: list every NPC's current turnsRemaining, sorted descending.
+ * Answers "have they all spent their turns?" without inferring from logs.
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import type { GamePlayer } from "../lib/game/types";
+
+async function main(): Promise<void> {
+  const db = getAdminDb();
+  if (!db) throw new Error("no db");
+  const snap = await db
+    .collection("game_players")
+    .where("isNpc", "==", true)
+    .get();
+
+  const rows = snap.docs.map((d) => {
+    const p = d.data() as GamePlayer;
+    return {
+      name: p.displayName ?? d.id.slice(0, 6),
+      caste: p.caste ?? "—",
+      turns: p.turnsRemaining ?? 0,
+      tiles: p.stats?.tilesHeld ?? 0,
+      unitsAlive: p.stats?.unitsAlive ?? 0,
+    };
+  });
+  rows.sort((a, b) => b.turns - a.turns);
+
+  const total = rows.reduce((s, r) => s + r.turns, 0);
+  const buckets = {
+    over100: rows.filter((r) => r.turns > 100).length,
+    "50-100": rows.filter((r) => r.turns >= 50 && r.turns <= 100).length,
+    "10-49": rows.filter((r) => r.turns >= 10 && r.turns < 50).length,
+    under10: rows.filter((r) => r.turns < 10).length,
+  };
+
+  console.log(`=== NPC turnsRemaining (${rows.length} NPCs) ===`);
+  for (const r of rows) {
+    console.log(
+      `  ${String(r.turns).padStart(4)}t  ${r.name.padEnd(28)} caste=${r.caste.padEnd(6)} tiles=${String(r.tiles).padStart(4)} units=${String(r.unitsAlive).padStart(4)}`
+    );
+  }
+  console.log(`\nTotal turns banked across NPCs: ${total}`);
+  console.log(
+    `Buckets — >100: ${buckets.over100}, 50–100: ${buckets["50-100"]}, 10–49: ${buckets["10-49"]}, <10: ${buckets.under10}`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/backfill-tile-base-units.ts
+++ b/scripts/backfill-tile-base-units.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-off backfill: stamp `baseUnits`, `baseRegenedAt`, `intrinsicBuffs` on
+ * every existing `game_tiles` document so the BASE+SUPER combat redesign
+ * has data to read against. Computes `baseUnits` via `baseUnitsTarget()`
+ * with the owner's caste + tile's age (entrenchment).
+ *
+ * Idempotent via `_baseFieldsBackfillKey === BACKFILL_KEY` — re-running is
+ * a no-op for tiles already stamped. Pass --force to re-stamp regardless
+ * (useful after rebalancing LAND_TYPE_BASE numbers).
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-tile-base-units.ts             # dry-run (default)
+ *   npx tsx scripts/backfill-tile-base-units.ts --apply     # commit
+ *   npx tsx scripts/backfill-tile-base-units.ts --apply --force
+ *   npx tsx scripts/backfill-tile-base-units.ts --limit=50  # sample N tiles
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { baseUnitsTarget } from "../lib/game/combat";
+import type { GamePlayer, GameTile, UnitStack } from "../lib/game/types";
+
+const BACKFILL_KEY = "2026-05-13-base-units";
+const STAMP_FIELD = "_baseFieldsBackfillKey";
+const PLAYERS = "game_players";
+const TILES = "game_tiles";
+const BATCH_CHUNK = 400; // Firestore caps a single batch at 500 ops; leave headroom.
+
+function sumStack(s: UnitStack): number {
+  return s.ground + s.siege + s.air;
+}
+
+function toDate(t: GameTile["createdAt"]): Date {
+  if (t instanceof Date) return t;
+  const ts = t as Timestamp;
+  return ts.toDate();
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  const force = process.argv.includes("--force");
+  const limitArg = process.argv.find((a) => a.startsWith("--limit="));
+  const limit = limitArg
+    ? Number.parseInt(limitArg.slice("--limit=".length), 10)
+    : null;
+  const dryRun = !apply;
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log(
+    `[backfill-base-units] mode=${dryRun ? "DRY-RUN" : "APPLY"} ` +
+      `stamp=${STAMP_FIELD}=${BACKFILL_KEY} force=${force} limit=${limit ?? "all"}`
+  );
+
+  // Load every player so we can look up caste + activeUpgrades for owned
+  // tiles. Single read; cheap relative to the 5k+ tile sweep.
+  const playersSnap = await db.collection(PLAYERS).get();
+  const players = new Map<string, GamePlayer>();
+  for (const d of playersSnap.docs) {
+    players.set(d.id, d.data() as GamePlayer);
+  }
+  console.log(`[backfill-base-units] Loaded ${players.size} player(s).`);
+
+  const tilesSnap = await db.collection(TILES).get();
+  console.log(`[backfill-base-units] Loaded ${tilesSnap.size} tile(s).`);
+
+  const now = new Date();
+  let alreadyStamped = 0;
+  let plannedUpdates: Array<{
+    tileId: string;
+    tile: GameTile;
+    baseUnits: UnitStack;
+    ownerLabel: string;
+  }> = [];
+
+  for (const doc of tilesSnap.docs) {
+    const tile = doc.data() as GameTile & {
+      [STAMP_FIELD]?: string;
+    };
+    if (!force && tile[STAMP_FIELD] === BACKFILL_KEY) {
+      alreadyStamped += 1;
+      continue;
+    }
+    const owner = tile.ownerId ? players.get(tile.ownerId) ?? null : null;
+    const baseUnits = baseUnitsTarget({
+      landType: tile.type,
+      caste: owner?.caste ?? null,
+      upgradeIds: tile.upgradeIds,
+      intrinsicBuffs: tile.intrinsicBuffs,
+      createdAt: toDate(tile.createdAt),
+      activeUpgrades: owner?.activeUpgrades ?? {},
+      productionSpellsActive: owner?.productionSpellsActive,
+      now,
+    });
+    plannedUpdates.push({
+      tileId: doc.id,
+      tile,
+      baseUnits,
+      ownerLabel: owner?.displayName ?? (tile.ownerId ? tile.ownerId.slice(0, 6) : "—"),
+    });
+  }
+  if (limit !== null) plannedUpdates = plannedUpdates.slice(0, limit);
+
+  // ── Summary distribution
+  const byType = new Map<string, { count: number; sumBase: number }>();
+  for (const p of plannedUpdates) {
+    const k = p.tile.type;
+    const cur = byType.get(k) ?? { count: 0, sumBase: 0 };
+    cur.count += 1;
+    cur.sumBase += sumStack(p.baseUnits);
+    byType.set(k, cur);
+  }
+  console.log(
+    `[backfill-base-units] Plan: ${plannedUpdates.length} update(s), already-stamped: ${alreadyStamped}`
+  );
+  for (const [type, s] of [...byType.entries()].sort()) {
+    const avg = s.count === 0 ? 0 : (s.sumBase / s.count).toFixed(1);
+    console.log(
+      `  ${type.padEnd(12)} count=${String(s.count).padStart(5)} avg-base=${avg}`
+    );
+  }
+  if (plannedUpdates.length > 0) {
+    console.log("\n[backfill-base-units] Sample (first 5):");
+    for (const p of plannedUpdates.slice(0, 5)) {
+      const bu = p.baseUnits;
+      console.log(
+        `  ${p.tileId.padEnd(10)} type=${p.tile.type.padEnd(11)} owner=${p.ownerLabel.padEnd(22)} ` +
+          `base=g${bu.ground}/s${bu.siege}/a${bu.air} (Σ${sumStack(bu)})`
+      );
+    }
+  }
+
+  if (dryRun) {
+    console.log("\n[backfill-base-units] DRY-RUN: no writes.");
+    return;
+  }
+
+  // ── Commit in batches
+  let written = 0;
+  let batch = db.batch();
+  let opsInBatch = 0;
+  for (const p of plannedUpdates) {
+    const ref = db.collection(TILES).doc(p.tileId);
+    batch.update(ref, {
+      baseUnits: p.baseUnits,
+      baseRegenedAt: now,
+      intrinsicBuffs: p.tile.intrinsicBuffs ?? [],
+      [STAMP_FIELD]: BACKFILL_KEY,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    opsInBatch += 1;
+    if (opsInBatch >= BATCH_CHUNK) {
+      await batch.commit();
+      written += opsInBatch;
+      console.log(`[backfill-base-units] Committed ${written}/${plannedUpdates.length}`);
+      batch = db.batch();
+      opsInBatch = 0;
+    }
+  }
+  if (opsInBatch > 0) {
+    await batch.commit();
+    written += opsInBatch;
+  }
+  console.log(`\n[backfill-base-units] Done. Updated ${written} tile(s).`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/run-npc-50-attack-blitz.ts
+++ b/scripts/run-npc-50-attack-blitz.ts
@@ -1,0 +1,715 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-off NPC blitz: grant +50 turns to every NPC, then spend those turns
+ * attack-first. Fallback when an NPC has no attack candidates:
+ *   - bordering enemy tiles but source < 5 units ⇒ recruit 1 cycle (+10 units,
+ *     5 turns) on the bordering tile with the most enemy neighbors, then loop.
+ *   - no bordering enemy tiles ⇒ bail (the NPC is isolated and can't act).
+ *
+ * Idempotent via `npcBlitzGrantKey` on the player doc — re-running with the
+ * same GRANT_KEY skips NPCs already granted this round. Dry-run is the
+ * default; pass --apply to actually write.
+ *
+ * Usage:
+ *   npx tsx scripts/run-npc-50-attack-blitz.ts                 # dry-run
+ *   npx tsx scripts/run-npc-50-attack-blitz.ts --apply         # commit
+ *   npx tsx scripts/run-npc-50-attack-blitz.ts --apply --limit=5
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON (admin SDK).
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import {
+  attackTileServer,
+  bulkBuildUnitsServer,
+  distributeTileServer,
+  farExpeditionExploreServer,
+  FAR_EXPEDITION_TURN_COST,
+} from "../lib/game/data-server";
+import { computeTileCapacity } from "../lib/game/combat";
+import { effectiveUnitCap, isShieldActive } from "../lib/game/turns";
+import { rebuildWorldSnapshotServer } from "../lib/game/world-snapshot";
+import type { GamePlayer, GameTile, UnitStack, UnitType } from "../lib/game/types";
+
+
+const TURNS_GRANTED = 50;
+const GRANT_KEY = "2026-05-13-npc-blitz";
+const GRANT_STAMP_FIELD = "npcBlitzGrantKey";
+const PLAYERS = "game_players";
+const TILES = "game_tiles";
+
+// Mirrors PERSONAS in lib/game/npc-weekly.ts. Duplicated intentionally —
+// this is a one-off blitz and we don't want to widen the lib's public API
+// for a script that gets archived after it runs.
+type PersonaName =
+  | "builder"
+  | "raider"
+  | "magus"
+  | "diplomat"
+  | "warmonger"
+  | "tactician";
+
+interface Persona {
+  preferredUnit: UnitType | null;
+  deployFraction: number;
+}
+
+const PERSONAS: Record<PersonaName, Persona> = {
+  builder:   { preferredUnit: null,     deployFraction: 0.5 },
+  diplomat:  { preferredUnit: null,     deployFraction: 0.4 },
+  tactician: { preferredUnit: null,     deployFraction: 0.65 },
+  magus:     { preferredUnit: "air",    deployFraction: 0.6 },
+  raider:    { preferredUnit: "ground", deployFraction: 0.7 },
+  warmonger: { preferredUnit: "siege",  deployFraction: 0.8 },
+};
+const PERSONA_NAMES: PersonaName[] = Object.keys(PERSONAS) as PersonaName[];
+
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = (h * 33) ^ s.charCodeAt(i);
+  return h >>> 0;
+}
+
+function personaNameForUid(uid: string): PersonaName {
+  return PERSONA_NAMES[djb2(uid) % PERSONA_NAMES.length]!;
+}
+
+function sumStack(s: UnitStack): number {
+  return s.ground + s.siege + s.air;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// World snapshot — every player (NPC + human) and every tile. Humans are
+// included because in this world only ~1/50 NPCs has an NPC-vs-NPC border;
+// the rest only border humans. The blitz widens findAttackCandidates to
+// allow human defenders so attacks actually fire.
+// ──────────────────────────────────────────────────────────────────────────
+interface World {
+  allPlayers: Map<string, GamePlayer>;
+  isNpc: Map<string, boolean>;
+  tilesById: Map<string, GameTile>;
+}
+
+async function loadWorld(db: Firestore): Promise<World> {
+  const playersSnap = await db.collection(PLAYERS).get();
+  const allPlayers = new Map<string, GamePlayer>();
+  const isNpc = new Map<string, boolean>();
+  for (const d of playersSnap.docs) {
+    const p = d.data() as GamePlayer & { isNpc?: boolean };
+    allPlayers.set(d.id, p);
+    isNpc.set(d.id, p.isNpc === true);
+  }
+
+  const tilesSnap = await db.collection(TILES).get();
+  const tilesById = new Map<string, GameTile>();
+  for (const d of tilesSnap.docs) {
+    tilesById.set(d.id, d.data() as GameTile);
+  }
+  return { allPlayers, isNpc, tilesById };
+}
+
+async function refreshMyTiles(db: Firestore, uid: string): Promise<GameTile[]> {
+  const snap = await db.collection(TILES).where("ownerId", "==", uid).get();
+  return snap.docs.map((d) => d.data() as GameTile);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Attack candidate scoring — mirrors npc-weekly.ts but without RNG noise
+// (we want deterministic dry-run output) and never targets humans.
+// ──────────────────────────────────────────────────────────────────────────
+interface AttackCandidate {
+  sourceTileId: string;
+  targetTileId: string;
+  defenderId: string;
+  sourceUnits: UnitStack;
+  targetCapacity: number;
+}
+
+function findAttackCandidates(
+  attackerUid: string,
+  myMilitary: GameTile[],
+  world: World,
+  now: Date
+): AttackCandidate[] {
+  const out: AttackCandidate[] = [];
+  for (const src of myMilitary) {
+    if (sumStack(src.units) < 5) continue;
+    for (const neighborId of src.neighborTileIds) {
+      const target = world.tilesById.get(neighborId);
+      if (!target) continue; // frontier / unrevealed
+      if (!target.ownerId) continue; // unowned (no one to attack)
+      if (target.ownerId === attackerUid) continue;
+      const defender = world.allPlayers.get(target.ownerId);
+      if (!defender) continue;
+      if (isShieldActive(defender, now)) continue;
+      const cap = computeTileCapacity(
+        target.type,
+        defender.caste,
+        target.upgradeIds,
+        defender.activeUpgrades ?? {}
+      );
+      const open = Math.max(0, cap - sumStack(target.units));
+      if (open < 1) continue;
+      out.push({
+        sourceTileId: src.tileId,
+        targetTileId: target.tileId,
+        defenderId: target.ownerId,
+        sourceUnits: { ...src.units },
+        targetCapacity: open,
+      });
+    }
+  }
+  return out;
+}
+
+function scoreCandidate(c: AttackCandidate, persona: Persona): number {
+  const total = sumStack(c.sourceUnits);
+  const boost = persona.preferredUnit
+    ? c.sourceUnits[persona.preferredUnit] / Math.max(1, total)
+    : 0.5;
+  return total * 1.0 + boost * 50 + c.targetCapacity * 0.1;
+}
+
+function pickUnitsToSend(
+  src: UnitStack,
+  persona: Persona,
+  capRoom: number
+): UnitStack {
+  const total = sumStack(src);
+  if (total <= 0 || capRoom <= 0) return { ground: 0, siege: 0, air: 0 };
+  let want = Math.min(Math.floor(total * persona.deployFraction), capRoom);
+  if (want <= 0) want = Math.min(1, total, capRoom);
+  const result: UnitStack = { ground: 0, siege: 0, air: 0 };
+  let remaining = want;
+  const order: UnitType[] = persona.preferredUnit
+    ? [
+        persona.preferredUnit,
+        ...(["ground", "siege", "air"] as UnitType[]).filter(
+          (t) => t !== persona.preferredUnit
+        ),
+      ]
+    : ["ground", "siege", "air"];
+  for (const t of order) {
+    if (remaining <= 0) break;
+    const take = Math.min(src[t], remaining);
+    result[t] = take;
+    remaining -= take;
+  }
+  return result;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Per-NPC blitz loop
+// ──────────────────────────────────────────────────────────────────────────
+interface NpcStats {
+  uid: string;
+  displayName: string;
+  persona: PersonaName;
+  turnsBefore: number;
+  turnsAfter: number;
+  attacks: number;
+  captured: number;
+  repelled: number;
+  stalemate: number;
+  recruitsCycles: number;
+  expansions: number;
+  bailReason: string | null;
+}
+
+async function runOneNpc(args: {
+  db: Firestore;
+  player: GamePlayer;
+  turnsBefore: number;
+  world: World;
+  dryRun: boolean;
+  now: Date;
+  personaName: PersonaName;
+  expand: boolean;
+  budgetCeiling: number;
+}): Promise<NpcStats> {
+  const { db, world, dryRun, now, personaName, expand, budgetCeiling } = args;
+  let player = args.player;
+  const uid = player.userId;
+  const persona = PERSONAS[personaName];
+
+  const stats: NpcStats = {
+    uid,
+    displayName: player.displayName,
+    persona: personaName,
+    turnsBefore: args.turnsBefore,
+    turnsAfter: player.turnsRemaining,
+    attacks: 0,
+    captured: 0,
+    repelled: 0,
+    stalemate: 0,
+    recruitsCycles: 0,
+    expansions: 0,
+    bailReason: null,
+  };
+
+  if (!player.caste) {
+    stats.bailReason = "no caste";
+    return stats;
+  }
+
+  let myTiles: GameTile[] = dryRun
+    ? [...world.tilesById.values()]
+        .filter((t) => t.ownerId === uid)
+        .map((t) => ({ ...t, units: { ...t.units } }))
+    : await refreshMyTiles(db, uid);
+  let myMilitary = myTiles.filter((t) => t.type === "military");
+  let myFood = myTiles.filter((t) => t.type === "food").length;
+  let myMagic = myTiles.filter((t) => t.type === "magic").length;
+
+  // In --expand mode we drain the NPC's turn bucket — keep cycling attack /
+  // recruit / expand until they're truly stuck. In blitz mode we cap at
+  // budgetCeiling so the +50 grant isn't an unbounded spend trigger.
+  let spent = 0;
+  const noBudget = expand;
+  const maxIters = 500;
+  let iter = 0;
+
+  // ── Closures share local state (player, spent, myFood, myMagic, etc.). ──
+  async function plantFoodTile(): Promise<boolean> {
+    if (player.turnsRemaining < 3) return false;
+    if (!noBudget && spent + 3 > budgetCeiling) return false;
+    if (dryRun) {
+      spent += 3;
+      myFood += 1;
+      player = { ...player, turnsRemaining: player.turnsRemaining - 3 };
+      return true;
+    }
+    try {
+      const fxR = await farExpeditionExploreServer(uid, now);
+      player = fxR.player;
+      spent += FAR_EXPEDITION_TURN_COST;
+      const id = fxR.tile.tileId;
+      world.tilesById.set(id, fxR.tile);
+      const dR = await distributeTileServer(uid, id, "food", now);
+      player = dR.player;
+      spent += 1;
+      world.tilesById.set(id, dR.tile);
+      myFood += 1;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Recruit 1 cycle on the given military tile. If the server rejects with a
+  // cap error (or stoppedEarly because cap), plant a food tile and retry —
+  // food tiles raise the cap by +5 each, military cycle wants +10 units.
+  // Hard upper bound on food plants prevents a runaway loop if the server
+  // keeps rejecting for non-cap reasons.
+  async function recruitWithFoodFallback(
+    tileId: string,
+    unitType: UnitType
+  ): Promise<boolean> {
+    const MAX_FOOD_RETRIES = 40;
+    for (let attempt = 0; attempt < MAX_FOOD_RETRIES; attempt++) {
+      const cap = effectiveUnitCap(player, myFood, myMagic);
+      if (player.stats.unitsAlive + 10 > cap) {
+        if (!(await plantFoodTile())) return false;
+        continue;
+      }
+      if (player.turnsRemaining < 5) return false;
+      if (!noBudget && spent + 5 > budgetCeiling) return false;
+
+      if (dryRun) {
+        spent += 5;
+        stats.recruitsCycles += 1;
+        player = {
+          ...player,
+          turnsRemaining: player.turnsRemaining - 5,
+          stats: { ...player.stats, unitsAlive: player.stats.unitsAlive + 10 },
+        };
+        const src = myMilitary.find((t) => t.tileId === tileId);
+        if (src) src.units = { ...src.units, [unitType]: src.units[unitType] + 10 };
+        return true;
+      }
+
+      try {
+        const r = await bulkBuildUnitsServer(
+          uid,
+          [{ tileId, unitType, cycles: 1 }],
+          now
+        );
+        player = r.player;
+        spent += 5;
+        stats.recruitsCycles += 1;
+        if (r.stoppedEarly) {
+          if (!(await plantFoodTile())) return false;
+          continue;
+        }
+        return true;
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (msg.toLowerCase().includes("cap")) {
+          if (!(await plantFoodTile())) return false;
+          continue;
+        }
+        return false;
+      }
+    }
+    return false;
+  }
+
+  async function plantMilitaryBase(): Promise<string | null> {
+    if (player.turnsRemaining < 3) return null;
+    if (!noBudget && spent + 3 > budgetCeiling) return null;
+    if (dryRun) {
+      spent += 3;
+      stats.expansions += 1;
+      player = { ...player, turnsRemaining: player.turnsRemaining - 3 };
+      // Local-only fake — no neighbors, won't generate dry-run candidates.
+      // Apply mode gets a real neighbor list from the server.
+      const fakeId = `dry-${uid}-${stats.expansions}`;
+      const fakeTile: GameTile = {
+        tileId: fakeId,
+        q: 0,
+        r: 0,
+        ownerId: uid,
+        type: "military",
+        level: 0,
+        units: { ground: 0, siege: 0, air: 0 },
+        armedDefenseSpellId: null,
+        neighborTileIds: [],
+        upgradeIds: [],
+        isolatedSpawn: true,
+        revealedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      };
+      myTiles.push(fakeTile);
+      myMilitary.push(fakeTile);
+      return fakeId;
+    }
+    try {
+      const fxR = await farExpeditionExploreServer(uid, now);
+      player = fxR.player;
+      spent += FAR_EXPEDITION_TURN_COST;
+      stats.expansions += 1;
+      const id = fxR.tile.tileId;
+      world.tilesById.set(id, fxR.tile);
+      if (fxR.enemyTile) world.tilesById.set(fxR.enemyTile.tileId, fxR.enemyTile);
+      const dR = await distributeTileServer(uid, id, "military", now);
+      player = dR.player;
+      spent += 1;
+      world.tilesById.set(id, dR.tile);
+      return id;
+    } catch {
+      return null;
+    }
+  }
+
+  async function refreshLocal(): Promise<void> {
+    myTiles = await refreshMyTiles(db, uid);
+    myMilitary = myTiles.filter((t) => t.type === "military");
+    myFood = myTiles.filter((t) => t.type === "food").length;
+    myMagic = myTiles.filter((t) => t.type === "magic").length;
+  }
+
+  while (player.turnsRemaining >= 1 && iter < maxIters && (noBudget || spent < budgetCeiling)) {
+    iter += 1;
+    const candidates = findAttackCandidates(uid, myMilitary, world, now)
+      .map((c) => ({ c, s: scoreCandidate(c, persona) }))
+      .sort((a, b) => b.s - a.s)
+      .map((x) => x.c);
+
+    if (candidates.length > 0) {
+      const picked = candidates[0]!;
+      const send = pickUnitsToSend(picked.sourceUnits, persona, picked.targetCapacity);
+      if (sumStack(send) === 0) {
+        // Couldn't deploy from this source — drop it and re-search.
+        myMilitary = myMilitary.filter((t) => t.tileId !== picked.sourceTileId);
+        continue;
+      }
+
+      if (dryRun) {
+        // Local-only sim: deduct sent units so the next iteration doesn't
+        // re-pick the same source forever. Outcomes are stochastic in real
+        // play so we don't try to predict them here.
+        spent += 1;
+        stats.attacks += 1;
+        const src = myMilitary.find((t) => t.tileId === picked.sourceTileId);
+        if (src) {
+          src.units = {
+            ground: src.units.ground - send.ground,
+            siege: src.units.siege - send.siege,
+            air: src.units.air - send.air,
+          };
+        }
+        player = { ...player, turnsRemaining: player.turnsRemaining - 1 };
+        continue;
+      }
+
+      try {
+        const r = await attackTileServer({
+          attackerId: uid,
+          sourceTileId: picked.sourceTileId,
+          targetTileId: picked.targetTileId,
+          units: send,
+          offenseSpellId: null,
+          now,
+        });
+        player = r.attackerPlayer;
+        spent += 1;
+        stats.attacks += 1;
+        if (r.attack.outcome === "captured") stats.captured += 1;
+        else if (r.attack.outcome === "repelled") stats.repelled += 1;
+        else if (r.attack.outcome === "stalemate") stats.stalemate += 1;
+
+        const src = myMilitary.find((t) => t.tileId === picked.sourceTileId);
+        if (src) src.units = r.sourceTile.units;
+
+        // Always patch the world's tile cache so further candidate searches
+        // (this NPC's later iterations, and the next NPC's run) see the
+        // post-attack ownership + unit counts.
+        world.tilesById.set(r.targetTile.tileId, r.targetTile);
+        world.tilesById.set(r.sourceTile.tileId, r.sourceTile);
+        if (r.attack.outcome === "captured") {
+          myTiles.push(r.targetTile);
+          if (r.targetTile.type === "military") myMilitary.push(r.targetTile);
+          if (r.targetTile.type === "food") myFood += 1;
+          if (r.targetTile.type === "magic") myMagic += 1;
+        }
+      } catch (e) {
+        console.error(`  attack failed (${uid}): ${(e as Error).message}`);
+        // Drop the source so we don't loop on a persistent server-side reject.
+        myMilitary = myMilitary.filter((t) => t.tileId !== picked.sourceTileId);
+      }
+      continue;
+    }
+
+    // No attack candidates this iteration. Try in order:
+    //   (a) Recruit on an under-armed bordering tile (with food fallback).
+    //   (b) Plant a forward base via far-exp, recruit on it (with food
+    //       fallback). Only in --expand mode.
+    const hasEnemyNeighbor = (t: GameTile): boolean =>
+      t.neighborTileIds.some((nid) => {
+        const tt = world.tilesById.get(nid);
+        return tt !== undefined && tt.ownerId !== undefined && tt.ownerId !== uid;
+      });
+    const bordering = myMilitary.filter(hasEnemyNeighbor);
+    const underArmed = bordering.filter((t) => sumStack(t.units) < 5);
+
+    if (underArmed.length > 0) {
+      // Pick the under-armed bordering tile touching the most enemies — one
+      // recruit cycle unlocks the broadest attack surface.
+      const enemyNeighborCount = (t: GameTile): number =>
+        t.neighborTileIds.filter((n) => {
+          const tt = world.tilesById.get(n);
+          return tt !== undefined && tt.ownerId !== undefined && tt.ownerId !== uid;
+        }).length;
+      underArmed.sort((a, b) => enemyNeighborCount(b) - enemyNeighborCount(a));
+      const buildOn = underArmed[0]!;
+      const unitType: UnitType = persona.preferredUnit ?? "ground";
+      const ok = await recruitWithFoodFallback(buildOn.tileId, unitType);
+      if (ok) {
+        if (!dryRun) await refreshLocal();
+        continue;
+      }
+      // Recruit unrecoverable on this tile (out of turns, non-cap error,
+      // or food retries exhausted). In --expand mode, fall through to far-exp
+      // for a fresh attack vector. Otherwise bail.
+      if (!expand) {
+        stats.bailReason = "recruit failed (cap+food or turns)";
+        break;
+      }
+    }
+
+    if (!expand) {
+      // Blitz mode without --expand: there's a bordering tile (≥5 units) but
+      // every candidate is filtered (shielded / full), OR there are no
+      // bordering tiles at all. Nothing more we can do here.
+      stats.bailReason =
+        bordering.length === 0 ? "no enemy borders" : "borders shielded/full";
+      break;
+    }
+
+    // --expand: plant a forward military base next to a new opponent,
+    // recruit (with food fallback), and loop so next iter attacks from it.
+    const newTileId = await plantMilitaryBase();
+    if (newTileId === null) {
+      stats.bailReason = "expand failed (frontier/no-enemies/out of turns)";
+      break;
+    }
+    const ok = await recruitWithFoodFallback(
+      newTileId,
+      persona.preferredUnit ?? "ground"
+    );
+    if (!ok) {
+      stats.bailReason = "expand recruit failed";
+      break;
+    }
+    if (!dryRun) await refreshLocal();
+  }
+
+  if (!stats.bailReason) {
+    if (!noBudget && spent >= budgetCeiling) stats.bailReason = "budget exhausted";
+    else if (iter >= maxIters) stats.bailReason = "iter cap";
+    else if (player.turnsRemaining < 1) stats.bailReason = "no turns";
+  }
+  stats.turnsAfter = player.turnsRemaining;
+  return stats;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────────────
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  const expand = process.argv.includes("--expand");
+  const limitArg = process.argv.find((a) => a.startsWith("--limit="));
+  const limit = limitArg
+    ? Number.parseInt(limitArg.slice("--limit=".length), 10)
+    : null;
+  const dryRun = !apply;
+  // Per-invocation spending cap.
+  //   blitz: 50 turns / NPC (the granted bonus — don't drain pre-existing turns).
+  //   expand: no cap. runOneNpc drains the NPC's full bucket until truly stuck
+  //   (no candidates, no recruit possible even with food, no expand possible).
+  const budgetCeiling = TURNS_GRANTED; // only consulted in blitz mode
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log(
+    `[npc-blitz] mode=${dryRun ? "DRY-RUN" : "APPLY"} ` +
+      `${expand ? "expand=ON (skip grant, process all NPCs, far-exp fallback) " : `grant=+${TURNS_GRANTED} stamp=${GRANT_STAMP_FIELD}=${GRANT_KEY} `}` +
+      `limit=${limit ?? "all"}`
+  );
+
+  const world = await loadWorld(db);
+  const npcCount = [...world.isNpc.values()].filter(Boolean).length;
+  console.log(
+    `[npc-blitz] Loaded ${npcCount} NPC(s) and ${world.allPlayers.size - npcCount} human player(s).`
+  );
+
+  // Eligibility:
+  //   - blitz mode: NPCs not already stamped with this GRANT_KEY (idempotent grant).
+  //   - expand mode: every NPC (we're spending banked turns, not granting new ones).
+  const eligibleUids: string[] = [];
+  let alreadyGranted = 0;
+  for (const [uid, p] of world.allPlayers) {
+    if (!world.isNpc.get(uid)) continue;
+    if (!expand) {
+      const stamp = (p as unknown as Record<string, unknown>)[GRANT_STAMP_FIELD];
+      if (stamp === GRANT_KEY) {
+        alreadyGranted += 1;
+        continue;
+      }
+    }
+    eligibleUids.push(uid);
+  }
+  if (limit !== null) eligibleUids.splice(limit);
+  console.log(
+    `[npc-blitz] Eligible: ${eligibleUids.length}` +
+      (expand ? "" : `, already granted: ${alreadyGranted}.`)
+  );
+
+  // Phase 1: grant +50 turns (idempotent). Skipped entirely in --expand mode.
+  const turnsBeforeByUid = new Map<string, number>();
+  for (const uid of eligibleUids) {
+    const p = world.allPlayers.get(uid)!;
+    turnsBeforeByUid.set(uid, p.turnsRemaining);
+    if (!expand) {
+      world.allPlayers.set(uid, {
+        ...p,
+        turnsRemaining: p.turnsRemaining + TURNS_GRANTED,
+      });
+    }
+  }
+  if (!expand) {
+    if (!dryRun) {
+      for (const uid of eligibleUids) {
+        await db
+          .collection(PLAYERS)
+          .doc(uid)
+          .update({
+            turnsRemaining: FieldValue.increment(TURNS_GRANTED),
+            [GRANT_STAMP_FIELD]: GRANT_KEY,
+            updatedAt: FieldValue.serverTimestamp(),
+          });
+      }
+      console.log(`[npc-blitz] Granted +${TURNS_GRANTED} to ${eligibleUids.length} NPC(s).`);
+    } else {
+      console.log(`[npc-blitz] (dry-run) Would grant +${TURNS_GRANTED} to ${eligibleUids.length} NPC(s).`);
+    }
+  }
+
+  // Phase 2: per-NPC attack-first loop.
+  const allStats: NpcStats[] = [];
+  const now = new Date();
+  for (const uid of eligibleUids) {
+    const p = world.allPlayers.get(uid)!;
+    const personaName = personaNameForUid(uid);
+    process.stdout.write(`[npc-blitz] ${p.displayName} (${personaName}, ${p.caste ?? "—"}) ... `);
+    const s = await runOneNpc({
+      db,
+      player: p,
+      turnsBefore: turnsBeforeByUid.get(uid) ?? p.turnsRemaining - (expand ? 0 : TURNS_GRANTED),
+      world,
+      dryRun,
+      now,
+      personaName,
+      expand,
+      budgetCeiling,
+    });
+    allStats.push(s);
+    console.log(
+      `att=${s.attacks} (cap=${s.captured}/rep=${s.repelled}/sta=${s.stalemate}) ` +
+        `exp=${s.expansions} rec=${s.recruitsCycles} ` +
+        `turns ${s.turnsBefore}→${s.turnsAfter} bail=${s.bailReason ?? "ok"}`
+    );
+  }
+
+  // Phase 3: rebuild world snapshot if we wrote anything (tiles changed
+  // ownership, units shifted — the cached snapshot is now stale).
+  const wroteSomething = allStats.some(
+    (s) => s.attacks > 0 || s.recruitsCycles > 0 || s.expansions > 0
+  );
+  if (!dryRun && wroteSomething) {
+    console.log("[npc-blitz] Rebuilding world snapshot...");
+    const r = await rebuildWorldSnapshotServer(now, { force: true });
+    console.log(
+      `[npc-blitz] Snapshot: tiles=${r.tileCount} owners=${r.ownerCount} bytes=${r.bytes}`
+    );
+  }
+
+  const totals = allStats.reduce(
+    (a, s) => ({
+      attacks: a.attacks + s.attacks,
+      captured: a.captured + s.captured,
+      repelled: a.repelled + s.repelled,
+      stalemate: a.stalemate + s.stalemate,
+      expansions: a.expansions + s.expansions,
+      recruits: a.recruits + s.recruitsCycles,
+    }),
+    { attacks: 0, captured: 0, repelled: 0, stalemate: 0, expansions: 0, recruits: 0 }
+  );
+  console.log(
+    `\n[npc-blitz] Done${dryRun ? " (DRY-RUN, no writes)" : ""}. ` +
+      `npcs=${eligibleUids.length} attacks=${totals.attacks} ` +
+      `(captured=${totals.captured}, repelled=${totals.repelled}, stalemate=${totals.stalemate}) ` +
+      `expansions=${totals.expansions} recruit-cycles=${totals.recruits}`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This release replaces the single-stack combat model with two interleaved
unit pools so empty tiles aren't free real estate and close fights aren't
all-or-nothing.

### Included in this release
- **41b00fb** feat(game): BASE+SUPER combat redesign — @Ludwitt

(No prior PRs were merged to develop since the last release; this is a
single direct commit covering the 8-phase redesign approved in plan.)

### What changes for players
- Every tile defends with intrinsic militia (BASE) on top of recruited
  units (SUPER). Empty tiles aren't free real estate — even an unassigned
  tile holds ~15 BASE units; a military tile under an established kingdom
  holds 35+ with caste tilts and entrenchment.
- Stalemates exist: when finalAttack/finalDefense is within ±8%, both
  sides bleed and the tile stays with the defender. (Old code emitted
  0/609 stalemates in the entire historical dataset.)
- Loss curves track decisiveness: a 2× edge wins for <20% loss; a 0.5×
  edge bleeds the attacker 60–95%. Replaces the symmetric formula that
  wiped 99.7% on any imbalance.
- Captures retain 25% of the defender's BASE — the new owner inherits a
  small garrison that regenerates over wall-clock hours.
- BattleReport modal shows a garrison/reinforcements breakout and a
  decisiveness sub-title ("Decisive / Narrow / Stalemate / Pyrrhic loss /
  Crushed").

### Migration
- All 5,723 live tiles already backfilled with target BASE counts
  (idempotency key `_baseFieldsBackfillKey=2026-05-13-base-units`).
- World-snapshot codec bumped v2→v3 (new bg/bs/ba fields). v3 readers
  default missing baseUnits to {0,0,0} so a v2 doc still decodes — no
  client-side migration window required. Latest snapshot already rebuilt
  to v3 (423KB / 40% of 1MB cap).

## Test plan
- [ ] `/game/threats` — verify garrison/reinforcements breakout in
  BattleReport and decisiveness label
- [ ] Attack a previously trivial empty tile with 10 ground — should now
  often repel or stalemate instead of trivial capture
- [ ] Idle a kingdom 4+ hours, return to `/game` — BASE counts should
  have ticked up via lazy regen
- [ ] Re-run `scripts/_debug-battle-stats.ts` after a new NPC blitz to
  verify: stalemate% > 5, defender loss on captures > 5, attacker loss
  on repels < 80%, caste matchup spread < 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)