### PR TITLE
fix(hackathons): feature upcoming in-person event

### DIFF
--- a/content/events.json
+++ b/content/events.json
@@ -94,7 +94,7 @@
         "Cursor IDE installed",
         "Registered Cursor account"
       ],
-      "featured": true
+      "featured": false
     },
     {
       "id": "cursor-boston-sports-hack-2026",


### PR DESCRIPTION
## Summary
- switch the completed May 13 PyData event to non-featured in `content/events.json`
- allow the existing featured in-person hackathon block to surface the upcoming Boston Tech Week workshop event
- keep the existing hackathons page layout and rendering logic unchanged

## Test plan
- [x] Validate `content/events.json` is valid JSON
- [x] Confirm branch diff contains only `content/events.json`

Made with [Cursor](https://cursor.com)