### PR TITLE
test: coverage push #9 — ludwitt-errors + hack-a-sprint state helpers

### DIFF
--- a/__tests__/app/auth/login/ludwitt-errors.test.ts
+++ b/__tests__/app/auth/login/ludwitt-errors.test.ts
@@ -1,0 +1,29 @@
+import { getLudwittErrorMessage } from "@/app/(auth)/login/_lib/ludwitt-errors";
+
+describe("getLudwittErrorMessage", () => {
+  it.each([
+    ["missing_params", "incomplete"],
+    ["invalid_state", "expired"],
+    ["not_configured", "isn't set up"],
+    ["token_failed", "reach Ludwitt"],
+    ["userinfo_failed", "account details"],
+    ["no_email", "doesn't have an email"],
+    ["firebase_user_failed", "create your account"],
+    ["token_persist_failed", "save your Ludwitt session"],
+    ["custom_token_failed", "sign-in session"],
+    ["finalize_failed", "expired"],
+    ["access_denied", "declined"],
+  ])("returns a specific message for code '%s'", (code, fragment) => {
+    expect(getLudwittErrorMessage(code)).toContain(fragment);
+  });
+
+  it("returns a generic message for null", () => {
+    expect(getLudwittErrorMessage(null)).toBe("Ludwitt sign-in failed. Please try again.");
+  });
+
+  it("returns the generic message for unknown codes", () => {
+    expect(getLudwittErrorMessage("totally-made-up")).toBe(
+      "Ludwitt sign-in failed. Please try again."
+    );
+  });
+});

--- a/__tests__/lib/hackathon-asprint-2026-state.test.ts
+++ b/__tests__/lib/hackathon-asprint-2026-state.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+import {
+  hackASprint2026PeerVoteDocId,
+  hackASprint2026ScoreDocId,
+  hackASprint2026ParticipantScoresDocId,
+} from "@/lib/hackathon-asprint-2026-state";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
+
+describe("hackathon-asprint-2026-state pure helpers", () => {
+  describe("hackASprint2026PeerVoteDocId", () => {
+    it("composes the event id and userId", () => {
+      expect(hackASprint2026PeerVoteDocId("u-octocat")).toBe(
+        `${HACK_A_SPRINT_2026_EVENT_ID}__u-octocat`
+      );
+    });
+
+    it("preserves the userId verbatim (no lowercasing)", () => {
+      expect(hackASprint2026PeerVoteDocId("U-MixedCase")).toContain("U-MixedCase");
+    });
+  });
+
+  describe("hackASprint2026ScoreDocId", () => {
+    it("composes the event id and lowercased submission id", () => {
+      expect(hackASprint2026ScoreDocId("Submission-XYZ")).toBe(
+        `${HACK_A_SPRINT_2026_EVENT_ID}__submission-xyz`
+      );
+    });
+
+    it("is stable across different cases of the same submission id", () => {
+      expect(hackASprint2026ScoreDocId("AbCdEf")).toBe(
+        hackASprint2026ScoreDocId("abcdef")
+      );
+    });
+  });
+
+  describe("hackASprint2026ParticipantScoresDocId (re-export)", () => {
+    it("is a function exposed by the state module", () => {
+      expect(typeof hackASprint2026ParticipantScoresDocId).toBe("function");
+      // The re-export is the canonical doc-id formatter from
+      // lib/hackathon-asprint-2026-participant-scoring — exercising it here
+      // pins the re-export, which is itself the contract.
+      const id = hackASprint2026ParticipantScoresDocId("u-1");
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
18 tests across two modules. `app/(auth)/login/_lib/ludwitt-errors.ts` 0%→100%; pure helpers in `lib/hackathon-asprint-2026-state.ts` covered. Ninth slice of the OpenSSF Silver test_statement_coverage80 lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)