### PR TITLE
release: develop to main 2026-05-15

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie-app-one.vercel.app",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Jackie is the un-project management tool that gets the job done -- personal progress tracking and cohort submission browsing in one focused app.",
+  "competeForWin": true
+}

--- a/content/summer-cohort/c1/w1-pm/submissions/alaskalam.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/alaskalam.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "alaskalam",
+  "name": "Alaska Lam",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocLmQ7ifOccOf7hUXstmUOPaxSIXkyeJyU1ubwSHSCHGFqLAjlnM=s96-c",
+  "repoUrl": "https://github.com/alaskalam/hot-tub-projects",
+  "liveUrl": "https://hot-tub-projects.streamlit.app/",
+  "loomUrl": "https://drive.google.com/drive/folders/17Rn9F64E8Pm6I205QFAC5IfMM9OCxnOf",
+  "pitch": "I should win because this thing turns project management into a ski lodge party where hot tubs and ski trails pop up when you do productive things!",
+  "competeForWin": true
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -56,12 +56,27 @@ Choose the approach that fits your workflow:
 
 ### Option A: Personal Firebase project (most common)
 
-1. Go to [Firebase Console](https://console.firebase.google.com/) and create a new project
-2. Enable **Authentication** (Email/Password + Google providers)
-3. Create a **Firestore Database** in test mode
-4. Create a **Storage** bucket
-5. Go to Project Settings > General > Your apps > Add a Web app
-6. Copy the config values into `.env.local` (use `.env.local.example` as the template — it has detailed instructions for each field)
+1. Go to [Firebase Console](https://console.firebase.google.com/) and create a new project.
+
+2. **Authentication** (matches `contexts/AuthContext.tsx` — Email/Password, Google, and GitHub popups):
+   1. Open **Build → Authentication → Get started**.
+   2. On **Sign-in method**, enable **Email/Password**, **Google** (set a support email on the consent screen), and **GitHub**.
+   3. For **GitHub**, Firebase shows an **Authorization callback URL** (typically `https://<your-project-id>.firebaseapp.com/__/auth/handler`). In [GitHub → Settings → Developer settings → OAuth Apps](https://github.com/settings/developers), create an OAuth App and paste that URL as **Authorization callback URL**. Copy the GitHub app’s **Client ID** and **Client secret** back into Firebase’s GitHub provider dialog and save.
+   4. Under **Authentication → Settings → Authorized domains**, add **`localhost`** (and your production domain when you deploy). Without `localhost`, Google/GitHub popup sign-in fails on `http://localhost:3000`.
+
+   > **Note:** Credentials for **Firebase** GitHub sign-in live only in the Firebase Console. The `NEXT_PUBLIC_GITHUB_*` and `GITHUB_CLIENT_SECRET` entries in [`.env.local.example`](../.env.local.example) are for this repo’s **profile link** flow (`/api/github/*`), not for the Firebase Auth GitHub button.
+
+3. **Firestore**: Create a database (test mode is fine for a personal sandbox; tighten rules before real data).
+
+4. **Realtime Database**: Create a default database instance. Put its URL in **`NEXT_PUBLIC_FIREBASE_DATABASE_URL`** — the web client calls `getDatabase()` in `lib/firebase.ts` when config is present.
+
+5. **Storage**: Create a default bucket; match **`NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET`** to what the console shows.
+
+6. **Web app config**: **Project settings → General → Your apps →** register a **Web** app. Copy **apiKey**, **authDomain**, **projectId**, **storageBucket**, **messagingSenderId**, **appId**, and the Realtime Database URL into **`.env.local`**, using [`.env.local.example`](../.env.local.example) as the template.
+
+7. **Optional but common for API routes and scripts:** add **`FIREBASE_SERVICE_ACCOUNT_JSON`** as described in [Formatting `FIREBASE_SERVICE_ACCOUNT_JSON`](#formatting-firebase_service_account_json).
+
+Restart **`npm run dev`** after editing `.env.local` so Next.js reloads env vars.
 
 ### Option B: Firebase Emulator (no cloud account needed)
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,15 @@
+const path = require('path')
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 })
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // If a package-lock.json exists above this repo (e.g. in $HOME), Next.js would pick that
+  // directory as the monorepo root and resolve node_modules there — breaking imports such as
+  // `firebase/auth`. Pin the tracing / Turbopack root to this application directory.
+  outputFileTracingRoot: path.join(__dirname),
+
   // Standalone output is only for Docker builds (see docker/Dockerfile). Omit on Vercel.
   ...(process.env.DOCKER_BUILD === '1' ? { output: 'standalone' } : {}),
   serverExternalPackages: ['@cursor/sdk'],

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --webpack -H localhost",
     "build": "next build --webpack",
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
+    "serve": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "test": "jest --config config/jest.config.js",


### PR DESCRIPTION
## Summary

Routine `develop` → `main` release.

## PRs included (since the previous release at 2026-05-15T00:30 — #910)

- #916 — fix(pr-studio): QA pass for idea runs API and UX — @rogerSuperBuilderAlpha
- #876 — fix(dev): pin Next workspace root and document Firebase Auth — @ikyalo01
- #908 — submission: Alaska Lam c1w1pm — @alaskalam *(via c1w1pm-submission → develop promotion #918)*
- #913 — submission: ProductChameleon (Ying Chen) c1w1pm — @ProductChameleon *(via c1w1pm-submission → develop promotion #918)*

## Credit

Thanks to:
- @rogerSuperBuilderAlpha — PR Studio QA fixes
- @ikyalo01 — Next.js workspace-root fix + Firebase Auth setup docs
- @alaskalam — Week 1 PM submission
- @ProductChameleon (Ying Chen) — Week 1 PM submission

## Test plan

- [x] `npm run build` — green
- [x] `npm start` verified locally at http://localhost:3003
- [x] Homepage, `/summer-cohort`, `/talks` return 200; both new submission cards render on `/summer-cohort`