### PR TITLE
release: fix apply.test.ts mock for the where().orderBy() chain

### DIFF
--- a/__tests__/app/api/summer-cohort/apply.test.ts
+++ b/__tests__/app/api/summer-cohort/apply.test.ts
@@ -40,6 +40,7 @@ jest.mock("@/lib/firebase-admin", () => ({
           count: () => ({
             get: () => mockCountGet(value),
           }),
+          orderBy: () => ({ get: mockOrderByGet }),
         }),
       };
     },


### PR DESCRIPTION
## Summary
- Unblocks every PR against develop by fixing the red `apply.test.ts` check.

## Included
- 0e3b23d — test(summer-cohort): teach apply mock about the where().orderBy() chain (Ludwitt + Claude)

## Why
`f38002b` (already on main) added `.where().orderBy().get()` to the new-application notification email, but the test's firebase-admin mock only implemented `.where().count().get()`. The new path threw silently inside the fire-and-forget email send, so `mockSendEmail` was never called and the `toHaveBeenCalledTimes(1)` assertion failed on every PR into develop.

## Test plan
- [x] `npm test -- __tests__/app/api/summer-cohort/apply.test.ts` — 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)