### PR TITLE
release: develop→main — SLSA attestation permission fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ on:
 permissions:
   contents: write
   pull-requests: read
-  id-token: write  # Required for Sigstore keyless signing
+  id-token: write       # Required for Sigstore keyless signing
+  attestations: write   # Required for actions/attest-build-provenance (SLSA L2)
 
 jobs:
   release:


### PR DESCRIPTION
Promotes PR #983 (SLSA attest permission fix) from develop to main.

Includes:
- PR #983 — `fix(release): add attestations: write permission for SLSA provenance` — @rogerSuperBuilderAlpha

After this lands, cut v0.2.2 to validate the full release pipeline including SLSA build provenance attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)