### PR TITLE
release: bme3412 Loom URL (2026-05-16)

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/bme3412.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/bme3412.json
@@ -3,6 +3,7 @@
   "name": "Brendan Erhard",
   "repoUrl": "https://github.com/bme3412/boston-cursor-week-1",
   "liveUrl": "https://boston-cursor-week-1.vercel.app/",
+  "loomUrl": "https://www.loom.com/share/20064c31f5df499fb9d5d6f29155befb",
   "pitch": "Launchpad — a cohort feed for Cursor Boston builders to share progress, PRs, and ship updates.",
   "competeForWin": true
 }


### PR DESCRIPTION
## Summary

One PR since the last release:

- **#950 — promote: c1w1pm-submission → develop** — @rogerSuperBuilderAlpha
  - **#949** bme3412 adds Loom demo URL to his Launchpad submission — makes his vote button render on the live cohort page

Content-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)