### PR TITLE
chore(pydata-2026): refine eligible finalist scores

### DIFF
--- a/lib/pydata-submissions.ts
+++ b/lib/pydata-submissions.ts
@@ -81,7 +81,7 @@ export interface PyDataSubmissionCollaborator {
 }
 
 export interface PyDataSubmissionScore {
-  /** Integer 1-10 from the LLM judge. */
+  /** Numeric 1-10 score from the LLM judge; decimals are used for tie-breaks. */
   score: number;
   /** Short justification from the judge. */
   rationale: string;

--- a/pydata-2026-submissions/amirmolavi/score.json
+++ b/pydata-2026-submissions/amirmolavi/score.json
@@ -1,7 +1,7 @@
 {
-  "score": 8,
-  "rationale": "This notebook tells a polished and accessible story around the Fulton Gap, with clear sample cuts, an effective radius-distribution visualization, and strong explanatory prose. The insight is compelling and easy to understand, and the notebook uses Marimo well as a guided narrative. It scores below the very top entries mainly because it recreates a known result rather than surfacing a more novel or actionable finding.",
+  "score": 8.1,
+  "rationale": "Refined tie-break score: this notebook is a polished Marimo narrative around the Fulton Gap, with careful sample cuts, effective visualizations, and an interactive irradiation filter that demonstrates the expected radius-valley shift. It is elegant and accessible, but among the tied 8s it is least novel because it primarily recreates a known published result rather than surfacing a new actionable or original finding.",
   "model": "gpt-5.5",
-  "scoredAt": "2026-05-14T01:05:00.000Z",
-  "scorerVersion": 1
+  "scoredAt": "2026-05-14T12:08:00.000Z",
+  "scorerVersion": 2
 }

--- a/pydata-2026-submissions/bradagi/score.json
+++ b/pydata-2026-submissions/bradagi/score.json
@@ -1,7 +1,7 @@
 {
-  "score": 8,
-  "rationale": "This notebook delivers a crisp and actionable insight from the UCI Bank Marketing data: the bank underused the 31-90 day recontact window where conversion was strongest, while over-dialing weaker windows and late attempts. The analysis is easy to follow, includes useful visual contrasts, and addresses an obvious seasonality confound with a within-month check. It is less technically ambitious than the very top submissions, but the storytelling and practical campaign recommendation are strong.",
+  "score": 8.8,
+  "rationale": "Refined tie-break score: this notebook delivers the strongest winner-eligible 8-range result because it turns the UCI Bank Marketing data into a crisp, operational recommendation: the bank underused the 31-90 day recontact window where conversion was strongest while over-dialing weaker late windows. It adds strong visual contrasts, checks the obvious seasonality confound within May, estimates missed opportunity, and separately analyzes dial-count exhaustion. It is less technically ambitious than the 9/10 entries, but it has the clearest actionable insight among the tied 8s.",
   "model": "gpt-5.5",
-  "scoredAt": "2026-05-14T00:56:00.000Z",
-  "scorerVersion": 1
+  "scoredAt": "2026-05-14T12:08:00.000Z",
+  "scorerVersion": 2
 }

--- a/pydata-2026-submissions/ori98/score.json
+++ b/pydata-2026-submissions/ori98/score.json
@@ -1,7 +1,7 @@
 {
-  "score": 8,
-  "rationale": "This notebook builds a thoughtful composite view of transit privilege across Boston neighborhoods by combining rapid-transit access, live alert exposure, and chronic wait-time reliability. The framing is clear, the geospatial joins and limitations are well explained, and the result is useful for comparing structural service advantage rather than just plotting stops. The main weakness is that the live alert component is a time-sensitive snapshot, so some rankings may be less stable than the narrative implies.",
+  "score": 8.5,
+  "rationale": "Refined tie-break score: this notebook builds a thoughtful composite measure of transit privilege by combining rapid-transit access, live alert exposure, and chronic Blue Book wait-time reliability. The geospatial joins, ethical framing, sensitivity controls, and factor breakdown make it more rigorous than a simple map. It ranks just below the top 8-range entry because the live-alert component is time-sensitive and the composite weighting remains exploratory, so the finding is useful but less cleanly decisive.",
   "model": "gpt-5.5",
-  "scoredAt": "2026-05-14T01:08:00.000Z",
-  "scorerVersion": 1
+  "scoredAt": "2026-05-14T12:08:00.000Z",
+  "scorerVersion": 2
 }

--- a/pydata-2026-submissions/rdspangler/score.json
+++ b/pydata-2026-submissions/rdspangler/score.json
@@ -1,7 +1,7 @@
 {
-  "score": 8,
-  "rationale": "The notebook has a clear, engaging story about how telescope technology shaped exoplanet discovery and then turns that context into an interactive Earth-like candidate explorer. It is polished, well-explained, and uses Marimo controls purposefully; the main weakness is that the insight is more broad exploratory storytelling than a single sharply defended quantitative claim.",
+  "score": 8.3,
+  "rationale": "Refined tie-break score: this is a polished, well-explained exoplanet explorer that combines discovery-history storytelling with interactive Earth-like candidate filtering and transparent ranking. The controls and candidate cards are strong for public exploration. It ranks below the higher 8-range entries because the main result is broader educational exploration rather than a single sharply defended quantitative claim.",
   "model": "gpt-5.5",
-  "scoredAt": "2026-05-14T00:52:00.000Z",
-  "scorerVersion": 1
+  "scoredAt": "2026-05-14T12:08:00.000Z",
+  "scorerVersion": 2
 }


### PR DESCRIPTION
## Summary
- Refine winner-eligible 8/10 submissions with decimal tie-break scores.
- Keep PR-created timestamps as the deadline source.
- Clarify score type comments to allow decimal tie-break scoring.

## Test plan
- npm test -- __tests__/lib/pydata-submissions.test.ts
- npx tsc --noEmit


Made with [Cursor](https://cursor.com)