### PR TITLE
submission: meleantonio — C1 Week 1 PM (placeholder)

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/meleantonio.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/meleantonio.json
@@ -1,0 +1,8 @@
+{
+  "githubHandle": "meleantonio",
+  "name": "Antonio Mele",
+  "repoUrl": "https://github.com/meleantonio/ai-native-pm-agentops",
+  "liveUrl": "https://ai-native-pm-agentops.vercel.app/",
+  "pitch": "Work in progress — won't be able to make it work by the deadline, consider it an idea in progress",
+  "competeForWin": false
+}


### PR DESCRIPTION
## Summary

Adds a placeholder Week 1 PM cohort submission JSON for **meleantonio** pointing at the [ai-native-pm-agentops](https://github.com/meleantonio/ai-native-pm-agentops) repo and [live demo](https://ai-native-pm-agentops.vercel.app/), with `competeForWin: false` per contributor note.

## Test plan

- [ ] Confirm `content/summer-cohort/c1/w1-pm/submissions/meleantonio.json` parses as valid JSON
- [ ] After merge on `c1w1pm-submission`, confirm submission appears under the cohort Week 1 PM flow as expected


Made with [Cursor](https://cursor.com)