### PR TITLE
promote: c1w1pm-submission → develop (Smokeybear10 late entry)

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
@@ -1,0 +1,8 @@
+{
+  "githubHandle": "Smokeybear10",
+  "name": "Thomas Ou",
+  "repoUrl": "https://github.com/Smokeybear10/shipped",
+  "liveUrl": "https://shipped-neon.vercel.app",
+  "pitch": "shipped — a self-referential cohort dashboard that pulls submissions straight from this repo: per-week feed, leaderboard, and a randomized Friday voting view.",
+  "competeForWin": false
+}


### PR DESCRIPTION
## Summary
Promotes the one outstanding contributor submission on \`c1w1pm-submission\` into \`develop\`:

- **#962** — submission: Smokeybear10 c1w1pm — @Smokeybear10 (Thomas Ou)
  - Live: https://shipped-neon.vercel.app
  - Repo: https://github.com/Smokeybear10/shipped
  - Late entry, \`competeForWin: false\`
  - File added: \`content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json\` (8 lines)

This is a content-only PR — single JSON file. No code changes.

## Test plan
- [ ] CI green
- [ ] Smokeybear10's card renders on the c1w1-pm cohort page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)