### PR TITLE
feat(talks): add UMass Lowell AICORE featured article

### DIFF
--- a/content/articles.json
+++ b/content/articles.json
@@ -1,6 +1,14 @@
 {
   "articles": [
     {
+      "id": "umass-lowell-aicore-applied-ai",
+      "title": "UMass Lowell Launches AICORE for Applied AI Research",
+      "source": "UMass Lowell News",
+      "url": "https://www.uml.edu/news/press-releases/2026/ai-computing-research.aspx",
+      "date": "2026-04-23",
+      "description": "New interdisciplinary AI center connects research, industry, and hands-on student experience to advance safe, practical AI applications in healthcare, defense, robotics, and beyond."
+    },
+    {
       "id": "mit-llm-agents",
       "title": "Helping AI agents search to get the best results out of large language models",
       "source": "MIT News",


### PR DESCRIPTION
## Summary
- add a new `Featured Articles` entry in `content/articles.json` for UMass Lowell's AICORE announcement
- include the provided title, article URL, and summary focused on applied, interdisciplinary AI
- place it at the top of the list so it appears prominently on the Talks page

## Test plan
- [x] Validate `content/articles.json` parses as valid JSON
- [x] Confirm only `content/articles.json` changed in this PR

Made with [Cursor](https://cursor.com)