### PR TITLE
submission: bme3412 c1w1pm — add Loom demo URL

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/bme3412.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/bme3412.json
@@ -3,6 +3,7 @@
   "name": "Brendan Erhard",
   "repoUrl": "https://github.com/bme3412/boston-cursor-week-1",
   "liveUrl": "https://boston-cursor-week-1.vercel.app/",
+  "loomUrl": "https://www.loom.com/share/20064c31f5df499fb9d5d6f29155befb",
   "pitch": "Launchpad — a cohort feed for Cursor Boston builders to share progress, PRs, and ship updates.",
   "competeForWin": true
 }


### PR DESCRIPTION
## Summary
- Add `loomUrl` to my c1w1pm submission (`bme3412.json`) pointing at the Launchpad demo video.

## Test plan
- [x] JSON parses
- [x] Field matches submission schema pattern used by other c1w1pm entries (e.g. `SimranKumari30.json`, `Steffi-Roy.json`)