### PR TITLE
release: c1w1pm Smokeybear10 promote (#971)

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json
@@ -1,0 +1,8 @@
+{
+  "githubHandle": "Smokeybear10",
+  "name": "Thomas Ou",
+  "repoUrl": "https://github.com/Smokeybear10/shipped",
+  "liveUrl": "https://shipped-neon.vercel.app",
+  "pitch": "shipped — a self-referential cohort dashboard that pulls submissions straight from this repo: per-week feed, leaderboard, and a randomized Friday voting view.",
+  "competeForWin": false
+}


### PR DESCRIPTION
## Release contents

Single content-only promote from `c1w1pm-submission` since the last release:

- **#971** — promote: c1w1pm-submission → develop (Smokeybear10 late entry) — @rogerSuperBuilderAlpha
  - Wraps **#962** — submission: Smokeybear10 c1w1pm — @Smokeybear10 (Thomas Ou)

Single file: `content/summer-cohort/c1/w1-pm/submissions/Smokeybear10.json` (8 lines). No code changes.

## Test plan
- [x] Single content file, content-only diff
- [ ] Smokeybear10's card renders on the c1w1-pm cohort page after Vercel deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)