### PR TITLE
test(lib): coverage push #2 — encryption, http-fetch, maintainer-user (Silver Phase 5.4)

### DIFF
--- a/__tests__/lib/cursor/encryption.test.ts
+++ b/__tests__/lib/cursor/encryption.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment node
+ */
+import {
+  decryptApiKey,
+  encryptApiKey,
+  fingerprintApiKey,
+} from "@/lib/cursor/encryption";
+
+describe("cursor/encryption", () => {
+  const originalEnv = process.env.CURSOR_KEY_ENC_KEY;
+
+  beforeAll(() => {
+    // 32 bytes, base64-encoded — deterministic test key, NOT a production secret.
+    process.env.CURSOR_KEY_ENC_KEY = Buffer.alloc(32, 0x42).toString("base64");
+    // Force re-read of the cached key by re-importing not necessary because the
+    // module caches lazily on first call; the env var is in place before any call.
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.CURSOR_KEY_ENC_KEY;
+    else process.env.CURSOR_KEY_ENC_KEY = originalEnv;
+  });
+
+  describe("encryptApiKey + decryptApiKey", () => {
+    it("round-trips arbitrary UTF-8 plaintext", () => {
+      const plaintext = "sk_test_abc123-éñc😀de";
+      const encrypted = encryptApiKey(plaintext);
+      expect(decryptApiKey(encrypted)).toBe(plaintext);
+    });
+
+    it("produces a fresh IV each call (non-deterministic ciphertext)", () => {
+      const plaintext = "sk_test_same_input";
+      const a = encryptApiKey(plaintext);
+      const b = encryptApiKey(plaintext);
+      expect(a.ciphertext).not.toBe(b.ciphertext);
+      expect(a.iv).not.toBe(b.iv);
+      // Both still decrypt back to the same plaintext.
+      expect(decryptApiKey(a)).toBe(plaintext);
+      expect(decryptApiKey(b)).toBe(plaintext);
+    });
+
+    it("returns the versioned envelope shape", () => {
+      const e = encryptApiKey("anything");
+      expect(e.v).toBe(1);
+      expect(typeof e.ciphertext).toBe("string");
+      expect(typeof e.iv).toBe("string");
+      expect(typeof e.authTag).toBe("string");
+    });
+
+    it("rejects tampered ciphertext (AES-GCM auth tag check)", () => {
+      const encrypted = encryptApiKey("secret");
+      const tampered = {
+        ...encrypted,
+        ciphertext: Buffer.from(encrypted.ciphertext, "base64")
+          .map((b, i) => (i === 0 ? b ^ 0xff : b))
+          .toString("base64"),
+      };
+      expect(() => decryptApiKey(tampered)).toThrow();
+    });
+  });
+
+  describe("fingerprintApiKey", () => {
+    it("returns first-7 + ellipsis + last-4 characters", () => {
+      expect(fingerprintApiKey("sk_test_abcdefghijklmnop")).toBe("sk_test...mnop");
+    });
+
+    it("does not leak the middle of the key", () => {
+      const key = "sk_secret_DO_NOT_LEAK_xyz";
+      const fp = fingerprintApiKey(key);
+      expect(fp).not.toContain("DO_NOT_LEAK");
+    });
+  });
+});

--- a/__tests__/lib/http-fetch.test.ts
+++ b/__tests__/lib/http-fetch.test.ts
@@ -1,0 +1,84 @@
+import { fetchWithTimeout } from "@/lib/http-fetch";
+
+describe("http-fetch", () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.useRealTimers();
+  });
+
+  it("delegates to fetch with an AbortController-backed signal", async () => {
+    let capturedInit: RequestInit | undefined;
+    global.fetch = jest.fn().mockImplementation(async (_url, init) => {
+      capturedInit = init;
+      return { ok: true } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await fetchWithTimeout("https://example.com");
+    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("forwards caller init options", async () => {
+    let capturedInit: RequestInit | undefined;
+    global.fetch = jest.fn().mockImplementation(async (_url, init) => {
+      capturedInit = init;
+      return { ok: true } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await fetchWithTimeout("https://example.com", { method: "POST", body: "hi" });
+    expect(capturedInit?.method).toBe("POST");
+    expect(capturedInit?.body).toBe("hi");
+  });
+
+  it("aborts when the timeout elapses", async () => {
+    let abortedFromTimer = false;
+    global.fetch = jest.fn().mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal;
+        signal?.addEventListener("abort", () => {
+          abortedFromTimer = true;
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const promise = fetchWithTimeout("https://example.com", {}, 50);
+    await expect(promise).rejects.toBeDefined();
+    expect(abortedFromTimer).toBe(true);
+  });
+
+  it("propagates an externally-aborted signal", async () => {
+    let observedAbort = false;
+    global.fetch = jest.fn().mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal;
+        if (signal?.aborted) {
+          observedAbort = true;
+          reject(new DOMException("aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          observedAbort = true;
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const external = new AbortController();
+    const promise = fetchWithTimeout("https://example.com", { signal: external.signal }, 30_000);
+    external.abort();
+    await expect(promise).rejects.toBeDefined();
+    expect(observedAbort).toBe(true);
+  });
+
+  it("does not call abort when the request finishes within the timeout", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockImplementation(async () => ({ ok: true }) as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await fetchWithTimeout("https://example.com", {}, 1_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/maintainer-user.test.ts
+++ b/__tests__/lib/maintainer-user.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+import { getUserGithubLoginFromFirestore } from "@/lib/maintainer-user";
+
+// Mock the admin-db getter so we can drive every branch.
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+import { getAdminDb } from "@/lib/firebase-admin";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+function mockDocSnapshot(snapData: { exists: boolean; data?: () => Record<string, unknown> }) {
+  return {
+    collection: () => ({
+      doc: () => ({
+        get: async () => snapData,
+      }),
+    }),
+  };
+}
+
+describe("maintainer-user — getUserGithubLoginFromFirestore", () => {
+  beforeEach(() => {
+    mockGetAdminDb.mockReset();
+  });
+
+  it("returns null when admin db is unavailable", async () => {
+    mockGetAdminDb.mockReturnValue(null as unknown as ReturnType<typeof getAdminDb>);
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when the user doc does not exist", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: false }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when the user doc has no github field", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: true, data: () => ({}) }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when github field is not an object", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: true, data: () => ({ github: "not-an-object" }) }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when github.login is missing", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: true, data: () => ({ github: {} }) }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when github.login is empty/whitespace", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({
+        exists: true,
+        data: () => ({ github: { login: "   " } }),
+      }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns the trimmed login when present", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({
+        exists: true,
+        data: () => ({ github: { login: "  octocat  " } }),
+      }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBe("octocat");
+  });
+
+  it("returns null when github.login is not a string", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({
+        exists: true,
+        data: () => ({ github: { login: 12345 } }),
+      }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Second incremental slice of the OpenSSF Silver test_statement_coverage80 lift. 19 new tests across 3 previously zero-coverage helper modules.

Coverage delta: **31.42% → 31.54% statements (+0.12pp)**.

| Module | Before | After |
|---|---|---|
| lib/cursor/encryption.ts | 0% | 100% |
| lib/http-fetch.ts | 43.75% | 100% |
| lib/maintainer-user.ts | 0% | 100% |

## Why these targets

- **encryption.ts** — AES-256-GCM round-trip plus tamper-rejection assertion (verifies the GCM auth tag actually catches tampered ciphertext).
- **http-fetch.ts** — covers the timeout-firing path and external-AbortController propagation (the two branches that were uncovered).
- **maintainer-user.ts** — all eight observable branches of getUserGithubLoginFromFirestore.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms tests pin observable behavior, not implementation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)