### PR TITLE
release(2026-05-16): /game/armageddon cast home + dashboard reorder

### DIFF
--- a/app/game/_components/dashboard/DashboardView.tsx
+++ b/app/game/_components/dashboard/DashboardView.tsx
@@ -179,6 +179,34 @@ export function DashboardView({ player, data }: DashboardViewProps) {
           topLeaders={data.topLeaders}
         />
 
+        <div className="mb-8">
+          <NavGrid phase={player.phase} />
+        </div>
+
+        <CommunityPanel user={data.user} isAdmin={isAdmin} />
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-6 mb-6">
+          <LandsCard counts={counts} />
+          <ArmyCard army={army} cap={unitCap} />
+          <ThreatCard threats={threats} shielded={shieldStatus.shielded} />
+          <ShieldCard shield={shieldStatus} />
+        </div>
+
+        {isAdmin && (
+          <div className="mb-8 pt-4 border-t border-dashed border-neutral-300 dark:border-neutral-700">
+            <p className="text-[11px] uppercase tracking-wide text-neutral-500 mb-2">
+              Admin
+            </p>
+            <button
+              onClick={handleAdminGrant}
+              className="px-4 py-2 border border-amber-400 text-amber-700 dark:text-amber-300 rounded-lg hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors text-sm"
+              title="Manual override. The Sunday cron is the primary mechanism."
+            >
+              Grant 100 turns (admin)
+            </button>
+          </div>
+        )}
+
         <div className="grid md:grid-cols-3 gap-6 mb-8">
           <div className="md:col-span-2 space-y-4">
             {player.phase === "play" && (
@@ -251,32 +279,6 @@ export function DashboardView({ player, data }: DashboardViewProps) {
         </div>
 
         <DashboardReports reports={recentReports} />
-
-        <CommunityPanel user={data.user} isAdmin={isAdmin} />
-
-        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-8 mb-6">
-          <LandsCard counts={counts} />
-          <ArmyCard army={army} cap={unitCap} />
-          <ThreatCard threats={threats} shielded={shieldStatus.shielded} />
-          <ShieldCard shield={shieldStatus} />
-        </div>
-
-        <NavGrid phase={player.phase} />
-
-        {isAdmin && (
-          <div className="mt-4 pt-4 border-t border-dashed border-neutral-300 dark:border-neutral-700">
-            <p className="text-[11px] uppercase tracking-wide text-neutral-500 mb-2">
-              Admin
-            </p>
-            <button
-              onClick={handleAdminGrant}
-              className="px-4 py-2 border border-amber-400 text-amber-700 dark:text-amber-300 rounded-lg hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors text-sm"
-              title="Manual override. The Sunday cron is the primary mechanism."
-            >
-              Grant 100 turns (admin)
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/app/game/_components/dashboard/NavGrid.tsx
+++ b/app/game/_components/dashboard/NavGrid.tsx
@@ -74,6 +74,7 @@ export function NavGrid({ phase }: NavGridProps) {
                 { href: "/game/upgrades", label: "Upgrades" },
                 { href: "/game/artifacts", label: "Artifacts" },
                 { href: "/game/attacks", label: "Attack log" },
+                { href: "/game/armageddon", label: "Armageddon" },
               ]
         }
       />

--- a/app/game/armageddon/_components/ApocalypsePanel.tsx
+++ b/app/game/armageddon/_components/ApocalypsePanel.tsx
@@ -6,10 +6,9 @@
 
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { User } from "firebase/auth";
-import type { GamePlayer, MapTile } from "@/lib/game/types";
+import type { GamePlayer } from "@/lib/game/types";
 import { magicMultiplier } from "@/lib/game/combat";
 import {
   ARMAGEDDON_TILE_GATE,
@@ -21,12 +20,15 @@ import {
 interface ApocalypsePanelProps {
   user: User;
   player: GamePlayer;
-  tiles: MapTile[];
+  /** Count of magic-typed tiles the player owns. Parent derives from its
+   *  own tile list and passes in — keeps this panel from importing MapTile
+   *  and lets the parent cache / override the value. */
+  magicLandCount: number;
   // Optional global counter so the panel can display "M / 7 seals broken"
   // without an extra fetch. Pass null when unknown.
   sealsBroken: number | null;
-  /** Refresh the dashboard-level player + worldMeta after a successful cast.
-   *  Called regardless of cast outcome (turns deducted either way). */
+  /** Called regardless of cast outcome (turns deducted either way). Use to
+   *  refresh parent state after the API returns. */
   onAfterCast?: () => void;
 }
 
@@ -38,24 +40,21 @@ interface LastCast {
 }
 
 /**
- * Top-of-page panel on /game/spells that surfaces the universal Armageddon
- * spell. Locked under ARMAGEDDON_TILE_GATE tiles. When unlocked, shows the
- * live success chance (derived from magic-land count + magic-multiplier
- * upgrades) and a destructive cast button. Outcome flash is rendered in-
- * place so the player doesn't lose context after rolling.
+ * Top-of-page panel on /game/armageddon that surfaces the universal
+ * Armageddon spell. Locked under ARMAGEDDON_TILE_GATE tiles. When
+ * unlocked, shows the live success chance (derived from magic-land
+ * count + magic-multiplier upgrades) and a destructive cast button.
+ * Outcome flash renders in-place so the player doesn't lose context
+ * after rolling.
  */
 export function ApocalypsePanel({
   user,
   player,
-  tiles,
+  magicLandCount,
   sealsBroken,
   onAfterCast,
 }: ApocalypsePanelProps) {
   const tilesHeld = player.stats?.tilesHeld ?? 0;
-  const magicLandCount = useMemo(
-    () => tiles.filter((t) => t.ownerId === player.userId && t.type === "magic").length,
-    [tiles, player.userId]
-  );
   const successChance = useMemo(() => {
     const mm = magicMultiplier(magicLandCount, player.activeUpgrades ?? {});
     return computeArmageddonSuccessChanceFromMultiplier(mm);
@@ -115,19 +114,11 @@ export function ApocalypsePanel({
           : "border-neutral-300 dark:border-neutral-800 bg-neutral-100/50 dark:bg-neutral-900/30 text-neutral-700 dark:text-neutral-300")
       }
     >
-      <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2">
-        <div>
-          <div className="text-xs uppercase tracking-widest opacity-70">
-            Apocalypse
-          </div>
-          <h2 className="text-2xl font-bold mt-1">Armageddon</h2>
+      <div className="mb-2">
+        <div className="text-xs uppercase tracking-widest opacity-70">
+          Apocalypse
         </div>
-        <Link
-          href="/game/armageddon"
-          className="text-xs underline opacity-80 hover:opacity-100"
-        >
-          Hall of fame →
-        </Link>
+        <h2 className="text-2xl font-bold mt-1">Armageddon</h2>
       </div>
 
       <p className="text-sm leading-relaxed mb-4 opacity-90">

--- a/app/game/armageddon/page.tsx
+++ b/app/game/armageddon/page.tsx
@@ -7,15 +7,34 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import type { ArmageddonEventRecord, SealRecord } from "@/lib/game/types";
+import type {
+  ArmageddonEventRecord,
+  GamePlayer,
+  GameWorldMeta,
+  MapTile,
+  SealRecord,
+} from "@/lib/game/types";
 import { SEAL_COUNT } from "@/lib/game/content/armageddon";
+import { ApocalypsePanel } from "./_components/ApocalypsePanel";
 
 interface HistoryResponse {
   success: boolean;
   history?: ArmageddonEventRecord[];
   error?: string;
+}
+
+interface PlayerResponse {
+  success: boolean;
+  player?: GamePlayer | null;
+  tiles?: MapTile[];
+  error?: string;
+}
+
+interface WorldMetaResponse {
+  success: boolean;
+  worldMeta?: GameWorldMeta;
 }
 
 function formatAbsolute(value: SealRecord["brokenAt"]): string {
@@ -35,13 +54,26 @@ function formatAbsolute(value: SealRecord["brokenAt"]): string {
  * snapshot. The on-disk record persists across the world wipe — this page
  * is the only place glory survives a season reset.
  */
-export default function ArmageddonHistoryPage() {
+export default function ArmageddonPage() {
   const { user, loading: authLoading } = useAuth();
   const [history, setHistory] = useState<ArmageddonEventRecord[]>([]);
+  const [player, setPlayer] = useState<GamePlayer | null>(null);
+  const [tiles, setTiles] = useState<MapTile[]>([]);
+  const [worldMeta, setWorldMeta] = useState<GameWorldMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchHistory = useCallback(async () => {
+  // Magic-tile count drives the displayed success chance + the server's
+  // success roll (formula matches castArmageddonServer). Derive once from
+  // the fetched tile list.
+  const magicLandCount = useMemo(() => {
+    if (!player) return 0;
+    return tiles.filter(
+      (t) => t.ownerId === player.userId && t.type === "magic"
+    ).length;
+  }, [tiles, player]);
+
+  const refresh = useCallback(async () => {
     if (!user) {
       setLoading(false);
       return;
@@ -50,12 +82,33 @@ export default function ArmageddonHistoryPage() {
     setLoading(true);
     try {
       const token = await user.getIdToken();
-      const res = await fetch("/api/game/armageddon", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = (await res.json()) as HistoryResponse;
-      if (!data.success) throw new Error(data.error ?? "Failed to load");
-      setHistory(data.history ?? []);
+      const [historyRes, playerRes, metaRes] = await Promise.all([
+        fetch("/api/game/armageddon", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch("/api/game/player", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch("/api/game/world-meta", {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+      const historyData = (await historyRes.json()) as HistoryResponse;
+      if (!historyData.success) {
+        throw new Error(historyData.error ?? "Failed to load history");
+      }
+      setHistory(historyData.history ?? []);
+
+      const playerData = (await playerRes.json()) as PlayerResponse;
+      if (playerData.success) {
+        setPlayer(playerData.player ?? null);
+        setTiles(playerData.tiles ?? []);
+      }
+
+      const metaData = (await metaRes.json()) as WorldMetaResponse;
+      if (metaData.success && metaData.worldMeta) {
+        setWorldMeta(metaData.worldMeta);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -66,13 +119,13 @@ export default function ArmageddonHistoryPage() {
   useEffect(() => {
     if (authLoading) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
-    void fetchHistory();
-  }, [authLoading, fetchHistory]);
+    void refresh();
+  }, [authLoading, refresh]);
 
   if (authLoading || loading) {
     return (
       <div className="min-h-screen flex items-center justify-center py-12 px-6">
-        <p className="text-sm text-neutral-500">Loading hall of fame…</p>
+        <p className="text-sm text-neutral-500">Loading Armageddon…</p>
       </div>
     );
   }
@@ -80,7 +133,7 @@ export default function ArmageddonHistoryPage() {
   if (!user) {
     return (
       <div className="min-h-screen py-12 px-6 max-w-3xl mx-auto">
-        <h1 className="text-2xl font-bold">Sign in to view the hall of fame.</h1>
+        <h1 className="text-2xl font-bold">Sign in to view Armageddon.</h1>
       </div>
     );
   }
@@ -89,7 +142,7 @@ export default function ArmageddonHistoryPage() {
     <div className="min-h-screen py-12 px-6">
       <div className="max-w-5xl mx-auto">
         <div className="flex items-baseline justify-between mb-6">
-          <h1 className="text-3xl font-bold">Hall of Fame — Past Armageddons</h1>
+          <h1 className="text-3xl font-bold">Armageddon</h1>
           <Link
             href="/game"
             className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
@@ -101,6 +154,30 @@ export default function ArmageddonHistoryPage() {
         {error && (
           <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
+
+        {player && player.caste && player.phase === "play" ? (
+          <ApocalypsePanel
+            user={user}
+            player={player}
+            magicLandCount={magicLandCount}
+            sealsBroken={worldMeta?.sealsBroken ?? null}
+            onAfterCast={refresh}
+          />
+        ) : (
+          <div className="rounded-lg border border-neutral-300 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900 p-5 mb-6 text-sm text-neutral-700 dark:text-neutral-300">
+            <p className="mb-1">
+              <strong>Armageddon is the end-game.</strong> Reach 10,000 tiles in
+              the play phase to unlock the cast.
+            </p>
+            <p className="text-neutral-500 dark:text-neutral-400">
+              {player
+                ? "Finish onboarding (caste pick + first lands) to begin building toward the gate."
+                : "Create your general first — head back to the dashboard."}
+            </p>
+          </div>
+        )}
+
+        <h2 className="text-xl font-semibold mb-4 mt-8">Hall of Fame — Past Armageddons</h2>
 
         {history.length === 0 ? (
           <div className="rounded-lg border border-neutral-300 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900 p-6 text-sm text-neutral-700 dark:text-neutral-300">

--- a/app/game/spells/_components/SpellsView.tsx
+++ b/app/game/spells/_components/SpellsView.tsx
@@ -8,7 +8,6 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import type { User } from "firebase/auth";
 import { ALL_SPELLS } from "@/lib/game/content";
 import {
   computeTileThreat,
@@ -17,7 +16,6 @@ import {
 } from "@/lib/game/threat";
 import type {
   GamePlayer,
-  GameWorldMeta,
   MapTile,
   SpellDefinition,
 } from "@/lib/game/types";
@@ -25,19 +23,15 @@ import { TIERS } from "../_lib/constants";
 import type { OwnerSummary } from "../_lib/types";
 import type { SpellActions } from "../_lib/use-spell-actions";
 import { ActiveProductionList } from "./ActiveProductionList";
-import { ApocalypsePanel } from "./ApocalypsePanel";
 import { ArmedTilesList } from "./ArmedTilesList";
 import { ReportLog } from "./ReportLog";
 import { TierSection } from "./TierSection";
 
 interface Props {
-  user: User;
   player: GamePlayer;
   tiles: MapTile[];
   borderTiles: MapTile[];
   owners: Map<string, OwnerSummary>;
-  worldMeta: GameWorldMeta | null;
-  onAfterArmageddon: () => void;
   error: string | null;
   actions: SpellActions;
 }
@@ -48,13 +42,10 @@ interface Props {
  * (`spellByTierAndType`, `armableTiles`, `threatRanked`).
  */
 export function SpellsView({
-  user,
   player,
   tiles,
   borderTiles,
   owners,
-  worldMeta,
-  onAfterArmageddon,
   error,
   actions,
 }: Props) {
@@ -152,14 +143,6 @@ export function SpellsView({
         {error && (
           <p className="mb-4 text-sm text-red-600 dark:text-red-400">{error}</p>
         )}
-
-        <ApocalypsePanel
-          user={user}
-          player={player}
-          tiles={tiles}
-          sealsBroken={worldMeta?.sealsBroken ?? null}
-          onAfterCast={onAfterArmageddon}
-        />
 
         <div className="space-y-6 mb-10">
           {TIERS.map(({ tier, minTiles }) => (

--- a/app/game/spells/_lib/use-spells-data.ts
+++ b/app/game/spells/_lib/use-spells-data.ts
@@ -13,7 +13,7 @@ import {
   saveCachedMap,
   type CachedMapView,
 } from "@/lib/game/local-map-cache";
-import type { GamePlayer, GameWorldMeta, MapTile } from "@/lib/game/types";
+import type { GamePlayer, MapTile } from "@/lib/game/types";
 import type { MapMeResponse, OwnerSummary, PlayerResponse } from "./types";
 
 /**
@@ -32,9 +32,6 @@ export function useSpellsData() {
   // handlers across the game pages.
   const [borderTiles, setBorderTiles] = useState<MapTile[]>([]);
   const [owners, setOwners] = useState<Map<string, OwnerSummary>>(new Map());
-  // Global game-world singleton (seal count + season + state). Used by
-  // the Apocalypse panel for the "M / 7 seals" display.
-  const [worldMeta, setWorldMeta] = useState<GameWorldMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,15 +46,10 @@ export function useSpellsData() {
     setError(null);
     try {
       const token = await user.getIdToken();
-      const [playerRes, metaRes] = await Promise.all([
-        fetch("/api/game/player", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-        fetch("/api/game/world-meta", {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-      ]);
-      const data = (await playerRes.json()) as PlayerResponse;
+      const res = await fetch("/api/game/player", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = (await res.json()) as PlayerResponse;
       if (!data.success) {
         const msg =
           typeof data.error === "string"
@@ -67,13 +59,6 @@ export function useSpellsData() {
       }
       setPlayer(data.player);
       setTiles(data.tiles ?? []);
-      const metaData = (await metaRes.json()) as {
-        success: boolean;
-        worldMeta?: GameWorldMeta;
-      };
-      if (metaData.success && metaData.worldMeta) {
-        setWorldMeta(metaData.worldMeta);
-      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -130,8 +115,6 @@ export function useSpellsData() {
     setTiles,
     borderTiles,
     owners,
-    worldMeta,
-    refreshPlayer,
     loading,
     error,
     setError,

--- a/app/game/spells/page.tsx
+++ b/app/game/spells/page.tsx
@@ -27,8 +27,6 @@ export default function SpellsPage() {
     setTiles,
     borderTiles,
     owners,
-    worldMeta,
-    refreshPlayer,
     loading,
     error,
     setError,
@@ -43,13 +41,10 @@ export default function SpellsPage() {
 
   return (
     <SpellsView
-      user={user}
       player={player}
       tiles={tiles}
       borderTiles={borderTiles}
       owners={owners}
-      worldMeta={worldMeta}
-      onAfterArmageddon={refreshPlayer}
       error={error}
       actions={actions}
     />


### PR DESCRIPTION
## Included PRs

- **#956** — feat(game): /game/armageddon is the cast home + dashboard reorder · @Ludwitt + Claude Opus 4.7 (1M context)

## Summary

- Moves the Armageddon cast button from /game/spells to /game/armageddon (cast panel on top, hall-of-fame history below) so qualifying players have a discoverable home for the end-game.
- Adds **Armageddon** to the dashboard NavGrid (play phase only).
- Reorders the dashboard so high-signal blocks (Seals, NavGrid, Community, overview cards) sit above the detailed action widgets.

Verified locally: `npx tsc --noEmit` clean, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)