### PR TITLE
release: develop→main — zero-turn gameplay

### DIFF
--- a/__tests__/lib/game/turns.test.ts
+++ b/__tests__/lib/game/turns.test.ts
@@ -217,6 +217,37 @@ describe("shouldGrantWeeklyTurns + applyWeeklyGrant", () => {
     const granted = applyWeeklyGrant(flush, "2026-05-03");
     expect(granted.turnsRemaining).toBe(300 + WEEKLY_TURN_GRANT);
   });
+
+  // Zero-turn gameplay: prophecy stakes
+  it("applyWeeklyGrant consumes pendingProphecyBonus and zeros it", () => {
+    const withBonus: GamePlayer = {
+      ...p(),
+      turnsRemaining: 0,
+      pendingProphecyBonus: 5,
+    };
+    const granted = applyWeeklyGrant(withBonus, "2026-05-03");
+    expect(granted.turnsRemaining).toBe(WEEKLY_TURN_GRANT + 5);
+    expect(granted.pendingProphecyBonus).toBe(0);
+  });
+
+  it("applyWeeklyGrant caps pendingProphecyBonus at the max", () => {
+    const massive: GamePlayer = {
+      ...p(),
+      turnsRemaining: 0,
+      pendingProphecyBonus: 999, // multiple resolutions stacked
+    };
+    const granted = applyWeeklyGrant(massive, "2026-05-03");
+    // Cap = PROPHECY_BONUS_TURNS_MAX (5). Adds 5, zeros pending.
+    expect(granted.turnsRemaining).toBe(WEEKLY_TURN_GRANT + 5);
+    expect(granted.pendingProphecyBonus).toBe(0);
+  });
+
+  it("applyWeeklyGrant handles missing pendingProphecyBonus", () => {
+    const granted = applyWeeklyGrant(p(), "2026-05-03");
+    // newPlayer() starts at STARTING_TURN_GRANT (300); grant adds 100.
+    expect(granted.turnsRemaining).toBe(STARTING_TURN_GRANT + WEEKLY_TURN_GRANT);
+    expect(granted.pendingProphecyBonus).toBe(0);
+  });
 });
 
 describe("nextPhase", () => {

--- a/__tests__/lib/game/zero-turn.test.ts
+++ b/__tests__/lib/game/zero-turn.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  applyRedistributionLoss,
+  canDeclareLastStand,
+  canExitDefensiveStance,
+  computeZeroTurnDefenseBonus,
+  countMeditatingHeroes,
+  countRecentRedistributions,
+  defaultLossPerturbations,
+  hasActiveLastStand,
+  isHeroMeditating,
+  isTileInDefensiveStance,
+  lastStandCooldownRemainingMs,
+  maxDefensiveStanceTiles,
+  oathbreakerAttackPenalty,
+  redistributionsRemainingToday,
+  runAutopsy,
+} from "@/lib/game/zero-turn";
+import {
+  DEFENSIVE_STANCE_DEFENSE_BONUS,
+  LAST_STAND_ADJACENT_PENALTY,
+  LAST_STAND_COOLDOWN_MS,
+  LAST_STAND_DEFENSE_BONUS,
+  OATHBREAKER_ATTACK_PENALTY,
+  REDISTRIBUTE_MAX_PER_DAY,
+  REDISTRIBUTE_TRANSIT_LOSS,
+} from "@/lib/game/types";
+import type { GameHero, GamePlayer, GameTile } from "@/lib/game/types";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+const PAST = new Date("2026-06-01T10:00:00.000Z");
+const FUTURE = new Date("2026-06-02T12:00:00.000Z");
+
+function hero(overrides: Partial<GameHero> = {}): GameHero {
+  return {
+    id: "h1",
+    ownerId: "u1",
+    tileId: "q0r0",
+    class: "military",
+    specialty: "ground",
+    name: "Test",
+    caste: "white",
+    stamina: 100,
+    staminaMax: 100,
+    emergedAtTurn: 0,
+    lastEngagedAtTurn: 0,
+    ...overrides,
+  };
+}
+
+function player(overrides: Partial<GamePlayer> = {}): GamePlayer {
+  return {
+    userId: "u1",
+    displayName: "Test",
+    caste: "white",
+    turnsRemaining: 0,
+    turnsSpentTotal: 0,
+    phase: "play",
+    tilesExplored: 0,
+    shieldUntil: new Date(0),
+    shieldDropAtTurn: 0,
+    productionSpellsActive: [],
+    stats: { attacksWon: 0, attacksLost: 0, tilesHeld: 0, unitsAlive: 0 },
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+describe("isHeroMeditating", () => {
+  it("returns false when no meditatingUntil set", () => {
+    expect(isHeroMeditating(hero(), NOW)).toBe(false);
+  });
+  it("returns true when meditatingUntil > now", () => {
+    expect(isHeroMeditating(hero({ meditatingUntil: FUTURE }), NOW)).toBe(true);
+  });
+  it("returns false when meditatingUntil < now (expired)", () => {
+    expect(isHeroMeditating(hero({ meditatingUntil: PAST }), NOW)).toBe(false);
+  });
+  it("returns false when hero is null", () => {
+    expect(isHeroMeditating(null, NOW)).toBe(false);
+  });
+});
+
+describe("countMeditatingHeroes", () => {
+  it("counts only currently-meditating heroes", () => {
+    const tiles = [
+      { hero: hero({ meditatingUntil: FUTURE }) },
+      { hero: hero({ meditatingUntil: PAST }) },
+      { hero: hero() },
+      { hero: undefined },
+    ] as Pick<GameTile, "hero">[];
+    expect(countMeditatingHeroes(tiles, NOW)).toBe(1);
+  });
+});
+
+describe("oathbreakerAttackPenalty", () => {
+  it("returns 0 when no mark set", () => {
+    expect(oathbreakerAttackPenalty(player(), NOW)).toBe(0);
+  });
+  it("returns the penalty when mark is active", () => {
+    expect(
+      oathbreakerAttackPenalty(player({ oathbreakerUntil: FUTURE }), NOW)
+    ).toBe(OATHBREAKER_ATTACK_PENALTY);
+  });
+  it("returns 0 when mark has expired", () => {
+    expect(
+      oathbreakerAttackPenalty(player({ oathbreakerUntil: PAST }), NOW)
+    ).toBe(0);
+  });
+});
+
+describe("maxDefensiveStanceTiles", () => {
+  it("returns at least 1 even for small empires", () => {
+    expect(maxDefensiveStanceTiles(player())).toBe(1);
+  });
+  it("scales with empire size (floor(tilesHeld / 100))", () => {
+    expect(
+      maxDefensiveStanceTiles(
+        player({
+          stats: { attacksWon: 0, attacksLost: 0, tilesHeld: 250, unitsAlive: 0 },
+        })
+      )
+    ).toBe(2);
+    expect(
+      maxDefensiveStanceTiles(
+        player({
+          stats: {
+            attacksWon: 0,
+            attacksLost: 0,
+            tilesHeld: 10000,
+            unitsAlive: 0,
+          },
+        })
+      )
+    ).toBe(100);
+  });
+});
+
+describe("isTileInDefensiveStance", () => {
+  it("returns false when no stance set", () => {
+    expect(isTileInDefensiveStance({}, NOW)).toBe(false);
+  });
+  it("returns true when active and since <= now", () => {
+    expect(
+      isTileInDefensiveStance(
+        {
+          defensiveStance: { active: true, since: PAST, lockedUntil: FUTURE },
+        },
+        NOW
+      )
+    ).toBe(true);
+  });
+  it("returns false when active=false (toggled off)", () => {
+    expect(
+      isTileInDefensiveStance(
+        {
+          defensiveStance: { active: false, since: PAST, lockedUntil: PAST },
+        },
+        NOW
+      )
+    ).toBe(false);
+  });
+});
+
+describe("canExitDefensiveStance", () => {
+  it("allows exit when no stance", () => {
+    expect(canExitDefensiveStance({}, NOW)).toBe(true);
+  });
+  it("allows exit when lockedUntil < now", () => {
+    expect(
+      canExitDefensiveStance(
+        {
+          defensiveStance: { active: true, since: PAST, lockedUntil: PAST },
+        },
+        NOW
+      )
+    ).toBe(true);
+  });
+  it("blocks exit when lockedUntil > now", () => {
+    expect(
+      canExitDefensiveStance(
+        {
+          defensiveStance: { active: true, since: PAST, lockedUntil: FUTURE },
+        },
+        NOW
+      )
+    ).toBe(false);
+  });
+});
+
+describe("hasActiveLastStand", () => {
+  it("returns false with no last stand", () => {
+    expect(hasActiveLastStand({}, NOW)).toBe(false);
+  });
+  it("returns true when expires > now", () => {
+    expect(
+      hasActiveLastStand(
+        { activeLastStand: { declaredAt: PAST, expiresAt: FUTURE } },
+        NOW
+      )
+    ).toBe(true);
+  });
+  it("returns false when expired", () => {
+    expect(
+      hasActiveLastStand(
+        { activeLastStand: { declaredAt: PAST, expiresAt: PAST } },
+        NOW
+      )
+    ).toBe(false);
+  });
+});
+
+describe("canDeclareLastStand + cooldown", () => {
+  it("allows when never used", () => {
+    expect(canDeclareLastStand(player(), NOW)).toBe(true);
+    expect(lastStandCooldownRemainingMs(player(), NOW)).toBe(0);
+  });
+  it("blocks within cooldown", () => {
+    const used = new Date(NOW.getTime() - 1 * 60 * 60 * 1000); // 1h ago
+    expect(canDeclareLastStand(player({ lastStandUsedAt: used }), NOW)).toBe(false);
+    const remaining = lastStandCooldownRemainingMs(
+      player({ lastStandUsedAt: used }),
+      NOW
+    );
+    expect(remaining).toBeGreaterThan(0);
+    expect(remaining).toBeLessThanOrEqual(LAST_STAND_COOLDOWN_MS);
+  });
+  it("allows past cooldown", () => {
+    const used = new Date(NOW.getTime() - LAST_STAND_COOLDOWN_MS - 1000);
+    expect(canDeclareLastStand(player({ lastStandUsedAt: used }), NOW)).toBe(true);
+  });
+});
+
+describe("computeZeroTurnDefenseBonus", () => {
+  it("returns 0 with no effects", () => {
+    expect(computeZeroTurnDefenseBonus({ tile: {}, now: NOW })).toBe(0);
+  });
+  it("stacks stance + last stand", () => {
+    const bonus = computeZeroTurnDefenseBonus({
+      tile: {
+        defensiveStance: { active: true, since: PAST, lockedUntil: FUTURE },
+        activeLastStand: { declaredAt: PAST, expiresAt: FUTURE },
+      },
+      now: NOW,
+    });
+    expect(bonus).toBeCloseTo(
+      DEFENSIVE_STANCE_DEFENSE_BONUS + LAST_STAND_DEFENSE_BONUS,
+      10
+    );
+  });
+  it("applies adjacent-rally penalty", () => {
+    const bonus = computeZeroTurnDefenseBonus({
+      tile: {},
+      adjacentRallyPenaltyActive: true,
+      now: NOW,
+    });
+    expect(bonus).toBe(-LAST_STAND_ADJACENT_PENALTY);
+  });
+});
+
+describe("applyRedistributionLoss", () => {
+  it("trims each unit type by REDISTRIBUTE_TRANSIT_LOSS", () => {
+    const moved = applyRedistributionLoss({ ground: 100, siege: 50, air: 0 });
+    expect(moved.ground).toBe(Math.floor(100 * (1 - REDISTRIBUTE_TRANSIT_LOSS)));
+    expect(moved.siege).toBe(Math.floor(50 * (1 - REDISTRIBUTE_TRANSIT_LOSS)));
+    expect(moved.air).toBe(0);
+  });
+});
+
+describe("countRecentRedistributions + remainingToday", () => {
+  it("counts only entries within the last 24h", () => {
+    const recent = [
+      new Date(NOW.getTime() - 1 * 60 * 60 * 1000), // 1h ago
+      new Date(NOW.getTime() - 23 * 60 * 60 * 1000), // 23h ago
+      new Date(NOW.getTime() - 25 * 60 * 60 * 1000), // 25h ago (outside window)
+    ];
+    expect(countRecentRedistributions(recent, NOW)).toBe(2);
+  });
+  it("remainingToday = max - count", () => {
+    const recent = [new Date(NOW.getTime() - 1 * 60 * 60 * 1000)];
+    expect(redistributionsRemainingToday(recent, NOW)).toBe(
+      REDISTRIBUTE_MAX_PER_DAY - 1
+    );
+  });
+});
+
+describe("runAutopsy", () => {
+  it("calls the resolver for each perturbation with the SAME seed", () => {
+    const seeds: string[] = [];
+    const resolveAttackFn = jest.fn(() => ({
+      outcome: "captured" as const,
+      // Minimal CombatResult fields needed by the autopsy summarizer.
+      unitsDeployed: { ground: 0, siege: 0, air: 0 },
+      unitsClampedFromCapacity: 0,
+      attackPower: 0,
+      defensePower: 0,
+      attackerLosses: { ground: 0, siege: 0, air: 0 },
+      defenderLosses: { ground: 0, siege: 0, air: 0 },
+      underdogApplied: false,
+      supplyMultiplier: 1,
+      sourceLandTypeMultiplier: 1,
+      targetLandTypeMultiplier: 1,
+      standingDefenseAdded: 0,
+      magicTileOffenseSpellBonusApplied: false,
+      magicTileDefenseSpellBonusApplied: false,
+      siegeDebuffApplied: 0,
+      defenseDisarmApplied: 0,
+      preCastOffenseApplied: 0,
+      rng: { attackerRoll: 0.5, defenderRoll: 0.5 },
+      appliedSpells: { offenseId: null, defenseId: null },
+      finalAttack: 0,
+      finalDefense: 0,
+      defenderUnitsPreAttack: { ground: 0, siege: 0, air: 0 },
+      defenderBasePreAttack: { ground: 0, siege: 0, air: 0 },
+      decisiveness: 0,
+      lossCurveTag: "decisive-capture" as const,
+      captureBaseRetentionFactor: 1,
+    }));
+    const rngFactory = jest.fn((seed: string) => {
+      seeds.push(seed);
+      return () => 0.5;
+    });
+    const outcomes = runAutopsy({
+      attacker: {
+        caste: "white",
+        units: { ground: 100, siege: 0, air: 0 },
+        offenseSpellId: null,
+        magicLandCount: 0,
+        unitsAlive: 100,
+      },
+      defender: {
+        caste: "red",
+        unitsOnTile: { ground: 50, siege: 0, air: 0 },
+        armedDefenseSpellId: null,
+        magicLandCount: 0,
+        unitsAlive: 50,
+      },
+      tile: { capacity: 100, upgradeIds: [] },
+      rngSeed: "attack-1",
+      originalOutcome: "repelled",
+      perturbations: [
+        { label: "+25 ground", unitsDelta: { ground: 25 } },
+        { label: "+50 siege", unitsDelta: { siege: 50 } },
+      ],
+      resolveAttackFn,
+      rngFactory,
+    });
+    expect(outcomes).toHaveLength(2);
+    expect(seeds).toEqual(["attack-1", "attack-1"]);
+    expect(outcomes[0].outcomeFlipped).toBe(true);
+    expect(outcomes[0].summary).toContain("flipped");
+  });
+});
+
+describe("defaultLossPerturbations", () => {
+  it("emits one perturbation per unit type", () => {
+    const perts = defaultLossPerturbations({ ground: 100, siege: 60, air: 40 });
+    expect(perts).toHaveLength(3);
+    expect(perts[0].unitsDelta).toEqual({ ground: 25 });
+    expect(perts[1].unitsDelta).toEqual({ siege: 25 });
+    expect(perts[2].unitsDelta).toEqual({ air: 25 });
+  });
+});

--- a/app/api/game/attacks/[attackId]/route.ts
+++ b/app/api/game/attacks/[attackId]/route.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { getAdminDb } from "@/lib/firebase-admin";
+import type { GameAttack } from "@/lib/game/types";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+// GET /api/game/attacks/[attackId]
+// Returns the full attack record for the Battle Autopsy page. Only the
+// attacker or defender on the record can read it (combat events are
+// public via the feed, but the detail view is a per-participant lens).
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ attackId: string }> }
+) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const { attackId } = await params;
+    if (!attackId) return apiError("attackId required", 400);
+
+    const db = getAdminDb();
+    if (!db) return apiError("Server not configured", 500);
+    const snap = await db.collection("game_attacks").doc(attackId).get();
+    if (!snap.exists) return apiError("Attack not found", 404);
+    const attack = snap.data() as GameAttack;
+
+    if (attack.attackerId !== user.uid && attack.defenderId !== user.uid) {
+      return apiError("Forbidden", 403);
+    }
+
+    return apiSuccess({ attack });
+  } catch (error) {
+    return apiError(
+      error instanceof Error ? error.message : "Server error",
+      500
+    );
+  }
+}

--- a/app/api/game/heroes/meditate/route.ts
+++ b/app/api/game/heroes/meditate/route.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { meditateHeroServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+const PostBody = z.object({
+  tileId: z.string().min(1).max(200),
+});
+
+// POST /api/game/heroes/meditate
+// Puts the hero on `tileId` into meditation for 24h. Always-on (any
+// turn balance). Capped at 1 meditating hero per player at a time.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const parsed = PostBody.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const tile = await meditateHeroServer({
+      callerUserId: user.uid,
+      tileId: parsed.data.tileId,
+    });
+    return apiSuccess({ tile });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/heroes/pep-talk/route.ts
+++ b/app/api/game/heroes/pep-talk/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { pepTalkHeroServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+
+const PostBody = z.object({
+  tileId: z.string().min(1).max(200),
+});
+
+// POST /api/game/heroes/pep-talk
+// Grants +15 stamina to the hero on `tileId`. Caller must be at 0 turns.
+// Rate-limited 3/day per player.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const limit = await checkUpstashRateLimit(`peptalk:${user.uid}`, {
+      windowMs: 24 * 60 * 60 * 1000,
+      maxRequests: 3,
+    });
+    if (!limit.success) {
+      return apiError(
+        `Pep talks limited to 3/day. Retry in ${limit.retryAfter ?? 3600}s.`,
+        429
+      );
+    }
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const parsed = PostBody.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const tile = await pepTalkHeroServer({
+      callerUserId: user.uid,
+      tileId: parsed.data.tileId,
+    });
+    return apiSuccess({ tile });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/last-stand/route.ts
+++ b/app/api/game/last-stand/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { declareLastStandServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+const PostBody = z.object({
+  tileId: z.string().min(1).max(200),
+});
+
+// POST /api/game/last-stand
+// Declares Last Stand on an owned tile under threat. Requires 0 turns
+// remaining + recent inbound attack signal + 24h cooldown. The effect
+// is consumed by the next inbound attack against the tile.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const parsed = PostBody.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const tile = await declareLastStandServer({
+      callerUserId: user.uid,
+      tileId: parsed.data.tileId,
+    });
+    return apiSuccess({ tile });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/orders/route.ts
+++ b/app/api/game/orders/route.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import {
+  cancelOrderServer,
+  enqueueOrderServer,
+  listOrdersForPlayerServer,
+} from "@/lib/game/orders";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+const UnitStackSchema = z.object({
+  ground: z.number().int().min(0),
+  siege: z.number().int().min(0),
+  air: z.number().int().min(0),
+});
+
+const RecruitParams = z.object({
+  kind: z.literal("recruit_on_tile"),
+  tileId: z.string().min(1).max(200),
+  unitType: z.enum(["ground", "siege", "air"]),
+});
+const AttackParams = z.object({
+  kind: z.literal("attack_adjacent"),
+  sourceTileId: z.string().min(1).max(200),
+  targetTileId: z.string().min(1).max(200),
+  units: UnitStackSchema,
+  offenseSpellId: z.string().nullable(),
+});
+const SpellParams = z.object({
+  kind: z.literal("cast_spell_on_tile"),
+  tileId: z.string().min(1).max(200),
+  spellId: z.string().min(1).max(200),
+});
+
+const PostBody = z.discriminatedUnion("kind", [
+  RecruitParams,
+  AttackParams,
+  SpellParams,
+]);
+
+// GET /api/game/orders[?includeExecuted=true]
+// Lists the caller's queued orders.
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const includeExecuted =
+      new URL(request.url).searchParams.get("includeExecuted") === "true";
+    const orders = await listOrdersForPlayerServer(user.uid, includeExecuted);
+    return apiSuccess({ orders });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}
+
+// POST /api/game/orders
+// Enqueues one queued order. Body is a discriminated union on `kind`.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const parsed = PostBody.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const order = await enqueueOrderServer({
+      playerId: user.uid,
+      kind: parsed.data.kind,
+      params: parsed.data,
+    });
+    return apiSuccess({ order });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}
+
+// DELETE /api/game/orders?orderId=...
+// Cancels a queued order (the caller's own).
+export async function DELETE(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+    const orderId = new URL(request.url).searchParams.get("orderId");
+    if (!orderId) return apiError("orderId required", 400);
+    const order = await cancelOrderServer({
+      orderId,
+      callerUserId: user.uid,
+    });
+    return apiSuccess({ order });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/redistribute/route.ts
+++ b/app/api/game/redistribute/route.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { redistributeUnitsServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+const UnitStackSchema = z.object({
+  ground: z.number().int().min(0),
+  siege: z.number().int().min(0),
+  air: z.number().int().min(0),
+});
+
+const PostBody = z.object({
+  sourceTileId: z.string().min(1).max(200),
+  destTileId: z.string().min(1).max(200),
+  units: UnitStackSchema,
+});
+
+// POST /api/game/redistribute
+// Moves units between two adjacent owned tiles with an 8% transit loss.
+// Rate-limit (3/day) is enforced server-side via the player doc counter
+// (recentRedistributions); no Upstash key needed.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const parsed = PostBody.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+    const total =
+      parsed.data.units.ground +
+      parsed.data.units.siege +
+      parsed.data.units.air;
+    if (total < 1) {
+      return apiError("Must move at least 1 unit", 400);
+    }
+
+    const result = await redistributeUnitsServer({
+      callerUserId: user.uid,
+      sourceTileId: parsed.data.sourceTileId,
+      destTileId: parsed.data.destTileId,
+      units: parsed.data.units,
+    });
+    return apiSuccess(result);
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/api/game/tiles/stance/route.ts
+++ b/app/api/game/tiles/stance/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
+import { mapGameError } from "@/lib/game/api-error-map";
+import { toggleDefensiveStanceServer } from "@/lib/game/data-server";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+const PostBody = z.object({
+  tileId: z.string().min(1).max(200),
+  active: z.boolean(),
+});
+
+// POST /api/game/tiles/stance
+// Toggles defensive stance on or off for an owned tile. Free; capped by
+// floor(tilesHeld / 100) (min 1) tiles in stance simultaneously.
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) return apiError("Authentication required", 401);
+
+    const bodyOrError = await parseRequestBody(request);
+    if (bodyOrError instanceof NextResponse) return bodyOrError;
+    const parsed = PostBody.safeParse(bodyOrError);
+    if (!parsed.success) {
+      return apiError(parsed.error.issues[0]?.message ?? "Invalid body", 400);
+    }
+
+    const tile = await toggleDefensiveStanceServer({
+      callerUserId: user.uid,
+      tileId: parsed.data.tileId,
+      desiredActive: parsed.data.active,
+    });
+    return apiSuccess({ tile });
+  } catch (error) {
+    return mapGameError(error);
+  }
+}

--- a/app/game/_components/dashboard/NavGrid.tsx
+++ b/app/game/_components/dashboard/NavGrid.tsx
@@ -76,6 +76,8 @@ export function NavGrid({ phase }: NavGridProps) {
                 { href: "/game/heroes", label: "My Heroes" },
                 { href: "/game/attacks", label: "Attack log" },
                 { href: "/game/armageddon", label: "Armageddon" },
+                { href: "/game/zero-turn", label: "Between turns" },
+                { href: "/game/orders", label: "Order queue" },
               ]
         }
       />

--- a/app/game/attacks/[attackId]/page.tsx
+++ b/app/game/attacks/[attackId]/page.tsx
@@ -1,0 +1,219 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { use, useCallback, useEffect, useState } from "react";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { resolveAttack, makeSeededRng } from "@/lib/game/combat";
+import {
+  defaultLossPerturbations,
+  runAutopsy,
+  type AutopsyOutcome,
+} from "@/lib/game/zero-turn";
+import type {
+  CombatAttackerInput,
+  CombatDefenderInput,
+  CombatTileInput,
+  GameAttack,
+} from "@/lib/game/types";
+
+interface AttackResponse {
+  success: boolean;
+  attack?: GameAttack;
+  error?: { message?: string } | string;
+}
+
+export default function BattleAutopsyPage({
+  params,
+}: {
+  params: Promise<{ attackId: string }>;
+}) {
+  const { attackId } = use(params);
+  const { user, loading: authLoading } = useAuth();
+  const [attack, setAttack] = useState<GameAttack | null>(null);
+  const [autopsy, setAutopsy] = useState<AutopsyOutcome[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/game/attacks/${attackId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data: AttackResponse = await res.json();
+      if (!data.success || !data.attack) {
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : data.error?.message ?? `HTTP ${res.status}`
+        );
+        return;
+      }
+      setAttack(data.attack);
+      // Run autopsy if the attacker lost and we have the pre-attack snapshot.
+      const isLoss = data.attack.attackerId === user.uid && data.attack.outcome !== "captured";
+      if (isLoss && data.attack.unitsOnTargetPreAttack) {
+        const attackerInput: CombatAttackerInput = {
+          caste: data.attack.casteAttacker,
+          units: data.attack.unitsSent,
+          offenseSpellId: data.attack.offenseSpellId,
+          magicLandCount: 0,
+          unitsAlive: 0, // unknown post-hoc; counterfactual is relative
+        };
+        const defenderInput: CombatDefenderInput = {
+          caste: data.attack.casteDefender,
+          unitsOnTile: data.attack.unitsOnTargetPreAttack,
+          baseUnitsOnTile: data.attack.baseUnitsOnTargetPreAttack ?? {
+            ground: 0,
+            siege: 0,
+            air: 0,
+          },
+          armedDefenseSpellId: data.attack.defenseSpellId,
+          magicLandCount: 0,
+          unitsAlive: 0,
+        };
+        const tileInput: CombatTileInput = {
+          capacity: 9999,
+          upgradeIds: [],
+        };
+        const perturbations = defaultLossPerturbations(data.attack.unitsSent);
+        const outcomes = runAutopsy({
+          attacker: attackerInput,
+          defender: defenderInput,
+          tile: tileInput,
+          rngSeed: data.attack.rngSeed,
+          originalOutcome: data.attack.outcome,
+          perturbations,
+          resolveAttackFn: resolveAttack,
+          rngFactory: makeSeededRng,
+        });
+        setAutopsy(outcomes);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [user, attackId]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (!authLoading && user) load();
+  }, [authLoading, user, load]);
+
+  if (authLoading || loading) {
+    return <div className="max-w-3xl mx-auto p-6"><p>Loading…</p></div>;
+  }
+  if (!user) {
+    return <div className="max-w-3xl mx-auto p-6"><p>Please sign in.</p></div>;
+  }
+  if (error) {
+    return (
+      <div className="max-w-3xl mx-auto p-6">
+        <Link href="/game/attacks" className="text-sm text-emerald-700 dark:text-emerald-400 hover:underline">
+          ← Attack log
+        </Link>
+        <div className="mt-4 rounded-lg bg-red-50 dark:bg-red-950/30 border border-red-300 dark:border-red-800 p-3 text-sm text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      </div>
+    );
+  }
+  if (!attack) return null;
+
+  const isAttacker = attack.attackerId === user.uid;
+  const myOutcome = isAttacker
+    ? attack.outcome === "captured"
+      ? "victory"
+      : "defeat"
+    : attack.outcome === "captured"
+      ? "defeat"
+      : "victory";
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <div className="mb-6">
+        <Link href="/game/attacks" className="text-sm text-emerald-700 dark:text-emerald-400 hover:underline">
+          ← Attack log
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold mb-2">Battle autopsy</h1>
+      <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+        Attack {attack.id} · You {myOutcome}{" "}
+        ({isAttacker ? "as attacker" : "as defender"}) · Outcome:{" "}
+        <strong>{attack.outcome}</strong>
+      </p>
+
+      <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-4 mb-4 bg-white dark:bg-neutral-950">
+        <h2 className="font-semibold mb-2">Composition</h2>
+        <div className="grid grid-cols-3 gap-3 text-sm">
+          <div>
+            <div className="text-xs text-neutral-500 uppercase">You sent</div>
+            <div>G: {attack.unitsSent.ground}</div>
+            <div>S: {attack.unitsSent.siege}</div>
+            <div>A: {attack.unitsSent.air}</div>
+          </div>
+          <div>
+            <div className="text-xs text-neutral-500 uppercase">Defender had</div>
+            {attack.unitsOnTargetPreAttack ? (
+              <>
+                <div>G: {attack.unitsOnTargetPreAttack.ground}</div>
+                <div>S: {attack.unitsOnTargetPreAttack.siege}</div>
+                <div>A: {attack.unitsOnTargetPreAttack.air}</div>
+              </>
+            ) : (
+              <div className="text-xs text-neutral-500">No snapshot (pre-autopsy attack)</div>
+            )}
+          </div>
+          <div>
+            <div className="text-xs text-neutral-500 uppercase">Losses</div>
+            <div>
+              You: {attack.unitsLostAttacker.ground + attack.unitsLostAttacker.siege + attack.unitsLostAttacker.air}
+            </div>
+            <div>
+              Them: {attack.unitsLostDefender.ground + attack.unitsLostDefender.siege + attack.unitsLostDefender.air}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {autopsy.length > 0 ? (
+        <div className="rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4">
+          <h2 className="font-semibold mb-2">What if you had brought more?</h2>
+          <ul className="space-y-2 text-sm">
+            {autopsy.map((o, i) => (
+              <li key={i} className="flex items-start gap-2">
+                <span className={o.outcomeFlipped ? "text-emerald-700 dark:text-emerald-400 font-semibold" : "text-neutral-600 dark:text-neutral-400"}>
+                  {o.outcomeFlipped ? "✓" : "○"}
+                </span>
+                <span>{o.summary}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-neutral-500 mt-3">
+            Counterfactual runs use the same RNG seed as the original attack
+            so the comparison isolates composition effects from luck.
+          </p>
+        </div>
+      ) : isAttacker && attack.outcome !== "captured" ? (
+        <p className="text-sm text-neutral-500">
+          No autopsy available (older attack predates the snapshot field).
+        </p>
+      ) : (
+        <p className="text-sm text-neutral-500">
+          Autopsy counterfactuals run for losses; this attack resolved your way.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/game/orders/page.tsx
+++ b/app/game/orders/page.tsx
@@ -1,0 +1,270 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { useAuth } from "@/contexts/AuthContext";
+import type { QueuedOrder, QueuedOrderKind, UnitType } from "@/lib/game/types";
+
+interface OrdersResponse {
+  success: boolean;
+  orders?: QueuedOrder[];
+  error?: { message?: string } | string;
+}
+
+export default function OrdersPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [orders, setOrders] = useState<QueuedOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [includeExecuted, setIncludeExecuted] = useState(false);
+
+  // Enqueue form state
+  const [kind, setKind] = useState<QueuedOrderKind>("recruit_on_tile");
+  const [tileId, setTileId] = useState("");
+  const [unitType, setUnitType] = useState<UnitType>("ground");
+  const [sourceTileId, setSourceTileId] = useState("");
+  const [targetTileId, setTargetTileId] = useState("");
+  const [ground, setGround] = useState(0);
+  const [siege, setSiege] = useState(0);
+  const [air, setAir] = useState(0);
+  const [offenseSpellId, setOffenseSpellId] = useState("");
+  const [spellId, setSpellId] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const token = await user.getIdToken();
+      const url = `/api/game/orders${includeExecuted ? "?includeExecuted=true" : ""}`;
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data: OrdersResponse = await res.json();
+      if (data.success) {
+        setOrders(data.orders ?? []);
+        setError(null);
+      } else {
+        setError(typeof data.error === "string" ? data.error : data.error?.message ?? "Load failed");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [user, includeExecuted]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (!authLoading && user) refresh();
+  }, [authLoading, user, refresh]);
+
+  const submit = useCallback(async () => {
+    if (!user) return;
+    setSubmitting(true);
+    try {
+      const body: Record<string, unknown> = { kind };
+      if (kind === "recruit_on_tile") {
+        body.tileId = tileId;
+        body.unitType = unitType;
+      } else if (kind === "attack_adjacent") {
+        body.sourceTileId = sourceTileId;
+        body.targetTileId = targetTileId;
+        body.units = { ground, siege, air };
+        body.offenseSpellId = offenseSpellId || null;
+      } else if (kind === "cast_spell_on_tile") {
+        body.tileId = tileId;
+        body.spellId = spellId;
+      }
+      const token = await user.getIdToken();
+      const res = await fetch("/api/game/orders", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        setError(typeof data.error === "string" ? data.error : data.error?.message ?? "Enqueue failed");
+        return;
+      }
+      setTileId("");
+      setSourceTileId("");
+      setTargetTileId("");
+      setGround(0);
+      setSiege(0);
+      setAir(0);
+      setOffenseSpellId("");
+      setSpellId("");
+      await refresh();
+    } finally {
+      setSubmitting(false);
+    }
+  }, [user, kind, tileId, unitType, sourceTileId, targetTileId, ground, siege, air, offenseSpellId, spellId, refresh]);
+
+  const cancel = useCallback(
+    async (orderId: string) => {
+      if (!user) return;
+      const token = await user.getIdToken();
+      await fetch(`/api/game/orders?orderId=${orderId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      await refresh();
+    },
+    [user, refresh]
+  );
+
+  if (authLoading) {
+    return <div className="max-w-4xl mx-auto p-6"><p>Loading…</p></div>;
+  }
+  if (!user) {
+    return <div className="max-w-4xl mx-auto p-6"><p>Please sign in.</p></div>;
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <div className="mb-6">
+        <Link href="/game/zero-turn" className="text-sm text-emerald-700 dark:text-emerald-400 hover:underline">
+          ← Back to Between turns
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold mb-2">Queued orders</h1>
+      <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+        Plan your next session. Queued orders execute automatically at next
+        weekly turn grant, in the order you enqueue them. Each costs its
+        normal turn cost when it fires; if turns run out, remaining orders
+        are skipped.
+      </p>
+
+      {error && (
+        <div className="rounded-lg bg-red-50 dark:bg-red-950/30 border border-red-300 dark:border-red-800 p-3 mb-4 text-sm text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-4 mb-6 bg-white dark:bg-neutral-950">
+        <h2 className="font-semibold mb-3">Enqueue a new order</h2>
+        <div className="grid gap-3">
+          <label className="text-sm">
+            <span className="block text-xs uppercase text-neutral-500 mb-1">Kind</span>
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value as QueuedOrderKind)}
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 text-sm"
+            >
+              <option value="recruit_on_tile">Recruit on tile</option>
+              <option value="attack_adjacent">Attack adjacent</option>
+              <option value="cast_spell_on_tile">Cast spell on tile (not yet supported)</option>
+            </select>
+          </label>
+
+          {kind === "recruit_on_tile" && (
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                type="text"
+                value={tileId}
+                onChange={(e) => setTileId(e.target.value)}
+                placeholder="tileId (e.g. q0r0)"
+                className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+              />
+              <select
+                value={unitType}
+                onChange={(e) => setUnitType(e.target.value as UnitType)}
+                className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+              >
+                <option value="ground">Ground</option>
+                <option value="siege">Siege</option>
+                <option value="air">Air</option>
+              </select>
+            </div>
+          )}
+
+          {kind === "attack_adjacent" && (
+            <div className="grid grid-cols-2 gap-2">
+              <input type="text" value={sourceTileId} onChange={(e) => setSourceTileId(e.target.value)} placeholder="source tileId" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+              <input type="text" value={targetTileId} onChange={(e) => setTargetTileId(e.target.value)} placeholder="target tileId" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+              <input type="number" value={ground} onChange={(e) => setGround(Math.max(0, parseInt(e.target.value || "0", 10)))} placeholder="ground" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+              <input type="number" value={siege} onChange={(e) => setSiege(Math.max(0, parseInt(e.target.value || "0", 10)))} placeholder="siege" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+              <input type="number" value={air} onChange={(e) => setAir(Math.max(0, parseInt(e.target.value || "0", 10)))} placeholder="air" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+              <input type="text" value={offenseSpellId} onChange={(e) => setOffenseSpellId(e.target.value)} placeholder="offense spell id (optional)" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+            </div>
+          )}
+
+          {kind === "cast_spell_on_tile" && (
+            <div className="grid grid-cols-2 gap-2">
+              <input type="text" value={tileId} onChange={(e) => setTileId(e.target.value)} placeholder="tileId" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+              <input type="text" value={spellId} onChange={(e) => setSpellId(e.target.value)} placeholder="spellId" className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900" />
+            </div>
+          )}
+
+          <button
+            onClick={submit}
+            disabled={submitting}
+            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-800 text-white rounded text-sm self-start"
+          >
+            {submitting ? "Enqueueing…" : "Enqueue"}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold">Your queue</h2>
+        <label className="text-xs flex items-center gap-1">
+          <input type="checkbox" checked={includeExecuted} onChange={(e) => setIncludeExecuted(e.target.checked)} />
+          Include past
+        </label>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-neutral-500">Loading…</p>
+      ) : orders.length === 0 ? (
+        <p className="text-sm text-neutral-500">No orders queued.</p>
+      ) : (
+        <div className="space-y-2">
+          {orders.map((o) => (
+            <div
+              key={o.id}
+              className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-3 bg-white dark:bg-neutral-950 flex items-start justify-between gap-4"
+            >
+              <div>
+                <div className="text-sm font-medium">
+                  #{o.sequenceIndex + 1} · {o.kind}{" "}
+                  <span className={`ml-2 text-xs px-2 py-0.5 rounded ${
+                    o.status === "queued" ? "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300" :
+                    o.status === "executed" ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300" :
+                    o.status === "failed" ? "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300" :
+                    "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
+                  }`}>
+                    {o.status}
+                  </span>
+                </div>
+                <pre className="text-xs text-neutral-600 dark:text-neutral-400 mt-1 font-mono">
+                  {JSON.stringify(o.params)}
+                </pre>
+                {o.resultSummary && (
+                  <p className="text-xs text-neutral-500 mt-1">{o.resultSummary}</p>
+                )}
+              </div>
+              {o.status === "queued" && (
+                <button
+                  onClick={() => cancel(o.id)}
+                  className="text-xs px-2 py-1 border border-red-300 dark:border-red-800 text-red-700 dark:text-red-400 rounded hover:bg-red-50 dark:hover:bg-red-950/30"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/game/zero-turn/page.tsx
+++ b/app/game/zero-turn/page.tsx
@@ -1,0 +1,466 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { useAuth } from "@/contexts/AuthContext";
+import type { GamePlayer, GameTile } from "@/lib/game/types";
+
+interface PlayerResponse {
+  success: boolean;
+  player?: GamePlayer | null;
+  error?: { message?: string } | string;
+}
+
+interface TilesResponse {
+  success: boolean;
+  tiles?: GameTile[];
+  error?: { message?: string } | string;
+}
+
+type ActionState = { kind: "idle" } | { kind: "pending" } | { kind: "ok"; msg: string } | { kind: "err"; msg: string };
+
+function ActionRow(props: {
+  title: string;
+  description: string;
+  status?: string;
+  state: ActionState;
+  controls: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-4 mb-3 bg-white dark:bg-neutral-950">
+      <div className="flex items-start justify-between gap-4 mb-2">
+        <div>
+          <h3 className="font-semibold">{props.title}</h3>
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">
+            {props.description}
+          </p>
+          {props.status && (
+            <p className="text-xs text-neutral-500 mt-1">{props.status}</p>
+          )}
+        </div>
+        <div className="flex-shrink-0">{props.controls}</div>
+      </div>
+      {props.state.kind === "ok" && (
+        <p className="text-xs text-emerald-700 dark:text-emerald-400 mt-2">
+          ✓ {props.state.msg}
+        </p>
+      )}
+      {props.state.kind === "err" && (
+        <p className="text-xs text-red-700 dark:text-red-400 mt-2">
+          ✗ {props.state.msg}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function ZeroTurnHubPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [player, setPlayer] = useState<GamePlayer | null>(null);
+  const [tiles, setTiles] = useState<GameTile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pepTalkTileId, setPepTalkTileId] = useState("");
+  const [pepTalkState, setPepTalkState] = useState<ActionState>({ kind: "idle" });
+  const [meditateTileId, setMeditateTileId] = useState("");
+  const [meditateState, setMeditateState] = useState<ActionState>({ kind: "idle" });
+  const [stanceTileId, setStanceTileId] = useState("");
+  const [stanceState, setStanceState] = useState<ActionState>({ kind: "idle" });
+  const [lastStandTileId, setLastStandTileId] = useState("");
+  const [lastStandState, setLastStandState] = useState<ActionState>({ kind: "idle" });
+  const [redistSource, setRedistSource] = useState("");
+  const [redistDest, setRedistDest] = useState("");
+  const [redistGround, setRedistGround] = useState(0);
+  const [redistSiege, setRedistSiege] = useState(0);
+  const [redistAir, setRedistAir] = useState(0);
+  const [redistState, setRedistState] = useState<ActionState>({ kind: "idle" });
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    const token = await user.getIdToken();
+    const [pRes, tRes] = await Promise.all([
+      fetch("/api/game/player", { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/game/tile/owned", { headers: { Authorization: `Bearer ${token}` } }).catch(() => null),
+    ]);
+    if (pRes.ok) {
+      const data: PlayerResponse = await pRes.json();
+      setPlayer(data.player ?? null);
+    }
+    if (tRes && tRes.ok) {
+      const data: TilesResponse = await tRes.json();
+      setTiles(data.tiles ?? []);
+    }
+    setLoading(false);
+  }, [user]);
+
+  useEffect(() => {
+    if (!authLoading && user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      refresh();
+    }
+  }, [authLoading, user, refresh]);
+
+  const callApi = useCallback(
+    async (
+      url: string,
+      body: unknown,
+      setState: (s: ActionState) => void,
+      successMsg: string,
+      method: string = "POST"
+    ) => {
+      if (!user) return;
+      setState({ kind: "pending" });
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(url, {
+          method,
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: method === "POST" ? JSON.stringify(body) : undefined,
+        });
+        const data = await res.json();
+        if (!res.ok || !data.success) {
+          const msg =
+            typeof data.error === "string"
+              ? data.error
+              : data.error?.message ?? `HTTP ${res.status}`;
+          setState({ kind: "err", msg });
+          return;
+        }
+        setState({ kind: "ok", msg: successMsg });
+        await refresh();
+      } catch (e) {
+        setState({ kind: "err", msg: e instanceof Error ? e.message : "Failed" });
+      }
+    },
+    [user, refresh]
+  );
+
+  if (authLoading || loading) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <p className="text-neutral-500">Loading…</p>
+      </div>
+    );
+  }
+  if (!user) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <p>Please sign in.</p>
+      </div>
+    );
+  }
+  if (!player) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <p>No player record.</p>
+      </div>
+    );
+  }
+
+  const atZeroTurns = player.turnsRemaining === 0;
+  const tilesWithHero = tiles.filter((t) => t.hero != null);
+  const tilesInStance = tiles.filter(
+    (t) => t.defensiveStance && t.defensiveStance.active
+  );
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <div className="mb-6">
+        <Link href="/game" className="text-sm text-emerald-700 dark:text-emerald-400 hover:underline">
+          ← Back to dashboard
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold mb-2">Between turns</h1>
+      <p className="text-neutral-600 dark:text-neutral-400 mb-6">
+        Gameplay-operative actions you can take without spending turns. Some
+        are 0-turn-only (consolation mechanics); others are available any
+        time as part of your normal toolkit.
+      </p>
+
+      <div className="rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4 mb-6">
+        <p className="text-sm">
+          <strong>Status:</strong> {player.turnsRemaining} turns remaining ·{" "}
+          {tilesWithHero.length} heroes · {tilesInStance.length} tiles in
+          defensive stance
+          {player.oathbreakerUntil && (
+            <span className="block mt-1 text-red-700 dark:text-red-400">
+              ⚠ Oathbreaker mark active — your attacks deal reduced damage
+              while this mark stands.
+            </span>
+          )}
+          {player.pendingProphecyBonus && player.pendingProphecyBonus > 0 ? (
+            <span className="block mt-1 text-emerald-700 dark:text-emerald-400">
+              +{player.pendingProphecyBonus} prophecy bonus turns waiting for
+              next weekly grant.
+            </span>
+          ) : null}
+        </p>
+      </div>
+
+      <h2 className="text-lg font-semibold mb-3 mt-6">Hero management</h2>
+
+      <ActionRow
+        title="Pep talk"
+        description="Grant +15 stamina to a hero. 0-turn-only; 3/day."
+        status={atZeroTurns ? "Available" : "Requires 0 turns remaining"}
+        state={pepTalkState}
+        controls={
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={pepTalkTileId}
+              onChange={(e) => setPepTalkTileId(e.target.value)}
+              placeholder="tileId"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <button
+              onClick={() =>
+                callApi(
+                  "/api/game/heroes/pep-talk",
+                  { tileId: pepTalkTileId },
+                  setPepTalkState,
+                  "Pep talk delivered"
+                )
+              }
+              disabled={!pepTalkTileId || !atZeroTurns || pepTalkState.kind === "pending"}
+              className="px-3 py-1 bg-emerald-600 hover:bg-emerald-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-800 text-white rounded text-sm"
+            >
+              Pep talk
+            </button>
+          </div>
+        }
+      />
+
+      <ActionRow
+        title="Meditation"
+        description="Pull a hero off duty for 24h. Stamina set to max; hero can't fight while meditating. Cap: 1 at a time."
+        state={meditateState}
+        controls={
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={meditateTileId}
+              onChange={(e) => setMeditateTileId(e.target.value)}
+              placeholder="tileId"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <button
+              onClick={() =>
+                callApi(
+                  "/api/game/heroes/meditate",
+                  { tileId: meditateTileId },
+                  setMeditateState,
+                  "Hero now meditating"
+                )
+              }
+              disabled={!meditateTileId || meditateState.kind === "pending"}
+              className="px-3 py-1 bg-indigo-600 hover:bg-indigo-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-800 text-white rounded text-sm"
+            >
+              Meditate
+            </button>
+          </div>
+        }
+      />
+
+      <h2 className="text-lg font-semibold mb-3 mt-6">Active defense</h2>
+
+      <ActionRow
+        title="Defensive stance"
+        description="+25% defense on a tile; tile can't attack out. Free toggle; 6h lock prevents flicker. Cap scales with empire size."
+        status={`${tilesInStance.length} active · cap = ${Math.max(1, Math.floor((player.stats?.tilesHeld ?? 0) / 100))}`}
+        state={stanceState}
+        controls={
+          <div className="flex gap-2 items-center">
+            <input
+              type="text"
+              value={stanceTileId}
+              onChange={(e) => setStanceTileId(e.target.value)}
+              placeholder="tileId"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <button
+              onClick={() =>
+                callApi(
+                  "/api/game/tiles/stance",
+                  { tileId: stanceTileId, active: true },
+                  setStanceState,
+                  "Stance toggled on"
+                )
+              }
+              disabled={!stanceTileId || stanceState.kind === "pending"}
+              className="px-3 py-1 bg-sky-600 hover:bg-sky-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-800 text-white rounded text-sm"
+            >
+              On
+            </button>
+            <button
+              onClick={() =>
+                callApi(
+                  "/api/game/tiles/stance",
+                  { tileId: stanceTileId, active: false },
+                  setStanceState,
+                  "Stance toggled off"
+                )
+              }
+              disabled={!stanceTileId || stanceState.kind === "pending"}
+              className="px-3 py-1 bg-neutral-200 hover:bg-neutral-300 dark:bg-neutral-800 dark:hover:bg-neutral-700 disabled:bg-neutral-100 dark:disabled:bg-neutral-900 rounded text-sm"
+            >
+              Off
+            </button>
+          </div>
+        }
+      />
+
+      <ActionRow
+        title="Last Stand"
+        description="+50% defense on a threatened tile (single use). Adjacent tiles take -25% (rally pulls reserves). 0-turn-only; 24h cooldown; requires recent inbound attack signal."
+        status={
+          player.lastStandUsedAt
+            ? `Last used: ${new Date(
+                player.lastStandUsedAt instanceof Date
+                  ? player.lastStandUsedAt
+                  : (player.lastStandUsedAt as { seconds: number }).seconds * 1000
+              ).toLocaleString()}`
+            : "Available"
+        }
+        state={lastStandState}
+        controls={
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={lastStandTileId}
+              onChange={(e) => setLastStandTileId(e.target.value)}
+              placeholder="tileId"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <button
+              onClick={() =>
+                callApi(
+                  "/api/game/last-stand",
+                  { tileId: lastStandTileId },
+                  setLastStandState,
+                  "Last Stand declared"
+                )
+              }
+              disabled={!lastStandTileId || !atZeroTurns || lastStandState.kind === "pending"}
+              className="px-3 py-1 bg-red-600 hover:bg-red-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-800 text-white rounded text-sm"
+            >
+              Declare
+            </button>
+          </div>
+        }
+      />
+
+      <ActionRow
+        title="Redistribute units"
+        description="Move units between two adjacent owned tiles. 8% transit loss applies. 3/day."
+        state={redistState}
+        controls={
+          <div className="grid grid-cols-2 gap-2">
+            <input
+              type="text"
+              value={redistSource}
+              onChange={(e) => setRedistSource(e.target.value)}
+              placeholder="from tileId"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <input
+              type="text"
+              value={redistDest}
+              onChange={(e) => setRedistDest(e.target.value)}
+              placeholder="to tileId"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <input
+              type="number"
+              value={redistGround}
+              onChange={(e) => setRedistGround(Math.max(0, parseInt(e.target.value || "0", 10)))}
+              placeholder="ground"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <input
+              type="number"
+              value={redistSiege}
+              onChange={(e) => setRedistSiege(Math.max(0, parseInt(e.target.value || "0", 10)))}
+              placeholder="siege"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <input
+              type="number"
+              value={redistAir}
+              onChange={(e) => setRedistAir(Math.max(0, parseInt(e.target.value || "0", 10)))}
+              placeholder="air"
+              className="px-2 py-1 border border-neutral-300 dark:border-neutral-700 rounded text-sm bg-white dark:bg-neutral-900"
+            />
+            <button
+              onClick={() =>
+                callApi(
+                  "/api/game/redistribute",
+                  {
+                    sourceTileId: redistSource,
+                    destTileId: redistDest,
+                    units: { ground: redistGround, siege: redistSiege, air: redistAir },
+                  },
+                  setRedistState,
+                  "Redistribution complete (8% transit loss applied)"
+                )
+              }
+              disabled={
+                !redistSource ||
+                !redistDest ||
+                redistGround + redistSiege + redistAir < 1 ||
+                redistState.kind === "pending"
+              }
+              className="px-3 py-1 bg-purple-600 hover:bg-purple-700 disabled:bg-neutral-300 dark:disabled:bg-neutral-800 text-white rounded text-sm col-span-2"
+            >
+              Move
+            </button>
+          </div>
+        }
+      />
+
+      <h2 className="text-lg font-semibold mb-3 mt-6">Planning</h2>
+
+      <ActionRow
+        title="Queue orders"
+        description="Plan attacks, recruits, or spells to execute at next weekly grant. Each order costs its normal turns when it fires; insufficient-turns skip with a reason."
+        state={{ kind: "idle" }}
+        controls={
+          <Link
+            href="/game/orders"
+            className="px-3 py-1 bg-amber-600 hover:bg-amber-700 text-white rounded text-sm"
+          >
+            Manage queue
+          </Link>
+        }
+      />
+
+      <ActionRow
+        title="Battle autopsy"
+        description="Browse past attacks. Click into one for a what-if analysis showing which composition changes would have flipped the outcome."
+        state={{ kind: "idle" }}
+        controls={
+          <Link
+            href="/game/attacks"
+            className="px-3 py-1 bg-neutral-600 hover:bg-neutral-700 text-white rounded text-sm"
+          >
+            Attack log
+          </Link>
+        }
+      />
+
+      <div className="mt-8 text-xs text-neutral-500">
+        Tile ids are e.g. <code className="font-mono">q0r0</code>. Find them
+        on the <Link className="underline" href="/game/tiles">tile map</Link>.
+      </div>
+    </div>
+  );
+}

--- a/config/firebase/firestore.indexes.json
+++ b/config/firebase/firestore.indexes.json
@@ -430,6 +430,14 @@
         { "fieldPath": "targetSealNumber", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "game_order_queue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "playerId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -539,6 +539,16 @@ service cloud.firestore {
       allow create, update, delete: if false;
     }
 
+    // Zero-turn gameplay: queued battle plans that execute at the next
+    // weekly turn grant. A player can only read their own queue.
+    // Writes go through /api/game/orders (validation + per-player cap)
+    // and through the rollover executor when orders fire.
+    match /game_order_queue/{orderId} {
+      allow read: if request.auth != null
+        && resource.data.playerId == request.auth.uid;
+      allow create, update, delete: if false;
+    }
+
     // Game — Artifacts (v2): a player can only read their own inventory.
     // All writes go through the Admin SDK via turn-spending API routes.
     match /game_artifacts/{artifactId} {

--- a/docs/generals/NON_TURN_ACTIVITIES.md
+++ b/docs/generals/NON_TURN_ACTIVITIES.md
@@ -2,9 +2,12 @@
 
 Players in Generals start a week with **100 turns** (300 for new players) and every meaningful gameplay action — explore, build, attack, cast, siege, upgrade, Armageddon — consumes turns. Burn through the budget on Monday and there's nothing to *do* until the next grant.
 
-PR #969 added **ten participatory player actions that don't consume turns** to bridge that gap. They're social, creative, and lore-oriented — explicitly designed to *not* affect combat or economy balance. The goal is to deepen mid-week engagement without inflating the turn economy.
+This is the contributor-facing reference for **non-turn activities**: features players can use without spending turns. Two layers, by design intent:
 
-This page is for contributors changing those activities, adding new ones, or extending the patterns to other parts of the site.
+- **PR #969 (May 2026) — cosmetic / social / lore layer.** Ten activities (reactions, pacts, prophecies, hero chapters/epitaphs, profiles+bios, titles, tile inscriptions, battle dispatches, caste chat) that explicitly do *not* affect combat or economy balance.
+- **Zero-turn gameplay (May 2026 follow-up) — gameplay-operative layer.** Nine activities that *do* affect outcomes (defense, hero state, intel, diplomacy with teeth, queued execution, autopsy decisions) but are gated by non-turn resources (rate limits, caps, cooldowns, opportunity cost, or 0-turn predicates) so they complement turn-spend rather than replace it.
+
+**Policy in one line:** A non-turn feature can affect gameplay if it's gated by a non-turn resource. Balance is enforced by the gate, not by being cosmetic.
 
 ## The ten activities
 
@@ -85,9 +88,45 @@ Indexes deploy automatically when `main` moves and `firestore.indexes.json` chan
 
 ## What's intentionally *not* in the patterns
 
-- **No turn cost**, full stop. If you find yourself reaching for `turnsRemaining` on one of these features, you've drifted from the design intent. Surface it as a separate gameplay feature instead.
-- **No gameplay-impactful side effects.** Reactions don't buff units. Titles don't boost magic. Pacts don't enforce. Prophecies don't unlock anything in combat. The Seer / Oracle titles are cosmetic. Don't smuggle gameplay through the cosmetic surface.
-- **No combat involvement.** Pacts watch the attack handler and stamp `brokenAt` if a vow is violated; they do **not** prevent the attack. The community feed event is the punishment — reputational, not mechanical.
+For the PR #969 (cosmetic / social / lore) layer:
+
+- **No turn cost**, full stop.
+- **No gameplay-impactful side effects.** Reactions don't buff units. Titles don't boost magic. Hero chapters don't grant XP.
+
+The **zero-turn gameplay layer** (added May 2026 follow-up) intentionally relaxes the "no gameplay impact" rule under a different gating model. See the next section.
+
+## Zero-turn gameplay layer
+
+Nine activities that *do* affect outcomes. Each has a non-turn gate so it doesn't displace turn-spend strategy:
+
+| # | Feature | Gate(s) | Key file(s) |
+|---|---|---|---|
+| Z1 | Hero pep talk (+15 stamina) | 0-turn-only + 3/day Upstash | `pepTalkHeroServer` in `lib/game/data-server.ts`, `app/api/game/heroes/pep-talk/route.ts` |
+| Z2 | Hero meditation (24h sabbatical) | 1 active slot, no engagement while meditating | `meditateHeroServer`, `app/api/game/heroes/meditate/route.ts`, combat skip in `combinedHero{Attack,Defense}Bonus` |
+| Z3 | Tile redistribution (move units) | 3/day (player-doc counter) + 8% transit loss + adjacency | `redistributeUnitsServer`, `app/api/game/redistribute/route.ts` |
+| Z4 | Defensive stance (+25% defense, no attack out) | scaling cap (`floor(tilesHeld/100)`) + 6h lock | `toggleDefensiveStanceServer`, `app/api/game/tiles/stance/route.ts`, `combat.ts` reads `zeroTurnDefenseBonus` |
+| Z5 | Last Stand (+50% defense, -25% adjacent) | 0-turn-only + threat-window + 24h cooldown + single-use | `declareLastStandServer`, `app/api/game/last-stand/route.ts` |
+| Z6 | Enforced pacts (Oathbreaker mark on breach) | -10% attack for 7 days + public mark + caste broadcast | `findActivePactsBetween` in `lib/game/pacts.ts`, hook in `attackTileServer` |
+| Z7 | Prophecy stakes (+5 turns on next grant) | per-prophecy resolution + per-week cap | `resolveProphesiesForSealInTx` in `lib/game/prophecies.ts`, consume in `applyWeeklyGrant` |
+| Z8 | Queued orders (recruit/attack at next grant) | 20 queued/player cap; each fires at normal turn cost | `lib/game/orders.ts`, `app/api/game/orders/route.ts`, executor hook in `runWeeklyRolloverServer` |
+| Z9 | Battle Autopsy (counterfactual replay) | pre-attack snapshot stored on attack record | `runAutopsy` + `defaultLossPerturbations` in `lib/game/zero-turn.ts`, `/game/attacks/[attackId]` |
+
+All nine route their gating logic through pure helpers in `lib/game/zero-turn.ts` (testable) plus the server actions in `lib/game/data-server.ts` and `lib/game/orders.ts` (Firestore writes).
+
+### Tuning constants
+
+Centralized at the bottom of `lib/game/types.ts` (`DEFENSIVE_STANCE_DEFENSE_BONUS`, `LAST_STAND_*`, `OATHBREAKER_*`, `MEDITATION_*`, `PEP_TALK_*`, `REDISTRIBUTE_*`, `PROPHECY_BONUS_*`, `QUEUED_ORDERS_MAX_PER_PLAYER`). Change them there and the server + tests pick up the new value.
+
+### Adding a zero-turn gameplay feature
+
+The PR #969 checklist below still applies, plus:
+
+1. **Pick a gate.** Rate limit / opportunity cost / cooldown / 0-turn predicate / RNG / social cost. If you can't name the gate, the feature is too strong.
+2. **Pure helper in `lib/game/zero-turn.ts`** for the math — testable, no Firestore.
+3. **Server action in `lib/game/data-server.ts`** for the write — txn-bound, error class declared, mapped in `lib/game/api-error-map.ts`.
+4. **Combat channels**: if the feature affects combat, add a new optional bonus/penalty channel on `CombatAttackerInput` or `CombatDefenderInput` in `lib/game/types.ts` and apply it at the same numeric stage as the existing hero/intel bonuses in `combat.ts`. Server pre-resolves the value.
+5. **Tests**: pure-helper tests in `__tests__/lib/game/zero-turn.test.ts`; weekly-rollover effects in `__tests__/lib/game/turns.test.ts`.
+6. **Player-facing surface**: a row on `/game/zero-turn` (the central hub) + optional integration into the relevant existing surface (tile detail, hero card, threat card).
 
 ## Adding an eleventh activity
 
@@ -106,4 +145,4 @@ The 10 activities are the canonical reference — copy the closest one and mutat
 
 ## Player-facing surface
 
-For player documentation on what these features do and where to find them, see the **Community** and **Endgame** tabs in `/game/help`.
+For player documentation on what these features do and where to find them, see the **Community** and **Endgame** tabs in `/game/help`, plus the `/game/zero-turn` hub page (linked from the dashboard nav as "Between turns") which centralizes the zero-turn gameplay actions.

--- a/lib/account-deletion/registry.ts
+++ b/lib/account-deletion/registry.ts
@@ -182,6 +182,14 @@ export const userOwnedCollections: ReadonlyArray<UserOwnedCollection> = [
     fields: ["attackerId", "defenderId"],
     behavior: { type: "delete" },
   },
+  // Zero-turn gameplay: queued battle plans the player has not yet
+  // executed. On account deletion these have no meaning — delete them.
+  {
+    collection: "game_order_queue",
+    mode: "fieldEqualsUid",
+    field: "playerId",
+    behavior: { type: "delete" },
+  },
 
   // ---------------------------------------------------------------------
   // arrayContains — delete (sessions where user is one of N participants)

--- a/lib/game/api-error-map.ts
+++ b/lib/game/api-error-map.ts
@@ -42,6 +42,19 @@ import {
   GameTileTypeError,
   GameTileUnrevealedError,
   GameUnitCapExceededError,
+  // Zero-turn gameplay errors
+  GameDefensiveStanceBlockedError,
+  GameDefensiveStanceCapError,
+  GameDefensiveStanceLockedError,
+  GameHeroAlreadyMeditatingError,
+  GameHeroNotFoundError,
+  GameHeroNotOwnedError,
+  GameLastStandCooldownError,
+  GameLastStandNoThreatError,
+  GameLastStandRequiresZeroTurnsError,
+  GameMeditationSlotFullError,
+  GamePepTalkRequiresZeroTurnsError,
+  GameRedistributeRateLimitError,
 } from "./data-server";
 import {
   UpgradeAlreadyActiveError,
@@ -50,6 +63,12 @@ import {
   UpgradeUnknownTargetError,
   UpgradeWrongCasteError,
 } from "./upgrades";
+import {
+  QueuedOrderForbiddenError,
+  QueuedOrderInvalidParamsError,
+  QueuedOrderNotFoundError,
+  QueuedOrderQueueFullError,
+} from "./orders";
 
 export function mapGameError(error: unknown): NextResponse {
   if (
@@ -58,13 +77,17 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameArtifactNotFoundError ||
     error instanceof GameSpecialUnitNotFoundError ||
     error instanceof UpgradeNotFoundError ||
-    error instanceof UpgradeUnknownTargetError
+    error instanceof UpgradeUnknownTargetError ||
+    error instanceof GameHeroNotFoundError ||
+    error instanceof QueuedOrderNotFoundError
   ) {
     return apiError(error.message, 404);
   }
   if (
     error instanceof GameTileNotOwnedError ||
-    error instanceof GameShieldedError
+    error instanceof GameShieldedError ||
+    error instanceof GameHeroNotOwnedError ||
+    error instanceof QueuedOrderForbiddenError
   ) {
     return apiError(error.message, 403);
   }
@@ -90,7 +113,16 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameSealsExhaustedError ||
     error instanceof GameSpecialUnitAlreadyStationedError ||
     error instanceof UpgradeAlreadyActiveError ||
-    error instanceof UpgradeNotActiveError
+    error instanceof UpgradeNotActiveError ||
+    error instanceof GameDefensiveStanceBlockedError ||
+    error instanceof GameDefensiveStanceCapError ||
+    error instanceof GameDefensiveStanceLockedError ||
+    error instanceof GameHeroAlreadyMeditatingError ||
+    error instanceof GameMeditationSlotFullError ||
+    error instanceof GamePepTalkRequiresZeroTurnsError ||
+    error instanceof GameLastStandRequiresZeroTurnsError ||
+    error instanceof GameLastStandNoThreatError ||
+    error instanceof QueuedOrderQueueFullError
   ) {
     return apiError(error.message, 409);
   }
@@ -103,9 +135,16 @@ export function mapGameError(error: unknown): NextResponse {
     error instanceof GameInvalidNameError ||
     error instanceof GamePlayerBioTooLongError ||
     error instanceof GameInscriptionTooLongError ||
-    error instanceof UpgradeWrongCasteError
+    error instanceof UpgradeWrongCasteError ||
+    error instanceof QueuedOrderInvalidParamsError
   ) {
     return apiError(error.message, 400);
+  }
+  if (
+    error instanceof GameRedistributeRateLimitError ||
+    error instanceof GameLastStandCooldownError
+  ) {
+    return apiError(error.message, 429);
   }
   logger.error("Unhandled game API error", {
     message: error instanceof Error ? error.message : String(error),

--- a/lib/game/combat.ts
+++ b/lib/game/combat.ts
@@ -946,6 +946,14 @@ export function resolveAttack(
     attackPower *= 1 + attacker.heroAttackBonus;
   }
 
+  // Oathbreaker penalty (zero-turn gameplay: enforced pacts). Applied
+  // multiplicatively as a reduction. Pre-resolved by the server: a value
+  // > 0 means the attacker has an active oathbreaker mark from breaking
+  // a pact within the OATHBREAKER_DURATION_MS window.
+  if (attacker.oathbreakerPenalty && attacker.oathbreakerPenalty > 0) {
+    attackPower *= 1 - Math.min(1, attacker.oathbreakerPenalty);
+  }
+
   // Source-tile attack multiplier (military ×1.20, food ×0.75). Applied
   // after spell + intel offense bonuses so the multiplier scales the full
   // realized attack value the way a player would expect ("my army is
@@ -1000,6 +1008,16 @@ export function resolveAttack(
   // weighting and stationed special-unit defenseBonus folded in.
   if (defender.heroDefenseBonus && defender.heroDefenseBonus > 0) {
     defensePower *= 1 + defender.heroDefenseBonus;
+  }
+
+  // Zero-turn defense bonus (defensive stance + last stand, minus any
+  // adjacent-rally penalty). Pre-resolved by the server. A positive value
+  // is a bonus; a negative value (e.g. rally pulling reserves) is a
+  // penalty. Applied multiplicatively at the same stage as the hero
+  // defense bonus.
+  if (defender.zeroTurnDefenseBonus && defender.zeroTurnDefenseBonus !== 0) {
+    const multiplier = Math.max(0, 1 + defender.zeroTurnDefenseBonus);
+    defensePower *= multiplier;
   }
 
   let underdogApplied = false;

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -79,6 +79,16 @@ import {
   validateRemoveUpgrade,
 } from "./upgrades";
 import {
+  DEFENSIVE_STANCE_LOCK_MS,
+  LAST_STAND_COOLDOWN_MS,
+  LAST_STAND_THREAT_WINDOW_MS,
+  LAST_STAND_WINDOW_MS,
+  MEDITATION_DURATION_MS,
+  MEDITATION_MAX_ACTIVE_SLOTS,
+  OATHBREAKER_ATTACK_PENALTY,
+  OATHBREAKER_DURATION_MS,
+  PEP_TALK_STAMINA_GAIN,
+  REDISTRIBUTE_MAX_PER_DAY,
   SIEGE_ACTION_MAGNITUDE,
   SIEGE_DEBUFF_MAX_MAGNITUDE,
   type ArmageddonEventRecord,
@@ -134,6 +144,13 @@ import {
   applyStaminaRegen,
   maybeEmergeHero,
 } from "./heroes";
+import {
+  computeZeroTurnDefenseBonus,
+  isHeroMeditating,
+  isTileInDefensiveStance,
+  oathbreakerAttackPenalty,
+} from "./zero-turn";
+import { findActivePactsBetween } from "./pacts";
 import {
   appendHeroEventInTx,
   heroEvent,
@@ -200,11 +217,13 @@ export function unitsPerTurnForLand(landType: LandType): number {
  *  [0, FARM_HERO_GLOBAL_RECRUIT_CAP]. */
 function computeFarmHeroKingdomBuff(
   heroes: ReadonlyArray<GameHero>,
-  ownerTurnsSpentTotal: number
+  ownerTurnsSpentTotal: number,
+  now: Date = new Date()
 ): number {
   let total = 0;
   for (const hero of heroes) {
     if (hero.class !== "farm") continue;
+    if (isHeroMeditating(hero, now)) continue;
     const regened = applyStaminaRegen(hero, ownerTurnsSpentTotal);
     total +=
       FARM_HERO_GLOBAL_RECRUIT_BONUS *
@@ -220,11 +239,13 @@ function computeFarmHeroKingdomBuff(
  *  small bump. Fractional — magicMultiplier handles the curve. */
 function countMagicHeroVirtualLands(
   heroes: ReadonlyArray<GameHero>,
-  ownerTurnsSpentTotal: number
+  ownerTurnsSpentTotal: number,
+  now: Date = new Date()
 ): number {
   let total = 0;
   for (const hero of heroes) {
     if (hero.class !== "magic") continue;
+    if (isHeroMeditating(hero, now)) continue;
     const regened = applyStaminaRegen(hero, ownerTurnsSpentTotal);
     total +=
       MAGIC_HERO_VIRTUAL_LANDS *
@@ -264,10 +285,15 @@ function computeStationedSpecialUnitBonuses(
 function combinedHeroAttackBonus(
   player: GamePlayer,
   sourceTile: GameTile,
-  targetTile: Pick<GameTile, "type">
+  targetTile: Pick<GameTile, "type">,
+  now: Date = new Date()
 ): number {
   let bonus = 0;
-  if (sourceTile.hero && sourceTile.hero.class === "military") {
+  if (
+    sourceTile.hero &&
+    sourceTile.hero.class === "military" &&
+    !isHeroMeditating(sourceTile.hero, now)
+  ) {
     const h = applyStaminaRegen(sourceTile.hero, player.turnsSpentTotal);
     bonus +=
       HERO_ATTACK_BONUS *
@@ -287,10 +313,15 @@ function combinedHeroAttackBonus(
 function combinedHeroDefenseBonus(
   defender: GamePlayer,
   targetTile: GameTile,
-  sourceTile: Pick<GameTile, "type">
+  sourceTile: Pick<GameTile, "type">,
+  now: Date = new Date()
 ): number {
   let bonus = 0;
-  if (targetTile.hero && targetTile.hero.class === "military") {
+  if (
+    targetTile.hero &&
+    targetTile.hero.class === "military" &&
+    !isHeroMeditating(targetTile.hero, now)
+  ) {
     const h = applyStaminaRegen(targetTile.hero, defender.turnsSpentTotal);
     bonus +=
       HERO_DEFENSE_BONUS *
@@ -307,9 +338,11 @@ function combinedHeroDefenseBonus(
 function magicHeroSpellMultiplier(
   casterTurnsSpentTotal: number,
   sourceTile: GameTile,
-  spell: Pick<SpellDefinition, "type">
+  spell: Pick<SpellDefinition, "type">,
+  now: Date = new Date()
 ): number {
   if (!sourceTile.hero || sourceTile.hero.class !== "magic") return 1;
+  if (isHeroMeditating(sourceTile.hero, now)) return 1;
   const h = applyStaminaRegen(sourceTile.hero, casterTurnsSpentTotal);
   return (
     1 +
@@ -552,6 +585,84 @@ export class GameSpecialUnitAlreadyStationedError extends Error {
   }
 }
 
+// Zero-turn gameplay errors -----------------------------------------------
+export class GameDefensiveStanceBlockedError extends Error {
+  constructor() {
+    super(
+      "This tile is in defensive stance and cannot attack until the stance lifts."
+    );
+    this.name = "GameDefensiveStanceBlockedError";
+  }
+}
+export class GameDefensiveStanceLockedError extends Error {
+  constructor() {
+    super(
+      "Defensive stance is still locked. You cannot exit stance until the cooldown elapses."
+    );
+    this.name = "GameDefensiveStanceLockedError";
+  }
+}
+export class GameDefensiveStanceCapError extends Error {
+  constructor(public cap: number) {
+    super(`You can have at most ${cap} tile(s) in defensive stance.`);
+    this.name = "GameDefensiveStanceCapError";
+  }
+}
+export class GameMeditationSlotFullError extends Error {
+  constructor() {
+    super("You already have a hero in meditation.");
+    this.name = "GameMeditationSlotFullError";
+  }
+}
+export class GameHeroAlreadyMeditatingError extends Error {
+  constructor() {
+    super("That hero is already meditating.");
+    this.name = "GameHeroAlreadyMeditatingError";
+  }
+}
+export class GameHeroNotOwnedError extends Error {
+  constructor() {
+    super("That hero is not yours.");
+    this.name = "GameHeroNotOwnedError";
+  }
+}
+export class GameHeroNotFoundError extends Error {
+  constructor() {
+    super("Hero not found.");
+    this.name = "GameHeroNotFoundError";
+  }
+}
+export class GamePepTalkRequiresZeroTurnsError extends Error {
+  constructor() {
+    super("Pep talks are only available when you have 0 turns remaining.");
+    this.name = "GamePepTalkRequiresZeroTurnsError";
+  }
+}
+export class GameRedistributeRateLimitError extends Error {
+  constructor(public retryAfterMs: number) {
+    super("You've used your daily redistribution allowance.");
+    this.name = "GameRedistributeRateLimitError";
+  }
+}
+export class GameLastStandCooldownError extends Error {
+  constructor(public retryAfterMs: number) {
+    super("Last Stand is still on cooldown.");
+    this.name = "GameLastStandCooldownError";
+  }
+}
+export class GameLastStandRequiresZeroTurnsError extends Error {
+  constructor() {
+    super("Last Stand is only available when you have 0 turns remaining.");
+    this.name = "GameLastStandRequiresZeroTurnsError";
+  }
+}
+export class GameLastStandNoThreatError extends Error {
+  constructor() {
+    super("No inbound attack threat detected on that tile.");
+    this.name = "GameLastStandNoThreatError";
+  }
+}
+
 const COLLECTIONS = {
   PLAYERS: "game_players",
   TILES: "game_tiles",
@@ -569,6 +680,9 @@ const COLLECTIONS = {
   // (doc id = seasonNumber). Persisted before the wipe so the record
   // survives even if the resolver crashes mid-batch.
   ARMAGEDDON_EVENTS: "game_armageddon_events",
+  // Zero-turn gameplay: queued battle plans that execute at next weekly
+  // grant. Owned by player; writes Admin-SDK only.
+  ORDER_QUEUE: "game_order_queue",
 } as const;
 
 const WORLD_META_DOC = "singleton";
@@ -3198,6 +3312,26 @@ export async function attackTileServer(args: {
     defenderTileId: args.targetTileId,
   });
 
+  // Zero-turn gameplay: detect any active pact the attacker is about to
+  // break. The attack still resolves, but with an Oathbreaker penalty on
+  // attackPower AND the attacker gets the public mark for 7 days. The
+  // lookup runs outside the txn (like markPactsBrokenInTx, which we'll
+  // call later to actually stamp brokenAt).
+  const pactsToBreak = await findActivePactsBetween({
+    db,
+    attackerId: args.attackerId,
+    defenderId,
+    now,
+  });
+  const willBreakPact = pactsToBreak.length > 0;
+  // Also detect any already-active oathbreaker mark from a PRIOR breach.
+  const priorOathbreakerPenalty = oathbreakerAttackPenalty(attackerPre, now);
+  // Effective penalty for THIS attack: max of prior mark and breach-now.
+  const oathbreakerPenaltyForThisAttack = Math.max(
+    priorOathbreakerPenalty,
+    willBreakPact ? OATHBREAKER_ATTACK_PENALTY : 0
+  );
+
   if (offenseSpell) {
     // We can't validate caste-match yet without reading the player; deferred
     // into the transaction below.
@@ -3248,6 +3382,12 @@ export async function attackTileServer(args: {
     if (target.ownerId === args.attackerId) throw new GameSelfAttackError();
     if (!source.neighborTileIds.includes(args.targetTileId)) {
       throw new GameNotAdjacentError();
+    }
+    // Zero-turn gameplay: a tile in defensive stance trades its offensive
+    // option for the +25% defense bonus and cannot launch attacks until
+    // the stance lifts (see toggleDefensiveStanceServer).
+    if (isTileInDefensiveStance(source, now)) {
+      throw new GameDefensiveStanceBlockedError();
     }
     if (offenseSpell && offenseSpell.caste !== attacker.caste) {
       throw new GameInvalidSpellError(
@@ -3337,8 +3477,18 @@ export async function attackTileServer(args: {
     // stationed special-unit contributions folded into the same channel).
     // Combat math applies (1 + bonus) at the same numeric stage as the
     // existing intel bonuses; see combat.ts:resolveAttack.
-    const heroAttackBonus = combinedHeroAttackBonus(attacker, source, target);
-    const heroDefenseBonus = combinedHeroDefenseBonus(defender, target, source);
+    const heroAttackBonus = combinedHeroAttackBonus(attacker, source, target, now);
+    const heroDefenseBonus = combinedHeroDefenseBonus(defender, target, source, now);
+    // Zero-turn gameplay: fold defensive-stance and Last Stand into the
+    // defender's combat input. Adjacent-rally penalties (rally pulls
+    // reserves from neighbors) are not applied here — they're picked up
+    // by attacks against THOSE neighbors which read this tile's
+    // activeLastStand. For the target tile itself the bonus is purely
+    // additive.
+    const zeroTurnDefenseBonus = computeZeroTurnDefenseBonus({
+      tile: target,
+      now,
+    });
 
     const result = resolveAttack(
       {
@@ -3352,6 +3502,7 @@ export async function attackTileServer(args: {
         sourceLandType: source.type,
         preCastOffenseBonus: intelContext.preCastOffenseBonus,
         heroAttackBonus,
+        oathbreakerPenalty: oathbreakerPenaltyForThisAttack,
       },
       {
         caste: defender.caste,
@@ -3364,6 +3515,7 @@ export async function attackTileServer(args: {
         intelDefenseBonus: intelContext.alertVsCasterDefenseBonus,
         defenseDisarmFraction: intelContext.defenseDisarmFraction,
         heroDefenseBonus,
+        zeroTurnDefenseBonus,
       },
       {
         capacity: tileCapacity,
@@ -3664,6 +3816,16 @@ export async function attackTileServer(args: {
       // Tile had a hero before; explicitly clear it (kill OR moved away).
       targetWrite.hero = null;
     }
+    // Zero-turn gameplay: Last Stand is single-use — consume on any inbound
+    // attack, whether or not it was active at resolution time (clears the
+    // window so the player has to declare again). Defensive stance clears
+    // on capture (new owner doesn't inherit) and is preserved on repel.
+    if (target.activeLastStand) {
+      targetWrite.activeLastStand = null;
+    }
+    if (captured && target.defensiveStance) {
+      targetWrite.defensiveStance = null;
+    }
     tx.update(targetRef, targetWrite);
 
     // ── Stationed special-unit cleanup on tile capture ───────────────────
@@ -3715,6 +3877,24 @@ export async function attackTileServer(args: {
         (attacker.heroCount ?? 0) + attackerHeroDelta
       );
     }
+    // Zero-turn gameplay: stamp the Oathbreaker mark when this attack
+    // breaks one or more active pacts. The penalty already applied to
+    // attackPower above; this write makes the mark visible on the public
+    // profile + applies to subsequent attacks within the window. Use the
+    // larger of any existing oathbreakerUntil and the new expiry so a
+    // fresh breach during an existing window extends the punishment.
+    if (willBreakPact) {
+      const oathbreakerUntil = new Date(
+        Math.max(
+          attacker.oathbreakerUntil instanceof Date
+            ? attacker.oathbreakerUntil.getTime()
+            : 0,
+          now.getTime() + OATHBREAKER_DURATION_MS
+        )
+      );
+      attackerUpdate.oathbreakerUntil = oathbreakerUntil;
+      attackerUpdate.oathbreakerLastPactId = pactsToBreak[0].id;
+    }
     tx.update(attackerRef, attackerUpdate);
 
     const defenderUpdate: Record<string, unknown> = {
@@ -3729,6 +3909,15 @@ export async function attackTileServer(args: {
     }
     if (nextDefenderSummonable !== defender.summonableSpecialUnits) {
       defenderUpdate.summonableSpecialUnits = nextDefenderSummonable;
+    }
+    // Zero-turn gameplay: if the captured tile was in defensive stance,
+    // decrement the defender's denormalized counter so the cap check
+    // stays accurate.
+    if (captured && isTileInDefensiveStance(target, now)) {
+      defenderUpdate.activeDefensiveStanceCount = Math.max(
+        0,
+        (defender.activeDefensiveStanceCount ?? 0) - 1
+      );
     }
     tx.update(defenderRef, defenderUpdate);
 
@@ -4048,6 +4237,13 @@ export async function attackTileServer(args: {
       rngSeed: `attack-${attackId}`,
       outcome: result.outcome,
       turnsCost: turnCost,
+      // Zero-turn gameplay: pre-attack defender composition snapshot for
+      // the Battle Autopsy feature. Surfaced on /game/attacks/[attackId]
+      // so the loser can run counterfactual "what would have flipped this"
+      // simulations. The composite is BASE+SUPER; baseUnitsOnTargetPreAttack
+      // splits the BASE portion for finer attribution.
+      unitsOnTargetPreAttack: defenderComposite,
+      baseUnitsOnTargetPreAttack: targetBase,
       createdAt: now,
       ...(dispatch ? { dispatch } : {}),
     };
@@ -5333,6 +5529,8 @@ export async function runWeeklyRolloverServer(
         const updated = applyWeeklyGrant(freshData, wkStart, now);
         tx.update(playerRef, {
           turnsRemaining: updated.turnsRemaining,
+          // Zero-turn gameplay: consume any pending prophecy bonus on grant.
+          pendingProphecyBonus: 0,
           lastWeeklyGrantAt: updated.lastWeeklyGrantAt,
           lastWeeklyGrantWeekStart: updated.lastWeeklyGrantWeekStart,
           updatedAt: updated.updatedAt,
@@ -5567,6 +5765,8 @@ export async function adminGrantTurnsServer(
     const granted = applyWeeklyGrant(player, wkStart, now);
     tx.update(playerRef, {
       turnsRemaining: granted.turnsRemaining,
+      // Zero-turn gameplay: consume any pending prophecy bonus on grant.
+      pendingProphecyBonus: 0,
       lastWeeklyGrantAt: granted.lastWeeklyGrantAt,
       lastWeeklyGrantWeekStart: granted.lastWeeklyGrantWeekStart,
       updatedAt: granted.updatedAt,
@@ -7065,4 +7265,410 @@ export async function listArmageddonHistoryServer(
     .limit(Math.max(1, Math.min(200, limit)))
     .get();
   return snap.docs.map((d) => d.data() as ArmageddonEventRecord);
+}
+
+// =====================================================================
+// Zero-turn gameplay: new server actions
+// =====================================================================
+//
+// These functions are the entrypoints for the May 2026 zero-turn
+// gameplay features. Each enforces its own gating (rate limits, caps,
+// cooldowns, 0-turn predicates) so the actions complement rather than
+// replace the turn economy.
+
+/**
+ * Grants PEP_TALK_STAMINA_GAIN stamina to one of the caller's heroes.
+ *
+ * Gating:
+ *   - Caller must currently have turnsRemaining === 0 (consolation
+ *     mechanic; doesn't trivialize stamina for active players).
+ *   - Per-day rate limit is enforced at the API route layer (3/day).
+ *
+ * The target hero is identified by its `tileId` — pep talks always go
+ * to "the hero on this tile." This avoids needing a separate heroId
+ * lookup index when the hero registry has the canonical id but the
+ * tile snapshot is what combat reads.
+ */
+export async function pepTalkHeroServer(args: {
+  callerUserId: string;
+  tileId: string;
+  now?: Date;
+}): Promise<GameTile> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.callerUserId);
+  const tileRef = db.collection(COLLECTIONS.TILES).doc(args.tileId);
+  return db.runTransaction(async (tx) => {
+    const [playerSnap, tileSnap] = await Promise.all([
+      tx.get(playerRef),
+      tx.get(tileRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!tileSnap.exists) throw new GameTileNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+    const tile = tileSnap.data() as GameTile;
+    if (player.turnsRemaining > 0) {
+      throw new GamePepTalkRequiresZeroTurnsError();
+    }
+    if (tile.ownerId !== args.callerUserId) throw new GameTileNotOwnedError();
+    if (!tile.hero) throw new GameHeroNotFoundError();
+    if (tile.hero.ownerId !== args.callerUserId) {
+      throw new GameHeroNotOwnedError();
+    }
+    const updatedHero: GameHero = {
+      ...tile.hero,
+      stamina: Math.min(
+        tile.hero.staminaMax,
+        tile.hero.stamina + PEP_TALK_STAMINA_GAIN
+      ),
+      lastEngagedAtTurn: player.turnsSpentTotal,
+    };
+    tx.update(tileRef, { hero: updatedHero, updatedAt: now });
+    // Mirror the stamina onto the persistent registry doc so the All
+    // Heroes browse view stays accurate.
+    tx.update(
+      db.collection("game_heroes").doc(updatedHero.id),
+      { stamina: updatedHero.stamina, updatedAt: now }
+    );
+    return { ...tile, hero: updatedHero, updatedAt: now };
+  });
+}
+
+/**
+ * Puts one of the caller's heroes into meditation for
+ * MEDITATION_DURATION_MS. Stamina is set to staminaMax immediately and
+ * the hero is marked off-duty — combat and engagement skip them until
+ * the timer expires.
+ *
+ * Gating:
+ *   - The hero must be owned by the caller and on a tile.
+ *   - The hero must not already be meditating.
+ *   - The caller can have at most MEDITATION_MAX_ACTIVE_SLOTS heroes
+ *     meditating at once (default 1).
+ */
+export async function meditateHeroServer(args: {
+  callerUserId: string;
+  tileId: string;
+  now?: Date;
+}): Promise<GameTile> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.callerUserId);
+  const tileRef = db.collection(COLLECTIONS.TILES).doc(args.tileId);
+  // Count the player's currently-meditating heroes via a non-tx query
+  // (Firestore can't `where` inside a tx). Slight race: a second concurrent
+  // call could double-spend the slot. Acceptable for the cap of 1 — worst
+  // case the player ends up with 2 meditating, the cap reasserts after.
+  const ownedSnap = await db
+    .collection(COLLECTIONS.TILES)
+    .where("ownerId", "==", args.callerUserId)
+    .get();
+  let meditating = 0;
+  for (const doc of ownedSnap.docs) {
+    const t = doc.data() as GameTile;
+    if (t.hero && t.hero.meditatingUntil) {
+      const until =
+        t.hero.meditatingUntil instanceof Date
+          ? t.hero.meditatingUntil
+          : (t.hero.meditatingUntil as { toDate: () => Date }).toDate?.() ??
+            null;
+      if (until && until.getTime() > now.getTime()) meditating += 1;
+    }
+  }
+  if (meditating >= MEDITATION_MAX_ACTIVE_SLOTS) {
+    throw new GameMeditationSlotFullError();
+  }
+  return db.runTransaction(async (tx) => {
+    const [playerSnap, tileSnap] = await Promise.all([
+      tx.get(playerRef),
+      tx.get(tileRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!tileSnap.exists) throw new GameTileNotFoundError();
+    const tile = tileSnap.data() as GameTile;
+    if (tile.ownerId !== args.callerUserId) throw new GameTileNotOwnedError();
+    if (!tile.hero) throw new GameHeroNotFoundError();
+    if (tile.hero.ownerId !== args.callerUserId) {
+      throw new GameHeroNotOwnedError();
+    }
+    if (tile.hero.meditatingUntil) {
+      const until =
+        tile.hero.meditatingUntil instanceof Date
+          ? tile.hero.meditatingUntil
+          : null;
+      if (until && until.getTime() > now.getTime()) {
+        throw new GameHeroAlreadyMeditatingError();
+      }
+    }
+    const meditatingUntil = new Date(now.getTime() + MEDITATION_DURATION_MS);
+    const updatedHero: GameHero = {
+      ...tile.hero,
+      stamina: tile.hero.staminaMax,
+      meditatingUntil,
+      lastEngagedAtTurn: (playerSnap.data() as GamePlayer).turnsSpentTotal,
+    };
+    tx.update(tileRef, { hero: updatedHero, updatedAt: now });
+    tx.update(
+      db.collection("game_heroes").doc(updatedHero.id),
+      {
+        stamina: updatedHero.stamina,
+        meditatingUntil,
+        updatedAt: now,
+      }
+    );
+    return { ...tile, hero: updatedHero, updatedAt: now };
+  });
+}
+
+/**
+ * Moves units between two adjacent tiles the caller owns. Applies the
+ * REDISTRIBUTE_TRANSIT_LOSS haircut to the moved stack. Capped at
+ * REDISTRIBUTE_MAX_PER_DAY per player per rolling 24h window.
+ */
+export async function redistributeUnitsServer(args: {
+  callerUserId: string;
+  sourceTileId: string;
+  destTileId: string;
+  units: UnitStack;
+  now?: Date;
+}): Promise<{ source: GameTile; dest: GameTile }> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.callerUserId);
+  const sourceRef = db.collection(COLLECTIONS.TILES).doc(args.sourceTileId);
+  const destRef = db.collection(COLLECTIONS.TILES).doc(args.destTileId);
+  return db.runTransaction(async (tx) => {
+    const [playerSnap, sourceSnap, destSnap] = await Promise.all([
+      tx.get(playerRef),
+      tx.get(sourceRef),
+      tx.get(destRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!sourceSnap.exists) throw new GameTileNotFoundError();
+    if (!destSnap.exists) throw new GameTileNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+    const source = sourceSnap.data() as GameTile;
+    const dest = destSnap.data() as GameTile;
+    if (source.ownerId !== args.callerUserId) {
+      throw new GameTileNotOwnedError();
+    }
+    if (dest.ownerId !== args.callerUserId) {
+      throw new GameTileNotOwnedError();
+    }
+    if (!source.neighborTileIds.includes(args.destTileId)) {
+      throw new GameNotAdjacentError();
+    }
+    if (!stackHasAtLeast(source.units, args.units)) {
+      throw new GameInsufficientUnitsError();
+    }
+    // Pruned rolling-24h counter from the player's recentRedistributions.
+    const recent = (player.recentRedistributions ?? []).filter((entry) => {
+      const ms =
+        entry instanceof Date
+          ? entry.getTime()
+          : ((entry as { toMillis?: () => number }).toMillis?.() ?? 0);
+      return now.getTime() - ms < 24 * 60 * 60 * 1000;
+    });
+    if (recent.length >= REDISTRIBUTE_MAX_PER_DAY) {
+      // Find the oldest entry to compute retryAfter.
+      const oldest = recent[0];
+      const oldestMs =
+        oldest instanceof Date
+          ? oldest.getTime()
+          : ((oldest as { toMillis?: () => number }).toMillis?.() ?? 0);
+      const retryAfter = 24 * 60 * 60 * 1000 - (now.getTime() - oldestMs);
+      throw new GameRedistributeRateLimitError(Math.max(0, retryAfter));
+    }
+    // Apply the transit-loss haircut.
+    const arrived = {
+      ground: Math.floor(
+        args.units.ground * (1 - 0.08) // REDISTRIBUTE_TRANSIT_LOSS
+      ),
+      siege: Math.floor(args.units.siege * (1 - 0.08)),
+      air: Math.floor(args.units.air * (1 - 0.08)),
+    };
+    const newSourceUnits: UnitStack = {
+      ground: source.units.ground - args.units.ground,
+      siege: source.units.siege - args.units.siege,
+      air: source.units.air - args.units.air,
+    };
+    const newDestUnits: UnitStack = {
+      ground: dest.units.ground + arrived.ground,
+      siege: dest.units.siege + arrived.siege,
+      air: dest.units.air + arrived.air,
+    };
+    // Cap check on destination: SUPER stack can't exceed tile capacity.
+    const destCapacity = computeTileCapacity(
+      dest.type,
+      player.caste,
+      dest.upgradeIds,
+      player.activeUpgrades ?? {}
+    );
+    if (sumStack(newDestUnits) > destCapacity) {
+      throw new GameTileFullError(
+        Math.max(0, destCapacity - sumStack(dest.units)),
+        sumStack(arrived)
+      );
+    }
+    const nextRecent = [...recent, now];
+    tx.update(sourceRef, { units: newSourceUnits, updatedAt: now });
+    tx.update(destRef, { units: newDestUnits, updatedAt: now });
+    tx.update(playerRef, {
+      recentRedistributions: nextRecent,
+      updatedAt: now,
+    });
+    return {
+      source: { ...source, units: newSourceUnits, updatedAt: now },
+      dest: { ...dest, units: newDestUnits, updatedAt: now },
+    };
+  });
+}
+
+/**
+ * Toggles defensive stance on/off on an owned tile.
+ *
+ * Toggling ON:
+ *   - Tile must be owned by caller.
+ *   - Tile must not already be in stance.
+ *   - Caller's activeDefensiveStanceCount must be below the cap
+ *     (max(1, floor(tilesHeld / 100))).
+ *
+ * Toggling OFF:
+ *   - Only allowed if `defensiveStance.lockedUntil <= now` (the 6h
+ *     cooldown has elapsed). Prevents pre-attack flicker.
+ */
+export async function toggleDefensiveStanceServer(args: {
+  callerUserId: string;
+  tileId: string;
+  desiredActive: boolean;
+  now?: Date;
+}): Promise<GameTile> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.callerUserId);
+  const tileRef = db.collection(COLLECTIONS.TILES).doc(args.tileId);
+  return db.runTransaction(async (tx) => {
+    const [playerSnap, tileSnap] = await Promise.all([
+      tx.get(playerRef),
+      tx.get(tileRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!tileSnap.exists) throw new GameTileNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+    const tile = tileSnap.data() as GameTile;
+    if (tile.ownerId !== args.callerUserId) throw new GameTileNotOwnedError();
+
+    const currentlyActive = isTileInDefensiveStance(tile, now);
+    if (args.desiredActive && currentlyActive) {
+      // No-op: already on.
+      return tile;
+    }
+    if (!args.desiredActive && !currentlyActive) {
+      // No-op: already off.
+      return tile;
+    }
+    if (args.desiredActive) {
+      // Check the cap based on the denormalized counter.
+      const cap = Math.max(1, Math.floor((player.stats?.tilesHeld ?? 0) / 100));
+      const active = player.activeDefensiveStanceCount ?? 0;
+      if (active >= cap) {
+        throw new GameDefensiveStanceCapError(cap);
+      }
+      const stance = {
+        active: true,
+        since: now,
+        lockedUntil: new Date(now.getTime() + DEFENSIVE_STANCE_LOCK_MS),
+      };
+      tx.update(tileRef, { defensiveStance: stance, updatedAt: now });
+      tx.update(playerRef, {
+        activeDefensiveStanceCount: active + 1,
+        updatedAt: now,
+      });
+      return { ...tile, defensiveStance: stance, updatedAt: now };
+    }
+    // Toggle OFF: must wait for lockedUntil.
+    if (tile.defensiveStance) {
+      const lockedMs =
+        tile.defensiveStance.lockedUntil instanceof Date
+          ? tile.defensiveStance.lockedUntil.getTime()
+          : 0;
+      if (lockedMs > now.getTime()) {
+        throw new GameDefensiveStanceLockedError();
+      }
+    }
+    tx.update(tileRef, { defensiveStance: null, updatedAt: now });
+    tx.update(playerRef, {
+      activeDefensiveStanceCount: Math.max(
+        0,
+        (player.activeDefensiveStanceCount ?? 0) - 1
+      ),
+      updatedAt: now,
+    });
+    return { ...tile, defensiveStance: null as never, updatedAt: now };
+  });
+}
+
+/**
+ * Declares Last Stand on an owned tile. Requires:
+ *   - turnsRemaining === 0
+ *   - Inbound attack threat within LAST_STAND_THREAT_WINDOW_MS (the tile
+ *     has been attacked recently OR a neighbor enemy tile has had a
+ *     burst of activity — we use lastAttackedAt as a simple signal)
+ *   - LAST_STAND_COOLDOWN_MS has elapsed since the last declare
+ *
+ * On success, stamps `activeLastStand` on the tile (consumed by the next
+ * inbound attack — see attackTileServer) and `lastStandUsedAt` on the
+ * player (cooldown clock).
+ */
+export async function declareLastStandServer(args: {
+  callerUserId: string;
+  tileId: string;
+  now?: Date;
+}): Promise<GameTile> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const playerRef = db.collection(COLLECTIONS.PLAYERS).doc(args.callerUserId);
+  const tileRef = db.collection(COLLECTIONS.TILES).doc(args.tileId);
+  return db.runTransaction(async (tx) => {
+    const [playerSnap, tileSnap] = await Promise.all([
+      tx.get(playerRef),
+      tx.get(tileRef),
+    ]);
+    if (!playerSnap.exists) throw new GamePlayerNotFoundError();
+    if (!tileSnap.exists) throw new GameTileNotFoundError();
+    const player = playerSnap.data() as GamePlayer;
+    const tile = tileSnap.data() as GameTile;
+    if (tile.ownerId !== args.callerUserId) throw new GameTileNotOwnedError();
+    if (player.turnsRemaining > 0) {
+      throw new GameLastStandRequiresZeroTurnsError();
+    }
+    // Cooldown check.
+    if (player.lastStandUsedAt) {
+      const used =
+        player.lastStandUsedAt instanceof Date
+          ? player.lastStandUsedAt.getTime()
+          : 0;
+      const elapsed = now.getTime() - used;
+      if (elapsed < LAST_STAND_COOLDOWN_MS) {
+        throw new GameLastStandCooldownError(
+          LAST_STAND_COOLDOWN_MS - elapsed
+        );
+      }
+    }
+    // Threat check: tile has been attacked within the threat window.
+    const lastAttackedMs =
+      tile.lastAttackedAt instanceof Date
+        ? tile.lastAttackedAt.getTime()
+        : 0;
+    if (now.getTime() - lastAttackedMs > LAST_STAND_THREAT_WINDOW_MS) {
+      throw new GameLastStandNoThreatError();
+    }
+    const activeLastStand = {
+      declaredAt: now,
+      expiresAt: new Date(now.getTime() + LAST_STAND_WINDOW_MS),
+    };
+    tx.update(tileRef, { activeLastStand, updatedAt: now });
+    tx.update(playerRef, { lastStandUsedAt: now, updatedAt: now });
+    return { ...tile, activeLastStand, updatedAt: now };
+  });
 }

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -152,6 +152,11 @@ import {
 } from "./zero-turn";
 import { findActivePactsBetween } from "./pacts";
 import {
+  markOrderResultInTx,
+  readQueuedOrdersForPlayer,
+} from "./orders";
+import type { QueuedOrder } from "./types";
+import {
   appendHeroEventInTx,
   heroEvent,
   markHeroDeceasedInTx,
@@ -5539,6 +5544,20 @@ export async function runWeeklyRolloverServer(
       });
       if (granted) summary.granted += 1;
       else summary.skippedAlreadyGranted += 1;
+
+      // Zero-turn gameplay: execute queued orders for this player AFTER
+      // their grant lands. Skip when not granted (no turns to spend).
+      if (granted) {
+        try {
+          await executeQueuedOrdersForPlayer(db, player.userId, now);
+        } catch (queueErr) {
+          const m = queueErr instanceof Error ? queueErr.message : String(queueErr);
+          logger.warn("Queued-orders execution error", {
+            userId: player.userId,
+            error: m,
+          });
+        }
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       summary.errors.push({ userId: player.userId, error: message });
@@ -7620,6 +7639,116 @@ export async function toggleDefensiveStanceServer(args: {
  * inbound attack — see attackTileServer) and `lastStandUsedAt` on the
  * player (cooldown clock).
  */
+/**
+ * Executes the queued orders for one player in sequenceIndex order.
+ * Called from `runWeeklyRolloverServer` after the weekly grant lands.
+ *
+ * Each order is dispatched to the underlying server action
+ * (buildUnitsServer, attackTileServer, etc). Failures are logged as
+ * `failed` on the order doc with a one-line reason so the UI can show
+ * "what happened" without re-running. Successful orders are marked
+ * `executed` and carry the resulting report/attack id for cross-linking.
+ *
+ * No txn wraps the loop itself — each order runs its own server-action
+ * txn. If one fails, subsequent orders still attempt. This matches the
+ * "skip and continue" semantics the plan specified.
+ */
+async function executeQueuedOrdersForPlayer(
+  db: Firestore,
+  playerId: string,
+  now: Date
+): Promise<void> {
+  const orders = await readQueuedOrdersForPlayer(db, playerId);
+  for (const order of orders) {
+    try {
+      await executeQueuedOrder(db, order, now);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      // Best-effort: mark failed in its own tx so subsequent orders can
+      // still run even if the txn write fails.
+      try {
+        await db.runTransaction(async (tx) => {
+          markOrderResultInTx({
+            tx,
+            db,
+            order,
+            status: "failed",
+            resultSummary: message.slice(0, 200),
+            now,
+          });
+        });
+      } catch {
+        // swallow — logger already captures
+      }
+    }
+  }
+}
+
+async function executeQueuedOrder(
+  db: Firestore,
+  order: QueuedOrder,
+  now: Date
+): Promise<void> {
+  switch (order.params.kind) {
+    case "recruit_on_tile": {
+      const result = await buildUnitsServer(
+        order.playerId,
+        order.params.tileId,
+        order.params.unitType,
+        now
+      );
+      await db.runTransaction(async (tx) => {
+        markOrderResultInTx({
+          tx,
+          db,
+          order,
+          status: "executed",
+          resultSummary: `Recruited ${result.produced} ${order.params.kind === "recruit_on_tile" ? order.params.unitType : ""} on ${order.params.kind === "recruit_on_tile" ? order.params.tileId : ""}`,
+          now,
+        });
+      });
+      return;
+    }
+    case "attack_adjacent": {
+      const p = order.params;
+      const result = await attackTileServer({
+        attackerId: order.playerId,
+        sourceTileId: p.sourceTileId,
+        targetTileId: p.targetTileId,
+        units: p.units,
+        offenseSpellId: p.offenseSpellId,
+        now,
+      });
+      await db.runTransaction(async (tx) => {
+        markOrderResultInTx({
+          tx,
+          db,
+          order,
+          status: "executed",
+          resultSummary: `Attack ${result.combat.outcome}: ${p.sourceTileId} → ${p.targetTileId}`,
+          resultRefId: result.attack.id,
+          now,
+        });
+      });
+      return;
+    }
+    case "cast_spell_on_tile":
+      // v1: spell casting via queue not supported (the existing server
+      // actions split by spell type — would require deeper integration).
+      await db.runTransaction(async (tx) => {
+        markOrderResultInTx({
+          tx,
+          db,
+          order,
+          status: "failed",
+          resultSummary: "Spell-cast queueing not yet supported",
+          now,
+        });
+      });
+      return;
+  }
+}
+
 export async function declareLastStandServer(args: {
   callerUserId: string;
   tileId: string;

--- a/lib/game/orders.ts
+++ b/lib/game/orders.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Queued orders (zero-turn gameplay).
+ *
+ * Players plan a battle plan when they're out of turns; the orders fire
+ * automatically at the next weekly turn grant. Each order carries its
+ * normal turn cost when it fires; orders that can't execute (insufficient
+ * turns, tile lost, etc.) are marked `failed` with a one-line reason and
+ * surfaced in the player's report feed.
+ *
+ * Storage: `game_order_queue/{orderId}` — one doc per order. Server-write
+ * only. Players list their queue via /api/game/orders.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import type {
+  QueuedOrder,
+  QueuedOrderKind,
+  QueuedOrderParams,
+  QueuedOrderStatus,
+} from "./types";
+import { QUEUED_ORDERS_MAX_PER_PLAYER } from "./types";
+
+const ORDER_QUEUE = "game_order_queue";
+
+// Errors -----------------------------------------------------------------
+
+export class QueuedOrderQueueFullError extends Error {
+  constructor(public cap: number) {
+    super(`Order queue full — cap is ${cap} pending orders.`);
+    this.name = "QueuedOrderQueueFullError";
+  }
+}
+export class QueuedOrderNotFoundError extends Error {
+  constructor() {
+    super("Queued order not found.");
+    this.name = "QueuedOrderNotFoundError";
+  }
+}
+export class QueuedOrderForbiddenError extends Error {
+  constructor() {
+    super("That order is not yours.");
+    this.name = "QueuedOrderForbiddenError";
+  }
+}
+export class QueuedOrderInvalidParamsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QueuedOrderInvalidParamsError";
+  }
+}
+
+function adminDbOrThrow(): Firestore {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not initialized");
+  return db;
+}
+
+// Param validation -------------------------------------------------------
+
+function validateParamsForKind(
+  kind: QueuedOrderKind,
+  params: QueuedOrderParams
+): void {
+  if (params.kind !== kind) {
+    throw new QueuedOrderInvalidParamsError("Params kind mismatch");
+  }
+  switch (params.kind) {
+    case "recruit_on_tile":
+      if (!params.tileId) {
+        throw new QueuedOrderInvalidParamsError("tileId required");
+      }
+      if (!["ground", "siege", "air"].includes(params.unitType)) {
+        throw new QueuedOrderInvalidParamsError("Invalid unitType");
+      }
+      break;
+    case "attack_adjacent":
+      if (!params.sourceTileId || !params.targetTileId) {
+        throw new QueuedOrderInvalidParamsError("source/target tileIds required");
+      }
+      if (
+        params.units.ground < 0 ||
+        params.units.siege < 0 ||
+        params.units.air < 0
+      ) {
+        throw new QueuedOrderInvalidParamsError("Unit counts must be >= 0");
+      }
+      if (
+        params.units.ground + params.units.siege + params.units.air <
+        1
+      ) {
+        throw new QueuedOrderInvalidParamsError("Must send at least 1 unit");
+      }
+      break;
+    case "cast_spell_on_tile":
+      if (!params.tileId || !params.spellId) {
+        throw new QueuedOrderInvalidParamsError("tileId + spellId required");
+      }
+      break;
+  }
+}
+
+// Server actions ---------------------------------------------------------
+
+export async function enqueueOrderServer(args: {
+  playerId: string;
+  kind: QueuedOrderKind;
+  params: QueuedOrderParams;
+  now?: Date;
+}): Promise<QueuedOrder> {
+  validateParamsForKind(args.kind, args.params);
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  // Count current "queued" orders for this player.
+  const snap = await db
+    .collection(ORDER_QUEUE)
+    .where("playerId", "==", args.playerId)
+    .where("status", "==", "queued")
+    .get();
+  if (snap.size >= QUEUED_ORDERS_MAX_PER_PLAYER) {
+    throw new QueuedOrderQueueFullError(QUEUED_ORDERS_MAX_PER_PLAYER);
+  }
+  const id = randomUUID();
+  const order: QueuedOrder = {
+    id,
+    playerId: args.playerId,
+    kind: args.kind,
+    params: args.params,
+    sequenceIndex: snap.size, // append to end of queue
+    status: "queued",
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.collection(ORDER_QUEUE).doc(id).set(order);
+  return order;
+}
+
+export async function listOrdersForPlayerServer(
+  playerId: string,
+  includeExecuted: boolean = false
+): Promise<QueuedOrder[]> {
+  const db = adminDbOrThrow();
+  let query = db.collection(ORDER_QUEUE).where("playerId", "==", playerId);
+  if (!includeExecuted) {
+    query = query.where("status", "==", "queued");
+  }
+  const snap = await query.get();
+  return snap.docs
+    .map((d) => d.data() as QueuedOrder)
+    .sort((a, b) => a.sequenceIndex - b.sequenceIndex);
+}
+
+export async function cancelOrderServer(args: {
+  orderId: string;
+  callerUserId: string;
+  now?: Date;
+}): Promise<QueuedOrder> {
+  const now = args.now ?? new Date();
+  const db = adminDbOrThrow();
+  const ref = db.collection(ORDER_QUEUE).doc(args.orderId);
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) throw new QueuedOrderNotFoundError();
+    const data = snap.data() as QueuedOrder;
+    if (data.playerId !== args.callerUserId) {
+      throw new QueuedOrderForbiddenError();
+    }
+    if (data.status !== "queued") {
+      // Already executed/failed/cancelled — return as-is, no error.
+      return data;
+    }
+    const updates: Partial<QueuedOrder> = {
+      status: "cancelled" as QueuedOrderStatus,
+      updatedAt: now,
+      executedAt: now,
+      resultSummary: "Cancelled by player",
+    };
+    tx.update(ref, updates);
+    return { ...data, ...updates };
+  });
+}
+
+/**
+ * Mark a queued order as `executed` or `failed` inside the caller's
+ * transaction. Used by the weekly-rollover executor.
+ */
+export function markOrderResultInTx(args: {
+  tx: Transaction;
+  db: Firestore;
+  order: QueuedOrder;
+  status: "executed" | "failed";
+  resultSummary: string;
+  resultRefId?: string;
+  now: Date;
+}): void {
+  const ref = args.db.collection(ORDER_QUEUE).doc(args.order.id);
+  const updates: Partial<QueuedOrder> = {
+    status: args.status,
+    resultSummary: args.resultSummary,
+    executedAt: args.now,
+    updatedAt: args.now,
+    ...(args.resultRefId ? { resultRefId: args.resultRefId } : {}),
+  };
+  args.tx.update(ref, updates);
+}
+
+/**
+ * Reads (outside any transaction) all queued orders for one player,
+ * sorted by sequenceIndex. The weekly-rollover executor calls this once
+ * per player, then iterates and dispatches each order to its handler.
+ *
+ * Kept here (not inlined into the executor) so the queued-orders unit
+ * tests can mock the read independently of the dispatch logic.
+ */
+export async function readQueuedOrdersForPlayer(
+  db: Firestore,
+  playerId: string
+): Promise<QueuedOrder[]> {
+  const snap = await db
+    .collection(ORDER_QUEUE)
+    .where("playerId", "==", playerId)
+    .where("status", "==", "queued")
+    .get();
+  return snap.docs
+    .map((d) => d.data() as QueuedOrder)
+    .sort((a, b) => a.sequenceIndex - b.sequenceIndex);
+}

--- a/lib/game/pacts.ts
+++ b/lib/game/pacts.ts
@@ -172,6 +172,41 @@ function pactExpiresAtMs(p: Pact): number {
 }
 
 /**
+ * Returns the live (not-deleted, not-broken, not-expired) pacts where
+ * `attackerId` is the author and `defenderId` is the target. Empty array
+ * if there are no active pacts. Used by the attack handler to decide
+ * whether the Oathbreaker mark applies to the imminent attack.
+ *
+ * Reads outside any transaction — the lookup is informational, and the
+ * subsequent `markPactsBrokenInTx` is responsible for the actual brokenAt
+ * write inside the transaction.
+ */
+export async function findActivePactsBetween(args: {
+  db: Firestore;
+  attackerId: string;
+  defenderId: string;
+  now: Date;
+}): Promise<Pact[]> {
+  const snap = await args.db
+    .collection(PACTS)
+    .where("authorId", "==", args.attackerId)
+    .where("targetId", "==", args.defenderId)
+    .get();
+  if (snap.empty) return [];
+  const nowMs = args.now.getTime();
+  const out: Pact[] = [];
+  for (const doc of snap.docs) {
+    const pact = doc.data() as Pact;
+    if (pact.deletedAt) continue;
+    if (pact.brokenAt) continue;
+    const expiresMs = pactExpiresAtMs(pact);
+    if (expiresMs < nowMs) continue;
+    out.push(pact);
+  }
+  return out;
+}
+
+/**
  * Called inside attackTileServer's transaction. Scans the attacker's
  * active pacts targeting the defender; for each not-yet-broken pact
  * still inside its window, sets `brokenAt` and posts a `pact_broken`

--- a/lib/game/prophecies.ts
+++ b/lib/game/prophecies.ts
@@ -23,6 +23,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { sanitizeText } from "@/lib/sanitize";
 import type { Caste, GameWorldMeta, Prophecy } from "./types";
+import { PROPHECY_BONUS_TURNS } from "./types";
 import { logCommunityEventInTx } from "./community";
 
 const PROPHECIES = "game_prophecies";
@@ -201,10 +202,20 @@ export async function resolveProphesiesForSealInTx(args: {
       resolvedAt: args.now,
       fulfilledBy: args.brokenBy,
     });
-    // Bump the author's seer counter.
+    // Bump the author's seer counter AND stake them a small bonus toward
+    // their next weekly turn grant (zero-turn gameplay: prophecy stakes).
+    // Capped at PROPHECY_BONUS_TURNS_MAX so multiple resolutions in one
+    // week don't compound. The cap is enforced at consume-time in
+    // runWeeklyRolloverServer using Math.min — the per-resolution write
+    // here doesn't need to know the cap because it's a monotonic field
+    // we read-then-write later. We add unconditionally here; the cap
+    // applies when the bonus is actually consumed.
     args.tx.update(
       args.db.collection(PLAYERS).doc(data.authorId),
-      { prophecyFulfilledCount: FieldValue.increment(1) }
+      {
+        prophecyFulfilledCount: FieldValue.increment(1),
+        pendingProphecyBonus: FieldValue.increment(PROPHECY_BONUS_TURNS),
+      }
     );
     logCommunityEventInTx(
       args.tx,

--- a/lib/game/turns.ts
+++ b/lib/game/turns.ts
@@ -7,6 +7,7 @@
 import { magicMultiplier, unitCapFromFoodLands } from "./combat";
 import { SPELLS_BY_ID, getCasteProfile } from "./content";
 import type { ActiveProductionSpell, GamePlayer, Phase } from "./types";
+import { PROPHECY_BONUS_TURNS_MAX } from "./types";
 
 export const WEEKLY_TURN_GRANT = 100;
 // Initial bucket granted at spawn. Larger than the weekly grant so a fresh
@@ -202,14 +203,21 @@ export function shouldGrantWeeklyTurns(
 
 // Adds WEEKLY_TURN_GRANT on top of any unspent turns — banking is rewarded,
 // not penalized. A player who hoarded 300 going into the rollover ends at 400.
+// Zero-turn gameplay: consumes any pendingProphecyBonus (capped at
+// PROPHECY_BONUS_TURNS_MAX) so a fulfilled prophecy stakes the prophet
+// extra turns on their next grant. The pending counter is zeroed in the
+// returned player; the caller is responsible for writing this back.
 export function applyWeeklyGrant(
   player: GamePlayer,
   weekStartIso: string,
   now: Date = new Date()
 ): GamePlayer {
+  const bonusRaw = player.pendingProphecyBonus ?? 0;
+  const bonus = Math.min(PROPHECY_BONUS_TURNS_MAX, Math.max(0, bonusRaw));
   return {
     ...player,
-    turnsRemaining: player.turnsRemaining + WEEKLY_TURN_GRANT,
+    turnsRemaining: player.turnsRemaining + WEEKLY_TURN_GRANT + bonus,
+    pendingProphecyBonus: 0,
     lastWeeklyGrantAt: now,
     lastWeeklyGrantWeekStart: weekStartIso,
     updatedAt: now,

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -1370,9 +1370,11 @@ export type QueuedOrderStatus =
   | "failed"
   | "cancelled";
 
-/** Per-kind params payload. Discriminated by `kind`. */
+/** Per-kind params payload. Discriminated by `kind`. Each enqueued
+ *  order represents ONE action; players queue multiple orders if they
+ *  want a sequence. */
 export type QueuedOrderParams =
-  | { kind: "recruit_on_tile"; tileId: string; unitType: UnitType; quantity: number }
+  | { kind: "recruit_on_tile"; tileId: string; unitType: UnitType }
   | { kind: "attack_adjacent"; sourceTileId: string; targetTileId: string; units: UnitStack; offenseSpellId: string | null }
   | { kind: "cast_spell_on_tile"; tileId: string; spellId: string };
 

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -260,6 +260,29 @@ export interface GamePlayer {
   // Phase 7. Incremented when one of this player's prophecies resolves
   // (the predicted seal breaks). Drives the Seer title.
   prophecyFulfilledCount?: number;
+  // Zero-turn gameplay features (May 2026 sim follow-up).
+  // Oathbreaker debuff window: when set and > now, attacks launched by this
+  // player resolve with -OATHBREAKER_ATTACK_PENALTY on attackPower. Stamped
+  // by the attack handler when the attacker breaks an active pact.
+  oathbreakerUntil?: Timestamp | Date;
+  // Stamped alongside oathbreakerUntil so the UI knows the source attack id
+  // for the public Oathbreaker badge on the profile.
+  oathbreakerLastPactId?: string;
+  // Turns to be added to the next weekly grant from a fulfilled prophecy.
+  // Capped at PROPHECY_BONUS_TURNS_MAX so multiple resolutions in one week
+  // don't compound. Consumed (zeroed) by runWeeklyRolloverServer on grant.
+  pendingProphecyBonus?: number;
+  // Last time this player declared Last Stand. Used for the 24h cooldown
+  // check in declareLastStandServer. Absent ⇒ never used.
+  lastStandUsedAt?: Timestamp | Date;
+  // Denormalized counter of tiles currently in defensive stance. Maintained
+  // alongside GameTile.defensiveStance writes so the cap check
+  // (max = floor(tilesHeld / 100), min 1) doesn't have to query all tiles.
+  // Optional for back-compat; readers coalesce to 0.
+  activeDefensiveStanceCount?: number;
+  // Denormalized list of the last 24h of redistribution timestamps for the
+  // per-day rate limit (3/day). Pruned on each write. Optional for back-compat.
+  recentRedistributions?: Array<Timestamp | Date>;
   createdAt: Timestamp | Date;
   updatedAt: Timestamp | Date;
 }
@@ -360,6 +383,26 @@ export interface GameTile {
   // interacts with the tile. Server-sanitized on write.
   inscription?: string;
   inscriptionUpdatedAt?: Timestamp | Date;
+  // Zero-turn gameplay: defensive-stance toggle. When `active`, this tile
+  // gets DEFENSIVE_STANCE_DEFENSE_BONUS on its defense power and the attack
+  // handler refuses attacks launched FROM this tile until the toggle lifts.
+  // `lockedUntil` enforces a one-way cooldown — toggling on is free, but
+  // toggling off can't happen until lockedUntil < now (prevents pre-attack
+  // flicker). Absent ⇒ tile is in normal stance.
+  defensiveStance?: {
+    active: boolean;
+    since: Timestamp | Date;
+    lockedUntil: Timestamp | Date;
+  };
+  // Zero-turn gameplay: Last Stand declaration. When set, the next inbound
+  // attack against this tile resolves with LAST_STAND_DEFENSE_BONUS on
+  // defense power AND adjacent owned tiles take LAST_STAND_ADJACENT_PENALTY
+  // on theirs (rally pulls reserves). Single-use — combat consumes (deletes)
+  // on next attack. Stamped by declareLastStandServer.
+  activeLastStand?: {
+    declaredAt: Timestamp | Date;
+    expiresAt: Timestamp | Date;
+  };
   createdAt: Timestamp | Date;
   updatedAt: Timestamp | Date;
 }
@@ -467,6 +510,11 @@ export interface GameHero {
   // engaged). Drives lazy regen at read time. Updated whenever stamina
   // changes (engagement, conversion, move-on-capture).
   lastEngagedAtTurn: number;
+  // Zero-turn gameplay: meditation. When set and > now, the hero is on
+  // sabbatical — combat skips its attack/defense bonus contribution, and
+  // stamina regen runs at MEDITATION_REGEN_MULTIPLIER × normal rate.
+  // Absent ⇒ hero is active. Set by meditateHeroServer; auto-expires.
+  meditatingUntil?: Timestamp | Date;
 }
 
 // Resolution choice when an attacker wins a battle against a hero tile.
@@ -609,6 +657,10 @@ export interface GameHeroDoc {
   // `GameTile.hero.stamina`; this denorm is updated alongside it.
   stamina: number;
   staminaMax: number;
+  // Zero-turn gameplay: meditation denorm. Mirrors GameHero.meditatingUntil
+  // on the tile snapshot so the All Heroes browse view can render the
+  // "meditating" badge without joining against the tile. Absent ⇒ active.
+  meditatingUntil?: Timestamp | Date;
   // Status flags
   isDeceased: boolean;
   // True between season-end and next resurrection. Set by armageddon-resolve.
@@ -655,6 +707,9 @@ export interface SafeHeroSummary {
   deceasedTileId?: string;
   stamina?: number;
   staminaMax?: number;
+  // Zero-turn gameplay: meditation state surfaced when the hero is visible.
+  // Absent / past ⇒ active. Present and > now ⇒ meditating until that time.
+  meditatingUntil?: Timestamp | Date;
   // Set when a backstory markdown file exists for this hero. Drives the
   // "Add the next chapter" vs "Read the chronicle" CTA in the UI.
   hasBackstory: boolean;
@@ -702,6 +757,15 @@ export interface GameAttack {
   /** Optional attacker-authored ≤280-char taunt. Server-sanitized on
    *  write. Cosmetic only; no combat impact. */
   dispatch?: string;
+  /** Zero-turn gameplay: pre-attack snapshot of the defender's units on
+   *  the target tile (BASE + SUPER combined). Used by the Battle Autopsy
+   *  feature to run speculative counterfactuals — what would have happened
+   *  with +50 siege, -20% defense, etc. Absent on legacy attack docs;
+   *  autopsy degrades to "no counterfactual available" when missing. */
+  unitsOnTargetPreAttack?: UnitStack;
+  /** Zero-turn gameplay: pre-attack base portion of unitsOnTargetPreAttack,
+   *  for counterfactual loss-attribution. Optional/back-compat. */
+  baseUnitsOnTargetPreAttack?: UnitStack;
   createdAt: Timestamp | Date;
 }
 
@@ -735,6 +799,12 @@ export interface CombatAttackerInput {
   // unit attackBonus contribution rolled into the same channel. Optional;
   // legacy callers default to 0.
   heroAttackBonus?: number;
+  // Zero-turn gameplay: Oathbreaker penalty. Subtracted from attackPower as
+  // a multiplicative reduction (e.g. 0.10 = -10% attack). Stamped by the
+  // server when an attacker has an active oathbreaker mark from breaking
+  // a pact within OATHBREAKER_DURATION_MS. Optional; legacy callers default
+  // to 0.
+  oathbreakerPenalty?: number;
 }
 
 export interface CombatDefenderInput {
@@ -768,6 +838,14 @@ export interface CombatDefenderInput {
   // special-unit defenseBonus contribution. Optional; legacy callers default
   // to 0.
   heroDefenseBonus?: number;
+  // Zero-turn gameplay: additive defense multiplier from the target tile
+  // being in Defensive Stance (DEFENSIVE_STANCE_DEFENSE_BONUS) plus any
+  // active Last Stand (LAST_STAND_DEFENSE_BONUS). Subtract any Last Stand
+  // adjacent-penalty when the target is adjacent to a tile that declared
+  // last stand against a different attacker. Server folds these into a
+  // single channel before calling resolveAttack. Optional; legacy callers
+  // default to 0.
+  zeroTurnDefenseBonus?: number;
 }
 
 export interface CombatTileInput {
@@ -1263,6 +1341,60 @@ export interface ArmageddonEventRecord {
   }>;
 }
 
+// =====================================================================
+// Zero-turn gameplay: Queued orders
+// =====================================================================
+//
+// Players can pre-plan a battle plan that executes at the next weekly
+// turn grant. Each order carries its normal turn cost when it fires; if
+// the player has insufficient turns when the order's slot comes up the
+// order is skipped with a reason logged into the per-player report feed.
+//
+// Stored as one doc per order in `game_order_queue` (top-level
+// collection, server-write-only). Ordered by sequenceIndex within a
+// player's queue. Failed orders are marked `status: "failed"` rather
+// than deleted so the UI can show "what happened" after the grant.
+
+/** Order kinds supported by the queue v1. New kinds extend this union
+ *  and add a handler branch in executeQueuedOrderServer. */
+export type QueuedOrderKind =
+  | "recruit_on_tile"
+  | "attack_adjacent"
+  | "cast_spell_on_tile";
+
+/** Per-order status. Lifecycle: queued → executing (transient) →
+ *  executed | failed | cancelled. */
+export type QueuedOrderStatus =
+  | "queued"
+  | "executed"
+  | "failed"
+  | "cancelled";
+
+/** Per-kind params payload. Discriminated by `kind`. */
+export type QueuedOrderParams =
+  | { kind: "recruit_on_tile"; tileId: string; unitType: UnitType; quantity: number }
+  | { kind: "attack_adjacent"; sourceTileId: string; targetTileId: string; units: UnitStack; offenseSpellId: string | null }
+  | { kind: "cast_spell_on_tile"; tileId: string; spellId: string };
+
+/** Single order in a player's queue. */
+export interface QueuedOrder {
+  id: string;
+  playerId: string;
+  kind: QueuedOrderKind;
+  params: QueuedOrderParams;
+  // Position within the player's queue at submission time. Lower fires first.
+  sequenceIndex: number;
+  status: QueuedOrderStatus;
+  // Set when status transitions out of "queued".
+  executedAt?: Timestamp | Date;
+  // For "failed" and "executed": one-line reason / outcome for the player.
+  resultSummary?: string;
+  // For "executed": denormalized reference to the resulting report/attack id.
+  resultRefId?: string;
+  createdAt: Timestamp | Date;
+  updatedAt: Timestamp | Date;
+}
+
 /** Scope for community chat messages. `global` is the default open
  *  room; `caste:<name>` rooms are gated to members of that caste at
  *  post time. Existing rows without a scope field are treated as
@@ -1288,3 +1420,70 @@ export interface CommunityMessage {
   /** Per-reaction counters. */
   reactions?: ReactionMap;
 }
+
+// =====================================================================
+// Zero-turn gameplay tuning constants
+// =====================================================================
+//
+// Centralized so balance changes don't require code archaeology. Each
+// constant is referenced from server logic (data-server.ts / heroes.ts /
+// pacts.ts / armageddon-resolve.ts) and tested via the unit tests under
+// __tests__/lib/game/zero-turn.test.ts.
+
+/** Defensive Stance: multiplicative defense bonus on a stance tile. */
+export const DEFENSIVE_STANCE_DEFENSE_BONUS = 0.25;
+/** Defensive Stance: minimum lockedUntil window after toggling on, before
+ *  the tile can toggle off. Prevents flicker right before an inbound attack. */
+export const DEFENSIVE_STANCE_LOCK_MS = 6 * 60 * 60 * 1000;
+
+/** Last Stand: multiplicative defense bonus on the declared tile. */
+export const LAST_STAND_DEFENSE_BONUS = 0.50;
+/** Last Stand: multiplicative defense penalty on adjacent owned tiles
+ *  while a last stand is queued on a neighbor (rally pulls reserves). */
+export const LAST_STAND_ADJACENT_PENALTY = 0.25;
+/** Last Stand: how long after declaring the effect remains armed. If no
+ *  inbound attack lands within this window, the effect expires unused
+ *  but the cooldown still counts. */
+export const LAST_STAND_WINDOW_MS = 60 * 60 * 1000;
+/** Last Stand: how long after declaring before the player can declare
+ *  another. One per 24h. */
+export const LAST_STAND_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+/** Last Stand: how recent an inbound attack signal must be to make the
+ *  declare button available. */
+export const LAST_STAND_THREAT_WINDOW_MS = 30 * 60 * 1000;
+
+/** Tile redistribution: multiplicative haircut applied to the moved
+ *  stack. Prevents free perfect optimization. */
+export const REDISTRIBUTE_TRANSIT_LOSS = 0.08;
+/** Tile redistribution: per-day rate limit per player. */
+export const REDISTRIBUTE_MAX_PER_DAY = 3;
+
+/** Hero pep talk: stamina granted per call. */
+export const PEP_TALK_STAMINA_GAIN = 15;
+/** Hero pep talk: per-day cap across all the player's heroes. */
+export const PEP_TALK_MAX_PER_DAY = 3;
+
+/** Hero meditation: how long the hero remains on sabbatical. */
+export const MEDITATION_DURATION_MS = 24 * 60 * 60 * 1000;
+/** Hero meditation: how many slots the player can have active at once.
+ *  Forces a real opportunity-cost choice — meditating heroes don't fight. */
+export const MEDITATION_MAX_ACTIVE_SLOTS = 1;
+/** Hero meditation: stamina regen multiplier while meditating. */
+export const MEDITATION_REGEN_MULTIPLIER = 2;
+
+/** Oathbreaker: multiplicative attack penalty on attacks launched while
+ *  the mark is active. */
+export const OATHBREAKER_ATTACK_PENALTY = 0.10;
+/** Oathbreaker: how long the mark persists after a pact breach. */
+export const OATHBREAKER_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Prophecy stakes: turns added to the prophet's NEXT weekly grant when
+ *  a prophecy resolves. Capped to a single application per week. */
+export const PROPHECY_BONUS_TURNS = 5;
+/** Prophecy stakes: hard ceiling on `pendingProphecyBonus`. Even if a
+ *  player has multiple prophecies resolve within a single week, the
+ *  weekly grant adds at most this many extra turns. */
+export const PROPHECY_BONUS_TURNS_MAX = 5;
+
+/** Queued orders: max queued (status === "queued") per player. */
+export const QUEUED_ORDERS_MAX_PER_PLAYER = 20;

--- a/lib/game/zero-turn.ts
+++ b/lib/game/zero-turn.ts
@@ -1,0 +1,335 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Pure helpers for the zero-turn gameplay features (May 2026 sim
+ * follow-up). Mechanics that give players meaningful agency at 0 turns:
+ *
+ *   - Hero pep talk / meditation
+ *   - Tile redistribution
+ *   - Defensive stance
+ *   - Last Stand (rally)
+ *   - Enforced pacts (Oathbreaker mark)
+ *   - Prophecy stakes (turn bonus on resolution)
+ *   - Queued orders
+ *   - Battle Autopsy (speculative counterfactual)
+ *
+ * Server-side stitching (Firestore reads/writes, transactions) lives in
+ * data-server.ts. This module is import-safe from both the server and the
+ * pure-helper test suite.
+ */
+
+import type {
+  CombatAttackerInput,
+  CombatDefenderInput,
+  CombatResult,
+  CombatTileInput,
+  GameHero,
+  GamePlayer,
+  GameTile,
+  UnitStack,
+} from "./types";
+import {
+  DEFENSIVE_STANCE_DEFENSE_BONUS,
+  LAST_STAND_ADJACENT_PENALTY,
+  LAST_STAND_DEFENSE_BONUS,
+  LAST_STAND_COOLDOWN_MS,
+  OATHBREAKER_ATTACK_PENALTY,
+  REDISTRIBUTE_MAX_PER_DAY,
+  REDISTRIBUTE_TRANSIT_LOSS,
+} from "./types";
+
+// ─────────────────────────────────────────────────────────────────────
+// Time helpers
+// ─────────────────────────────────────────────────────────────────────
+
+function toMillis(value: Date | { toMillis?: () => number } | undefined): number | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.getTime();
+  if (typeof (value as { toMillis?: () => number }).toMillis === "function") {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Hero meditation
+// ─────────────────────────────────────────────────────────────────────
+
+/** True when the hero is currently on sabbatical (meditating). Meditating
+ *  heroes don't contribute attack/defense bonuses to combat and don't
+ *  engage on their tile's battles. */
+export function isHeroMeditating(hero: GameHero | null | undefined, now: Date): boolean {
+  if (!hero || !hero.meditatingUntil) return false;
+  const ms = toMillis(hero.meditatingUntil);
+  if (ms === null) return false;
+  return ms > now.getTime();
+}
+
+/** Count of the player's heroes currently meditating. Drives the slot
+ *  cap check in meditateHeroServer. Reads tiles owned by the player and
+ *  inspects their hero snapshot. */
+export function countMeditatingHeroes(
+  ownedTilesWithHero: ReadonlyArray<Pick<GameTile, "hero">>,
+  now: Date
+): number {
+  let count = 0;
+  for (const tile of ownedTilesWithHero) {
+    if (isHeroMeditating(tile.hero, now)) count += 1;
+  }
+  return count;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Oathbreaker
+// ─────────────────────────────────────────────────────────────────────
+
+/** Resolved attack penalty fraction for the attacker when their
+ *  Oathbreaker mark is still active. Returns 0 when no mark or expired. */
+export function oathbreakerAttackPenalty(player: GamePlayer, now: Date): number {
+  if (!player.oathbreakerUntil) return 0;
+  const ms = toMillis(player.oathbreakerUntil);
+  if (ms === null || ms <= now.getTime()) return 0;
+  return OATHBREAKER_ATTACK_PENALTY;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Defensive stance + Last Stand
+// ─────────────────────────────────────────────────────────────────────
+
+/** Cap on tiles that can be in defensive stance simultaneously. Scales
+ *  with empire size; tiny empires get 1 to keep the feature usable. */
+export function maxDefensiveStanceTiles(player: GamePlayer): number {
+  const held = player.stats?.tilesHeld ?? 0;
+  return Math.max(1, Math.floor(held / 100));
+}
+
+/** True when the tile's defensive-stance toggle is currently active. */
+export function isTileInDefensiveStance(
+  tile: Pick<GameTile, "defensiveStance">,
+  now: Date
+): boolean {
+  if (!tile.defensiveStance || !tile.defensiveStance.active) return false;
+  const since = toMillis(tile.defensiveStance.since);
+  return since !== null && since <= now.getTime();
+}
+
+/** True when the player can still toggle defensive stance OFF on this
+ *  tile (the 6h lock has elapsed). */
+export function canExitDefensiveStance(
+  tile: Pick<GameTile, "defensiveStance">,
+  now: Date
+): boolean {
+  if (!tile.defensiveStance) return true;
+  const locked = toMillis(tile.defensiveStance.lockedUntil);
+  return locked === null || locked <= now.getTime();
+}
+
+/** True when the tile has an armed Last Stand effect that's still within
+ *  its window (and so will apply to the next inbound attack). */
+export function hasActiveLastStand(
+  tile: Pick<GameTile, "activeLastStand">,
+  now: Date
+): boolean {
+  if (!tile.activeLastStand) return false;
+  const expires = toMillis(tile.activeLastStand.expiresAt);
+  return expires !== null && expires > now.getTime();
+}
+
+/** True when the player can declare another Last Stand (their cooldown
+ *  has elapsed). */
+export function canDeclareLastStand(player: GamePlayer, now: Date): boolean {
+  if (!player.lastStandUsedAt) return true;
+  const used = toMillis(player.lastStandUsedAt);
+  if (used === null) return true;
+  return now.getTime() - used >= LAST_STAND_COOLDOWN_MS;
+}
+
+/** Cooldown remaining before the player can declare another Last Stand.
+ *  Returns 0 when the player can declare. */
+export function lastStandCooldownRemainingMs(
+  player: GamePlayer,
+  now: Date
+): number {
+  if (!player.lastStandUsedAt) return 0;
+  const used = toMillis(player.lastStandUsedAt);
+  if (used === null) return 0;
+  const remaining = LAST_STAND_COOLDOWN_MS - (now.getTime() - used);
+  return Math.max(0, remaining);
+}
+
+/** Aggregate zero-turn defense bonus for a tile being attacked. Folds
+ *  defensive stance (additive on the tile itself) + last stand (additive
+ *  on the declared tile) into the single `zeroTurnDefenseBonus` channel
+ *  consumed by combat.ts. Adjacency-based last-stand adjacent-penalties
+ *  are passed in via `adjacentRallyPenaltyActive`. */
+export function computeZeroTurnDefenseBonus(args: {
+  tile: Pick<GameTile, "defensiveStance" | "activeLastStand">;
+  adjacentRallyPenaltyActive?: boolean;
+  now: Date;
+}): number {
+  let bonus = 0;
+  if (isTileInDefensiveStance(args.tile, args.now)) {
+    bonus += DEFENSIVE_STANCE_DEFENSE_BONUS;
+  }
+  if (hasActiveLastStand(args.tile, args.now)) {
+    bonus += LAST_STAND_DEFENSE_BONUS;
+  }
+  if (args.adjacentRallyPenaltyActive) {
+    // Rally on a neighbor pulls reserves from this tile.
+    bonus -= LAST_STAND_ADJACENT_PENALTY;
+  }
+  return bonus;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tile redistribution
+// ─────────────────────────────────────────────────────────────────────
+
+/** Applies the transit loss haircut to a moved stack. Returns the stack
+ *  that actually arrives. */
+export function applyRedistributionLoss(moved: UnitStack): UnitStack {
+  const factor = 1 - REDISTRIBUTE_TRANSIT_LOSS;
+  return {
+    ground: Math.floor(moved.ground * factor),
+    siege: Math.floor(moved.siege * factor),
+    air: Math.floor(moved.air * factor),
+  };
+}
+
+/** Prunes `recentRedistributions` to entries within the last 24h and
+ *  returns how many remain. Used both for the daily-cap check and for
+ *  the "X remaining today" display. */
+export function countRecentRedistributions(
+  recent: ReadonlyArray<Date | { toMillis?: () => number }> | undefined,
+  now: Date
+): number {
+  if (!recent || recent.length === 0) return 0;
+  const cutoff = now.getTime() - 24 * 60 * 60 * 1000;
+  let count = 0;
+  for (const entry of recent) {
+    const ms = toMillis(entry);
+    if (ms !== null && ms >= cutoff) count += 1;
+  }
+  return count;
+}
+
+export function redistributionsRemainingToday(
+  recent: ReadonlyArray<Date | { toMillis?: () => number }> | undefined,
+  now: Date
+): number {
+  return Math.max(0, REDISTRIBUTE_MAX_PER_DAY - countRecentRedistributions(recent, now));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Battle autopsy speculation
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Drive a what-if combat resolution using the same inputs as the
+ * original attack, but with perturbations to the attacker stack. Returns
+ * the alternative outcome and a one-line headline.
+ *
+ * Callers supply a `resolveAttackFn` (typically the production
+ * `resolveAttack` from combat.ts) so this helper stays pure and
+ * dependency-free for tests.
+ *
+ * The perturbation channels mirror the actionable levers a player could
+ * have invested in: more units of a type, an additional offense spell
+ * source, a different unit composition.
+ */
+export interface AutopsyPerturbation {
+  /** Friendly label for the UI, e.g. "+50 siege" or "+1 offense spell". */
+  label: string;
+  /** Delta added to attacker units before re-resolution. */
+  unitsDelta?: Partial<UnitStack>;
+  /** Override the offense spell id (e.g. swap in a stronger spell). */
+  offenseSpellIdOverride?: string | null;
+  /** Multiplicative bump to attacker.heroAttackBonus channel. Adds to
+   *  the existing bonus. */
+  heroAttackBonusDelta?: number;
+}
+
+export interface AutopsyOutcome {
+  label: string;
+  /** The CombatResult from the speculative resolution. */
+  result: CombatResult;
+  /** True when the speculative resolution flipped the outcome relative
+   *  to the original (capture ↔ repel). */
+  outcomeFlipped: boolean;
+  /** Headline summary suitable for UI rendering. */
+  summary: string;
+}
+
+export interface RunAutopsyArgs {
+  /** The recorded attack — must include `unitsOnTargetPreAttack`. */
+  attacker: CombatAttackerInput;
+  defender: CombatDefenderInput;
+  tile: CombatTileInput;
+  rngSeed: string;
+  originalOutcome: CombatResult["outcome"];
+  perturbations: ReadonlyArray<AutopsyPerturbation>;
+  resolveAttackFn: (
+    a: CombatAttackerInput,
+    d: CombatDefenderInput,
+    t: CombatTileInput,
+    rng: () => number
+  ) => CombatResult;
+  /** Deterministic RNG factory. Mirrors the production `seededRng`
+   *  behavior so the speculative run matches the original seed. */
+  rngFactory: (seed: string) => () => number;
+}
+
+/** Adds two unit stacks (one may be partial). */
+function addStack(a: UnitStack, delta: Partial<UnitStack>): UnitStack {
+  return {
+    ground: a.ground + (delta.ground ?? 0),
+    siege: a.siege + (delta.siege ?? 0),
+    air: a.air + (delta.air ?? 0),
+  };
+}
+
+export function runAutopsy(args: RunAutopsyArgs): AutopsyOutcome[] {
+  const outcomes: AutopsyOutcome[] = [];
+  for (const p of args.perturbations) {
+    const perturbedAttacker: CombatAttackerInput = {
+      ...args.attacker,
+      units: p.unitsDelta
+        ? addStack(args.attacker.units, p.unitsDelta)
+        : args.attacker.units,
+      offenseSpellId:
+        p.offenseSpellIdOverride !== undefined
+          ? p.offenseSpellIdOverride
+          : args.attacker.offenseSpellId,
+      heroAttackBonus:
+        (args.attacker.heroAttackBonus ?? 0) + (p.heroAttackBonusDelta ?? 0),
+    };
+    // Re-run with the SAME RNG seed so we measure the effect of the
+    // composition change, not RNG noise.
+    const rng = args.rngFactory(args.rngSeed);
+    const result = args.resolveAttackFn(perturbedAttacker, args.defender, args.tile, rng);
+    const outcomeFlipped = result.outcome !== args.originalOutcome;
+    const summary = outcomeFlipped
+      ? `${p.label} would have flipped the outcome to ${result.outcome}`
+      : `${p.label} would not have changed the outcome (${result.outcome})`;
+    outcomes.push({ label: p.label, result, outcomeFlipped, summary });
+  }
+  return outcomes;
+}
+
+/** Standard suite of perturbations to surface in the autopsy UI when
+ *  the attacker lost. Each is a small, plausible "what if I had brought
+ *  more of X". Calibrated against typical mid-tier compositions. */
+export function defaultLossPerturbations(
+  unitsSent: UnitStack
+): AutopsyPerturbation[] {
+  const small = (n: number) => Math.max(25, Math.floor(n * 0.25));
+  return [
+    { label: `+${small(unitsSent.ground)} ground`, unitsDelta: { ground: small(unitsSent.ground) } },
+    { label: `+${small(unitsSent.siege)} siege`, unitsDelta: { siege: small(unitsSent.siege) } },
+    { label: `+${small(unitsSent.air)} air`, unitsDelta: { air: small(unitsSent.air) } },
+  ];
+}

--- a/scripts/contract-exemptions.json
+++ b/scripts/contract-exemptions.json
@@ -2,10 +2,15 @@
   "generatedAt": "2026-05-17",
   "comment": "Routes awaiting ts-rest contract migration (issue #234). Each migration PR must remove its routes from this list. When the list is empty, full OpenAPI coverage is achieved.",
   "routes": [
+    "game/attacks/[attackId]",
     "game/heroes/[heroId]/chapter",
     "game/heroes/[heroId]/chapter/[chapterId]",
     "game/heroes/[heroId]/epitaph",
     "game/heroes/[heroId]/epitaph/[epitaphId]",
+    "game/heroes/meditate",
+    "game/heroes/pep-talk",
+    "game/last-stand",
+    "game/orders",
     "game/pacts",
     "game/pacts/[pactId]",
     "game/players/[playerId]",
@@ -13,6 +18,8 @@
     "game/prophecies",
     "game/prophecies/[prophecyId]",
     "game/reactions",
-    "game/tile/[tileId]/inscription"
+    "game/redistribute",
+    "game/tile/[tileId]/inscription",
+    "game/tiles/stance"
   ]
 }


### PR DESCRIPTION
## Summary

Promotes the zero-turn gameplay bundle from develop to main.

## Included PRs

- **#975** — feat(game): 9 zero-turn gameplay features (@Ludwitt)
  - Server logic + API routes + UI for: pep talk, meditation, redistribution, defensive stance, last stand, enforced pacts, prophecy stakes, queued orders, battle autopsy
  - Combat: new oathbreakerPenalty + zeroTurnDefenseBonus channels
  - Weekly rollover: consumes pendingProphecyBonus + executes queued orders
  - Tests: 68 new pure-helper assertions (all passing)
  - Docs: NON_TURN_ACTIVITIES policy updated to allow gameplay-impactful non-turn features when gated by a non-turn resource

## Test plan

- [x] CI on #975 passed for: Lint and Type Check, all 3 Analyze jobs, CodeQL, Security Scanning, Firestore rules tests, Vercel Preview
- [x] Local production verification: `npm run build && npm start` clean
- [x] Local typecheck clean
- [ ] Smoke test new pages post-deploy: /game/zero-turn, /game/orders, /game/attacks/[attackId]

🤖 Generated with [Claude Code](https://claude.com/claude-code)