### PR TITLE
release: develop → main — coverage pushes #4 + #5 (Silver Phase 5.4)

### DIFF
--- a/__tests__/lib/events-calendar-buckets.test.ts
+++ b/__tests__/lib/events-calendar-buckets.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment node
+ */
+import {
+  EVENTS_LISTING_TIMEZONE,
+  partitionEventsForBrowse,
+  todayYmdInListingTz,
+} from "@/lib/events-calendar-buckets";
+import type { Event } from "@/types/events";
+
+const mkEvent = (overrides: Partial<Event>): Event =>
+  ({
+    id: "e-1",
+    title: "Test",
+    date: "2026-06-01",
+    ...overrides,
+  } as unknown as Event);
+
+describe("events-calendar-buckets", () => {
+  describe("EVENTS_LISTING_TIMEZONE", () => {
+    it("is America/New_York for Boston-area listings", () => {
+      expect(EVENTS_LISTING_TIMEZONE).toBe("America/New_York");
+    });
+  });
+
+  describe("todayYmdInListingTz", () => {
+    it("returns YYYY-MM-DD format", () => {
+      const ymd = todayYmdInListingTz(new Date("2026-06-15T20:00:00Z"));
+      expect(ymd).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("uses the listing timezone (Eastern) by default", () => {
+      // 2026-06-15 03:00 UTC == 2026-06-14 23:00 ET (still 2026-06-14 in Boston)
+      expect(todayYmdInListingTz(new Date("2026-06-15T03:00:00Z"))).toBe("2026-06-14");
+    });
+
+    it("supports a custom timezone", () => {
+      // Tokyo is UTC+9; 2026-06-14 23:00 UTC == 2026-06-15 08:00 in Tokyo
+      expect(
+        todayYmdInListingTz(new Date("2026-06-14T23:00:00Z"), "Asia/Tokyo")
+      ).toBe("2026-06-15");
+    });
+  });
+
+  describe("partitionEventsForBrowse", () => {
+    const today = "2026-06-15";
+
+    it("splits events into today / future / past correctly", () => {
+      const events = [
+        mkEvent({ id: "today-1", date: "2026-06-15", title: "Today event" }),
+        mkEvent({ id: "future-1", date: "2026-07-01", title: "Future event" }),
+        mkEvent({ id: "past-1", date: "2026-05-01", title: "Past event" }),
+      ];
+      const { today: t, future: f, past: p } = partitionEventsForBrowse(events, today);
+      expect(t.map((e) => e.id)).toEqual(["today-1"]);
+      expect(f.map((e) => e.id)).toEqual(["future-1"]);
+      expect(p.map((e) => e.id)).toEqual(["past-1"]);
+    });
+
+    it("treats TBD events as future", () => {
+      const events = [mkEvent({ id: "tbd-1", date: "TBD", title: "Maybe" } as unknown as Partial<Event>)];
+      const { future } = partitionEventsForBrowse(events, today);
+      expect(future.map((e) => e.id)).toEqual(["tbd-1"]);
+    });
+
+    it("uses only the date prefix (ignores time-of-day)", () => {
+      const events = [
+        mkEvent({ id: "today-with-time", date: "2026-06-15T18:00:00Z" } as unknown as Partial<Event>),
+      ];
+      const { today: t } = partitionEventsForBrowse(events, today);
+      expect(t.map((e) => e.id)).toEqual(["today-with-time"]);
+    });
+
+    it("de-duplicates by event.id (first wins)", () => {
+      const events = [
+        mkEvent({ id: "dup", date: "2026-07-01", title: "first" }),
+        mkEvent({ id: "dup", date: "2026-08-01", title: "second" }),
+      ];
+      const { future } = partitionEventsForBrowse(events, today);
+      expect(future).toHaveLength(1);
+      expect(future[0].title).toBe("first");
+    });
+
+    it("sorts future events ascending by date, then by title case-insensitively", () => {
+      const events = [
+        mkEvent({ id: "f3", date: "2026-08-01", title: "beta" }),
+        mkEvent({ id: "f1", date: "2026-07-01", title: "Charlie" }),
+        mkEvent({ id: "f2", date: "2026-07-01", title: "alpha" }),
+      ];
+      const { future } = partitionEventsForBrowse(events, today);
+      expect(future.map((e) => e.id)).toEqual(["f2", "f1", "f3"]);
+    });
+
+    it("places TBD events at the end of the future list", () => {
+      const events = [
+        mkEvent({ id: "tbd", date: "TBD" } as unknown as Partial<Event>),
+        mkEvent({ id: "real", date: "2026-07-01" }),
+      ];
+      const { future } = partitionEventsForBrowse(events, today);
+      expect(future.map((e) => e.id)).toEqual(["real", "tbd"]);
+    });
+
+    it("sorts past events descending by date, then by title", () => {
+      const events = [
+        mkEvent({ id: "p1", date: "2026-04-01", title: "older" }),
+        mkEvent({ id: "p2", date: "2026-05-01", title: "newer" }),
+        mkEvent({ id: "p3", date: "2026-05-01", title: "Also newer" }),
+      ];
+      const { past } = partitionEventsForBrowse(events, today);
+      expect(past.map((e) => e.id)).toEqual(["p3", "p2", "p1"]);
+    });
+  });
+});

--- a/__tests__/lib/game/api-error-map.test.ts
+++ b/__tests__/lib/game/api-error-map.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment node
+ */
+import { mapGameError } from "@/lib/game/api-error-map";
+import {
+  GameAlreadyRevealedError,
+  GameArmageddonInProgressError,
+  GameArtifactAlreadyUsedError,
+  GameArtifactNotFoundError,
+  GameCasteAlreadySetError,
+  GameCasteChangeUnavailableError,
+  GameDefensiveStanceBlockedError,
+  GameDefensiveStanceCapError,
+  GameDefensiveStanceLockedError,
+  GameFrontierExhaustedError,
+  GameHeroAlreadyMeditatingError,
+  GameHeroNotFoundError,
+  GameHeroNotOwnedError,
+  GameInscriptionTooLongError,
+  GameInsufficientTurnsError,
+  GameInsufficientUnitsError,
+  GameInvalidCasteError,
+  GameInvalidLandTypeError,
+  GameInvalidNameError,
+  GameInvalidPhaseError,
+  GameInvalidSpellError,
+  GameLastStandCooldownError,
+  GameLastStandNoThreatError,
+  GameLastStandRequiresZeroTurnsError,
+  GameMeditationSlotFullError,
+  GameNameTakenError,
+  GameNoEnemyKingdomsError,
+  GameNoUnrevealedTilesError,
+  GameNotAdjacentError,
+  GamePepTalkRequiresZeroTurnsError,
+  GamePlayerAlreadyExistsError,
+  GamePlayerBioTooLongError,
+  GamePlayerNotFoundError,
+  GameRedistributeRateLimitError,
+  GameSealsExhaustedError,
+  GameSelfAttackError,
+  GameShieldedError,
+  GameSpecialUnitAlreadyStationedError,
+  GameSpecialUnitNotFoundError,
+  GameStaleSeasonError,
+  GameTileFullError,
+  GameTileNotFoundError,
+  GameTileNotOwnedError,
+  GameTileTypeError,
+  GameTileUnrevealedError,
+  GameUnitCapExceededError,
+} from "@/lib/game/data-server";
+import {
+  UpgradeAlreadyActiveError,
+  UpgradeNotActiveError,
+  UpgradeNotFoundError,
+  UpgradeUnknownTargetError,
+  UpgradeWrongCasteError,
+} from "@/lib/game/upgrades";
+import {
+  QueuedOrderForbiddenError,
+  QueuedOrderInvalidParamsError,
+  QueuedOrderNotFoundError,
+  QueuedOrderQueueFullError,
+} from "@/lib/game/orders";
+
+async function statusOf(err: unknown): Promise<number> {
+  return mapGameError(err).status;
+}
+
+describe("game/api-error-map — mapGameError", () => {
+  describe("404 Not Found", () => {
+    it.each([
+      ["GamePlayerNotFoundError", new GamePlayerNotFoundError("x")],
+      ["GameTileNotFoundError", new GameTileNotFoundError("x")],
+      ["GameArtifactNotFoundError", new GameArtifactNotFoundError("x")],
+      ["GameSpecialUnitNotFoundError", new GameSpecialUnitNotFoundError("x")],
+      ["UpgradeNotFoundError", new UpgradeNotFoundError("x")],
+      ["UpgradeUnknownTargetError", new UpgradeUnknownTargetError("x")],
+      ["GameHeroNotFoundError", new GameHeroNotFoundError("x")],
+      ["QueuedOrderNotFoundError", new QueuedOrderNotFoundError("x")],
+    ])("maps %s → 404", async (_name, err) => {
+      expect(await statusOf(err)).toBe(404);
+    });
+  });
+
+  describe("403 Forbidden", () => {
+    it.each([
+      ["GameTileNotOwnedError", new GameTileNotOwnedError("x")],
+      ["GameShieldedError", new GameShieldedError("x")],
+      ["GameHeroNotOwnedError", new GameHeroNotOwnedError("x")],
+      ["QueuedOrderForbiddenError", new QueuedOrderForbiddenError("x")],
+    ])("maps %s → 403", async (_name, err) => {
+      expect(await statusOf(err)).toBe(403);
+    });
+  });
+
+  describe("409 Conflict", () => {
+    it.each([
+      ["GamePlayerAlreadyExistsError", new GamePlayerAlreadyExistsError("x")],
+      ["GameAlreadyRevealedError", new GameAlreadyRevealedError("x")],
+      ["GameCasteAlreadySetError", new GameCasteAlreadySetError("x")],
+      ["GameCasteChangeUnavailableError", new GameCasteChangeUnavailableError("x")],
+      ["GameInvalidPhaseError", new GameInvalidPhaseError("x")],
+      ["GameInsufficientTurnsError", new GameInsufficientTurnsError("x")],
+      ["GameInsufficientUnitsError", new GameInsufficientUnitsError("x")],
+      ["GameTileUnrevealedError", new GameTileUnrevealedError("x")],
+      ["GameNoUnrevealedTilesError", new GameNoUnrevealedTilesError("x")],
+      ["GameTileFullError", new GameTileFullError("x")],
+      ["GameUnitCapExceededError", new GameUnitCapExceededError("x")],
+      ["GameTileTypeError", new GameTileTypeError("x")],
+      ["GameFrontierExhaustedError", new GameFrontierExhaustedError("x")],
+      ["GameNoEnemyKingdomsError", new GameNoEnemyKingdomsError("x")],
+      ["GameArtifactAlreadyUsedError", new GameArtifactAlreadyUsedError("x")],
+      ["GameNameTakenError", new GameNameTakenError("x")],
+      ["GameArmageddonInProgressError", new GameArmageddonInProgressError("x")],
+      ["GameStaleSeasonError", new GameStaleSeasonError("x")],
+      ["GameSealsExhaustedError", new GameSealsExhaustedError("x")],
+      ["GameSpecialUnitAlreadyStationedError", new GameSpecialUnitAlreadyStationedError("x")],
+      ["UpgradeAlreadyActiveError", new UpgradeAlreadyActiveError("x")],
+      ["UpgradeNotActiveError", new UpgradeNotActiveError("x")],
+      ["GameDefensiveStanceBlockedError", new GameDefensiveStanceBlockedError("x")],
+      ["GameDefensiveStanceCapError", new GameDefensiveStanceCapError("x")],
+      ["GameDefensiveStanceLockedError", new GameDefensiveStanceLockedError("x")],
+      ["GameHeroAlreadyMeditatingError", new GameHeroAlreadyMeditatingError("x")],
+      ["GameMeditationSlotFullError", new GameMeditationSlotFullError("x")],
+      ["GamePepTalkRequiresZeroTurnsError", new GamePepTalkRequiresZeroTurnsError("x")],
+      ["GameLastStandRequiresZeroTurnsError", new GameLastStandRequiresZeroTurnsError("x")],
+      ["GameLastStandNoThreatError", new GameLastStandNoThreatError("x")],
+      ["QueuedOrderQueueFullError", new QueuedOrderQueueFullError("x")],
+    ])("maps %s → 409", async (_name, err) => {
+      expect(await statusOf(err)).toBe(409);
+    });
+  });
+
+  describe("400 Bad Request", () => {
+    it.each([
+      ["GameInvalidLandTypeError", new GameInvalidLandTypeError("x")],
+      ["GameInvalidCasteError", new GameInvalidCasteError("x")],
+      ["GameInvalidSpellError", new GameInvalidSpellError("x")],
+      ["GameNotAdjacentError", new GameNotAdjacentError("x")],
+      ["GameSelfAttackError", new GameSelfAttackError("x")],
+      ["GameInvalidNameError", new GameInvalidNameError("x")],
+      ["GamePlayerBioTooLongError", new GamePlayerBioTooLongError("x")],
+      ["GameInscriptionTooLongError", new GameInscriptionTooLongError("x")],
+      ["UpgradeWrongCasteError", new UpgradeWrongCasteError("x")],
+      ["QueuedOrderInvalidParamsError", new QueuedOrderInvalidParamsError("x")],
+    ])("maps %s → 400", async (_name, err) => {
+      expect(await statusOf(err)).toBe(400);
+    });
+  });
+
+  describe("429 Rate Limited", () => {
+    it.each([
+      ["GameRedistributeRateLimitError", new GameRedistributeRateLimitError("x")],
+      ["GameLastStandCooldownError", new GameLastStandCooldownError("x")],
+    ])("maps %s → 429", async (_name, err) => {
+      expect(await statusOf(err)).toBe(429);
+    });
+  });
+
+  describe("500 Server Error (unhandled)", () => {
+    it("maps an unknown Error → 500", async () => {
+      expect(await statusOf(new Error("some unknown error"))).toBe(500);
+    });
+
+    it("maps a non-Error value → 500", async () => {
+      expect(await statusOf("a string thrown")).toBe(500);
+      expect(await statusOf({ weird: "object" })).toBe(500);
+      expect(await statusOf(null)).toBe(500);
+    });
+  });
+});

--- a/__tests__/lib/maintainer-application.test.ts
+++ b/__tests__/lib/maintainer-application.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ */
+import {
+  MAINTAINER_APPLICATION_BRANCH,
+  MAINTAINER_APPLICATION_SCHEMA_VERSION,
+  buildMaintainerApplicationDraft,
+  formatMaintainerApplicationJson,
+  getMaintainerApplicationBranchTreeUrl,
+  getMaintainerApplicationFilePath,
+  getMaintainerApplicationRepoBaseUrl,
+} from "@/lib/maintainer-application";
+
+describe("maintainer-application", () => {
+  describe("constants", () => {
+    it("exposes the application branch name", () => {
+      expect(MAINTAINER_APPLICATION_BRANCH).toBe("maintainer-application");
+    });
+
+    it("uses schema version 1", () => {
+      expect(MAINTAINER_APPLICATION_SCHEMA_VERSION).toBe(1);
+    });
+  });
+
+  describe("getMaintainerApplicationRepoBaseUrl + branch tree URL", () => {
+    it("returns an https github URL", () => {
+      expect(getMaintainerApplicationRepoBaseUrl()).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+$/);
+    });
+
+    it("branch tree URL appends /tree/maintainer-application", () => {
+      const base = getMaintainerApplicationRepoBaseUrl();
+      expect(getMaintainerApplicationBranchTreeUrl()).toBe(`${base}/tree/${MAINTAINER_APPLICATION_BRANCH}`);
+    });
+  });
+
+  describe("getMaintainerApplicationFilePath", () => {
+    it("places files under maintainer-applications/<login>.json", () => {
+      expect(getMaintainerApplicationFilePath("octocat")).toBe("maintainer-applications/octocat.json");
+    });
+
+    it("sanitizes unsafe characters in the login", () => {
+      expect(getMaintainerApplicationFilePath("foo/bar")).toBe("maintainer-applications/foo-bar.json");
+      expect(getMaintainerApplicationFilePath("oct@cat")).toBe("maintainer-applications/oct-cat.json");
+      expect(getMaintainerApplicationFilePath("oct cat")).toBe("maintainer-applications/oct-cat.json");
+    });
+
+    it("preserves alphanumerics, dot, hyphen, underscore", () => {
+      expect(getMaintainerApplicationFilePath("oct.cat_1-2")).toBe(
+        "maintainer-applications/oct.cat_1-2.json"
+      );
+    });
+
+    it("falls back to 'github-username' when login is all whitespace", () => {
+      expect(getMaintainerApplicationFilePath("   ")).toBe(
+        "maintainer-applications/github-username.json"
+      );
+    });
+
+    it("falls back to 'github-username' when login is empty", () => {
+      expect(getMaintainerApplicationFilePath("")).toBe(
+        "maintainer-applications/github-username.json"
+      );
+    });
+
+    it("trims surrounding whitespace before sanitizing", () => {
+      expect(getMaintainerApplicationFilePath("  octocat  ")).toBe(
+        "maintainer-applications/octocat.json"
+      );
+    });
+  });
+
+  describe("buildMaintainerApplicationDraft", () => {
+    it("returns a payload with the current schema version and empty user-supplied fields", () => {
+      const draft = buildMaintainerApplicationDraft({
+        githubLogin: "octocat",
+        discordUsername: "oct#1234",
+        displayName: "Octo Cat",
+        siteEmail: "oct@example.com",
+      });
+      expect(draft.schemaVersion).toBe(MAINTAINER_APPLICATION_SCHEMA_VERSION);
+      expect(draft.githubLogin).toBe("octocat");
+      expect(draft.discordUsername).toBe("oct#1234");
+      expect(draft.displayName).toBe("Octo Cat");
+      expect(draft.siteEmail).toBe("oct@example.com");
+      expect(draft.whyMaintainer).toBe("");
+      expect(draft.relevantExperience).toBe("");
+      expect(draft.availability).toBe("");
+      expect(draft.agreedToCodeOfConduct).toBe(false);
+      // ISO 8601 (with milliseconds, UTC)
+      expect(draft.submittedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+
+    it("preserves null siteEmail", () => {
+      const draft = buildMaintainerApplicationDraft({
+        githubLogin: "x",
+        discordUsername: "y",
+        displayName: "z",
+        siteEmail: null,
+      });
+      expect(draft.siteEmail).toBeNull();
+    });
+  });
+
+  describe("formatMaintainerApplicationJson", () => {
+    it("returns pretty-printed JSON with trailing newline", () => {
+      const draft = buildMaintainerApplicationDraft({
+        githubLogin: "x",
+        discordUsername: "y",
+        displayName: "z",
+        siteEmail: null,
+      });
+      const out = formatMaintainerApplicationJson(draft);
+      expect(out.endsWith("\n")).toBe(true);
+      expect(out).toContain('"githubLogin": "x"');
+      // Indented with 2 spaces
+      expect(out).toContain('  "githubLogin"');
+    });
+
+    it("produces parse-back-identical output", () => {
+      const draft = buildMaintainerApplicationDraft({
+        githubLogin: "foo",
+        discordUsername: "bar",
+        displayName: "baz",
+        siteEmail: "x@y.com",
+      });
+      const reparsed = JSON.parse(formatMaintainerApplicationJson(draft));
+      expect(reparsed).toEqual(draft);
+    });
+  });
+});

--- a/__tests__/lib/treasure-hunt-eligibility.test.ts
+++ b/__tests__/lib/treasure-hunt-eligibility.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @jest-environment node
+ */
+import {
+  TREASURE_HUNT_PR_WINDOW_HOURS,
+  checkTreasureHuntEligibility,
+  emailAlreadyWon,
+  treasureHuntEnabled,
+} from "@/lib/treasure-hunt-eligibility";
+import type { Firestore } from "firebase-admin/firestore";
+
+jest.mock("@/lib/hackathon-showcase", () => ({
+  githubUserHasRecentlyMergedPr: jest.fn(),
+}));
+
+import { githubUserHasRecentlyMergedPr } from "@/lib/hackathon-showcase";
+
+const mockHasPr = githubUserHasRecentlyMergedPr as jest.MockedFunction<
+  typeof githubUserHasRecentlyMergedPr
+>;
+
+type UserDoc = Record<string, unknown>;
+type ProgressDoc = Record<string, unknown>;
+
+function fakeDb(
+  user: UserDoc | undefined,
+  progress: ProgressDoc | undefined,
+  emailWonResult: boolean = false
+): Firestore {
+  return {
+    collection: (name: string) => ({
+      doc: (_id: string) => ({
+        get: async () => ({
+          exists: !!(name === "users" ? user : progress),
+          data: () => (name === "users" ? user : progress),
+        }),
+      }),
+      where: () => ({
+        limit: () => ({
+          get: async () => ({ empty: !emailWonResult }),
+        }),
+      }),
+    }),
+  } as unknown as Firestore;
+}
+
+describe("treasure-hunt-eligibility", () => {
+  const originalEnv = process.env.TREASURE_HUNT_ENABLED;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.TREASURE_HUNT_ENABLED;
+    else process.env.TREASURE_HUNT_ENABLED = originalEnv;
+    mockHasPr.mockReset();
+  });
+
+  describe("constants", () => {
+    it("exposes a 24h PR window", () => {
+      expect(TREASURE_HUNT_PR_WINDOW_HOURS).toBe(24);
+    });
+  });
+
+  describe("treasureHuntEnabled", () => {
+    it("defaults to true when env is unset", () => {
+      delete process.env.TREASURE_HUNT_ENABLED;
+      expect(treasureHuntEnabled()).toBe(true);
+    });
+
+    it("is true for any value other than literal 'false'", () => {
+      process.env.TREASURE_HUNT_ENABLED = "true";
+      expect(treasureHuntEnabled()).toBe(true);
+      process.env.TREASURE_HUNT_ENABLED = "1";
+      expect(treasureHuntEnabled()).toBe(true);
+    });
+
+    it("returns false only for the exact string 'false'", () => {
+      process.env.TREASURE_HUNT_ENABLED = "false";
+      expect(treasureHuntEnabled()).toBe(false);
+    });
+  });
+
+  describe("checkTreasureHuntEligibility", () => {
+    it("returns feature_disabled when env disables the hunt", async () => {
+      process.env.TREASURE_HUNT_ENABLED = "false";
+      const result = await checkTreasureHuntEligibility(fakeDb({}, {}), "u1");
+      expect(result).toEqual({ ok: false, reason: "feature_disabled" });
+    });
+
+    it("returns not_signed_in for empty uid", async () => {
+      const result = await checkTreasureHuntEligibility(fakeDb({}, {}), "");
+      expect(result).toEqual({ ok: false, reason: "not_signed_in" });
+    });
+
+    it("returns no_github when user has no github.login", async () => {
+      const result = await checkTreasureHuntEligibility(fakeDb({}, {}), "u1");
+      expect(result).toEqual({ ok: false, reason: "no_github" });
+    });
+
+    it("returns no_github when github field is not an object", async () => {
+      const result = await checkTreasureHuntEligibility(
+        fakeDb({ github: "octocat" }, {}),
+        "u1"
+      );
+      expect(result).toEqual({ ok: false, reason: "no_github" });
+    });
+
+    it("returns no_discord when github is linked but discord is missing", async () => {
+      const result = await checkTreasureHuntEligibility(
+        fakeDb({ github: { login: "octocat" } }, {}),
+        "u1"
+      );
+      expect(result).toEqual({ ok: false, reason: "no_discord" });
+    });
+
+    it("returns already_won if treasureHuntProgress has a prizeCodeId", async () => {
+      const result = await checkTreasureHuntEligibility(
+        fakeDb(
+          { github: { login: "octocat" }, discord: { username: "oct#1" } },
+          { prizeCodeId: "code-123" }
+        ),
+        "u1"
+      );
+      expect(result).toEqual({ ok: false, reason: "already_won" });
+    });
+
+    it("returns no_recent_pr if no qualifying PR exists", async () => {
+      mockHasPr.mockResolvedValueOnce(false);
+      const result = await checkTreasureHuntEligibility(
+        fakeDb({ github: { login: "octocat" }, discord: { username: "oct#1" } }, {}),
+        "u1"
+      );
+      expect(result).toEqual({ ok: false, reason: "no_recent_pr" });
+    });
+
+    it("returns ok+identity when all gates pass", async () => {
+      mockHasPr.mockResolvedValueOnce(true);
+      const result = await checkTreasureHuntEligibility(
+        fakeDb({ github: { login: " octocat " }, discord: { username: " oct#1 " } }, {}),
+        "u1"
+      );
+      expect(result).toEqual({ ok: true, githubLogin: "octocat", discordUsername: "oct#1" });
+      expect(mockHasPr).toHaveBeenCalledWith("octocat", 24);
+    });
+  });
+
+  describe("emailAlreadyWon", () => {
+    it("returns false for empty string", async () => {
+      expect(await emailAlreadyWon(fakeDb({}, {}), "")).toBe(false);
+    });
+
+    it("returns false when no winner record exists", async () => {
+      expect(await emailAlreadyWon(fakeDb({}, {}, false), "x@example.com")).toBe(false);
+    });
+
+    it("returns true when a winner record exists", async () => {
+      expect(await emailAlreadyWon(fakeDb({}, {}, true), "x@example.com")).toBe(true);
+    });
+
+    it("lowercases + trims before checking", async () => {
+      // Behavioral assertion: the mock doesn't care about input shape, but
+      // the function should still handle whitespace and case without throwing.
+      expect(await emailAlreadyWon(fakeDb({}, {}, true), "  X@Example.COM  ")).toBe(true);
+    });
+  });
+});

--- a/__tests__/lib/treasure-hunt-paths.test.ts
+++ b/__tests__/lib/treasure-hunt-paths.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment node
+ */
+import {
+  TREASURE_HUNT_PATHS,
+  getKonamiToken,
+  getOracleAnswer,
+  getPath,
+  listPaths,
+} from "@/lib/treasure-hunt-paths";
+
+const CTX = { uid: "u1", email: "u1@example.com" };
+
+describe("treasure-hunt-paths", () => {
+  describe("TREASURE_HUNT_PATHS registry", () => {
+    it("exposes the expected 7 paths", () => {
+      const expected = [
+        "code-reader",
+        "konami",
+        "oracle",
+        "librarian",
+        "badge-collector",
+        "cartographer",
+        "cookbook-alchemist",
+      ];
+      expect(Object.keys(TREASURE_HUNT_PATHS).sort()).toEqual(expected.sort());
+    });
+
+    it("every path has the required fields", () => {
+      for (const path of Object.values(TREASURE_HUNT_PATHS)) {
+        expect(path.id).toBeTruthy();
+        expect(path.name).toBeTruthy();
+        expect(path.emoji).toBeTruthy();
+        expect(path.hint).toBeTruthy();
+        expect(typeof path.verify).toBe("function");
+      }
+    });
+  });
+
+  describe("listPaths", () => {
+    it("returns all paths from the registry", () => {
+      expect(listPaths()).toHaveLength(Object.keys(TREASURE_HUNT_PATHS).length);
+    });
+  });
+
+  describe("getPath", () => {
+    it("returns a path by id", () => {
+      expect(getPath("code-reader")?.id).toBe("code-reader");
+    });
+
+    it("returns null for unknown ids", () => {
+      expect(getPath("does-not-exist")).toBeNull();
+    });
+  });
+
+  describe("code-reader path", () => {
+    it("accepts the canonical answer (case-insensitive, whitespace-tolerant)", async () => {
+      const p = TREASURE_HUNT_PATHS["code-reader"];
+      expect(await p.verify("resolve_hack_a_sprint_2026_credit_for_user", CTX)).toBe(true);
+      expect(await p.verify("  Resolve_Hack_A_Sprint_2026_Credit_For_User  ", CTX)).toBe(true);
+    });
+
+    it("rejects an incorrect answer", async () => {
+      const p = TREASURE_HUNT_PATHS["code-reader"];
+      expect(await p.verify("wrong", CTX)).toBe(false);
+    });
+  });
+
+  describe("konami path + getKonamiToken", () => {
+    it("returns a 12-character hex token", () => {
+      expect(getKonamiToken()).toMatch(/^[0-9a-f]{12}$/);
+    });
+
+    it("verifies a freshly-minted token", async () => {
+      const token = getKonamiToken();
+      const p = TREASURE_HUNT_PATHS["konami"];
+      expect(await p.verify(token, CTX)).toBe(true);
+    });
+
+    it("rejects an unrelated string", async () => {
+      const p = TREASURE_HUNT_PATHS["konami"];
+      expect(await p.verify("abc123abc123", CTX)).toBe(false);
+    });
+  });
+
+  describe("oracle path + getOracleAnswer", () => {
+    it("returns a 64-character hex digest", () => {
+      expect(getOracleAnswer()).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("verifies the freshly-computed oracle answer", async () => {
+      const answer = getOracleAnswer();
+      const p = TREASURE_HUNT_PATHS["oracle"];
+      expect(await p.verify(answer, CTX)).toBe(true);
+    });
+  });
+
+  describe("env-driven paths use defaults when env is unset", () => {
+    const originalSlug = process.env.TREASURE_HUNT_LIBRARIAN_SLUG;
+    const originalBadge = process.env.TREASURE_HUNT_BADGE_ANSWER;
+    const originalGeohash = process.env.TREASURE_HUNT_CARTOGRAPHER_GEOHASH;
+    const originalCookbook = process.env.TREASURE_HUNT_COOKBOOK_ANSWER;
+
+    afterAll(() => {
+      const restore = (k: string, v: string | undefined) => {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      };
+      restore("TREASURE_HUNT_LIBRARIAN_SLUG", originalSlug);
+      restore("TREASURE_HUNT_BADGE_ANSWER", originalBadge);
+      restore("TREASURE_HUNT_CARTOGRAPHER_GEOHASH", originalGeohash);
+      restore("TREASURE_HUNT_COOKBOOK_ANSWER", originalCookbook);
+    });
+
+    it("librarian falls back to 'open-sesame' default", async () => {
+      delete process.env.TREASURE_HUNT_LIBRARIAN_SLUG;
+      expect(await TREASURE_HUNT_PATHS["librarian"].verify("open-sesame", CTX)).toBe(true);
+    });
+
+    it("librarian uses env override when set", async () => {
+      process.env.TREASURE_HUNT_LIBRARIAN_SLUG = "custom-slug";
+      expect(await TREASURE_HUNT_PATHS["librarian"].verify("custom-slug", CTX)).toBe(true);
+      expect(await TREASURE_HUNT_PATHS["librarian"].verify("open-sesame", CTX)).toBe(false);
+    });
+
+    it("badge-collector falls back to default phrase", async () => {
+      delete process.env.TREASURE_HUNT_BADGE_ANSWER;
+      expect(
+        await TREASURE_HUNT_PATHS["badge-collector"].verify(
+          "firstprshowcasewinnermaintainer",
+          CTX
+        )
+      ).toBe(true);
+    });
+
+    it("cartographer falls back to default geohash", async () => {
+      delete process.env.TREASURE_HUNT_CARTOGRAPHER_GEOHASH;
+      expect(await TREASURE_HUNT_PATHS["cartographer"].verify("drt2zmw", CTX)).toBe(true);
+    });
+
+    it("cookbook-alchemist falls back to default phrase", async () => {
+      delete process.env.TREASURE_HUNT_COOKBOOK_ANSWER;
+      expect(
+        await TREASURE_HUNT_PATHS["cookbook-alchemist"].verify("promptcachinglovesyou", CTX)
+      ).toBe(true);
+    });
+  });
+
+  describe("answer normalization is timing-safe", () => {
+    it("rejects answers of different length without leaking via timing", async () => {
+      // Behavioral assertion: short and long incorrect answers both return false.
+      const p = TREASURE_HUNT_PATHS["code-reader"];
+      expect(await p.verify("", CTX)).toBe(false);
+      expect(await p.verify("a", CTX)).toBe(false);
+      expect(await p.verify("a".repeat(1000), CTX)).toBe(false);
+    });
+  });
+});

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -53,17 +53,19 @@ const customJestConfig = {
   // allowlisted lore subcollections — chapters, epitaphs). Registry
   // additions are static data covered transitively by the existing
   // registry self-check test; cascade-test growth lags by ~1pp.
-  // Current totals (2026-05-18 CI): statements ~31.9%, branches ~23.7%, lines ~32.4%, functions ~24.0%.
+  // Current totals (2026-05-18 CI, after coverage pushes #1-5): statements ~32.4%,
+  // branches ~24.4%, lines ~33.6%, functions ~25.8%.
   // Floors set ~0.5pp below current → any regression fails CI.
   // Ratchet these UP as tests are added; the OSS-readiness lift (Phase 5.4)
-  // targets statements ≥75% by adding ~150 tests across the 95 untested API
-  // route handlers and the game data layer at lib/game/data-server.ts etc.
+  // targets statements ≥80% (OpenSSF Silver `test_statement_coverage80`) by
+  // adding tests across the 95 untested API route handlers and the game data
+  // layer at lib/game/data-server.ts etc.
   coverageThreshold: {
     global: {
-      branches: 23,
-      functions: 23,
-      lines: 32,
-      statements: 31,
+      branches: 24,
+      functions: 25,
+      lines: 33,
+      statements: 32,
     },
   },
   // Generate JSON summary for CI coverage checks


### PR DESCRIPTION
## Summary

Promotes two commits from develop:

- **#997** *test(lib/game): coverage push #4 — mapGameError* — 86 tests covering all error-class → HTTP status mappings in game/api-error-map + events-calendar-buckets + treasure-hunt-paths registry
- **#998** *test(lib): coverage push #5 — maintainer-application + treasure-hunt-eligibility* — 30 tests covering both modules end-to-end. Also ratchets jest coverage thresholds up: statements 31→32, branches 23→24, functions 23→25, lines 32→33.

Tests-only + jest threshold update — no runtime change.

## OpenSSF Silver status

After this merges:
- ✅ assurance_case — Met
- ✅ version_tags_signed — Met (v0.3.0 signed tag live)
- 🔴 test_statement_coverage80 — currently 32.38% vs 80% target. Coverage pushes #1-5 are the first five slices of the multi-week initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)