### PR TITLE
feat(release): CI workflow to cut Sigstore-signed release tags

### DIFF
--- a/.github/workflows/cut-signed-tag.yml
+++ b/.github/workflows/cut-signed-tag.yml
@@ -1,0 +1,101 @@
+name: Cut signed release tag
+
+# Cuts a Sigstore-signed (gitsign / keyless OIDC) annotated tag from the
+# current ref. Pushing the tag triggers the existing `Release` workflow,
+# which verifies the signature block and runs the rest of the release flow.
+#
+# Why this exists: the OpenSSF Best Practices Silver criterion
+# `version_tags_signed` requires release tags to be cryptographically
+# signed. Doing this locally requires every maintainer to install gitsign
+# and complete an OIDC browser flow. Doing it in CI requires neither — the
+# Actions runner's OIDC token IS the signing identity, with no browser
+# step. This workflow is the on-ramp.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag (e.g., v0.3.0 — must match vMAJOR.MINOR.PATCH)'
+        required: true
+        type: string
+      ref:
+        description: 'Commit, branch, or tag to tag (defaults to main)'
+        required: false
+        default: 'main'
+        type: string
+      message:
+        description: 'Tag message (defaults to "release: <version>")'
+        required: false
+        type: string
+
+permissions:
+  contents: write          # push the tag
+  id-token: write          # mint OIDC token for gitsign
+
+jobs:
+  cut-signed-tag:
+    name: Cut signed tag via gitsign
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version input
+        run: |
+          if ! echo "${{ inputs.version }}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+(\.[0-9]+)?)?$'; then
+            echo "::error::version must match v<MAJOR>.<MINOR>.<PATCH> (optionally followed by -<pre>); got '${{ inputs.version }}'"
+            exit 1
+          fi
+
+      - name: Checkout requested ref
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Reject duplicate tag
+        run: |
+          if git rev-parse "refs/tags/${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ inputs.version }} already exists. Pick a different version."
+            exit 1
+          fi
+
+      - name: Install gitsign
+        env:
+          GITSIGN_VERSION: '0.13.0'
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/sigstore/gitsign/releases/download/v${GITSIGN_VERSION}/gitsign_${GITSIGN_VERSION}_linux_amd64" \
+            -o /usr/local/bin/gitsign
+          chmod +x /usr/local/bin/gitsign
+          gitsign --version
+
+      - name: Configure git + gitsign for keyless signing
+        run: |
+          # Identity required by git; cert identity comes from the OIDC token.
+          git config --global user.email "noreply@cursorboston.com"
+          git config --global user.name  "Cursor Boston Release Bot"
+          git config --global commit.gpgsign true
+          git config --global tag.gpgsign true
+          git config --global gpg.x509.program gitsign
+          git config --global gpg.format x509
+          # gitsign in CI uses the Actions OIDC token; no browser flow.
+          git config --global gitsign.connectorID "https://token.actions.githubusercontent.com"
+
+      - name: Create signed annotated tag
+        env:
+          MSG: ${{ inputs.message }}
+        run: |
+          TAG="${{ inputs.version }}"
+          if [ -z "$MSG" ]; then
+            MSG="release: $TAG"
+          fi
+          git tag -s "$TAG" -m "$MSG"
+          # Confirm the tag object carries a signature block.
+          if ! git cat-file -p "$TAG" | grep -qE '^-----BEGIN (PGP SIGNATURE|SIGNED MESSAGE|SSH SIGNATURE)-----'; then
+            echo "::error::gitsign produced an unsigned tag. Aborting."
+            exit 1
+          fi
+          echo "Signed tag $TAG created at $(git rev-parse "$TAG")."
+
+      - name: Push tag
+        run: |
+          git push origin "refs/tags/${{ inputs.version }}"
+          echo "Pushed ${{ inputs.version }}. The Release workflow will now verify the signature and publish."

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,16 +9,19 @@ Releases are **tag-driven**. The workflow [`.github/workflows/release.yml`](../.
 
 ## Steps
 
-1. Ensure `develop` is green (all required checks passing).
-2. From the commit you want to tag (usually the merge commit on `main` or `develop` per your policy), create a **signed** annotated tag (see [§ Signed tags](#signed-tags) below for one-time setup):
-   ```bash
-   git checkout main   # release from main; develop is also acceptable per repo policy
-   git pull
-   git tag -s v0.3.0 -m "release: v0.3.0"
-   git push origin v0.3.0
-   ```
-   The `-s` flag is required for releases from v0.3.0 forward — the release workflow rejects unsigned tags. The signature uses [gitsign](https://github.com/sigstore/gitsign) (keyless OIDC via Sigstore) by default; GPG also works.
-3. The **Release** workflow creates the GitHub Release. Verify assets, signed SBOMs (`.cosign.bundle`), and notes on the [Releases](https://github.com/rogerSuperBuilderAlpha/cursor-boston/releases) page.
+1. Ensure `develop` is green (all required checks passing) and that the develop → main release PR has merged.
+2. **Cut the signed tag** — preferred path is the **Cut signed release tag** GitHub Actions workflow, which uses the runner's OIDC token to sign via Sigstore (no local install needed):
+   - Go to **Actions → Cut signed release tag → Run workflow**.
+   - Inputs: `version` = `v0.3.0`, `ref` = `main` (default), `message` optional.
+   - The workflow creates a gitsign-signed annotated tag and pushes it. Pushing the tag triggers the **Release** workflow, which verifies the signature, signs the SBOMs via cosign, attests SLSA L2 provenance, and publishes the GitHub Release.
+   - Local-machine fallback (if Actions is unavailable) — see [§ Signed tags](#signed-tags) for one-time gitsign or GPG setup, then:
+     ```bash
+     git checkout main && git pull
+     git tag -s v0.3.0 -m "release: v0.3.0"
+     git push origin v0.3.0
+     ```
+   - Unsigned tags are rejected by the release workflow from v0.3.0 forward.
+3. Verify the GitHub Release on the [Releases](https://github.com/rogerSuperBuilderAlpha/cursor-boston/releases) page — assets include `sbom.json`, `sbom.spdx.json`, `*.cosign.bundle` signature bundles, and a SLSA provenance attestation.
 4. Update [CHANGELOG.md](../CHANGELOG.md) with the released version (keep [Keep a Changelog](https://keepachangelog.com/) style).
 
 ## Signed tags


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/cut-signed-tag.yml\` — a workflow_dispatch-only workflow that uses [gitsign](https://github.com/sigstore/gitsign) with the runner's GitHub Actions OIDC token to produce a signed annotated tag and push it.

Pushing the tag triggers the existing Release workflow, which already verifies the signature block (added in PR #987), signs SBOMs via cosign, and attests SLSA L2 provenance.

## Why

The OpenSSF Best Practices Silver criterion \`version_tags_signed\` requires release tags to be cryptographically signed. Doing this on a maintainer laptop needs:
- one-time gitsign install
- a browser OIDC flow per release

Doing it in CI needs neither — the Actions runner's OIDC token IS the signing identity. This makes \"sign every release tag\" the path of least resistance instead of a chore.

## Changes

- \`.github/workflows/cut-signed-tag.yml\` (new) — workflow_dispatch with \`version\`, \`ref\`, optional \`message\` inputs. Validates the version format, rejects duplicate tags, installs gitsign 0.13.0, configures git for keyless x509 signing pointing at \`token.actions.githubusercontent.com\`, signs the tag, asserts the tag object carries a signature block, pushes.
- \`docs/RELEASING.md\` — makes the CI workflow the primary release path; documents the local gitsign / GPG flow as fallback.

## Test plan

- [ ] CI green on this PR
- [ ] After merge to main: trigger \"Cut signed release tag\" with \`version=v0.3.0\`, \`ref=main\`. Workflow should:
  - Create a signed tag visible on \`/tags\` page
  - Trigger the existing Release workflow
  - Release workflow's \"Verify release tag is signed\" step should report \"Policy satisfied\"
  - Release should publish with all four expected assets (\`sbom.json\`, \`sbom.json.cosign.bundle\`, \`sbom.spdx.json\`, \`sbom.spdx.json.cosign.bundle\`) plus SLSA attestation
- [ ] Update OpenSSF Silver form \`version_tags_signed\` → Met with link to the signed tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)