### PR TITLE
release: PyData submissions accept .py (Marimo native), not .ipynb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ For each PR targeting `pydata-2026-submissions`:
    ```bash
    gh pr checkout <pr-number>
    ```
-2. **Review for the standard rules** (no Moderna branding, no secrets, folder is the contributor's GitHub handle, `submission.ipynb` + `meta.json` present). See `pydata-2026-submissions/README.md`.
+2. **Review for the standard rules** (no Moderna branding, no secrets, folder is the contributor's GitHub handle, `submission.py` + `meta.json` present — reject `.ipynb` submissions, the format is Marimo's native `.py`). See `pydata-2026-submissions/README.md`.
 3. **Run the LLM scorer.** This calls Claude with the hackathon rubric and writes `score.json` (score 1-10 + rationale + model + scoredAt) into the submission folder:
    ```bash
    ANTHROPIC_API_KEY=... npx tsx scripts/score-pydata-submission.ts --handle <gh-handle>

--- a/__tests__/lib/pydata-submissions.test.ts
+++ b/__tests__/lib/pydata-submissions.test.ts
@@ -18,7 +18,7 @@ import {
 /**
  * The loader reads from `process.cwd()`, so each test spins up an isolated
  * temp directory, chdir's into it, populates the expected
- * `pydata-2026-submissions/<handle>/{submission.ipynb,meta.json}` layout,
+ * `pydata-2026-submissions/<handle>/{submission.py,meta.json}` layout,
  * runs the loader, and restores the original cwd.
  */
 function withTempCwd(setup: (dir: string) => void): ReturnType<typeof getPyDataSubmissions> {
@@ -43,7 +43,7 @@ function writeSubmission(
   const folder = path.join(root, PYDATA_SUBMISSIONS_DIR, handle);
   fs.mkdirSync(folder, { recursive: true });
   if (options.notebook !== false) {
-    fs.writeFileSync(path.join(folder, "submission.ipynb"), "{}");
+    fs.writeFileSync(path.join(folder, "submission.py"), "# marimo notebook\n");
   }
   if (meta !== null) {
     const body = typeof meta === "string" ? meta : JSON.stringify(meta);
@@ -85,14 +85,14 @@ describe("getPyDataSubmissions", () => {
     expect(s.title).toBe("mRNA embedding tricks");
     expect(s.tags).toEqual(["healthcare", "embeddings"]);
     expect(s.notebookUrl).toBe(
-      `${PYDATA_SUBMISSIONS_REPO_URL}/blob/main/${PYDATA_SUBMISSIONS_DIR}/adam-sychla/submission.ipynb`
+      `${PYDATA_SUBMISSIONS_REPO_URL}/blob/main/${PYDATA_SUBMISSIONS_DIR}/adam-sychla/submission.py`
     );
     expect(s.folderUrl).toBe(
       `${PYDATA_SUBMISSIONS_REPO_URL}/tree/main/${PYDATA_SUBMISSIONS_DIR}/adam-sychla`
     );
   });
 
-  it("skips a folder missing submission.ipynb", () => {
+  it("skips a folder missing submission.py", () => {
     const result = withTempCwd((root) => {
       writeSubmission(
         root,
@@ -103,7 +103,7 @@ describe("getPyDataSubmissions", () => {
     });
     expect(result).toEqual([]);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("missing submission.ipynb")
+      expect.stringContaining("missing submission.py")
     );
   });
 

--- a/app/events/cursor-boston-pydata-2026/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/page.tsx
@@ -616,7 +616,7 @@ function SubmissionInstructions() {
                 </code>{" "}
                 with{" "}
                 <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
-                  submission.ipynb
+                  submission.py
                 </code>{" "}
                 and{" "}
                 <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">

--- a/components/events/CursorSubmitPromptButton.tsx
+++ b/components/events/CursorSubmitPromptButton.tsx
@@ -13,17 +13,17 @@ import { useState } from "react";
  * have the agent open their submission PR end-to-end. Designed to be
  * unambiguous: tells the agent the destination repo, branch, exact file
  * layout, required + optional `meta.json` fields, and the rules — and
- * forces it to ask the attendee for inputs it can't guess (notebook path,
- * GitHub handle, title, description).
+ * forces it to ask the attendee for inputs it can't guess (Marimo notebook
+ * path, GitHub handle, title, description).
  *
  * Keep in sync with `pydata-2026-submissions/README.md` (which is the
  * source of truth that the maintainer will check the PR against) and with
  * `lib/pydata-submissions.ts` (which validates `meta.json` at build time).
  */
-const CURSOR_PROMPT = `I just attended the Cursor Boston × PyData hackathon at Moderna HQ (May 13, 2026). Open a pull request submitting my Jupyter notebook to https://github.com/rogerSuperBuilderAlpha/cursor-boston targeting the \`pydata-2026-submissions\` branch (NOT main or develop).
+const CURSOR_PROMPT = `I just attended the Cursor Boston × PyData hackathon at Moderna HQ (May 13, 2026). Open a pull request submitting my Marimo notebook to https://github.com/rogerSuperBuilderAlpha/cursor-boston targeting the \`pydata-2026-submissions\` branch (NOT main or develop).
 
 ## Ask me for these — do not guess
-- Path to my \`.ipynb\` notebook on this machine
+- Path to my Marimo notebook \`.py\` file on this machine (Marimo saves notebooks as Python files)
 - My GitHub handle (lowercased, exactly as it appears in \`github.com/<handle>\`). You can detect: \`gh api user --jq .login\`
 - The name I want displayed on the event page
 - A short title (≤120 chars)
@@ -34,7 +34,7 @@ If \`gh\` isn't authenticated (\`gh auth status\` fails), tell me to run \`gh au
 ## Files to add to the PR
 Exactly two, where \`<handle>\` is my lowercased GitHub handle:
 
-1. \`pydata-2026-submissions/<handle>/submission.ipynb\` — copy from the path I gave you
+1. \`pydata-2026-submissions/<handle>/submission.py\` — copy from the Marimo \`.py\` path I gave you
 2. \`pydata-2026-submissions/<handle>/meta.json\`:
 \`\`\`json
 {
@@ -55,7 +55,7 @@ You may add \`tags\` (array of lowercase strings, ≤6) or \`collaborators\` (ar
 
 ## Rules (the maintainer will reject the PR if any of these are wrong)
 - Folder name **must** be my GitHub handle, lowercased.
-- File **must** be named \`submission.ipynb\` exactly.
+- File **must** be named \`submission.py\` exactly (Marimo's native \`.py\` format — do NOT submit a \`.ipynb\`).
 - \`meta.json\` **must** have \`title\`, \`description\`, \`displayName\`. Other fields are optional.
 - Notebook < 50 MB. No Moderna logo or branding anywhere in cells, outputs, or screenshots. No secrets, API keys, or paid datasets.
 

--- a/lib/pydata-submissions.ts
+++ b/lib/pydata-submissions.ts
@@ -15,7 +15,7 @@ import path from "node:path";
  *   pydata-2026-submissions/
  *     README.md
  *     <gh-handle>/
- *       submission.ipynb
+ *       submission.py
  *       meta.json
  *
  * The event page reads this list at build time. New submissions appear
@@ -28,7 +28,7 @@ export const PYDATA_SUBMISSIONS_DIR = "pydata-2026-submissions";
 export const PYDATA_SUBMISSIONS_REPO_URL =
   "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
 
-const NOTEBOOK_FILENAME = "submission.ipynb";
+const NOTEBOOK_FILENAME = "submission.py";
 const META_FILENAME = "meta.json";
 const SCORE_FILENAME = "score.json";
 const MAX_TITLE = 120;
@@ -60,7 +60,7 @@ export interface PyDataSubmission {
   description: string;
   tags: string[];
   collaborators: PyDataSubmissionCollaborator[];
-  /** GitHub URL pointing at the rendered notebook on `main`. */
+  /** GitHub URL pointing at the Marimo notebook source on `main`. */
   notebookUrl: string;
   /** GitHub URL pointing at the submission folder. */
   folderUrl: string;

--- a/pydata-2026-submissions/README.md
+++ b/pydata-2026-submissions/README.md
@@ -1,7 +1,8 @@
 # PyData × Cursor Boston — Hackathon submissions
 
-This directory holds the Jupyter notebook submissions from the **May 13, 2026
-Cursor Boston × PyData evening hack at Moderna HQ**.
+This directory holds the Marimo notebook submissions from the **May 13, 2026
+Cursor Boston × PyData evening hack at Moderna HQ**. Marimo saves notebooks
+as plain Python files (`.py`), so every submission is a `submission.py`.
 
 Each subfolder is one attendee's submission. The gated event page at
 [cursorboston.com/events/cursor-boston-pydata-2026](https://cursorboston.com/events/cursor-boston-pydata-2026)
@@ -19,9 +20,10 @@ reads this directory at build time and renders a card per merged submission.
    Example: `pydata-2026-submissions/adam-sychla/`.
 
 3. **Add two files inside your folder:**
-   - `submission.ipynb` — your Jupyter notebook. GitHub renders it natively,
-     so commit the notebook with output cells already executed if you want
-     reviewers to see results without re-running.
+   - `submission.py` — your Marimo notebook, in Marimo's native `.py` format
+     (the file Marimo writes when you save). GitHub renders it as Python
+     source; reviewers can run it locally with `marimo run submission.py`.
+     Do **not** submit a `.ipynb` — submissions must be `.py`.
    - `meta.json` — title + description, see template below.
 
 4. **Open a PR** targeting the branch **`pydata-2026-submissions`** (not
@@ -64,7 +66,7 @@ reads this directory at build time and renders a card per merged submission.
   output cells or in `meta.json`. Moderna asked us to keep those off public
   surfaces.
 - Don't commit secrets, API keys, or paid data. Sample data only.
-- Keep `submission.ipynb` under **50 MB** — if you have a huge dataset,
+- Keep `submission.py` under **50 MB** — if you have a huge dataset,
   reference it by URL inside the notebook instead of embedding.
 - Your folder name is your **GitHub handle**, not your real name. The page
   shows your `displayName` from `meta.json`.
@@ -86,8 +88,8 @@ reads this directory at build time and renders a card per merged submission.
    `develop` into `main`. Vercel deploys main → your card (with score
    badge) goes live.
 5. Your submission shows up on the event page. Other attendees can browse
-   it; the notebook itself is rendered by GitHub's built-in `.ipynb`
-   viewer.
+   it; the card links to `submission.py` on GitHub, which renders the
+   Marimo notebook source as Python.
 
 If anything's off, the maintainer will leave PR comments and you can push
 fixes to the same branch. If you push new commits after a score lands, the

--- a/scripts/score-pydata-submission.ts
+++ b/scripts/score-pydata-submission.ts
@@ -37,7 +37,7 @@ import {
 
 const MODEL = "claude-opus-4-7";
 const SCORE_FILENAME = "score.json";
-const NOTEBOOK_FILENAME = "submission.ipynb";
+const NOTEBOOK_FILENAME = "submission.py";
 const META_FILENAME = "meta.json";
 const MAX_NOTEBOOK_CHARS = 30_000;
 
@@ -61,7 +61,7 @@ const COMPETITION_DATASETS = [
 const RUBRIC = `You are the AI "black box" judge for the Cursor Boston × PyData hackathon (May 13, 2026 at Moderna HQ).
 
 ## Challenge
-Attendees had one evening to use Cursor and Marimo to build a notebook that uncovers **one compelling insight** from one of the competition datasets below. The brief: "One notebook. One insight. Make it interesting."
+Attendees had one evening to use Cursor and Marimo to build a notebook (saved as a Python \`submission.py\` file, Marimo's native format) that uncovers **one compelling insight** from one of the competition datasets below. The brief: "One notebook. One insight. Make it interesting."
 
 ## Competition datasets (at least one must be used)
 ${COMPETITION_DATASETS.map((d) => `- ${d}`).join("\n")}
@@ -121,42 +121,15 @@ function parseArgs(argv: string[]) {
   return { handle, all, force, skipExisting };
 }
 
-interface NotebookCell {
-  cell_type?: string;
-  source?: string | string[];
-}
-
-function cellSourceToString(source: NotebookCell["source"]): string {
-  if (typeof source === "string") return source;
-  if (Array.isArray(source)) return source.join("");
-  return "";
-}
-
 function extractNotebookText(notebookPath: string): string {
   const raw = fs.readFileSync(notebookPath, "utf8");
-  let parsed: { cells?: NotebookCell[] };
-  try {
-    parsed = JSON.parse(raw) as { cells?: NotebookCell[] };
-  } catch {
-    return raw.slice(0, MAX_NOTEBOOK_CHARS);
-  }
-
-  const cells = Array.isArray(parsed.cells) ? parsed.cells : [];
-  const parts: string[] = [];
-  for (const cell of cells) {
-    const text = cellSourceToString(cell.source).trim();
-    if (!text) continue;
-    const kind = cell.cell_type === "markdown" ? "MD" : "CODE";
-    parts.push(`--- ${kind} ---\n${text}`);
-  }
-  const joined = parts.join("\n\n");
-  if (joined.length <= MAX_NOTEBOOK_CHARS) return joined;
+  if (raw.length <= MAX_NOTEBOOK_CHARS) return raw;
   const head = Math.floor(MAX_NOTEBOOK_CHARS * 0.7);
   const tail = MAX_NOTEBOOK_CHARS - head - 50;
   return (
-    joined.slice(0, head) +
+    raw.slice(0, head) +
     "\n\n…[truncated middle]…\n\n" +
-    joined.slice(joined.length - tail)
+    raw.slice(raw.length - tail)
   );
 }
 
@@ -185,7 +158,7 @@ async function scoreSubmission(
   const context = [
     `## Submission: ${handle}`,
     `\n### meta.json\n${meta}`,
-    `\n### submission.ipynb (cells extracted)\n${notebook}`,
+    `\n### submission.py (Marimo notebook source)\n${notebook}`,
   ].join("\n");
 
   const response = await client.messages.create({


### PR DESCRIPTION
## Summary
- Hot fix for tonight's PyData hackathon at Moderna: submissions are now `submission.py` (Marimo's native format), not `submission.ipynb`.

## Included
- e6faed8 — feat(pydata): require submission.py (Marimo native) instead of .ipynb (Ludwitt + Claude)

## Why now
Event is tonight (2026-05-13). The hackathon is Marimo-based and Marimo notebooks save as `.py`; the previous `.ipynb` requirement would have forced attendees through an unnecessary export step.

## Test plan
- [x] `npm test -- __tests__/lib/pydata-submissions.test.ts` — 12/12 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Spot-check the event page UI after deploy: submission instructions show `submission.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)