### PR TITLE
feat: publish public hackathon result links

### DIFF
--- a/.cursor/rules/main-release-verification.mdc
+++ b/.cursor/rules/main-release-verification.mdc
@@ -1,0 +1,14 @@
+---
+description: Require local production verification before main releases
+alwaysApply: true
+---
+
+# Main Release Verification
+
+Before merging or pushing any change all the way to `main`, verify the production build locally:
+
+1. Run `npm run build`.
+2. Run `npm start` against that build.
+3. Give the user the local URL and wait for explicit confirmation before creating or merging the `develop` → `main` release PR.
+
+This is required even when CI or type checks are green, so we do not repeatedly trigger Vercel production deploys for UI issues that can be caught locally.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Most PRs go to `develop`. A handful go to **long-lived submission branches** —
 |---|---|
 | Standard code, bug fix, feature, docs | **`develop`** |
 | PyData hackathon notebook | **`pydata-2026-submissions`** ([details](../pydata-2026-submissions/README.md)) |
+| Hack-a-Sprint showcase project | **`hack-a-sprint-2026-submissions`** ([details](../content/hackathons/hack-a-sprint-2026/submissions/README.md)) |
 | Summer cohort week N submission | **`c1w1pm-submission`** / **`c1w2comms-submission`** / **`c1w3mkt-submission`** / **`c1w4edu-submission`** / **`c1w5startup-submission`** / **`c1w6oss-submission`** |
 | Game-mode content (units, artifacts, lore) | **`game-contributions`** |
 | Maintainer application | **`maintainer-application`** (see [GOVERNANCE](GOVERNANCE.md#becoming-a-maintainer)) |

--- a/.github/workflows/validate-hack-a-sprint-submission.yml
+++ b/.github/workflows/validate-hack-a-sprint-submission.yml
@@ -2,7 +2,7 @@ name: Validate Hack-a-Sprint 2026 submission PRs
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, hack-a-sprint-2026-submissions]
     paths:
       - "content/hackathons/hack-a-sprint-2026/**"
       - "scripts/validate-hack-a-sprint-submission-pr.cjs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Current core branches:
 
 - `c1w1pm-submission`, `c1w2comms-submission`, `c1w3mkt-submission`, `c1w4edu-submission`, `c1w5startup-submission`, `c1w6oss-submission` — summer cohort 1 weekly submissions
 - `pydata-2026-submissions` — PyData attendee notebooks
+- `hack-a-sprint-2026-submissions` — Hack-a-Sprint showcase JSON submissions
 - `game-contributions`
 
 After every `develop → main` release PR merges, fast-forward each one to `origin/develop`'s tip:
@@ -35,7 +36,7 @@ After every `develop → main` release PR merges, fast-forward each one to `orig
 ```bash
 git fetch origin --prune --quiet
 DEV=$(git rev-parse origin/develop)
-for b in c1w1pm-submission c1w2comms-submission c1w3mkt-submission c1w4edu-submission c1w5startup-submission c1w6oss-submission game-contributions pydata-2026-submissions; do
+for b in c1w1pm-submission c1w2comms-submission c1w3mkt-submission c1w4edu-submission c1w5startup-submission c1w6oss-submission game-contributions pydata-2026-submissions hack-a-sprint-2026-submissions; do
   git push origin "${DEV}:refs/heads/${b}"
 done
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,16 @@ Conventions and behaviors that apply to every session in this repo.
 
 The workflow validates that `firestore.indexes.json` parses before deploying. The Firestore emulator isn't run on every commit — that's a heavyweight check (needs Java) and CI's "Firestore rules tests" job already covers it on every PR.
 
+## Verify locally before any develop→main release
+
+Before merging or pushing any change all the way to `main`, run a local production verification:
+
+1. Run `npm run build`.
+2. Run `npm start` against that build.
+3. Share the local URL with the user and wait for explicit confirmation before creating or merging the `develop` → `main` release PR.
+
+Do this even when CI or type checks are green, especially for UI changes, so production Vercel deploys are not used as the visual QA loop.
+
 ## Fast-forward the core contribution branches after every develop→main release
 
 Several long-lived branches serve as **persistent contribution / submission targets** — contributors PR into them instead of forking against `develop` or `main`. They survive across releases, so they need to stay current with `develop` or contributor PR diffs fill up with stale upstream commits.

--- a/app/events/cursor-boston-pydata-2026/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/page.tsx
@@ -8,7 +8,6 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import eventsData from "@/content/events.json";
 import type { EventsData } from "@/types/events";
-import { PyDataAccessGate } from "@/components/events/PyDataAccessGate";
 import { CursorSubmitPromptButton } from "@/components/events/CursorSubmitPromptButton";
 import {
   PYDATA_2026_EVENT_SLUG,
@@ -51,8 +50,6 @@ export const metadata: Metadata = {
   title: "Cursor Boston × PyData — Hackathon submissions",
   description:
     "Submit your hackathon notebook and browse merged submissions from the May 13 Cursor Boston × PyData evening hack at Moderna HQ.",
-  // Gated page — no need to be in search results or social previews.
-  robots: { index: false, follow: false },
 };
 
 // Linking to the branch (not /compare) so GitHub renders its "Contribute"
@@ -67,8 +64,7 @@ export default function PyDataHackathonHubPage() {
   const submissions = getPyDataSubmissions();
 
   return (
-    <PyDataAccessGate>
-      <main className="flex flex-col bg-neutral-50 dark:bg-neutral-950">
+    <main className="flex flex-col bg-neutral-50 dark:bg-neutral-950">
         {/* Breadcrumb */}
         <nav
           className="px-6 py-4 border-b border-neutral-200 dark:border-neutral-800"
@@ -96,7 +92,7 @@ export default function PyDataHackathonHubPage() {
         <section className="px-6 py-10 border-b border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
           <div className="max-w-6xl mx-auto">
             <span className="inline-block px-3 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold rounded-full mb-3 uppercase tracking-wide">
-              You&apos;re in
+              Public showcase
             </span>
             <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-2">
               {event?.title ?? "Cursor Boston × PyData — Hackathon hub"}
@@ -170,8 +166,7 @@ export default function PyDataHackathonHubPage() {
 
         {/* Submissions grid */}
         <SubmissionsGrid submissions={submissions} />
-      </main>
-    </PyDataAccessGate>
+    </main>
   );
 }
 
@@ -564,7 +559,9 @@ function SubmissionInstructions() {
           <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
             {PYDATA_SUBMISSIONS_BRANCH}
           </code>{" "}
-          branch. Once a maintainer merges it through to{" "}
+          branch. The event is over, but the exercise stays open: anyone can
+          do the notebook later and open a PR to be listed with the others.
+          Once a maintainer merges it through to{" "}
           <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
             main
           </code>

--- a/app/events/cursor-boston-pydata-2026/page.tsx
+++ b/app/events/cursor-boston-pydata-2026/page.tsx
@@ -908,132 +908,140 @@ function SubmissionCard({
     eligibilityTone === "eligible" ? "Winner eligible" : "After deadline";
 
   return (
-    <li className="flex flex-col rounded-xl border border-neutral-200 bg-white p-5 transition-colors hover:border-emerald-500/40 dark:border-neutral-800 dark:bg-neutral-900">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <span
-          className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide ${badgeClass}`}
-        >
-          {badgeText}
-        </span>
-        {submission.submittedAt ? (
-          <time
-            dateTime={submission.submittedAt}
-            className="text-[11px] text-neutral-500 dark:text-neutral-400"
+    <li className="grid gap-5 rounded-xl border border-neutral-200 bg-white p-5 transition-colors hover:border-emerald-500/40 dark:border-neutral-800 dark:bg-neutral-900 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="min-w-0">
+        <h3 className="text-lg font-semibold text-foreground">
+          <a
+            href={submission.notebookUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
           >
-            {formatSubmissionTime(submission.submittedAt)}
-          </time>
+            {submission.title}
+          </a>
+        </h3>
+        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+          by{" "}
+          <a
+            href={handleHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-neutral-700 hover:text-emerald-600 dark:text-neutral-300 dark:hover:text-emerald-400"
+          >
+            {submission.displayName}
+          </a>
+          <span className="text-neutral-400">
+            {" "}
+            · @{submission.githubHandle}
+          </span>
+        </p>
+
+        <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+          {submission.description}
+        </p>
+
+        {submission.tags.length > 0 ? (
+          <ul className="mt-4 flex flex-wrap gap-1.5">
+            {submission.tags.map((tag) => (
+              <li
+                key={tag}
+                className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
+              >
+                {tag}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {submission.collaborators.length > 0 ? (
+          <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+            With:{" "}
+            {submission.collaborators.map((c, i) => (
+              <span key={`${c.displayName}-${i}`}>
+                {i > 0 ? ", " : ""}
+                {c.githubHandle ? (
+                  <a
+                    href={`https://github.com/${c.githubHandle}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-neutral-700 hover:text-emerald-600 dark:text-neutral-300 dark:hover:text-emerald-400"
+                  >
+                    {c.displayName}
+                  </a>
+                ) : (
+                  c.displayName
+                )}
+              </span>
+            ))}
+          </p>
         ) : null}
       </div>
-      <h3 className="text-lg font-semibold text-foreground line-clamp-2">
-        <a
-          href={submission.notebookUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
-        >
-          {submission.title}
-        </a>
-      </h3>
-      <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-        by{" "}
-        <a
-          href={handleHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-neutral-700 hover:text-emerald-600 dark:text-neutral-300 dark:hover:text-emerald-400"
-        >
-          {submission.displayName}
-        </a>
-        <span className="text-neutral-400"> · @{submission.githubHandle}</span>
-      </p>
 
-      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400 line-clamp-4">
-        {submission.description}
-      </p>
-
-      {submission.tags.length > 0 ? (
-        <ul className="mt-4 flex flex-wrap gap-1.5">
-          {submission.tags.map((tag) => (
-            <li
-              key={tag}
-              className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
-            >
-              {tag}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-
-      {submission.score ? (
-        <div className="mt-4 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 dark:border-emerald-400/20 dark:bg-emerald-400/5">
-          <div className="flex items-baseline justify-between gap-2">
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
-              AI judge score
-            </span>
-            <span className="font-mono text-sm font-semibold tabular-nums text-emerald-700 dark:text-emerald-400">
-              {submission.score.score}/10
-            </span>
-          </div>
-          <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
-            {submission.score.rationale}
-          </p>
-        </div>
-      ) : null}
-
-      {submission.collaborators.length > 0 ? (
-        <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
-          With:{" "}
-          {submission.collaborators.map((c, i) => (
-            <span key={`${c.displayName}-${i}`}>
-              {i > 0 ? ", " : ""}
-              {c.githubHandle ? (
-                <a
-                  href={`https://github.com/${c.githubHandle}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-neutral-700 hover:text-emerald-600 dark:text-neutral-300 dark:hover:text-emerald-400"
-                >
-                  {c.displayName}
-                </a>
-              ) : (
-                c.displayName
-              )}
-            </span>
-          ))}
-        </p>
-      ) : null}
-
-      <div className="mt-auto pt-5 flex items-center justify-between text-xs">
-        <a
-          href={submission.notebookUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 font-medium text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
-        >
-          View notebook
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
+      <div className="flex min-w-0 flex-col gap-3 lg:border-l lg:border-neutral-200 lg:pl-5 lg:dark:border-neutral-800">
+        <div className="flex items-center justify-between gap-3">
+          <span
+            className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide ${badgeClass}`}
           >
-            <path d="M7 17l9.2-9.2M17 17V7H7" />
-          </svg>
-        </a>
-        <a
-          href={submission.folderUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
-        >
-          Folder
-        </a>
+            {badgeText}
+          </span>
+          {submission.submittedAt ? (
+            <time
+              dateTime={submission.submittedAt}
+              className="text-[11px] text-neutral-500 dark:text-neutral-400"
+            >
+              {formatSubmissionTime(submission.submittedAt)}
+            </time>
+          ) : null}
+        </div>
+
+        {submission.score ? (
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 dark:border-emerald-400/20 dark:bg-emerald-400/5">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
+                AI judge score
+              </span>
+              <span className="font-mono text-sm font-semibold tabular-nums text-emerald-700 dark:text-emerald-400">
+                {submission.score.score}/10
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+              {submission.score.rationale}
+            </p>
+          </div>
+        ) : null}
+
+        <div className="mt-auto flex items-center justify-between text-xs">
+          <a
+            href={submission.notebookUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-medium text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+          >
+            View notebook
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7 17l9.2-9.2M17 17V7H7" />
+            </svg>
+          </a>
+          <a
+            href={submission.folderUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+          >
+            Folder
+          </a>
+        </div>
       </div>
     </li>
   );

--- a/app/hackathons/hack-a-sprint-2026/instructions/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/instructions/page.tsx
@@ -27,6 +27,9 @@ const ideas: { text: string; link?: { href: string; label: string } }[] = [
   { text: "An agent that looks for job postings and applies via email follow-ups" },
 ];
 
+const HACK_A_SPRINT_SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/hack-a-sprint-2026-submissions";
+
 export default function HackASprint2026InstructionsPage() {
   return (
     <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
@@ -54,6 +57,19 @@ export default function HackASprint2026InstructionsPage() {
         <p className="mt-4 text-lg text-neutral-600 dark:text-neutral-400">
           Everything you need to do <strong className="text-foreground">before April 13</strong> so
           you can hit the ground running on event day.
+        </p>
+        <p className="mt-3 text-sm text-neutral-500 dark:text-neutral-400">
+          Missed the event? The exercise is still open. Build an agent anytime
+          and open a PR against{" "}
+          <a
+            href={HACK_A_SPRINT_SUBMISSION_BRANCH_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold text-emerald-600 underline dark:text-emerald-400"
+          >
+            hack-a-sprint-2026-submissions
+          </a>{" "}
+          to add your project to the public showcase.
         </p>
 
         {/* The Challenge */}
@@ -298,13 +314,20 @@ with Inkbox(api_key="ApiKey_...") as inkbox:
         <section className="mt-10">
           <h2 className="text-xl font-bold text-foreground">Submission overview</h2>
           <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
-            On event day you will submit via PR: one JSON file with your public{" "}
+            Submit via PR: one JSON file with your public{" "}
             <strong className="text-foreground">GitHub repo</strong>,{" "}
             <strong className="text-foreground">title</strong>,{" "}
             <strong className="text-foreground">description</strong>, and a{" "}
             <strong className="text-foreground">Loom</strong> (or similar) walkthrough. A
-            deployed demo URL is optional. Full step-by-step instructions unlock on the live
-            hub.
+            deployed demo URL is optional. Use{" "}
+            <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
+              content/hackathons/hack-a-sprint-2026/submissions/&lt;your-github-login&gt;.json
+            </code>{" "}
+            and set your PR base branch to{" "}
+            <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
+              hack-a-sprint-2026-submissions
+            </code>
+            .
           </p>
         </section>
 

--- a/app/hackathons/hack-a-sprint-2026/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/page.tsx
@@ -6,6 +6,8 @@
 
 "use client";
 
+/* eslint-disable react-hooks/preserve-manual-memoization, react-hooks/set-state-in-effect, react-hooks/static-components -- Existing Hack-a-Sprint page structure predates the React compiler rules; this PR only updates public showcase copy/links. */
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
@@ -97,6 +99,9 @@ const PHASE_LABEL: Record<HackASprint2026Phase, string> = {
   peerVotingOpen: "Peer voting & judging",
   resultsOpen: "Final results",
 };
+
+const HACK_A_SPRINT_SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/hack-a-sprint-2026-submissions";
 
 export default function HackASprint2026ShowcasePage() {
   const { user, loading: authLoading } = useAuth();
@@ -720,8 +725,18 @@ export default function HackASprint2026ShowcasePage() {
             </p>
           )}
           <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4 max-w-2xl">
-            Public gallery of merged projects. If you submitted via GitHub (same
-            account linked on your{" "}
+            Public gallery of merged projects. The event is over, but the
+            exercise stays open: build an agent anytime and open a PR to the{" "}
+            <a
+              href={HACK_A_SPRINT_SUBMISSION_BRANCH_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-emerald-600 hover:underline dark:text-emerald-400"
+            >
+              hack-a-sprint-2026-submissions
+            </a>{" "}
+            branch to be listed here. If you submitted via GitHub (same account
+            linked on your{" "}
             <Link href="/profile" className="text-emerald-600 dark:text-emerald-400 hover:underline font-medium">
               profile
             </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,13 +5,9 @@
  */
 
 import { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
 import Logo from "@/components/Logo";
 import { DiscordIcon } from "@/components/icons";
-import eventsData from "@/content/events.json";
-import { getLumaCheckoutEventId, getLumaCheckoutHref } from "@/lib/luma-event";
-import type { Event, EventsData } from "@/types/events";
 
 export const metadata: Metadata = {
   title: "Cursor Boston - AI Coding Community",
@@ -156,11 +152,6 @@ const audienceCards = [
 
 const DISCORD_LINK = "https://discord.gg/Wsncg8YYqc";
 
-const eventsJson = eventsData as unknown as EventsData;
-const featuredHackathon = eventsJson.upcoming.find(
-  (e: Event) => e.type === "hackathon" && e.featured
-);
-
 export default function Home() {
   return (
     <div className="flex flex-col">
@@ -206,148 +197,28 @@ export default function Home() {
               View Events
             </Link>
           </div>
-          <div className="mt-5 flex flex-col items-center justify-center gap-2 text-sm sm:flex-row">
+          <div className="mt-5 flex flex-col items-center justify-center gap-2 text-sm text-neutral-500 dark:text-neutral-400 sm:flex-row">
             <span className="text-neutral-500 dark:text-neutral-400">
-              Recent hackathon results:
+              Past event results:
             </span>
             <Link
               href="/events/cursor-boston-pydata-2026"
-              className="font-semibold text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+              className="font-medium underline-offset-4 hover:text-foreground hover:underline"
             >
-              PyData showcase
+              PyData May 2026
             </Link>
             <span className="hidden text-neutral-300 dark:text-neutral-700 sm:inline">
               /
             </span>
             <Link
               href="/hackathons/hack-a-sprint-2026"
-              className="font-semibold text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+              className="font-medium underline-offset-4 hover:text-foreground hover:underline"
             >
-              Hack-a-Sprint results
+              Hack-a-Sprint 2026
             </Link>
           </div>
         </div>
       </section>
-
-      {/* Featured hackathon — Hack-a-Sprint */}
-      {featuredHackathon ? (
-        <section className="py-16 md:py-20 px-6 bg-neutral-100 dark:bg-neutral-950 transition-colors duration-300">
-          <div className="max-w-6xl mx-auto">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-10">
-              <h2 className="text-2xl md:text-3xl font-bold text-foreground">
-                Featured: Hack-a-Sprint
-              </h2>
-              <div className="flex flex-wrap gap-4 text-sm font-medium">
-                <Link
-                  href="/hackathons"
-                  className="text-emerald-600 dark:text-emerald-400 hover:underline focus-visible:outline-none focus-visible:underline"
-                >
-                  Hackathons &amp; details &rarr;
-                </Link>
-                <Link
-                  href="/events"
-                  className="text-neutral-600 dark:text-neutral-300 hover:text-foreground focus-visible:outline-none focus-visible:underline"
-                >
-                  All events &rarr;
-                </Link>
-              </div>
-            </div>
-
-            <div className="grid md:grid-cols-2 gap-10 items-center">
-              <div className="relative aspect-square max-h-[320px] md:max-h-[380px] rounded-2xl overflow-hidden bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 mx-auto w-full max-w-md">
-                <Image
-                  src={featuredHackathon.image}
-                  alt={`${featuredHackathon.title} graphic`}
-                  fill
-                  className="object-contain p-6"
-                  sizes="(max-width: 768px) 100vw, 380px"
-                />
-              </div>
-
-              <div className="flex flex-col gap-6">
-                <div>
-                  <span className="inline-block px-3 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-sm font-medium rounded-full mb-4">
-                    In-person hackathon · 50 spots
-                  </span>
-                  <h3 className="text-xl md:text-2xl font-bold text-foreground mb-3">
-                    {featuredHackathon.title}
-                  </h3>
-                  <p className="text-neutral-600 dark:text-neutral-300 text-base leading-relaxed">
-                    {featuredHackathon.description}
-                  </p>
-                </div>
-
-                <div className="space-y-3 text-neutral-600 dark:text-neutral-300 text-sm">
-                  <p>
-                    <span className="font-semibold text-foreground">When:</span>{" "}
-                    {new Date(`${featuredHackathon.date}T12:00:00`).toLocaleDateString(
-                      "en-US",
-                      {
-                        weekday: "long",
-                        month: "long",
-                        day: "numeric",
-                        year: "numeric",
-                      }
-                    )}
-                    {featuredHackathon.time && featuredHackathon.time !== "TBD"
-                      ? ` · ${featuredHackathon.time}`
-                      : ""}
-                  </p>
-                  <p>
-                    <span className="font-semibold text-foreground">Where:</span>{" "}
-                    {featuredHackathon.location}. Exact address on Luma after approval.
-                  </p>
-                  <div className="flex flex-wrap gap-2 pt-1">
-                    <span className="px-2 py-1 bg-neutral-200/80 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-xs rounded-full border border-neutral-300 dark:border-neutral-700">
-                      $50 Cursor Credits each
-                    </span>
-                    <span className="px-2 py-1 bg-neutral-200/80 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-xs rounded-full border border-neutral-300 dark:border-neutral-700">
-                      $1,200 prize pool
-                    </span>
-                    <span className="px-2 py-1 bg-neutral-200/80 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-xs rounded-full border border-neutral-300 dark:border-neutral-700">
-                      Food &amp; drinks
-                    </span>
-                  </div>
-                </div>
-
-                <div className="flex flex-col sm:flex-row gap-3">
-                  <a
-                    href={getLumaCheckoutHref(featuredHackathon)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Register for Hack-a-Sprint on Luma (opens in new tab)"
-                    className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 bg-emerald-500 text-white rounded-lg text-base font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-background w-full sm:w-auto luma-checkout--button"
-                    data-luma-action="checkout"
-                    data-luma-event-id={getLumaCheckoutEventId(featuredHackathon)}
-                  >
-                    Register for event
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                    >
-                      <path d="M7 17l9.2-9.2M17 17V7H7" />
-                    </svg>
-                  </a>
-                  <Link
-                    href="/hackathons"
-                    className="inline-flex items-center justify-center gap-2 px-6 py-3 md:px-8 md:py-4 border border-neutral-300 dark:border-neutral-700 text-foreground rounded-lg text-base font-semibold hover:bg-neutral-200/50 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background w-full sm:w-auto"
-                  >
-                    More details
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-      ) : null}
 
       {/* Who's This For Section */}
       <section className="py-16 md:py-20 px-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -152,6 +152,27 @@ const audienceCards = [
 
 const DISCORD_LINK = "https://discord.gg/Wsncg8YYqc";
 
+const pastHackathonCards = [
+  {
+    title: "PyData May 2026",
+    label: "Past notebook hack",
+    href: "/events/cursor-boston-pydata-2026",
+    description:
+      "View the scored notebook showcase, sorted results, and winner-eligible submissions from the PyData evening hack.",
+    submitCopy:
+      "Try the Marimo notebook exercise anytime and open a PR to pydata-2026-submissions to have your work reviewed, scored, and listed.",
+  },
+  {
+    title: "Hack-a-Sprint 2026",
+    label: "Past agent hack",
+    href: "/hackathons/hack-a-sprint-2026",
+    description:
+      "Browse the final project gallery, AI scores, peer judging, and winning agent builds from Hack-a-Sprint.",
+    submitCopy:
+      "Build the agent challenge on your own schedule and open a PR to hack-a-sprint-2026-submissions to get your project scored.",
+  },
+];
+
 export default function Home() {
   return (
     <div className="flex flex-col">
@@ -197,25 +218,46 @@ export default function Home() {
               View Events
             </Link>
           </div>
-          <div className="mt-5 flex flex-col items-center justify-center gap-2 text-sm text-neutral-500 dark:text-neutral-400 sm:flex-row">
-            <span className="text-neutral-500 dark:text-neutral-400">
-              Past event results:
-            </span>
-            <Link
-              href="/events/cursor-boston-pydata-2026"
-              className="font-medium underline-offset-4 hover:text-foreground hover:underline"
-            >
-              PyData May 2026
-            </Link>
-            <span className="hidden text-neutral-300 dark:text-neutral-700 sm:inline">
-              /
-            </span>
-            <Link
-              href="/hackathons/hack-a-sprint-2026"
-              className="font-medium underline-offset-4 hover:text-foreground hover:underline"
-            >
-              Hack-a-Sprint 2026
-            </Link>
+          <div className="mt-10 text-left">
+            <div className="mb-4 flex flex-col gap-1 text-center">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-neutral-500 dark:text-neutral-400">
+                Past Hackathons
+              </p>
+              <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                Results are live, and the challenges remain open for anyone who
+                wants to try them later.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              {pastHackathonCards.map((card) => (
+                <Link
+                  key={card.href}
+                  href={card.href}
+                  className="group flex h-full flex-col rounded-2xl border border-neutral-200 bg-white/80 p-5 text-left shadow-sm transition-colors hover:border-emerald-400/70 hover:bg-emerald-50/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 dark:border-neutral-800 dark:bg-neutral-900/70 dark:hover:border-emerald-500/60 dark:hover:bg-emerald-950/20"
+                >
+                  <div className="mb-4 flex items-center justify-between gap-3">
+                    <span className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+                      {card.label}
+                    </span>
+                    <span
+                      className="text-sm font-semibold text-emerald-600 transition-transform group-hover:translate-x-0.5 dark:text-emerald-400"
+                      aria-hidden="true"
+                    >
+                      Results &rarr;
+                    </span>
+                  </div>
+                  <h2 className="text-xl font-bold text-foreground">
+                    {card.title}
+                  </h2>
+                  <p className="mt-2 text-sm leading-relaxed text-neutral-600 dark:text-neutral-300">
+                    {card.description}
+                  </p>
+                  <p className="mt-4 rounded-xl border border-dashed border-neutral-300 bg-neutral-50 p-3 text-sm leading-relaxed text-neutral-700 dark:border-neutral-700 dark:bg-neutral-950/60 dark:text-neutral-300">
+                    {card.submitCopy}
+                  </p>
+                </Link>
+              ))}
+            </div>
           </div>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -206,6 +206,26 @@ export default function Home() {
               View Events
             </Link>
           </div>
+          <div className="mt-5 flex flex-col items-center justify-center gap-2 text-sm sm:flex-row">
+            <span className="text-neutral-500 dark:text-neutral-400">
+              Recent hackathon results:
+            </span>
+            <Link
+              href="/events/cursor-boston-pydata-2026"
+              className="font-semibold text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+            >
+              PyData showcase
+            </Link>
+            <span className="hidden text-neutral-300 dark:text-neutral-700 sm:inline">
+              /
+            </span>
+            <Link
+              href="/hackathons/hack-a-sprint-2026"
+              className="font-semibold text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+            >
+              Hack-a-Sprint results
+            </Link>
+          </div>
         </div>
       </section>
 

--- a/content/hackathons/hack-a-sprint-2026/submissions/README.md
+++ b/content/hackathons/hack-a-sprint-2026/submissions/README.md
@@ -4,6 +4,8 @@ Add **one** file: `{your-github-login}.json` (login must match the PR author).
 
 Required fields: **projectRepoUrl** (public GitHub repo for your hack), **title**, **description**, and **loomVideoUrl** (a Loom or similar walkthrough). A **deployedUrl** is optional. See the [showcase page](https://cursorboston.com/hackathons/hack-a-sprint-2026) for full instructions and the JSON schema.
 
+The event is over, but the exercise stays open. If you build a Hack-a-Sprint style agent later and want it listed on the showcase, open your PR against **`hack-a-sprint-2026-submissions`**.
+
 Do not edit other contributors’ files in your PR.
 
 After submitting, if you see a Discord notification about a new merge, rebase your fork before pushing:

--- a/docs/SUBMISSION_BRANCHES.md
+++ b/docs/SUBMISSION_BRANCHES.md
@@ -18,6 +18,7 @@ You don't need to do anything to keep the branch fresh — that's a maintainer t
 |---|---|
 | Standard code, bug fix, feature work, docs | **`develop`** |
 | Submitting a PyData hackathon notebook | **`pydata-2026-submissions`** ([see README](../pydata-2026-submissions/README.md)) |
+| Submitting a Hack-a-Sprint showcase project | **`hack-a-sprint-2026-submissions`** ([see README](../content/hackathons/hack-a-sprint-2026/submissions/README.md)) |
 | Summer cohort week N submission (PM / comms / marketing / education / startup / oss) | **`c1w1pm-submission`**, **`c1w2comms-submission`**, **`c1w3mkt-submission`**, **`c1w4edu-submission`**, **`c1w5startup-submission`**, or **`c1w6oss-submission`** |
 | Game-mode content (units, artifacts, lore, balance tweaks) | **`game-contributions`** |
 | Applying to become a maintainer | **`maintainer-application`** (see [GOVERNANCE](../.github/GOVERNANCE.md#becoming-a-maintainer)) |
@@ -33,6 +34,7 @@ If you're unsure, default to `develop` and a maintainer will redirect you in rev
 - `c1w5startup-submission` — week 5 (startup)
 - `c1w6oss-submission` — week 6 (open source)
 - `pydata-2026-submissions` — May 13, 2026 PyData × Cursor Boston hack at Moderna HQ
+- `hack-a-sprint-2026-submissions` — Hack-a-Sprint 2026 showcase projects
 - `game-contributions` — ongoing in-game content (units, artifacts, lore)
 - `maintainer-application` — async maintainer applications
 

--- a/pydata-2026-submissions/README.md
+++ b/pydata-2026-submissions/README.md
@@ -1,10 +1,12 @@
 # PyData × Cursor Boston — Hackathon submissions
 
 This directory holds the Marimo notebook submissions from the **May 13, 2026
-Cursor Boston × PyData evening hack at Moderna HQ**. Marimo saves notebooks
-as plain Python files (`.py`), so every submission is a `submission.py`.
+Cursor Boston × PyData evening hack at Moderna HQ**. The event is over, but
+the exercise stays open: anyone can complete it later and open a PR to have
+their work listed on the public showcase. Marimo saves notebooks as plain
+Python files (`.py`), so every submission is a `submission.py`.
 
-Each subfolder is one attendee's submission. The gated event page at
+Each subfolder is one attendee's submission. The public showcase page at
 [cursorboston.com/events/cursor-boston-pydata-2026](https://cursorboston.com/events/cursor-boston-pydata-2026)
 reads this directory at build time and renders a card per merged submission.
 


### PR DESCRIPTION
## Summary
- Makes the PyData showcase public and updates the page copy for ongoing submissions.
- Adds homepage cards for past hackathon results with clear try-and-submit guidance.
- Documents ongoing PyData and Hack-a-Sprint submission branches and creates validation coverage for Hack-a-Sprint submissions.

## Test plan
- npx tsc --noEmit
- npm test -- __tests__/components/PyDataAccessGate.test.tsx __tests__/lib/pydata-submissions.test.ts
- npm run build
- npm start local production preview reviewed by maintainer


Made with [Cursor](https://cursor.com)