### PR TITLE
release: develop → main — coverage pushes #2 + #3 (Silver Phase 5.4)

### DIFF
--- a/__tests__/lib/cursor/encryption.test.ts
+++ b/__tests__/lib/cursor/encryption.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment node
+ */
+import {
+  decryptApiKey,
+  encryptApiKey,
+  fingerprintApiKey,
+} from "@/lib/cursor/encryption";
+
+describe("cursor/encryption", () => {
+  const originalEnv = process.env.CURSOR_KEY_ENC_KEY;
+
+  beforeAll(() => {
+    // 32 bytes, base64-encoded — deterministic test key, NOT a production secret.
+    process.env.CURSOR_KEY_ENC_KEY = Buffer.alloc(32, 0x42).toString("base64");
+    // Force re-read of the cached key by re-importing not necessary because the
+    // module caches lazily on first call; the env var is in place before any call.
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.CURSOR_KEY_ENC_KEY;
+    else process.env.CURSOR_KEY_ENC_KEY = originalEnv;
+  });
+
+  describe("encryptApiKey + decryptApiKey", () => {
+    it("round-trips arbitrary UTF-8 plaintext", () => {
+      const plaintext = "sk_test_abc123-éñc😀de";
+      const encrypted = encryptApiKey(plaintext);
+      expect(decryptApiKey(encrypted)).toBe(plaintext);
+    });
+
+    it("produces a fresh IV each call (non-deterministic ciphertext)", () => {
+      const plaintext = "sk_test_same_input";
+      const a = encryptApiKey(plaintext);
+      const b = encryptApiKey(plaintext);
+      expect(a.ciphertext).not.toBe(b.ciphertext);
+      expect(a.iv).not.toBe(b.iv);
+      // Both still decrypt back to the same plaintext.
+      expect(decryptApiKey(a)).toBe(plaintext);
+      expect(decryptApiKey(b)).toBe(plaintext);
+    });
+
+    it("returns the versioned envelope shape", () => {
+      const e = encryptApiKey("anything");
+      expect(e.v).toBe(1);
+      expect(typeof e.ciphertext).toBe("string");
+      expect(typeof e.iv).toBe("string");
+      expect(typeof e.authTag).toBe("string");
+    });
+
+    it("rejects tampered ciphertext (AES-GCM auth tag check)", () => {
+      const encrypted = encryptApiKey("secret");
+      const tampered = {
+        ...encrypted,
+        ciphertext: Buffer.from(encrypted.ciphertext, "base64")
+          .map((b, i) => (i === 0 ? b ^ 0xff : b))
+          .toString("base64"),
+      };
+      expect(() => decryptApiKey(tampered)).toThrow();
+    });
+  });
+
+  describe("fingerprintApiKey", () => {
+    it("returns first-7 + ellipsis + last-4 characters", () => {
+      expect(fingerprintApiKey("sk_test_abcdefghijklmnop")).toBe("sk_test...mnop");
+    });
+
+    it("does not leak the middle of the key", () => {
+      const key = "sk_secret_DO_NOT_LEAK_xyz";
+      const fp = fingerprintApiKey(key);
+      expect(fp).not.toContain("DO_NOT_LEAK");
+    });
+  });
+});

--- a/__tests__/lib/game/titles.test.ts
+++ b/__tests__/lib/game/titles.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment node
+ */
+import { derivePlayerTitles } from "@/lib/game/titles";
+import type { GamePlayer } from "@/lib/game/types";
+
+const basePlayer = (overrides: Partial<GamePlayer> = {}): GamePlayer =>
+  ({
+    stats: {},
+    ...overrides,
+  } as unknown as GamePlayer);
+
+describe("game/titles — derivePlayerTitles", () => {
+  it("returns empty for a new player with no milestones", () => {
+    expect(derivePlayerTitles(basePlayer())).toEqual([]);
+  });
+
+  describe("tiles tier", () => {
+    it("awards Tile Knight at 100", () => {
+      const titles = derivePlayerTitles(basePlayer({ stats: { tilesHeld: 100 } } as unknown as Partial<GamePlayer>));
+      expect(titles.map((t) => t.id)).toContain("tile-knight-100");
+    });
+
+    it("upgrades to Tile Lord at 500", () => {
+      const titles = derivePlayerTitles(basePlayer({ stats: { tilesHeld: 500 } } as unknown as Partial<GamePlayer>));
+      expect(titles.map((t) => t.id)).toContain("tile-lord-500");
+      expect(titles.map((t) => t.id)).not.toContain("tile-knight-100");
+    });
+
+    it("upgrades to Tile Baron at 1000+", () => {
+      const titles = derivePlayerTitles(basePlayer({ stats: { tilesHeld: 1500 } } as unknown as Partial<GamePlayer>));
+      expect(titles.map((t) => t.id)).toContain("tile-baron-1k");
+    });
+  });
+
+  describe("attacks tier", () => {
+    it("awards First Blood at 1", () => {
+      const titles = derivePlayerTitles(basePlayer({ stats: { attacksWon: 1 } } as unknown as Partial<GamePlayer>));
+      expect(titles.map((t) => t.id)).toContain("first-blood");
+    });
+
+    it("upgrades to Warlord at 500", () => {
+      const titles = derivePlayerTitles(basePlayer({ stats: { attacksWon: 500 } } as unknown as Partial<GamePlayer>));
+      expect(titles.map((t) => t.id)).toContain("warlord-500");
+    });
+  });
+
+  describe("turns tier", () => {
+    it("awards Veteran General at 10000+", () => {
+      const titles = derivePlayerTitles(basePlayer({ turnsSpentTotal: 10_000 }));
+      expect(titles.map((t) => t.id)).toContain("veteran-10k");
+    });
+
+    it("awards Campaigner at 1000-9999", () => {
+      const titles = derivePlayerTitles(basePlayer({ turnsSpentTotal: 1_000 }));
+      expect(titles.map((t) => t.id)).toContain("campaigner-1k");
+    });
+  });
+
+  describe("sealbreaker", () => {
+    it("Sealbreaker (singular) at 1 seal", () => {
+      const titles = derivePlayerTitles(basePlayer({ armageddonSealsBroken: 1 }));
+      const t = titles.find((x) => x.id === "sealbreaker");
+      expect(t?.label).toBe("Sealbreaker");
+      expect(t?.description).toContain("1 Armageddon seal.");
+    });
+
+    it("Sealbreaker (plural) at 2 seals", () => {
+      const titles = derivePlayerTitles(basePlayer({ armageddonSealsBroken: 2 }));
+      const t = titles.find((x) => x.id === "sealbreaker");
+      expect(t?.description).toContain("2 Armageddon seals.");
+    });
+
+    it("Apocalypse Bringer at 3+ seals", () => {
+      const titles = derivePlayerTitles(basePlayer({ armageddonSealsBroken: 3 }));
+      const t = titles.find((x) => x.id === "sealbreaker");
+      expect(t?.label).toBe("Apocalypse Bringer");
+    });
+  });
+
+  describe("hero commander", () => {
+    it("Hero Commander at 1 hero (singular phrasing)", () => {
+      const titles = derivePlayerTitles(basePlayer({ heroCount: 1 }));
+      const t = titles.find((x) => x.id === "hero-commander");
+      expect(t?.label).toBe("Hero Commander");
+      expect(t?.description).toContain("1 hero.");
+    });
+
+    it("Hero Commander plural at 2-4", () => {
+      const titles = derivePlayerTitles(basePlayer({ heroCount: 2 }));
+      const t = titles.find((x) => x.id === "hero-commander");
+      expect(t?.description).toContain("2 heroes.");
+    });
+
+    it("Hero Marshal at 5+", () => {
+      const titles = derivePlayerTitles(basePlayer({ heroCount: 5 }));
+      const t = titles.find((x) => x.id === "hero-commander");
+      expect(t?.label).toBe("Hero Marshal");
+    });
+  });
+
+  describe("renegade", () => {
+    it("awarded when casteChangesUsed ≥ 1", () => {
+      const titles = derivePlayerTitles(basePlayer({ casteChangesUsed: 1 }));
+      expect(titles.map((t) => t.id)).toContain("renegade");
+    });
+
+    it("not awarded when casteChangesUsed = 0", () => {
+      const titles = derivePlayerTitles(basePlayer({ casteChangesUsed: 0 }));
+      expect(titles.map((t) => t.id)).not.toContain("renegade");
+    });
+  });
+
+  describe("seer / oracle", () => {
+    it("Seer at 1 fulfilled prophecy", () => {
+      const titles = derivePlayerTitles(basePlayer({ prophecyFulfilledCount: 1 }));
+      const t = titles.find((x) => x.id === "seer");
+      expect(t?.label).toBe("Seer");
+    });
+
+    it("Oracle at 3+ fulfilled prophecies", () => {
+      const titles = derivePlayerTitles(basePlayer({ prophecyFulfilledCount: 3 }));
+      const t = titles.find((x) => x.id === "seer");
+      expect(t?.label).toBe("Oracle");
+    });
+  });
+
+  describe("multi-title", () => {
+    it("composes multiple titles for a high-achievement player", () => {
+      const titles = derivePlayerTitles(
+        basePlayer({
+          stats: { tilesHeld: 1500, attacksWon: 600 } as unknown as GamePlayer["stats"],
+          turnsSpentTotal: 12_000,
+          armageddonSealsBroken: 4,
+          heroCount: 6,
+          casteChangesUsed: 1,
+          prophecyFulfilledCount: 3,
+        })
+      );
+      const ids = titles.map((t) => t.id);
+      expect(ids).toContain("tile-baron-1k");
+      expect(ids).toContain("warlord-500");
+      expect(ids).toContain("veteran-10k");
+      expect(ids).toContain("sealbreaker");
+      expect(ids).toContain("hero-commander");
+      expect(ids).toContain("renegade");
+      expect(ids).toContain("seer");
+    });
+  });
+});

--- a/__tests__/lib/http-fetch.test.ts
+++ b/__tests__/lib/http-fetch.test.ts
@@ -1,0 +1,84 @@
+import { fetchWithTimeout } from "@/lib/http-fetch";
+
+describe("http-fetch", () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.useRealTimers();
+  });
+
+  it("delegates to fetch with an AbortController-backed signal", async () => {
+    let capturedInit: RequestInit | undefined;
+    global.fetch = jest.fn().mockImplementation(async (_url, init) => {
+      capturedInit = init;
+      return { ok: true } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await fetchWithTimeout("https://example.com");
+    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("forwards caller init options", async () => {
+    let capturedInit: RequestInit | undefined;
+    global.fetch = jest.fn().mockImplementation(async (_url, init) => {
+      capturedInit = init;
+      return { ok: true } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await fetchWithTimeout("https://example.com", { method: "POST", body: "hi" });
+    expect(capturedInit?.method).toBe("POST");
+    expect(capturedInit?.body).toBe("hi");
+  });
+
+  it("aborts when the timeout elapses", async () => {
+    let abortedFromTimer = false;
+    global.fetch = jest.fn().mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal;
+        signal?.addEventListener("abort", () => {
+          abortedFromTimer = true;
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const promise = fetchWithTimeout("https://example.com", {}, 50);
+    await expect(promise).rejects.toBeDefined();
+    expect(abortedFromTimer).toBe(true);
+  });
+
+  it("propagates an externally-aborted signal", async () => {
+    let observedAbort = false;
+    global.fetch = jest.fn().mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal;
+        if (signal?.aborted) {
+          observedAbort = true;
+          reject(new DOMException("aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          observedAbort = true;
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const external = new AbortController();
+    const promise = fetchWithTimeout("https://example.com", { signal: external.signal }, 30_000);
+    external.abort();
+    await expect(promise).rejects.toBeDefined();
+    expect(observedAbort).toBe(true);
+  });
+
+  it("does not call abort when the request finishes within the timeout", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockImplementation(async () => ({ ok: true }) as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await fetchWithTimeout("https://example.com", {}, 1_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/maintainer-user.test.ts
+++ b/__tests__/lib/maintainer-user.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+import { getUserGithubLoginFromFirestore } from "@/lib/maintainer-user";
+
+// Mock the admin-db getter so we can drive every branch.
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+import { getAdminDb } from "@/lib/firebase-admin";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+function mockDocSnapshot(snapData: { exists: boolean; data?: () => Record<string, unknown> }) {
+  return {
+    collection: () => ({
+      doc: () => ({
+        get: async () => snapData,
+      }),
+    }),
+  };
+}
+
+describe("maintainer-user — getUserGithubLoginFromFirestore", () => {
+  beforeEach(() => {
+    mockGetAdminDb.mockReset();
+  });
+
+  it("returns null when admin db is unavailable", async () => {
+    mockGetAdminDb.mockReturnValue(null as unknown as ReturnType<typeof getAdminDb>);
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when the user doc does not exist", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: false }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when the user doc has no github field", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: true, data: () => ({}) }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when github field is not an object", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: true, data: () => ({ github: "not-an-object" }) }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when github.login is missing", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({ exists: true, data: () => ({ github: {} }) }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns null when github.login is empty/whitespace", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({
+        exists: true,
+        data: () => ({ github: { login: "   " } }),
+      }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+
+  it("returns the trimmed login when present", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({
+        exists: true,
+        data: () => ({ github: { login: "  octocat  " } }),
+      }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBe("octocat");
+  });
+
+  it("returns null when github.login is not a string", async () => {
+    mockGetAdminDb.mockReturnValue(
+      mockDocSnapshot({
+        exists: true,
+        data: () => ({ github: { login: 12345 } }),
+      }) as unknown as ReturnType<typeof getAdminDb>
+    );
+    expect(await getUserGithubLoginFromFirestore("u1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Promotes two commits from develop:

- **#993** *test(lib): unit tests for 3 more zero-coverage helper modules* — by @Ludwitt — encryption, http-fetch, maintainer-user (19 tests)
- **#995** *test(lib/game): unit tests for derivePlayerTitles* — by @Ludwitt — derivePlayerTitles (19 tests)

Tests-only — no runtime change. Coverage 31.42% → 31.5x% statements.

## OpenSSF Silver status

- ✅ assurance_case — Met
- ✅ version_tags_signed — Met (v0.3.0 signed tag exists)
- 🔴 test_statement_coverage80 — 31.5x% vs 80% target. Coverage pushes #1, #2, #3 are the first three slices of the multi-week initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)