### PR TITLE
feat(pydata-2026): jonathanlittel — UCI Bank Marketing: more calls, more loans?

### DIFF
--- a/hackathon-notebook.py
+++ b/hackathon-notebook.py
@@ -1,0 +1,163 @@
+# /// script
+# dependencies = [
+#     "marimo",
+#     "matplotlib==3.10.9",
+#     "numpy==2.4.4",
+#     "pandas==3.0.3",
+# ]
+# requires-python = ">=3.13"
+# ///
+
+import marimo
+
+__generated_with = "0.23.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    import marimo as mo
+
+    mo.md("Hello!")
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
+    import io
+    import zipfile
+    import urllib.request
+
+    import pandas as pd
+
+    _URL = "https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank.zip"
+    with urllib.request.urlopen(_URL) as resp:
+        _buf = io.BytesIO(resp.read())
+    with zipfile.ZipFile(_buf) as zf:
+        df = pd.read_csv(zf.open("bank-full.csv"), sep=";")
+    df
+
+    return (df,)
+
+
+@app.cell(hide_code=True)
+def _(df, mo):
+    cat_cols = df.select_dtypes(include=["object", "string"]).columns.tolist()
+    _s = df[cat_cols].nunique().rename("n_distinct")
+    nunique_df = _s.reset_index().rename(columns={"index": "column"})
+    num_desc = df.describe().T.reset_index().rename(columns={"index": "column"})
+    _miss = df.isna().sum().rename("missing")
+    missing_df = _miss.reset_index().rename(columns={"index": "column"})
+    _y = df["y"].value_counts().rename("count")
+    y_df = _y.reset_index().rename(columns={"index": "y"})
+
+    mo.vstack(
+        [
+            mo.md("# Bank marketing — summary statistics"),
+            mo.md(
+                "**Dataset:** [UCI ML Repository #222 — Bank Marketing](https://archive.ics.uci.edu/dataset/222/bank+marketing)  \n"
+                "**File loaded:** `bank-full.csv` from `bank.zip` (semicolon-separated)."
+            ),
+            mo.md(f"**Shape:** {df.shape[0]:,} rows × {df.shape[1]} columns"),
+            mo.md("## dtypes"),
+            mo.md("\n".join(f"- `{c}`: `{t}`" for c, t in df.dtypes.items())),
+            mo.md("## Missing values"),
+            mo.ui.table(missing_df),
+            mo.md("## Numeric summary (`describe`)"),
+            mo.ui.table(num_desc),
+            mo.md("## Categorical columns — distinct value counts"),
+            mo.ui.table(nunique_df),
+            mo.md("## Target `y`"),
+            mo.ui.table(y_df),
+        ]
+    )
+
+    return
+
+
+@app.cell(hide_code=True)
+def _(df, mo):
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    # UCI Bank Marketing has no customer id or loan-origination date. "Starting period" is
+    # proxied by the first contact in the current campaign (`campaign == 1`).
+    _bal_start = df.loc[df["campaign"] == 1, "balance"]
+
+    fig1, ax1 = plt.subplots(figsize=(9, 4.5))
+    ax1.hist(
+        _bal_start,
+        bins=60,
+        color="#2c5282",
+        edgecolor="white",
+        linewidth=0.35,
+        log=True,
+    )
+    ax1.set_xlabel("Average yearly balance (euros)")
+    ax1.set_ylabel("Count (log scale)")
+    ax1.set_title("Histogram of balance at starting period (campaign = 1)")
+    ax1.spines["top"].set_visible(False)
+    ax1.spines["right"].set_visible(False)
+    fig1.tight_layout()
+
+    # Second histogram: split by how many campaign contacts so far (1–3 vs 4+). "3 or more"
+    # in the prompt is treated as strictly more than 3 so groups do not overlap.
+    _bal_few = df.loc[df["campaign"].between(1, 3, inclusive="both"), "balance"]
+    _bal_many = df.loc[df["campaign"] > 3, "balance"]
+    _edges = np.linspace(df["balance"].min(), df["balance"].max(), 61)
+
+    fig2, ax2 = plt.subplots(figsize=(9, 4.5))
+    ax2.hist(
+        _bal_few,
+        bins=_edges,
+        color="#2c5282",
+        edgecolor="white",
+        linewidth=0.35,
+        log=True,
+        alpha=0.65,
+        label="1–3",
+    )
+    ax2.hist(
+        _bal_many,
+        bins=_edges,
+        color="#c05621",
+        edgecolor="white",
+        linewidth=0.35,
+        log=True,
+        alpha=0.65,
+        label="4+",
+    )
+    ax2.set_xlabel("Average yearly balance (euros)")
+    ax2.set_ylabel("Count (log scale)")
+    ax2.set_title("Histogram of balance by prior marketing calls in this campaign")
+    ax2.legend(title="Number of marketing calls before loan")
+    ax2.spines["top"].set_visible(False)
+    ax2.spines["right"].set_visible(False)
+    fig2.tight_layout()
+
+    mo.vstack(
+        [
+            mo.md(
+                "The public UCI file does not record **when a loan began** or a stable **customer id** across calls. "
+                "For the first plot, **starting period** means **`campaign == 1`**. "
+                "For the second plot, **`campaign`** counts contacts in the **current** campaign on that row; "
+                "we treat that as a stand-in for how many marketing calls occurred **before** the modeled outcome, "
+                "and group **1–3** vs **4+** so bins do not double-count the same call count. "
+                "Both histograms use a **log-scaled count axis**."
+            ),
+            mo.mpl.interactive(fig1),
+            mo.mpl.interactive(fig2),
+        ]
+    )
+
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pydata-2026-submissions/jonathanlittel/meta.json
+++ b/pydata-2026-submissions/jonathanlittel/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "UCI Bank Marketing: more calls, more loans?",
+  "description": "Looks at marketing data by a Portuguese bank, and compares the number of marketing touches with the average loan size taken by customers.",
+  "displayName": "Jonathan Littel",
+  "tags": ["exploratory", "histogram", "pandas"]
+}

--- a/pydata-2026-submissions/jonathanlittel/score.json
+++ b/pydata-2026-submissions/jonathanlittel/score.json
@@ -1,0 +1,7 @@
+{
+  "score": 3,
+  "rationale": "The notebook loads the UCI Bank Marketing data, gives summary statistics, and explores whether more campaign contacts are associated with customer balance. It is honest about missing customer/loan timing limitations, but the analysis is narrow, mostly descriptive, and does not establish a strong or actionable insight. The result is a small exploratory check rather than a compelling hackathon finding.",
+  "model": "gpt-5.5",
+  "scoredAt": "2026-05-14T01:41:00.000Z",
+  "scorerVersion": 1
+}

--- a/pydata-2026-submissions/jonathanlittel/submission.py
+++ b/pydata-2026-submissions/jonathanlittel/submission.py
@@ -4,6 +4,7 @@
 #     "matplotlib==3.10.9",
 #     "numpy==2.4.4",
 #     "pandas==3.0.3",
+#     "scipy==1.17.1",
 # ]
 # requires-python = ">=3.13"
 # ///
@@ -19,12 +20,11 @@ def _():
     return
 
 
-@app.cell(hide_code=True)
+@app.cell
 def _():
     import marimo as mo
 
-    mo.md("Hello!")
-
+    mo.md("## Bank Marketing Data Analysis")
     return (mo,)
 
 
@@ -41,9 +41,9 @@ def _():
         _buf = io.BytesIO(resp.read())
     with zipfile.ZipFile(_buf) as zf:
         df = pd.read_csv(zf.open("bank-full.csv"), sep=";")
-    df
+    (df, pd)
 
-    return (df,)
+    return df, pd
 
 
 @app.cell(hide_code=True)
@@ -77,12 +77,11 @@ def _(df, mo):
             mo.ui.table(y_df),
         ]
     )
-
     return
 
 
 @app.cell(hide_code=True)
-def _(df, mo):
+def _(df, mo, pd):
     import matplotlib.pyplot as plt
     import numpy as np
 
@@ -106,50 +105,57 @@ def _(df, mo):
     ax1.spines["right"].set_visible(False)
     fig1.tight_layout()
 
-    # Second histogram: split by how many campaign contacts so far (1–3 vs 4+). "3 or more"
-    # in the prompt is treated as strictly more than 3 so groups do not overlap.
-    _bal_few = df.loc[df["campaign"].between(1, 3, inclusive="both"), "balance"]
-    _bal_many = df.loc[df["campaign"] > 3, "balance"]
-    _edges = np.linspace(df["balance"].min(), df["balance"].max(), 61)
+    # `campaign` = number of contacts in the current campaign on this row (integer >= 1).
+    _n_bins = 5
+    _call_bins = pd.cut(
+        df["campaign"],
+        bins=_n_bins,
+        include_lowest=True,
+        duplicates="drop",
+    )
+    _by_bin = (
+        df.assign(_call_bins=_call_bins)
+        .groupby("_call_bins", observed=True)
+        .agg(mean_balance=("balance", "mean"), n=("balance", "count"))
+        .reset_index()
+    )
+    _labels = [str(iv) for iv in _by_bin["_call_bins"]]
+    _x = np.arange(len(_by_bin))
 
     fig2, ax2 = plt.subplots(figsize=(9, 4.5))
-    ax2.hist(
-        _bal_few,
-        bins=_edges,
+    ax2.bar(
+        _x,
+        _by_bin["mean_balance"],
         color="#2c5282",
         edgecolor="white",
-        linewidth=0.35,
-        log=True,
-        alpha=0.65,
-        label="1–3",
+        linewidth=0.6,
     )
-    ax2.hist(
-        _bal_many,
-        bins=_edges,
-        color="#c05621",
-        edgecolor="white",
-        linewidth=0.35,
-        log=True,
-        alpha=0.65,
-        label="4+",
-    )
-    ax2.set_xlabel("Average yearly balance (euros)")
-    ax2.set_ylabel("Count (log scale)")
-    ax2.set_title("Histogram of balance by prior marketing calls in this campaign")
-    ax2.legend(title="Number of marketing calls before loan")
+    ax2.set_xticks(_x, labels=_labels, rotation=25, ha="right")
+    ax2.set_xlabel("Number of marketing calls (this campaign), equal-width bins")
+    ax2.set_ylabel("Mean balance (euros)")
+    ax2.set_title("Mean balance by binned call count")
+    ax2.bar_label(ax2.containers[0], labels=[f"n={int(n)}" for n in _by_bin["n"]], padding=3, fontsize=8)
     ax2.spines["top"].set_visible(False)
     ax2.spines["right"].set_visible(False)
     fig2.tight_layout()
+
+    _r_pearson = df["campaign"].corr(df["balance"], method="pearson")
+    _r_spearman = df["campaign"].corr(df["balance"], method="spearman")
 
     mo.vstack(
         [
             mo.md(
                 "The public UCI file does not record **when a loan began** or a stable **customer id** across calls. "
                 "For the first plot, **starting period** means **`campaign == 1`**. "
-                "For the second plot, **`campaign`** counts contacts in the **current** campaign on that row; "
-                "we treat that as a stand-in for how many marketing calls occurred **before** the modeled outcome, "
-                "and group **1–3** vs **4+** so bins do not double-count the same call count. "
-                "Both histograms use a **log-scaled count axis**."
+                "The second chart bins **`campaign`** (contacts so far in this campaign) into **five equal-width** "
+                "intervals and plots the **mean balance** per bin (bar labels show row counts). "
+                "The first chart still uses a **log-scaled count** axis."
+            ),
+            mo.md(
+                f"**Correlation (full sample, n = {len(df):,}):**  \n"
+                f"- **Pearson r** (`campaign` vs `balance`): `{_r_pearson:.4f}`  \n"
+                f"- **Spearman rho** (rank): `{_r_spearman:.4f}`  \n"
+                "These are marginal associations only (no controls); outreach rules may target wealthier clients."
             ),
             mo.mpl.interactive(fig1),
             mo.mpl.interactive(fig2),


### PR DESCRIPTION
## Submission

**Folder:** `pydata-2026-submissions/jonathanlittel/`  
**Handle:** jonathanlittel  
**Dataset:** UCI Bank Marketing (Portuguese bank telemarketing, ~45k rows)

## What it does

Explores whether the number of marketing contacts in a campaign correlates with a customer's average yearly account balance.

- Loads the dataset directly from the UCI zip URL
- Summarises dtypes, missing values, numeric stats, categoricals, and the `y` target
- Histogram of account balance for first-contact customers (log-scaled count axis)
- Bar chart of mean balance binned by call count (5 equal-width bins, with row-count labels)
- Pearson r and Spearman rho correlation stats printed inline

## Checklist

- [x] Folder named after GitHub handle (`jonathanlittel`)
- [x] `submission.py` — Marimo native `.py` format (not `.ipynb`)
- [x] `meta.json` — title + description + tags
- [x] PR targets `pydata-2026-submissions` branch
- [x] DCO sign-off on commit (`-s`)

**Next steps:** show a linear model between loan amount and marketing touches — hit a Cursor usage limit before getting there.