### PR TITLE
feat(talks): add Eric Ma Cursor + Marimo featured talk

### DIFF
--- a/content/talks.json
+++ b/content/talks.json
@@ -1,5 +1,15 @@
 {
-  "talks": [],
+  "talks": [
+    {
+      "id": "pydata-x-cursor-marimo-demo-2026-05-13",
+      "title": "Cursor + Marimo Demo: Agentic Data Science at PyData x Cursor Boston",
+      "speaker": "Eric Ma",
+      "date": "2026-05-13",
+      "description": "A live demo of agentic data science where Cursor Agent Mode interacts directly with a Marimo notebook kernel runtime for faster iterative analysis. Eric walked through a protein data example, notebook visualizations, and practical prompting patterns that teams can reuse for exploratory data work.",
+      "category": "development",
+      "videoUrl": "https://www.youtube.com/watch?v=DvSxrCcfWFs"
+    }
+  ],
   "categories": [
     {
       "id": "academic",


### PR DESCRIPTION
## Summary
- add the first Featured Talk entry in `content/talks.json` for Eric Ma's May 13 PyData x Cursor Boston talk
- include a concise, audience-friendly blurb that mentions Cursor Agent Mode + Marimo kernel runtime workflows
- attach the recording link so visitors can watch directly from the Talks page

## Test plan
- [x] Validate `content/talks.json` parses as valid JSON
- [x] Confirm only `content/talks.json` is included in this branch diff
- [x] Run full `npm run type-check` and `npm run lint` in an environment with up-to-date Node/dependencies

Made with [Cursor](https://cursor.com)