### PR TITLE
release(2026-05-17): fix Hall of the Fallen 500 (missing index)

### DIFF
--- a/config/firebase/firestore.indexes.json
+++ b/config/firebase/firestore.indexes.json
@@ -384,6 +384,14 @@
       ]
     },
     {
+      "collectionGroup": "game_heroes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "awaitingResurrection", "order": "ASCENDING" },
+        { "fieldPath": "lastEventAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "events",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## What's in this release

- **#967** fix(game): add firestore index for \`awaitingResurrection\` hero lookup — @Ludwitt

Fixes a production 500 on \`/api/game/heroes?scope=fallen\` (the "Hall of the Fallen" tab on \`/game/armageddon\`) caused by a missing composite index. Heroes v2 (#963) shipped the deceased index but not the limbo counterpart.

## Deploy

\`firestore.indexes.json\` deploys automatically via \`.github/workflows/firestore-deploy.yml\` when this hits \`main\` and the file changed.

## Verification

- Reviewed by [Claude]: JSON parses, index mirrors the existing \`isDeceased\` shape, no surrounding code changes.