### PR TITLE
submission: Smokeybear10 c1w1pm — crew

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
@@ -1,8 +1,8 @@
 {
   "githubHandle": "Smokeybear10",
   "name": "Thomas Ou",
-  "repoUrl": "https://github.com/Smokeybear10/cursor-boston-w1pm-placeholder",
-  "liveUrl": "https://example.com",
-  "pitch": "Late entry — placeholder while I get the PM tool shipped.",
+  "repoUrl": "https://github.com/Smokeybear10/shipped",
+  "liveUrl": "https://shipped-neon.vercel.app",
+  "pitch": "shipped — a self-referential cohort dashboard that pulls submissions straight from this repo: per-week feed, leaderboard, and a randomized Friday voting view.",
   "competeForWin": false
 }

--- a/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
@@ -1,0 +1,8 @@
+{
+  "githubHandle": "Smokeybear10",
+  "name": "Thomas Ou",
+  "repoUrl": "https://github.com/Smokeybear10/cursor-boston-w1pm-placeholder",
+  "liveUrl": "https://example.com",
+  "pitch": "Late entry — placeholder while I get the PM tool shipped.",
+  "competeForWin": false
+}


### PR DESCRIPTION
Late entry, not competing for the win.

**Live:** https://c4ew.vercel.app
**Repo:** https://github.com/Smokeybear10/205-PROJ.crew

`crew` answers the cohort prompt by inverting it: instead of yet another task tracker, it shows you the *people* and how they actually work together — inferred from co-authored commits and PR reviews on any public GitHub repo.

- Paste any `org/repo` or full GitHub URL → contributor graph in ~3 seconds
- Paste just a username → grid of all that user's public repos
- Force-directed canvas with cluster detection (greedy modularity), avatars rendered inside top-20 nodes, curved gradient edges, drift filter (all-time / 1y / 90d / 30d)
- Auto-generated narrative summary on every repo: top contributor, bus factor, top collaborating pair, who's drifted
- Pre-baked demos on the landing page include the cohort repo itself: see `https://c4ew.vercel.app/g/rogerSuperBuilderAlpha/cursor-boston`

Stack: Next.js 16, React 19, Tailwind v4, react-force-graph-2d. Server-side GitHub REST with 15-min in-memory cache. Open source.

DCO signed.