### PR TITLE
fix(game): add firestore index for awaitingResurrection hero lookup

### DIFF
--- a/config/firebase/firestore.indexes.json
+++ b/config/firebase/firestore.indexes.json
@@ -384,6 +384,14 @@
       ]
     },
     {
+      "collectionGroup": "game_heroes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "awaitingResurrection", "order": "ASCENDING" },
+        { "fieldPath": "lastEventAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "events",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## What

Adds the missing composite index `awaitingResurrection:ASC + lastEventAt:DESC` on the `game_heroes` collection.

## Why

`loadFallenHeroes` in \`lib/game/heroes-server.ts\` runs two parallel queries to build the Hall of the Fallen list:

\`\`\`ts
collection.where("isDeceased", "==", true).orderBy("lastEventAt", "desc").get(),
collection.where("awaitingResurrection", "==", true).orderBy("lastEventAt", "desc").get(),
\`\`\`

Heroes v2 (#963) shipped the \`isDeceased + lastEventAt\` composite index but not the \`awaitingResurrection + lastEventAt\` one. Firestore requires a composite index whenever an equality filter is combined with an orderBy on a different field, so the limbo query throws \`FAILED_PRECONDITION\` → 500 on \`/api/game/heroes?scope=fallen\`.

Symptom: "Hall of the Fallen" tab on \`/game/armageddon\` shows "Internal server error".

## Deploy path

\`config/firebase/firestore.indexes.json\` is deployed automatically by \`.github/workflows/firestore-deploy.yml\` on push to \`main\` (per CLAUDE.md). Index build for a small collection is fast.