### PR TITLE
release: develop → main 2026-05-15

### DIFF
--- a/__tests__/app/pr-ideas/pr-studio-types.test.ts
+++ b/__tests__/app/pr-ideas/pr-studio-types.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ */
+
+import {
+  displayState,
+  formatIdeaRunsApiError,
+  formatIdeaRunsApiErrorMessage,
+  hasLaunchableIdeaContent,
+  emptyIdeaForm,
+  type CursorIdeaRun,
+} from "@/app/pr-ideas/_lib/types";
+
+describe("displayState", () => {
+  const base: CursorIdeaRun = {
+    id: "r1",
+    status: "finished",
+    workflowStage: "pr_open",
+    prompt: "p",
+    inputs: {},
+    pr: { status: "opening" },
+  };
+
+  it("treats PR opening as running (not finished)", () => {
+    expect(displayState(base)).toBe("running");
+  });
+
+  it("returns pr_open when URL is present", () => {
+    expect(
+      displayState({
+        ...base,
+        pr: { status: "pr_open", url: "https://github.com/org/repo/pull/1" },
+      })
+    ).toBe("pr_open");
+  });
+
+  it("returns awaiting_input when questions need answers", () => {
+    expect(
+      displayState({
+        ...base,
+        status: "running",
+        workflowStage: "questions",
+        questions: [{ id: "q1", question: "Why?" }],
+        pr: { status: "not_started" },
+      })
+    ).toBe("awaiting_input");
+  });
+
+  it("returns failed for error status", () => {
+    expect(
+      displayState({
+        ...base,
+        status: "error",
+        pr: { status: "not_started" },
+      })
+    ).toBe("failed");
+  });
+});
+
+describe("formatIdeaRunsApiError", () => {
+  it("maps cursor_not_connected", () => {
+    expect(formatIdeaRunsApiErrorMessage("cursor_not_connected")).toMatch(/connect/i);
+  });
+
+  it("appends error id when provided", () => {
+    expect(formatIdeaRunsApiError("list_failed", "abc12345")).toContain("Ref: abc12345");
+  });
+});
+
+describe("hasLaunchableIdeaContent", () => {
+  it("is false for empty idea form", () => {
+    expect(hasLaunchableIdeaContent(emptyIdeaForm())).toBe(false);
+  });
+
+  it("is true when freeform has text", () => {
+    expect(hasLaunchableIdeaContent({ ...emptyIdeaForm(), freeform: "hello" })).toBe(true);
+  });
+
+  it("requires an issue in issue mode", () => {
+    expect(
+      hasLaunchableIdeaContent({
+        ...emptyIdeaForm(),
+        mode: "issue",
+        issue: null,
+      })
+    ).toBe(false);
+  });
+});

--- a/__tests__/app/pr-ideas/use-idea-runs-poll.test.tsx
+++ b/__tests__/app/pr-ideas/use-idea-runs-poll.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useIdeaRuns } from "@/app/pr-ideas/_hooks/useIdeaRuns";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: jest.fn(),
+  }),
+}));
+
+describe("useIdeaRuns polling backoff", () => {
+  const mockUser = {
+    getIdToken: jest.fn().mockResolvedValue("test-token"),
+  } as unknown as User;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("pauses polling message after three consecutive 500 responses on loadRuns", async () => {
+    global.fetch = jest.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      json: async () => ({ error: "list_failed", errorId: "e1" }),
+    })) as unknown as typeof fetch;
+
+    const { result } = renderHook(() =>
+      useIdeaRuns({ user: mockUser, cursorConnected: true })
+    );
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.loadRuns(true, "refreshing");
+    });
+    await act(async () => {
+      await result.current.loadRuns(true, "refreshing");
+    });
+
+    await waitFor(() => {
+      expect(result.current.error ?? "").toContain("Polling paused");
+    });
+  });
+});

--- a/app/api/cursor/idea-runs/[runId]/route.ts
+++ b/app/api/cursor/idea-runs/[runId]/route.ts
@@ -5,11 +5,13 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
 import { cursorContract } from "@/lib/api-schemas/cursor";
 import {
   deleteCursorAgent,
   getCursorApiKeyForUser,
   getCursorRunSnapshot,
+  MissingCursorConnectionError,
 } from "@/lib/cursor/cloud-agents";
 import {
   applyRunSnapshot,
@@ -19,6 +21,7 @@ import {
 } from "@/lib/cursor/idea-run-store";
 import { CURSOR_IDEA_RUNS_COLLECTION } from "@/lib/cursor/idea-runs";
 import { getAdminDb } from "@/lib/firebase-admin";
+import { jsonWithLoggedError } from "@/lib/server/api-request-error";
 import { logger } from "@/lib/logger";
 import { getVerifiedUser } from "@/lib/server-auth";
 
@@ -49,29 +52,63 @@ export async function GET(
   }
 
   const { runId } = await context.params;
-  const run = await getUserOwnedIdeaRun(db, user.uid, runId);
+  let run = await getUserOwnedIdeaRun(db, user.uid, runId);
   if (!run) {
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
 
   try {
     if (run.cursorAgentId && activeRunId(run) && shouldRefreshFromCursor(run)) {
-      const apiKey = await getCursorApiKeyForUser(db, user.uid);
-      const snapshot = await getCursorRunSnapshot(apiKey, run.cursorAgentId, activeRunId(run)!);
-      const refreshed =
-        run.workflowStage === "questions" ||
-        run.workflowStage === "planning" ||
-        run.workflowStage === "building" ||
-        run.workflowStage === "pr_open"
-          ? await applyWorkflowRunSnapshot(db, run, snapshot)
-          : await applyRunSnapshot(db, run, snapshot);
-      return NextResponse.json({ ok: true, run: serializeCursorIdeaRun(refreshed) });
+      let apiKey: string;
+      try {
+        apiKey = await getCursorApiKeyForUser(db, user.uid);
+      } catch (keyErr) {
+        if (keyErr instanceof MissingCursorConnectionError) {
+          return NextResponse.json({
+            ok: true,
+            run: serializeCursorIdeaRun(run),
+            refreshSkipped: "cursor_not_connected",
+          });
+        }
+        throw keyErr;
+      }
+
+      try {
+        const snapshot = await getCursorRunSnapshot(apiKey, run.cursorAgentId, activeRunId(run)!);
+        const refreshed =
+          run.workflowStage === "questions" ||
+          run.workflowStage === "planning" ||
+          run.workflowStage === "building" ||
+          run.workflowStage === "pr_open"
+            ? await applyWorkflowRunSnapshot(db, run, snapshot)
+            : await applyRunSnapshot(db, run, snapshot);
+        return NextResponse.json({ ok: true, run: serializeCursorIdeaRun(refreshed) });
+      } catch (refreshErr) {
+        const message =
+          refreshErr instanceof Error ? refreshErr.message : String(refreshErr);
+        logger.logError(refreshErr, { stage: "cursor_idea_run_get_refresh", uid: user.uid, runId });
+        await db
+          .collection(CURSOR_IDEA_RUNS_COLLECTION)
+          .doc(run.id)
+          .set(
+            {
+              cursorStatusDetail: `Could not sync Cloud Agent status: ${message.slice(0, 260)}`,
+              updatedAt: FieldValue.serverTimestamp(),
+            },
+            { merge: true }
+          );
+        run = (await getUserOwnedIdeaRun(db, user.uid, runId)) ?? run;
+        return NextResponse.json({ ok: true, run: serializeCursorIdeaRun(run) });
+      }
     }
 
     return NextResponse.json({ ok: true, run: serializeCursorIdeaRun(run) });
   } catch (err) {
-    logger.logError(err, { stage: "cursor_idea_run_get", uid: user.uid, runId });
-    return NextResponse.json({ error: "refresh_failed" }, { status: 500 });
+    return jsonWithLoggedError(500, err, { error: "refresh_failed" }, {
+      stage: "cursor_idea_run_get",
+      uid: user.uid,
+      runId,
+    });
   }
 }
 
@@ -140,7 +177,10 @@ export async function DELETE(
     await db.collection(CURSOR_IDEA_RUNS_COLLECTION).doc(run.id).delete();
     return NextResponse.json({ deleted: true });
   } catch (err) {
-    logger.logError(err, { stage: "cursor_idea_run_delete", uid: user.uid, runId });
-    return NextResponse.json({ error: "delete_failed" }, { status: 500 });
+    return jsonWithLoggedError(500, err, { error: "delete_failed" }, {
+      stage: "cursor_idea_run_delete",
+      uid: user.uid,
+      runId,
+    });
   }
 }

--- a/app/api/cursor/idea-runs/route.ts
+++ b/app/api/cursor/idea-runs/route.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/cursor/idea-runs";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { logger } from "@/lib/logger";
+import { jsonWithLoggedError } from "@/lib/server/api-request-error";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import { getVerifiedUser } from "@/lib/server-auth";
 
@@ -48,7 +49,12 @@ async function handlePost(request: NextRequest): Promise<NextResponse> {
 
   const db = getAdminDb();
   if (!db) {
-    return NextResponse.json({ error: "not_configured" }, { status: 500 });
+    return jsonWithLoggedError(
+      500,
+      new Error("Firebase Admin not configured"),
+      { error: "not_configured" },
+      { stage: "cursor_idea_run_post", uid: user.uid }
+    );
   }
 
   let body: unknown;
@@ -129,8 +135,10 @@ async function handlePost(request: NextRequest): Promise<NextResponse> {
         { merge: true }
       )
       .catch(() => undefined);
-    logger.logError(err, { stage: "cursor_idea_run_launch", uid: user.uid });
-    return NextResponse.json({ error: "launch_failed" }, { status: 500 });
+    return jsonWithLoggedError(500, err, { error: "launch_failed" }, {
+      stage: "cursor_idea_run_launch",
+      uid: user.uid,
+    });
   }
 }
 
@@ -142,7 +150,12 @@ async function handleGet(request: NextRequest): Promise<NextResponse> {
 
   const db = getAdminDb();
   if (!db) {
-    return NextResponse.json({ error: "not_configured" }, { status: 500 });
+    return jsonWithLoggedError(
+      500,
+      new Error("Firebase Admin not configured"),
+      { error: "not_configured" },
+      { stage: "cursor_idea_runs_list", uid: user.uid }
+    );
   }
 
   try {
@@ -166,8 +179,10 @@ async function handleGet(request: NextRequest): Promise<NextResponse> {
       runs: runs.map(serializeCursorIdeaRun),
     });
   } catch (err) {
-    logger.logError(err, { stage: "cursor_idea_runs_list", uid: user.uid });
-    return NextResponse.json({ error: "list_failed" }, { status: 500 });
+    return jsonWithLoggedError(500, err, { error: "list_failed" }, {
+      stage: "cursor_idea_runs_list",
+      uid: user.uid,
+    });
   }
 }
 

--- a/app/pr-ideas/_components/LaunchPanel.tsx
+++ b/app/pr-ideas/_components/LaunchPanel.tsx
@@ -7,10 +7,11 @@
 "use client";
 
 import { ExternalLink, GitPullRequestArrow, Lightbulb, Loader2, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { TagsField } from "./TagsField";
 import {
   emptyIdeaForm,
+  hasLaunchableIdeaContent,
   IDEA_FIELD_OPTIONS,
   type GithubIssueOption,
   type IdeaFormKey,
@@ -21,6 +22,10 @@ interface LaunchPanelProps {
   open: boolean;
   hasRuns: boolean;
   launching: boolean;
+  form: LaunchFormState;
+  setForm: Dispatch<SetStateAction<LaunchFormState>>;
+  launchError: string | null;
+  onDismissError: () => void;
   issues: GithubIssueOption[];
   issuesLoading: boolean;
   issuesError: string | null;
@@ -33,6 +38,10 @@ export function LaunchPanel({
   open,
   hasRuns,
   launching,
+  form,
+  setForm,
+  launchError,
+  onDismissError,
   issues,
   issuesLoading,
   issuesError,
@@ -41,7 +50,7 @@ export function LaunchPanel({
   onLaunch,
 }: LaunchPanelProps) {
   const [activeField, setActiveField] = useState<IdeaFormKey | null>(null);
-  const [form, setForm] = useState<LaunchFormState>(() => emptyIdeaForm());
+  const canLaunch = hasLaunchableIdeaContent(form);
 
   useEffect(() => {
     if (open && form.mode === "issue") onLoadIssues();
@@ -56,7 +65,10 @@ export function LaunchPanel({
   };
 
   return (
-    <section id="pr-ideas-launch-panel" className="rounded-3xl border border-neutral-800 bg-neutral-950/85 shadow-2xl shadow-black/20">
+    <section
+      id="pr-ideas-launch-panel"
+      className="rounded-3xl border border-neutral-800 bg-neutral-950/85 shadow-2xl shadow-black/20 dark:bg-neutral-950/85"
+    >
       <div className="flex flex-col gap-3 px-5 py-4 md:px-6">
         <div className="flex items-center justify-between gap-4">
           <div>
@@ -67,7 +79,12 @@ export function LaunchPanel({
                 : "Start here. Choose freeform exploration or a tracked repo issue."}
             </p>
           </div>
-          <button type="button" onClick={onToggle} className="rounded-lg border border-neutral-800 p-2 text-neutral-400 hover:bg-neutral-900" aria-label="Close launch panel">
+          <button
+            type="button"
+            onClick={onToggle}
+            className="rounded-lg border border-neutral-800 p-2 text-neutral-400 hover:bg-neutral-900"
+            aria-label="Close launch panel"
+          >
             <X size={18} />
           </button>
         </div>
@@ -83,7 +100,7 @@ export function LaunchPanel({
           >
             <Lightbulb size={18} />
             <span>
-              <span className="block text-sm font-semibold">Launch Idea Explorer</span>
+              <span className="block text-sm font-semibold">Generate ideas</span>
               <span className="block text-xs text-neutral-400">Use tags and your own description.</span>
             </span>
           </button>
@@ -98,7 +115,7 @@ export function LaunchPanel({
           >
             <GitPullRequestArrow size={18} />
             <span>
-              <span className="block text-sm font-semibold">Review GitHub Issues</span>
+              <span className="block text-sm font-semibold">Start from a GitHub issue</span>
               <span className="block text-xs text-neutral-400">Pick an open issue from the repo.</span>
             </span>
           </button>
@@ -107,6 +124,18 @@ export function LaunchPanel({
 
       {open && (
         <div className="border-t border-neutral-800 px-5 pb-5 pt-4 md:px-6 md:pb-6">
+          {launchError && (
+            <div className="mb-4 flex items-start justify-between gap-3 rounded-xl border border-red-500/40 bg-red-500/15 p-3 text-sm text-red-950 dark:text-red-100">
+              <span>{launchError}</span>
+              <button
+                type="button"
+                onClick={onDismissError}
+                className="shrink-0 rounded-lg border border-red-400/50 px-2 py-0.5 text-xs font-medium hover:bg-red-500/20"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
           {form.mode === "idea" ? (
             <>
               <div
@@ -166,57 +195,84 @@ export function LaunchPanel({
               </label>
             </>
           ) : (
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,22rem)]">
               <div className="max-h-96 space-y-2 overflow-y-auto rounded-2xl border border-neutral-800 bg-neutral-950 p-3">
                 {issuesLoading && <p className="p-3 text-sm text-neutral-400">Loading GitHub issues...</p>}
                 {issuesError && <p className="p-3 text-sm text-red-200">{issuesError}</p>}
-                {!issuesLoading && !issuesError && issues.map((issue) => (
-                  <button
-                    key={issue.number}
-                    type="button"
-                    onClick={() => setForm((current) => ({ ...current, issue }))}
-                    className={`w-full rounded-xl border p-3 text-left transition-colors ${
-                      form.issue?.number === issue.number
-                        ? "border-emerald-400/60 bg-emerald-400/10"
-                        : "border-neutral-800 bg-neutral-900/70 hover:bg-neutral-900"
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <p className="text-sm font-semibold text-white">#{issue.number} {issue.title}</p>
-                      <a
-                        href={issue.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        onClick={(event) => event.stopPropagation()}
-                        className="mt-0.5 shrink-0 text-neutral-500 hover:text-emerald-300"
-                        aria-label={`Open issue #${issue.number} on GitHub`}
-                      >
-                        <ExternalLink size={13} />
-                      </a>
-                    </div>
-                    {issue.labels.length > 0 && (
-                      <div className="mt-2 flex flex-wrap gap-1.5">
-                        {issue.labels.slice(0, 4).map((label) => (
-                          <span key={label} className="rounded-full border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400">
-                            {label}
-                          </span>
-                        ))}
+                {!issuesLoading &&
+                  !issuesError &&
+                  issues.map((issue) => (
+                    <button
+                      key={issue.number}
+                      type="button"
+                      onClick={() =>
+                        setForm((current) => ({
+                          ...current,
+                          issue: current.issue?.number === issue.number ? null : issue,
+                        }))
+                      }
+                      className={`w-full rounded-xl border p-3 text-left transition-colors ${
+                        form.issue?.number === issue.number
+                          ? "border-emerald-400/60 bg-emerald-400/10"
+                          : "border-neutral-800 bg-neutral-900/70 hover:bg-neutral-900"
+                      }`}
+                    >
+                      <div className="grid grid-cols-[1fr_auto] gap-2 items-start">
+                        <p className="min-w-0 text-sm font-semibold leading-snug text-white">
+                          #{issue.number} {issue.title}
+                        </p>
+                        <a
+                          href={issue.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(event) => event.stopPropagation()}
+                          className="mt-0.5 shrink-0 text-neutral-500 hover:text-emerald-300"
+                          aria-label={`Open issue #${issue.number} on GitHub`}
+                        >
+                          <ExternalLink size={13} />
+                        </a>
                       </div>
-                    )}
-                  </button>
-                ))}
+                      {issue.labels.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          {issue.labels.slice(0, 4).map((label) => (
+                            <span
+                              key={label}
+                              className="rounded-full border border-neutral-700 px-2 py-0.5 text-[11px] text-neutral-400"
+                            >
+                              {label}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </button>
+                  ))}
               </div>
-              <label className="block">
-                <span className="text-sm font-medium text-neutral-200">Describe how you want to approach it</span>
+              <label className="block min-h-0">
+                <span className="text-sm font-medium text-neutral-200">
+                  Describe how you want to approach it (optional but recommended)
+                </span>
                 <textarea
                   value={form.freeform}
                   onChange={(event) => setForm((current) => ({ ...current, freeform: event.target.value }))}
-                  rows={10}
+                  rows={6}
                   className="mt-2 w-full rounded-2xl border border-neutral-800 bg-neutral-950 px-4 py-3 text-sm text-white placeholder:text-neutral-600 focus:border-emerald-400 focus:outline-none"
                   placeholder="Example: I want Cursor to find the smallest useful implementation path, avoid database changes, and focus on tests."
                 />
-                <p className="mt-2 text-xs text-neutral-500">
-                  {form.issue ? `Selected #${form.issue.number}` : "Select an issue from the list before launching."}
+                <p className="mt-2 flex flex-wrap items-center gap-x-2 text-xs text-neutral-500">
+                  {form.issue ? (
+                    <>
+                      <span>Selected #{form.issue.number}</span>
+                      <button
+                        type="button"
+                        className="text-emerald-400 hover:text-emerald-300"
+                        onClick={() => setForm((c) => ({ ...c, issue: null }))}
+                      >
+                        Clear selection
+                      </button>
+                    </>
+                  ) : (
+                    <span>Select an issue from the list before launching.</span>
+                  )}
                 </p>
               </label>
             </div>
@@ -225,16 +281,21 @@ export function LaunchPanel({
           <button
             type="button"
             onClick={handleLaunch}
-            disabled={launching || (form.mode === "issue" && !form.issue)}
+            disabled={launching || !canLaunch}
             className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-400 px-5 py-3.5 font-semibold text-neutral-950 hover:bg-emerald-300 disabled:opacity-60"
           >
             {launching && <Loader2 size={16} className="animate-spin" />}
             {launching
-              ? "Launching Cloud Agent..."
+              ? "Launching Cloud Agent…"
               : form.mode === "issue"
-                ? "Launch Cloud Agent from issue"
-                : "Launch Cursor idea run"}
+                ? "Launch from GitHub issue"
+                : "Generate ideas"}
           </button>
+          {!canLaunch && (
+            <p className="mt-2 text-center text-xs text-neutral-500">
+              Add at least one interest, skill, preferred area, constraint, or description before launching.
+            </p>
+          )}
         </div>
       )}
     </section>

--- a/app/pr-ideas/_components/RunDetail.tsx
+++ b/app/pr-ideas/_components/RunDetail.tsx
@@ -6,15 +6,19 @@
 
 "use client";
 
-import { CheckCircle2, Copy, ExternalLink, Loader2, RefreshCw, Trash2, X } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Copy, ExternalLink, Loader2, RefreshCw, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { PromptMarkdown } from "@/components/cookbook/PromptMarkdown";
 import {
+  DISPLAY_STATE_PILL,
+  displayState,
+  displayStateLabel,
+  expectedWaitMaxMs,
   formatDuration,
   formatRunDate,
   getRunTitle,
   isActiveRun,
-  STATUS_STYLES,
+  typicalWaitLabel,
   type CursorIdeaRun,
   type LoadingState,
 } from "../_lib/types";
@@ -38,57 +42,6 @@ function SkeletonBlock({ className = "" }: { className?: string }) {
   return <div className={`animate-pulse rounded-xl bg-neutral-800/80 ${className}`} />;
 }
 
-function WorkflowBadge({ run }: { run: CursorIdeaRun }) {
-  const label = run.pr?.status && run.pr.status !== "not_started"
-    ? formatPrStatus(run.pr.status)
-    : formatWorkflowStage(run.workflowStage);
-  return (
-    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200">
-      {label}
-    </span>
-  );
-}
-
-function formatWorkflowStage(stage?: CursorIdeaRun["workflowStage"]): string {
-  switch (stage) {
-    case "questions":
-      return "questions";
-    case "planning":
-      return "planning";
-    case "plan_approval":
-      return "plan approval";
-    case "building":
-      return "building";
-    case "ready_for_pr":
-      return "ready for PR";
-    case "pr_open":
-      return "PR open";
-    case "pr_commented_on":
-      return "PR commented on";
-    case "pr_merged":
-      return "PR merged";
-    case "ideas":
-    default:
-      return "ideas";
-  }
-}
-
-function formatPrStatus(status: NonNullable<CursorIdeaRun["pr"]>["status"]): string {
-  switch (status) {
-    case "opening":
-      return "opening PR";
-    case "pr_open":
-      return "PR open";
-    case "pr_commented_on":
-      return "PR commented on";
-    case "pr_merged":
-      return "PR merged";
-    case "not_started":
-    default:
-      return "not started";
-  }
-}
-
 function extractSuggestionOptions(result?: string | null): string[] {
   if (!result) return [];
   const options: string[] = [];
@@ -102,22 +55,6 @@ function extractSuggestionOptions(result?: string | null): string[] {
     if (options.length >= 5) break;
   }
   return options;
-}
-
-function expectedAgentWindow(run: CursorIdeaRun): string {
-  switch (run.workflowStage) {
-    case "questions":
-      return "usually 30-90 seconds";
-    case "planning":
-      return "usually 1-3 minutes";
-    case "building":
-      return "usually 5-15 minutes";
-    case "pr_open":
-      return "usually 1-3 minutes";
-    case "ideas":
-    default:
-      return "usually 2-5 minutes";
-  }
 }
 
 function agentRunningLabel(run: CursorIdeaRun): string {
@@ -182,6 +119,16 @@ const WORKFLOW_STEPS = [
   { id: "pr", label: "PR" },
 ] as const;
 
+function scrollToWorkflowSection(stepId: (typeof WORKFLOW_STEPS)[number]["id"]) {
+  if (typeof document === "undefined") return;
+  document.getElementById(`pr-studio-${stepId}`)?.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function artifactCursorHref(cursorAgentUrl: string | undefined, path: string): string | undefined {
+  if (!cursorAgentUrl) return undefined;
+  return `${cursorAgentUrl}#path=${encodeURIComponent(path)}`;
+}
+
 function currentStepIndex(run: CursorIdeaRun): number {
   if (run.pr?.status && run.pr.status !== "not_started") return 5;
   if (run.workflowStage === "ready_for_pr" || run.workflowStage === "building" || run.buildResult) return 4;
@@ -209,6 +156,7 @@ interface AgentRunningModalProps {
   elapsed: number;
   canCancel: boolean;
   cancelling: boolean;
+  appearsStuck: boolean;
   onClose: () => void;
   onCancel: () => void;
 }
@@ -218,6 +166,7 @@ function AgentRunningModal({
   elapsed,
   canCancel,
   cancelling,
+  appearsStuck,
   onClose,
   onCancel,
 }: AgentRunningModalProps) {
@@ -247,8 +196,18 @@ function AgentRunningModal({
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-start gap-3">
-          <div className="rounded-full border border-emerald-500/30 bg-emerald-500/15 p-2">
-            <Loader2 size={18} className="animate-spin text-emerald-300" />
+          <div
+            className={`rounded-full border p-2 ${
+              appearsStuck
+                ? "border-amber-500/40 bg-amber-500/15"
+                : "border-emerald-500/30 bg-emerald-500/15"
+            }`}
+          >
+            {appearsStuck ? (
+              <AlertTriangle size={18} className="text-amber-300" />
+            ) : (
+              <Loader2 size={18} className="animate-spin text-emerald-300" />
+            )}
           </div>
           <div className="min-w-0 flex-1">
             <h3 id="agent-running-title" className="text-base font-semibold text-white">
@@ -271,8 +230,8 @@ function AgentRunningModal({
             <dd className="mt-1 text-sm text-white">{formatDuration(elapsed) ?? "0s"}</dd>
           </div>
           <div className="rounded-lg border border-neutral-800 bg-neutral-900/70 px-3 py-2">
-            <dt className="uppercase tracking-[0.14em] text-neutral-500">Expected</dt>
-            <dd className="mt-1 text-sm text-white">{expectedAgentWindow(run)}</dd>
+            <dt className="uppercase tracking-[0.14em] text-neutral-500">Typical</dt>
+            <dd className="mt-1 text-sm text-white">{typicalWaitLabel(run, appearsStuck)}</dd>
           </div>
         </dl>
         <p className="mt-4 text-xs text-neutral-400">
@@ -351,13 +310,15 @@ export function RunDetail({
     [run?.activity]
   );
   const elapsed = run ? elapsedForRun(run, now) : 0;
+  const appearsStuck = Boolean(run && agentWorking && elapsed > 2 * expectedWaitMaxMs(run));
+  const canCancelRun = Boolean(run && (active || agentWorking));
   const cancelling = run ? runAction === `cancel:${run.id}` : false;
 
   useEffect(() => {
-    if (!agentWorking) return undefined;
+    if (!agentWorking || appearsStuck) return undefined;
     const intervalId = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(intervalId);
-  }, [agentWorking]);
+  }, [agentWorking, appearsStuck]);
 
   // Modal auto-hides via conditional render (`modalOpen && agentWorking`); no
   // synchronization effect needed. Per-run state is reset by remounting the
@@ -369,7 +330,9 @@ export function RunDetail({
       body?: Record<string, unknown>
     ) => {
       if (!run) return Promise.resolve(null);
-      setModalOpen(true);
+      if (action !== "recover-agent") {
+        setModalOpen(true);
+      }
       return onAdvanceWorkflow(run.id, action, body);
     },
     [run, onAdvanceWorkflow]
@@ -412,15 +375,25 @@ export function RunDetail({
     await navigator.clipboard.writeText(content);
   };
 
+  const copyId = async (text: string | undefined | null) => {
+    if (!text) return;
+    await navigator.clipboard.writeText(text);
+  };
+
   const busyPrefix = runAction?.endsWith(`:${run.id}`) ? runAction.split(":")[0] : null;
   const suggestionOptions = extractSuggestionOptions(run.result);
   const stepIndex = currentStepIndex(run);
+  const derived = displayState(run);
+  const showPillPulse = derived === "running";
   const outputContent = run.pr?.url
     ? `PR opened: ${run.pr.url}`
     : run.buildResult ?? run.buildPlan ?? run.result ?? null;
 
   return (
-    <section className="relative overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-950/85">
+    <section
+      id="pr-studio-run-detail"
+      className="relative overflow-hidden rounded-2xl border border-neutral-200 bg-background/90 dark:border-neutral-800 dark:bg-neutral-950/85"
+    >
       {agentWorking && syncing && <div className="h-0.5 w-full animate-pulse bg-emerald-400" />}
 
       <div className="p-4 md:p-5">
@@ -428,17 +401,16 @@ export function RunDetail({
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
               <span
-                className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-0.5 text-[11px] ${STATUS_STYLES[run.status]}`}
+                className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-0.5 text-[11px] ${DISPLAY_STATE_PILL[derived]}`}
               >
-                {active && <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" />}
-                {run.status}
+                {showPillPulse && <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" />}
+                {displayStateLabel(derived)}
               </span>
-              <WorkflowBadge run={run} />
             </div>
-            <h2 className="mt-2 text-xl font-semibold tracking-tight text-white md:text-2xl">
+            <h2 className="mt-2 min-w-0 truncate text-xl font-semibold tracking-tight text-foreground md:text-2xl">
               {getRunTitle(run)}
             </h2>
-            <p className={`mt-0.5 text-xs text-neutral-500 ${agentWorking && syncing ? "animate-pulse" : ""}`}>
+            <p className={`mt-0.5 text-xs text-neutral-500 dark:text-neutral-500 ${agentWorking && syncing && !appearsStuck ? "animate-pulse" : ""}`}>
               Updated {formatRunDate(run.updatedAt)}
             </p>
           </div>
@@ -466,24 +438,73 @@ export function RunDetail({
           </div>
         </div>
 
-        <dl className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-neutral-400">
-          <div className="flex items-center gap-1.5">
-            <dt className="uppercase tracking-[0.14em] text-neutral-500">Agent</dt>
-            <dd className="max-w-[12rem] truncate text-neutral-200">{run.cursorAgentId ?? "Pending"}</dd>
+        <dl className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-neutral-600 dark:text-neutral-400">
+          <div className="flex min-w-0 max-w-full items-center gap-1.5">
+            <dt className="shrink-0 uppercase tracking-[0.14em] text-neutral-500">Agent</dt>
+            <dd className="min-w-0 truncate text-neutral-800 dark:text-neutral-200">{run.cursorAgentId ?? "Pending"}</dd>
+            <button
+              type="button"
+              onClick={() => void copyId(run.cursorAgentId)}
+              disabled={!run.cursorAgentId}
+              className="shrink-0 rounded border border-neutral-300 p-1 text-neutral-600 hover:bg-neutral-100 disabled:opacity-40 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+              aria-label="Copy agent id"
+            >
+              <Copy size={12} />
+            </button>
           </div>
-          <div className="flex items-center gap-1.5">
-            <dt className="uppercase tracking-[0.14em] text-neutral-500">Run</dt>
-            <dd className="max-w-[12rem] truncate text-neutral-200">{run.cursorRunId ?? run.id}</dd>
+          <div className="flex min-w-0 max-w-full items-center gap-1.5">
+            <dt className="shrink-0 uppercase tracking-[0.14em] text-neutral-500">Run</dt>
+            <dd className="min-w-0 truncate text-neutral-800 dark:text-neutral-200">{run.cursorRunId ?? run.id}</dd>
+            <button
+              type="button"
+              onClick={() => void copyId(run.cursorRunId ?? run.id)}
+              className="shrink-0 rounded border border-neutral-300 p-1 text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+              aria-label="Copy run id"
+            >
+              <Copy size={12} />
+            </button>
           </div>
           <div className="flex items-center gap-1.5">
             <dt className="uppercase tracking-[0.14em] text-neutral-500">Duration</dt>
-            <dd className="text-neutral-200">{formatDuration(run.durationMs) ?? "In progress"}</dd>
+            <dd className="text-neutral-800 dark:text-neutral-200">{formatDuration(run.durationMs) ?? "In progress"}</dd>
           </div>
           <div className="flex items-center gap-1.5">
             <dt className="uppercase tracking-[0.14em] text-neutral-500">Finished</dt>
-            <dd className="text-neutral-200">{run.finishedAt ? formatRunDate(run.finishedAt) : "Not yet"}</dd>
+            <dd className="text-neutral-800 dark:text-neutral-200">{run.finishedAt ? formatRunDate(run.finishedAt) : "Not yet"}</dd>
           </div>
         </dl>
+
+        <div
+          id="pr-studio-source"
+          className="mt-3 scroll-mt-20 rounded-xl border border-neutral-200 bg-neutral-50/80 p-3 text-xs dark:border-neutral-800 dark:bg-neutral-900/60"
+        >
+          <h4 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-neutral-500">Source</h4>
+          <p className="mt-2 whitespace-pre-wrap text-neutral-800 dark:text-neutral-200">{run.prompt}</p>
+          <dl className="mt-2 grid gap-1 text-neutral-600 dark:text-neutral-400">
+            {run.inputs.mode ? (
+              <div>
+                <dt className="inline text-neutral-500">Mode · </dt>
+                <dd className="inline">{run.inputs.mode}</dd>
+              </div>
+            ) : null}
+            {run.inputs.issueNumber ? (
+              <div>
+                <dt className="inline text-neutral-500">Issue · </dt>
+                <dd className="inline">
+                  #{run.inputs.issueNumber} {run.inputs.issueTitle}
+                </dd>
+              </div>
+            ) : null}
+            {[run.inputs.interests, run.inputs.skills, run.inputs.preferredArea, run.inputs.freeform].some(Boolean) ? (
+              <div className="text-neutral-700 dark:text-neutral-300">
+                {run.inputs.interests ? <p>Interests: {run.inputs.interests}</p> : null}
+                {run.inputs.skills ? <p>Skills: {run.inputs.skills}</p> : null}
+                {run.inputs.preferredArea ? <p>Area: {run.inputs.preferredArea}</p> : null}
+                {run.inputs.freeform ? <p>{run.inputs.freeform}</p> : null}
+              </div>
+            ) : null}
+          </dl>
+        </div>
 
         {run.error && (
           <div className="mt-3 rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
@@ -491,47 +512,100 @@ export function RunDetail({
           </div>
         )}
 
-        <div className="mt-4 rounded-xl border border-emerald-500/20 bg-emerald-500/[0.04] px-4 py-3">
+        <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-500/[0.06] px-4 py-3 dark:border-emerald-500/20 dark:bg-emerald-500/[0.04]">
           <div className="flex flex-wrap items-baseline justify-between gap-2">
-            <h3 className="text-sm font-semibold text-white">{workflowHeading(run)}</h3>
-            <p className="text-xs text-neutral-400">{workflowDescription(run)}</p>
+            <h3 className="text-sm font-semibold text-emerald-950 dark:text-white">{workflowHeading(run)}</h3>
+            <p className="text-xs text-neutral-600 dark:text-neutral-400">{workflowDescription(run)}</p>
           </div>
 
           <ol className="mt-3 flex flex-wrap items-center gap-1.5 text-[11px]">
             {WORKFLOW_STEPS.map((step, index) => (
-              <li
-                key={step.id}
-                className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 ${
-                  index <= stepIndex
-                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-100"
-                    : "border-neutral-800 bg-neutral-950 text-neutral-500"
-                }`}
-              >
-                {index < stepIndex ? (
-                  <CheckCircle2 size={11} />
-                ) : (
-                  <span className="h-1.5 w-1.5 rounded-full bg-current" />
-                )}
-                {step.label}
+              <li key={step.id}>
+                <button
+                  type="button"
+                  onClick={() => scrollToWorkflowSection(step.id)}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 transition-colors ${
+                    index <= stepIndex
+                      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-900 hover:bg-emerald-500/15 dark:text-emerald-100"
+                      : "border-neutral-200 bg-neutral-100 text-neutral-600 hover:border-neutral-400 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-500"
+                  }`}
+                >
+                  {index < stepIndex ? (
+                    <CheckCircle2 size={11} />
+                  ) : (
+                    <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                  )}
+                  {step.label}
+                </button>
               </li>
             ))}
           </ol>
         </div>
 
         <div className="mt-4 space-y-4">
-          <div className="rounded-xl border border-neutral-800 bg-neutral-950 p-4">
+          <div className="rounded-xl border border-neutral-200 bg-neutral-50/50 p-4 dark:border-neutral-800 dark:bg-neutral-950">
             <div className="flex items-start justify-between gap-3">
-              <h4 className="text-sm font-semibold text-white">Current action</h4>
-              {agentWorking && (
+              <h4 className="text-sm font-semibold text-foreground">Current action</h4>
+              {agentWorking && !appearsStuck && (
                 <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-0.5 text-[11px] text-emerald-200">
                   <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-300" />
                   Cloud Agent
                 </span>
               )}
+              {agentWorking && appearsStuck && (
+                <span className="inline-flex items-center gap-2 rounded-full border border-amber-500/40 bg-amber-500/15 px-2.5 py-0.5 text-[11px] text-amber-200">
+                  <AlertTriangle size={11} />
+                  Needs attention
+                </span>
+              )}
             </div>
 
             <div className="mt-3 space-y-3">
-                {agentWorking && (
+                {agentWorking && appearsStuck && (
+                  <div className="rounded-lg border border-amber-500/35 bg-amber-500/10 p-3 dark:bg-amber-500/[0.08]">
+                    <p className="text-sm font-semibold text-amber-950 dark:text-amber-100">This run looks stuck</p>
+                    <p className="mt-1 text-xs text-amber-900/90 dark:text-amber-100/90">
+                      {typicalWaitLabel(run, true)}. Try refreshing the snapshot, canceling, or starting a fresh agent.
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => onRefresh(run.id)}
+                        disabled={refreshing}
+                        className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 px-3 py-2 text-xs font-semibold text-amber-950 hover:bg-amber-500/15 disabled:opacity-50 dark:text-amber-100"
+                      >
+                        {refreshing ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+                        Refresh
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onMutate(run.id, "cancel")}
+                        disabled={cancelling}
+                        className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 px-3 py-2 text-xs font-semibold text-amber-950 hover:bg-amber-500/15 disabled:opacity-50 dark:text-amber-100"
+                      >
+                        {cancelling && <Loader2 size={12} className="animate-spin" />}
+                        Cancel run
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleAdvance("recover-agent")}
+                        disabled={busyPrefix === "recover-agent"}
+                        className="inline-flex items-center gap-2 rounded-lg bg-amber-400 px-3 py-2 text-xs font-semibold text-amber-950 hover:bg-amber-300 disabled:opacity-50"
+                      >
+                        {busyPrefix === "recover-agent" && <Loader2 size={12} className="animate-spin" />}
+                        Start a fresh Cloud Agent
+                      </button>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                      <div className="rounded-lg border border-neutral-200 bg-white px-2.5 py-1.5 dark:border-neutral-800 dark:bg-neutral-950">
+                        <span className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">Elapsed </span>
+                        <span className="text-neutral-900 dark:text-white">{formatDuration(elapsed) ?? "0s"}</span>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {agentWorking && !appearsStuck && (
                   <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/[0.05] p-3">
                     <p className="text-sm font-medium text-white">{agentRunningLabel(run)}</p>
                     <div className="mt-2 flex flex-wrap gap-2 text-xs">
@@ -540,15 +614,15 @@ export function RunDetail({
                         <span className="text-white">{formatDuration(elapsed) ?? "0s"}</span>
                       </div>
                       <div className="rounded-lg border border-neutral-800 bg-neutral-950 px-2.5 py-1.5">
-                        <span className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">Expected </span>
-                        <span className="text-white">{expectedAgentWindow(run)}</span>
+                        <span className="text-[10px] uppercase tracking-[0.14em] text-neutral-500">Typical </span>
+                        <span className="text-white">{typicalWaitLabel(run, false)}</span>
                       </div>
                     </div>
                   </div>
                 )}
 
                 {run.workflowStage === "ideas" && run.result && !run.selectedIdea && (
-                  <div className="space-y-3">
+                  <div id="pr-studio-direction" className="scroll-mt-24 space-y-3">
                     <p className="text-sm font-medium text-white">Choose what Cursor should turn into a PR.</p>
                     {suggestionOptions.length > 0 && (
                       <div className="flex flex-wrap gap-2">
@@ -596,7 +670,7 @@ export function RunDetail({
                 )}
 
                 {run.workflowStage === "questions" && run.questions && run.questions.length > 0 && !run.answersSubmittedAt && (
-                  <div className="space-y-3">
+                  <div id="pr-studio-questions" className="scroll-mt-24 space-y-3">
                     {run.questions.map((question) => (
                       <div key={question.id} className="rounded-lg border border-neutral-800 bg-neutral-900 p-3">
                         <p className="text-sm text-neutral-200">{question.question}</p>
@@ -671,9 +745,11 @@ export function RunDetail({
                 )}
 
                 {run.pr?.url && (
+                  <div id="pr-studio-pr" className="scroll-mt-24">
                   <a href={run.pr.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-2 text-sm font-semibold text-emerald-300 hover:text-emerald-200">
                     View PR <ExternalLink size={14} />
                   </a>
+                  </div>
                 )}
 
                 {error && (
@@ -681,8 +757,8 @@ export function RunDetail({
                     <p>{error}</p>
                     <button
                       type="button"
-                      onClick={() => handleAdvance("recover-agent")}
-                      disabled={busyPrefix === "recover-agent" || actionsLocked}
+                      onClick={() => void handleAdvance("recover-agent")}
+                      disabled={busyPrefix === "recover-agent"}
                       className="inline-flex items-center gap-2 rounded-lg border border-red-300/40 px-3 py-2 text-xs font-semibold text-red-100 hover:bg-red-500/10 disabled:opacity-50"
                     >
                       {busyPrefix === "recover-agent" && <Loader2 size={14} className="animate-spin" />}
@@ -693,10 +769,12 @@ export function RunDetail({
               </div>
             </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="flex flex-col rounded-xl border border-neutral-800 bg-neutral-950 p-4">
+          <div
+            className={`grid gap-4 ${resultExpanded ? "md:grid-cols-1" : "md:grid-cols-2"}`}
+          >
+            <div className="flex flex-col rounded-xl border border-neutral-200 bg-neutral-50/80 p-4 dark:border-neutral-800 dark:bg-neutral-950">
               <div className="flex items-center justify-between gap-3">
-                <h4 className="text-sm font-semibold text-white">Cloud Agent log</h4>
+                <h4 className="text-sm font-semibold text-foreground">Cloud Agent log</h4>
                 <span className="inline-flex items-center gap-1.5 text-xs text-neutral-500">
                   {syncing && <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />}
                   {syncing
@@ -707,27 +785,27 @@ export function RunDetail({
                 </span>
               </div>
               {run.cursorStatusDetail && (
-                <div className="mt-2 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.04] px-2.5 py-1.5 text-xs text-emerald-100">
+                <div className="mt-2 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.04] px-2.5 py-1.5 text-xs text-emerald-800 dark:text-emerald-100">
                   {run.cursorStatusDetail}
                 </div>
               )}
               <div className="mt-2 max-h-[18rem] space-y-2 overflow-y-auto">
                 {recentActivity.length > 0 ? (
                   recentActivity.map((item) => (
-                    <div key={item.id} className="rounded-lg border border-neutral-800 bg-neutral-900/70 p-2">
-                      <p className="text-[10px] uppercase tracking-[0.14em] text-emerald-300">
+                    <div key={item.id} className="rounded-lg border border-neutral-200 bg-white/80 p-2 dark:border-neutral-800 dark:bg-neutral-900/70">
+                      <p className="text-[10px] uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
                         {item.kind ?? (item.role === "assistant" ? "agent" : "prompt")}
                       </p>
                       <PromptMarkdown content={item.summary} className="mt-1 line-clamp-4 text-sm" />
                     </div>
                   ))
                 ) : agentWorking ? (
-                  <div className="space-y-3 rounded-lg border border-neutral-800 bg-neutral-900/70 p-3">
-                    <div className="flex items-center gap-2 text-sm text-neutral-200">
+                  <div className="space-y-3 rounded-lg border border-neutral-200 bg-white/80 p-3 dark:border-neutral-800 dark:bg-neutral-900/70">
+                    <div className="flex items-center gap-2 text-sm text-neutral-800 dark:text-neutral-200">
                       <Loader2 size={14} className="animate-spin text-emerald-300" />
                       <span>{agentRunningLabel(run)}</span>
                     </div>
-                    <p className="text-xs leading-relaxed text-neutral-400">
+                    <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-400">
                       The agent is working in the cloud but hasn&apos;t streamed any conversation steps to this
                       run yet. Conversation steps appear here after the agent emits its first message — Cursor
                       sometimes batches the first few seconds.
@@ -737,7 +815,7 @@ export function RunDetail({
                         href={run.cursorAgentUrl}
                         target="_blank"
                         rel="noreferrer"
-                        className="inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-300 hover:text-emerald-200"
+                        className="inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-600 hover:text-emerald-500 dark:text-emerald-300 dark:hover:text-emerald-200"
                       >
                         Watch live in Cursor <ExternalLink size={12} />
                       </a>
@@ -749,16 +827,27 @@ export function RunDetail({
               </div>
             </div>
 
-            <div className="flex flex-col rounded-xl border border-neutral-800 bg-neutral-950 p-4">
+            <div
+              id="pr-studio-output"
+              className="flex flex-col rounded-xl border border-neutral-200 bg-neutral-50/80 p-4 dark:border-neutral-800 dark:bg-neutral-950"
+            >
               <div className="flex items-center justify-between gap-3">
-                <h4 className="text-sm font-semibold text-white">Output</h4>
+                <h4 className="text-sm font-semibold text-foreground">Output</h4>
                 <div className="flex gap-1.5">
                   {outputContent && (
                     <>
-                      <button type="button" onClick={() => setResultExpanded((current) => !current)} className="rounded-lg border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-900">
-                        {resultExpanded ? "Collapse" : "Expand"}
+                      <button
+                        type="button"
+                        onClick={() => setResultExpanded((current) => !current)}
+                        className="rounded-lg border border-neutral-300 px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-900"
+                      >
+                        {resultExpanded ? "Full width" : "Expand"}
                       </button>
-                      <button type="button" onClick={copyResult} className="inline-flex items-center gap-1 rounded-lg border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-900">
+                      <button
+                        type="button"
+                        onClick={() => void copyResult()}
+                        className="inline-flex items-center gap-1 rounded-lg border border-neutral-300 px-2 py-1 text-xs text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-900"
+                      >
                         <Copy size={12} /> Copy
                       </button>
                     </>
@@ -766,11 +855,15 @@ export function RunDetail({
                 </div>
               </div>
               {outputContent ? (
-                <div className={`mt-2 rounded-lg border border-neutral-800 bg-neutral-900/60 p-3 ${resultExpanded ? "" : "max-h-[18rem] overflow-y-auto"}`}>
+                <div
+                  className={`mt-2 rounded-lg border border-neutral-200 bg-white/80 p-3 dark:border-neutral-800 dark:bg-neutral-900/60`}
+                >
+                  {run.buildPlan ? <div id="pr-studio-plan" className="relative -mt-2 h-0 scroll-mt-28" aria-hidden /> : null}
+                  {run.buildResult ? <div id="pr-studio-build" className="relative -mt-2 h-0 scroll-mt-28" aria-hidden /> : null}
                   <PromptMarkdown content={outputContent} className="space-y-3" />
                 </div>
               ) : (
-                <p className="mt-2 rounded-lg border border-neutral-800 bg-neutral-900/60 p-3 text-sm text-neutral-500">
+                <p className="mt-2 rounded-lg border border-neutral-200 bg-white/60 p-3 text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/60">
                   Output will appear here when the current step completes.
                 </p>
               )}
@@ -779,24 +872,49 @@ export function RunDetail({
         </div>
 
         {run.artifacts && run.artifacts.length > 0 && (
-          <div className="mt-4 rounded-xl border border-neutral-800 bg-neutral-900/60 p-3">
-            <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">Artifacts</h3>
-            <ul className="mt-2 space-y-0.5 text-xs text-neutral-400">
-              {run.artifacts.map((artifact) => (
-                <li key={artifact.path}>{artifact.path}</li>
-              ))}
+          <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50/80 p-3 dark:border-neutral-800 dark:bg-neutral-900/60">
+            <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-neutral-500">
+              Artifacts (open in Cursor)
+            </h3>
+            <ul className="mt-2 space-y-1.5 text-xs text-neutral-600 dark:text-neutral-400">
+              {run.artifacts.map((artifact) => {
+                const href = artifactCursorHref(run.cursorAgentUrl, artifact.path);
+                return (
+                  <li key={artifact.path} className="flex flex-wrap items-center gap-2">
+                    {href ? (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="break-all text-emerald-700 hover:underline dark:text-emerald-300"
+                      >
+                        {artifact.path}
+                      </a>
+                    ) : (
+                      <span className="break-all">{artifact.path}</span>
+                    )}
+                    <button
+                      type="button"
+                      className="shrink-0 rounded border border-neutral-300 px-1.5 py-0.5 text-[10px] hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+                      onClick={() => void copyId(artifact.path)}
+                    >
+                      Copy path
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}
 
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-neutral-800 pt-3">
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-neutral-200 pt-3 dark:border-neutral-800">
           <div className="flex flex-wrap gap-2">
-            {active && (
+            {canCancelRun && (
               <button
                 type="button"
                 onClick={() => onMutate(run.id, "cancel")}
                 disabled={runAction === `cancel:${run.id}`}
-                className="rounded-lg border border-amber-500/30 px-2.5 py-1.5 text-xs text-amber-200 hover:bg-amber-500/10 disabled:opacity-50"
+                className="rounded-lg border border-amber-500/30 px-2.5 py-1.5 text-xs text-amber-800 hover:bg-amber-500/10 dark:text-amber-200 disabled:opacity-50"
               >
                 Cancel run
               </button>
@@ -806,10 +924,10 @@ export function RunDetail({
                 type="button"
                 onClick={() => onMutate(run.id, "archive")}
                 disabled={runAction === `archive:${run.id}` || actionsLocked}
-                title={actionsLocked ? "Cancel the running agent before archiving" : undefined}
-                className="rounded-lg border border-neutral-700 px-2.5 py-1.5 text-xs text-neutral-300 hover:bg-neutral-900 disabled:opacity-50"
+                title={actionsLocked ? "Cancel the running agent before hiding" : undefined}
+                className="rounded-lg border border-neutral-300 px-2.5 py-1.5 text-xs text-neutral-700 hover:bg-neutral-100 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-900"
               >
-                Archive agent
+                Hide
               </button>
             )}
           </div>
@@ -818,10 +936,10 @@ export function RunDetail({
             onClick={() => onMutate(run.id, "delete")}
             disabled={runAction === `delete:${run.id}` || actionsLocked}
             title={actionsLocked ? "Cancel the running agent before deleting" : undefined}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/30 px-2.5 py-1.5 text-xs text-red-300 hover:bg-red-500/10 disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/30 px-2.5 py-1.5 text-xs text-red-700 hover:bg-red-500/10 disabled:opacity-50 dark:text-red-300"
           >
             <Trash2 size={12} />
-            Delete
+            Delete run permanently
           </button>
         </div>
       </div>
@@ -830,8 +948,9 @@ export function RunDetail({
         <AgentRunningModal
           run={run}
           elapsed={elapsed}
-          canCancel={active}
+          canCancel={canCancelRun}
           cancelling={cancelling}
+          appearsStuck={appearsStuck}
           onClose={() => setModalOpen(false)}
           onCancel={handleCancelFromModal}
         />

--- a/app/pr-ideas/_components/RunsRail.tsx
+++ b/app/pr-ideas/_components/RunsRail.tsx
@@ -7,29 +7,15 @@
 "use client";
 
 import {
+  displayState,
+  displayStateLabel,
   formatRunDate,
   getRunTitle,
-  isActiveRun,
+  DISPLAY_STATE_DOT,
+  DISPLAY_STATE_RAIL_TEXT,
   type CursorIdeaRun,
-  type CursorIdeaRunStatus,
   type LoadingState,
 } from "../_lib/types";
-
-const STATUS_TEXT_COLOR: Record<CursorIdeaRunStatus, string> = {
-  starting: "text-sky-300",
-  running: "text-amber-300",
-  finished: "text-emerald-300",
-  error: "text-red-300",
-  cancelled: "text-neutral-400",
-};
-
-const STATUS_DOT_COLOR: Record<CursorIdeaRunStatus, string> = {
-  starting: "bg-sky-400",
-  running: "bg-amber-400",
-  finished: "bg-emerald-400",
-  error: "bg-red-400",
-  cancelled: "bg-neutral-500",
-};
 
 interface RunsRailProps {
   runs: CursorIdeaRun[];
@@ -42,7 +28,7 @@ export function RunsRail({ runs, selectedRunId, loadingState, onSelect }: RunsRa
   const showSkeletons = loadingState === "initial" && runs.length === 0;
 
   return (
-    <aside className="rounded-2xl border border-neutral-800 bg-neutral-950/85 p-3 md:p-4">
+    <aside className="rounded-2xl border border-neutral-200 bg-background/90 p-3 dark:border-neutral-800 dark:bg-neutral-950/85 md:p-4">
       <div className="mb-3 flex items-center justify-between gap-2">
         <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-500">
           Runs
@@ -71,7 +57,8 @@ export function RunsRail({ runs, selectedRunId, loadingState, onSelect }: RunsRa
       ) : (
         <div className="flex gap-2 overflow-x-auto pb-1 lg:block lg:space-y-2 lg:overflow-visible">
           {runs.map((run) => {
-            const active = isActiveRun(run.status);
+            const derived = displayState(run);
+            const pulse = derived === "running";
             const selected = selectedRunId === run.id;
             return (
               <button
@@ -81,20 +68,20 @@ export function RunsRail({ runs, selectedRunId, loadingState, onSelect }: RunsRa
                 className={`block w-full min-w-[14rem] rounded-xl border p-2.5 text-left transition-colors lg:min-w-0 ${
                   selected
                     ? "border-emerald-500/50 bg-emerald-500/10"
-                    : "border-neutral-800 bg-neutral-900/70 hover:border-neutral-700"
+                    : "border-neutral-200 bg-neutral-100/80 hover:border-neutral-400 dark:border-neutral-800 dark:bg-neutral-900/70 dark:hover:border-neutral-700"
                 }`}
               >
                 <div className="flex items-start gap-2">
                   <span
-                    className={`mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT_COLOR[run.status]} ${active ? "animate-pulse" : ""}`}
-                    title={run.status}
+                    className={`mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full ${DISPLAY_STATE_DOT[derived]} ${pulse ? "animate-pulse" : ""}`}
+                    title={displayStateLabel(derived)}
                   />
                   <div className="min-w-0 flex-1">
-                    <p className="line-clamp-2 text-xs font-medium leading-snug text-white" title={getRunTitle(run)}>
+                    <p className="line-clamp-2 text-xs font-medium leading-snug text-foreground" title={getRunTitle(run)}>
                       {getRunTitle(run)}
                     </p>
                     <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-[10px] text-neutral-500">
-                      <span className={STATUS_TEXT_COLOR[run.status]}>{run.status}</span>
+                      <span className={DISPLAY_STATE_RAIL_TEXT[derived]}>{displayStateLabel(derived)}</span>
                       <span>·</span>
                       <span>{formatRunDate(run.createdAt)}</span>
                     </p>

--- a/app/pr-ideas/_hooks/useIdeaRuns.ts
+++ b/app/pr-ideas/_hooks/useIdeaRuns.ts
@@ -10,7 +10,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { User } from "firebase/auth";
 import type { LaunchFormState, CursorIdeaRun, GithubIssueOption, LoadingState } from "../_lib/types";
-import { isActiveRun } from "../_lib/types";
+import {
+  formatIdeaRunsApiError,
+  isActiveRun,
+} from "../_lib/types";
 
 type RunAction = "cancel" | "archive" | "delete";
 type WorkflowAction = "questions" | "answers" | "approve-plan" | "open-pr" | "recover-agent";
@@ -36,6 +39,7 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
   const [runErrors, setRunErrors] = useState<Record<string, string>>({});
   const [visibilityState, setVisibilityState] = useState<"visible" | "hidden">("visible");
   const [pollPausedUntil, setPollPausedUntil] = useState(0);
+  const [, setPollFailCount] = useState(0);
   const [githubIssues, setGithubIssues] = useState<GithubIssueOption[]>([]);
   const [githubIssuesLoading, setGithubIssuesLoading] = useState(false);
   const [githubIssuesError, setGithubIssuesError] = useState<string | null>(null);
@@ -78,6 +82,20 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
     [user]
   );
 
+  const bumpPollFailures = useCallback(() => {
+    setPollFailCount((current) => {
+      const next = current + 1;
+      if (next >= 3) {
+        setPollPausedUntil(Date.now() + 30_000);
+        setError(
+          "Polling paused after repeated server errors. Wait a few seconds, use Retry below, or refresh the page."
+        );
+        return 0;
+      }
+      return next;
+    });
+  }, []);
+
   const loadRuns = useCallback(
     async (refresh = true, mode: LoadingState = "refreshing") => {
       if (!user || !cursorConnected) return;
@@ -85,18 +103,24 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
       setError(null);
       try {
         const res = await authFetch(`/api/cursor/idea-runs?refresh=${refresh ? "true" : "false"}`);
+        const payload = (await res.json().catch(() => ({}))) as {
+          runs?: CursorIdeaRun[];
+          error?: string;
+          errorId?: string;
+        };
         if (!res.ok) {
           if (res.status === 429) {
             const retryAfter = Number(res.headers.get("Retry-After") ?? "60");
             setPollPausedUntil(Date.now() + Math.max(retryAfter, 10) * 1000);
             setError("Cursor idea runs are syncing too often. Pausing refresh briefly.");
           } else {
-            setError("Could not load recent idea runs.");
+            if (res.status >= 500) bumpPollFailures();
+            setError(formatIdeaRunsApiError(payload.error, payload.errorId));
           }
           return;
         }
-        const body = (await res.json()) as { runs?: CursorIdeaRun[] };
-        const nextRuns = body.runs ?? [];
+        setPollFailCount(0);
+        const nextRuns = payload.runs ?? [];
         setRuns(nextRuns);
         setSelectedRunId((current) => {
           if (current && nextRuns.some((run) => run.id === current)) return current;
@@ -108,7 +132,7 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
         setLoadingState("idle");
       }
     },
-    [authFetch, cursorConnected, user]
+    [authFetch, bumpPollFailures, cursorConnected, user]
   );
 
   const syncRunSnapshot = useCallback(
@@ -117,16 +141,33 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
       setSyncingRunId(runId);
       try {
         const res = await authFetch(`/api/cursor/idea-runs/${runId}`);
+        const payload = (await res.json().catch(() => ({}))) as {
+          run?: CursorIdeaRun;
+          error?: string;
+          errorId?: string;
+          refreshSkipped?: string;
+        };
         if (!res.ok) {
           if (res.status === 429) {
             const retryAfter = Number(res.headers.get("Retry-After") ?? "60");
             setPollPausedUntil(Date.now() + Math.max(retryAfter, 10) * 1000);
+          } else if (res.status >= 500) {
+            bumpPollFailures();
           }
           return;
         }
-        const body = (await res.json().catch(() => ({}))) as { run?: CursorIdeaRun };
-        if (body.run) {
-          setRuns((current) => current.map((run) => (run.id === runId ? body.run! : run)));
+        if (payload.refreshSkipped === "cursor_not_connected") {
+          router.replace("/profile/cursor?return=/pr-ideas");
+          return;
+        }
+        setPollFailCount(0);
+        if (payload.run) {
+          setRuns((current) => current.map((run) => (run.id === runId ? payload.run! : run)));
+          setRunErrors((current) => {
+            const next = { ...current };
+            delete next[runId];
+            return next;
+          });
         }
       } catch {
         // Keep the existing UI visible; transient status checks should not blank the page.
@@ -134,7 +175,7 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
         setSyncingRunId((current) => (current === runId ? null : current));
       }
     },
-    [authFetch, cursorConnected, user]
+    [authFetch, bumpPollFailures, cursorConnected, router, user]
   );
 
   useEffect(() => {
@@ -224,16 +265,18 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
         const body = (await res.json().catch(() => ({}))) as {
           run?: CursorIdeaRun;
           error?: string;
+          errorId?: string;
         };
         if (!res.ok || !body.run) {
           if (body.error === "cursor_not_connected") {
             router.replace("/profile/cursor?return=/pr-ideas");
           } else {
-            setError("Could not launch the idea explorer.");
+            setError(formatIdeaRunsApiError(body.error, body.errorId));
           }
           return null;
         }
 
+        setPollFailCount(0);
         setRuns((current) => [body.run!, ...current.filter((run) => run.id !== body.run!.id)]);
         setSelectedRunId(body.run.id);
         return body.run;
@@ -274,12 +317,28 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
       setError(null);
       try {
         const res = await authFetch(`/api/cursor/idea-runs/${runId}`);
-        const body = (await res.json().catch(() => ({}))) as { run?: CursorIdeaRun };
-        if (!res.ok || !body.run) {
-          setError("Could not refresh that run.");
+        const body = (await res.json().catch(() => ({}))) as {
+          run?: CursorIdeaRun;
+          error?: string;
+          errorId?: string;
+          refreshSkipped?: string;
+        };
+        if (body.refreshSkipped === "cursor_not_connected") {
+          router.replace("/profile/cursor?return=/pr-ideas");
           return;
         }
+        if (!res.ok || !body.run) {
+          setError(formatIdeaRunsApiError(body.error, body.errorId));
+          if (res.status >= 500) bumpPollFailures();
+          return;
+        }
+        setPollFailCount(0);
         setRuns((current) => current.map((run) => (run.id === runId ? body.run! : run)));
+        setRunErrors((current) => {
+          const next = { ...current };
+          delete next[runId];
+          return next;
+        });
       } catch {
         setError("Network error while refreshing the run.");
       } finally {
@@ -287,12 +346,17 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
         setLoadingState("idle");
       }
     },
-    [authFetch]
+    [authFetch, bumpPollFailures, router]
   );
+
+  const clearError = useCallback(() => setError(null), []);
 
   const mutateRun = useCallback(
     async (runId: string, action: RunAction) => {
-      if (action === "delete" && !window.confirm("Delete this Cursor agent and local run record?")) {
+      if (
+        action === "delete" &&
+        !window.confirm("Delete this run permanently? This removes the run and its Cloud Agent record.")
+      ) {
         return;
       }
       setRunAction(`${action}:${runId}`);
@@ -302,10 +366,13 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
           `/api/cursor/idea-runs/${runId}${action === "delete" ? "" : `/${action}`}`,
           { method: action === "delete" ? "DELETE" : "POST" }
         );
-        const body = (await res.json().catch(() => ({}))) as { run?: CursorIdeaRun };
+        const body = (await res.json().catch(() => ({}))) as {
+          run?: CursorIdeaRun;
+          error?: string;
+          errorId?: string;
+        };
         if (!res.ok) {
-          const payload = (await res.json().catch(() => ({}))) as { error?: string };
-          setError(payload.error ? `Could not ${action}: ${payload.error}` : `Could not ${action} that run.`);
+          setError(formatIdeaRunsApiError(body.error, body.errorId) || `Could not ${action} that run.`);
           return;
         }
         if (action === "delete") {
@@ -339,12 +406,16 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
           method: "POST",
           ...(body ? { body: JSON.stringify(body) } : {}),
         });
-        const payload = (await res.json().catch(() => ({}))) as { run?: CursorIdeaRun; error?: string };
+        const payload = (await res.json().catch(() => ({}))) as {
+          run?: CursorIdeaRun;
+          error?: string;
+          errorId?: string;
+        };
         if (!res.ok || !payload.run) {
           const message =
             payload.error === "agent_recovery_required"
               ? "The previous Cursor Cloud Agent is no longer available. Start a fresh Cloud Agent from this context."
-              : "Could not advance that idea run.";
+              : formatIdeaRunsApiError(payload.error, payload.errorId) || "Could not advance that idea run.";
           setRunErrors((current) => ({
             ...current,
             [runId]: message,
@@ -388,6 +459,7 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
     githubIssuesLoading,
     githubIssuesError,
     loadRuns,
+    clearError,
     loadGithubIssues,
     launchIdeaRun,
     refreshRun,

--- a/app/pr-ideas/_lib/types.ts
+++ b/app/pr-ideas/_lib/types.ts
@@ -162,6 +162,155 @@ export function isActiveRun(status: CursorIdeaRunStatus): boolean {
   return status === "starting" || status === "running";
 }
 
+export type PrStudioDisplayState =
+  | "queued"
+  | "running"
+  | "awaiting_input"
+  | "finished"
+  | "cancelled"
+  | "failed"
+  | "pr_open";
+
+/** Single source of truth for status pill + rail dots (avoids contradictory raw chips). */
+export function displayState(run: CursorIdeaRun): PrStudioDisplayState {
+  if (run.pr?.url) return "pr_open";
+  if (run.status === "error") return "failed";
+  if (run.status === "cancelled") return "cancelled";
+  if (run.pr?.status === "opening") return "running";
+  if (run.workflowStage === "plan_approval" && run.buildPlan) return "awaiting_input";
+  if (run.questions && run.questions.length > 0 && !run.answersSubmittedAt) return "awaiting_input";
+  if (run.workflowStage === "ready_for_pr" && run.buildResult && !run.pr?.url) return "awaiting_input";
+  if (run.result && !run.selectedIdea && run.workflowStage === "ideas") return "awaiting_input";
+  if (run.status === "running" || run.status === "starting") return "running";
+  if (run.workflowStage === "questions" && (!run.questions || run.questions.length === 0)) {
+    return "running";
+  }
+  if (run.workflowStage === "planning" && !run.buildPlan) return "running";
+  if (run.workflowStage === "building" && !run.buildResult) return "running";
+  if (run.status === "finished") return "finished";
+  return "queued";
+}
+
+export function displayStateLabel(state: PrStudioDisplayState): string {
+  switch (state) {
+    case "queued":
+      return "queued";
+    case "running":
+      return "running";
+    case "awaiting_input":
+      return "needs your input";
+    case "finished":
+      return "finished";
+    case "cancelled":
+      return "cancelled";
+    case "failed":
+      return "failed";
+    case "pr_open":
+      return "PR open";
+    default:
+      return state;
+  }
+}
+
+export const DISPLAY_STATE_PILL: Record<PrStudioDisplayState, string> = {
+  queued: "border-neutral-600 bg-neutral-800 text-neutral-200",
+  running: "border-amber-500/30 bg-amber-500/10 text-amber-200",
+  awaiting_input: "border-sky-500/30 bg-sky-500/10 text-sky-200",
+  finished: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
+  cancelled: "border-neutral-600 bg-neutral-800 text-neutral-300",
+  failed: "border-red-500/30 bg-red-500/10 text-red-200",
+  pr_open: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
+};
+
+export const DISPLAY_STATE_DOT: Record<PrStudioDisplayState, string> = {
+  queued: "bg-neutral-500",
+  running: "bg-amber-400",
+  awaiting_input: "bg-sky-400",
+  finished: "bg-emerald-400",
+  cancelled: "bg-neutral-500",
+  failed: "bg-red-400",
+  pr_open: "bg-emerald-400",
+};
+
+export const DISPLAY_STATE_RAIL_TEXT: Record<PrStudioDisplayState, string> = {
+  queued: "text-neutral-400",
+  running: "text-amber-300",
+  awaiting_input: "text-sky-300",
+  finished: "text-emerald-300",
+  cancelled: "text-neutral-400",
+  failed: "text-red-300",
+  pr_open: "text-emerald-300",
+};
+
+/** Upper bound (ms) for "typical" wait — used for stuck detection (2× this). */
+export function expectedWaitMaxMs(run: CursorIdeaRun): number {
+  switch (run.workflowStage) {
+    case "questions":
+      return 90_000;
+    case "planning":
+      return 3 * 60_000;
+    case "building":
+      return 15 * 60_000;
+    case "pr_open":
+      return 3 * 60_000;
+    case "ideas":
+    default:
+      return 5 * 60_000;
+  }
+}
+
+export function typicalWaitLabel(run: CursorIdeaRun, pastTypicalWindow: boolean): string {
+  if (pastTypicalWindow) return "Past typical window";
+  switch (run.workflowStage) {
+    case "questions":
+      return "Typical: 30–90 seconds";
+    case "planning":
+      return "Typical: 1–3 minutes";
+    case "building":
+      return "Typical: 5–15 minutes";
+    case "pr_open":
+      return "Typical: 1–3 minutes";
+    case "ideas":
+    default:
+      return "Typical: 2–5 minutes";
+  }
+}
+
+export function hasLaunchableIdeaContent(form: LaunchFormState): boolean {
+  if (form.mode === "issue") return Boolean(form.issue);
+  return (
+    form.interests.length > 0 ||
+    form.skills.length > 0 ||
+    form.preferredArea.length > 0 ||
+    form.constraints.length > 0 ||
+    form.freeform.trim().length > 0
+  );
+}
+
+const IDEA_RUNS_ERROR_MESSAGES: Record<string, string> = {
+  unauthenticated: "Sign in to continue.",
+  not_found: "That run was not found.",
+  not_configured: "Server is not configured for Cursor idea runs.",
+  invalid_body: "Invalid request.",
+  cursor_not_connected: "Connect your Cursor account first.",
+  launch_failed: "Could not launch the Cloud Agent.",
+  list_failed: "Could not load your runs.",
+  refresh_failed: "Could not refresh that run.",
+  delete_failed: "Could not delete that run.",
+  approval_failed: "Could not approve the build plan.",
+  agent_recovery_required: "Start a fresh Cloud Agent from this screen.",
+};
+
+export function formatIdeaRunsApiErrorMessage(code?: string): string {
+  if (!code) return "Something went wrong.";
+  return IDEA_RUNS_ERROR_MESSAGES[code] ?? `Error: ${code}`;
+}
+
+export function formatIdeaRunsApiError(code?: string, errorId?: string): string {
+  const msg = formatIdeaRunsApiErrorMessage(code);
+  return errorId ? `${msg} Ref: ${errorId}` : msg;
+}
+
 export function getRunTitle(run: CursorIdeaRun): string {
   if (run.inputs.mode === "issue" && run.inputs.issueNumber && run.inputs.issueTitle) {
     return `#${run.inputs.issueNumber} ${run.inputs.issueTitle}`;

--- a/app/pr-ideas/page.tsx
+++ b/app/pr-ideas/page.tsx
@@ -7,19 +7,45 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, startTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Bot, Plus } from "lucide-react";
+import { Bot, Plus, X } from "lucide-react";
 import { CursorIcon } from "@/components/icons";
 import { useAuth } from "@/contexts/AuthContext";
 import { LaunchPanel } from "./_components/LaunchPanel";
 import { RunDetail } from "./_components/RunDetail";
 import { RunsRail } from "./_components/RunsRail";
 import { useIdeaRuns } from "./_hooks/useIdeaRuns";
+import { emptyIdeaForm, type LaunchFormState } from "./_lib/types";
 
-function capLabel(value?: number): string {
-  if (value === undefined) return "Cap not set";
-  return value === 0 ? "Unlimited cap" : `$${value}/mo cap`;
+function planSummary(monthlyCapUsd: number): string {
+  if (monthlyCapUsd === 0) return "Unlimited";
+  return `$${monthlyCapUsd}/mo`;
+}
+
+const LAUNCH_DRAFT_PREFIX = "pr-studio-launch-draft:";
+const ONBOARDING_PREFIX = "pr-studio-onboarding-dismissed:";
+
+function loadLaunchDraft(uid: string): LaunchFormState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(`${LAUNCH_DRAFT_PREFIX}${uid}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<LaunchFormState>;
+    return {
+      ...emptyIdeaForm(),
+      ...parsed,
+      interests: parsed.interests ?? [],
+      skills: parsed.skills ?? [],
+      preferredArea: parsed.preferredArea ?? [],
+      constraints: parsed.constraints ?? [],
+      freeform: typeof parsed.freeform === "string" ? parsed.freeform : "",
+      mode: parsed.mode === "issue" ? "issue" : "idea",
+      issue: parsed.issue ?? null,
+    };
+  } catch {
+    return null;
+  }
 }
 
 export default function PrIdeasPage() {
@@ -27,6 +53,8 @@ export default function PrIdeasPage() {
   const { user, userProfile, loading } = useAuth();
   const cursorInfo = userProfile?.cursor ?? null;
   const [launchOpen, setLaunchOpen] = useState(false);
+  const [launchForm, setLaunchForm] = useState<LaunchFormState>(() => emptyIdeaForm());
+  const [onboardingDismissed, setOnboardingDismissed] = useState(false);
 
   const {
     runs,
@@ -48,11 +76,62 @@ export default function PrIdeasPage() {
     refreshRun,
     mutateRun,
     advanceWorkflow,
+    clearError,
   } = useIdeaRuns({ user, cursorConnected: Boolean(cursorInfo) });
+
+  useEffect(() => {
+    if (!user?.uid) return;
+    const draft = loadLaunchDraft(user.uid);
+    startTransition(() => {
+      if (draft) setLaunchForm(draft);
+      try {
+        setOnboardingDismissed(
+          typeof window !== "undefined" &&
+            window.localStorage.getItem(`${ONBOARDING_PREFIX}${user.uid}`) === "1"
+        );
+      } catch {
+        setOnboardingDismissed(false);
+      }
+    });
+  }, [user?.uid]);
+
+  useEffect(() => {
+    if (!user?.uid || typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(`${LAUNCH_DRAFT_PREFIX}${user.uid}`, JSON.stringify(launchForm));
+    } catch {
+      /* ignore quota */
+    }
+  }, [launchForm, user?.uid]);
+
+  const dismissOnboarding = () => {
+    if (!user?.uid) return;
+    try {
+      window.localStorage.setItem(`${ONBOARDING_PREFIX}${user.uid}`, "1");
+    } catch {
+      /* ignore */
+    }
+    setOnboardingDismissed(true);
+  };
 
   const connectedLabel = useMemo(() => {
     if (!cursorInfo) return "Checking Cursor connection";
-    return `${cursorInfo.apiKeyFingerprint} · ${capLabel(cursorInfo.monthlyCapUsd)}`;
+    return cursorInfo.apiKeyFingerprint;
+  }, [cursorInfo]);
+
+  const billingChip = useMemo(() => {
+    if (!cursorInfo) return null;
+    return (
+      <>
+        <span className="min-w-0 truncate">
+          Plan: {planSummary(cursorInfo.monthlyCapUsd)}
+          {/* TODO: surface `usedUsd` from profile/API when available for “Used: $X.XX”. */}
+        </span>
+        <Link href="/profile/cursor" className="shrink-0 text-emerald-600 hover:text-emerald-500 dark:text-emerald-300 dark:hover:text-emerald-200">
+          Manage
+        </Link>
+      </>
+    );
   }, [cursorInfo]);
 
   useEffect(() => {
@@ -78,33 +157,44 @@ export default function PrIdeasPage() {
   const authOrInitialLoading = loading || Boolean(user && !userProfile);
   const pageLoadingState = authOrInitialLoading ? "initial" : loadingState;
 
+  const showOnboardingStrip =
+    Boolean(cursorInfo) && !hasRuns && !onboardingDismissed && !authOrInitialLoading;
+
+  const mainGridClass =
+    launchOpen && cursorInfo
+      ? "grid items-start gap-4 lg:grid-cols-1 xl:grid-cols-[minmax(0,15rem)_minmax(0,1fr)]"
+      : "grid items-start gap-4 lg:grid-cols-[minmax(0,15rem)_minmax(0,1fr)]";
+
   return (
     <main className="min-h-[80vh] px-4 py-5 md:px-6 md:py-6">
       <div className="mx-auto w-full max-w-[1600px] space-y-4">
-        <section className="rounded-2xl border border-neutral-800 bg-neutral-950/90 px-4 py-3 shadow-xl shadow-black/20 md:px-5 md:py-4">
+        <section className="rounded-2xl border border-neutral-200 bg-background/90 px-4 py-3 shadow-xl shadow-black/10 dark:border-neutral-800 dark:bg-neutral-950/90 dark:shadow-black/20 md:px-5 md:py-4">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-emerald-500/20 bg-emerald-500/10 text-emerald-300">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300">
                 <Bot size={18} />
               </div>
               <div className="min-w-0">
-                <h1 className="text-xl font-semibold tracking-tight text-white md:text-2xl">
-                  PR Idea Explorer
-                </h1>
-                <p className="mt-0.5 text-xs text-neutral-400">
-                  Launch a Cursor Cloud Agent and turn your interests into a reviewable PR.
+                <h1 className="text-xl font-semibold tracking-tight text-foreground md:text-2xl">PR Studio</h1>
+                <p className="mt-0.5 text-xs text-neutral-600 dark:text-neutral-400">
+                  Generate ideas and ship a reviewable PR with a Cursor Cloud Agent.
                 </p>
               </div>
             </div>
 
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="inline-flex items-center gap-2 rounded-full border border-neutral-800 bg-neutral-900 px-3 py-1.5 text-xs text-neutral-300">
-                <CursorIcon size={14} />
-                <span className="truncate max-w-[18rem]">{connectedLabel}</span>
-                <Link href="/profile/cursor" className="text-emerald-300 hover:text-emerald-200">
-                  Manage
-                </Link>
-              </div>
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              {billingChip && (
+                <div className="inline-flex max-w-full min-w-0 flex-wrap items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1.5 text-xs text-neutral-800 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200">
+                  <CursorIcon size={14} className="shrink-0" />
+                  {billingChip}
+                </div>
+              )}
+              {!cursorInfo && (
+                <div className="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1.5 text-xs text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300">
+                  <CursorIcon size={14} />
+                  <span className="truncate">{connectedLabel}</span>
+                </div>
+              )}
               {!launchOpen && (
                 <button
                   type="button"
@@ -114,19 +204,37 @@ export default function PrIdeasPage() {
                   aria-controls="pr-ideas-launch-panel"
                 >
                   <Plus size={14} />
-                  Start from source
+                  New PR idea
                 </button>
               )}
             </div>
           </div>
         </section>
 
-        {error && (
-          <div className="flex flex-col gap-3 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200 sm:flex-row sm:items-center sm:justify-between">
+        {showOnboardingStrip && (
+          <div className="flex items-start gap-3 rounded-2xl border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-sky-950 dark:text-sky-100">
+            <p className="min-w-0 flex-1">
+              PR Studio runs a Cursor Cloud Agent for you: it explores the repo, asks you questions, plans a
+              change, builds it, and opens a PR. Pick a starting point below.
+            </p>
+            <button
+              type="button"
+              onClick={dismissOnboarding}
+              className="shrink-0 rounded-lg border border-sky-400/40 p-1.5 hover:bg-sky-500/20"
+              aria-label="Dismiss intro"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        )}
+
+        {error && !launchOpen && (
+          <div className="flex flex-col gap-3 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-950 dark:text-red-200 sm:flex-row sm:items-center sm:justify-between">
             <span>{error}</span>
             <button
               type="button"
               onClick={() => {
+                clearError();
                 if (selectedRunId) {
                   void refreshRun(selectedRunId);
                 } else if (cursorInfo) {
@@ -134,27 +242,35 @@ export default function PrIdeasPage() {
                 }
               }}
               disabled={!cursorInfo}
-              className="rounded-lg border border-red-400/40 px-3 py-1.5 text-xs font-semibold text-red-100 disabled:opacity-50"
+              className="rounded-lg border border-red-400/40 px-3 py-1.5 text-xs font-semibold text-red-900 dark:text-red-100 disabled:opacity-50"
             >
-              Retry
+              Refresh
             </button>
           </div>
         )}
 
-        {cursorInfo && launchOpen && (
+        {launchOpen && cursorInfo && (
           <LaunchPanel
             open={launchOpen}
             hasRuns={hasRuns}
             launching={runAction === "launch"}
+            form={launchForm}
+            setForm={setLaunchForm}
+            launchError={error}
+            onDismissError={clearError}
             issues={githubIssues}
             issuesLoading={githubIssuesLoading}
             issuesError={githubIssuesError}
-            onToggle={() => setLaunchOpen((current) => !current)}
+            onToggle={() => {
+              setLaunchOpen((current) => !current);
+              clearError();
+            }}
             onLoadIssues={loadGithubIssues}
             onLaunch={async (form) => {
               const run = await launchIdeaRun(form);
               if (run) {
                 setLaunchOpen(false);
+                setLaunchForm(emptyIdeaForm());
                 return true;
               }
               return false;
@@ -162,7 +278,15 @@ export default function PrIdeasPage() {
           />
         )}
 
-        <div className="grid items-start gap-4 lg:grid-cols-[240px_minmax(0,1fr)]">
+        {launchOpen && cursorInfo && (
+          <p className="text-center text-xs xl:hidden">
+            <a href="#pr-studio-run-detail" className="text-emerald-600 hover:underline dark:text-emerald-300">
+              Back to selected run
+            </a>
+          </p>
+        )}
+
+        <div className={mainGridClass}>
           <RunsRail
             runs={runs}
             selectedRunId={selectedRunId}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -411,7 +411,7 @@ export default function AppShell({ children }: { children: ReactNode }) {
               expandedWidth ? "justify-between" : "flex-col justify-center gap-2",
             ].join(" ")}
           >
-            <ThemeToggle />
+            {pathname !== "/pr-ideas" ? <ThemeToggle /> : null}
             <button
               type="button"
               onClick={toggleCollapsed}

--- a/lib/server/api-request-error.ts
+++ b/lib/server/api-request-error.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { randomUUID } from "crypto";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+export function requestErrorId(): string {
+  return randomUUID().slice(0, 8);
+}
+
+/** Log the error with an `errorId` and return a JSON body that includes it. */
+export function jsonWithLoggedError(
+  status: number,
+  err: unknown,
+  body: Record<string, unknown>,
+  logMeta: Record<string, string | undefined>
+): NextResponse {
+  const errorId = requestErrorId();
+  logger.logError(err instanceof Error ? err : new Error(String(err)), {
+    ...logMeta,
+    errorId,
+  });
+  return NextResponse.json({ ...body, errorId }, { status });
+}
+
+export function jsonWithLoggedMessage(
+  status: number,
+  message: string,
+  body: Record<string, unknown>,
+  logMeta: Record<string, string | undefined>
+): NextResponse {
+  const errorId = requestErrorId();
+  logger.logError(new Error(message), {
+    ...logMeta,
+    errorId,
+  });
+  return NextResponse.json({ ...body, errorId }, { status });
+}


### PR DESCRIPTION
## Summary
Batch release bringing `develop` to production, including **PR Studio QA pass** (#916): resilient idea-runs API, polling backoff, unified run display state, stuck-run recovery, and UX polish.

## Test plan
- [x] Local `npm run build` on release tip
- [x] HTTP 200 on `http://localhost:3000/pr-ideas` (server already bound :3000)
- [ ] Confirm Vercel production deploy after merge

## Post-merge
- Fast-forward contributor submission branches from `origin/develop` per `CLAUDE.md`.

Made with [Cursor](https://cursor.com)