### PR TITLE
fix(pydata): render submissions one per row

### DIFF
--- a/app/events/cursor-boston-pydata-2026/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/page.tsx
@@ -861,7 +861,7 @@ function SubmissionSection({
           No submissions in this group.
         </div>
       ) : (
-        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <ul className="grid gap-4">
           {submissions.map((s) => (
             <SubmissionCard
               key={s.githubHandle}


### PR DESCRIPTION
## Summary
- Render PyData submission cards as a single vertical list in each eligibility section.
- Removes the responsive two/three-column card grid.

## Test plan
- npx tsc --noEmit


Made with [Cursor](https://cursor.com)