### PR TITLE
promote: c1w1pm-submission → develop (Week 1 PM batch)

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie-app-one.vercel.app",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Jackie is the un-project management tool that gets the job done -- personal progress tracking and cohort submission browsing in one focused app.",
+  "competeForWin": true
+}

--- a/content/summer-cohort/c1/w1-pm/submissions/alaskalam.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/alaskalam.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "alaskalam",
+  "name": "Alaska Lam",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocLmQ7ifOccOf7hUXstmUOPaxSIXkyeJyU1ubwSHSCHGFqLAjlnM=s96-c",
+  "repoUrl": "https://github.com/alaskalam/hot-tub-projects",
+  "liveUrl": "https://hot-tub-projects.streamlit.app/",
+  "loomUrl": "https://drive.google.com/drive/folders/17Rn9F64E8Pm6I205QFAC5IfMM9OCxnOf",
+  "pitch": "I should win because this thing turns project management into a ski lodge party where hot tubs and ski trails pop up when you do productive things!",
+  "competeForWin": true
+}


### PR DESCRIPTION
Bulk-promote merged Week 1 PM submissions into `develop`.

## Submissions included
- #908 @alaskalam — Alaska Lam c1w1pm submission
- #913 @ProductChameleon — ProductChameleon (Ying Chen) week 1 PM submission

After this lands, the next `develop → main` release will surface both cards on the c1w1pm event page.