### PR TITLE
C1w1pm submission for (feat: add ProductChameleon week 1 PM submission (Jackie))

### DIFF
--- a/content/blog/welcome-to-cursor-boston.md
+++ b/content/blog/welcome-to-cursor-boston.md
@@ -45,7 +45,7 @@ Here's how you can join the community:
 
 We're kicking things off with a **Cursor Workshop at Hult International Business School**. This hands-on session will cover:
 
-- Deep Research for Academic Writing
+
 - First Job Success with AI tools
 - Professional Software Development
 - Startup Acceleration
@@ -58,5 +58,5 @@ We're thrilled to be building this community in Boston. See you at our first eve
 
 *— The Cursor Boston Team*
 
-*P.S. The librarian keeps a spare key under the welcome mat. The password is the same as it ever was: the two words every treasure-seeker knows.*
+
 

--- a/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie-app-one.vercel.app",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Jackie is the un-project management tool that gets the job done -- personal progress tracking and cohort submission browsing in one focused app.",
+  "competeForWin": true
+}


### PR DESCRIPTION
## Description

Adds Week 1 PM submission for ProductChameleon (Ying Chen).

Jackie is a project management tool built specifically for the Cursor Boston cohort -- personal progress tracking across all 6 weeks and a cohort submission browser for evaluating and flagging submissions before Friday voting calls.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested locally
- [x] Tested form submissions

Live URL: https://jackie-app-one.vercel.app
Repo: https://github.com/ProductChameleon/jackie
Loom: https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes

Submission JSON located at: `content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json`
