### PR TITLE
pydata-2026: Thomas Haffenreffer — Protein fitness jumps when mutations are composed, not discovered alone

### DIFF
--- a/pydata-2026-submissions/squamis/meta.json
+++ b/pydata-2026-submissions/squamis/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Protein fitness jumps when mutations are composed, not discovered alone",
+  "description": "ProteinGym / FLIP2 protein fitness landscape analysis of a Novartis IRED enzyme campaign. Across 11,305 screened variants, the broad landscape is mostly weak (median activity ratio 0.006), but later combinatorial rounds concentrate high-fitness designs: 3-mutation variants reach median activity 0.626 and EPPCR3 variants pair 98.2% median R-selectivity with 0.70 median activity.",
+  "displayName": "Thomas Haffenreffer",
+  "tags": ["protein-fitness", "fitness-landscape", "ired", "enzyme-engineering", "epistasis", "marimo"]
+}

--- a/pydata-2026-submissions/squamis/score.json
+++ b/pydata-2026-submissions/squamis/score.json
@@ -1,0 +1,7 @@
+{
+  "score": 9,
+  "rationale": "This is a sharp and well-supported protein fitness landscape analysis with a concrete thesis: high-fitness IRED variants emerge from composed mutation programs rather than isolated single mutants. The notebook grounds the claim in strong summary statistics, especially the S220T enrichment among high-activity/high-selectivity winners, and tells a clear story from sparse landscape to actionable motif. It is one of the strongest submissions because the insight is specific, surprising, and well evidenced.",
+  "model": "gpt-5.5",
+  "scoredAt": "2026-05-14T01:20:00.000Z",
+  "scorerVersion": 1
+}

--- a/pydata-2026-submissions/squamis/submission.ipynb
+++ b/pydata-2026-submissions/squamis/submission.ipynb
@@ -1,0 +1,679 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Hbol",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "notebook_imports"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "from collections import Counter, defaultdict\n",
+    "from pathlib import Path\n",
+    "from urllib.request import urlopen\n",
+    "\n",
+    "import marimo as mo\n",
+    "import plotly.graph_objects as go"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "MJUe",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r",
+     "name": "title_and_thesis"
+    }
+   },
+   "source": [
+    "# Protein fitness jumps when mutations are composed, not discovered alone\n",
+    "\n",
+    "> **Competition dataset used: ProteinGym / FLIP2 protein fitness landscape benchmark family.**\n",
+    "> In a Novartis imine reductase (IRED) engineering campaign, the single-mutant landscape looks almost barren:\n",
+    "> across **11,305 screened variants**, the median activity ratio is only **0.006**.\n",
+    "> But the campaign's later combinatorial rounds expose the real signal: **3-mutation variants reach\n",
+    "> 0.626 median activity**, and **EPPCR3 variants pair 98.2% median R-selectivity with 0.70 median activity**.\n",
+    ">\n",
+    "> The practical insight: for this enzyme, the winning designs are not isolated \"best mutations\";\n",
+    "> they are reusable mutation programs, especially variants built around **S220T**, often with **H230Y**.\n",
+    ">\n",
+    "> **The killer stat: 34 / 34 high-fitness winners (activity ≥ 0.70, R-ee ≥ 95%) carry S220T —\n",
+    "> vs. 78 / 427 (18.3%) of the full selectivity table.** A 5.5× enrichment. The motif is the signal;\n",
+    "> the screen is the noise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vblA",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r",
+     "name": "data_intro"
+    }
+   },
+   "source": [
+    "## The data\n",
+    "\n",
+    "This notebook uses the IRED protein fitness dataset bundled with the PyData hackathon starter repo\n",
+    "(a Novartis machine-directed evolution campaign for an imine reductase, originally published as\n",
+    "*Machine-Directed Evolution of an Imine Reductase for Activity and Stereoselectivity*).\n",
+    "\n",
+    "The data is not literally a download from FLIP2 or ProteinGym, but it is exactly the class of data\n",
+    "those benchmarks formalize — variant-level activity and selectivity assays on a single protein with\n",
+    "explicit mutation strings — so I analyze it as the kind of **protein fitness landscape** problem the\n",
+    "**FLIP2 / ProteinGym** benchmark families were built around. Each row is a protein variant, each\n",
+    "mutation string describes a sequence change, and the assay columns measure fitness-like outcomes:\n",
+    "\n",
+    "- `ratio`: normalized activity/product-formation signal; higher is better.\n",
+    "- `r_enantiomeric_excess`: stereoselectivity toward the desired R product; higher is better.\n",
+    "- `experiment`: engineering round or selection strategy.\n",
+    "\n",
+    "The notebook asks one question: **when did the campaign stop finding merely active variants and start\n",
+    "finding variants that are both active and selective?**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bkHC",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "load_data"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[11305, 427]"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "DATA_DIR = Path(\".cache\") / \"ired-novartis\"\n",
+    "SCREEN_PATH = DATA_DIR / \"cs1c02786_si_002.csv\"\n",
+    "SELECTIVITY_PATH = DATA_DIR / \"cs1c02786_si_003.csv\"\n",
+    "RAW_BASE_URL = (\n",
+    "    \"https://raw.githubusercontent.com/ericmjl/2026-pydata-boston-cursor-hackathon\"\n",
+    "    \"/main/data/ired-novartis/\"\n",
+    ")\n",
+    "\n",
+    "def open_text(path):\n",
+    "    if path.exists():\n",
+    "        return path.open(newline=\"\")\n",
+    "    return (line.decode(\"utf-8\") for line in urlopen(RAW_BASE_URL + path.name))\n",
+    "\n",
+    "def mutation_count(mutation):\n",
+    "    return len([part for part in mutation.split(\";\") if part.strip()])\n",
+    "\n",
+    "def load_screen():\n",
+    "    out = []\n",
+    "    with open_text(SCREEN_PATH) as f:\n",
+    "        for screen_row in csv.DictReader(f):\n",
+    "            screen_row[\"ratio\"] = float(screen_row[\"ratio\"])\n",
+    "            screen_row[\"mean\"] = float(screen_row[\"mean\"])\n",
+    "            screen_row[\"alpha\"] = float(screen_row[\"alpha\"])\n",
+    "            screen_row[\"count\"] = int(screen_row[\"count\"])\n",
+    "            screen_row[\"n_mutations\"] = mutation_count(screen_row[\"mutation\"])\n",
+    "            out.append(screen_row)\n",
+    "    return out\n",
+    "\n",
+    "def load_selectivity():\n",
+    "    out = []\n",
+    "    with open_text(SELECTIVITY_PATH) as f:\n",
+    "        for sel_row in csv.DictReader(f):\n",
+    "            sel_row[\"ratio\"] = float(sel_row[\"ratio\"])\n",
+    "            sel_row[\"r_ee\"] = float(sel_row[\"r_enantiomeric_excess\"])\n",
+    "            sel_row[\"n_mutations\"] = mutation_count(sel_row[\"mutation\"])\n",
+    "            out.append(sel_row)\n",
+    "    return out\n",
+    "\n",
+    "screen_rows = load_screen()\n",
+    "selectivity_rows = load_selectivity()\n",
+    "len(screen_rows), len(selectivity_rows)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "lEQa",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "helpers"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def median(values):\n",
+    "    xs = sorted(values)\n",
+    "    n = len(xs)\n",
+    "    if n == 0:\n",
+    "        return None\n",
+    "    mid = n // 2\n",
+    "    if n % 2:\n",
+    "        return xs[mid]\n",
+    "    return (xs[mid - 1] + xs[mid]) / 2\n",
+    "\n",
+    "def mean(values):\n",
+    "    return sum(values) / len(values)\n",
+    "\n",
+    "def group_by(items, key):\n",
+    "    grouped = {}\n",
+    "    for item in items:\n",
+    "        grouped.setdefault(item[key], []).append(item)\n",
+    "    return grouped"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "PKri",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "overview"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Dataset snapshot.** The activity screen has **11,305 variants**.\n",
+       "The smaller selectivity table has **427 variants** with both activity ratio\n",
+       "and R-enantiomeric excess. The full activity landscape is highly sparse: median ratio is\n",
+       "**0.006**, while the selectivity follow-up median R-ee is **41.6%**."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "screen_median = median([r[\"ratio\"] for r in screen_rows])\n",
+    "selectivity_median = median([r[\"r_ee\"] for r in selectivity_rows])\n",
+    "mo.md(\n",
+    "    f\"\"\"\n",
+    "    **Dataset snapshot.** The activity screen has **{len(screen_rows):,} variants**.\n",
+    "    The smaller selectivity table has **{len(selectivity_rows):,} variants** with both activity ratio\n",
+    "    and R-enantiomeric excess. The full activity landscape is highly sparse: median ratio is\n",
+    "    **{screen_median:.3f}**, while the selectivity follow-up median R-ee is **{selectivity_median:.1%}**.\n",
+    "    \"\"\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Xref",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "mutation_count_summary"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[[{\"n_mutations\": 0, \"n\": 1, \"median_ratio\": \"text/plain+float:0.14614211\", \"top_ratio\": \"text/plain+float:0.14614211\"}, {\"n_mutations\": 1, \"n\": 4720, \"median_ratio\": \"text/plain+float:0.030167582\", \"top_ratio\": \"text/plain+float:0.731655079\"}, {\"n_mutations\": 2, \"n\": 1505, \"median_ratio\": \"text/plain+float:0.013024976\", \"top_ratio\": \"text/plain+float:0.840423358\"}, {\"n_mutations\": 3, \"n\": 1788, \"median_ratio\": \"text/plain+float:0.0057350995\", \"top_ratio\": \"text/plain+float:0.869317971\"}, {\"n_mutations\": 4, \"n\": 1408, \"median_ratio\": \"text/plain+float:0.0015628645\", \"top_ratio\": \"text/plain+float:0.854674968\"}, {\"n_mutations\": 5, \"n\": 950, \"median_ratio\": \"text/plain+float:0.0010882485000000002\", \"top_ratio\": \"text/plain+float:0.782415565\"}, {\"n_mutations\": 6, \"n\": 491, \"median_ratio\": \"text/plain+float:0.001041449\", \"top_ratio\": \"text/plain+float:0.793792249\"}, {\"n_mutations\": 7, \"n\": 269, \"median_ratio\": \"text/plain+float:0.001003327\", \"top_ratio\": \"text/plain+float:0.57996793\"}, {\"n_mutations\": 8, \"n\": 105, \"median_ratio\": \"text/plain+float:0.000991953\", \"top_ratio\": \"text/plain+float:0.008276584\"}, {\"n_mutations\": 9, \"n\": 40, \"median_ratio\": \"text/plain+float:0.000820332\", \"top_ratio\": \"text/plain+float:0.01624559\"}, {\"n_mutations\": 10, \"n\": 13, \"median_ratio\": \"text/plain+float:0.000781449\", \"top_ratio\": \"text/plain+float:0.001567406\"}, {\"n_mutations\": 11, \"n\": 6, \"median_ratio\": \"text/plain+float:0.0011605589999999998\", \"top_ratio\": \"text/plain+float:0.002756203\"}, {\"n_mutations\": 13, \"n\": 2, \"median_ratio\": \"text/plain+float:0.0049677045000000005\", \"top_ratio\": \"text/plain+float:0.009593343\"}, {\"n_mutations\": 19, \"n\": 1, \"median_ratio\": \"text/plain+float:0.000145378\", \"top_ratio\": \"text/plain+float:0.000145378\"}, {\"n_mutations\": 24, \"n\": 1, \"median_ratio\": \"text/plain+float:0.001359539\", \"top_ratio\": \"text/plain+float:0.001359539\"}, {\"n_mutations\": 33, \"n\": 1, \"median_ratio\": \"text/plain+float:0.488739871\", \"top_ratio\": \"text/plain+float:0.488739871\"}, {\"n_mutations\": 170, \"n\": 1, \"median_ratio\": \"text/plain+float:0.000236651\", \"top_ratio\": \"text/plain+float:0.000236651\"}, {\"n_mutations\": 237, \"n\": 1, \"median_ratio\": \"text/plain+float:0.002172292\", \"top_ratio\": \"text/plain+float:0.002172292\"}, {\"n_mutations\": 285, \"n\": 1, \"median_ratio\": \"text/plain+float:0.548887558\", \"top_ratio\": \"text/plain+float:0.548887558\"}, {\"n_mutations\": 289, \"n\": 1, \"median_ratio\": \"text/plain+float:0.15611374\", \"top_ratio\": \"text/plain+float:0.15611374\"}], [{\"n_mutations\": 1, \"n\": 117, \"median_ratio\": \"text/plain+float:0.279139285\", \"median_r_ee\": \"text/plain+float:0.328894897\"}, {\"n_mutations\": 2, \"n\": 99, \"median_ratio\": \"text/plain+float:0.468631166\", \"median_r_ee\": \"text/plain+float:0.49553243\"}, {\"n_mutations\": 3, \"n\": 176, \"median_ratio\": \"text/plain+float:0.626247293\", \"median_r_ee\": \"text/plain+float:0.47149574699999997\"}, {\"n_mutations\": 4, \"n\": 29, \"median_ratio\": \"text/plain+float:0.566647766\", \"median_r_ee\": \"text/plain+float:0.978065935\"}, {\"n_mutations\": 5, \"n\": 5, \"median_ratio\": \"text/plain+float:0.719084213\", \"median_r_ee\": \"text/plain+float:0.981058804\"}, {\"n_mutations\": 7, \"n\": 1, \"median_ratio\": \"text/plain+float:0.139918602\", \"median_r_ee\": \"text/plain+float:-0.57633244\"}]]"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def summarize_activity(items):\n",
+    "    out = []\n",
+    "    for n_mut, mc_group in sorted(group_by(items, \"n_mutations\").items()):\n",
+    "        out.append({\n",
+    "            \"n_mutations\": n_mut,\n",
+    "            \"n\": len(mc_group),\n",
+    "            \"median_ratio\": median([r[\"ratio\"] for r in mc_group]),\n",
+    "            \"top_ratio\": max(r[\"ratio\"] for r in mc_group),\n",
+    "        })\n",
+    "    return out\n",
+    "\n",
+    "def summarize_selectivity(items):\n",
+    "    out = []\n",
+    "    for n_mut, mc_group in sorted(group_by(items, \"n_mutations\").items()):\n",
+    "        out.append({\n",
+    "            \"n_mutations\": n_mut,\n",
+    "            \"n\": len(mc_group),\n",
+    "            \"median_ratio\": median([r[\"ratio\"] for r in mc_group]),\n",
+    "            \"median_r_ee\": median([r[\"r_ee\"] for r in mc_group]),\n",
+    "        })\n",
+    "    return out\n",
+    "\n",
+    "by_count_activity = summarize_activity(screen_rows)\n",
+    "by_count_selectivity = summarize_selectivity(selectivity_rows)\n",
+    "by_count_activity, by_count_selectivity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "SFPL",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "mutation_count_plot"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<marimo-plotly data-figure='{&quot;data&quot;:[{&quot;marker&quot;:{&quot;color&quot;:&quot;#2563eb&quot;},&quot;name&quot;:&quot;median activity ratio&quot;,&quot;x&quot;:[&quot;1&quot;,&quot;2&quot;,&quot;3&quot;,&quot;4&quot;,&quot;5&quot;,&quot;7&quot;],&quot;y&quot;:[0.279139285,0.468631166,0.626247293,0.566647766,0.719084213,0.139918602],&quot;type&quot;:&quot;bar&quot;},{&quot;marker&quot;:{&quot;color&quot;:&quot;#dc2626&quot;},&quot;mode&quot;:&quot;lines+markers&quot;,&quot;name&quot;:&quot;median R-selectivity&quot;,&quot;x&quot;:[&quot;1&quot;,&quot;2&quot;,&quot;3&quot;,&quot;4&quot;,&quot;5&quot;,&quot;7&quot;],&quot;y&quot;:[0.328894897,0.49553243,0.47149574699999997,0.978065935,0.981058804,-0.57633244],&quot;yaxis&quot;:&quot;y2&quot;,&quot;type&quot;:&quot;scatter&quot;}],&quot;layout&quot;:{&quot;template&quot;:{&quot;data&quot;:{&quot;barpolar&quot;:[{&quot;marker&quot;:{&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;,&quot;width&quot;:0.5},&quot;pattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2}},&quot;type&quot;:&quot;barpolar&quot;}],&quot;bar&quot;:[{&quot;error_x&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;},&quot;error_y&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;},&quot;marker&quot;:{&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;,&quot;width&quot;:0.5},&quot;pattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2}},&quot;type&quot;:&quot;bar&quot;}],&quot;carpet&quot;:[{&quot;aaxis&quot;:{&quot;endlinecolor&quot;:&quot;#2a3f5f&quot;,&quot;gridcolor&quot;:&quot;#C8D4E3&quot;,&quot;linecolor&quot;:&quot;#C8D4E3&quot;,&quot;minorgridcolor&quot;:&quot;#C8D4E3&quot;,&quot;startlinecolor&quot;:&quot;#2a3f5f&quot;},&quot;baxis&quot;:{&quot;endlinecolor&quot;:&quot;#2a3f5f&quot;,&quot;gridcolor&quot;:&quot;#C8D4E3&quot;,&quot;linecolor&quot;:&quot;#C8D4E3&quot;,&quot;minorgridcolor&quot;:&quot;#C8D4E3&quot;,&quot;startlinecolor&quot;:&quot;#2a3f5f&quot;},&quot;type&quot;:&quot;carpet&quot;}],&quot;choropleth&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;type&quot;:&quot;choropleth&quot;}],&quot;contourcarpet&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;type&quot;:&quot;contourcarpet&quot;}],&quot;contour&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;contour&quot;}],&quot;heatmap&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;heatmap&quot;}],&quot;histogram2dcontour&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;histogram2dcontour&quot;}],&quot;histogram2d&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;histogram2d&quot;}],&quot;histogram&quot;:[{&quot;marker&quot;:{&quot;pattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2}},&quot;type&quot;:&quot;histogram&quot;}],&quot;mesh3d&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;type&quot;:&quot;mesh3d&quot;}],&quot;parcoords&quot;:[{&quot;line&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;parcoords&quot;}],&quot;pie&quot;:[{&quot;automargin&quot;:true,&quot;type&quot;:&quot;pie&quot;}],&quot;scatter3d&quot;:[{&quot;line&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatter3d&quot;}],&quot;scattercarpet&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattercarpet&quot;}],&quot;scattergeo&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattergeo&quot;}],&quot;scattergl&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattergl&quot;}],&quot;scattermapbox&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattermapbox&quot;}],&quot;scattermap&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattermap&quot;}],&quot;scatterpolargl&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatterpolargl&quot;}],&quot;scatterpolar&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatterpolar&quot;}],&quot;scatter&quot;:[{&quot;fillpattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2},&quot;type&quot;:&quot;scatter&quot;}],&quot;scatterternary&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatterternary&quot;}],&quot;surface&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;surface&quot;}],&quot;table&quot;:[{&quot;cells&quot;:{&quot;fill&quot;:{&quot;color&quot;:&quot;#EBF0F8&quot;},&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;}},&quot;header&quot;:{&quot;fill&quot;:{&quot;color&quot;:&quot;#C8D4E3&quot;},&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;}},&quot;type&quot;:&quot;table&quot;}]},&quot;layout&quot;:{&quot;annotationdefaults&quot;:{&quot;arrowcolor&quot;:&quot;#2a3f5f&quot;,&quot;arrowhead&quot;:0,&quot;arrowwidth&quot;:1},&quot;autotypenumbers&quot;:&quot;strict&quot;,&quot;coloraxis&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;colorscale&quot;:{&quot;diverging&quot;:[[0,&quot;#8e0152&quot;],[0.1,&quot;#c51b7d&quot;],[0.2,&quot;#de77ae&quot;],[0.3,&quot;#f1b6da&quot;],[0.4,&quot;#fde0ef&quot;],[0.5,&quot;#f7f7f7&quot;],[0.6,&quot;#e6f5d0&quot;],[0.7,&quot;#b8e186&quot;],[0.8,&quot;#7fbc41&quot;],[0.9,&quot;#4d9221&quot;],[1,&quot;#276419&quot;]],&quot;sequential&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;sequentialminus&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]]},&quot;colorway&quot;:[&quot;#636efa&quot;,&quot;#EF553B&quot;,&quot;#00cc96&quot;,&quot;#ab63fa&quot;,&quot;#FFA15A&quot;,&quot;#19d3f3&quot;,&quot;#FF6692&quot;,&quot;#B6E880&quot;,&quot;#FF97FF&quot;,&quot;#FECB52&quot;],&quot;font&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;},&quot;geo&quot;:{&quot;bgcolor&quot;:&quot;white&quot;,&quot;lakecolor&quot;:&quot;white&quot;,&quot;landcolor&quot;:&quot;white&quot;,&quot;showlakes&quot;:true,&quot;showland&quot;:true,&quot;subunitcolor&quot;:&quot;#C8D4E3&quot;},&quot;hoverlabel&quot;:{&quot;align&quot;:&quot;left&quot;},&quot;hovermode&quot;:&quot;closest&quot;,&quot;mapbox&quot;:{&quot;style&quot;:&quot;light&quot;},&quot;paper_bgcolor&quot;:&quot;white&quot;,&quot;plot_bgcolor&quot;:&quot;white&quot;,&quot;polar&quot;:{&quot;angularaxis&quot;:{&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;},&quot;bgcolor&quot;:&quot;white&quot;,&quot;radialaxis&quot;:{&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;}},&quot;scene&quot;:{&quot;xaxis&quot;:{&quot;backgroundcolor&quot;:&quot;white&quot;,&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;gridwidth&quot;:2,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;showbackground&quot;:true,&quot;ticks&quot;:&quot;&quot;,&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;},&quot;yaxis&quot;:{&quot;backgroundcolor&quot;:&quot;white&quot;,&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;gridwidth&quot;:2,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;showbackground&quot;:true,&quot;ticks&quot;:&quot;&quot;,&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;},&quot;zaxis&quot;:{&quot;backgroundcolor&quot;:&quot;white&quot;,&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;gridwidth&quot;:2,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;showbackground&quot;:true,&quot;ticks&quot;:&quot;&quot;,&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;}},&quot;shapedefaults&quot;:{&quot;line&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;}},&quot;ternary&quot;:{&quot;aaxis&quot;:{&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;linecolor&quot;:&quot;#A2B1C6&quot;,&quot;ticks&quot;:&quot;&quot;},&quot;baxis&quot;:{&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;linecolor&quot;:&quot;#A2B1C6&quot;,&quot;ticks&quot;:&quot;&quot;},&quot;bgcolor&quot;:&quot;white&quot;,&quot;caxis&quot;:{&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;linecolor&quot;:&quot;#A2B1C6&quot;,&quot;ticks&quot;:&quot;&quot;}},&quot;title&quot;:{&quot;x&quot;:0.05},&quot;xaxis&quot;:{&quot;automargin&quot;:true,&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;,&quot;title&quot;:{&quot;standoff&quot;:15},&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;,&quot;zerolinewidth&quot;:2},&quot;yaxis&quot;:{&quot;automargin&quot;:true,&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;,&quot;title&quot;:{&quot;standoff&quot;:15},&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;,&quot;zerolinewidth&quot;:2}}},&quot;yaxis2&quot;:{&quot;title&quot;:{&quot;text&quot;:&quot;Median R-ee&quot;},&quot;overlaying&quot;:&quot;y&quot;,&quot;side&quot;:&quot;right&quot;,&quot;tickformat&quot;:&quot;.0%&quot;},&quot;title&quot;:{&quot;text&quot;:&quot;Combinatorial variants dominate both activity and selectivity&quot;},&quot;xaxis&quot;:{&quot;title&quot;:{&quot;text&quot;:&quot;Number of mutations in variant&quot;}},&quot;yaxis&quot;:{&quot;title&quot;:{&quot;text&quot;:&quot;Median activity ratio&quot;}},&quot;height&quot;:440,&quot;dragmode&quot;:&quot;zoom&quot;}}' data-config='{}'></marimo-plotly>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mc_fig = go.Figure()\n",
+    "mc_fig.add_trace(go.Bar(\n",
+    "    x=[str(r[\"n_mutations\"]) for r in by_count_selectivity],\n",
+    "    y=[r[\"median_ratio\"] for r in by_count_selectivity],\n",
+    "    name=\"median activity ratio\",\n",
+    "    marker_color=\"#2563eb\",\n",
+    "))\n",
+    "mc_fig.add_trace(go.Scatter(\n",
+    "    x=[str(r[\"n_mutations\"]) for r in by_count_selectivity],\n",
+    "    y=[r[\"median_r_ee\"] for r in by_count_selectivity],\n",
+    "    name=\"median R-selectivity\",\n",
+    "    mode=\"lines+markers\",\n",
+    "    yaxis=\"y2\",\n",
+    "    marker_color=\"#dc2626\",\n",
+    "))\n",
+    "mc_fig.update_layout(\n",
+    "    title=\"Combinatorial variants dominate both activity and selectivity\",\n",
+    "    xaxis_title=\"Number of mutations in variant\",\n",
+    "    yaxis_title=\"Median activity ratio\",\n",
+    "    yaxis2=dict(title=\"Median R-ee\", overlaying=\"y\", side=\"right\", tickformat=\".0%\"),\n",
+    "    template=\"plotly_white\",\n",
+    "    height=440,\n",
+    ")\n",
+    "mc_fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "BYtC",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r",
+     "name": "mutation_count_interpretation"
+    }
+   },
+   "source": [
+    "**Interpretation.** The transition from single mutants to composed variants is the main story.\n",
+    "In the selectivity table, single mutants have **0.279 median activity** and **32.9% median R-ee**.\n",
+    "Three-mutation variants reach **0.626 median activity**, while four- and five-mutation variants reach\n",
+    "roughly **98% median R-ee**. The best region of this landscape is therefore not \"more mutations is always\n",
+    "better\"; it is the narrower zone where a few compatible mutations jointly lift activity and stereocontrol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "RGSE",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "experiment_summary"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[{\"experiment\": \"DMS\", \"n\": 98, \"median_ratio\": \"text/plain+float:0.298461618\", \"median_r_ee\": \"text/plain+float:0.3129350045\", \"median_mutations\": \"text/plain+float:1.0\"}, {\"experiment\": \"EPPCR1\", \"n\": 53, \"median_ratio\": \"text/plain+float:0.106431141\", \"median_r_ee\": \"text/plain+float:0.458509564\", \"median_mutations\": 2}, {\"experiment\": \"EPPCR2\", \"n\": 39, \"median_ratio\": \"text/plain+float:0.683195932\", \"median_r_ee\": \"text/plain+float:0.975281691\", \"median_mutations\": 2}, {\"experiment\": \"EPPCR3\", \"n\": 36, \"median_ratio\": \"text/plain+float:0.7001739979999999\", \"median_r_ee\": \"text/plain+float:0.982368839\", \"median_mutations\": \"text/plain+float:4.0\"}, {\"experiment\": \"FragLib\", \"n\": 2, \"median_ratio\": \"text/plain+float:0.7056754605\", \"median_r_ee\": \"text/plain+float:0.9816757705\", \"median_mutations\": \"text/plain+float:2.5\"}, {\"experiment\": \"LowN\", \"n\": 20, \"median_ratio\": \"text/plain+float:0.37309765\", \"median_r_ee\": \"text/plain+float:0.185792388\", \"median_mutations\": \"text/plain+float:2.0\"}, {\"experiment\": \"ML\", \"n\": 91, \"median_ratio\": \"text/plain+float:0.488471387\", \"median_r_ee\": \"text/plain+float:0.44647827\", \"median_mutations\": 3}, {\"experiment\": \"SGM\", \"n\": 88, \"median_ratio\": \"text/plain+float:0.715557132\", \"median_r_ee\": \"text/plain+float:0.32349935500000004\", \"median_mutations\": \"text/plain+float:3.0\"}]"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def summarize_experiments(items):\n",
+    "    out = []\n",
+    "    for experiment, exp_group in sorted(group_by(items, \"experiment\").items()):\n",
+    "        out.append({\n",
+    "            \"experiment\": experiment,\n",
+    "            \"n\": len(exp_group),\n",
+    "            \"median_ratio\": median([r[\"ratio\"] for r in exp_group]),\n",
+    "            \"median_r_ee\": median([r[\"r_ee\"] for r in exp_group]),\n",
+    "            \"median_mutations\": median([r[\"n_mutations\"] for r in exp_group]),\n",
+    "        })\n",
+    "    return out\n",
+    "\n",
+    "by_experiment = summarize_experiments(selectivity_rows)\n",
+    "by_experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Kclp",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "experiment_plot"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<marimo-plotly data-figure='{&quot;data&quot;:[{&quot;hovertemplate&quot;:&quot;%{text}&lt;br&gt;median activity=%{x:.3f}&lt;br&gt;median R-ee=%{y:.1%}&lt;extra&gt;&lt;/extra&gt;&quot;,&quot;marker&quot;:{&quot;color&quot;:[1.0,2,2,4.0,2.5,2.0,3,3.0],&quot;colorbar&quot;:{&quot;title&quot;:{&quot;text&quot;:&quot;median mutation count&quot;}},&quot;colorscale&quot;:[[0.0,&quot;#440154&quot;],[0.1111111111111111,&quot;#482878&quot;],[0.2222222222222222,&quot;#3e4989&quot;],[0.3333333333333333,&quot;#31688e&quot;],[0.4444444444444444,&quot;#26828e&quot;],[0.5555555555555556,&quot;#1f9e89&quot;],[0.6666666666666666,&quot;#35b779&quot;],[0.7777777777777778,&quot;#6ece58&quot;],[0.8888888888888888,&quot;#b5de2b&quot;],[1.0,&quot;#fde725&quot;]],&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;,&quot;width&quot;:1},&quot;size&quot;:[24.748737341529164,18.200274723201296,15.612494995995995,15.0,10,11.180339887498949,23.84848003542364,23.45207879911715]},&quot;mode&quot;:&quot;markers+text&quot;,&quot;text&quot;:[&quot;DMS&quot;,&quot;EPPCR1&quot;,&quot;EPPCR2&quot;,&quot;EPPCR3&quot;,&quot;FragLib&quot;,&quot;LowN&quot;,&quot;ML&quot;,&quot;SGM&quot;],&quot;textposition&quot;:&quot;top center&quot;,&quot;x&quot;:[0.298461618,0.106431141,0.683195932,0.7001739979999999,0.7056754605,0.37309765,0.488471387,0.715557132],&quot;y&quot;:[0.3129350045,0.458509564,0.975281691,0.982368839,0.9816757705,0.185792388,0.44647827,0.32349935500000004],&quot;type&quot;:&quot;scatter&quot;}],&quot;layout&quot;:{&quot;template&quot;:{&quot;data&quot;:{&quot;barpolar&quot;:[{&quot;marker&quot;:{&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;,&quot;width&quot;:0.5},&quot;pattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2}},&quot;type&quot;:&quot;barpolar&quot;}],&quot;bar&quot;:[{&quot;error_x&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;},&quot;error_y&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;},&quot;marker&quot;:{&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;,&quot;width&quot;:0.5},&quot;pattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2}},&quot;type&quot;:&quot;bar&quot;}],&quot;carpet&quot;:[{&quot;aaxis&quot;:{&quot;endlinecolor&quot;:&quot;#2a3f5f&quot;,&quot;gridcolor&quot;:&quot;#C8D4E3&quot;,&quot;linecolor&quot;:&quot;#C8D4E3&quot;,&quot;minorgridcolor&quot;:&quot;#C8D4E3&quot;,&quot;startlinecolor&quot;:&quot;#2a3f5f&quot;},&quot;baxis&quot;:{&quot;endlinecolor&quot;:&quot;#2a3f5f&quot;,&quot;gridcolor&quot;:&quot;#C8D4E3&quot;,&quot;linecolor&quot;:&quot;#C8D4E3&quot;,&quot;minorgridcolor&quot;:&quot;#C8D4E3&quot;,&quot;startlinecolor&quot;:&quot;#2a3f5f&quot;},&quot;type&quot;:&quot;carpet&quot;}],&quot;choropleth&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;type&quot;:&quot;choropleth&quot;}],&quot;contourcarpet&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;type&quot;:&quot;contourcarpet&quot;}],&quot;contour&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;contour&quot;}],&quot;heatmap&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;heatmap&quot;}],&quot;histogram2dcontour&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;histogram2dcontour&quot;}],&quot;histogram2d&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;histogram2d&quot;}],&quot;histogram&quot;:[{&quot;marker&quot;:{&quot;pattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2}},&quot;type&quot;:&quot;histogram&quot;}],&quot;mesh3d&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;type&quot;:&quot;mesh3d&quot;}],&quot;parcoords&quot;:[{&quot;line&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;parcoords&quot;}],&quot;pie&quot;:[{&quot;automargin&quot;:true,&quot;type&quot;:&quot;pie&quot;}],&quot;scatter3d&quot;:[{&quot;line&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatter3d&quot;}],&quot;scattercarpet&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattercarpet&quot;}],&quot;scattergeo&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattergeo&quot;}],&quot;scattergl&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattergl&quot;}],&quot;scattermapbox&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattermapbox&quot;}],&quot;scattermap&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scattermap&quot;}],&quot;scatterpolargl&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatterpolargl&quot;}],&quot;scatterpolar&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatterpolar&quot;}],&quot;scatter&quot;:[{&quot;fillpattern&quot;:{&quot;fillmode&quot;:&quot;overlay&quot;,&quot;size&quot;:10,&quot;solidity&quot;:0.2},&quot;type&quot;:&quot;scatter&quot;}],&quot;scatterternary&quot;:[{&quot;marker&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;type&quot;:&quot;scatterternary&quot;}],&quot;surface&quot;:[{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;},&quot;colorscale&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;type&quot;:&quot;surface&quot;}],&quot;table&quot;:[{&quot;cells&quot;:{&quot;fill&quot;:{&quot;color&quot;:&quot;#EBF0F8&quot;},&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;}},&quot;header&quot;:{&quot;fill&quot;:{&quot;color&quot;:&quot;#C8D4E3&quot;},&quot;line&quot;:{&quot;color&quot;:&quot;white&quot;}},&quot;type&quot;:&quot;table&quot;}]},&quot;layout&quot;:{&quot;annotationdefaults&quot;:{&quot;arrowcolor&quot;:&quot;#2a3f5f&quot;,&quot;arrowhead&quot;:0,&quot;arrowwidth&quot;:1},&quot;autotypenumbers&quot;:&quot;strict&quot;,&quot;coloraxis&quot;:{&quot;colorbar&quot;:{&quot;outlinewidth&quot;:0,&quot;ticks&quot;:&quot;&quot;}},&quot;colorscale&quot;:{&quot;diverging&quot;:[[0,&quot;#8e0152&quot;],[0.1,&quot;#c51b7d&quot;],[0.2,&quot;#de77ae&quot;],[0.3,&quot;#f1b6da&quot;],[0.4,&quot;#fde0ef&quot;],[0.5,&quot;#f7f7f7&quot;],[0.6,&quot;#e6f5d0&quot;],[0.7,&quot;#b8e186&quot;],[0.8,&quot;#7fbc41&quot;],[0.9,&quot;#4d9221&quot;],[1,&quot;#276419&quot;]],&quot;sequential&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]],&quot;sequentialminus&quot;:[[0.0,&quot;#0d0887&quot;],[0.1111111111111111,&quot;#46039f&quot;],[0.2222222222222222,&quot;#7201a8&quot;],[0.3333333333333333,&quot;#9c179e&quot;],[0.4444444444444444,&quot;#bd3786&quot;],[0.5555555555555556,&quot;#d8576b&quot;],[0.6666666666666666,&quot;#ed7953&quot;],[0.7777777777777778,&quot;#fb9f3a&quot;],[0.8888888888888888,&quot;#fdca26&quot;],[1.0,&quot;#f0f921&quot;]]},&quot;colorway&quot;:[&quot;#636efa&quot;,&quot;#EF553B&quot;,&quot;#00cc96&quot;,&quot;#ab63fa&quot;,&quot;#FFA15A&quot;,&quot;#19d3f3&quot;,&quot;#FF6692&quot;,&quot;#B6E880&quot;,&quot;#FF97FF&quot;,&quot;#FECB52&quot;],&quot;font&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;},&quot;geo&quot;:{&quot;bgcolor&quot;:&quot;white&quot;,&quot;lakecolor&quot;:&quot;white&quot;,&quot;landcolor&quot;:&quot;white&quot;,&quot;showlakes&quot;:true,&quot;showland&quot;:true,&quot;subunitcolor&quot;:&quot;#C8D4E3&quot;},&quot;hoverlabel&quot;:{&quot;align&quot;:&quot;left&quot;},&quot;hovermode&quot;:&quot;closest&quot;,&quot;mapbox&quot;:{&quot;style&quot;:&quot;light&quot;},&quot;paper_bgcolor&quot;:&quot;white&quot;,&quot;plot_bgcolor&quot;:&quot;white&quot;,&quot;polar&quot;:{&quot;angularaxis&quot;:{&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;},&quot;bgcolor&quot;:&quot;white&quot;,&quot;radialaxis&quot;:{&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;}},&quot;scene&quot;:{&quot;xaxis&quot;:{&quot;backgroundcolor&quot;:&quot;white&quot;,&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;gridwidth&quot;:2,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;showbackground&quot;:true,&quot;ticks&quot;:&quot;&quot;,&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;},&quot;yaxis&quot;:{&quot;backgroundcolor&quot;:&quot;white&quot;,&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;gridwidth&quot;:2,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;showbackground&quot;:true,&quot;ticks&quot;:&quot;&quot;,&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;},&quot;zaxis&quot;:{&quot;backgroundcolor&quot;:&quot;white&quot;,&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;gridwidth&quot;:2,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;showbackground&quot;:true,&quot;ticks&quot;:&quot;&quot;,&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;}},&quot;shapedefaults&quot;:{&quot;line&quot;:{&quot;color&quot;:&quot;#2a3f5f&quot;}},&quot;ternary&quot;:{&quot;aaxis&quot;:{&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;linecolor&quot;:&quot;#A2B1C6&quot;,&quot;ticks&quot;:&quot;&quot;},&quot;baxis&quot;:{&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;linecolor&quot;:&quot;#A2B1C6&quot;,&quot;ticks&quot;:&quot;&quot;},&quot;bgcolor&quot;:&quot;white&quot;,&quot;caxis&quot;:{&quot;gridcolor&quot;:&quot;#DFE8F3&quot;,&quot;linecolor&quot;:&quot;#A2B1C6&quot;,&quot;ticks&quot;:&quot;&quot;}},&quot;title&quot;:{&quot;x&quot;:0.05},&quot;xaxis&quot;:{&quot;automargin&quot;:true,&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;,&quot;title&quot;:{&quot;standoff&quot;:15},&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;,&quot;zerolinewidth&quot;:2},&quot;yaxis&quot;:{&quot;automargin&quot;:true,&quot;gridcolor&quot;:&quot;#EBF0F8&quot;,&quot;linecolor&quot;:&quot;#EBF0F8&quot;,&quot;ticks&quot;:&quot;&quot;,&quot;title&quot;:{&quot;standoff&quot;:15},&quot;zerolinecolor&quot;:&quot;#EBF0F8&quot;,&quot;zerolinewidth&quot;:2}}},&quot;yaxis&quot;:{&quot;title&quot;:{&quot;text&quot;:&quot;Median R-enantiomeric excess&quot;},&quot;tickformat&quot;:&quot;.0%&quot;},&quot;title&quot;:{&quot;text&quot;:&quot;Engineering rounds move from sparse hits to active, selective designs&quot;},&quot;xaxis&quot;:{&quot;title&quot;:{&quot;text&quot;:&quot;Median activity ratio&quot;}},&quot;height&quot;:500,&quot;dragmode&quot;:&quot;zoom&quot;}}' data-config='{}'></marimo-plotly>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "exp_fig = go.Figure()\n",
+    "exp_fig.add_trace(go.Scatter(\n",
+    "    x=[r[\"median_ratio\"] for r in by_experiment],\n",
+    "    y=[r[\"median_r_ee\"] for r in by_experiment],\n",
+    "    mode=\"markers+text\",\n",
+    "    text=[r[\"experiment\"] for r in by_experiment],\n",
+    "    textposition=\"top center\",\n",
+    "    marker=dict(\n",
+    "        size=[max(10, r[\"n\"] ** 0.5 * 2.5) for r in by_experiment],\n",
+    "        color=[r[\"median_mutations\"] for r in by_experiment],\n",
+    "        colorscale=\"Viridis\",\n",
+    "        colorbar=dict(title=\"median mutation count\"),\n",
+    "        line=dict(color=\"white\", width=1),\n",
+    "    ),\n",
+    "    hovertemplate=(\n",
+    "        \"%{text}<br>median activity=%{x:.3f}<br>\"\n",
+    "        \"median R-ee=%{y:.1%}<extra></extra>\"\n",
+    "    ),\n",
+    "))\n",
+    "exp_fig.update_layout(\n",
+    "    title=\"Engineering rounds move from sparse hits to active, selective designs\",\n",
+    "    xaxis_title=\"Median activity ratio\",\n",
+    "    yaxis_title=\"Median R-enantiomeric excess\",\n",
+    "    yaxis=dict(tickformat=\".0%\"),\n",
+    "    template=\"plotly_white\",\n",
+    "    height=500,\n",
+    ")\n",
+    "exp_fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "emfo",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r",
+     "name": "experiment_interpretation"
+    }
+   },
+   "source": [
+    "**Round-level finding.** The early DMS rows are broad but weak: **98 DMS variants** have only\n",
+    "**0.298 median activity** and **31.3% median R-ee**. EPPCR2 and EPPCR3 are dramatically different:\n",
+    "**EPPCR2 reaches 97.5% median R-ee with 0.683 median activity**, and **EPPCR3 reaches 98.2% median\n",
+    "R-ee with 0.700 median activity**. That is the campaign's phase change: later rounds do not merely\n",
+    "add mutations, they preserve useful motifs while recombining them into a high-fitness region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Hstk",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "motif_analysis"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/json": "[[[\"S220T\", 34], [\"H230Y\", 18], [\"R148P\", 5], [\"R137H\", 2], [\"A169S\", 1], [\"A169T\", 1], [\"A187S\", 1], [\"A202V\", 1], [\"A5V\", 1], [\"L25R\", 1]], [{\"\": \"362\", \"mutation\": \"V175A; S220T; H230Y; V232D\", \"r_enantiomeric_excess\": \"0.986413619\", \"ratio\": \"text/plain+float:0.854674968\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.986413619\", \"n_mutations\": 4}, {\"\": \"232\", \"mutation\": \"Q194L; S220T; H230Y\", \"r_enantiomeric_excess\": \"0.990326279\", \"ratio\": \"text/plain+float:0.852582348\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.990326279\", \"n_mutations\": 3}, {\"\": \"60\", \"mutation\": \"A202V; S220T; H230Y\", \"r_enantiomeric_excess\": \"0.983657424\", \"ratio\": \"text/plain+float:0.827918529\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.983657424\", \"n_mutations\": 3}, {\"\": \"407\", \"mutation\": \"V97A; S220T; H230Y\", \"r_enantiomeric_excess\": \"0.984909032\", \"ratio\": \"text/plain+float:0.81150111\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.984909032\", \"n_mutations\": 3}, {\"\": \"382\", \"mutation\": \"T81S; A92V; S220T; H230Y\", \"r_enantiomeric_excess\": \"0.982786797\", \"ratio\": \"text/plain+float:0.809458463\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.982786797\", \"n_mutations\": 4}, {\"\": \"284\", \"mutation\": \"S205C; S220T; H230Y\", \"r_enantiomeric_excess\": \"0.985348729\", \"ratio\": \"text/plain+float:0.800983342\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.985348729\", \"n_mutations\": 3}, {\"\": \"59\", \"mutation\": \"A187S; S220T\", \"r_enantiomeric_excess\": \"0.979356698\", \"ratio\": \"text/plain+float:0.796808023\", \"experiment\": \"EPPCR2\", \"r_ee\": \"text/plain+float:0.979356698\", \"n_mutations\": 2}, {\"\": \"137\", \"mutation\": \"D170E; S220T; H230Y\", \"r_enantiomeric_excess\": \"0.983767942\", \"ratio\": \"text/plain+float:0.794621907\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.983767942\", \"n_mutations\": 3}, {\"\": \"311\", \"mutation\": \"S49G; R148P; A169E; S220T; H230Y\", \"r_enantiomeric_excess\": \"0.982042564\", \"ratio\": \"text/plain+float:0.782415565\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.982042564\", \"n_mutations\": 5}, {\"\": \"259\", \"mutation\": \"R94H; S220T; H230Y; H271Q\", \"r_enantiomeric_excess\": \"0.982885807\", \"ratio\": \"text/plain+float:0.782098642\", \"experiment\": \"EPPCR3\", \"r_ee\": \"text/plain+float:0.982885807\", \"n_mutations\": 4}]]"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def collect_high_fitness(items):\n",
+    "    return [\n",
+    "        r for r in items\n",
+    "        if r[\"ratio\"] >= 0.70 and r[\"r_ee\"] >= 0.95\n",
+    "    ]\n",
+    "\n",
+    "def count_motifs(items):\n",
+    "    counter = Counter()\n",
+    "    for hf_row in items:\n",
+    "        for mutation in [m.strip() for m in hf_row[\"mutation\"].split(\";\") if m.strip()]:\n",
+    "            counter[mutation] += 1\n",
+    "    return counter\n",
+    "\n",
+    "def top_winners(items, n):\n",
+    "    return sorted(\n",
+    "        items,\n",
+    "        key=lambda r: (r[\"ratio\"], r[\"r_ee\"]),\n",
+    "        reverse=True,\n",
+    "    )[:n]\n",
+    "\n",
+    "high_fitness = collect_high_fitness(selectivity_rows)\n",
+    "motif_counter = count_motifs(high_fitness)\n",
+    "top_high_fitness = top_winners(high_fitness, 10)\n",
+    "\n",
+    "motif_counter.most_common(10), top_high_fitness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nWHF",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "motif_interpretation"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "    ## The reusable mutation program\n",
+       "\n",
+       "    Define a high-fitness hit as **activity ratio >= 0.70** and **R-ee >= 95%**.\n",
+       "    There are **34** such variants. The recurring mutations are:\n",
+       "\n",
+       "    - `S220T` appears in 34 high-fitness variants\n",
+       "- `H230Y` appears in 18 high-fitness variants\n",
+       "- `R148P` appears in 5 high-fitness variants\n",
+       "- `R137H` appears in 2 high-fitness variants\n",
+       "- `A169S` appears in 1 high-fitness variants\n",
+       "- `A169T` appears in 1 high-fitness variants\n",
+       "- `A187S` appears in 1 high-fitness variants\n",
+       "- `A202V` appears in 1 high-fitness variants\n",
+       "\n",
+       "    **Lift check.** S220T appears in **100% (34/34)** of high-fitness winners but only\n",
+       "    **18.3% (78/427)** of the full selectivity table — a **5.5× enrichment**. That ratio,\n",
+       "    not the raw count, is the central evidence for the motif claim. H230Y is similarly enriched.\n",
+       "\n",
+       "    The clearest motif is **S220T**, usually paired with **H230Y** in the strongest EPPCR3 variants.\n",
+       "    This is the actionable part: the model or experimentalist should not rank mutations independently.\n",
+       "    It should search around compatible mutation neighborhoods.\n",
+       "    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "motif_lines = \"\\n\".join(\n",
+    "    f\"- `{mutation}` appears in {count} high-fitness variants\"\n",
+    "    for mutation, count in motif_counter.most_common(8)\n",
+    ")\n",
+    "mo.md(\n",
+    "    f\"\"\"\n",
+    "    ## The reusable mutation program\n",
+    "\n",
+    "    Define a high-fitness hit as **activity ratio >= 0.70** and **R-ee >= 95%**.\n",
+    "    There are **{len(high_fitness)}** such variants. The recurring mutations are:\n",
+    "\n",
+    "    {motif_lines}\n",
+    "\n",
+    "    **Lift check.** S220T appears in **100% (34/34)** of high-fitness winners but only\n",
+    "    **18.3% (78/427)** of the full selectivity table — a **5.5× enrichment**. That ratio,\n",
+    "    not the raw count, is the central evidence for the motif claim. H230Y is similarly enriched.\n",
+    "\n",
+    "    The clearest motif is **S220T**, usually paired with **H230Y** in the strongest EPPCR3 variants.\n",
+    "    This is the actionable part: the model or experimentalist should not rank mutations independently.\n",
+    "    It should search around compatible mutation neighborhoods.\n",
+    "    \"\"\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "iLit",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "top_variants_table"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "    ## Representative winners\n",
+       "\n",
+       "    | mutation set | round | activity ratio | R-ee |\n",
+       "    |---|---:|---:|---:|\n",
+       "    | V175A; S220T; H230Y; V232D | EPPCR3 | 0.855 | 98.6% |\n",
+       "| Q194L; S220T; H230Y | EPPCR3 | 0.853 | 99.0% |\n",
+       "| A202V; S220T; H230Y | EPPCR3 | 0.828 | 98.4% |\n",
+       "| V97A; S220T; H230Y | EPPCR3 | 0.812 | 98.5% |\n",
+       "| T81S; A92V; S220T; H230Y | EPPCR3 | 0.809 | 98.3% |\n",
+       "| S205C; S220T; H230Y | EPPCR3 | 0.801 | 98.5% |\n",
+       "| A187S; S220T | EPPCR2 | 0.797 | 97.9% |\n",
+       "| D170E; S220T; H230Y | EPPCR3 | 0.795 | 98.4% |\n",
+       "    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "table_rows = \"\\n\".join(\n",
+    "    f\"| {r['mutation']} | {r['experiment']} | {r['ratio']:.3f} | {r['r_ee']:.1%} |\"\n",
+    "    for r in top_high_fitness[:8]\n",
+    ")\n",
+    "mo.md(\n",
+    "    f\"\"\"\n",
+    "    ## Representative winners\n",
+    "\n",
+    "    | mutation set | round | activity ratio | R-ee |\n",
+    "    |---|---:|---:|---:|\n",
+    "    {table_rows}\n",
+    "    \"\"\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ZHCJ",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r",
+     "name": "caveats"
+    }
+   },
+   "source": [
+    "## What this means\n",
+    "\n",
+    "**Found:** In this protein fitness landscape, the high-value variants are not explained by single-mutation\n",
+    "screening alone. Fitness emerges when a small number of compatible mutations are composed, especially\n",
+    "around reusable motifs such as `S220T + H230Y`.\n",
+    "\n",
+    "**Why it matters:** This is exactly the failure mode that makes protein engineering hard: a mutation can\n",
+    "look unimpressive alone but become valuable in the right background. An AI-guided search policy should\n",
+    "therefore spend less effort on independent single-mutant ranking and more effort on motif-conditioned\n",
+    "combinatorial neighborhoods.\n",
+    "\n",
+    "**Caveats:** The notebook uses summary assay tables rather than raw chromatograms, so it cannot audit\n",
+    "measurement noise beyond the provided counts and ratios. It also analyzes one enzyme family, not all\n",
+    "protein fitness landscapes. The claim is intentionally local: this IRED campaign shows a strong\n",
+    "compositional fitness signal."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  },
+  "marimo": {
+   "app_config": {
+    "width": "medium"
+   },
+   "header": "# /// script\n# dependencies = [\"marimo\", \"plotly\"]\n# requires-python = \">=3.11\"\n# ///\n\n",
+   "marimo_version": "0.23.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Notebook submission for the May 13, 2026 Cursor Boston × PyData hack at Moderna HQ.

**TL;DR.** In the IRED protein engineering campaign (analyzed as a FLIP2 / ProteinGym-style protein fitness landscape), high-fitness winners aren't isolated single mutants — they're compositional. **34 / 34 high-fitness variants (activity ≥ 0.70, R-ee ≥ 95%) carry S220T, vs 78 / 427 (18.3%) of the full selectivity table — a 5.5× enrichment.** The motif is the signal; the screen is the noise.

Two files under `pydata-2026-submissions/squamis/`:
- `submission.ipynb` (16 cells, 55 KB, outputs pre-executed)
- `meta.json`