### PR TITLE
release(2026-05-16): Armageddon end-game

### DIFF
--- a/app/api/game/armageddon/route.ts
+++ b/app/api/game/armageddon/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// @contracts: getArmageddonHistory (lib/api-schemas/game.ts)
+//
+// Pure GET with a single numeric `limit` query param; clamped server-side.
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { listArmageddonHistoryServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+/**
+ * GET /api/game/armageddon
+ *
+ * Returns past Armageddons (hall of fame), most-recent season first.
+ * Each entry includes the 7 seal audit, top-10 weighted-draw winners,
+ * and a top-50-by-tilesHeld snapshot. Used by the /game/armageddon
+ * history page. Auth required.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const url = new URL(request.url);
+    const rawLimit = url.searchParams.get("limit");
+    const limit = rawLimit ? Math.max(1, Math.min(200, Number(rawLimit))) : 50;
+
+    const history = await listArmageddonHistoryServer(limit);
+    return apiSuccess({ history });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/spell/armageddon/route.ts
+++ b/app/api/game/spell/armageddon/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// @contracts: castArmageddon (lib/api-schemas/game.ts)
+//
+// POST with no body — Armageddon takes no parameters. All validation
+// (tile gate, turn cost, season match, seal availability) lives in
+// castArmageddonServer's transaction.
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { castArmageddonServer } from "@/lib/game/data-server";
+import { resolveArmageddon } from "@/lib/game/armageddon-resolve";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/game/spell/armageddon
+ *
+ * No request body — Armageddon takes no parameters. Authentication is the
+ * only gate the route enforces; everything else (tile gate, turn cost,
+ * season check, seal-availability) lives inside castArmageddonServer's
+ * transaction.
+ *
+ * When the cast breaks the 7th seal, the resolver is fired in the
+ * background AFTER this response is sent. The casting player's UI doesn't
+ * have to wait for the wipe to complete; it sees `shouldTriggerResolve:
+ * true` in the response and can render a "you ended the world" moment
+ * immediately.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const result = await castArmageddonServer({ userId: user.uid });
+
+    if (result.shouldTriggerResolve) {
+      // Fire-and-forget. Errors are logged but don't fail the caster's
+      // response. resolveArmageddon is idempotent — a follow-up call from
+      // another player's later cast / a cron job would resume cleanly.
+      void resolveArmageddon({
+        expectedSeason: result.seasonNumber,
+        triggeredBy: {
+          userId: result.player.userId,
+          displayName: result.player.displayName,
+          caste: result.player.caste!,
+        },
+      }).catch((err) => {
+        logger.error("[armageddon] resolveArmageddon failed", {
+          message: err instanceof Error ? err.message : String(err),
+          seasonNumber: result.seasonNumber,
+        });
+      });
+    }
+
+    return apiSuccess({
+      // Renamed to avoid colliding with the api-wrapper's outer `success`
+      // field (which is always true for 2xx). `sealBroken` is the actual
+      // cast-roll outcome: true → a seal broke, false → the roll fizzled.
+      sealBroken: result.success,
+      successChance: result.successChance,
+      sealsBroken: result.sealsBroken,
+      seasonNumber: result.seasonNumber,
+      player: result.player,
+      shouldTriggerResolve: result.shouldTriggerResolve,
+    });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/world-meta/route.ts
+++ b/app/api/game/world-meta/route.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// @contracts: getWorldMeta (lib/api-schemas/game.ts)
+//
+// Pure GET, no body / query / path params — the contract entry exists
+// for OpenAPI coverage but the route has no runtime input to validate.
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { getWorldMetaServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+/**
+ * GET /api/game/world-meta
+ *
+ * Returns the global game-world singleton: season number, seals broken,
+ * per-seal audit, armageddonState. Used by the dashboard to render the
+ * SealsPanel and to gate the Armageddon spell card. Auth required (same
+ * gate as the rest of /api/game/*).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const worldMeta = await getWorldMetaServer();
+    const res = apiSuccess({ worldMeta });
+    // Short cache: seals change rarely, but the resolving-state flip
+    // needs to propagate within ~30s so the banner appears for
+    // everyone shortly after seal 7 breaks.
+    res.headers.set(
+      "Cache-Control",
+      "private, max-age=15, stale-while-revalidate=30"
+    );
+    return res;
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/_components/dashboard/DashboardView.tsx
+++ b/app/game/_components/dashboard/DashboardView.tsx
@@ -23,6 +23,7 @@ import { LandsCard } from "./LandsCard";
 import { ArmyCard } from "./ArmyCard";
 import { ThreatCard } from "./ThreatCard";
 import { ShieldCard } from "./ShieldCard";
+import { SealsPanel } from "./SealsPanel";
 import { ExploreFrontier } from "./ExploreFrontier";
 import { FarExpedition } from "./FarExpedition";
 import { SpyAction } from "./SpyAction";
@@ -174,6 +175,8 @@ export function DashboardView({ player, data }: DashboardViewProps) {
         />
 
         <RecommendedAction rec={recommended} phase={player.phase} />
+
+        <SealsPanel worldMeta={data.worldMeta} />
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <LandsCard counts={counts} />

--- a/app/game/_components/dashboard/SealsPanel.tsx
+++ b/app/game/_components/dashboard/SealsPanel.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import type { GameWorldMeta, SealRecord } from "@/lib/game/types";
+import { SEAL_COUNT } from "@/lib/game/content/armageddon";
+
+function formatRelative(value: SealRecord["brokenAt"]): string {
+  if (!value) return "";
+  const d =
+    value instanceof Date
+      ? value
+      : typeof (value as { toDate?: () => Date }).toDate === "function"
+        ? (value as { toDate: () => Date }).toDate()
+        : new Date(0);
+  const diffMs = Date.now() - d.getTime();
+  if (diffMs < 60_000) return "just now";
+  const m = Math.floor(diffMs / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const days = Math.floor(h / 24);
+  return `${days}d ago`;
+}
+
+interface SealsPanelProps {
+  worldMeta: GameWorldMeta | null;
+}
+
+/**
+ * Global end-game status panel. Renders the 7 Seals with broken/unbroken
+ * state and per-seal attribution tooltips. Mounted full-width above the
+ * per-player cards because it's shared state (every player sees the same
+ * count). When armageddonState === "resolving", overlays a banner so
+ * everyone knows turn-spending is briefly refused.
+ */
+export function SealsPanel({ worldMeta }: SealsPanelProps) {
+  if (!worldMeta) return null;
+  const sealsBroken = worldMeta.sealsBroken ?? 0;
+  const seasonNumber = worldMeta.seasonNumber ?? 1;
+  const armageddonState = worldMeta.armageddonState ?? "active";
+
+  // Build the canonical 7-slot view, defaulting any missing entries.
+  const seals: SealRecord[] = Array.from({ length: SEAL_COUNT }, (_, i) => {
+    return worldMeta.seals?.[i] ?? { index: i, broken: false };
+  });
+
+  return (
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-4 mb-6">
+      <div className="flex items-baseline justify-between mb-3">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-neutral-500">
+            Season {seasonNumber} — The Seven Seals
+          </div>
+          <div className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+            {sealsBroken} / {SEAL_COUNT} broken
+          </div>
+        </div>
+        <Link
+          href="/game/armageddon"
+          className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+        >
+          View hall of fame →
+        </Link>
+      </div>
+
+      {armageddonState === "resolving" && (
+        <div className="mb-3 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm font-semibold text-red-900 dark:border-red-700 dark:bg-red-950 dark:text-red-200">
+          Armageddon is upon us — the world is being remade. Turn-spending
+          actions are refused until the next age begins.
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {seals.map((s, i) => {
+          const broken = s.broken;
+          const tooltip = broken
+            ? `Broken by ${s.brokenBy?.displayName ?? "—"}` +
+              (s.brokenBy?.caste ? ` (${s.brokenBy.caste})` : "") +
+              `\n${formatRelative(s.brokenAt)}`
+            : `Seal ${i + 1} — unbroken`;
+          return (
+            <div
+              key={i}
+              title={tooltip}
+              className={
+                "flex flex-col items-center w-14 h-14 rounded-md border text-xs select-none " +
+                (broken
+                  ? "border-red-700 bg-red-100 text-red-900 dark:border-red-500 dark:bg-red-950 dark:text-red-200"
+                  : "border-neutral-300 bg-neutral-50 text-neutral-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400")
+              }
+            >
+              <div className="text-lg leading-none mt-2">
+                {broken ? "✦" : "○"}
+              </div>
+              <div className="mt-1 text-[10px]">#{i + 1}</div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+        At <span className="font-mono">10,000</span> tiles, the Armageddon
+        spell unlocks. Each cast costs 100 turns and rolls for a single
+        Seal — your magic-optimized kingdom raises the odds. When the 7th
+        Seal breaks, the world ends and a weighted lottery decides who
+        carries glory into the next age.
+      </p>
+    </div>
+  );
+}

--- a/app/game/_lib/dashboard-actions.ts
+++ b/app/game/_lib/dashboard-actions.ts
@@ -12,6 +12,7 @@ import type {
   GameArtifact,
   GamePlayer,
   GameTile,
+  GameWorldMeta,
   IntelReport,
   LandType,
   MapTile,
@@ -40,6 +41,9 @@ export interface DashboardMutators {
   /** Patch the artifacts inventory after a use / find. Pass artifact docs
    *  with `used` flipped or freshly-found artifacts. */
   mergeArtifacts: (updates: GameArtifact[]) => void;
+  /** Patch the dashboard's worldMeta snapshot (seal count, season number,
+   *  armageddon state). Used by the Armageddon cast handler. */
+  setWorldMeta?: (m: GameWorldMeta | null) => void;
 }
 
 /**
@@ -709,6 +713,65 @@ export async function castSpell(
     };
   } catch (e) {
     mut.setError(e instanceof Error ? e.message : "Spell cast failed");
+    return null;
+  }
+}
+
+/**
+ * POST /api/game/spell/armageddon — fire the end-game Armageddon spell.
+ * No body. Costs 100 turns regardless of outcome. Returns:
+ *   - success: was a seal broken?
+ *   - successChance: the probability rolled against (for display)
+ *   - sealsBroken: global count after this cast (0..7)
+ *   - shouldTriggerResolve: true when this cast broke seal #7
+ */
+export async function castArmageddon(
+  user: User,
+  mut: DashboardMutators
+): Promise<{
+  sealBroken: boolean;
+  successChance: number;
+  sealsBroken: number;
+  seasonNumber: number;
+  shouldTriggerResolve: boolean;
+} | null> {
+  mut.setError(null);
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch("/api/game/spell/armageddon", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({}),
+    });
+    const data = await res.json();
+    if (!data.success) {
+      throw new Error(asErrorMessage(data, "Armageddon cast failed"));
+    }
+    if (data.player) mut.setPlayer(data.player as GamePlayer);
+    // Patch the local worldMeta snapshot if the dashboard hook wired it.
+    // The full seal-attribution detail arrives on the next world-meta
+    // refetch (called from the dashboard hook after this resolves).
+    if (mut.setWorldMeta) {
+      mut.setWorldMeta({
+        playerCount: 0, // unknown here; overwritten on next refetch
+        seasonNumber: data.seasonNumber as number,
+        sealsBroken: data.sealsBroken as number,
+        seals: [],
+        armageddonState: data.shouldTriggerResolve ? "resolving" : "active",
+      });
+    }
+    return {
+      sealBroken: Boolean(data.sealBroken),
+      successChance: Number(data.successChance ?? 0),
+      sealsBroken: Number(data.sealsBroken ?? 0),
+      seasonNumber: Number(data.seasonNumber ?? 1),
+      shouldTriggerResolve: Boolean(data.shouldTriggerResolve),
+    };
+  } catch (e) {
+    mut.setError(e instanceof Error ? e.message : "Armageddon cast failed");
     return null;
   }
 }

--- a/app/game/_lib/dashboard-fetch.ts
+++ b/app/game/_lib/dashboard-fetch.ts
@@ -13,7 +13,12 @@ import {
   type CachedMapView,
   type CachedOwnerSummary,
 } from "@/lib/game/local-map-cache";
-import type { GameArtifact, GamePlayer, MapTile } from "@/lib/game/types";
+import type {
+  GameArtifact,
+  GamePlayer,
+  GameWorldMeta,
+  MapTile,
+} from "@/lib/game/types";
 import type { Eligibility, OwnerSummary } from "./dashboard-types";
 
 /** State setters the initial-load fetcher reaches back into. */
@@ -25,6 +30,7 @@ export interface FetchSetters {
   setWorldTiles: (t: MapTile[]) => void;
   setWorldOwners: (m: Map<string, OwnerSummary>) => void;
   setArtifacts: (a: GameArtifact[]) => void;
+  setWorldMeta: (m: GameWorldMeta | null) => void;
   setError: (msg: string | null) => void;
   setLoading: (v: boolean) => void;
 }
@@ -60,6 +66,12 @@ interface ArtifactsResponse {
   error?: { message?: string } | string;
 }
 
+interface WorldMetaResponse {
+  success: boolean;
+  worldMeta?: GameWorldMeta;
+  error?: { message?: string } | string;
+}
+
 /**
  * Initial-load fetcher: pulls the player, eligibility, and (from cache
  * or fresh) the personal map view. Hand-runs once on mount and again
@@ -73,7 +85,7 @@ export async function fetchInitialData(
   set.setLoading(true);
   try {
     const token = await user.getIdToken();
-    const [playerRes, elgRes, artifactsRes] = await Promise.all([
+    const [playerRes, elgRes, artifactsRes, worldMetaRes] = await Promise.all([
       fetch("/api/game/player", {
         headers: { Authorization: `Bearer ${token}` },
       }),
@@ -81,6 +93,9 @@ export async function fetchInitialData(
         headers: { Authorization: `Bearer ${token}` },
       }),
       fetch("/api/game/artifacts?limit=100", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      fetch("/api/game/world-meta", {
         headers: { Authorization: `Bearer ${token}` },
       }),
     ]);
@@ -102,6 +117,11 @@ export async function fetchInitialData(
     const artifactsData = (await artifactsRes.json()) as ArtifactsResponse;
     if (artifactsData.success && Array.isArray(artifactsData.artifacts)) {
       set.setArtifacts(artifactsData.artifacts.filter((a) => !a.used));
+    }
+
+    const worldMetaData = (await worldMetaRes.json()) as WorldMetaResponse;
+    if (worldMetaData.success && worldMetaData.worldMeta) {
+      set.setWorldMeta(worldMetaData.worldMeta);
     }
 
     // Map data — cache is source of truth. If absent, fetch /map/me

--- a/app/game/_lib/use-dashboard-data.ts
+++ b/app/game/_lib/use-dashboard-data.ts
@@ -12,6 +12,7 @@ import { mergeTiles as mergeTilesIntoCache } from "@/lib/game/local-map-cache";
 import type {
   GameArtifact,
   GamePlayer,
+  GameWorldMeta,
   LandType,
   MapTile,
   TurnReport,
@@ -23,6 +24,7 @@ import {
   armDefenseSpell,
   attack,
   bulkDistribute,
+  castArmageddon,
   castIntelSpell,
   castSpell,
   createPlayer,
@@ -94,6 +96,12 @@ export function useDashboardData() {
   // every action button knows what's available without a refetch.
   const [artifacts, setArtifacts] = useState<GameArtifact[]>([]);
 
+  // Global game-world singleton: season, seal count, armageddon state.
+  // Fetched alongside player on mount, patched in place after the player
+  // casts Armageddon, and refetched whenever the server returns a state
+  // change (resolving, fresh season).
+  const [worldMeta, setWorldMeta] = useState<GameWorldMeta | null>(null);
+
   /**
    * Patch the local owned-tile list AND the localStorage map cache so
    * downstream pages read the same data without an extra fetch.
@@ -153,6 +161,7 @@ export function useDashboardData() {
     mergeOwnedTiles,
     mergeBorderTiles,
     mergeArtifacts,
+    setWorldMeta,
   };
 
   const fetchPlayer = useCallback(async () => {
@@ -168,6 +177,7 @@ export function useDashboardData() {
       setWorldTiles,
       setWorldOwners,
       setArtifacts,
+      setWorldMeta,
       setError,
       setLoading,
     });
@@ -345,6 +355,23 @@ export function useDashboardData() {
     [user]
   );
 
+  const handleCastArmageddon = useCallback(async () => {
+    if (!user) return null;
+    const result = await castArmageddon(user, mut);
+    // If the cast broke seal #7, refetch worldMeta + player shortly after
+    // so the dashboard picks up the resolver's eventual "armageddonState
+    // === active, seasonNumber++" flip and the deleted player doc. The
+    // wipe takes seconds; a single delayed refetch covers the typical
+    // case and the user can manually refresh if the wipe runs long.
+    if (result?.shouldTriggerResolve) {
+      setTimeout(() => {
+        void fetchPlayer();
+      }, 12_000);
+    }
+    return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mut is rebuilt every render but its members are stable
+  }, [user, fetchPlayer]);
+
   return {
     user,
     authLoading,
@@ -392,6 +419,8 @@ export function useDashboardData() {
     handleSiege,
     handleFlyover,
     handleCastSpell,
+    worldMeta,
+    handleCastArmageddon,
   };
 }
 

--- a/app/game/armageddon/page.tsx
+++ b/app/game/armageddon/page.tsx
@@ -1,0 +1,235 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { ArmageddonEventRecord, SealRecord } from "@/lib/game/types";
+import { SEAL_COUNT } from "@/lib/game/content/armageddon";
+
+interface HistoryResponse {
+  success: boolean;
+  history?: ArmageddonEventRecord[];
+  error?: string;
+}
+
+function formatAbsolute(value: SealRecord["brokenAt"]): string {
+  if (!value) return "—";
+  const d =
+    value instanceof Date
+      ? value
+      : typeof (value as { toDate?: () => Date }).toDate === "function"
+        ? (value as { toDate: () => Date }).toDate()
+        : new Date(0);
+  return d.toLocaleString();
+}
+
+/**
+ * Hall of fame for past Armageddons. Lists every resolved season with its
+ * 10 weighted-draw winners, the 7-seal audit trail, and a top-50-by-tiles
+ * snapshot. The on-disk record persists across the world wipe — this page
+ * is the only place glory survives a season reset.
+ */
+export default function ArmageddonHistoryPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [history, setHistory] = useState<ArmageddonEventRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    setError(null);
+    setLoading(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/armageddon", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as HistoryResponse;
+      if (!data.success) throw new Error(data.error ?? "Failed to load");
+      setHistory(data.history ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
+    void fetchHistory();
+  }, [authLoading, fetchHistory]);
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center py-12 px-6">
+        <p className="text-sm text-neutral-500">Loading hall of fame…</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen py-12 px-6 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold">Sign in to view the hall of fame.</h1>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen py-12 px-6">
+      <div className="max-w-5xl mx-auto">
+        <div className="flex items-baseline justify-between mb-6">
+          <h1 className="text-3xl font-bold">Hall of Fame — Past Armageddons</h1>
+          <Link
+            href="/game"
+            className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+          >
+            ← Dashboard
+          </Link>
+        </div>
+
+        {error && (
+          <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        {history.length === 0 ? (
+          <div className="rounded-lg border border-neutral-300 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900 p-6 text-sm text-neutral-700 dark:text-neutral-300">
+            <p className="mb-2">
+              No Armageddons have resolved yet. We are in the first age.
+            </p>
+            <p className="text-neutral-500 dark:text-neutral-400">
+              When the seventh Seal breaks, a weighted lottery decides
+              who carries glory into the next age — and their names are
+              recorded here forever.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-8">
+            {history.map((ev) => (
+              <ArmageddonCard key={ev.seasonNumber} ev={ev} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ArmageddonCard({ ev }: { ev: ArmageddonEventRecord }) {
+  return (
+    <div className="rounded-lg border border-red-300 dark:border-red-800 bg-red-50/50 dark:bg-red-950/20 p-5">
+      <div className="flex flex-wrap items-baseline justify-between gap-2 mb-3">
+        <div>
+          <div className="text-xs uppercase tracking-widest text-red-700 dark:text-red-300 opacity-90">
+            Season {ev.seasonNumber} — Armageddon
+          </div>
+          <h2 className="text-xl font-bold text-red-900 dark:text-red-100">
+            {formatAbsolute(ev.triggeredAt)}
+          </h2>
+        </div>
+        <div className="text-sm text-red-800 dark:text-red-200">
+          The seventh Seal broken by{" "}
+          <strong>{ev.triggeredBy.displayName}</strong>{" "}
+          <span className="opacity-70">({ev.triggeredBy.caste})</span>
+        </div>
+      </div>
+
+      <p className="text-xs text-neutral-600 dark:text-neutral-400 mb-4">
+        {ev.totalParticipants.toLocaleString()} participants ·{" "}
+        {ev.totalTickets.toLocaleString()} total tickets
+      </p>
+
+      <div className="grid md:grid-cols-2 gap-4 mb-4">
+        <div className="rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3">
+          <div className="text-xs uppercase text-neutral-500 mb-2">
+            The Seven Seals
+          </div>
+          <ol className="space-y-1 text-sm">
+            {Array.from({ length: SEAL_COUNT }, (_, i) => {
+              const s = ev.seals?.[i];
+              return (
+                <li key={i} className="font-mono text-xs">
+                  <span className="text-red-700 dark:text-red-300">
+                    ✦ Seal #{i + 1}
+                  </span>{" "}
+                  →{" "}
+                  {s?.broken && s.brokenBy ? (
+                    <>
+                      <strong>{s.brokenBy.displayName}</strong>{" "}
+                      <span className="opacity-70">({s.brokenBy.caste})</span>{" "}
+                      <span className="opacity-60">
+                        {formatAbsolute(s.brokenAt)}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="opacity-50">unbroken (anomaly)</span>
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+
+        <div className="rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3">
+          <div className="text-xs uppercase text-neutral-500 mb-2">
+            Lottery winners
+          </div>
+          {ev.winners.length === 0 ? (
+            <p className="text-sm opacity-60">No participants drew tickets.</p>
+          ) : (
+            <ol className="space-y-1 text-sm">
+              {ev.winners.map((w) => (
+                <li key={w.userId} className="flex justify-between gap-3">
+                  <span className="truncate">
+                    <span className="font-mono text-xs opacity-60 mr-2">
+                      #{w.rank}
+                    </span>
+                    <strong>{w.displayName}</strong>{" "}
+                    <span className="text-xs opacity-70">({w.caste})</span>
+                  </span>
+                  <span className="font-mono text-xs whitespace-nowrap opacity-70">
+                    {w.tickets.toLocaleString()} tix
+                  </span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+
+      {ev.topByTilesSnapshot.length > 0 && (
+        <details className="rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3">
+          <summary className="text-xs uppercase text-neutral-500 cursor-pointer">
+            Top kingdoms by tiles ({ev.topByTilesSnapshot.length})
+          </summary>
+          <ol className="mt-2 space-y-1 text-sm">
+            {ev.topByTilesSnapshot.map((p) => (
+              <li key={p.userId} className="flex justify-between gap-3">
+                <span className="truncate">
+                  <span className="font-mono text-xs opacity-60 mr-2">
+                    #{p.rank}
+                  </span>
+                  <strong>{p.displayName}</strong>{" "}
+                  <span className="text-xs opacity-70">({p.caste})</span>
+                </span>
+                <span className="font-mono text-xs whitespace-nowrap opacity-70">
+                  {p.tilesHeld.toLocaleString()} tiles · {p.sealsBroken} seals
+                </span>
+              </li>
+            ))}
+          </ol>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/app/game/spells/_components/ApocalypsePanel.tsx
+++ b/app/game/spells/_components/ApocalypsePanel.tsx
@@ -1,0 +1,234 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { User } from "firebase/auth";
+import type { GamePlayer, MapTile } from "@/lib/game/types";
+import { magicMultiplier } from "@/lib/game/combat";
+import {
+  ARMAGEDDON_TILE_GATE,
+  ARMAGEDDON_TURN_COST,
+  SEAL_COUNT,
+  computeArmageddonSuccessChanceFromMultiplier,
+} from "@/lib/game/content/armageddon";
+
+interface ApocalypsePanelProps {
+  user: User;
+  player: GamePlayer;
+  tiles: MapTile[];
+  // Optional global counter so the panel can display "M / 7 seals broken"
+  // without an extra fetch. Pass null when unknown.
+  sealsBroken: number | null;
+  /** Refresh the dashboard-level player + worldMeta after a successful cast.
+   *  Called regardless of cast outcome (turns deducted either way). */
+  onAfterCast?: () => void;
+}
+
+interface LastCast {
+  sealBroken: boolean;
+  successChance: number;
+  sealsBroken: number;
+  shouldTriggerResolve: boolean;
+}
+
+/**
+ * Top-of-page panel on /game/spells that surfaces the universal Armageddon
+ * spell. Locked under ARMAGEDDON_TILE_GATE tiles. When unlocked, shows the
+ * live success chance (derived from magic-land count + magic-multiplier
+ * upgrades) and a destructive cast button. Outcome flash is rendered in-
+ * place so the player doesn't lose context after rolling.
+ */
+export function ApocalypsePanel({
+  user,
+  player,
+  tiles,
+  sealsBroken,
+  onAfterCast,
+}: ApocalypsePanelProps) {
+  const tilesHeld = player.stats?.tilesHeld ?? 0;
+  const magicLandCount = useMemo(
+    () => tiles.filter((t) => t.ownerId === player.userId && t.type === "magic").length,
+    [tiles, player.userId]
+  );
+  const successChance = useMemo(() => {
+    const mm = magicMultiplier(magicLandCount, player.activeUpgrades ?? {});
+    return computeArmageddonSuccessChanceFromMultiplier(mm);
+  }, [magicLandCount, player.activeUpgrades]);
+
+  const unlocked = tilesHeld >= ARMAGEDDON_TILE_GATE;
+  const affordable = player.turnsRemaining >= ARMAGEDDON_TURN_COST;
+  const allSealsBroken = sealsBroken !== null && sealsBroken >= SEAL_COUNT;
+  const canCast = unlocked && affordable && !allSealsBroken;
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [last, setLast] = useState<LastCast | null>(null);
+
+  const cast = async () => {
+    if (!canCast || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/spell/armageddon", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({}),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        const msg =
+          typeof data.error === "string"
+            ? data.error
+            : data.error?.message ?? "Armageddon cast failed";
+        throw new Error(msg);
+      }
+      setLast({
+        sealBroken: Boolean(data.sealBroken),
+        successChance: Number(data.successChance ?? successChance),
+        sealsBroken: Number(data.sealsBroken ?? 0),
+        shouldTriggerResolve: Boolean(data.shouldTriggerResolve),
+      });
+      if (onAfterCast) onAfterCast();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Armageddon cast failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className={
+        "rounded-lg border p-5 mb-6 " +
+        (unlocked
+          ? "border-red-800 bg-red-950/30 text-red-100 dark:border-red-700"
+          : "border-neutral-300 dark:border-neutral-800 bg-neutral-100/50 dark:bg-neutral-900/30 text-neutral-700 dark:text-neutral-300")
+      }
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
+        <div>
+          <div className="text-xs uppercase tracking-widest opacity-70">
+            Apocalypse
+          </div>
+          <h2 className="text-2xl font-bold mt-1">Armageddon</h2>
+        </div>
+        <Link
+          href="/game/armageddon"
+          className="text-xs underline opacity-80 hover:opacity-100"
+        >
+          Hall of fame →
+        </Link>
+      </div>
+
+      <p className="text-sm leading-relaxed mb-4 opacity-90">
+        Strike the heavens. Risk{" "}
+        <strong className="font-mono">{ARMAGEDDON_TURN_COST}</strong> turns to
+        break one of the seven Seals. Low base chance — your magic-optimized
+        kingdom raises the odds. When the seventh Seal breaks, the world ends
+        and is remade.
+      </p>
+
+      {!unlocked && (
+        <div className="rounded-md bg-neutral-200 dark:bg-neutral-800 px-3 py-2 text-sm">
+          🔒 Locked. Unlocks at{" "}
+          <strong className="font-mono">
+            {ARMAGEDDON_TILE_GATE.toLocaleString()}
+          </strong>{" "}
+          tiles. You hold{" "}
+          <strong className="font-mono">{tilesHeld.toLocaleString()}</strong>.
+        </div>
+      )}
+
+      {unlocked && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm mb-4">
+            <div>
+              <div className="text-xs uppercase opacity-70">Cost</div>
+              <div className="font-mono text-lg">{ARMAGEDDON_TURN_COST}t</div>
+            </div>
+            <div>
+              <div className="text-xs uppercase opacity-70">Success chance</div>
+              <div className="font-mono text-lg text-amber-300">
+                {(successChance * 100).toFixed(1)}%
+              </div>
+            </div>
+            <div>
+              <div className="text-xs uppercase opacity-70">Magic tiles</div>
+              <div className="font-mono text-lg">{magicLandCount}</div>
+            </div>
+            <div>
+              <div className="text-xs uppercase opacity-70">Seals broken</div>
+              <div className="font-mono text-lg">
+                {sealsBroken ?? "—"} / {SEAL_COUNT}
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={cast}
+            disabled={!canCast || busy}
+            className={
+              "w-full sm:w-auto px-6 py-3 rounded-md font-semibold text-sm transition " +
+              (canCast && !busy
+                ? "bg-red-700 hover:bg-red-600 text-white"
+                : "bg-neutral-600 text-neutral-300 cursor-not-allowed")
+            }
+          >
+            {busy
+              ? "Striking the heavens…"
+              : allSealsBroken
+                ? "All seals broken — Armageddon is upon us"
+                : !affordable
+                  ? `Need ${ARMAGEDDON_TURN_COST} turns (have ${player.turnsRemaining})`
+                  : "Cast Armageddon (100 turns)"}
+          </button>
+        </>
+      )}
+
+      {error && (
+        <div className="mt-3 rounded-md bg-red-200 px-3 py-2 text-sm text-red-900 dark:bg-red-900 dark:text-red-100">
+          {error}
+        </div>
+      )}
+
+      {last && (
+        <div
+          className={
+            "mt-3 rounded-md px-3 py-2 text-sm " +
+            (last.sealBroken
+              ? "bg-amber-200 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100"
+              : "bg-neutral-200 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-200")
+          }
+        >
+          {last.sealBroken ? (
+            <>
+              <strong>A Seal cracks.</strong> The world dims briefly. Seals
+              broken: {last.sealsBroken} / {SEAL_COUNT}.
+              {last.shouldTriggerResolve && (
+                <div className="mt-1 font-semibold">
+                  The seventh Seal has broken. The world is being remade.
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <strong>The ritual fizzles.</strong> No seal breaks this time.
+              Odds were {(last.successChance * 100).toFixed(1)}%.
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/game/spells/_components/SpellsView.tsx
+++ b/app/game/spells/_components/SpellsView.tsx
@@ -8,6 +8,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import type { User } from "firebase/auth";
 import { ALL_SPELLS } from "@/lib/game/content";
 import {
   computeTileThreat,
@@ -16,6 +17,7 @@ import {
 } from "@/lib/game/threat";
 import type {
   GamePlayer,
+  GameWorldMeta,
   MapTile,
   SpellDefinition,
 } from "@/lib/game/types";
@@ -23,15 +25,19 @@ import { TIERS } from "../_lib/constants";
 import type { OwnerSummary } from "../_lib/types";
 import type { SpellActions } from "../_lib/use-spell-actions";
 import { ActiveProductionList } from "./ActiveProductionList";
+import { ApocalypsePanel } from "./ApocalypsePanel";
 import { ArmedTilesList } from "./ArmedTilesList";
 import { ReportLog } from "./ReportLog";
 import { TierSection } from "./TierSection";
 
 interface Props {
+  user: User;
   player: GamePlayer;
   tiles: MapTile[];
   borderTiles: MapTile[];
   owners: Map<string, OwnerSummary>;
+  worldMeta: GameWorldMeta | null;
+  onAfterArmageddon: () => void;
   error: string | null;
   actions: SpellActions;
 }
@@ -42,10 +48,13 @@ interface Props {
  * (`spellByTierAndType`, `armableTiles`, `threatRanked`).
  */
 export function SpellsView({
+  user,
   player,
   tiles,
   borderTiles,
   owners,
+  worldMeta,
+  onAfterArmageddon,
   error,
   actions,
 }: Props) {
@@ -143,6 +152,14 @@ export function SpellsView({
         {error && (
           <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
+
+        <ApocalypsePanel
+          user={user}
+          player={player}
+          tiles={tiles}
+          sealsBroken={worldMeta?.sealsBroken ?? null}
+          onAfterCast={onAfterArmageddon}
+        />
 
         <div className="space-y-6 mb-10">
           {TIERS.map(({ tier, minTiles }) => (

--- a/app/game/spells/_lib/constants.ts
+++ b/app/game/spells/_lib/constants.ts
@@ -32,6 +32,7 @@ export const TYPE_LABEL: Record<SpellType, string> = {
   siege: "Siege",
   disarm: "Disarm",
   attrition: "Attrition",
+  armageddon: "Armageddon",
 };
 
 export const RARITY_TEXT: Record<string, string> = {

--- a/app/game/spells/_lib/use-spells-data.ts
+++ b/app/game/spells/_lib/use-spells-data.ts
@@ -13,7 +13,7 @@ import {
   saveCachedMap,
   type CachedMapView,
 } from "@/lib/game/local-map-cache";
-import type { GamePlayer, MapTile } from "@/lib/game/types";
+import type { GamePlayer, GameWorldMeta, MapTile } from "@/lib/game/types";
 import type { MapMeResponse, OwnerSummary, PlayerResponse } from "./types";
 
 /**
@@ -32,6 +32,9 @@ export function useSpellsData() {
   // handlers across the game pages.
   const [borderTiles, setBorderTiles] = useState<MapTile[]>([]);
   const [owners, setOwners] = useState<Map<string, OwnerSummary>>(new Map());
+  // Global game-world singleton (seal count + season + state). Used by
+  // the Apocalypse panel for the "M / 7 seals" display.
+  const [worldMeta, setWorldMeta] = useState<GameWorldMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,10 +49,15 @@ export function useSpellsData() {
     setError(null);
     try {
       const token = await user.getIdToken();
-      const res = await fetch("/api/game/player", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = (await res.json()) as PlayerResponse;
+      const [playerRes, metaRes] = await Promise.all([
+        fetch("/api/game/player", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch("/api/game/world-meta", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+      const data = (await playerRes.json()) as PlayerResponse;
       if (!data.success) {
         const msg =
           typeof data.error === "string"
@@ -59,6 +67,13 @@ export function useSpellsData() {
       }
       setPlayer(data.player);
       setTiles(data.tiles ?? []);
+      const metaData = (await metaRes.json()) as {
+        success: boolean;
+        worldMeta?: GameWorldMeta;
+      };
+      if (metaData.success && metaData.worldMeta) {
+        setWorldMeta(metaData.worldMeta);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -115,6 +130,8 @@ export function useSpellsData() {
     setTiles,
     borderTiles,
     owners,
+    worldMeta,
+    refreshPlayer,
     loading,
     error,
     setError,

--- a/app/game/spells/page.tsx
+++ b/app/game/spells/page.tsx
@@ -27,6 +27,8 @@ export default function SpellsPage() {
     setTiles,
     borderTiles,
     owners,
+    worldMeta,
+    refreshPlayer,
     loading,
     error,
     setError,
@@ -41,10 +43,13 @@ export default function SpellsPage() {
 
   return (
     <SpellsView
+      user={user}
       player={player}
       tiles={tiles}
       borderTiles={borderTiles}
       owners={owners}
+      worldMeta={worldMeta}
+      onAfterArmageddon={refreshPlayer}
       error={error}
       actions={actions}
     />

--- a/app/game/threats/_components/ThreatRow.tsx
+++ b/app/game/threats/_components/ThreatRow.tsx
@@ -170,7 +170,10 @@ export function ThreatRow(props: ThreatRowProps) {
         s.id,
         realizedSpellMagnitude({
           baseStrength: s.baseStrength,
-          caste: s.caste,
+          // Offense spells are always caste-bound; Armageddon is the only
+          // "neutral"-caste spell and it has type !== "offense" so it never
+          // appears in offenseSpells. Cast narrows the runtime invariant.
+          caste: s.caste as Exclude<typeof s.caste, "neutral">,
           spellType: s.type,
           magicLandCount: myMagicLandCount,
           activeUpgrades: player.activeUpgrades ?? {},

--- a/app/game/tiles/_components/tile-action-panels.tsx
+++ b/app/game/tiles/_components/tile-action-panels.tsx
@@ -339,7 +339,9 @@ export function EnemyTilePanel({
   const selectedOffenseExpected = selectedOffense
     ? realizedSpellMagnitude({
         baseStrength: selectedOffense.baseStrength,
-        caste: selectedOffense.caste,
+        // Offense spells are always caste-bound; the "neutral"-caste
+        // Armageddon spell never appears here (different SpellType).
+        caste: selectedOffense.caste as Exclude<typeof selectedOffense.caste, "neutral">,
         spellType: selectedOffense.type,
         magicLandCount: playerMagicLandCount,
         activeUpgrades: player.activeUpgrades ?? {},
@@ -540,7 +542,7 @@ export function EnemyTilePanel({
             {offenseSpells.map((s) => {
               const expected = realizedSpellMagnitude({
                 baseStrength: s.baseStrength,
-                caste: s.caste,
+                caste: s.caste as Exclude<typeof s.caste, "neutral">,
                 spellType: s.type,
                 magicLandCount: playerMagicLandCount,
                 activeUpgrades: player.activeUpgrades ?? {},

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -454,6 +454,16 @@ service cloud.firestore {
       allow create, update, delete: if false;
     }
 
+    // Game — Armageddon hall of fame. One doc per resolved Armageddon
+    // (doc id = seasonNumber). Persists the lottery winners + seal audit
+    // trail + top-by-tiles snapshot so glory survives the world wipe.
+    // Authenticated read; writes are Admin-SDK only via the resolver
+    // (lib/game/armageddon-resolve.ts).
+    match /game_armageddon_events/{eventId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if false;
+    }
+
     // Game — Community chat (free-form message board). Reads are
     // authenticated. All writes (create + soft-delete) flow through
     // /api/game/community/chat which validates ownership and admin

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**171 paths, 207 operations across 32 areas.**
+**172 paths, 208 operations across 32 areas.**
 
 ---
 
@@ -430,6 +430,7 @@ _Talk-submission moderation queue._
 | POST | `/api/summer-cohort/confirm-dev-env` | Yes | Admitted cohort participant confirms dev environment is set up (Node + Git + IDE) |
 | GET | `/api/summer-cohort/intake-survey` | Yes | Get the current user's intake-survey response |
 | POST | `/api/summer-cohort/intake-survey` | Yes | Submit (or re-submit) the intake survey |
+| GET | `/api/summer-cohort/my-score/{weekId}` | Yes | Return only the calling user's own AI-judge score for a vote-format week — other users' scores are never exposed by this endpoint |
 | GET | `/api/summer-cohort/submissions/{weekId}` | No | Public read of merged submissions on a vote-format week |
 | GET | `/api/summer-cohort/votes` | No | Aggregate vote counts for a vote-format week |
 | POST | `/api/summer-cohort/votes` | Yes | Toggle the current user's vote for a submission |

--- a/lib/game/api-error-map.ts
+++ b/lib/game/api-error-map.ts
@@ -9,6 +9,7 @@ import { apiError } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import {
   GameAlreadyRevealedError,
+  GameArmageddonInProgressError,
   GameArtifactAlreadyUsedError,
   GameArtifactNotFoundError,
   GameCasteAlreadySetError,
@@ -27,8 +28,10 @@ import {
   GameNotAdjacentError,
   GamePlayerAlreadyExistsError,
   GamePlayerNotFoundError,
+  GameSealsExhaustedError,
   GameSelfAttackError,
   GameShieldedError,
+  GameStaleSeasonError,
   GameTileFullError,
   GameTileNotFoundError,
   GameTileNotOwnedError,
@@ -77,6 +80,9 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameNoEnemyKingdomsError ||
     error instanceof GameArtifactAlreadyUsedError ||
     error instanceof GameNameTakenError ||
+    error instanceof GameArmageddonInProgressError ||
+    error instanceof GameStaleSeasonError ||
+    error instanceof GameSealsExhaustedError ||
     error instanceof UpgradeAlreadyActiveError ||
     error instanceof UpgradeNotActiveError
   ) {

--- a/lib/game/armageddon-resolve.ts
+++ b/lib/game/armageddon-resolve.ts
@@ -1,0 +1,342 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Armageddon resolution orchestrator. Fired from the API route AFTER the
+ * cast transaction that broke the 7th seal commits — i.e. with
+ * worldMeta.armageddonState === "resolving" already in place. Runs as a
+ * fire-and-forget background job so the casting player's response is not
+ * blocked on the full wipe.
+ *
+ * Steps, in order:
+ *   1. Read all participants → compute weighted tickets.
+ *   2. Weighted top-N draw without replacement (seeded RNG → reproducible).
+ *   3. Write the hall-of-fame doc (game_armageddon_events/{season}). This
+ *      lands BEFORE any deletes so the record survives a mid-wipe crash.
+ *   4. Log armageddon_completed + per-winner armageddon_winner events.
+ *   5. Batch-delete all tiles, attacks, artifacts, intel-effects, AND
+ *      player docs. Returning players spawn fresh via the normal
+ *      createPlayerWithSpawnServer flow on their next /game visit.
+ *   6. Bump worldMeta: seasonNumber++, sealsBroken=0, seals reset,
+ *      armageddonState="active", armageddonResolvedAt=now.
+ *
+ * Idempotency: if the hall-of-fame doc already exists for this season,
+ * the resolver assumes it ran already and re-enters at step 5 to clean
+ * up any straggler docs and ensure the worldMeta is bumped. Safe to call
+ * twice.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  CollectionReference,
+  Firestore,
+  Query,
+} from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logger } from "@/lib/logger";
+import { makeSeededRng } from "./combat";
+import {
+  SEAL_COUNT,
+  TOP_BY_TILES_SNAPSHOT_COUNT,
+  WINNER_COUNT,
+  computeLotteryTickets,
+} from "./content/armageddon";
+import type {
+  ArmageddonEventRecord,
+  ArmageddonWinner,
+  Caste,
+  GamePlayer,
+  GameWorldMeta,
+  SealRecord,
+} from "./types";
+
+const COLLECTIONS = {
+  PLAYERS: "game_players",
+  TILES: "game_tiles",
+  ATTACKS: "game_attacks",
+  WORLD_META: "game_world_meta",
+  ARTIFACTS: "game_artifacts",
+  INTEL_EFFECTS: "game_intel_effects",
+  COMMUNITY_EVENTS: "game_community_events",
+  ARMAGEDDON_EVENTS: "game_armageddon_events",
+} as const;
+const WORLD_META_DOC = "singleton";
+
+/** Firestore batched-write limit is 500; leave headroom. */
+const BATCH_SIZE = 400;
+
+function adminDbOrThrow(): Firestore {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not initialized");
+  return db;
+}
+
+interface Participant {
+  userId: string;
+  displayName: string;
+  caste: Caste;
+  tilesHeld: number;
+  sealsBroken: number;
+  tickets: number;
+}
+
+/** Weighted draw of `count` winners without replacement, using a seeded
+ *  RNG so the same season's seal-7 break always yields the same winners
+ *  (reproducibility + auditability — anyone can verify the draw). */
+function drawWinners(
+  participants: Participant[],
+  count: number,
+  rng: () => number
+): ArmageddonWinner[] {
+  // Mutable copy of weights so we can zero-out picked players.
+  const pool = participants.map((p) => ({ p, weight: p.tickets }));
+  const winners: ArmageddonWinner[] = [];
+  for (let rank = 1; rank <= count; rank++) {
+    let total = 0;
+    for (const e of pool) total += e.weight;
+    if (total <= 0) break;
+    let roll = rng() * total;
+    for (const e of pool) {
+      roll -= e.weight;
+      if (roll <= 0 && e.weight > 0) {
+        winners.push({
+          rank,
+          userId: e.p.userId,
+          displayName: e.p.displayName,
+          caste: e.p.caste,
+          tilesHeld: e.p.tilesHeld,
+          sealsBroken: e.p.sealsBroken,
+          tickets: e.p.tickets,
+        });
+        e.weight = 0;
+        break;
+      }
+    }
+  }
+  return winners;
+}
+
+/** Deletes every doc in `query`'s result set, batched to BATCH_SIZE per
+ *  write. Returns the total deletion count. Safe to call multiple times
+ *  (a second call on an empty collection is a no-op). */
+async function deleteAllInQuery(
+  db: Firestore,
+  query: Query | CollectionReference
+): Promise<number> {
+  let total = 0;
+  while (true) {
+    const snap = await query.limit(BATCH_SIZE).get();
+    if (snap.empty) break;
+    const batch = db.batch();
+    for (const doc of snap.docs) batch.delete(doc.ref);
+    await batch.commit();
+    total += snap.size;
+    if (snap.size < BATCH_SIZE) break;
+  }
+  return total;
+}
+
+/** Write one community event out-of-transaction. The resolver runs
+ *  outside any tx (the wipe is too large for a single tx), so we don't
+ *  use logCommunityEventInTx; we just write directly. */
+async function logEvent(
+  db: Firestore,
+  fields: Record<string, unknown>,
+  now: Date
+): Promise<void> {
+  const id = randomUUID();
+  await db
+    .collection(COLLECTIONS.COMMUNITY_EVENTS)
+    .doc(id)
+    .set({ id, createdAt: now, ...fields });
+}
+
+/**
+ * Resolves the Armageddon for the given expected season number. Caller
+ * should be the API route handler that observed `shouldTriggerResolve`
+ * from castArmageddonServer. The function is idempotent — calling twice
+ * for the same season is safe.
+ */
+export async function resolveArmageddon(args: {
+  expectedSeason: number;
+  triggeredBy: { userId: string; displayName: string; caste: Caste };
+  now?: Date;
+}): Promise<void> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+
+  // ── Step 1: snapshot worldMeta + sanity-check we're the right caller.
+  const metaRef = db.collection(COLLECTIONS.WORLD_META).doc(WORLD_META_DOC);
+  const metaSnap = await metaRef.get();
+  const meta = (metaSnap.data() ?? {}) as Partial<GameWorldMeta>;
+  const currentSeason = meta.seasonNumber ?? 1;
+  if (currentSeason !== args.expectedSeason) {
+    logger.warn(
+      `[armageddon-resolve] season drift: expected ${args.expectedSeason}, current ${currentSeason} — skipping`
+    );
+    return;
+  }
+  if (meta.armageddonState !== "resolving") {
+    logger.warn(
+      `[armageddon-resolve] state is ${meta.armageddonState ?? "unset"}, expected "resolving" — skipping`
+    );
+    return;
+  }
+
+  const hallRef = db
+    .collection(COLLECTIONS.ARMAGEDDON_EVENTS)
+    .doc(String(currentSeason));
+  const hallSnap = await hallRef.get();
+
+  // Skip the snapshot/draw/log if we've already done it for this season
+  // (idempotent re-entry after a partial-success run).
+  if (!hallSnap.exists) {
+    // ── Step 2: snapshot participants (read ALL players).
+    const playersSnap = await db.collection(COLLECTIONS.PLAYERS).get();
+    const participants: Participant[] = [];
+    for (const doc of playersSnap.docs) {
+      const p = doc.data() as GamePlayer;
+      if (!p.caste) continue;          // skip unsetup accounts
+      const sealsBroken = p.armageddonSealsBroken ?? 0;
+      const tickets = computeLotteryTickets(p.stats.tilesHeld, sealsBroken);
+      if (tickets <= 0) continue;
+      participants.push({
+        userId: p.userId,
+        displayName: p.displayName,
+        caste: p.caste,
+        tilesHeld: p.stats.tilesHeld,
+        sealsBroken,
+        tickets,
+      });
+    }
+
+    // ── Step 3: weighted top-N draw.
+    const rng = makeSeededRng(`armageddon-resolve-s${currentSeason}`);
+    const winners = drawWinners(participants, WINNER_COUNT, rng);
+
+    // ── Step 4: top-by-tiles snapshot (separate from lottery; preserves
+    // who had the biggest kingdom regardless of luck).
+    const topByTiles = [...participants]
+      .sort((a, b) => b.tilesHeld - a.tilesHeld)
+      .slice(0, TOP_BY_TILES_SNAPSHOT_COUNT)
+      .map((p, i) => ({
+        rank: i + 1,
+        userId: p.userId,
+        displayName: p.displayName,
+        caste: p.caste,
+        tilesHeld: p.tilesHeld,
+        sealsBroken: p.sealsBroken,
+      }));
+
+    const totalTickets = participants.reduce((s, p) => s + p.tickets, 0);
+    const seals: SealRecord[] = (meta.seals ?? []).slice(0, SEAL_COUNT);
+
+    const record: ArmageddonEventRecord = {
+      seasonNumber: currentSeason,
+      triggeredAt: now,
+      triggeredBy: args.triggeredBy,
+      seals,
+      totalParticipants: participants.length,
+      totalTickets,
+      winners,
+      topByTilesSnapshot: topByTiles,
+    };
+
+    // ── Step 5: persist hall-of-fame BEFORE any destructive operation.
+    await hallRef.set(record);
+
+    // ── Step 6: community events. armageddon_completed + per-winner rows.
+    await logEvent(
+      db,
+      {
+        kind: "armageddon_completed",
+        actorUserId: args.triggeredBy.userId,
+        actorDisplayName: args.triggeredBy.displayName,
+        actorCaste: args.triggeredBy.caste,
+        seasonNumber: currentSeason,
+      },
+      now
+    );
+    for (const w of winners) {
+      await logEvent(
+        db,
+        {
+          kind: "armageddon_winner",
+          actorUserId: w.userId,
+          actorDisplayName: w.displayName,
+          actorCaste: w.caste,
+          seasonNumber: currentSeason,
+          winnerRank: w.rank,
+          tilesHeld: w.tilesHeld,
+          sealsBroken: w.sealsBroken,
+          tickets: w.tickets,
+        },
+        now
+      );
+    }
+    logger.info(
+      `[armageddon-resolve] season ${currentSeason}: ${participants.length} participants, ${winners.length} winners drawn`
+    );
+  } else {
+    logger.info(
+      `[armageddon-resolve] hall-of-fame for season ${currentSeason} already exists — skipping draw, resuming wipe`
+    );
+  }
+
+  // ── Step 7: batch-delete the world. Order matters for surprise: tiles
+  // first (largest), then artifacts/intel-effects (mid), attacks last
+  // (small but most numerous per-player). Players LAST so any straggler
+  // tile-attribution code that reads owner has a chance to fail cleanly.
+  const tilesDeleted = await deleteAllInQuery(
+    db,
+    db.collection(COLLECTIONS.TILES)
+  );
+  const artifactsDeleted = await deleteAllInQuery(
+    db,
+    db.collection(COLLECTIONS.ARTIFACTS)
+  );
+  const intelDeleted = await deleteAllInQuery(
+    db,
+    db.collection(COLLECTIONS.INTEL_EFFECTS)
+  );
+  const attacksDeleted = await deleteAllInQuery(
+    db,
+    db.collection(COLLECTIONS.ATTACKS)
+  );
+  const playersDeleted = await deleteAllInQuery(
+    db,
+    db.collection(COLLECTIONS.PLAYERS)
+  );
+
+  logger.info(
+    `[armageddon-resolve] wipe summary: tiles=${tilesDeleted}, artifacts=${artifactsDeleted}, intel=${intelDeleted}, attacks=${attacksDeleted}, players=${playersDeleted}`
+  );
+
+  // ── Step 8: bump worldMeta — fresh seals, new season, state=active.
+  // playerCount is NOT reset; it remains the lifetime spawn counter that
+  // drives the hex-spiral spawn placement. The next season's players will
+  // spawn at indices N, N+1, N+2... — distinct from any pre-Armageddon
+  // location (the tiles are gone anyway).
+  const freshSeals: SealRecord[] = Array.from({ length: SEAL_COUNT }, (_, i) => ({
+    index: i,
+    broken: false,
+  }));
+  await metaRef.set(
+    {
+      seasonNumber: currentSeason + 1,
+      sealsBroken: 0,
+      seals: freshSeals,
+      armageddonState: "active",
+      armageddonResolvedAt: now,
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+
+  logger.info(
+    `[armageddon-resolve] season ${currentSeason} → ${currentSeason + 1} complete`
+  );
+}

--- a/lib/game/community.ts
+++ b/lib/game/community.ts
@@ -80,12 +80,47 @@ interface MilestoneEvent extends BaseEventInput {
   kind: "milestone_1k_tiles";
 }
 
+interface SealBrokenEvent extends BaseEventInput {
+  kind: "seal_broken";
+  sealIndex: number;       // 0..6
+  seasonNumber: number;
+}
+
+interface ArmageddonStartedEvent extends BaseEventInput {
+  kind: "armageddon_started";
+  seasonNumber: number;
+}
+
+interface ArmageddonCompletedEvent extends BaseEventInput {
+  kind: "armageddon_completed";
+  seasonNumber: number;
+}
+
+interface ArmageddonWinnerEvent extends BaseEventInput {
+  kind: "armageddon_winner";
+  seasonNumber: number;
+  winnerRank: number;      // 1..10
+  tilesHeld: number;
+  sealsBroken: number;
+  tickets: number;
+}
+
+interface ArmageddonCastFailedEvent extends BaseEventInput {
+  kind: "armageddon_cast_failed";
+  seasonNumber: number;
+}
+
 export type CommunityEventInput =
   | PlayerJoinEvent
   | CastePickEvent
   | CasteChangeEvent
   | AttackEvent
-  | MilestoneEvent;
+  | MilestoneEvent
+  | SealBrokenEvent
+  | ArmageddonStartedEvent
+  | ArmageddonCompletedEvent
+  | ArmageddonWinnerEvent
+  | ArmageddonCastFailedEvent;
 
 /**
  * Writes one community-event doc inside an existing transaction.
@@ -127,6 +162,22 @@ export function logCommunityEventInTx(
     };
   } else if (input.kind === "caste_change") {
     extra = { fromCaste: input.fromCaste, toCaste: input.toCaste };
+  } else if (input.kind === "seal_broken") {
+    extra = { sealIndex: input.sealIndex, seasonNumber: input.seasonNumber };
+  } else if (
+    input.kind === "armageddon_started" ||
+    input.kind === "armageddon_completed" ||
+    input.kind === "armageddon_cast_failed"
+  ) {
+    extra = { seasonNumber: input.seasonNumber };
+  } else if (input.kind === "armageddon_winner") {
+    extra = {
+      seasonNumber: input.seasonNumber,
+      winnerRank: input.winnerRank,
+      tilesHeld: input.tilesHeld,
+      sealsBroken: input.sealsBroken,
+      tickets: input.tickets,
+    };
   }
   tx.set(ref, { ...base, ...extra });
 }
@@ -158,6 +209,22 @@ export async function logCommunityEvent(
     };
   } else if (input.kind === "caste_change") {
     extra = { fromCaste: input.fromCaste, toCaste: input.toCaste };
+  } else if (input.kind === "seal_broken") {
+    extra = { sealIndex: input.sealIndex, seasonNumber: input.seasonNumber };
+  } else if (
+    input.kind === "armageddon_started" ||
+    input.kind === "armageddon_completed" ||
+    input.kind === "armageddon_cast_failed"
+  ) {
+    extra = { seasonNumber: input.seasonNumber };
+  } else if (input.kind === "armageddon_winner") {
+    extra = {
+      seasonNumber: input.seasonNumber,
+      winnerRank: input.winnerRank,
+      tilesHeld: input.tilesHeld,
+      sealsBroken: input.sealsBroken,
+      tickets: input.tickets,
+    };
   }
   await ref.set({ ...base, ...extra });
 }

--- a/lib/game/content/armageddon.ts
+++ b/lib/game/content/armageddon.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * End-game tuning. The Armageddon spell unlocks at ARMAGEDDON_TILE_GATE
+ * tiles held; each cast burns ARMAGEDDON_TURN_COST turns whether it
+ * succeeds or fails. Success breaks one of SEAL_COUNT global Seals; the
+ * 7th seal ends the season and triggers a top-WINNER_COUNT weighted
+ * lottery (tickets = tilesHeld × (1 + sealsBroken)).
+ *
+ * Success probability is BASE_SUCCESS × magicMultiplier(magicLandCount,
+ * activeUpgrades), clamped to SUCCESS_HARD_CAP. The magic multiplier soft-
+ * caps at ~3.75 in vanilla content, so realistic peak success is around
+ * 18.75% — but magic-multiplier upgrades push the cap higher and let
+ * heavy-investment kingdoms approach SUCCESS_HARD_CAP.
+ */
+
+// NOTE: This module is imported transitively by `lib/game/combat.ts` (via
+// content/index → content/spells/armageddon → here). To avoid a circular
+// import (which webpack surfaces as "Cannot access 'e' before init"),
+// this file must NOT import from combat.ts or upgrades.ts. The math helpers
+// below take an already-computed magicMultiplier value as input; callers
+// compose them with `magicMultiplier(magicLandCount, activeUpgrades)`
+// from combat.ts at the call site.
+
+export const ARMAGEDDON_TILE_GATE = 10_000;
+export const ARMAGEDDON_TURN_COST = 100;
+export const BASE_SUCCESS = 0.05;
+export const SUCCESS_HARD_CAP = 0.5;
+export const SEAL_COUNT = 7;
+export const WINNER_COUNT = 10;
+/** Snapshot the top-N by tilesHeld into the hall-of-fame doc, regardless of
+ *  whether they won the lottery. Lets returning players see whose kingdoms
+ *  were largest in past seasons. */
+export const TOP_BY_TILES_SNAPSHOT_COUNT = 50;
+
+/** Pure: returns the success probability for an Armageddon cast given a
+ *  precomputed magicMultiplier. Identical formula is rendered to the UI
+ *  (so the player sees their odds) and rolled on the server (so the
+ *  server is the source of truth). */
+export function computeArmageddonSuccessChanceFromMultiplier(
+  magicMultiplierValue: number
+): number {
+  const raw = BASE_SUCCESS * magicMultiplierValue;
+  return Math.min(SUCCESS_HARD_CAP, raw);
+}
+
+/** Weighted ticket count for a single player at lottery draw time. */
+export function computeLotteryTickets(
+  tilesHeld: number,
+  sealsBroken: number
+): number {
+  if (tilesHeld <= 0) return 0;
+  return tilesHeld * (1 + Math.max(0, sealsBroken));
+}

--- a/lib/game/content/castes.ts
+++ b/lib/game/content/castes.ts
@@ -36,6 +36,9 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       siege: 0.85,
       disarm: 1.30,
       attrition: 0.85,
+      // Armageddon is caste-agnostic — success rolls off magic-tile count,
+      // not caste affinity — so every caste reads 1.0 here.
+      armageddon: 1.0,
     },
     supplyMultiplier: 1.25,
     lore:
@@ -53,6 +56,7 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       siege: 0.85,
       disarm: 1.10,
       attrition: 1.05,
+      armageddon: 1.0,
     },
     supplyMultiplier: 0.75,
     lore:
@@ -70,6 +74,7 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       siege: 1.00,
       disarm: 0.95,
       attrition: 1.30,
+      armageddon: 1.0,
     },
     supplyMultiplier: 0.5,
     lore:
@@ -87,6 +92,7 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       siege: 1.30,
       disarm: 0.85,
       attrition: 1.00,
+      armageddon: 1.0,
     },
     supplyMultiplier: 1.0,
     lore:
@@ -104,6 +110,7 @@ export const CASTE_PROFILES: Record<Caste, CasteProfile> = {
       siege: 1.00,
       disarm: 1.10,
       attrition: 0.85,
+      armageddon: 1.0,
     },
     supplyMultiplier: 1.5,
     lore:

--- a/lib/game/content/index.ts
+++ b/lib/game/content/index.ts
@@ -71,6 +71,8 @@ import { WHITE_SIEGE_SPELLS } from "./spells/white/siege";
 import { WHITE_DISARM_SPELLS } from "./spells/white/disarm";
 import { WHITE_ATTRITION_SPELLS } from "./spells/white/attrition";
 
+import { ARMAGEDDON_SPELLS } from "./spells/armageddon";
+
 import { BUILDINGS } from "./buildings";
 import { ALL_UPGRADES } from "./upgrades";
 
@@ -100,6 +102,9 @@ export const ALL_SPELLS: SpellDefinition[] = [
   ...GREEN_DEFENSE_SPELLS, ...GREEN_OFFENSE_SPELLS, ...GREEN_PRODUCTION_SPELLS,
   ...GREEN_INTEL_SPELLS,
   ...GREEN_SIEGE_SPELLS, ...GREEN_DISARM_SPELLS, ...GREEN_ATTRITION_SPELLS,
+  // End-game: caste-agnostic Armageddon spell. Routed through its own
+  // server entrypoint; included here so the spell catalog UI surfaces it.
+  ...ARMAGEDDON_SPELLS,
 ];
 
 export const ALL_BUILDINGS: BuildingDefinition[] = BUILDINGS;

--- a/lib/game/content/spells/armageddon.ts
+++ b/lib/game/content/spells/armageddon.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * The single caste-agnostic Armageddon spell. Listed in ALL_SPELLS so it
+ * appears in the player's spell browser, but routed through its own
+ * server entry-point (castArmageddonServer) — NOT castSpellServer — so
+ * it doesn't inherit caste-match / adjacency validation.
+ *
+ * Tuning lives in lib/game/content/armageddon.ts (gate, turn cost, success
+ * formula). This file only carries the catalog row.
+ */
+
+import type { SpellDefinition } from "../../types";
+import {
+  ARMAGEDDON_TILE_GATE,
+  ARMAGEDDON_TURN_COST,
+} from "../armageddon";
+
+export const ARMAGEDDON_SPELL_ID = "armageddon";
+
+export const ARMAGEDDON_SPELL: SpellDefinition = {
+  id: ARMAGEDDON_SPELL_ID,
+  caste: "neutral",
+  type: "armageddon",
+  name: "Armageddon",
+  // baseStrength is ignored — Armageddon is binary (succeeds → 1 seal
+  // breaks; fails → nothing happens). Success probability is derived from
+  // magicMultiplier in computeArmageddonSuccessChance, not baseStrength.
+  baseStrength: 0,
+  description:
+    "Strike the heavens. Risk 100 turns to break one of the seven Seals. " +
+    "Low base chance — only a heavily magic-optimized kingdom approaches the cap. " +
+    "When the seventh Seal breaks, the world ends and is remade.",
+  tier: 5,
+  minTilesRequired: ARMAGEDDON_TILE_GATE,
+  turnCost: ARMAGEDDON_TURN_COST,
+  lore:
+    "Whoever sets the seventh Seal upon the altar names the age of the next world. " +
+    "The risk is the point: cheap rituals are heard by no god worth hearing.",
+};
+
+/** Convenience list to mirror the other spell-content exports' shape. */
+export const ARMAGEDDON_SPELLS: SpellDefinition[] = [ARMAGEDDON_SPELL];

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -15,12 +15,19 @@ import {
   baseUnitsTarget,
   computeTileCapacity,
   distributeUnitKills,
+  magicMultiplier,
   makeSeededRng,
   realizedSpellMagnitude,
   resolveAttack,
   rollSpellEffectiveness,
 } from "./combat";
 import { ARTIFACTS_BY_ID, SPELLS_BY_ID } from "./content";
+import {
+  ARMAGEDDON_TILE_GATE,
+  ARMAGEDDON_TURN_COST,
+  SEAL_COUNT,
+  computeArmageddonSuccessChanceFromMultiplier,
+} from "./content/armageddon";
 import { rollArtifact } from "./artifacts";
 import { logCommunityEventInTx } from "./community";
 import { buildIntelReportServer } from "./intel";
@@ -71,6 +78,7 @@ import {
 import {
   SIEGE_ACTION_MAGNITUDE,
   SIEGE_DEBUFF_MAX_MAGNITUDE,
+  type ArmageddonEventRecord,
   type ArtifactDefinition,
   type Caste,
   type CombatResult,
@@ -78,9 +86,11 @@ import {
   type GameAttack,
   type GamePlayer,
   type GameTile,
+  type GameWorldMeta,
   type IntelReport,
   type LandType,
   type MapTile,
+  type SealRecord,
   type TurnAction,
   type TurnReport,
   type UnitStack,
@@ -306,6 +316,33 @@ export class GameNoEnemyKingdomsError extends Error {
   }
 }
 
+export class GameArmageddonInProgressError extends Error {
+  constructor() {
+    super(
+      "Armageddon is upon us. The world is being remade — turn-spending actions are temporarily refused."
+    );
+    this.name = "GameArmageddonInProgressError";
+  }
+}
+
+export class GameStaleSeasonError extends Error {
+  constructor(playerSeason: number, worldSeason: number) {
+    super(
+      `Your record is from season ${playerSeason}, but the current season is ${worldSeason}. Claim your fresh spawn to continue.`
+    );
+    this.name = "GameStaleSeasonError";
+  }
+}
+
+export class GameSealsExhaustedError extends Error {
+  constructor() {
+    super(
+      "All seven Seals have been broken — Armageddon is already underway."
+    );
+    this.name = "GameSealsExhaustedError";
+  }
+}
+
 const COLLECTIONS = {
   PLAYERS: "game_players",
   TILES: "game_tiles",
@@ -319,6 +356,10 @@ const COLLECTIONS = {
   // Community chat: free-form messages from authenticated players,
   // moderated by author or by an admin (delete-only).
   COMMUNITY_MESSAGES: "game_community_messages",
+  // End-game / Armageddon hall-of-fame: one doc per past Armageddon
+  // (doc id = seasonNumber). Persisted before the wipe so the record
+  // survives even if the resolver crashes mid-batch.
+  ARMAGEDDON_EVENTS: "game_armageddon_events",
 } as const;
 
 const WORLD_META_DOC = "singleton";
@@ -339,6 +380,69 @@ function adminDbOrThrow() {
   const db = getAdminDb();
   if (!db) throw new Error("Firebase Admin not initialized");
   return db;
+}
+
+// ── End-game / Armageddon helpers ─────────────────────────────────────
+// Coalesce a possibly-pre-Armageddon worldMeta doc to a full GameWorldMeta
+// with safe defaults. Pre-Armageddon docs (and freshly-bootstrapped envs)
+// don't have sealsBroken / armageddonState / seasonNumber set; treat
+// season as 1 and state as "active" so legacy reads behave correctly.
+function defaultedWorldMeta(raw: Partial<GameWorldMeta> | undefined): GameWorldMeta {
+  return {
+    playerCount: raw?.playerCount ?? 0,
+    seasonNumber: raw?.seasonNumber ?? 1,
+    sealsBroken: raw?.sealsBroken ?? 0,
+    seals: raw?.seals ?? [],
+    armageddonState: raw?.armageddonState ?? "active",
+    armageddonStartedAt: raw?.armageddonStartedAt,
+    armageddonResolvedAt: raw?.armageddonResolvedAt,
+    lastSpawnAt: raw?.lastSpawnAt,
+    updatedAt: raw?.updatedAt,
+  };
+}
+
+/** Refuses turn-spending actions while the world is being remade. Also
+ *  refuses stale player docs (left over from a prior season after a
+ *  partial wipe — should be rare since the resolver deletes them, but
+ *  defends against the edge case). Call this immediately after reading
+ *  both the player doc and the worldMeta singleton inside a transaction. */
+function assertGameActiveInTx(
+  player: GamePlayer,
+  worldMeta: GameWorldMeta
+): void {
+  if (worldMeta.armageddonState && worldMeta.armageddonState !== "active") {
+    throw new GameArmageddonInProgressError();
+  }
+  const playerSeason = player.seasonNumber ?? 1;
+  const worldSeason = worldMeta.seasonNumber ?? 1;
+  if (playerSeason !== worldSeason) {
+    throw new GameStaleSeasonError(playerSeason, worldSeason);
+  }
+}
+
+/** Reads the world-meta singleton inside a transaction and returns a
+ *  fully-defaulted GameWorldMeta. Mutators that need to update meta should
+ *  hold the underlying doc reference; this helper just sources values. */
+async function readWorldMetaInTx(
+  tx: Transaction,
+  db: Firestore
+): Promise<{ meta: GameWorldMeta; ref: FirebaseFirestore.DocumentReference }> {
+  const ref = db.collection(COLLECTIONS.WORLD_META).doc(WORLD_META_DOC);
+  const snap = await tx.get(ref);
+  const raw = snap.exists ? (snap.data() as Partial<GameWorldMeta>) : undefined;
+  return { meta: defaultedWorldMeta(raw), ref };
+}
+
+/** Read-only world-meta fetch for dashboard / hall-of-fame surfacing.
+ *  Returns the defaulted shape even when the doc doesn't exist yet. */
+export async function getWorldMetaServer(): Promise<GameWorldMeta> {
+  const db = adminDbOrThrow();
+  const snap = await db
+    .collection(COLLECTIONS.WORLD_META)
+    .doc(WORLD_META_DOC)
+    .get();
+  const raw = snap.exists ? (snap.data() as Partial<GameWorldMeta>) : undefined;
+  return defaultedWorldMeta(raw);
 }
 
 // Rolls (3% chance) for an artifact and stages a tx.set() to persist it if
@@ -2098,7 +2202,10 @@ export async function castIntelSpellServer(
     source: "spell",
     sourceId: spell.id,
     capturedAtTurn: txResult.turnsSpentTotal,
-    attackerCaste: spell.caste,
+    // spell.caste is widened to Caste | "neutral" for Armageddon, but intel
+    // spells are caste-bound (validated inside the tx). Read the validated
+    // caste off the returned player so the type narrows to a real Caste.
+    attackerCaste: txResult.player.caste as Caste,
   });
 
   // Black & Green spies are detected by the defender; the alert is now
@@ -5253,4 +5360,206 @@ export async function removeUpgradeServer(args: {
       },
     };
   });
+}
+
+// =====================================================================
+// End-game / Armageddon
+// =====================================================================
+
+/**
+ * Casts the universal end-game Armageddon spell. Costs ARMAGEDDON_TURN_COST
+ * turns regardless of outcome (the spell is a deliberate gamble). On a
+ * successful roll, breaks one of the 7 global Seals; when the 7th breaks,
+ * the worldMeta state flips to "resolving" and the caller should fire the
+ * resolveArmageddon orchestrator outside this transaction.
+ *
+ * Concurrency: two casts racing on seal #7 serialize on the worldMeta
+ * singleton — Firestore aborts and retries the loser, which then re-reads
+ * sealsBroken === SEAL_COUNT and short-circuits with GameSealsExhaustedError.
+ * The losing player's turns were already deducted by their own retry; this
+ * is by design — the spell is high-risk by construction.
+ */
+export async function castArmageddonServer(args: {
+  userId: string;
+  now?: Date;
+}): Promise<{
+  success: boolean;
+  successChance: number;
+  sealsBroken: number;       // after this cast
+  seasonNumber: number;
+  player: GamePlayer;
+  shouldTriggerResolve: boolean;
+}> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.userId);
+
+  // Pre-tx land-count read (mirrors castSpellServer). Magic-land count is
+  // the primary input to the success formula; a few ms of staleness is fine.
+  const landCounts = await getOwnedLandCounts(args.userId);
+
+  return db.runTransaction(async (tx) => {
+    const [playerSnap, worldMetaResult] = await Promise.all([
+      tx.get(playerRef),
+      readWorldMetaInTx(tx, db),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+    const worldMeta = worldMetaResult.meta;
+
+    assertGameActiveInTx(player, worldMeta);
+
+    if (player.phase !== "play") {
+      throw new GameInvalidPhaseError("play", player.phase);
+    }
+    if (player.caste === null) {
+      throw new GameInvalidPhaseError("play (caste required)", player.phase);
+    }
+    if (player.stats.tilesHeld < ARMAGEDDON_TILE_GATE) {
+      throw new GameInvalidSpellError(
+        `Armageddon requires ${ARMAGEDDON_TILE_GATE} tiles held; you have ${player.stats.tilesHeld}`
+      );
+    }
+    if (player.turnsRemaining < ARMAGEDDON_TURN_COST) {
+      throw new GameInsufficientTurnsError(
+        ARMAGEDDON_TURN_COST,
+        player.turnsRemaining
+      );
+    }
+    const sealsBrokenBefore = worldMeta.sealsBroken ?? 0;
+    if (sealsBrokenBefore >= SEAL_COUNT) {
+      throw new GameSealsExhaustedError();
+    }
+
+    // Success roll. Seed includes a fresh cast id so replays are independent
+    // and no two casts share a deterministic outcome.
+    const castId = randomUUID();
+    const rng = makeSeededRng(`armageddon-${castId}`);
+    const mm = magicMultiplier(
+      landCounts.magic,
+      player.activeUpgrades ?? {}
+    );
+    const successChance = computeArmageddonSuccessChanceFromMultiplier(mm);
+    const success = rng() < successChance;
+
+    // Turns + cast counter deduct regardless of success (high-risk gamble).
+    const turnsSpentTotal = player.turnsSpentTotal + ARMAGEDDON_TURN_COST;
+    const armageddonCastsAttempted =
+      (player.armageddonCastsAttempted ?? 0) + 1;
+    let armageddonSealsBroken = player.armageddonSealsBroken ?? 0;
+
+    const seasonNumber = worldMeta.seasonNumber ?? 1;
+    let sealsBrokenAfter = sealsBrokenBefore;
+    let shouldTriggerResolve = false;
+
+    if (success) {
+      const sealIndex = sealsBrokenBefore;
+      // Build the canonical 7-slot seals array, defaulting any missing
+      // entries to unbroken. The Armageddon flow always writes back a full
+      // length-7 array so readers don't need null-checks.
+      const seals: SealRecord[] = Array.from({ length: SEAL_COUNT }, (_, i) => {
+        const existing = worldMeta.seals?.[i];
+        if (existing) return existing;
+        return { index: i, broken: false };
+      });
+      seals[sealIndex] = {
+        index: sealIndex,
+        broken: true,
+        brokenBy: {
+          userId: player.userId,
+          displayName: player.displayName,
+          caste: player.caste,
+        },
+        brokenAt: now,
+      };
+      sealsBrokenAfter = sealsBrokenBefore + 1;
+      armageddonSealsBroken += 1;
+
+      const metaPatch: Partial<GameWorldMeta> = {
+        sealsBroken: sealsBrokenAfter,
+        seals,
+        seasonNumber, // re-stamp for backfill on legacy docs
+        updatedAt: now,
+      };
+      if (sealsBrokenAfter >= SEAL_COUNT) {
+        metaPatch.armageddonState = "resolving";
+        metaPatch.armageddonStartedAt = now;
+        shouldTriggerResolve = true;
+      }
+      tx.set(worldMetaResult.ref, metaPatch, { merge: true });
+
+      logCommunityEventInTx(
+        tx,
+        db,
+        {
+          kind: "seal_broken",
+          actorUserId: player.userId,
+          actorDisplayName: player.displayName,
+          actorCaste: player.caste,
+          sealIndex,
+          seasonNumber,
+        },
+        now
+      );
+      if (shouldTriggerResolve) {
+        logCommunityEventInTx(
+          tx,
+          db,
+          {
+            kind: "armageddon_started",
+            actorUserId: player.userId,
+            actorDisplayName: player.displayName,
+            actorCaste: player.caste,
+            seasonNumber,
+          },
+          now
+        );
+      }
+    }
+    // (Failure-event logging is skipped to keep the community feed signal-
+    // to-noise high; a failed cast is a private experience for the caster.)
+
+    tx.update(playerRef, {
+      turnsRemaining: player.turnsRemaining - ARMAGEDDON_TURN_COST,
+      turnsSpentTotal,
+      armageddonCastsAttempted,
+      armageddonSealsBroken,
+      seasonNumber, // backfill in case the doc predated the field
+      updatedAt: now,
+    });
+
+    const updatedPlayer: GamePlayer = {
+      ...player,
+      turnsRemaining: player.turnsRemaining - ARMAGEDDON_TURN_COST,
+      turnsSpentTotal,
+      armageddonCastsAttempted,
+      armageddonSealsBroken,
+      seasonNumber,
+      updatedAt: now,
+    };
+
+    return {
+      success,
+      successChance,
+      sealsBroken: sealsBrokenAfter,
+      seasonNumber,
+      player: updatedPlayer,
+      shouldTriggerResolve,
+    };
+  });
+}
+
+/** Lists the most-recent N past Armageddons (hall-of-fame). Doc ID is the
+ *  season number, so ordering by ID descending is the canonical order.
+ *  No composite index required. */
+export async function listArmageddonHistoryServer(
+  limit: number = 50
+): Promise<ArmageddonEventRecord[]> {
+  const db = adminDbOrThrow();
+  const snap = await db
+    .collection(COLLECTIONS.ARMAGEDDON_EVENTS)
+    .orderBy("seasonNumber", "desc")
+    .limit(Math.max(1, Math.min(200, limit)))
+    .get();
+  return snap.docs.map((d) => d.data() as ArmageddonEventRecord);
 }

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -29,7 +29,13 @@ export type SpellType =
   //                  proportionally to current composition.
   | "siege"
   | "disarm"
-  | "attrition";
+  | "attrition"
+  // End-game tier. Caste-agnostic, single global spell. Cast via
+  // castArmageddonServer (not castSpellServer); success rolls against a
+  // success-chance derived from the caster's magic-optimization, and on
+  // success breaks one of the 7 global Seals. When the 7th breaks, the
+  // game enters resolution and resets. See lib/game/content/armageddon.ts.
+  | "armageddon";
 
 // Reveal scope for intel-type artifacts and spells. Used by both
 // SpellDefinition.intelScope and ArtifactDefinition.intelDepth (the latter
@@ -68,7 +74,10 @@ export type SpellTier = 1 | 2 | 3 | 4 | 5;
 
 export interface SpellDefinition {
   id: string;
-  caste: Caste;
+  // "neutral" is reserved for caste-agnostic spells (currently: Armageddon).
+  // Caste-bound casting flows must check `spell.caste === player.caste`; the
+  // Armageddon spell bypasses that check via its dedicated server entrypoint.
+  caste: Caste | "neutral";
   type: SpellType;
   name: string;
   // Flat power applied to attacker (offense) or defender (defense) combat totals,
@@ -224,6 +233,14 @@ export interface GamePlayer {
   // to {} via getActiveUpgrades(player) before use.
   activeUpgrades?: Record<string, string>;
   stats: PlayerStats;
+  // ── End-game / Armageddon (optional for backward-compat with existing docs;
+  // readers treat undefined as 0 / season 1). All three reset to zero when
+  // the player respawns post-Armageddon. seasonNumber is stamped at spawn
+  // time and checked against worldMeta.seasonNumber on every turn-spending
+  // action so a stale doc from a prior season can't act in the new one.
+  armageddonSealsBroken?: number;
+  armageddonCastsAttempted?: number;
+  seasonNumber?: number;
   createdAt: Timestamp | Date;
   updatedAt: Timestamp | Date;
 }
@@ -673,7 +690,15 @@ export type CommunityEventKind =
   | "caste_pick"
   | "caste_change"
   | "attack"
-  | "milestone_1k_tiles";
+  | "milestone_1k_tiles"
+  // End-game / Armageddon lifecycle events. All denormalized at write-time
+  // (actor name + caste captured into the event row) so the feed survives
+  // the post-Armageddon player-doc wipe.
+  | "seal_broken"
+  | "armageddon_started"
+  | "armageddon_completed"
+  | "armageddon_winner"
+  | "armageddon_cast_failed";
 
 /** Single entry in the `game_community_events` log. Denormalized so the
  *  feed renderer never needs to join against game_players. */
@@ -693,6 +718,110 @@ export interface CommunityEvent {
   // Caste-change-specific fields
   fromCaste?: Caste;
   toCaste?: Caste;
+  // Armageddon-specific fields
+  sealIndex?: number;            // seal_broken: which of the 7 (0..6)
+  seasonNumber?: number;         // armageddon_started / completed / winner
+  winnerRank?: number;           // armageddon_winner: 1..10
+  tilesHeld?: number;            // armageddon_winner: tile count at draw
+  sealsBroken?: number;          // armageddon_winner: personal seals broken
+  tickets?: number;              // armageddon_winner: weighted ticket count
+}
+
+// =====================================================================
+// End-game / Armageddon
+// =====================================================================
+
+/** State of the global game-world singleton (`game_world_meta/singleton`).
+ *  All fields except `playerCount` are introduced by the Armageddon end-game.
+ *  Fields are optional so existing docs (which predate Armageddon) parse —
+ *  readers coalesce to safe defaults (sealsBroken=0, armageddonState="active",
+ *  seasonNumber=1) when absent. */
+export interface GameWorldMeta {
+  /** Lifetime count of player spawns — drives the hex-spiral spawn index.
+   *  Not reset by Armageddon (otherwise post-reset spawn centers would
+   *  collide with pre-reset ghost tiles in the next world). */
+  playerCount: number;
+  /** Current season number, starting at 1. Incremented when an Armageddon
+   *  fully resolves. Every player doc carries the seasonNumber it was
+   *  spawned in; any mismatch on a turn-spending action errors out and
+   *  prompts the player to claim a fresh spawn. */
+  seasonNumber?: number;
+  /** 0..7. Increments each time a player successfully casts Armageddon
+   *  and breaks a Seal. At 7 the world enters resolution. */
+  sealsBroken?: number;
+  /** Per-seal audit. Length 7 always (or absent for pre-Armageddon docs).
+   *  Each entry records who broke it and when. */
+  seals?: SealRecord[];
+  /** Lifecycle gate. "active" → casts allowed; "resolving" → 7th seal just
+   *  broke, the wipe job is running, ALL turn-spending mutations refuse;
+   *  flipped back to "active" by the resolver after the new season is
+   *  staged. */
+  armageddonState?: "active" | "resolving";
+  /** Wall-clock instant the 7th seal broke. Used by the UI banner. */
+  armageddonStartedAt?: Timestamp | Date;
+  /** Wall-clock instant the most recent resolver bumped season + reset. */
+  armageddonResolvedAt?: Timestamp | Date;
+  lastSpawnAt?: Timestamp | Date;
+  updatedAt?: Timestamp | Date;
+}
+
+/** One of the 7 Seals. Unbroken seals have only `index` and `broken=false`.
+ *  Broken seals carry the casting player's identity (denormalized so the UI
+ *  doesn't need to join against the player doc — which may be wiped). */
+export interface SealRecord {
+  index: number;       // 0..6
+  broken: boolean;
+  brokenBy?: {
+    userId: string;
+    displayName: string;
+    caste: Caste;
+  };
+  brokenAt?: Timestamp | Date;
+}
+
+/** One ranked winner of an Armageddon lottery draw. */
+export interface ArmageddonWinner {
+  rank: number;             // 1..10
+  userId: string;
+  displayName: string;
+  caste: Caste;
+  tilesHeld: number;        // at moment of draw
+  sealsBroken: number;      // personally broken this season
+  tickets: number;          // weighted lottery tickets = tilesHeld × (1 + sealsBroken)
+}
+
+/** A single Armageddon's hall-of-fame record. One doc per past Armageddon
+ *  in `game_armageddon_events`, doc id = seasonNumber. Persisted before
+ *  the world wipe so the historical record survives even if the wipe
+ *  crashes mid-batch. */
+export interface ArmageddonEventRecord {
+  seasonNumber: number;
+  triggeredAt: Timestamp | Date;
+  /** Player who broke the 7th seal. */
+  triggeredBy: {
+    userId: string;
+    displayName: string;
+    caste: Caste;
+  };
+  /** Full audit trail of all 7 seals from this season. */
+  seals: SealRecord[];
+  /** Number of players with > 0 tickets at draw time. */
+  totalParticipants: number;
+  /** Sum of all tickets at draw time. */
+  totalTickets: number;
+  /** Top-10 weighted-draw winners, in rank order. May be < 10 if fewer
+   *  participants had tickets. */
+  winners: ArmageddonWinner[];
+  /** Snapshot of top-50-by-tilesHeld at draw time, for posterity. May
+   *  overlap with winners (the same player can appear in both). */
+  topByTilesSnapshot: Array<{
+    rank: number;       // 1..50
+    userId: string;
+    displayName: string;
+    caste: Caste;
+    tilesHeld: number;
+    sealsBroken: number;
+  }>;
 }
 
 /** Single message in the `game_community_messages` collection. */

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -45,6 +45,7 @@ Licensed GPL-3.0-only.
     /events/cursor-boston-pydata-2026/register
     /events/request
     /game
+    /game/armageddon
     /game/artifacts
     /game/attacks
     /game/help
@@ -114,7 +115,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (207 endpoints)
+## API (208 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -417,6 +418,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     POST   /api/summer-cohort/confirm-dev-env [Yes] — Admitted cohort participant confirms dev environment is set up (Node + Git + IDE)
     GET    /api/summer-cohort/intake-survey [Yes] — Get the current user's intake-survey response
     POST   /api/summer-cohort/intake-survey [Yes] — Submit (or re-submit) the intake survey
+    GET    /api/summer-cohort/my-score/{weekId} [Yes] — Return only the calling user's own AI-judge score for a vote-format week — other users' scores are never exposed by this endpoint
     GET    /api/summer-cohort/submissions/{weekId} — Public read of merged submissions on a vote-format week
     GET    /api/summer-cohort/votes — Aggregate vote counts for a vote-format week
     POST   /api/summer-cohort/votes [Yes] — Toggle the current user's vote for a submission


### PR DESCRIPTION
## Included PRs

- **#952** — feat(game): Armageddon end-game with 7 seals, weighted lottery, and hall of fame · @Ludwitt + Claude Opus 4.7 (1M context)

## Summary

Ships the end-game loop for /game.

- New universal **Armageddon** spell unlocks at 10,000 tiles. 100 turns per cast. Success chance derived from magic-multiplier (5% base → 50% cap).
- Each success breaks 1 of 7 global Seals. When the 7th breaks, the world wipes — weighted top-10 lottery (\`tickets = tilesHeld × (1 + sealsBroken)\`) writes a permanent hall-of-fame entry, then tiles/attacks/artifacts/intel-effects/player docs are batch-deleted and \`worldMeta.seasonNumber\` advances.
- New collection \`game_armageddon_events\` preserves every past season's seal audit + winners + top-by-tiles snapshot. Glory survives the wipe.

Verified locally: \`npx tsc --noEmit\` clean, \`npm run build\` clean, \`npm start\` runs.

## Test plan

- [ ] Click /game — SealsPanel renders 0/7
- [ ] Click /game/spells — Apocalypse panel is locked under 10k tiles
- [ ] Click /game/armageddon — empty hall-of-fame state
- [ ] End-to-end seal-break + wipe test (requires a test account at ≥10k tiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)