### PR TITLE
release(2026-05-17): Resilient Coders ecosystem entry

### DIFF
--- a/content/ecosystem.json
+++ b/content/ecosystem.json
@@ -309,6 +309,16 @@
       "website": "https://www.flagshippioneering.com",
       "description": "Venture firm and platform that originates, founds, and scales companies at the frontier of life sciences and AI.",
       "tags": ["VC", "life sciences", "biotech"]
+    },
+    {
+      "id": "resilient-coders",
+      "name": "Resilient Coders",
+      "fullName": "Resilient Coders",
+      "category": "nonprofit",
+      "location": "Boston, MA",
+      "website": "https://www.resilientcoders.org",
+      "description": "Resilient Coders is a free and stipended coding bootcamp that trains underrepresented talent for software engineering careers.",
+      "tags": ["software engineering", "workforce development", "community"]
     }
   ]
 }


### PR DESCRIPTION
## What's in this release

One PR shipping develop → main since #965 (which went out earlier today):

- **#960** docs: add Resilient Coders ecosystem entry — @CodingWCal

## Verification

- `npm run build` ✓
- `npm start` + visited `/ecosystem` locally; Resilient Coders card renders alongside existing nonprofit entries.

Thanks @CodingWCal for the contribution!