### PR TITLE
release: develop → main — coverage push #1 (Silver Phase 5.4)

### DIFF
--- a/__tests__/lib/ludwitt-config.test.ts
+++ b/__tests__/lib/ludwitt-config.test.ts
@@ -1,0 +1,119 @@
+import type { NextRequest } from "next/server";
+import {
+  LUDWITT_API_TIMEOUT_MS,
+  fetchLudwittWithTimeout,
+  getLudwittClientId,
+  getLudwittClientSecret,
+  getLudwittRedirectUri,
+} from "@/lib/ludwitt-config";
+
+describe("ludwitt-config", () => {
+  const originalClientId = process.env.NEXT_PUBLIC_LUDWITT_CLIENT_ID;
+  const originalClientSecret = process.env.LUDWITT_CLIENT_SECRET;
+  const originalRedirect = process.env.NEXT_PUBLIC_LUDWITT_REDIRECT_URI;
+
+  const restoreEnv = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+
+  afterEach(() => {
+    restoreEnv("NEXT_PUBLIC_LUDWITT_CLIENT_ID", originalClientId);
+    restoreEnv("LUDWITT_CLIENT_SECRET", originalClientSecret);
+    restoreEnv("NEXT_PUBLIC_LUDWITT_REDIRECT_URI", originalRedirect);
+  });
+
+  describe("getLudwittClientId", () => {
+    it("returns the env value when present", () => {
+      process.env.NEXT_PUBLIC_LUDWITT_CLIENT_ID = "client-abc";
+      expect(getLudwittClientId()).toBe("client-abc");
+    });
+
+    it("returns null when missing", () => {
+      delete process.env.NEXT_PUBLIC_LUDWITT_CLIENT_ID;
+      expect(getLudwittClientId()).toBeNull();
+    });
+
+    it("returns null when empty string", () => {
+      process.env.NEXT_PUBLIC_LUDWITT_CLIENT_ID = "";
+      expect(getLudwittClientId()).toBeNull();
+    });
+  });
+
+  describe("getLudwittClientSecret", () => {
+    it("returns the env value when present", () => {
+      process.env.LUDWITT_CLIENT_SECRET = "sec-xyz";
+      expect(getLudwittClientSecret()).toBe("sec-xyz");
+    });
+
+    it("returns null when missing", () => {
+      delete process.env.LUDWITT_CLIENT_SECRET;
+      expect(getLudwittClientSecret()).toBeNull();
+    });
+  });
+
+  describe("getLudwittRedirectUri", () => {
+    const mockRequest = (url: string): NextRequest =>
+      ({ url } as NextRequest);
+
+    it("returns NEXT_PUBLIC_LUDWITT_REDIRECT_URI when set", () => {
+      process.env.NEXT_PUBLIC_LUDWITT_REDIRECT_URI = "https://override.example.com/cb";
+      expect(getLudwittRedirectUri(mockRequest("https://app.example.com/x"))).toBe(
+        "https://override.example.com/cb"
+      );
+    });
+
+    it("derives from the request origin + /auth/callback when env is unset", () => {
+      delete process.env.NEXT_PUBLIC_LUDWITT_REDIRECT_URI;
+      expect(getLudwittRedirectUri(mockRequest("https://app.example.com/whatever"))).toBe(
+        "https://app.example.com/auth/callback"
+      );
+    });
+
+    it("preserves the port from the request URL", () => {
+      delete process.env.NEXT_PUBLIC_LUDWITT_REDIRECT_URI;
+      expect(getLudwittRedirectUri(mockRequest("http://localhost:3000/x"))).toBe(
+        "http://localhost:3000/auth/callback"
+      );
+    });
+  });
+
+  describe("fetchLudwittWithTimeout", () => {
+    const realFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = realFetch;
+    });
+
+    it("delegates to fetch with an AbortController signal", async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      global.fetch = jest.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return { ok: true } as unknown as Response;
+      }) as unknown as typeof fetch;
+
+      await fetchLudwittWithTimeout("https://x.example.com");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe("https://x.example.com");
+      expect(calls[0].init?.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("merges caller-provided init options", async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      global.fetch = jest.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return { ok: true } as unknown as Response;
+      }) as unknown as typeof fetch;
+
+      await fetchLudwittWithTimeout("https://x.example.com", { method: "POST", body: "hi" });
+      expect(calls[0].init?.method).toBe("POST");
+      expect(calls[0].init?.body).toBe("hi");
+      expect(calls[0].init?.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("exposes a sane timeout constant", () => {
+      expect(LUDWITT_API_TIMEOUT_MS).toBeGreaterThanOrEqual(1_000);
+      expect(LUDWITT_API_TIMEOUT_MS).toBeLessThanOrEqual(60_000);
+    });
+  });
+});

--- a/__tests__/lib/luma-event.test.ts
+++ b/__tests__/lib/luma-event.test.ts
@@ -1,0 +1,57 @@
+import { getLumaCheckoutEventId, getLumaCheckoutHref } from "@/lib/luma-event";
+
+describe("luma-event", () => {
+  describe("getLumaCheckoutEventId", () => {
+    it("prefers lumaCheckoutEventId when present", () => {
+      expect(
+        getLumaCheckoutEventId({
+          lumaEventId: "evt-999",
+          lumaCheckoutEventId: "chk-123",
+        })
+      ).toBe("chk-123");
+    });
+
+    it("falls back to lumaEventId when lumaCheckoutEventId is missing", () => {
+      expect(
+        getLumaCheckoutEventId({ lumaEventId: "evt-999" } as Parameters<typeof getLumaCheckoutEventId>[0])
+      ).toBe("evt-999");
+    });
+
+    it("falls back to lumaEventId when lumaCheckoutEventId is empty string", () => {
+      expect(
+        getLumaCheckoutEventId({
+          lumaEventId: "evt-fallback",
+          lumaCheckoutEventId: "",
+        } as Parameters<typeof getLumaCheckoutEventId>[0])
+      ).toBe("");
+    });
+  });
+
+  describe("getLumaCheckoutHref", () => {
+    it("builds a luma.com/event URL when lumaCheckoutEventId is set", () => {
+      expect(
+        getLumaCheckoutHref({
+          lumaUrl: "https://lu.ma/other",
+          lumaCheckoutEventId: "evt-123",
+        })
+      ).toBe("https://luma.com/event/evt-123");
+    });
+
+    it("falls back to lumaUrl when lumaCheckoutEventId is missing", () => {
+      expect(
+        getLumaCheckoutHref({
+          lumaUrl: "https://lu.ma/fallback",
+        } as Parameters<typeof getLumaCheckoutHref>[0])
+      ).toBe("https://lu.ma/fallback");
+    });
+
+    it("falls back to lumaUrl when lumaCheckoutEventId is empty string", () => {
+      expect(
+        getLumaCheckoutHref({
+          lumaUrl: "https://lu.ma/fallback",
+          lumaCheckoutEventId: "",
+        } as Parameters<typeof getLumaCheckoutHref>[0])
+      ).toBe("https://lu.ma/fallback");
+    });
+  });
+});

--- a/__tests__/lib/maintainer-meeting.test.ts
+++ b/__tests__/lib/maintainer-meeting.test.ts
@@ -1,0 +1,35 @@
+import {
+  MAINTAINER_ZOOM_JOIN_URL,
+  MAINTAINER_ZOOM_MEETING_ID,
+  MAINTAINER_ZOOM_MEETING_ID_DISPLAY,
+  MAINTAINER_ZOOM_ONE_TAP,
+  MAINTAINER_ZOOM_ORGANIZER,
+} from "@/lib/maintainer-meeting";
+
+describe("maintainer-meeting constants", () => {
+  it("exposes a Zoom join URL pointing at the bentley.zoom.us tenant", () => {
+    expect(MAINTAINER_ZOOM_JOIN_URL).toMatch(/^https:\/\/bentley\.zoom\.us\/j\/\d+$/);
+  });
+
+  it("keeps the meeting id and join URL in sync", () => {
+    expect(MAINTAINER_ZOOM_JOIN_URL.endsWith(`/${MAINTAINER_ZOOM_MEETING_ID}`)).toBe(true);
+  });
+
+  it("renders the display-formatted meeting id without spaces equal to the raw id", () => {
+    expect(MAINTAINER_ZOOM_MEETING_ID_DISPLAY.replace(/\s/g, "")).toBe(
+      MAINTAINER_ZOOM_MEETING_ID
+    );
+  });
+
+  it("names a human organizer", () => {
+    expect(MAINTAINER_ZOOM_ORGANIZER.length).toBeGreaterThan(0);
+  });
+
+  it("provides one-tap dial entries that reference the meeting id", () => {
+    expect(MAINTAINER_ZOOM_ONE_TAP.length).toBeGreaterThan(0);
+    for (const entry of MAINTAINER_ZOOM_ONE_TAP) {
+      expect(entry.label.length).toBeGreaterThan(0);
+      expect(entry.href).toMatch(new RegExp(`tel:\\+\\d+,,${MAINTAINER_ZOOM_MEETING_ID}#`));
+    }
+  });
+});

--- a/__tests__/lib/server/api-request-error.test.ts
+++ b/__tests__/lib/server/api-request-error.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+import {
+  jsonWithLoggedError,
+  jsonWithLoggedMessage,
+  requestErrorId,
+} from "@/lib/server/api-request-error";
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    logError: jest.fn(),
+  },
+}));
+
+import { logger } from "@/lib/logger";
+
+const mockLogError = logger.logError as jest.MockedFunction<typeof logger.logError>;
+
+describe("api-request-error", () => {
+  beforeEach(() => {
+    mockLogError.mockClear();
+  });
+
+  describe("requestErrorId", () => {
+    it("returns an 8-character id", () => {
+      const id = requestErrorId();
+      expect(id).toHaveLength(8);
+    });
+
+    it("returns a different id on each call", () => {
+      const a = requestErrorId();
+      const b = requestErrorId();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("jsonWithLoggedError", () => {
+    it("returns a NextResponse with the given status and merges errorId into body", async () => {
+      const err = new Error("boom");
+      const res = jsonWithLoggedError(500, err, { code: "SERVER_ERROR" }, { route: "/api/x" });
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.code).toBe("SERVER_ERROR");
+      expect(typeof body.errorId).toBe("string");
+      expect(body.errorId).toHaveLength(8);
+    });
+
+    it("logs the error with the supplied metadata + errorId", () => {
+      const err = new Error("boom");
+      jsonWithLoggedError(500, err, {}, { route: "/api/x", method: "POST" });
+      expect(mockLogError).toHaveBeenCalledTimes(1);
+      const call = mockLogError.mock.calls[0];
+      expect(call[0]).toBe(err);
+      expect(call[1]).toMatchObject({ route: "/api/x", method: "POST" });
+      expect(typeof (call[1] as Record<string, string>).errorId).toBe("string");
+    });
+
+    it("wraps non-Error values in an Error before logging", () => {
+      jsonWithLoggedError(400, "not-an-error", {}, {});
+      const call = mockLogError.mock.calls[0];
+      expect(call[0]).toBeInstanceOf(Error);
+      expect((call[0] as Error).message).toBe("not-an-error");
+    });
+  });
+
+  describe("jsonWithLoggedMessage", () => {
+    it("returns a NextResponse with the given status and merges errorId into body", async () => {
+      const res = jsonWithLoggedMessage(403, "forbidden", { code: "FORBIDDEN" }, {});
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("FORBIDDEN");
+      expect(typeof body.errorId).toBe("string");
+    });
+
+    it("logs a synthetic Error with the message", () => {
+      jsonWithLoggedMessage(403, "forbidden", {}, { route: "/api/x" });
+      const call = mockLogError.mock.calls[0];
+      expect(call[0]).toBeInstanceOf(Error);
+      expect((call[0] as Error).message).toBe("forbidden");
+    });
+  });
+});

--- a/__tests__/lib/summer-cohort-admin-access.test.ts
+++ b/__tests__/lib/summer-cohort-admin-access.test.ts
@@ -1,0 +1,67 @@
+import {
+  SUMMER_COHORT_ADMIN_EMAILS_ENV,
+  getSummerCohortAdminEmailSet,
+  isSummerCohortAdminEmail,
+} from "@/lib/summer-cohort-admin-access";
+
+describe("summer-cohort-admin-access", () => {
+  const originalEnv = process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV];
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV];
+    else process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV] = originalEnv;
+  });
+
+  describe("getSummerCohortAdminEmailSet", () => {
+    it("returns an empty set when the env var is unset", () => {
+      delete process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV];
+      expect(getSummerCohortAdminEmailSet().size).toBe(0);
+    });
+
+    it("returns an empty set when the env var is an empty string", () => {
+      process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV] = "";
+      expect(getSummerCohortAdminEmailSet().size).toBe(0);
+    });
+
+    it("parses a comma-separated list and lowercases each entry", () => {
+      process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV] = "Roger@Example.com,Brad@Example.com";
+      const set = getSummerCohortAdminEmailSet();
+      expect(set.has("roger@example.com")).toBe(true);
+      expect(set.has("brad@example.com")).toBe(true);
+      expect(set.size).toBe(2);
+    });
+
+    it("trims whitespace and skips empties", () => {
+      process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV] = " a@x.com , , b@x.com ,";
+      const set = getSummerCohortAdminEmailSet();
+      expect(set.size).toBe(2);
+      expect(set.has("a@x.com")).toBe(true);
+      expect(set.has("b@x.com")).toBe(true);
+    });
+  });
+
+  describe("isSummerCohortAdminEmail", () => {
+    beforeEach(() => {
+      process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV] = "roger@example.com,brad@example.com";
+    });
+
+    it("returns true for an allow-listed email (case-insensitive)", () => {
+      expect(isSummerCohortAdminEmail("Roger@Example.com")).toBe(true);
+      expect(isSummerCohortAdminEmail("brad@example.com")).toBe(true);
+    });
+
+    it("returns false for an email not on the list", () => {
+      expect(isSummerCohortAdminEmail("stranger@example.com")).toBe(false);
+    });
+
+    it("returns false for null/undefined/empty inputs", () => {
+      expect(isSummerCohortAdminEmail(null)).toBe(false);
+      expect(isSummerCohortAdminEmail(undefined)).toBe(false);
+      expect(isSummerCohortAdminEmail("")).toBe(false);
+    });
+
+    it("trims whitespace before comparison", () => {
+      expect(isSummerCohortAdminEmail("  roger@example.com  ")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Promotes one commit from develop:

- **#989** *test(lib): unit tests for 5 zero-coverage helper modules* — 37 new tests; coverage 31.22% → 31.42% statements. First slice of the multi-week OpenSSF Silver \`test_statement_coverage80\` lift (docs/REVIEW_ACTION_PLAN.md Phase 5.4).

Tests-only — no runtime change.

## Test plan

- [ ] CI green
- [ ] After merge: continue coverage push and (separately) cut v0.3.0 as a signed tag to close \`version_tags_signed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)