### PR TITLE
fix(pydata): sort submissions by score

### DIFF
--- a/__tests__/lib/pydata-submissions.test.ts
+++ b/__tests__/lib/pydata-submissions.test.ts
@@ -38,7 +38,7 @@ function writeSubmission(
   root: string,
   handle: string,
   meta: unknown | null,
-  options: { notebook?: boolean } = {}
+  options: { notebook?: boolean; score?: unknown } = {}
 ): void {
   const folder = path.join(root, PYDATA_SUBMISSIONS_DIR, handle);
   fs.mkdirSync(folder, { recursive: true });
@@ -48,6 +48,9 @@ function writeSubmission(
   if (meta !== null) {
     const body = typeof meta === "string" ? meta : JSON.stringify(meta);
     fs.writeFileSync(path.join(folder, "meta.json"), body);
+  }
+  if (options.score !== undefined) {
+    fs.writeFileSync(path.join(folder, "score.json"), JSON.stringify(options.score));
   }
 }
 
@@ -153,27 +156,40 @@ describe("getPyDataSubmissions", () => {
     expect(result.map((s) => s.githubHandle)).toEqual(["valid-user"]);
   });
 
-  it("falls back to handle when displayName is missing, sorts alphabetically", () => {
+  it("falls back to handle when displayName is missing, sorts by score then alphabetically", () => {
     const result = withTempCwd((root) => {
       writeSubmission(root, "zach", {
         title: "Z work",
         description: "Z description",
+      }, {
+        score: {
+          score: 9,
+          rationale: "Strong.",
+          model: "test",
+          scoredAt: "2026-05-14T00:00:00.000Z",
+        },
+      });
+      writeSubmission(root, "barry", {
+        title: "B work",
+        description: "B description",
+      }, {
+        score: {
+          score: 9,
+          rationale: "Also strong.",
+          model: "test",
+          scoredAt: "2026-05-14T00:00:00.000Z",
+        },
       });
       writeSubmission(root, "amy", {
         title: "A work",
         description: "A description",
         displayName: "Amy A",
       });
-      writeSubmission(root, "barry", {
-        title: "B work",
-        description: "B description",
-      });
     });
-    // displayName for "zach" falls back to the handle "zach"; "amy" maps
-    // to its set displayName "Amy A"; "barry" falls back to "barry".
-    // Sort is alphabetical case-insensitive: Amy A, barry, zach.
-    expect(result.map((s) => s.displayName)).toEqual(["Amy A", "barry", "zach"]);
-    expect(result.map((s) => s.githubHandle)).toEqual(["amy", "barry", "zach"]);
+    // Scores sort descending first; equal scores use displayName as a stable
+    // case-insensitive tie-breaker. Unscored submissions come last.
+    expect(result.map((s) => s.displayName)).toEqual(["barry", "zach", "Amy A"]);
+    expect(result.map((s) => s.githubHandle)).toEqual(["barry", "zach", "amy"]);
   });
 
   it("clamps tags to a max of 6 and ignores non-string entries", () => {

--- a/lib/pydata-submissions.ts
+++ b/lib/pydata-submissions.ts
@@ -232,10 +232,15 @@ export function getPyDataSubmissions(): PyDataSubmission[] {
     submissions.push(submission);
   }
 
-  // Alphabetical by displayName so the grid has a stable ordering across
-  // builds — nothing "wins" by submitting early.
-  submissions.sort((a, b) =>
-    a.displayName.localeCompare(b.displayName, undefined, { sensitivity: "base" })
-  );
+  // Show the strongest judged submissions first. Keep unscored entries last and
+  // use display name as a stable tie-breaker so equal scores don't jump around.
+  submissions.sort((a, b) => {
+    const aScore = a.score?.score ?? -Infinity;
+    const bScore = b.score?.score ?? -Infinity;
+    if (bScore !== aScore) return bScore - aScore;
+    return a.displayName.localeCompare(b.displayName, undefined, {
+      sensitivity: "base",
+    });
+  });
   return submissions;
 }


### PR DESCRIPTION
## Summary
- Sort PyData submissions by judge score descending.
- Keep unscored submissions last and tie-break by display name.
- Update loader tests for score ordering.

## Test plan
- npm test -- __tests__/lib/pydata-submissions.test.ts


Made with [Cursor](https://cursor.com)