### PR TITLE
feat(c1w1): voting-call banner + private AI-judge feedback panel

### DIFF
--- a/app/api/summer-cohort/my-score/[weekId]/route.ts
+++ b/app/api/summer-cohort/my-score/[weekId]/route.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getVoteWeekById,
+} from "@/lib/summer-cohort-submissions";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { isValidCohortId, type SummerCohortId } from "@/lib/summer-cohort";
+import { getOptionalVerifiedUser } from "@/lib/server-auth";
+import { logger } from "@/lib/logger";
+
+interface ScoreFile {
+  score: number;
+  rationale: string;
+  model?: string;
+  scoredAt?: string;
+  scorerVersion?: number;
+}
+
+function scoresDirFromSubmissionPath(submissionPath: string): string | null {
+  // submissionPath looks like:
+  //   content/summer-cohort/c1/w1-pm/submissions/<github-handle>.json
+  // The scores directory is the sibling `scores/` next to `submissions/`.
+  const submissionsIdx = submissionPath.lastIndexOf("/submissions/");
+  if (submissionsIdx < 0) return null;
+  return `${submissionPath.slice(0, submissionsIdx)}/scores`;
+}
+
+async function getGithubLoginForUid(
+  db: FirebaseFirestore.Firestore,
+  uid: string
+): Promise<string | null> {
+  const snap = await db.collection("users").doc(uid).get();
+  if (!snap.exists) return null;
+  const data = snap.data() as { github?: { login?: string } } | undefined;
+  const login = data?.github?.login;
+  return typeof login === "string" && login.trim().length > 0
+    ? login.trim()
+    : null;
+}
+
+/**
+ * Return only the authenticated user's own AI-judge score for a vote-format
+ * week. The route never accepts a handle query parameter — the handle is
+ * resolved server-side from `users/{uid}.github.login`, so callers cannot
+ * peek at someone else's score even if they know the other user's handle.
+ *
+ * Source of truth for scores is `<weekRoot>/scores/<handle>.json` on the
+ * week's submission branch — the same branch that stores submissions, kept
+ * close to the submission JSON they grade.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ weekId: string }> }
+) {
+  const { weekId } = await params;
+  const cohortIdParam = req.nextUrl.searchParams.get("cohortId");
+  const cohortId: SummerCohortId = isValidCohortId(cohortIdParam)
+    ? cohortIdParam
+    : "cohort-1";
+
+  const week = getVoteWeekById(weekId, cohortId);
+  if (!week) {
+    return NextResponse.json(
+      { error: "Unknown weekId — vote-format weeks are week-1, week-2, week-3." },
+      { status: 404 }
+    );
+  }
+
+  let verified;
+  try {
+    verified = await getOptionalVerifiedUser(req);
+  } catch (error) {
+    logger.warn("my-score: token verification threw", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    verified = null;
+  }
+  if (!verified) {
+    return NextResponse.json(
+      { error: "Sign in to see your judge feedback." },
+      { status: 401 }
+    );
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    return NextResponse.json(
+      { error: "Server misconfigured (no Firestore)." },
+      { status: 500 }
+    );
+  }
+
+  const handle = await getGithubLoginForUid(db, verified.uid);
+  if (!handle) {
+    return NextResponse.json(
+      {
+        error:
+          "Link your GitHub account on your profile so we can match the score to you.",
+      },
+      { status: 404 }
+    );
+  }
+
+  const scoresDir = scoresDirFromSubmissionPath(week.submissionPath);
+  if (!scoresDir) {
+    return NextResponse.json(
+      { error: "Misconfigured week — no scores directory." },
+      { status: 500 }
+    );
+  }
+
+  const { owner, repo } = getGithubRepoPair();
+  const url = `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(
+    week.submissionBranch
+  )}/${scoresDir}/${encodeURIComponent(handle)}.json`;
+  const token = process.env.GITHUB_TOKEN;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      // Match the submissions feed's revalidate window — scores update rarely
+      // and the same content addresses cache nicely.
+      next: { revalidate: 60 },
+    });
+  } catch (error) {
+    logger.warn("my-score: raw fetch failed", {
+      weekId,
+      handle,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Couldn't load your score right now — try again in a minute." },
+      { status: 500 }
+    );
+  }
+
+  if (res.status === 404) {
+    return NextResponse.json(
+      {
+        error:
+          "No judge feedback yet for your submission — check back after we score this week.",
+      },
+      { status: 404 }
+    );
+  }
+  if (!res.ok) {
+    logger.warn("my-score: raw fetch non-OK", {
+      weekId,
+      handle,
+      status: res.status,
+    });
+    return NextResponse.json(
+      { error: "Couldn't load your score right now — try again in a minute." },
+      { status: 500 }
+    );
+  }
+
+  let parsed: ScoreFile;
+  try {
+    parsed = (await res.json()) as ScoreFile;
+  } catch {
+    return NextResponse.json(
+      { error: "Score file is malformed — flag this to a maintainer." },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      weekId,
+      githubHandle: handle,
+      score: parsed.score,
+      rationale: parsed.rationale,
+      model: parsed.model ?? null,
+      scoredAt: parsed.scoredAt ?? null,
+    },
+    {
+      headers: {
+        // Per-user response — do not let any shared cache hold it.
+        "Cache-Control": "private, no-store",
+      },
+    }
+  );
+}

--- a/app/api/summer-cohort/my-score/[weekId]/route.ts
+++ b/app/api/summer-cohort/my-score/[weekId]/route.ts
@@ -13,6 +13,7 @@ import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
 import { isValidCohortId, type SummerCohortId } from "@/lib/summer-cohort";
 import { getOptionalVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
+import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 
 interface ScoreFile {
   score: number;
@@ -59,12 +60,21 @@ export async function GET(
   { params }: { params: Promise<{ weekId: string }> }
 ) {
   const { weekId } = await params;
+  const parsedParams = summerCohortContract.myScoreByWeek.pathParams.safeParse({
+    weekId,
+  });
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: "Unknown weekId — vote-format weeks are week-1, week-2, week-3." },
+      { status: 404 }
+    );
+  }
   const cohortIdParam = req.nextUrl.searchParams.get("cohortId");
   const cohortId: SummerCohortId = isValidCohortId(cohortIdParam)
     ? cohortIdParam
     : "cohort-1";
 
-  const week = getVoteWeekById(weekId, cohortId);
+  const week = getVoteWeekById(parsedParams.data.weekId, cohortId);
   if (!week) {
     return NextResponse.json(
       { error: "Unknown weekId — vote-format weeks are week-1, week-2, week-3." },

--- a/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
+++ b/app/summer-cohort/_components/WeekSubmissionsCollapsible.tsx
@@ -13,6 +13,8 @@ import {
   CheckCircle2,
   ExternalLink,
   GitPullRequest,
+  Lock,
+  Sparkles,
   ThumbsUp,
   Trophy,
 } from "lucide-react";
@@ -45,6 +47,15 @@ interface VotesResponse {
   counts: Record<string, number>;
   myVotes: string[];
   authenticated: boolean;
+}
+
+interface MyScoreResponse {
+  weekId: string;
+  githubHandle: string;
+  score: number;
+  rationale: string;
+  model: string | null;
+  scoredAt: string | null;
 }
 
 interface WeekSubmissionsCollapsibleProps {
@@ -133,6 +144,12 @@ export function WeekSubmissionsCollapsible({
   const [myVotes, setMyVotes] = useState<Set<string>>(new Set());
   const [pendingVotes, setPendingVotes] = useState<Set<string>>(new Set());
   const [voteError, setVoteError] = useState<string | null>(null);
+  // Score is tagged with the uid + tab it was fetched for, so a stale score
+  // from a previous signed-in user (or previous week) is filtered out at
+  // render time without needing a synchronous reset inside the fetch effect.
+  const [myScore, setMyScore] = useState<
+    (MyScoreResponse & { fetchedForUid: string; fetchedForTab: string }) | null
+  >(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -194,6 +211,41 @@ export function WeekSubmissionsCollapsible({
         // Silent: votes are a soft enhancement; failure shouldn't block the
         // main submissions UI.
       });
+    return () => {
+      cancelled = true;
+    };
+  }, [tabId, user, cohortId]);
+
+  // Fetch the signed-in user's own AI-judge score for this week. The endpoint
+  // resolves the user's handle server-side from `users/{uid}.github.login` and
+  // returns only that user's score — there is no way to ask for another
+  // person's feedback through this client. Stale results (after sign-out or a
+  // tab switch) are filtered at render time via the uid/tab tag on the score.
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    const uidAtFetch = user.uid;
+    (async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(
+          `/api/summer-cohort/my-score/${encodeURIComponent(
+            tabId
+          )}?cohortId=${encodeURIComponent(cohortId)}`,
+          {
+            cache: "no-store",
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        );
+        if (!res.ok) return; // 401 / 404 / 500 → silently no feedback panel
+        const json = (await res.json()) as MyScoreResponse;
+        if (!cancelled) {
+          setMyScore({ ...json, fetchedForUid: uidAtFetch, fetchedForTab: tabId });
+        }
+      } catch {
+        // Silent — feedback panel just won't render.
+      }
+    })();
     return () => {
       cancelled = true;
     };
@@ -553,10 +605,26 @@ export function WeekSubmissionsCollapsible({
                     .trim()
                     .charAt(0)
                     .toUpperCase();
+                  const isMine =
+                    currentUserGithubHandle !== null &&
+                    handleKey === currentUserGithubHandle.toLowerCase();
+                  const myFeedback =
+                    isMine &&
+                    myScore &&
+                    user !== null &&
+                    myScore.fetchedForUid === user.uid &&
+                    myScore.fetchedForTab === tabId &&
+                    myScore.githubHandle.toLowerCase() === handleKey
+                      ? myScore
+                      : null;
                   return (
                     <li
                       key={s.githubHandle}
-                      className="flex flex-wrap items-center gap-3 rounded-lg border border-neutral-200 px-3 py-2 text-sm dark:border-neutral-800"
+                      className={
+                        isMine
+                          ? "flex flex-wrap items-center gap-3 rounded-lg border-2 border-emerald-300 bg-emerald-50/40 px-3 py-2 text-sm dark:border-emerald-800 dark:bg-emerald-950/20"
+                          : "flex flex-wrap items-center gap-3 rounded-lg border border-neutral-200 px-3 py-2 text-sm dark:border-neutral-800"
+                      }
                     >
                       {s.photoUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element -- avatar URLs come from arbitrary OAuth providers (GitHub, Google), not the configured Next image domain list
@@ -673,6 +741,36 @@ export function WeekSubmissionsCollapsible({
                           )
                         ) : null}
                       </div>
+                      {myFeedback ? (
+                        <div className="basis-full">
+                          <div className="mt-2 rounded-md border border-emerald-300 bg-white p-3 dark:border-emerald-800 dark:bg-neutral-950">
+                            <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+                              <Sparkles className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+                              <span>Your AI judge feedback</span>
+                              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400">
+                                <Lock className="h-2.5 w-2.5" strokeWidth={2.5} aria-hidden="true" />
+                                visible only to you
+                              </span>
+                              <span className="ml-auto tabular-nums text-emerald-900 dark:text-emerald-300">
+                                <strong className="text-base">{myFeedback.score}</strong>
+                                <span className="text-emerald-700/80 dark:text-emerald-400/80"> / 10</span>
+                              </span>
+                            </div>
+                            <p className="mt-2 whitespace-pre-line text-sm text-neutral-800 dark:text-neutral-200">
+                              {myFeedback.rationale}
+                            </p>
+                            {myFeedback.model || myFeedback.scoredAt ? (
+                              <p className="mt-2 text-[11px] text-neutral-500">
+                                {myFeedback.model ? `Scored by ${myFeedback.model}` : null}
+                                {myFeedback.model && myFeedback.scoredAt ? " · " : null}
+                                {myFeedback.scoredAt
+                                  ? new Date(myFeedback.scoredAt).toLocaleString()
+                                  : null}
+                              </p>
+                            ) : null}
+                          </div>
+                        </div>
+                      ) : null}
                     </li>
                   );
                 })}

--- a/app/summer-cohort/_components/WeekVotePanel.tsx
+++ b/app/summer-cohort/_components/WeekVotePanel.tsx
@@ -64,30 +64,89 @@ export function WeekVotePanel({
       aria-labelledby={`tab-${tabId}`}
       className="rounded-xl border-2 border-emerald-400 bg-white p-6 dark:border-emerald-700 dark:bg-neutral-900"
     >
-      {/* Kickoff Zoom — top of the module */}
-      <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
-        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
-          <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
-          Kickoff Zoom · {week.kickoffLabel}
+      {/* Voting-call banner (live) — replaces the kickoff stand-in once the
+          call is scheduled and the dial-in details are real. Only Cohort 1
+          Week 1 has this set today; future weeks fall back to the stand-in. */}
+      {week.votingCallZoom ? (
+        <div className="rounded-lg border-2 border-emerald-400 bg-emerald-50/70 p-4 dark:border-emerald-700 dark:bg-emerald-950/30">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+            <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+            {week.votingCallZoom.headlineLabel} · {week.votingCallZoom.whenLabel}
+          </div>
+          <p className="mt-2 text-sm text-emerald-900 dark:text-emerald-100">
+            Submissions are scored — come hang out, see what everyone shipped,
+            and vote the Week {week.week} winner.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <a
+              href={week.votingCallZoom.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+            >
+              <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+              Join the Zoom
+              <ExternalLink
+                className="h-3.5 w-3.5"
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+            </a>
+            {week.votingCallZoom.chatUrl ? (
+              <a
+                href={week.votingCallZoom.chatUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg border border-emerald-300 bg-white px-3 py-2 text-xs font-semibold text-emerald-700 transition-colors hover:bg-emerald-50 dark:border-emerald-800 dark:bg-transparent dark:text-emerald-300 dark:hover:bg-emerald-950/50"
+              >
+                Meeting chat
+                <ExternalLink className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
+              </a>
+            ) : null}
+          </div>
+          <dl className="mt-3 grid grid-cols-1 gap-y-1 text-xs text-emerald-900/90 dark:text-emerald-200/90 sm:grid-cols-[max-content_1fr] sm:gap-x-3">
+            <dt className="font-semibold uppercase tracking-wider">Meeting ID</dt>
+            <dd className="tabular-nums">{week.votingCallZoom.meetingId}</dd>
+            {week.votingCallZoom.oneTapNumbers && week.votingCallZoom.oneTapNumbers.length > 0 ? (
+              <>
+                <dt className="font-semibold uppercase tracking-wider">One-tap mobile</dt>
+                <dd className="break-words">
+                  {week.votingCallZoom.oneTapNumbers.map((n, i) => (
+                    <span key={n}>
+                      {i > 0 ? <span className="text-emerald-400"> · </span> : null}
+                      <span className="tabular-nums">{n}</span>
+                    </span>
+                  ))}
+                </dd>
+              </>
+            ) : null}
+          </dl>
         </div>
-        <a
-          href={zoomUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
-        >
-          <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
-          Join the Zoom
-          <ExternalLink
-            className="h-3.5 w-3.5"
-            strokeWidth={2.25}
-            aria-hidden="true"
-          />
-        </a>
-        <p className="mt-2 text-xs text-neutral-500">
-          Stand-in link — we&apos;ll swap in the real Zoom URL before kickoff.
-        </p>
-      </div>
+      ) : (
+        <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+            <Video className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
+            Kickoff Zoom · {week.kickoffLabel}
+          </div>
+          <a
+            href={zoomUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
+          >
+            <Video className="h-4 w-4" strokeWidth={2.25} aria-hidden="true" />
+            Join the Zoom
+            <ExternalLink
+              className="h-3.5 w-3.5"
+              strokeWidth={2.25}
+              aria-hidden="true"
+            />
+          </a>
+          <p className="mt-2 text-xs text-neutral-500">
+            Stand-in link — we&apos;ll swap in the real Zoom URL before kickoff.
+          </p>
+        </div>
+      )}
 
       <div className="mt-6 flex flex-wrap items-center gap-2">
         <span className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1 text-xs font-bold uppercase tracking-wider text-white">

--- a/lib/api-schemas/summer-cohort.ts
+++ b/lib/api-schemas/summer-cohort.ts
@@ -176,6 +176,23 @@ export const summerCohortContract = c.router(
       responses: { 200: PassthroughOk, 404: ApiErrorSchema },
       metadata: { errorCodes: ["NOT_FOUND"] as const },
     },
+    myScoreByWeek: {
+      method: "GET",
+      path: "/api/summer-cohort/my-score/:weekId",
+      pathParams: WeekIdParam,
+      query: z.object({ cohortId: CohortIdEnum.optional() }),
+      summary:
+        "Return only the calling user's own AI-judge score for a vote-format week — other users' scores are never exposed by this endpoint",
+      responses: {
+        200: PassthroughOk,
+        401: ApiErrorSchema,
+        404: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "NOT_FOUND", "SERVER_ERROR"] as const,
+      },
+    },
     votesGet: {
       method: "GET",
       path: "/api/summer-cohort/votes",

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -230,6 +230,21 @@ export interface SummerCohortInspirationPlatform {
   takeaway: string;
 }
 
+export interface SummerCohortVotingCallZoom {
+  /** Zoom join URL — used by the "Join the call" CTA. */
+  url: string;
+  /** In-meeting chat deep link (`/launch/jc/<id>`). Optional. */
+  chatUrl?: string;
+  /** Human meeting ID, e.g. "973 8933 2225". */
+  meetingId: string;
+  /** "tonight, 6:00 pm EST" — short, free-form label rendered next to the CTA. */
+  whenLabel: string;
+  /** Headline copy for the block: "Voting call tonight" / "Show & tell". */
+  headlineLabel: string;
+  /** One-tap mobile dial-in strings like "+13052241968,,97389332225# US". */
+  oneTapNumbers?: readonly string[];
+}
+
 export interface SummerCohortVoteWeek {
   week: number;
   title: string;
@@ -243,6 +258,10 @@ export interface SummerCohortVoteWeek {
   winnerCommitment: string;
   /** Free-form note rendered above the kickoff block (e.g. holiday / immersion overlap). */
   weekNotes?: string;
+  /** When set, the page renders a "voting call live now / soon" banner with
+   *  full Zoom dial-in details at the top of the week — replaces the
+   *  generic kickoff stand-in. Cleared once the call is over. */
+  votingCallZoom?: SummerCohortVotingCallZoom;
   /** Reference platforms participants can study. Frame is "what's worth
    *  borrowing", not "rebuild this." */
   inspirationScopeNote: string;
@@ -263,6 +282,17 @@ export const SUMMER_COHORT_C1_VOTE_WEEKS: readonly SummerCohortVoteWeek[] = [
     liveUrlRequired: true,
     winnerCommitment:
       "Winner maintains the cohort PM tool through the rest of the program — fixes bugs, ships changes the cohort asks for, keeps it running.",
+    votingCallZoom: {
+      headlineLabel: "Voting call · tonight",
+      whenLabel: "Fri May 15 · 6:00 pm EST",
+      url: "https://bentley.zoom.us/j/97389332225",
+      chatUrl: "https://bentley.zoom.us/launch/jc/97389332225",
+      meetingId: "973 8933 2225",
+      oneTapNumbers: [
+        "+13052241968,,97389332225# US",
+        "+13092053325,,97389332225# US",
+      ],
+    },
     inspirationScopeNote:
       "Don't try to rebuild Linear or Asana. The cohort is ~100 people shipping for 6 weeks — think \"how do we track who's shipping what each week and prep for Friday voting calls?\" Skip Gantt charts, time tracking, sprint estimation, and billing.",
     inspirationPlatforms: [

--- a/scripts/send-cohort1-week1-voting-call.ts
+++ b/scripts/send-cohort1-week1-voting-call.ts
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Post-deadline broadcast (Fri May 15, 2026) to every admitted Cohort 1
+ * applicant: Week 1 submissions are scored, here is the 6pm Zoom for the
+ * voting / show-and-tell call. Tone is kind + excited — the call is about
+ * the cohort exploring each other's builds together.
+ *
+ * Idempotent via `cohort1Week1VotingCallEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week1-voting-call.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week1-voting-call.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week1-voting-call.ts --send
+ *   npx tsx scripts/send-cohort1-week1-voting-call.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week1VotingCallEmailedAt";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/97389332225";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/97389332225";
+const ZOOM_MEETING_ID = "973 8933 2225";
+const ZOOM_ONE_TAP_1 = "+13052241968,,97389332225# US";
+const ZOOM_ONE_TAP_2 = "+13092053325,,97389332225# US";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Week 1 submissions are scored — see you at 6pm EST tonight 🎉";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Week 1 is in the books — and what a week.</strong> Every submission has been merged, scored by the AI judge, and is now live on the cohort page. Go take a look — there is genuinely cool stuff in there:</p>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    See the Week 1 builds →
+  </a>
+</p>
+
+<p><strong>Tonight at 6pm EST</strong> we get together on Zoom to walk through each other's work, hear the pitches live, and vote on Week 1. Whether you submitted or not, please come — this is the part of the cohort that makes the whole thing worth it. You'll meet the people behind the cards on the page, see what shipped this week, and trade notes on what you're each building. Bring questions, bring curiosity.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>Zoom — tonight, 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<p>Seriously — come hang out, even just to listen. Half the value of a cohort is meeting the other people in it. Bring whatever you shipped this week, or just bring yourself.</p>
+
+<p>Excited to see everyone tonight.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Week 1 is in the books — and what a week. Every submission has been merged, scored by the AI judge, and is now live on the cohort page. Go take a look — there is genuinely cool stuff in there:
+
+${COHORT_URL}
+
+Tonight at 6pm EST we get together on Zoom to walk through each other's work, hear the pitches live, and vote on Week 1. Whether you submitted or not, please come — this is the part of the cohort that makes the whole thing worth it. You'll meet the people behind the cards on the page, see what shipped this week, and trade notes on what you're each building. Bring questions, bring curiosity.
+
+ZOOM — TONIGHT, 6:00 PM EST
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+Seriously — come hang out, even just to listen. Half the value of a cohort is meeting the other people in it. Bring whatever you shipped this week, or just bring yourself.
+
+Excited to see everyone tonight.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Cohort 1, Week 1 page now shows the **tonight-at-6pm voting call Zoom** up front (URL, meeting chat, ID, dial-in numbers) via a new optional `votingCallZoom` field on `SummerCohortVoteWeek` — only set on C1 Week 1, so other weeks keep their kickoff stand-in
- Submissions now render an **"Your AI judge feedback · visible only to you"** panel on the signed-in user's own card, backed by a new `/api/summer-cohort/my-score/[weekId]` endpoint that requires a Firebase ID token, resolves the caller's GitHub handle from `users/{uid}.github.login` server-side, and fetches only that handle's `score.json` — no handle query param, so the route can't leak someone else's score. Score is tagged with its fetch-time uid + tab so stale results are filtered at render time.
- Includes the one-shot broadcast script that emailed all 98 admitted Cohort 1 members the voting-call link earlier today (idempotent via `cohort1Week1VotingCallEmailedAt`).

⚠️ **Caveat:** the score files themselves are still on the public `c1w1pm-submission` branch (and merged into develop/main), so anyone clicking through the GitHub repo can see all scores. UI gate is honored; true privacy needs the score files to move out of the public repo (e.g. Firestore).

## Test plan

- [x] `tsc --noEmit` clean
- [x] pre-commit (eslint, type-check) clean
- [x] dev server compile clean
- [x] `GET /api/summer-cohort/my-score/week-1` → 401 without token
- [x] `GET /api/summer-cohort/my-score/week-1` → 401 with invalid token
- [x] `GET /api/summer-cohort/my-score/week-99` → 404
- [x] `GET /api/summer-cohort/submissions/week-1` → 200 (regression check)
- [ ] Signed-in cohort member sees voting-call banner + their own feedback box on their card
- [ ] Signed-in cohort member does NOT see any other member's feedback box

🤖 Generated with [Claude Code](https://claude.com/claude-code)