### PR TITLE
release: develop→main — OpenSSF Best Practices badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@
 </p>
 
 <p align="center">
+  <a href="https://www.bestpractices.dev/projects/12883"><img src="https://www.bestpractices.dev/projects/12883/badge" alt="OpenSSF Best Practices" height="28" /></a>
+</p>
+
+<p align="center">
   <a href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/actions/workflows/ci.yml"><img src="https://github.com/rogerSuperBuilderAlpha/cursor-boston/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="https://codecov.io/gh/rogerSuperBuilderAlpha/cursor-boston"><img src="https://codecov.io/gh/rogerSuperBuilderAlpha/cursor-boston/branch/develop/graph/badge.svg" alt="Codecov" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/rogerSuperBuilderAlpha/cursor-boston"><img src="https://api.scorecard.dev/projects/github.com/rogerSuperBuilderAlpha/cursor-boston/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/releases/latest"><img src="https://img.shields.io/github/v/release/rogerSuperBuilderAlpha/cursor-boston?include_prereleases&sort=semver&label=release" alt="Latest release" /></a>
   <a href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
   <a href="https://discord.gg/Wsncg8YYqc"><img src="https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord" alt="Discord" /></a>
   <a href="https://lu.ma/cursor-boston"><img src="https://img.shields.io/badge/Luma-Events-emerald" alt="Luma Events" /></a>


### PR DESCRIPTION
Promotes PR #985 (README badge) from develop to main.

Includes:
- PR #985 — `docs(readme): add prominent OpenSSF Best Practices badge + release badge` — @rogerSuperBuilderAlpha

The badge is live at https://www.bestpractices.dev/projects/12883 — readers landing on main will see the badge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)