### PR TITLE
promote: c1w1pm-submission → develop (bme3412 Loom URL)

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/bme3412.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/bme3412.json
@@ -3,6 +3,7 @@
   "name": "Brendan Erhard",
   "repoUrl": "https://github.com/bme3412/boston-cursor-week-1",
   "liveUrl": "https://boston-cursor-week-1.vercel.app/",
+  "loomUrl": "https://www.loom.com/share/20064c31f5df499fb9d5d6f29155befb",
   "pitch": "Launchpad — a cohort feed for Cursor Boston builders to share progress, PRs, and ship updates.",
   "competeForWin": true
 }


### PR DESCRIPTION
Brings #949 (bme3412 added Loom demo URL to his Launchpad submission) onto develop so his vote button renders on the cohort page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)