### PR TITLE
docs(readme): add prominent OpenSSF Best Practices badge + release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@
 </p>
 
 <p align="center">
+  <a href="https://www.bestpractices.dev/projects/12883"><img src="https://www.bestpractices.dev/projects/12883/badge" alt="OpenSSF Best Practices" height="28" /></a>
+</p>
+
+<p align="center">
   <a href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/actions/workflows/ci.yml"><img src="https://github.com/rogerSuperBuilderAlpha/cursor-boston/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://codecov.io/gh/rogerSuperBuilderAlpha/cursor-boston"><img src="https://codecov.io/gh/rogerSuperBuilderAlpha/cursor-boston/branch/develop/graph/badge.svg" alt="Codecov" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/rogerSuperBuilderAlpha/cursor-boston"><img src="https://api.scorecard.dev/projects/github.com/rogerSuperBuilderAlpha/cursor-boston/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/releases/latest"><img src="https://img.shields.io/github/v/release/rogerSuperBuilderAlpha/cursor-boston?include_prereleases&sort=semver&label=release" alt="Latest release" /></a>
   <a href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
   <a href="https://discord.gg/Wsncg8YYqc"><img src="https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord" alt="Discord" /></a>
   <a href="https://lu.ma/cursor-boston"><img src="https://img.shields.io/badge/Luma-Events-emerald" alt="Luma Events" /></a>


### PR DESCRIPTION
## Summary

Earned the OpenSSF Best Practices **Passing** badge today (project [#12883](https://www.bestpractices.dev/projects/12883)) — **100% on all 67 Passing-tier criteria**.

Adds the badge to README.md prominently on its own row above the existing badge strip (Kubernetes / Apache pattern), height-boosted to 28px so it's the visual lead.

Also adds a **Latest release** badge — now that we actually have releases (v0.2.0 / v0.2.1 / v0.2.2 from today).

## Preview

\`\`\`
[OpenSSF Best Practices badge — own row, 28px tall]

[CI] [Codecov] [Scorecard] [Latest release] [PRs welcome] [Discord] [Luma] [Node>=22] [License GPLv3]
\`\`\`

## Higher tiers (Phase 5+ targets)

The project page shows progress against the higher tiers — useful as a roadmap:

- **Silver: 50%** — main remaining items are tied to bus-factor (≥ 2 active maintainers operationally, which closes when Brad / Neha / Aaron accept their invitations), and a few documentation specifics (cryptography rationale, code-of-conduct enforcement record).
- **Gold: 30%** — multi-year track record + reproducible builds + signed releases as default + comprehensive cryptography review. Most of these unlock organically over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)