### PR TITLE
promote: c1w1pm-submission → develop (nebullii vote fix + Jon Littel placeholder)

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/jonathanlittel.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/jonathanlittel.json
@@ -1,0 +1,8 @@
+{
+  "githubHandle": "jonathanlittel",
+  "name": "Jon Littel",
+  "repoUrl": "https://github.com/jonathanlittel/cursor-boston-w1pm-placeholder",
+  "liveUrl": "https://example.com",
+  "pitch": "Let's see some good PM apps!",
+  "competeForWin": false
+}

--- a/content/summer-cohort/c1/w1-pm/submissions/nebullii.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/nebullii.json
@@ -4,7 +4,7 @@
     "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocL7lUmR1B71l9kqbcggS2ik1rswuvJ48rOm5QZjBkl2okUbraA=s96-c",
     "repoUrl": "https://github.com/nebullii/pm-os",
     "liveUrl": "https://pm-os-gamma.vercel.app",
-    "Youtube": "https://youtu.be/1a94xTF3QeM",
+    "loomUrl": "https://youtu.be/1a94xTF3QeM",
     "pitch": "PM OS should win because it uses GitHub as the source of truth to show what actually shipped, not just what people claim they’re working on.",
     "competeForWin": true
   }


### PR DESCRIPTION
Two commits to roll into develop:

- **#946 — fix(c1w1pm): rename nebullii's Youtube field → loomUrl** — makes Neha vote-eligible so the cohort can vote on her PM OS submission during tonight's voting call.
- **#925 — submission: jonathanlittel c1w1pm placeholder** — Jon Littel placeholder submission (competeForWin: false, ineligible for the win — counts as participation only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)