### PR TITLE
Add ProductChameleon week 1 PM submission

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie-app-one.vercel.app",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Jackie is the un-project management tool that gets the job done -- personal progress tracking and cohort submission browsing in one focused app.",
+  "competeForWin": true
+}


### PR DESCRIPTION
## Description

Adds Week 1 PM submission for ProductChameleon (Ying Chen).

Jackie is a project management tool built specifically for the Cursor Boston cohort — personal progress tracking across all 6 weeks and a cohort submission browser for evaluating submissions before Friday voting calls. The app is meant to be a demo. It'll be wire to real data if it gets chosen to move forward.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested locally
- [x] Tested form submissions

## Additional Notes

Submission JSON located at: `content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json`

Live URL: https://jackie-app-one.vercel.app
Repo: https://github.com/ProductChameleon/jackie
Loom: https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f