### PR TITLE
release: develop → main — coverage pushes #7-10 (Silver Phase 5.4)

### DIFF
--- a/__tests__/app/auth/login/ludwitt-errors.test.ts
+++ b/__tests__/app/auth/login/ludwitt-errors.test.ts
@@ -1,0 +1,29 @@
+import { getLudwittErrorMessage } from "@/app/(auth)/login/_lib/ludwitt-errors";
+
+describe("getLudwittErrorMessage", () => {
+  it.each([
+    ["missing_params", "incomplete"],
+    ["invalid_state", "expired"],
+    ["not_configured", "isn't set up"],
+    ["token_failed", "reach Ludwitt"],
+    ["userinfo_failed", "account details"],
+    ["no_email", "doesn't have an email"],
+    ["firebase_user_failed", "create your account"],
+    ["token_persist_failed", "save your Ludwitt session"],
+    ["custom_token_failed", "sign-in session"],
+    ["finalize_failed", "expired"],
+    ["access_denied", "declined"],
+  ])("returns a specific message for code '%s'", (code, fragment) => {
+    expect(getLudwittErrorMessage(code)).toContain(fragment);
+  });
+
+  it("returns a generic message for null", () => {
+    expect(getLudwittErrorMessage(null)).toBe("Ludwitt sign-in failed. Please try again.");
+  });
+
+  it("returns the generic message for unknown codes", () => {
+    expect(getLudwittErrorMessage("totally-made-up")).toBe(
+      "Ludwitt sign-in failed. Please try again."
+    );
+  });
+});

--- a/__tests__/lib/api-schemas/all-contracts-load.test.ts
+++ b/__tests__/lib/api-schemas/all-contracts-load.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ *
+ * Smoke test: every ts-rest contract module must load and expose its
+ * router with the expected shape (method + path on every endpoint).
+ * Importing the modules executes their c.router(...) calls — that's
+ * what bumps these previously-0%-statement files into coverage, but
+ * the assertions also catch accidental router-shape regressions.
+ */
+
+import { accountContract } from "@/lib/api-schemas/account";
+import { agentsContract } from "@/lib/api-schemas/agents";
+import { analyticsContract } from "@/lib/api-schemas/analytics";
+import { authContract } from "@/lib/api-schemas/auth";
+import { badgesContract } from "@/lib/api-schemas/badges";
+import { certificateContract } from "@/lib/api-schemas/certificate";
+import { cfpContract } from "@/lib/api-schemas/cfp";
+import { communityContract } from "@/lib/api-schemas/community";
+import { cookbookContract } from "@/lib/api-schemas/cookbook";
+import { cursorContract } from "@/lib/api-schemas/cursor";
+import { discordContract } from "@/lib/api-schemas/discord";
+import { eventsContract } from "@/lib/api-schemas/events";
+import { gameContract } from "@/lib/api-schemas/game";
+import { githubContract } from "@/lib/api-schemas/github";
+import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+import { healthContract } from "@/lib/api-schemas/health";
+import { hiringPartnersContract } from "@/lib/api-schemas/hiring-partners";
+import { huntContract } from "@/lib/api-schemas/hunt";
+import { internalContract } from "@/lib/api-schemas/internal";
+import { liveContract } from "@/lib/api-schemas/live";
+import { ludwittContract } from "@/lib/api-schemas/ludwitt";
+import { maintainersContract } from "@/lib/api-schemas/maintainers";
+import { membersContract } from "@/lib/api-schemas/members";
+import { mentorshipContract } from "@/lib/api-schemas/mentorship";
+import { notificationsContract } from "@/lib/api-schemas/notifications";
+import { notifyAdminContract } from "@/lib/api-schemas/notify-admin";
+import { pairContract } from "@/lib/api-schemas/pair";
+import { profileContract } from "@/lib/api-schemas/profile";
+import { questionsContract } from "@/lib/api-schemas/questions";
+import { showcaseContract } from "@/lib/api-schemas/showcase";
+import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
+import { talksContract } from "@/lib/api-schemas/talks";
+import { apiContract } from "@/lib/api-schemas";
+
+type AnyRouter = Record<string, { method?: string; path?: string }>;
+
+const ALL_CONTRACTS: Array<[string, AnyRouter]> = [
+  ["accountContract", accountContract as unknown as AnyRouter],
+  ["agentsContract", agentsContract as unknown as AnyRouter],
+  ["analyticsContract", analyticsContract as unknown as AnyRouter],
+  ["authContract", authContract as unknown as AnyRouter],
+  ["badgesContract", badgesContract as unknown as AnyRouter],
+  ["certificateContract", certificateContract as unknown as AnyRouter],
+  ["cfpContract", cfpContract as unknown as AnyRouter],
+  ["communityContract", communityContract as unknown as AnyRouter],
+  ["cookbookContract", cookbookContract as unknown as AnyRouter],
+  ["cursorContract", cursorContract as unknown as AnyRouter],
+  ["discordContract", discordContract as unknown as AnyRouter],
+  ["eventsContract", eventsContract as unknown as AnyRouter],
+  ["gameContract", gameContract as unknown as AnyRouter],
+  ["githubContract", githubContract as unknown as AnyRouter],
+  ["hackathonsContract", hackathonsContract as unknown as AnyRouter],
+  ["healthContract", healthContract as unknown as AnyRouter],
+  ["hiringPartnersContract", hiringPartnersContract as unknown as AnyRouter],
+  ["huntContract", huntContract as unknown as AnyRouter],
+  ["internalContract", internalContract as unknown as AnyRouter],
+  ["liveContract", liveContract as unknown as AnyRouter],
+  ["ludwittContract", ludwittContract as unknown as AnyRouter],
+  ["maintainersContract", maintainersContract as unknown as AnyRouter],
+  ["membersContract", membersContract as unknown as AnyRouter],
+  ["mentorshipContract", mentorshipContract as unknown as AnyRouter],
+  ["notificationsContract", notificationsContract as unknown as AnyRouter],
+  ["notifyAdminContract", notifyAdminContract as unknown as AnyRouter],
+  ["pairContract", pairContract as unknown as AnyRouter],
+  ["profileContract", profileContract as unknown as AnyRouter],
+  ["questionsContract", questionsContract as unknown as AnyRouter],
+  ["showcaseContract", showcaseContract as unknown as AnyRouter],
+  ["summerCohortContract", summerCohortContract as unknown as AnyRouter],
+  ["talksContract", talksContract as unknown as AnyRouter],
+];
+
+const VALID_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+describe("api-schemas — contract registry", () => {
+  it.each(ALL_CONTRACTS)("%s loads and is a non-empty router object", (name, contract) => {
+    expect(contract).toBeDefined();
+    expect(typeof contract).toBe("object");
+    // Subroutes can be either endpoints or nested routers; just ensure non-empty.
+    expect(Object.keys(contract).length).toBeGreaterThan(0);
+  });
+
+  it.each(ALL_CONTRACTS)(
+    "%s endpoints declare a known HTTP method and a path",
+    (_name, contract) => {
+      // Walk the contract and assert every leaf endpoint has a method + path.
+      const walk = (node: unknown, trail: string[] = []) => {
+        if (!node || typeof node !== "object") return;
+        const obj = node as Record<string, unknown>;
+        if (typeof obj.method === "string" && typeof obj.path === "string") {
+          expect(VALID_METHODS.has(obj.method.toUpperCase())).toBe(true);
+          expect(obj.path.length).toBeGreaterThan(0);
+          return;
+        }
+        for (const [k, v] of Object.entries(obj)) {
+          walk(v, [...trail, k]);
+        }
+      };
+      walk(contract);
+    }
+  );
+
+  describe("the umbrella apiContract", () => {
+    it("exposes all sub-routers under expected keys", () => {
+      const root = apiContract as unknown as Record<string, unknown>;
+      // Spot check a sampling — full enumeration is on each sub-contract above.
+      const expectedKeys = [
+        "account",
+        "auth",
+        "community",
+        "events",
+        "game",
+        "hackathons",
+        "talks",
+      ];
+      for (const k of expectedKeys) {
+        expect(root[k]).toBeDefined();
+      }
+    });
+  });
+});

--- a/__tests__/lib/game-ui-constants.test.ts
+++ b/__tests__/lib/game-ui-constants.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ *
+ * Smoke test for the game-UI helper modules under app/game/*\/_lib/.
+ * Importing executes module-scope code (typed const tables, helper
+ * functions, color maps) — bumping these previously-0%-statement
+ * files into coverage. The shallow assertions also catch accidental
+ * deletes of the public surface.
+ */
+
+import {
+  MIN_UNITS_PER_CYCLE_RECRUITABLE,
+  RARITY_TEXT as RECRUIT_RARITY_TEXT,
+  TURNS_PER_CYCLE,
+  UNITS_PER_CYCLE,
+  UNITS_PER_CYCLE_BY_LAND,
+  unitsPerCycleForLand,
+} from "@/app/game/recruit/_lib/constants";
+import {
+  CASTES,
+  CASTE_PRESENTATION,
+  DISTRIBUTABLE,
+  RARITY_COLORS,
+} from "@/app/game/setup/_lib/constants";
+import {
+  RARITY_TEXT as SPELLS_RARITY_TEXT,
+  TIERS,
+  TYPE_COLUMNS,
+  TYPE_LABEL,
+} from "@/app/game/spells/_lib/constants";
+
+describe("app/game/*/_lib/constants", () => {
+  describe("recruit/_lib/constants", () => {
+    it("UNITS_PER_CYCLE = 10 (military baseline)", () => {
+      expect(UNITS_PER_CYCLE).toBe(10);
+    });
+
+    it("TURNS_PER_CYCLE = 5", () => {
+      expect(TURNS_PER_CYCLE).toBe(5);
+    });
+
+    it("MIN_UNITS_PER_CYCLE_RECRUITABLE = 5 (conservative lower bound)", () => {
+      expect(MIN_UNITS_PER_CYCLE_RECRUITABLE).toBe(5);
+    });
+
+    it("UNITS_PER_CYCLE_BY_LAND has the documented per-type yield", () => {
+      expect(UNITS_PER_CYCLE_BY_LAND.military).toBe(10);
+      expect(UNITS_PER_CYCLE_BY_LAND.food).toBe(5);
+      expect(UNITS_PER_CYCLE_BY_LAND.magic).toBe(5);
+      expect(UNITS_PER_CYCLE_BY_LAND.unrevealed).toBe(0);
+      expect(UNITS_PER_CYCLE_BY_LAND.unassigned).toBe(0);
+    });
+
+    it("unitsPerCycleForLand mirrors the table", () => {
+      expect(unitsPerCycleForLand("military")).toBe(10);
+      expect(unitsPerCycleForLand("food")).toBe(5);
+      expect(unitsPerCycleForLand("magic")).toBe(5);
+      expect(unitsPerCycleForLand("unrevealed")).toBe(0);
+    });
+
+    it("RARITY_TEXT covers the 4 rarity tiers", () => {
+      expect(RECRUIT_RARITY_TEXT.common).toBeTruthy();
+      expect(RECRUIT_RARITY_TEXT.rare).toBeTruthy();
+      expect(RECRUIT_RARITY_TEXT.epic).toBeTruthy();
+      expect(RECRUIT_RARITY_TEXT.legendary).toBeTruthy();
+    });
+  });
+
+  describe("setup/_lib/constants", () => {
+    it("CASTES lists 5 castes", () => {
+      expect(CASTES).toHaveLength(5);
+      expect(new Set(CASTES)).toEqual(new Set(["white", "blue", "black", "red", "green"]));
+    });
+
+    it("DISTRIBUTABLE lists the 3 distributable land types", () => {
+      expect(new Set(DISTRIBUTABLE)).toEqual(new Set(["military", "food", "magic"]));
+    });
+
+    it("CASTE_PRESENTATION has a swatch + tagline for every caste", () => {
+      for (const caste of CASTES) {
+        const p = CASTE_PRESENTATION[caste];
+        expect(p.swatch).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+        expect(p.tagline.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("RARITY_COLORS covers the 4 rarity tiers", () => {
+      expect(Object.keys(RARITY_COLORS)).toEqual(
+        expect.arrayContaining(["common", "rare", "epic", "legendary"])
+      );
+    });
+  });
+
+  describe("spells/_lib/constants", () => {
+    it("TIERS lists 5 ascending tiers with non-decreasing minTiles", () => {
+      expect(TIERS).toHaveLength(5);
+      for (let i = 1; i < TIERS.length; i++) {
+        expect(TIERS[i].tier).toBe(TIERS[i - 1].tier + 1);
+        expect(TIERS[i].minTiles).toBeGreaterThan(TIERS[i - 1].minTiles);
+      }
+    });
+
+    it("TYPE_COLUMNS lists the table's column order", () => {
+      expect(TYPE_COLUMNS).toEqual(["defense", "offense", "production"]);
+    });
+
+    it("TYPE_LABEL has a label for every column type + extras", () => {
+      for (const t of TYPE_COLUMNS) {
+        expect(TYPE_LABEL[t]).toBeTruthy();
+      }
+      // Extra spell types not in the table column list still get a label.
+      expect(TYPE_LABEL.intel).toBeTruthy();
+      expect(TYPE_LABEL.armageddon).toBeTruthy();
+    });
+
+    it("RARITY_TEXT covers the 4 rarity tiers", () => {
+      expect(Object.keys(SPELLS_RARITY_TEXT)).toEqual(
+        expect.arrayContaining(["common", "rare", "epic", "legendary"])
+      );
+    });
+  });
+});

--- a/__tests__/lib/hackathon-asprint-2026-participant-scoring.test.ts
+++ b/__tests__/lib/hackathon-asprint-2026-participant-scoring.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment node
+ */
+import {
+  computePeerAverages,
+  hackASprint2026ParticipantScoresDocId,
+  normalizeParticipantScores,
+  participantBallotComplete,
+  participantPrizeEligibility,
+  type SubmissionIdentity,
+} from "@/lib/hackathon-asprint-2026-participant-scoring";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
+
+const subs: SubmissionIdentity[] = [
+  { submissionId: "Sub-A", githubLogin: "alice" },
+  { submissionId: "Sub-B", githubLogin: "bob" },
+  { submissionId: "Sub-C", githubLogin: "carol" },
+  { submissionId: "Sub-D", githubLogin: "dan" },
+  { submissionId: "Sub-E", githubLogin: "erin" },
+  { submissionId: "Sub-F", githubLogin: "frank" },
+  { submissionId: "Sub-G", githubLogin: "george" },
+];
+
+describe("hackathon-asprint-2026-participant-scoring", () => {
+  describe("hackASprint2026ParticipantScoresDocId", () => {
+    it("composes the event id and userId", () => {
+      expect(hackASprint2026ParticipantScoresDocId("u1")).toBe(
+        `${HACK_A_SPRINT_2026_EVENT_ID}__u1`
+      );
+    });
+  });
+
+  describe("normalizeParticipantScores", () => {
+    it("returns {} for undefined or non-object input", () => {
+      expect(normalizeParticipantScores(undefined)).toEqual({});
+      expect(normalizeParticipantScores(null as unknown as Record<string, unknown>)).toEqual({});
+    });
+
+    it("keeps integers in [1,10] and lowercases keys", () => {
+      expect(
+        normalizeParticipantScores({ "Sub-A": 7, "Sub-B": 10, "Sub-C": 1 })
+      ).toEqual({ "sub-a": 7, "sub-b": 10, "sub-c": 1 });
+    });
+
+    it("drops values outside [1,10]", () => {
+      expect(normalizeParticipantScores({ a: 0, b: 11, c: -3 })).toEqual({});
+    });
+
+    it("drops non-integer values (decimals, NaN, non-numeric)", () => {
+      expect(normalizeParticipantScores({ a: 3.5, b: "x", c: NaN, d: null })).toEqual({});
+    });
+
+    it("coerces string-formatted integers", () => {
+      expect(normalizeParticipantScores({ a: "5", b: "10" })).toEqual({ a: 5, b: 10 });
+    });
+  });
+
+  describe("participantBallotComplete", () => {
+    it("is true when there are no other submissions", () => {
+      expect(participantBallotComplete({}, "alice", [subs[0]])).toBe(true);
+    });
+
+    it("is false when scores is undefined and others exist", () => {
+      expect(participantBallotComplete(undefined, "alice", subs)).toBe(false);
+    });
+
+    it("is true when every non-own submission has a valid 1-10 score", () => {
+      const scores = {
+        "sub-b": 7,
+        "sub-c": 9,
+        "sub-d": 10,
+        "sub-e": 1,
+        "sub-f": 5,
+        "sub-g": 8,
+      };
+      expect(participantBallotComplete(scores, "alice", subs)).toBe(true);
+    });
+
+    it("is false if any non-own submission is missing a score", () => {
+      const scores = { "sub-b": 7, "sub-c": 9 };
+      expect(participantBallotComplete(scores, "alice", subs)).toBe(false);
+    });
+
+    it("does NOT require a score for the voter's own submission", () => {
+      const scores = {
+        "sub-b": 7,
+        "sub-c": 9,
+        "sub-d": 10,
+        "sub-e": 1,
+        "sub-f": 5,
+        "sub-g": 8,
+      };
+      // alice owns Sub-A; she doesn't score herself, ballot is still complete.
+      expect(scores["sub-a"]).toBeUndefined();
+      expect(participantBallotComplete(scores, "Alice", subs)).toBe(true);
+    });
+  });
+
+  describe("participantPrizeEligibility", () => {
+    it("requires min(6, #others) high-scores (>8) AND ballot completeness", () => {
+      const scores = {
+        "sub-b": 9,
+        "sub-c": 10,
+        "sub-d": 9,
+        "sub-e": 9,
+        "sub-f": 9,
+        "sub-g": 9,
+      };
+      const r = participantPrizeEligibility(scores, "alice", subs);
+      expect(r.requiredHighScores).toBe(6);
+      expect(r.highScoreCount).toBe(6);
+      expect(r.eligible).toBe(true);
+    });
+
+    it("is ineligible when ballot is complete but high-scores are too few", () => {
+      const scores = {
+        "sub-b": 7,
+        "sub-c": 7,
+        "sub-d": 9,
+        "sub-e": 9,
+        "sub-f": 7,
+        "sub-g": 7,
+      };
+      const r = participantPrizeEligibility(scores, "alice", subs);
+      expect(r.highScoreCount).toBe(2);
+      expect(r.eligible).toBe(false);
+    });
+
+    it("is ineligible if scores is undefined", () => {
+      const r = participantPrizeEligibility(undefined, "alice", subs);
+      expect(r.eligible).toBe(false);
+    });
+
+    it("is trivially eligible when there are no other submissions", () => {
+      const r = participantPrizeEligibility(undefined, "alice", [subs[0]]);
+      expect(r.eligible).toBe(true);
+      expect(r.requiredHighScores).toBe(0);
+    });
+
+    it("scales requiredHighScores down when #others < 6", () => {
+      const trio = subs.slice(0, 3); // alice + bob + carol
+      const r = participantPrizeEligibility(
+        { "sub-b": 9, "sub-c": 9 },
+        "alice",
+        trio
+      );
+      expect(r.requiredHighScores).toBe(2);
+      expect(r.eligible).toBe(true);
+    });
+  });
+
+  describe("computePeerAverages", () => {
+    it("returns null for submissions with no peer votes", () => {
+      const out = computePeerAverages(subs.slice(0, 2), [], new Map());
+      expect(out.get("sub-a")).toBeNull();
+      expect(out.get("sub-b")).toBeNull();
+    });
+
+    it("computes the mean across voters, excluding self-votes", () => {
+      const voters = [
+        { userId: "u-bob", scores: { "sub-a": 8, "sub-b": 10 } }, // bob can't vote for himself
+        { userId: "u-carol", scores: { "sub-a": 10 } },
+      ];
+      const voterGh = new Map([
+        ["u-bob", "bob"],
+        ["u-carol", "carol"],
+      ]);
+      const out = computePeerAverages(subs.slice(0, 2), voters, voterGh);
+      // Sub-A: avg of bob's 8 and carol's 10 = 9
+      expect(out.get("sub-a")).toBe(9);
+      // Sub-B (bob's): bob's self-vote excluded, carol didn't vote → null
+      expect(out.get("sub-b")).toBeNull();
+    });
+
+    it("skips voters with no resolved github login", () => {
+      const voters = [{ userId: "u-anon", scores: { "sub-a": 7 } }];
+      // voter not in the github map → vote ignored
+      const out = computePeerAverages(subs.slice(0, 1), voters, new Map());
+      expect(out.get("sub-a")).toBeNull();
+    });
+
+    it("skips non-numeric score entries", () => {
+      const voters = [
+        {
+          userId: "u-bob",
+          scores: { "sub-a": "not-a-number" as unknown as number },
+        },
+      ];
+      const out = computePeerAverages(subs.slice(0, 1), voters, new Map([["u-bob", "bob"]]));
+      expect(out.get("sub-a")).toBeNull();
+    });
+  });
+});

--- a/__tests__/lib/hackathon-asprint-2026-state.test.ts
+++ b/__tests__/lib/hackathon-asprint-2026-state.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+import {
+  hackASprint2026PeerVoteDocId,
+  hackASprint2026ScoreDocId,
+  hackASprint2026ParticipantScoresDocId,
+} from "@/lib/hackathon-asprint-2026-state";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
+
+describe("hackathon-asprint-2026-state pure helpers", () => {
+  describe("hackASprint2026PeerVoteDocId", () => {
+    it("composes the event id and userId", () => {
+      expect(hackASprint2026PeerVoteDocId("u-octocat")).toBe(
+        `${HACK_A_SPRINT_2026_EVENT_ID}__u-octocat`
+      );
+    });
+
+    it("preserves the userId verbatim (no lowercasing)", () => {
+      expect(hackASprint2026PeerVoteDocId("U-MixedCase")).toContain("U-MixedCase");
+    });
+  });
+
+  describe("hackASprint2026ScoreDocId", () => {
+    it("composes the event id and lowercased submission id", () => {
+      expect(hackASprint2026ScoreDocId("Submission-XYZ")).toBe(
+        `${HACK_A_SPRINT_2026_EVENT_ID}__submission-xyz`
+      );
+    });
+
+    it("is stable across different cases of the same submission id", () => {
+      expect(hackASprint2026ScoreDocId("AbCdEf")).toBe(
+        hackASprint2026ScoreDocId("abcdef")
+      );
+    });
+  });
+
+  describe("hackASprint2026ParticipantScoresDocId (re-export)", () => {
+    it("is a function exposed by the state module", () => {
+      expect(typeof hackASprint2026ParticipantScoresDocId).toBe("function");
+      // The re-export is the canonical doc-id formatter from
+      // lib/hackathon-asprint-2026-participant-scoring — exercising it here
+      // pins the re-export, which is itself the contract.
+      const id = hackASprint2026ParticipantScoresDocId("u-1");
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Promotes four commits from develop:

- **#1002** push #7 — load all 32 ts-rest contracts (api-schemas/game.ts 1425 LOC unlocked)
- **#1003** push #8 — game UI constants (setup/recruit/spells)
- **#1004** push #9 — ludwitt-errors + hack-a-sprint state helpers
- **#1005** push #10 — hackathon participant scoring (54% → 100%)

Tests-only. ~100 new tests across this batch. Coverage cumulative this session: 31.22% → ~33.2% statements (and climbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)