### PR TITLE
feat(summer-cohort): bring cohort-2 dashboard to parity with cohort-1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Several long-lived branches serve as **persistent contribution / submission targ
 Current core branches:
 
 - `c1w1pm-submission`, `c1w2comms-submission`, `c1w3mkt-submission`, `c1w4edu-submission`, `c1w5startup-submission`, `c1w6oss-submission` — summer cohort 1 weekly submissions
+- `c2w1pm-submission`, `c2w2comms-submission`, `c2w3mkt-submission` — summer cohort 2 vote-format weekly submissions (create from `origin/develop` before c2 Week 1 kickoff on Mon Jun 29; the dashboard already references these branches via `SUMMER_COHORT_C2_VOTE_WEEKS` in `lib/summer-cohort.ts`)
 - `pydata-2026-submissions` — PyData attendee notebooks
 - `hack-a-sprint-2026-submissions` — Hack-a-Sprint showcase JSON submissions
 - `game-contributions`
@@ -36,8 +37,8 @@ After every `develop → main` release PR merges, fast-forward each one to `orig
 ```bash
 git fetch origin --prune --quiet
 DEV=$(git rev-parse origin/develop)
-for b in c1w1pm-submission c1w2comms-submission c1w3mkt-submission c1w4edu-submission c1w5startup-submission c1w6oss-submission game-contributions pydata-2026-submissions hack-a-sprint-2026-submissions; do
-  git push origin "${DEV}:refs/heads/${b}"
+for b in c1w1pm-submission c1w2comms-submission c1w3mkt-submission c1w4edu-submission c1w5startup-submission c1w6oss-submission c2w1pm-submission c2w2comms-submission c2w3mkt-submission game-contributions pydata-2026-submissions hack-a-sprint-2026-submissions; do
+ git push origin "${DEV}:refs/heads/${b}"
 done
 ```
 

--- a/app/api/summer-cohort/confirm-dev-env/route.ts
+++ b/app/api/summer-cohort/confirm-dev-env/route.ts
@@ -23,9 +23,12 @@ export const dynamic = "force-dynamic";
  * POST /api/summer-cohort/confirm-dev-env
  *
  * Auth-required. Stamps `cohort1DevEnvConfirmedAt` on the current user's
- * cohort application. Gated to admitted Cohort 1 applicants — the readiness
+ * cohort application. Gated to ANY admitted cohort applicant — the readiness
  * modal already hides the affordance from anyone else, but we re-check here
  * so the API can't be poked from a stale tab.
+ *
+ * Field name still says "cohort1" for back-compat with existing data; it's
+ * the cohort-agnostic dev-env confirmation timestamp now.
  *
  * Idempotent: re-stamps the timestamp on every call. The modal closes once
  * the timestamp is non-null, so re-clicks have no UX consequence.
@@ -58,9 +61,9 @@ async function handlePost(request: NextRequest) {
   const app = appSnap.data() || {};
   const status = typeof app.status === "string" ? app.status : "pending";
   const cohorts = Array.isArray(app.cohorts) ? (app.cohorts as string[]) : [];
-  if (status !== "admitted" || !cohorts.includes("cohort-1")) {
+  if (status !== "admitted" || cohorts.length === 0) {
     return NextResponse.json(
-      { error: "Only admitted Cohort 1 applicants can confirm dev env" },
+      { error: "Only admitted cohort applicants can confirm dev env" },
       { status: 403 }
     );
   }

--- a/app/api/summer-cohort/submissions/[weekId]/route.ts
+++ b/app/api/summer-cohort/submissions/[weekId]/route.ts
@@ -4,11 +4,12 @@
  * See LICENSE file for details.
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import {
   fetchSummerCohortSubmissions,
   getVoteWeekById,
 } from "@/lib/summer-cohort-submissions";
+import { isValidCohortId, type SummerCohortId } from "@/lib/summer-cohort";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 
 interface RouteParams {
@@ -16,11 +17,15 @@ interface RouteParams {
 }
 
 /**
- * Public read-only feed of merged submissions on a Cohort 1 vote-format week.
+ * Public read-only feed of merged submissions on a vote-format week.
  * Source of truth is the week's submission branch in GitHub; this route just
  * caches the GitHub Contents API call so the client tab can render counts.
+ *
+ * Accepts an optional `?cohortId=cohort-1|cohort-2` query so the same
+ * "week-1" / "week-2" / "week-3" path maps to the right cohort's submission
+ * branch. Defaults to cohort-1 for back-compat with older clients.
  */
-export async function GET(_req: Request, { params }: RouteParams) {
+export async function GET(req: NextRequest, { params }: RouteParams) {
   const { weekId } = await params;
   const parsedParams = summerCohortContract.submissionsByWeek.pathParams.safeParse({ weekId });
   if (!parsedParams.success) {
@@ -29,7 +34,13 @@ export async function GET(_req: Request, { params }: RouteParams) {
       { status: 404 }
     );
   }
-  const week = getVoteWeekById(parsedParams.data.weekId);
+
+  const cohortIdParam = req.nextUrl.searchParams.get("cohortId");
+  const cohortId: SummerCohortId = isValidCohortId(cohortIdParam)
+    ? cohortIdParam
+    : "cohort-1";
+
+  const week = getVoteWeekById(parsedParams.data.weekId, cohortId);
   if (!week) {
     return NextResponse.json(
       { error: "Unknown weekId — vote-format weeks are week-1, week-2, week-3." },

--- a/app/api/summer-cohort/votes/route.ts
+++ b/app/api/summer-cohort/votes/route.ts
@@ -8,22 +8,51 @@ import { type NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { SUMMER_COHORT_VOTES_COLLECTION } from "@/lib/summer-cohort";
+import {
+  SUMMER_COHORT_VOTES_COLLECTION,
+  isValidCohortId,
+  type SummerCohortId,
+} from "@/lib/summer-cohort";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 
 const VALID_WEEK_IDS = new Set(["week-1", "week-2", "week-3"]);
 
 /**
- * Simple, deterministic doc ID so a (weekId, submitterHandle, voterUid) triple
- * resolves to exactly one Firestore document. Toggling = create-if-absent /
- * delete-if-present.
+ * Simple, deterministic doc ID so a (cohortId, weekId, submitterHandle,
+ * voterUid) quad resolves to exactly one Firestore document. Toggling =
+ * create-if-absent / delete-if-present.
+ *
+ * Cohort 1 keeps the original schema (no cohort prefix in the doc ID, no
+ * cohortId field) for back-compat with the votes that already exist. New
+ * cohorts (cohort-2+) use the prefixed format AND write a `cohortId` field
+ * so reads can scope to a single cohort.
  */
 function voteDocId(
+  cohortId: SummerCohortId,
   weekId: string,
   submitterHandle: string,
   voterUid: string
 ): string {
-  return `${weekId}__${submitterHandle.toLowerCase()}__${voterUid}`;
+  const base = `${weekId}__${submitterHandle.toLowerCase()}__${voterUid}`;
+  return cohortId === "cohort-1" ? base : `${cohortId}__${base}`;
+}
+
+/**
+ * Whether a vote doc matches the cohort the caller asked about. Cohort 1 docs
+ * are the legacy schema with no `cohortId` field, so treat missing-field as
+ * cohort-1 for back-compat.
+ */
+function voteDocMatchesCohort(
+  data: Record<string, unknown>,
+  cohortId: SummerCohortId
+): boolean {
+  const docCohort =
+    typeof data.cohortId === "string" ? data.cohortId : "cohort-1";
+  return docCohort === cohortId;
+}
+
+function readCohortIdFromQuery(value: string | null): SummerCohortId {
+  return isValidCohortId(value) ? value : "cohort-1";
 }
 
 function isValidHandle(value: unknown): value is string {
@@ -63,6 +92,9 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     );
   }
+  const cohortId = readCohortIdFromQuery(
+    request.nextUrl.searchParams.get("cohortId")
+  );
 
   const db = getAdminDb();
   if (!db) {
@@ -80,6 +112,7 @@ export async function GET(request: NextRequest) {
   const myVotes: string[] = [];
   for (const doc of snap.docs) {
     const data = doc.data();
+    if (!voteDocMatchesCohort(data, cohortId)) continue;
     const handle =
       typeof data.submitterHandle === "string"
         ? data.submitterHandle.toLowerCase()
@@ -94,6 +127,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json(
     {
       weekId,
+      cohortId,
       counts,
       myVotes: user ? myVotes : [],
       authenticated: Boolean(user),
@@ -143,6 +177,14 @@ export async function POST(request: NextRequest) {
   }
   const weekId = parsedBody.data.weekId;
   const submitterHandle = parsedBody.data.submitterHandle;
+  // cohortId is optional in the body for back-compat; missing → cohort-1.
+  const rawCohort =
+    typeof (parsedBody.data as { cohortId?: unknown }).cohortId === "string"
+      ? ((parsedBody.data as { cohortId?: string }).cohortId as string)
+      : null;
+  const cohortId: SummerCohortId = isValidCohortId(rawCohort)
+    ? rawCohort
+    : "cohort-1";
 
   if (!isValidWeekId(weekId)) {
     return NextResponse.json(
@@ -162,7 +204,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Server not configured" }, { status: 500 });
   }
 
-  const docId = voteDocId(weekId, submitterHandle, user.uid);
+  const docId = voteDocId(cohortId, weekId, submitterHandle, user.uid);
   const ref = db.collection(SUMMER_COHORT_VOTES_COLLECTION).doc(docId);
   const existing = await ref.get();
 
@@ -171,28 +213,39 @@ export async function POST(request: NextRequest) {
     await ref.delete();
     voted = false;
   } else {
-    await ref.set({
+    // Cohort 1 docs stay unfielded for back-compat with the millions of
+    // existing rows; cohorts 2+ get a `cohortId` field so the GET filter can
+    // scope correctly.
+    const baseFields = {
       weekId,
       submitterHandle: submitterHandle.toLowerCase(),
       voterUid: user.uid,
       createdAt: FieldValue.serverTimestamp(),
-    });
+    };
+    await ref.set(
+      cohortId === "cohort-1" ? baseFields : { ...baseFields, cohortId }
+    );
     voted = true;
   }
 
   // Recount this submission for the response so the client gets an authoritative
-  // post-toggle number rather than relying on optimistic estimation.
+  // post-toggle number rather than relying on optimistic estimation. Need to
+  // filter by cohort in-memory since we can't easily compose "field absent OR
+  // equal to value" in a single Firestore query.
   const countSnap = await db
     .collection(SUMMER_COHORT_VOTES_COLLECTION)
     .where("weekId", "==", weekId)
     .where("submitterHandle", "==", submitterHandle.toLowerCase())
-    .count()
     .get();
+  const count = countSnap.docs.filter((doc) =>
+    voteDocMatchesCohort(doc.data(), cohortId)
+  ).length;
 
   return NextResponse.json({
     weekId,
+    cohortId,
     submitterHandle: submitterHandle.toLowerCase(),
     voted,
-    count: countSnap.data().count,
+    count,
   });
 }

--- a/app/summer-cohort/_components/InfoTabPanel.tsx
+++ b/app/summer-cohort/_components/InfoTabPanel.tsx
@@ -17,12 +17,13 @@ import {
 } from "lucide-react";
 import {
   SUMMER_COHORTS,
-  SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER,
   SUMMER_COHORT_DEMO_DAY,
   SUMMER_COHORT_IMMERSION,
   SUMMER_COHORT_MEETING_CADENCE,
   SUMMER_COHORT_PHILOSOPHY,
   SUMMER_COHORT_WEEKS,
+  type SummerCohort,
+  type SummerCohortId,
 } from "@/lib/summer-cohort";
 import { WinnerCommitmentsCard } from "./WinnerCommitmentsCard";
 
@@ -33,14 +34,38 @@ interface CompletedSetupApplication {
 }
 
 interface InfoTabPanelProps {
-  cohort1Count: number;
+  /** Cohort id this dashboard is for — drives the headline copy + the
+   *  participant count shown in the "in your cohort" tile. */
+  cohortId: SummerCohortId;
+  /** Cohort label, e.g. "Cohort 1" / "Cohort 2". */
+  cohortLabel: string;
+  /** Participant count in the user's cohort. */
+  cohortCount: number;
+  /** Discord invite URL for the user's cohort. */
+  discordInviteUrl: string;
   /** When provided, renders a small "setup recorded" summary at the top of
    *  the tab — mirrors the "done" rows previously shown in the What's-next
    *  card above the tabs, once those rows are all green. */
   application?: CompletedSetupApplication;
 }
 
-export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
+function findCohort(cohortId: SummerCohortId): SummerCohort {
+  return (
+    SUMMER_COHORTS.find((c) => c.id === cohortId) ??
+    (SUMMER_COHORTS[0] as SummerCohort)
+  );
+}
+
+export function InfoTabPanel({
+  cohortId,
+  cohortLabel,
+  cohortCount,
+  discordInviteUrl,
+  application,
+}: InfoTabPanelProps) {
+  const cohort = findCohort(cohortId);
+  const discordChannel = cohortId === "cohort-2" ? "#cohort-2" : "#cohort-1";
+  const showImmersion = cohortId === "cohort-1";
   return (
     <div
       role="tabpanel"
@@ -64,9 +89,11 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
               Comfortable presenting + maintaining if you win:{" "}
               <strong>{application.wantsToPresent ? "yes" : "no"}</strong>
             </li>
-            <li>
-              May 26 immersion event: <strong>RSVP confirmed</strong>
-            </li>
+            {showImmersion ? (
+              <li>
+                May 26 immersion event: <strong>RSVP confirmed</strong>
+              </li>
+            ) : null}
           </ul>
         </section>
       ) : null}
@@ -84,7 +111,7 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
               Cohort Discord
             </div>
             <p className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-              The cohort lives in #cohort-1 on Discord.
+              The cohort lives in {discordChannel} on Discord.
             </p>
             <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">
               Day-to-day questions, build help, voting-call prep, and demos
@@ -93,7 +120,7 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
             </p>
           </div>
           <a
-            href={SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER}
+            href={discordInviteUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="shrink-0 inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#4752C4]"
@@ -136,8 +163,9 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
           ))}
         </ul>
         <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
-          First Zoom kickoffs: Cohort 1 on Mon May 11, Cohort 2 on Mon Jun 29.
-          Watch your email and the Week tabs above for meeting links.
+          Your kickoff: <strong>{cohort.label}</strong> on{" "}
+          <strong>{cohort.startLabel}</strong>. Watch your email and the Week
+          tabs above for the meeting link.
         </p>
       </section>
 
@@ -172,8 +200,8 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
               <Users className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
               In your cohort
             </div>
-            <p className="mt-1 text-2xl font-bold tabular-nums">{cohort1Count}</p>
-            <p className="mt-0.5 text-xs text-neutral-500">people in Cohort 1</p>
+            <p className="mt-1 text-2xl font-bold tabular-nums">{cohortCount}</p>
+            <p className="mt-0.5 text-xs text-neutral-500">people in {cohortLabel}</p>
           </div>
           <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
             <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
@@ -182,7 +210,8 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
             </div>
             <p className="mt-1 text-2xl font-bold tabular-nums">6</p>
             <p className="mt-0.5 text-xs text-neutral-500">
-              weeks · May 11 → Jun 19
+              weeks · {cohort.startLabel.replace(/^[A-Za-z]+,\s*/, "")} →{" "}
+              {cohort.endLabel.replace(/^[A-Za-z]+,\s*/, "")}
             </p>
           </div>
           <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-950/40">
@@ -239,37 +268,41 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
         </ol>
       </section>
 
-      {/* Calendar anchors: immersion + demo day */}
+      {/* Calendar anchors: immersion (c1 only) + demo day */}
       <section className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
         <h3 className="text-base font-semibold">Anchor events</h3>
         <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
-          Two dates that bracket the program. Block them on your calendar.
+          {showImmersion
+            ? "Two dates that bracket the program. Block them on your calendar."
+            : "One date that closes the program. Block it on your calendar."}
         </p>
-        <div className="mt-5 grid gap-3 sm:grid-cols-2">
-          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
-            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
-              <Calendar
-                className="h-3.5 w-3.5"
-                strokeWidth={2.25}
-                aria-hidden="true"
-              />
-              {SUMMER_COHORT_IMMERSION.label}
+        <div className={`mt-5 grid gap-3 ${showImmersion ? "sm:grid-cols-2" : "sm:grid-cols-1"}`}>
+          {showImmersion ? (
+            <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                <Calendar
+                  className="h-3.5 w-3.5"
+                  strokeWidth={2.25}
+                  aria-hidden="true"
+                />
+                {SUMMER_COHORT_IMMERSION.label}
+              </div>
+              <p className="mt-1 text-sm font-semibold">
+                {SUMMER_COHORT_IMMERSION.title}
+              </p>
+              <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                {SUMMER_COHORT_IMMERSION.description}
+              </p>
+              <a
+                href={SUMMER_COHORT_IMMERSION.lumaUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-flex items-center gap-2 text-xs font-semibold text-emerald-700 underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600 dark:text-emerald-400"
+              >
+                RSVP on Luma →
+              </a>
             </div>
-            <p className="mt-1 text-sm font-semibold">
-              {SUMMER_COHORT_IMMERSION.title}
-            </p>
-            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-              {SUMMER_COHORT_IMMERSION.description}
-            </p>
-            <a
-              href={SUMMER_COHORT_IMMERSION.lumaUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-flex items-center gap-2 text-xs font-semibold text-emerald-700 underline decoration-emerald-600/60 underline-offset-2 hover:decoration-emerald-600 dark:text-emerald-400"
-            >
-              RSVP on Luma →
-            </a>
-          </div>
+          ) : null}
           <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
             <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
               <Users
@@ -277,7 +310,7 @@ export function InfoTabPanel({ cohort1Count, application }: InfoTabPanelProps) {
                 strokeWidth={2.25}
                 aria-hidden="true"
               />
-              Fri, Jun 19 — closing
+              {cohort.endLabel} — closing
             </div>
             <p className="mt-1 text-sm font-semibold">
               {SUMMER_COHORT_DEMO_DAY.title}

--- a/app/summer-cohort/_components/SetupInstructionsPanel.tsx
+++ b/app/summer-cohort/_components/SetupInstructionsPanel.tsx
@@ -10,7 +10,14 @@ import { CheckCircle2, ExternalLink, Laptop, MessageCircle } from "lucide-react"
 
 const ALC_URL = "https://ludwitt.com/alc";
 
-export function SetupInstructionsPanel() {
+interface SetupInstructionsPanelProps {
+  /** Kickoff date headline, e.g. "Mon, May 11" / "Mon, Jun 29". */
+  kickoffLabel: string;
+}
+
+export function SetupInstructionsPanel({
+  kickoffLabel,
+}: SetupInstructionsPanelProps) {
   return (
     <section
       role="tabpanel"
@@ -31,8 +38,8 @@ export function SetupInstructionsPanel() {
         Get your machine ready
       </h2>
       <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
-        You&apos;ll be writing and shipping code from your laptop starting Mon
-        May 11. Three things have to be installed and working:
+        You&apos;ll be writing and shipping code from your laptop starting{" "}
+        {kickoffLabel}. Three things have to be installed and working:
       </p>
 
       <ul className="mt-5 space-y-3 text-sm text-neutral-800 dark:text-neutral-200">

--- a/app/summer-cohort/_components/SetupReadinessModal.tsx
+++ b/app/summer-cohort/_components/SetupReadinessModal.tsx
@@ -18,6 +18,10 @@ import {
 const ALC_URL = "https://ludwitt.com/alc";
 
 interface SetupReadinessModalProps {
+  /** Cohort label used in the modal headline, e.g. "Cohort 1" / "Cohort 2". */
+  cohortLabel: string;
+  /** Kickoff date headline, e.g. "Mon, May 11 · 6–7pm EST". */
+  kickoffLabel: string;
   /** Discord is not connected — triggers the modal to pop. */
   needsDiscord: boolean;
   /** GitHub is not connected — triggers the modal to pop. */
@@ -25,7 +29,7 @@ interface SetupReadinessModalProps {
   /** Intake survey not yet submitted — displayed only, never triggers pop. */
   needsSurvey: boolean;
   /**
-   * Cohort 1 admit hasn't self-attested their dev environment is ready
+   * Admit hasn't self-attested their dev environment is ready
    * (Node + Git + Cursor / Claude Code). Triggers the modal to pop and
    * surfaces a single "Yes, I'm ready" button.
    */
@@ -43,12 +47,14 @@ interface SetupReadinessModalProps {
 }
 
 /**
- * Sticky readiness modal for admitted Cohort 1 admits.
- * Pops on every page load while Discord OR GitHub is missing.
- * Closing only suppresses for the current page-load — no localStorage flag
- * — so users keep being nudged until they connect both.
+ * Sticky readiness modal for admitted cohort participants.
+ * Pops on every page load while Discord, GitHub, or dev-env confirmation is
+ * missing. Closing only suppresses for the current page-load — no localStorage
+ * flag — so users keep being nudged until everything is done.
  */
 export function SetupReadinessModal({
+  cohortLabel,
+  kickoffLabel,
   needsDiscord,
   needsGithub,
   needsSurvey,
@@ -146,11 +152,11 @@ export function SetupReadinessModal({
           id="setup-readiness-title"
           className="pr-8 text-xl font-bold text-white md:text-2xl"
         >
-          Cohort 1 kicks off TONIGHT at 6pm EST — final readiness check
+          Final readiness check — before {cohortLabel} kickoff
         </h2>
         <p className="mt-2 text-sm text-neutral-400">
-          Knock these out before 6pm so kickoff is about the work, not
-          logistics.
+          {cohortLabel} kickoff: <span className="font-semibold text-neutral-200">{kickoffLabel}</span>.
+          Knock these out so kickoff is about the work, not logistics.
         </p>
 
         <ul className="mt-5 space-y-2">
@@ -200,8 +206,8 @@ export function SetupReadinessModal({
             Haven&apos;t installed Node, Git, or an IDE yet?
           </div>
           <p className="mt-1.5 text-sm text-neutral-200">
-            Not required, but <strong>highly</strong> encouraged today —
-            tonight&apos;s kickoff is at 6pm EST. The 20-minute walkthrough at{" "}
+            Not required, but <strong>highly</strong> encouraged before
+            kickoff. The 20-minute walkthrough at{" "}
             <span className="font-mono">ludwitt.com/alc</span> covers Node,
             Git, and <strong>Cursor</strong> (or <strong>Claude Code</strong>)
             end-to-end so you don&apos;t spend kickoff debugging install

--- a/app/summer-cohort/_components/Week4LudwittPanel.tsx
+++ b/app/summer-cohort/_components/Week4LudwittPanel.tsx
@@ -7,15 +7,19 @@
 "use client";
 
 import { Calendar, ExternalLink, Sparkles, Video } from "lucide-react";
-import {
-  SUMMER_COHORT_C1_WEEK_4,
-  SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
-} from "@/lib/summer-cohort";
+import { type SummerCohortWeek4 } from "@/lib/summer-cohort";
 
-export function Week4LudwittPanel() {
-  const week = SUMMER_COHORT_C1_WEEK_4;
-  const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
+interface Week4LudwittPanelProps {
+  week: SummerCohortWeek4;
+  cohortLabel: string;
+  zoomUrl: string;
+}
 
+export function Week4LudwittPanel({
+  week,
+  cohortLabel,
+  zoomUrl,
+}: Week4LudwittPanelProps) {
   return (
     <section
       role="tabpanel"
@@ -25,7 +29,7 @@ export function Week4LudwittPanel() {
     >
       <div className="flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
-          Cohort 1 · Week 4
+          {cohortLabel} · Week 4
         </span>
         <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
           <Sparkles className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
@@ -107,9 +111,9 @@ export function Week4LudwittPanel() {
         </div>
         <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
           The Ludwitt PR template, accepted-tool spec, and revenue-share terms
-          will be finalized at the Mon Jun 1 kickoff. By then you&apos;ll know
-          how the cohort PM tool, comms platform, and marketing site (built in
-          weeks 1–3) play into the workflow.
+          will be finalized at the {week.kickoffLabel.split("·")[0]?.trim() ?? week.kickoffLabel} kickoff.
+          By then you&apos;ll know how the cohort PM tool, comms platform, and
+          marketing site (built in weeks 1–3) play into the workflow.
         </p>
         <p className="mt-3 text-xs text-neutral-500">
           This section will be filled in before the week opens.

--- a/app/summer-cohort/_components/Week5StartupPanel.tsx
+++ b/app/summer-cohort/_components/Week5StartupPanel.tsx
@@ -7,15 +7,19 @@
 "use client";
 
 import { ExternalLink, Rocket, Video } from "lucide-react";
-import {
-  SUMMER_COHORT_C1_WEEK_5,
-  SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
-} from "@/lib/summer-cohort";
+import { type SummerCohortWeek5 } from "@/lib/summer-cohort";
 
-export function Week5StartupPanel() {
-  const week = SUMMER_COHORT_C1_WEEK_5;
-  const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
+interface Week5StartupPanelProps {
+  week: SummerCohortWeek5;
+  cohortLabel: string;
+  zoomUrl: string;
+}
 
+export function Week5StartupPanel({
+  week,
+  cohortLabel,
+  zoomUrl,
+}: Week5StartupPanelProps) {
   return (
     <section
       role="tabpanel"
@@ -25,7 +29,7 @@ export function Week5StartupPanel() {
     >
       <div className="flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
-          Cohort 1 · Week 5
+          {cohortLabel} · Week 5
         </span>
         <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
           <Rocket className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />

--- a/app/summer-cohort/_components/Week6OssPanel.tsx
+++ b/app/summer-cohort/_components/Week6OssPanel.tsx
@@ -8,15 +8,21 @@
 
 import { ExternalLink, GitMerge, Trophy, Video } from "lucide-react";
 import {
-  SUMMER_COHORT_C1_WEEK_6,
-  SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
   SUMMER_COHORT_DEMO_DAY,
+  type SummerCohortWeek6,
 } from "@/lib/summer-cohort";
 
-export function Week6OssPanel() {
-  const week = SUMMER_COHORT_C1_WEEK_6;
-  const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
+interface Week6OssPanelProps {
+  week: SummerCohortWeek6;
+  cohortLabel: string;
+  zoomUrl: string;
+}
 
+export function Week6OssPanel({
+  week,
+  cohortLabel,
+  zoomUrl,
+}: Week6OssPanelProps) {
   return (
     <section
       role="tabpanel"
@@ -26,7 +32,7 @@ export function Week6OssPanel() {
     >
       <div className="flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
-          Cohort 1 · Week 6 — Final
+          {cohortLabel} · Week 6 — Final
         </span>
         <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-400">
           <GitMerge

--- a/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
+++ b/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
@@ -17,7 +17,7 @@ import {
   Trophy,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import type { SummerCohortVoteWeek } from "@/lib/summer-cohort";
+import type { SummerCohortId, SummerCohortVoteWeek } from "@/lib/summer-cohort";
 
 interface SubmissionRow {
   githubHandle: string;
@@ -50,6 +50,10 @@ interface VotesResponse {
 interface WeekSubmissionsCollapsibleProps {
   week: SummerCohortVoteWeek;
   tabId: string;
+  /** Cohort the dashboard is rendering for. Threads through to the submissions
+   *  + votes APIs so cohort-1 and cohort-2 see separate submission feeds and
+   *  separate vote tallies. */
+  cohortId: SummerCohortId;
   /** Logged-in user's GitHub login (lowercased), if connected. Used to surface
    *  "you're submitted" / "not yet" status and to gate expansion. */
   currentUserGithubHandle: string | null;
@@ -114,6 +118,7 @@ function statusForUser(
 export function WeekSubmissionsCollapsible({
   week,
   tabId,
+  cohortId,
   currentUserGithubHandle,
   currentUserDisplayName,
   currentUserPhotoUrl,
@@ -131,7 +136,12 @@ export function WeekSubmissionsCollapsible({
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/summer-cohort/submissions/${tabId}`, { cache: "no-store" })
+    fetch(
+      `/api/summer-cohort/submissions/${tabId}?cohortId=${encodeURIComponent(
+        cohortId
+      )}`,
+      { cache: "no-store" }
+    )
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return (await res.json()) as SubmissionsResponse;
@@ -149,7 +159,7 @@ export function WeekSubmissionsCollapsible({
     return () => {
       cancelled = true;
     };
-  }, [tabId]);
+  }, [tabId, cohortId]);
 
   // Fetch vote tallies. Refetch when auth state changes so signed-in users
   // see their `myVotes` populated, and signed-out users get a clean view.
@@ -166,7 +176,9 @@ export function WeekSubmissionsCollapsible({
         }
       }
       const res = await fetch(
-        `/api/summer-cohort/votes?weekId=${encodeURIComponent(tabId)}`,
+        `/api/summer-cohort/votes?weekId=${encodeURIComponent(
+          tabId
+        )}&cohortId=${encodeURIComponent(cohortId)}`,
         { cache: "no-store", headers }
       );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -185,7 +197,7 @@ export function WeekSubmissionsCollapsible({
     return () => {
       cancelled = true;
     };
-  }, [tabId, user]);
+  }, [tabId, user, cohortId]);
 
   const toggleVote = useCallback(
     async (submitterHandle: string) => {
@@ -216,7 +228,11 @@ export function WeekSubmissionsCollapsible({
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify({ weekId: tabId, submitterHandle: handleKey }),
+          body: JSON.stringify({
+            weekId: tabId,
+            submitterHandle: handleKey,
+            cohortId,
+          }),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const json = (await res.json()) as {
@@ -255,7 +271,7 @@ export function WeekSubmissionsCollapsible({
         });
       }
     },
-    [user, myVotes, pendingVotes, tabId]
+    [user, myVotes, pendingVotes, tabId, cohortId]
   );
 
   const yourStatus = useMemo(

--- a/app/summer-cohort/_components/WeekVotePanel.tsx
+++ b/app/summer-cohort/_components/WeekVotePanel.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import {
   SUMMER_COHORT_C1_WEEK_1,
-  SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
+  type SummerCohortId,
   type SummerCohortVoteWeek,
 } from "@/lib/summer-cohort";
 import { WeekSubmissionsCollapsible } from "./WeekSubmissionsCollapsible";
@@ -27,6 +27,13 @@ const WILDCARDS = SUMMER_COHORT_C1_WEEK_1.wildcardSlots;
 interface WeekVotePanelProps {
   week: SummerCohortVoteWeek;
   tabId: string;
+  /** Cohort id this dashboard is for. Threads through to the submissions /
+   *  votes APIs so cohort-1 and cohort-2 see separate submission feeds. */
+  cohortId: SummerCohortId;
+  /** Cohort label used in the Week-N badge. */
+  cohortLabel: string;
+  /** Zoom URL for this cohort's kickoff + voting call. */
+  zoomUrl: string;
   /** Lower-cased GitHub handle of the signed-in user, if connected — used by
    *  the submissions collapsible to render "you're submitted" status. */
   currentUserGithubHandle: string | null;
@@ -41,12 +48,14 @@ interface WeekVotePanelProps {
 export function WeekVotePanel({
   week,
   tabId,
+  cohortId,
+  cohortLabel,
+  zoomUrl,
   currentUserGithubHandle,
   currentUserDisplayName,
   currentUserPhotoUrl,
   onSwitchToMyInfo,
 }: WeekVotePanelProps) {
-  const zoomUrl = SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER;
 
   return (
     <section
@@ -82,7 +91,7 @@ export function WeekVotePanel({
 
       <div className="mt-6 flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">
-          Cohort 1 · Week {week.week}
+          {cohortLabel} · Week {week.week}
         </span>
         <span className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
           {week.deadlineLabel.split("·")[0]?.trim()} deadline
@@ -106,6 +115,7 @@ export function WeekVotePanel({
         <WeekSubmissionsCollapsible
           week={week}
           tabId={tabId}
+          cohortId={cohortId}
           currentUserGithubHandle={currentUserGithubHandle}
           currentUserDisplayName={currentUserDisplayName}
           currentUserPhotoUrl={currentUserPhotoUrl}

--- a/app/summer-cohort/_components/WinnerCommitmentsCard.tsx
+++ b/app/summer-cohort/_components/WinnerCommitmentsCard.tsx
@@ -253,11 +253,11 @@ export function WinnerCommitmentsCard() {
           </h3>
           <p className="mt-1">
             You can participate fully without putting yourself up for the
-            vote. There are 60+ people in Cohort 1 — we&apos;re not going to
-            run short of volunteers. Everything else (building, voting, the
-            in-person events, the demo day with hiring partners) is still
-            yours. The only thing to skip is the &quot;submit to win&quot;
-            step.
+            vote. There are dozens of people in the cohort — we&apos;re not
+            going to run short of volunteers. Everything else (building,
+            voting, the in-person events, the demo day with hiring partners)
+            is still yours. The only thing to skip is the &quot;submit to
+            win&quot; step.
           </p>
         </div>
       </div>

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -25,10 +25,11 @@ import { useDiscordConnection } from "@/app/(auth)/profile/_hooks/useDiscordConn
 import {
   SUMMER_COHORTS,
   SUMMER_COHORT_C1_DEFAULT_TAB,
-  SUMMER_COHORT_C1_VOTE_WEEKS,
   SUMMER_COHORT_GOAL_PER_COHORT,
   SUMMER_COHORT_IMMERSION,
   SUMMER_COHORT_RETURN_TO,
+  getPrimarySummerCohort,
+  getSummerCohortRuntime,
   type SummerCohortId,
 } from "@/lib/summer-cohort";
 import { ClaimSpotByPRCard } from "./_components/ClaimSpotByPRCard";
@@ -56,7 +57,9 @@ interface ApplicationDto {
   isLocal: boolean | null;
   wantsToPresent: boolean | null;
   mayImmersionRsvped: boolean;
-  /** Server timestamp (ms) of when the user self-attested dev env ready. */
+  /** Server timestamp (ms) of when the user self-attested dev env ready.
+   *  Field name still says "cohort1" for back-compat with existing data;
+   *  it's the cohort-agnostic dev-env confirmation now. */
   cohort1DevEnvConfirmedAt: number | null;
   createdAt: number | null;
   updatedAt: number | null;
@@ -561,15 +564,15 @@ function SummerCohortPageInner() {
     };
   }, [loading, user]);
 
-  // Fetch intake-survey status whenever the user is an admitted Cohort 1
-  // applicant. Non-admitted users never see the gate, so the effect short-
-  // circuits without touching state — `showSurveyGate` already requires
-  // `showTabs`, so a stale `intakeStatus` can't leak through to the UI.
+  // Fetch intake-survey status whenever the user is an admitted cohort
+  // applicant (any cohort). Non-admitted users never see the gate, so the
+  // effect short-circuits without touching state — `showSurveyGate` already
+  // requires `showTabs`, so a stale `intakeStatus` can't leak through to the UI.
   useEffect(() => {
     if (loading || !user) return;
     if (
       application?.status !== "admitted" ||
-      !application.cohorts.includes("cohort-1")
+      application.cohorts.length === 0
     ) {
       return;
     }
@@ -601,7 +604,7 @@ function SummerCohortPageInner() {
     if (intakeStatus !== "incomplete") return;
     if (
       application?.status !== "admitted" ||
-      !application.cohorts.includes("cohort-1")
+      application.cohorts.length === 0
     ) {
       return;
     }
@@ -777,25 +780,39 @@ function SummerCohortPageInner() {
     return (id: SummerCohortId) => map.get(id) || id;
   }, []);
 
+  // Primary cohort drives the dashboard runtime (dates, branches, zoom/discord
+  // placeholders). Cohort 1 takes priority when the user is admitted to both.
+  const primaryCohort: SummerCohortId | null = application
+    ? getPrimarySummerCohort(application.cohorts)
+    : null;
+  const runtime = primaryCohort ? getSummerCohortRuntime(primaryCohort) : null;
   const showTabs =
-    application?.status === "admitted" &&
-    application.cohorts.includes("cohort-1");
+    application?.status === "admitted" && primaryCohort !== null;
   // Soft gate: the intake survey is now a tab, not a blocker. The tab
   // appears (with a callout banner above the tabs) until the user has
   // submitted. Once submitted, the tab disappears.
   const showIntakeSurveyTab = showTabs && intakeStatus === "incomplete";
   const myInfoVisible = !showTabs || activeTab === "my-info";
-  const cohort1Count = applicationCounts["cohort-1"] ?? 0;
+  const cohortCount = primaryCohort ? applicationCounts[primaryCohort] ?? 0 : 0;
 
   const localityDone =
     application?.isLocal !== null && application?.wantsToPresent !== null;
   const rsvpDone = application?.mayImmersionRsvped === true;
-  const moveCompletedSetupToInfo = showTabs && localityDone && rsvpDone;
+  // Only cohort 1 has an in-person immersion event; for other cohorts the
+  // "RSVP done" check is moot, so the completed-setup summary becomes a pure
+  // locality check.
+  const isCohort1Primary = primaryCohort === "cohort-1";
+  const moveCompletedSetupToInfo =
+    showTabs &&
+    localityDone &&
+    (isCohort1Primary ? rsvpDone : true);
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
-      {showTabs ? (
+      {showTabs && runtime ? (
         <SetupReadinessModal
+          cohortLabel={runtime.label}
+          kickoffLabel={runtime.kickoffLabel}
           needsDiscord={!discord.discordInfo}
           needsGithub={!github.githubInfo?.login}
           needsSurvey={intakeStatus === "incomplete"}
@@ -895,7 +912,7 @@ function SummerCohortPageInner() {
       ) : (
         <>
           {application ? (
-            showTabs ? (
+            showTabs && runtime && primaryCohort ? (
               <>
                 <ApplicationStatusPanel
                   application={application}
@@ -946,21 +963,27 @@ function SummerCohortPageInner() {
                     ) : (
                       <IntakeSurveyForm
                         defaultEmail={user?.email ?? application.email ?? ""}
-                        cohortId={application.cohorts[0] ?? "cohort-1"}
+                        cohortId={primaryCohort}
                         onComplete={() => setIntakeStatus("completed")}
                       />
                     )
                   ) : activeTab === "info" ? (
                     <InfoTabPanel
-                      cohort1Count={cohort1Count}
+                      cohortId={primaryCohort}
+                      cohortLabel={runtime.label}
+                      cohortCount={cohortCount}
+                      discordInviteUrl={runtime.discordInviteUrl}
                       application={
                         moveCompletedSetupToInfo ? application : undefined
                       }
                     />
                   ) : activeTab === "week-1" ? (
                     <WeekVotePanel
-                      week={SUMMER_COHORT_C1_VOTE_WEEKS[0]}
+                      week={runtime.voteWeeks[0]}
                       tabId="week-1"
+                      cohortId={primaryCohort}
+                      cohortLabel={runtime.label}
+                      zoomUrl={runtime.zoomUrl}
                       currentUserGithubHandle={
                         github.githubInfo?.login ?? null
                       }
@@ -972,8 +995,11 @@ function SummerCohortPageInner() {
                     />
                   ) : activeTab === "week-2" ? (
                     <WeekVotePanel
-                      week={SUMMER_COHORT_C1_VOTE_WEEKS[1]}
+                      week={runtime.voteWeeks[1]}
                       tabId="week-2"
+                      cohortId={primaryCohort}
+                      cohortLabel={runtime.label}
+                      zoomUrl={runtime.zoomUrl}
                       currentUserGithubHandle={
                         github.githubInfo?.login ?? null
                       }
@@ -985,8 +1011,11 @@ function SummerCohortPageInner() {
                     />
                   ) : activeTab === "week-3" ? (
                     <WeekVotePanel
-                      week={SUMMER_COHORT_C1_VOTE_WEEKS[2]}
+                      week={runtime.voteWeeks[2]}
                       tabId="week-3"
+                      cohortId={primaryCohort}
+                      cohortLabel={runtime.label}
+                      zoomUrl={runtime.zoomUrl}
                       currentUserGithubHandle={
                         github.githubInfo?.login ?? null
                       }
@@ -997,13 +1026,27 @@ function SummerCohortPageInner() {
                       onSwitchToMyInfo={() => setActiveTab("my-info")}
                     />
                   ) : activeTab === "week-4" ? (
-                    <Week4LudwittPanel />
+                    <Week4LudwittPanel
+                      week={runtime.week4}
+                      cohortLabel={runtime.label}
+                      zoomUrl={runtime.zoomUrl}
+                    />
                   ) : activeTab === "week-5" ? (
-                    <Week5StartupPanel />
+                    <Week5StartupPanel
+                      week={runtime.week5}
+                      cohortLabel={runtime.label}
+                      zoomUrl={runtime.zoomUrl}
+                    />
                   ) : activeTab === "week-6" ? (
-                    <Week6OssPanel />
+                    <Week6OssPanel
+                      week={runtime.week6}
+                      cohortLabel={runtime.label}
+                      zoomUrl={runtime.zoomUrl}
+                    />
                   ) : activeTab === "setup" ? (
-                    <SetupInstructionsPanel />
+                    <SetupInstructionsPanel
+                      kickoffLabel={runtime.kickoffLabel}
+                    />
                   ) : activeTab === "game" ? (
                     <GamePromoPanel />
                   ) : null}

--- a/docs/API.md
+++ b/docs/API.md
@@ -415,7 +415,7 @@ _Talk-submission moderation queue._
 | DELETE | `/api/summer-cohort/apply` | Yes | Withdraw the current user's summer-cohort application |
 | GET | `/api/summer-cohort/apply` | Yes | Get the current user's summer-cohort application + counts |
 | POST | `/api/summer-cohort/apply` | Yes | Create or update the current user's summer-cohort application |
-| POST | `/api/summer-cohort/confirm-dev-env` | Yes | Cohort 1 admit confirms dev environment is set up (Node + Git + IDE) |
+| POST | `/api/summer-cohort/confirm-dev-env` | Yes | Admitted cohort participant confirms dev environment is set up (Node + Git + IDE) |
 | GET | `/api/summer-cohort/intake-survey` | Yes | Get the current user's intake-survey response |
 | POST | `/api/summer-cohort/intake-survey` | Yes | Submit (or re-submit) the intake survey |
 | GET | `/api/summer-cohort/submissions/{weekId}` | No | Public read of merged submissions on a vote-format week |

--- a/lib/api-schemas/summer-cohort.ts
+++ b/lib/api-schemas/summer-cohort.ts
@@ -36,8 +36,12 @@ const IntakeSurveyBody = z
 
 const WeekIdParam = z.object({ weekId: z.string().min(1) });
 
+const CohortIdEnum = z.enum(["cohort-1", "cohort-2"]);
+
 const VotesQuery = z.object({
   weekId: z.enum(["week-1", "week-2", "week-3"]),
+  // Optional for back-compat with old clients; defaults to cohort-1 server-side.
+  cohortId: CohortIdEnum.optional(),
 });
 
 const VotesPostBody = z
@@ -48,6 +52,8 @@ const VotesPostBody = z
       .min(1)
       .max(80)
       .regex(/^[a-zA-Z0-9_-]+$/),
+    // Optional for back-compat with old clients; defaults to cohort-1 server-side.
+    cohortId: CohortIdEnum.optional(),
   })
   .openapi("SummerCohortVoteBody");
 
@@ -122,7 +128,7 @@ export const summerCohortContract = c.router(
       method: "POST",
       path: "/api/summer-cohort/confirm-dev-env",
       summary:
-        "Cohort 1 admit confirms dev environment is set up (Node + Git + IDE)",
+        "Admitted cohort participant confirms dev environment is set up (Node + Git + IDE)",
       body: ConfirmDevEnvBody,
       responses: {
         200: ConfirmDevEnvResponse,

--- a/lib/summer-cohort-submissions.ts
+++ b/lib/summer-cohort-submissions.ts
@@ -9,6 +9,8 @@ import { getGithubRepoPair } from "./github-recent-merged-prs";
 import { logger } from "./logger";
 import {
   SUMMER_COHORT_C1_VOTE_WEEKS,
+  SUMMER_COHORT_C2_VOTE_WEEKS,
+  type SummerCohortId,
   type SummerCohortVoteWeek,
 } from "./summer-cohort";
 
@@ -51,14 +53,32 @@ function getDirectoryPath(submissionPath: string): string {
   return idx >= 0 ? submissionPath.slice(0, idx) : submissionPath;
 }
 
-const VOTE_WEEK_BY_ID: Record<string, SummerCohortVoteWeek> = {
-  "week-1": SUMMER_COHORT_C1_VOTE_WEEKS[0],
-  "week-2": SUMMER_COHORT_C1_VOTE_WEEKS[1],
-  "week-3": SUMMER_COHORT_C1_VOTE_WEEKS[2],
+const VOTE_WEEK_BY_ID: Record<
+  SummerCohortId,
+  Record<string, SummerCohortVoteWeek>
+> = {
+  "cohort-1": {
+    "week-1": SUMMER_COHORT_C1_VOTE_WEEKS[0],
+    "week-2": SUMMER_COHORT_C1_VOTE_WEEKS[1],
+    "week-3": SUMMER_COHORT_C1_VOTE_WEEKS[2],
+  },
+  "cohort-2": {
+    "week-1": SUMMER_COHORT_C2_VOTE_WEEKS[0],
+    "week-2": SUMMER_COHORT_C2_VOTE_WEEKS[1],
+    "week-3": SUMMER_COHORT_C2_VOTE_WEEKS[2],
+  },
 };
 
-export function getVoteWeekById(weekId: string): SummerCohortVoteWeek | null {
-  return VOTE_WEEK_BY_ID[weekId] ?? null;
+/**
+ * Look up a vote-format week (week-1 / week-2 / week-3) for a given cohort.
+ * Different cohorts have different submission branches + dates, so callers
+ * must specify which cohort's view they're rendering.
+ */
+export function getVoteWeekById(
+  weekId: string,
+  cohortId: SummerCohortId = "cohort-1"
+): SummerCohortVoteWeek | null {
+  return VOTE_WEEK_BY_ID[cohortId]?.[weekId] ?? null;
 }
 
 interface ContentsApiItem {

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -171,6 +171,14 @@ export const SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER =
 export const SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER =
   "https://discord.gg/PLACEHOLDER";
 
+// TODO: swap in the real Zoom link before 2026-06-29.
+export const SUMMER_COHORT_C2_ZOOM_URL_PLACEHOLDER =
+  "https://zoom.us/j/PLACEHOLDER-C2";
+
+// TODO: swap in the real Discord invite link / channel URL before kickoff.
+export const SUMMER_COHORT_C2_DISCORD_INVITE_URL_PLACEHOLDER =
+  "https://discord.gg/PLACEHOLDER-C2";
+
 /** Hard cap on Cohort 1 admits. Auto-admit-on-PR-merge respects this.
  *  Bumped 2026-05-10 when we admitted everyone who applied to lock the roster
  *  before the May 11 kickoff. */
@@ -458,3 +466,175 @@ export const SUMMER_COHORT_PHILOSOPHY =
 
 /** Stretch target for applicants per cohort — drives the counter UI. */
 export const SUMMER_COHORT_GOAL_PER_COHORT = 100;
+
+// ---------------------------------------------------------------------------
+// Cohort 2 — same shape as Cohort 1, dates shifted to the Jun 29 → Aug 7 run.
+//
+// Submission branches mirror the c1 pattern (`c1w1pm-submission` → `c2w1pm-submission`).
+// The c2 branches don't exist yet at the time of writing — they'll be created
+// before Week 1 kickoff. The submissions API returns empty cleanly when the
+// branch is missing, so the UI still works pre-kickoff.
+// ---------------------------------------------------------------------------
+
+export const SUMMER_COHORT_C2_VOTE_WEEKS: readonly SummerCohortVoteWeek[] = [
+  {
+    week: 1,
+    title: "Project Management Build",
+    oneLiner:
+      "Everyone builds a PM tool. The cohort picks a winner on Friday; the winner runs the cohort PM tool for the rest of the program.",
+    kickoffLabel: "Mon, Jun 29 · 6–7pm EST",
+    deadlineLabel: "Fri, Jul 3 · 5pm EST",
+    votingCallLabel: "Fri, Jul 3 · 6pm EST",
+    submissionBranch: "c2w1pm-submission",
+    submissionPath:
+      "content/summer-cohort/c2/w1-pm/submissions/<github-handle>.json",
+    liveUrlRequired: true,
+    winnerCommitment: SUMMER_COHORT_C1_VOTE_WEEKS[0].winnerCommitment,
+    inspirationScopeNote: SUMMER_COHORT_C1_VOTE_WEEKS[0].inspirationScopeNote,
+    inspirationPlatforms: SUMMER_COHORT_C1_VOTE_WEEKS[0].inspirationPlatforms,
+  },
+  {
+    week: 2,
+    title: "Communications Build",
+    oneLiner:
+      "Everyone builds a comms platform for the cohort. Same vote-and-pick-a-winner format. Winner runs comms for the rest of the cohort.",
+    kickoffLabel: "Mon, Jul 6 · 6–7pm EST",
+    deadlineLabel: "Fri, Jul 10 · 5pm EST",
+    votingCallLabel: "Fri, Jul 10 · 6pm EST",
+    submissionBranch: "c2w2comms-submission",
+    submissionPath:
+      "content/summer-cohort/c2/w2-comms/submissions/<github-handle>.json",
+    liveUrlRequired: true,
+    winnerCommitment: SUMMER_COHORT_C1_VOTE_WEEKS[1].winnerCommitment,
+    inspirationScopeNote: SUMMER_COHORT_C1_VOTE_WEEKS[1].inspirationScopeNote,
+    inspirationPlatforms: SUMMER_COHORT_C1_VOTE_WEEKS[1].inspirationPlatforms,
+  },
+  {
+    week: 3,
+    title: "Vibe Marketing Build",
+    oneLiner:
+      "Everyone builds a marketing platform that does outbound, not just inbound — gets the cohort's work into the public eye AND handles the replies that come back. Same vote format; winner maintains it.",
+    kickoffLabel: "Mon, Jul 13 · 6–7pm EST",
+    deadlineLabel: "Fri, Jul 17 · 5pm EST",
+    votingCallLabel: "Fri, Jul 17 · 6pm EST",
+    submissionBranch: "c2w3mkt-submission",
+    submissionPath:
+      "content/summer-cohort/c2/w3-mkt/submissions/<github-handle>.json",
+    liveUrlRequired: true,
+    winnerCommitment: SUMMER_COHORT_C1_VOTE_WEEKS[2].winnerCommitment,
+    inspirationScopeNote: SUMMER_COHORT_C1_VOTE_WEEKS[2].inspirationScopeNote,
+    inspirationPlatforms: SUMMER_COHORT_C1_VOTE_WEEKS[2].inspirationPlatforms,
+  },
+] as const;
+
+export const SUMMER_COHORT_C2_WEEK_4 = {
+  week: 4,
+  title: "Ludwitt Education Tool",
+  oneLiner: SUMMER_COHORT_C1_WEEK_4.oneLiner,
+  kickoffLabel: "Mon, Jul 20 · 6–7pm EST",
+  deadlineLabel: "Fri, Jul 24 · 5pm EST",
+} as const;
+
+export const SUMMER_COHORT_C2_WEEK_5 = {
+  week: 5,
+  title: "Your Own Startup",
+  oneLiner: SUMMER_COHORT_C1_WEEK_5.oneLiner,
+  kickoffLabel: "Mon, Jul 27 · 6–7pm EST",
+  showAndTellLabel: "Fri, Jul 31 · 6pm EST",
+} as const;
+
+export const SUMMER_COHORT_C2_WEEK_6 = {
+  week: 6,
+  title: "Open-Source PR",
+  oneLiner: SUMMER_COHORT_C1_WEEK_6.oneLiner,
+  kickoffLabel: "Mon, Aug 3 · 6–7pm EST",
+  demoDayLabel: "Fri, Aug 7 · time TBD",
+} as const;
+
+/** Default tab when an admitted cohort-2 user lands on /summer-cohort. */
+export const SUMMER_COHORT_C2_DEFAULT_TAB = "week-1" as const;
+
+// ---------------------------------------------------------------------------
+// Cohort runtime — single accessor that the page + week panels read from so
+// the UI is the same shape for either cohort and only the dates / branches /
+// connection placeholders differ.
+// ---------------------------------------------------------------------------
+
+export interface SummerCohortWeek4 {
+  readonly week: number;
+  readonly title: string;
+  readonly oneLiner: string;
+  readonly kickoffLabel: string;
+  readonly deadlineLabel: string;
+}
+
+export interface SummerCohortWeek5 {
+  readonly week: number;
+  readonly title: string;
+  readonly oneLiner: string;
+  readonly kickoffLabel: string;
+  readonly showAndTellLabel: string;
+}
+
+export interface SummerCohortWeek6 {
+  readonly week: number;
+  readonly title: string;
+  readonly oneLiner: string;
+  readonly kickoffLabel: string;
+  readonly demoDayLabel: string;
+}
+
+export interface SummerCohortRuntime {
+  readonly cohortId: SummerCohortId;
+  readonly label: string;
+  /** "Mon, May 11" / "Mon, Jun 29" — the Week 1 kickoff date headline. */
+  readonly kickoffLabel: string;
+  readonly zoomUrl: string;
+  readonly discordInviteUrl: string;
+  readonly voteWeeks: readonly SummerCohortVoteWeek[];
+  readonly week4: SummerCohortWeek4;
+  readonly week5: SummerCohortWeek5;
+  readonly week6: SummerCohortWeek6;
+}
+
+const COHORT_1_RUNTIME: SummerCohortRuntime = {
+  cohortId: "cohort-1",
+  label: "Cohort 1",
+  kickoffLabel: SUMMER_COHORT_C1_WEEK_1.kickoffLabel,
+  zoomUrl: SUMMER_COHORT_C1_ZOOM_URL_PLACEHOLDER,
+  discordInviteUrl: SUMMER_COHORT_C1_DISCORD_INVITE_URL_PLACEHOLDER,
+  voteWeeks: SUMMER_COHORT_C1_VOTE_WEEKS,
+  week4: SUMMER_COHORT_C1_WEEK_4,
+  week5: SUMMER_COHORT_C1_WEEK_5,
+  week6: SUMMER_COHORT_C1_WEEK_6,
+};
+
+const COHORT_2_RUNTIME: SummerCohortRuntime = {
+  cohortId: "cohort-2",
+  label: "Cohort 2",
+  kickoffLabel: SUMMER_COHORT_C2_VOTE_WEEKS[0].kickoffLabel,
+  zoomUrl: SUMMER_COHORT_C2_ZOOM_URL_PLACEHOLDER,
+  discordInviteUrl: SUMMER_COHORT_C2_DISCORD_INVITE_URL_PLACEHOLDER,
+  voteWeeks: SUMMER_COHORT_C2_VOTE_WEEKS,
+  week4: SUMMER_COHORT_C2_WEEK_4,
+  week5: SUMMER_COHORT_C2_WEEK_5,
+  week6: SUMMER_COHORT_C2_WEEK_6,
+};
+
+export function getSummerCohortRuntime(
+  cohortId: SummerCohortId
+): SummerCohortRuntime {
+  return cohortId === "cohort-2" ? COHORT_2_RUNTIME : COHORT_1_RUNTIME;
+}
+
+/**
+ * Pick the cohort whose dashboard the user should see. Cohort 1 takes priority
+ * if the user is admitted to both — c1 is the active run; c2 is upcoming.
+ */
+export function getPrimarySummerCohort(
+  cohorts: readonly string[]
+): SummerCohortId | null {
+  if (cohorts.includes("cohort-1")) return "cohort-1";
+  if (cohorts.includes("cohort-2")) return "cohort-2";
+  return null;
+}


### PR DESCRIPTION
## Summary

A user registered for cohort-2 yesterday and saw none of the cohort-1 dashboard — no intake survey gate, no week tabs, no setup readiness modal — because every gate hardcoded `cohorts.includes("cohort-1")` and every week panel imported `SUMMER_COHORT_C1_*` constants directly. This PR adds a cohort-2 runtime (vote weeks, week 4–6 dates, zoom/discord placeholders, default tab) alongside cohort-1's and threads it through every panel and API so the same UX renders for either cohort with its own dates and submission branches.

Assumes cohort-2 launches tomorrow (May 15) even though the actual kickoff is **Jun 29**, so any cohort-2 admit who lands on the dashboard today should already see the intake survey + week panels with their own dates.

### What changed

- **`lib/summer-cohort.ts`** — add `SUMMER_COHORT_C2_VOTE_WEEKS` + `_WEEK_4/5/6` configs, zoom/discord placeholders, `getSummerCohortRuntime(cohortId)` helper, and `getPrimarySummerCohort(cohorts)` to pick the user's primary cohort (cohort-1 wins if they're in both, for back-compat).
- **`app/summer-cohort/page.tsx`** — generalize `showTabs` and the intake survey gate to "any admitted cohort"; drive the dashboard from `primaryCohort` + runtime; skip the cohort-1-only May 26 immersion-RSVP step for cohort-2.
- **All week panels** (`WeekVotePanel`, `Week4LudwittPanel`, `Week5StartupPanel`, `Week6OssPanel`) take `cohortLabel` + `zoomUrl` + `week` props instead of importing the c1 constants directly.
- **`InfoTabPanel`** takes `cohortId` / `cohortLabel` / `cohortCount` / `discordInviteUrl`; Discord channel name and "Anchor events" section adapt per cohort (no May 26 card for c2).
- **`SetupReadinessModal`** — no longer says "TONIGHT 6pm EST"; takes `cohortLabel` + `kickoffLabel` so it reads correctly pre-kickoff for either cohort.
- **`SetupInstructionsPanel`** — takes `kickoffLabel`.
- **`WeekSubmissionsCollapsible`** — threads `cohortId` through to `/api/summer-cohort/submissions` and `/api/summer-cohort/votes`.
- **API**:
  - `/api/summer-cohort/confirm-dev-env` now accepts any admitted cohort (was c1-only).
  - `/api/summer-cohort/submissions/[weekId]` accepts `?cohortId=…`.
  - `/api/summer-cohort/votes` scopes by `cohortId`. Existing cohort-1 docs keep their legacy schema for back-compat — missing `cohortId` is treated as `cohort-1`, so no migration needed.
- **`WinnerCommitmentsCard`** — replace `"60+ people in Cohort 1"` with cohort-agnostic phrasing.
- **`CLAUDE.md`** — add `c2w1pm-submission` / `c2w2comms-submission` / `c2w3mkt-submission` to the core-branches list and post-release fast-forward loop.

### Out of scope (operational follow-ups before Jun 29)

- [ ] Create the three c2 submission branches on `origin` from `origin/develop`.
- [ ] Swap the c2 zoom + discord placeholder URLs (`PLACEHOLDER-C2`) in `lib/summer-cohort.ts` for real ones.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --testPathPatterns="summer-cohort"` — 32 tests pass
- [x] Full Jest suite — 193 suites / 2066 tests pass
- [x] `eslint --max-warnings=0` on staged files — clean
- [ ] Reviewer spot-check: the cohort-2 test user lands on the dashboard and sees the readiness modal + intake survey + Week 1 panel with the Jun 29 kickoff date.
- [ ] Reviewer spot-check: an existing cohort-1 user still sees their own May 26 immersion card + Cohort 1 zoom/discord + their existing votes.


Made with [Cursor](https://cursor.com)