### PR TITLE
fix(release): add attestations: write permission for SLSA provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ on:
 permissions:
   contents: write
   pull-requests: read
-  id-token: write  # Required for Sigstore keyless signing
+  id-token: write       # Required for Sigstore keyless signing
+  attestations: write   # Required for actions/attest-build-provenance (SLSA L2)
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

v0.2.1 succeeded as the first cosign-signed release ([release page](https://github.com/rogerSuperBuilderAlpha/cursor-boston/releases/tag/v0.2.1)). Bundles attached, SBOMs signed end-to-end. The final remaining step in the release workflow — SLSA build provenance attestation — failed:

\`\`\`
Failed to persist attestation: Resource not accessible by integration
https://docs.github.com/rest/repos/attestations
\`\`\`

## Cause

\`actions/attest-build-provenance@v3\` calls the GitHub \`repos/attestations\` REST API, which requires the workflow to have the \`attestations: write\` permission. Our \`release.yml\` permissions block had \`contents: write\`, \`id-token: write\`, and \`pull-requests: read\` — but not \`attestations: write\`.

## Fix

Add the permission. One-line change.

## After this merges

Cut v0.2.2 to validate the SLSA attestation step end-to-end. Once it succeeds, the release pipeline is fully validated for the first time:

| Step | First validated in |
|---|---|
| Lint + type-check + tests + Firestore rules | v0.2.0 |
| Build + CycloneDX SBOM + SPDX SBOM | v0.2.0 |
| GitHub Release creation + SBOM attachment | v0.2.0 |
| Cosign keyless signing (v2 --bundle) | v0.2.1 |
| SLSA build provenance attestation | v0.2.2 (target) |

Scorecard \`Signed-Releases\` will move from -1 to ≥ 8 on the next weekly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)