### PR TITLE
feat(pydata): show deadline eligibility groups

### DIFF
--- a/__tests__/lib/pydata-submissions.test.ts
+++ b/__tests__/lib/pydata-submissions.test.ts
@@ -93,6 +93,8 @@ describe("getPyDataSubmissions", () => {
     expect(s.folderUrl).toBe(
       `${PYDATA_SUBMISSIONS_REPO_URL}/tree/main/${PYDATA_SUBMISSIONS_DIR}/adam-sychla`
     );
+    expect(s.submittedAt).toBeNull();
+    expect(s.winnerEligible).toBe(false);
   });
 
   it("skips a folder missing submission.py", () => {
@@ -190,6 +192,51 @@ describe("getPyDataSubmissions", () => {
     // case-insensitive tie-breaker. Unscored submissions come last.
     expect(result.map((s) => s.displayName)).toEqual(["barry", "zach", "Amy A"]);
     expect(result.map((s) => s.githubHandle)).toEqual(["barry", "zach", "amy"]);
+  });
+
+  it("marks submissions opened before the winner cutoff as eligible", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "aaravraina3",
+        {
+          title: "Eligible",
+          description: "Submitted before the deadline.",
+          displayName: "Eligible Person",
+        },
+        {
+          score: {
+            score: 9,
+            rationale: "Strong.",
+            model: "test",
+            scoredAt: "2026-05-14T00:00:00.000Z",
+          },
+        }
+      );
+      writeSubmission(
+        root,
+        "trevordcampbell",
+        {
+          title: "Late",
+          description: "Submitted after the deadline.",
+          displayName: "Late Person",
+        },
+        {
+          score: {
+            score: 9,
+            rationale: "Also strong.",
+            model: "test",
+            scoredAt: "2026-05-14T00:00:00.000Z",
+          },
+        }
+      );
+    });
+
+    const byHandle = Object.fromEntries(result.map((s) => [s.githubHandle, s]));
+    expect(byHandle.aaravraina3.submittedAt).toBe("2026-05-14T00:40:39Z");
+    expect(byHandle.aaravraina3.winnerEligible).toBe(true);
+    expect(byHandle.trevordcampbell.submittedAt).toBe("2026-05-14T01:04:01Z");
+    expect(byHandle.trevordcampbell.winnerEligible).toBe(false);
   });
 
   it("clamps tags to a max of 6 and ignores non-string entries", () => {

--- a/app/events/cursor-boston-pydata-2026/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/page.tsx
@@ -757,31 +757,120 @@ function Step({
 }
 
 function SubmissionsGrid({ submissions }: { submissions: PyDataSubmission[] }) {
+  const eligible = submissions.filter((s) => s.winnerEligible);
+  const afterDeadline = submissions.filter((s) => !s.winnerEligible);
+
   return (
     <section className="px-6 py-12">
       <div className="max-w-6xl mx-auto">
-        <div className="mb-6 flex items-baseline justify-between gap-4 flex-wrap">
-          <h2 className="text-2xl md:text-3xl font-bold text-foreground">
-            Merged submissions{" "}
-            <span className="text-neutral-500 font-normal tabular-nums">
-              ({submissions.length})
-            </span>
-          </h2>
-          <p className="text-sm text-neutral-500 dark:text-neutral-400">
-            Each card links to the rendered notebook on GitHub.
+        <div className="mb-8 rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-5 dark:border-emerald-400/20 dark:bg-emerald-400/5">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:text-emerald-300">
+            Final judging board
           </p>
+          <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h2 className="text-2xl md:text-3xl font-bold text-foreground">
+                Merged submissions{" "}
+                <span className="text-neutral-500 font-normal tabular-nums">
+                  ({submissions.length})
+                </span>
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm text-neutral-600 dark:text-neutral-300">
+                Cards are sorted by AI judge score. Only PRs opened before 9:00
+                PM Eastern on May 13 are winner eligible; later PRs are shown
+                separately for showcase visibility.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-right">
+              <div className="rounded-xl bg-white px-4 py-3 shadow-sm dark:bg-neutral-950">
+                <p className="text-2xl font-bold tabular-nums text-emerald-700 dark:text-emerald-300">
+                  {eligible.length}
+                </p>
+                <p className="text-[11px] font-medium uppercase tracking-wide text-neutral-500">
+                  Eligible
+                </p>
+              </div>
+              <div className="rounded-xl bg-white px-4 py-3 shadow-sm dark:bg-neutral-950">
+                <p className="text-2xl font-bold tabular-nums text-amber-700 dark:text-amber-300">
+                  {afterDeadline.length}
+                </p>
+                <p className="text-[11px] font-medium uppercase tracking-wide text-neutral-500">
+                  After 9 PM
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
 
         {submissions.length === 0 ? (
           <EmptyState />
         ) : (
-          <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {submissions.map((s) => (
-              <SubmissionCard key={s.githubHandle} submission={s} />
-            ))}
-          </ul>
+          <div className="space-y-10">
+            <SubmissionSection
+              title="Winner eligible"
+              description="PR opened before 9:00 PM Eastern on May 13."
+              submissions={eligible}
+              tone="eligible"
+            />
+            <SubmissionSection
+              title="After deadline showcase"
+              description="PR opened after 9:00 PM Eastern. Included on the page, but not eligible for winner selection."
+              submissions={afterDeadline}
+              tone="late"
+            />
+          </div>
         )}
       </div>
+    </section>
+  );
+}
+
+function SubmissionSection({
+  title,
+  description,
+  submissions,
+  tone,
+}: {
+  title: string;
+  description: string;
+  submissions: PyDataSubmission[];
+  tone: "eligible" | "late";
+}) {
+  const countColor =
+    tone === "eligible"
+      ? "text-emerald-700 dark:text-emerald-300"
+      : "text-amber-700 dark:text-amber-300";
+
+  return (
+    <section>
+      <div className="mb-4 flex items-baseline justify-between gap-4 flex-wrap">
+        <div>
+          <h3 className="text-xl font-bold text-foreground">
+            {title}{" "}
+            <span className={`font-mono text-base font-semibold ${countColor}`}>
+              ({submissions.length})
+            </span>
+          </h3>
+          <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+            {description}
+          </p>
+        </div>
+      </div>
+      {submissions.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-neutral-300 bg-white p-5 text-sm text-neutral-500 dark:border-neutral-700 dark:bg-neutral-900">
+          No submissions in this group.
+        </div>
+      ) : (
+        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {submissions.map((s) => (
+            <SubmissionCard
+              key={s.githubHandle}
+              submission={s}
+              eligibilityTone={tone}
+            />
+          ))}
+        </ul>
+      )}
     </section>
   );
 }
@@ -803,10 +892,38 @@ function EmptyState() {
   );
 }
 
-function SubmissionCard({ submission }: { submission: PyDataSubmission }) {
+function SubmissionCard({
+  submission,
+  eligibilityTone,
+}: {
+  submission: PyDataSubmission;
+  eligibilityTone: "eligible" | "late";
+}) {
   const handleHref = `https://github.com/${submission.githubHandle}`;
+  const badgeClass =
+    eligibilityTone === "eligible"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+      : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  const badgeText =
+    eligibilityTone === "eligible" ? "Winner eligible" : "After deadline";
+
   return (
     <li className="flex flex-col rounded-xl border border-neutral-200 bg-white p-5 transition-colors hover:border-emerald-500/40 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <span
+          className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide ${badgeClass}`}
+        >
+          {badgeText}
+        </span>
+        {submission.submittedAt ? (
+          <time
+            dateTime={submission.submittedAt}
+            className="text-[11px] text-neutral-500 dark:text-neutral-400"
+          >
+            {formatSubmissionTime(submission.submittedAt)}
+          </time>
+        ) : null}
+      </div>
       <h3 className="text-lg font-semibold text-foreground line-clamp-2">
         <a
           href={submission.notebookUrl}
@@ -920,4 +1037,15 @@ function SubmissionCard({ submission }: { submission: PyDataSubmission }) {
       </div>
     </li>
   );
+}
+
+function formatSubmissionTime(iso: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(new Date(iso));
 }

--- a/lib/pydata-submissions.ts
+++ b/lib/pydata-submissions.ts
@@ -36,6 +36,44 @@ const MAX_DESCRIPTION = 500;
 const MAX_TAGS = 6;
 const MAX_COLLABORATORS = 10;
 const MAX_RATIONALE = 1000;
+const WINNER_ELIGIBLE_CUTOFF_ISO = "2026-05-14T01:00:00.000Z";
+
+const SUBMISSION_PR_CREATED_AT: Record<string, string> = {
+  aaravraina3: "2026-05-14T00:40:39Z",
+  aarongrace978: "2026-05-14T01:09:53Z",
+  amirmolavi: "2026-05-14T00:48:53Z",
+  ankittejyadav: "2026-05-14T01:18:21Z",
+  bradagi: "2026-05-14T00:01:10Z",
+  buenogrande: "2026-05-14T00:56:23Z",
+  danysigha: "2026-05-14T00:54:50Z",
+  dengziwu123: "2026-05-14T00:49:54Z",
+  dimavrem22: "2026-05-14T00:56:07Z",
+  ed2uiz: "2026-05-13T23:28:49Z",
+  gavinsadler: "2026-05-13T23:05:38Z",
+  harryj12: "2026-05-14T00:58:38Z",
+  johnnywang1998: "2026-05-14T00:17:31Z",
+  jonathanlittel: "2026-05-14T00:58:40Z",
+  mahtaraatwit: "2026-05-14T01:10:41Z",
+  mallikagaikwad: "2026-05-14T01:24:26Z",
+  manisha002307735: "2026-05-14T01:11:27Z",
+  ori98: "2026-05-14T00:44:57Z",
+  "paramjeet-singh-neu": "2026-05-14T00:58:49Z",
+  pjsk02: "2026-05-14T01:05:56Z",
+  pocketp1ck: "2026-05-14T01:01:37Z",
+  rdspangler: "2026-05-14T00:46:39Z",
+  saadai113: "2026-05-14T01:49:05Z",
+  saiff7: "2026-05-14T01:37:07Z",
+  sanaz01: "2026-05-14T01:10:42Z",
+  shuaeb6: "2026-05-14T01:05:51Z",
+  simrankumari30: "2026-05-14T01:31:56Z",
+  squamis: "2026-05-14T00:56:20Z",
+  "t-siddharth": "2026-05-14T00:28:58Z",
+  trevordcampbell: "2026-05-14T01:04:01Z",
+  varun7778: "2026-05-14T01:08:07Z",
+  vimaleshraja: "2026-05-14T01:01:31Z",
+  vishalprasanna11: "2026-05-14T00:56:43Z",
+  "xiaolong-y": "2026-05-13T23:06:48Z",
+};
 
 export interface PyDataSubmissionCollaborator {
   displayName: string;
@@ -70,6 +108,10 @@ export interface PyDataSubmission {
    * before the PR is merged. Absent if not yet scored.
    */
   score: PyDataSubmissionScore | null;
+  /** PR creation time used for winner eligibility cutoff decisions. */
+  submittedAt: string | null;
+  /** True when the original PR was opened before 9 PM Eastern on May 13. */
+  winnerEligible: boolean;
 }
 
 function clampString(s: unknown, max: number): string {
@@ -161,6 +203,10 @@ function buildSubmission(
     clampString(meta.displayName, 80) || handleDir;
   const tags = parseTags(meta.tags);
   const collaborators = parseCollaborators(meta.collaborators);
+  const submittedAt = SUBMISSION_PR_CREATED_AT[handleDir] ?? null;
+  const winnerEligible = submittedAt
+    ? Date.parse(submittedAt) < Date.parse(WINNER_ELIGIBLE_CUTOFF_ISO)
+    : false;
 
   return {
     githubHandle: handleDir,
@@ -172,6 +218,8 @@ function buildSubmission(
     notebookUrl: `${PYDATA_SUBMISSIONS_REPO_URL}/blob/main/${PYDATA_SUBMISSIONS_DIR}/${handleDir}/${NOTEBOOK_FILENAME}`,
     folderUrl: `${PYDATA_SUBMISSIONS_REPO_URL}/tree/main/${PYDATA_SUBMISSIONS_DIR}/${handleDir}`,
     score,
+    submittedAt,
+    winnerEligible,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add deadline eligibility metadata for PyData submissions based on PR creation time.
- Split the submissions page into winner-eligible and after-deadline showcase sections.
- Keep both sections sorted by judge score and show submission timestamps on cards.

## Test plan
- npm test -- __tests__/lib/pydata-submissions.test.ts
- npx tsc --noEmit


Made with [Cursor](https://cursor.com)