### PR TITLE
release: develop → main — coverage pushes #15-22 (Silver Phase 5.4)

### DIFF
--- a/__tests__/lib/game/content-armageddon.test.ts
+++ b/__tests__/lib/game/content-armageddon.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import {
+  ARMAGEDDON_TILE_GATE,
+  ARMAGEDDON_TURN_COST,
+  BASE_SUCCESS,
+  SEAL_COUNT,
+  SUCCESS_HARD_CAP,
+  TOP_BY_TILES_SNAPSHOT_COUNT,
+  WINNER_COUNT,
+  computeArmageddonSuccessChanceFromMultiplier,
+  computeLotteryTickets,
+} from "@/lib/game/content/armageddon";
+
+describe("game/content/armageddon", () => {
+  describe("constants", () => {
+    it("ARMAGEDDON_TILE_GATE = 10,000 (unlock gate)", () => {
+      expect(ARMAGEDDON_TILE_GATE).toBe(10_000);
+    });
+
+    it("ARMAGEDDON_TURN_COST = 100 (per cast)", () => {
+      expect(ARMAGEDDON_TURN_COST).toBe(100);
+    });
+
+    it("BASE_SUCCESS, SUCCESS_HARD_CAP form a sensible probability range", () => {
+      expect(BASE_SUCCESS).toBeGreaterThan(0);
+      expect(BASE_SUCCESS).toBeLessThan(1);
+      expect(SUCCESS_HARD_CAP).toBeGreaterThan(BASE_SUCCESS);
+      expect(SUCCESS_HARD_CAP).toBeLessThanOrEqual(1);
+    });
+
+    it("SEAL_COUNT = 7 (biblical), WINNER_COUNT = 10, SNAPSHOT = 50", () => {
+      expect(SEAL_COUNT).toBe(7);
+      expect(WINNER_COUNT).toBe(10);
+      expect(TOP_BY_TILES_SNAPSHOT_COUNT).toBe(50);
+    });
+  });
+
+  describe("computeArmageddonSuccessChanceFromMultiplier", () => {
+    it("returns BASE_SUCCESS when multiplier = 1", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(1)).toBe(BASE_SUCCESS);
+    });
+
+    it("scales linearly with multiplier below the hard cap", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(2)).toBeCloseTo(BASE_SUCCESS * 2, 10);
+      expect(computeArmageddonSuccessChanceFromMultiplier(3)).toBeCloseTo(BASE_SUCCESS * 3, 10);
+    });
+
+    it("clamps at SUCCESS_HARD_CAP for very large multipliers", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(1000)).toBe(SUCCESS_HARD_CAP);
+    });
+
+    it("returns 0 when multiplier is 0", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(0)).toBe(0);
+    });
+  });
+
+  describe("computeLotteryTickets", () => {
+    it("returns 0 when tilesHeld is 0 or negative", () => {
+      expect(computeLotteryTickets(0, 5)).toBe(0);
+      expect(computeLotteryTickets(-10, 5)).toBe(0);
+    });
+
+    it("returns tilesHeld with no seals broken (multiplier = 1)", () => {
+      expect(computeLotteryTickets(1000, 0)).toBe(1000);
+    });
+
+    it("scales by (1 + sealsBroken)", () => {
+      expect(computeLotteryTickets(1000, 1)).toBe(2000);
+      expect(computeLotteryTickets(1000, 3)).toBe(4000);
+      expect(computeLotteryTickets(1000, 6)).toBe(7000);
+    });
+
+    it("treats negative sealsBroken as 0 (defensive)", () => {
+      expect(computeLotteryTickets(1000, -1)).toBe(1000);
+    });
+  });
+});

--- a/__tests__/lib/game/hero-registry-events.test.ts
+++ b/__tests__/lib/game/hero-registry-events.test.ts
@@ -1,0 +1,379 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the heroEvent payload-builder namespace + viewerWasOwner.
+ * The InTx writer helpers (upsertHeroInTx, markHeroDeceasedInTx, etc.)
+ * each take a Transaction; we exercise them via a fake-tx so we can
+ * assert their argument shape without standing up a real Firestore.
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  HEROES_COLLECTION,
+  HERO_EVENTS_SUBCOLLECTION,
+  appendHeroEventInTx,
+  clearHeroForArmageddonInTx,
+  heroEvent,
+  heroEventsCollection,
+  markHeroDeceasedInTx,
+  transferHeroOwnerInTx,
+  upsertHeroInTx,
+  viewerWasOwner,
+} from "@/lib/game/hero-registry";
+import type { GameHero } from "@/lib/game/types";
+
+function fakeRef(): unknown {
+  return { __fakeRef: true };
+}
+
+function fakeDb() {
+  const collectionCalls: string[] = [];
+  const docCalls: string[] = [];
+  const db = {
+    collection: (name: string) => {
+      collectionCalls.push(name);
+      return {
+        doc: (id: string) => {
+          docCalls.push(`${name}/${id}`);
+          return {
+            __fakeRef: true,
+            collection: (sub: string) => {
+              collectionCalls.push(`${name}/${id}/${sub}`);
+              return {
+                doc: (eid: string) => {
+                  docCalls.push(`${name}/${id}/${sub}/${eid}`);
+                  return { __fakeRef: true };
+                },
+                where: () => ({
+                  limit: () => ({
+                    get: async () => ({ empty: false }),
+                  }),
+                }),
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Firestore;
+  return { db, collectionCalls, docCalls };
+}
+
+function fakeTx() {
+  const sets: Array<{ ref: unknown; data: Record<string, unknown>; opts?: unknown }> = [];
+  const tx = {
+    set: (ref: unknown, data: Record<string, unknown>, opts?: unknown) => {
+      sets.push({ ref, data, opts });
+    },
+  } as unknown as Transaction;
+  return { tx, sets };
+}
+
+describe("hero-registry — constants + ref helpers", () => {
+  it("exposes collection + subcollection names", () => {
+    expect(HEROES_COLLECTION).toBe("game_heroes");
+    expect(HERO_EVENTS_SUBCOLLECTION).toBe("events");
+  });
+
+  it("heroEventsCollection points at game_heroes/{id}/events", () => {
+    const { db, collectionCalls } = fakeDb();
+    heroEventsCollection(db, "h-1");
+    expect(collectionCalls).toContain("game_heroes");
+    expect(collectionCalls).toContain("game_heroes/h-1/events");
+  });
+});
+
+describe("hero-registry — InTx writers", () => {
+  const baseHero: GameHero = {
+    id: "h-1",
+    name: "Aria",
+    class: "warrior",
+    specialty: "siege",
+    caste: "red",
+    ownerId: "u-owner",
+    tileId: "tile-1",
+    stamina: 5,
+    staminaMax: 10,
+    emergedAtTurn: 10,
+  } as unknown as GameHero;
+
+  describe("upsertHeroInTx", () => {
+    it("writes a merge: true patch with the hero fields", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      upsertHeroInTx({ tx, db, hero: baseHero, seasonNumber: 3, now: new Date("2026-01-01") });
+      expect(sets).toHaveLength(1);
+      expect(sets[0].opts).toEqual({ merge: true });
+      const data = sets[0].data;
+      expect(data.id).toBe("h-1");
+      expect(data.currentOwnerId).toBe("u-owner");
+      expect(data.currentTileId).toBe("tile-1");
+      expect(data.emergedSeasonNumber).toBe(3);
+      expect(data.isDeceased).toBe(false);
+      expect(data.awaitingResurrection).toBe(false);
+    });
+  });
+
+  describe("appendHeroEventInTx", () => {
+    it("writes the event under the hero's events subcollection and returns the id", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      const id = appendHeroEventInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        event: heroEvent.emerged({ tileId: "t-1", ownerId: "u-1" } as GameHero, 1),
+        now: new Date("2026-01-01"),
+      });
+      expect(typeof id).toBe("string");
+      // Two sets: the event doc, then the parent hero's lastEventAt bump.
+      expect(sets.length).toBeGreaterThanOrEqual(1);
+      const eventWrite = sets[0];
+      const ev = eventWrite.data;
+      expect(ev.id).toBe(id);
+      expect(ev.kind).toBe("emerged");
+      expect(ev.tileId).toBe("t-1");
+    });
+
+    it("strips undefined optional fields from the event payload", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      appendHeroEventInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        event: heroEvent.emerged({ tileId: "t-1", ownerId: "u-1" } as GameHero, 1),
+        now: new Date(),
+      });
+      const ev = sets[0].data;
+      // emerged events have no attackerId / defenderId / outcome
+      expect("attackerId" in ev).toBe(false);
+      expect("defenderId" in ev).toBe(false);
+      expect("outcome" in ev).toBe(false);
+    });
+  });
+
+  describe("markHeroDeceasedInTx", () => {
+    it("sets deceased flags and clears location fields", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      markHeroDeceasedInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        deceasedTileId: "tile-9",
+        now: new Date("2026-01-01"),
+      });
+      const d = sets[0].data;
+      expect(d.isDeceased).toBe(true);
+      expect(d.awaitingResurrection).toBe(false);
+      expect(d.deceasedTileId).toBe("tile-9");
+      expect(d.currentTileId).toBeNull();
+      expect(d.currentOwnerId).toBeNull();
+      expect(d.stamina).toBe(0);
+    });
+  });
+
+  describe("transferHeroOwnerInTx", () => {
+    it("patches ownerId, tileId and stamina with merge: true", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      transferHeroOwnerInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        newOwnerId: "u-new",
+        newTileId: "tile-new",
+        newStamina: 7,
+        now: new Date(),
+      });
+      expect(sets[0].opts).toEqual({ merge: true });
+      expect(sets[0].data.currentOwnerId).toBe("u-new");
+      expect(sets[0].data.currentTileId).toBe("tile-new");
+      expect(sets[0].data.stamina).toBe(7);
+    });
+  });
+
+  describe("clearHeroForArmageddonInTx", () => {
+    it("flips alive heroes to limbo (awaitingResurrection)", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      clearHeroForArmageddonInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        seasonNumber: 4,
+        wasAlive: true,
+        tileIdAtSeasonEnd: "tile-9",
+        ownerIdAtSeasonEnd: "u-9",
+        now: new Date(),
+      });
+      expect(sets[0].data.awaitingResurrection).toBe(true);
+      expect(sets[0].data.currentOwnerId).toBeNull();
+      expect(sets[0].data.currentTileId).toBeNull();
+    });
+
+    it("is a no-op for deceased heroes (no tx.set)", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      clearHeroForArmageddonInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        seasonNumber: 4,
+        wasAlive: false,
+        tileIdAtSeasonEnd: "tile-9",
+        ownerIdAtSeasonEnd: "u-9",
+        now: new Date(),
+      });
+      expect(sets).toHaveLength(0);
+    });
+  });
+});
+
+describe("hero-registry — heroEvent payload builders", () => {
+  it("emerged carries kind + tileId + ownerIdAtTime + seasonNumber", () => {
+    const ev = heroEvent.emerged({ tileId: "t", ownerId: "o" } as GameHero, 5);
+    expect(ev).toMatchObject({
+      kind: "emerged",
+      tileId: "t",
+      ownerIdAtTime: "o",
+      seasonNumber: 5,
+    });
+  });
+
+  it("engagedAttacker carries combat-specific fields", () => {
+    const ev = heroEvent.engagedAttacker({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      defenderId: "d",
+      targetTileId: "tt",
+      outcome: "victory",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({
+      kind: "engaged_attacker",
+      defenderId: "d",
+      targetTileId: "tt",
+      outcome: "victory",
+    });
+  });
+
+  it("engagedDefender carries attackerId + outcome", () => {
+    const ev = heroEvent.engagedDefender({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      attackerId: "a",
+      outcome: "loss",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({
+      kind: "engaged_defender",
+      attackerId: "a",
+      outcome: "loss",
+    });
+  });
+
+  it("slain carries attackerId", () => {
+    const ev = heroEvent.slain({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      attackerId: "a",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "slain", attackerId: "a" });
+  });
+
+  it("defected sets ownerIdAtTime = fromOwnerId", () => {
+    const ev = heroEvent.defected({
+      tileId: "t",
+      fromOwnerId: "f",
+      toOwnerId: "to",
+      seasonNumber: 1,
+    });
+    expect(ev.ownerIdAtTime).toBe("f");
+    expect(ev).toMatchObject({ kind: "defected", fromOwnerId: "f", toOwnerId: "to" });
+  });
+
+  it("movedOnCapture carries fromTileId", () => {
+    const ev = heroEvent.movedOnCapture({
+      tileId: "to",
+      fromTileId: "from",
+      ownerIdAtTime: "o",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "moved_on_capture", fromTileId: "from" });
+  });
+
+  it("spellCast carries spellId + targetTileId", () => {
+    const ev = heroEvent.spellCast({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      spellId: "fireball",
+      targetTileId: "tt",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "spell_cast", spellId: "fireball", targetTileId: "tt" });
+  });
+
+  it("recruited carries unitType + unitsBuilt", () => {
+    const ev = heroEvent.recruited({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      unitType: "ground" as unknown as ReturnType<typeof heroEvent.recruited>["unitType"],
+      unitsBuilt: 25,
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "recruited", unitsBuilt: 25 });
+  });
+
+  it("specialUnitSummoned carries specialUnitDefId", () => {
+    const ev = heroEvent.specialUnitSummoned({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      specialUnitDefId: "dragon",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "special_unit_summoned", specialUnitDefId: "dragon" });
+  });
+
+  it("seasonEnded accepts a null ownerIdAtTime (deceased heroes)", () => {
+    const ev = heroEvent.seasonEnded({ tileId: "t", ownerIdAtTime: null, seasonNumber: 1 });
+    expect(ev).toMatchObject({ kind: "season_ended", ownerIdAtTime: null });
+  });
+});
+
+describe("hero-registry — viewerWasOwner", () => {
+  it("returns true when at least one event has ownerIdAtTime == viewer", async () => {
+    const db = {
+      collection: () => ({
+        doc: () => ({
+          collection: () => ({
+            where: () => ({
+              limit: () => ({
+                get: async () => ({ empty: false }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as Firestore;
+    expect(await viewerWasOwner(db, "h-1", "u-1")).toBe(true);
+  });
+
+  it("returns false when the query returns no events", async () => {
+    const db = {
+      collection: () => ({
+        doc: () => ({
+          collection: () => ({
+            where: () => ({
+              limit: () => ({
+                get: async () => ({ empty: true }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as Firestore;
+    expect(await viewerWasOwner(db, "h-1", "u-1")).toBe(false);
+  });
+});

--- a/__tests__/lib/game/orders.test.ts
+++ b/__tests__/lib/game/orders.test.ts
@@ -1,0 +1,368 @@
+/**
+ * @jest-environment node
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  QueuedOrderForbiddenError,
+  QueuedOrderInvalidParamsError,
+  QueuedOrderNotFoundError,
+  QueuedOrderQueueFullError,
+  cancelOrderServer,
+  enqueueOrderServer,
+  listOrdersForPlayerServer,
+  markOrderResultInTx,
+  readQueuedOrdersForPlayer,
+} from "@/lib/game/orders";
+import type {
+  QueuedOrder,
+  QueuedOrderParams,
+} from "@/lib/game/types";
+import { QUEUED_ORDERS_MAX_PER_PLAYER } from "@/lib/game/types";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+import { getAdminDb } from "@/lib/firebase-admin";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+type QueuedDoc = { data: () => QueuedOrder };
+
+function fakeDb(opts: {
+  queueDocs?: QueuedOrder[];
+  setSink?: { id?: string; data?: unknown };
+  cancelInitial?: QueuedOrder | null;
+  cancelExists?: boolean;
+  txUpdateSink?: { ref?: unknown; updates?: Partial<QueuedOrder> };
+}): Firestore {
+  return {
+    collection: (_name: string) => ({
+      doc: (id: string) => ({
+        set: async (data: unknown) => {
+          if (opts.setSink) {
+            opts.setSink.id = id;
+            opts.setSink.data = data;
+          }
+          return undefined;
+        },
+      }),
+      where: (..._args: unknown[]) => ({
+        where: (..._args2: unknown[]) => ({
+          get: async () => ({
+            size: opts.queueDocs?.length ?? 0,
+            docs: (opts.queueDocs ?? []).map<QueuedDoc>((q) => ({ data: () => q })),
+          }),
+        }),
+        get: async () => ({
+          docs: (opts.queueDocs ?? []).map<QueuedDoc>((q) => ({ data: () => q })),
+        }),
+      }),
+    }),
+    runTransaction: async (cb: (tx: Transaction) => Promise<QueuedOrder>) => {
+      const tx = {
+        get: async (_ref: unknown) => ({
+          exists: opts.cancelExists ?? !!opts.cancelInitial,
+          data: () => opts.cancelInitial,
+        }),
+        update: (ref: unknown, updates: Partial<QueuedOrder>) => {
+          if (opts.txUpdateSink) {
+            opts.txUpdateSink.ref = ref;
+            opts.txUpdateSink.updates = updates;
+          }
+        },
+      } as unknown as Transaction;
+      return cb(tx);
+    },
+  } as unknown as Firestore;
+}
+
+describe("game/orders", () => {
+  beforeEach(() => mockGetAdminDb.mockReset());
+
+  describe("error classes", () => {
+    it("QueuedOrderQueueFullError carries cap in the message", () => {
+      const err = new QueuedOrderQueueFullError(5);
+      expect(err.message).toContain("5");
+      expect(err.cap).toBe(5);
+      expect(err.name).toBe("QueuedOrderQueueFullError");
+    });
+    it("QueuedOrderNotFoundError + QueuedOrderForbiddenError have stable names", () => {
+      expect(new QueuedOrderNotFoundError().name).toBe("QueuedOrderNotFoundError");
+      expect(new QueuedOrderForbiddenError().name).toBe("QueuedOrderForbiddenError");
+    });
+    it("QueuedOrderInvalidParamsError preserves the message", () => {
+      expect(new QueuedOrderInvalidParamsError("bad").message).toBe("bad");
+    });
+  });
+
+  describe("enqueueOrderServer — param validation", () => {
+    it("rejects recruit_on_tile with missing tileId", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "recruit_on_tile",
+        tileId: "",
+        unitType: "ground",
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "recruit_on_tile", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects recruit_on_tile with invalid unitType", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "recruit_on_tile",
+        tileId: "t",
+        unitType: "horse",
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "recruit_on_tile", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects attack_adjacent with missing tile ids", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "attack_adjacent",
+        sourceTileId: "",
+        targetTileId: "",
+        units: { ground: 1, siege: 0, air: 0 },
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "attack_adjacent", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects attack_adjacent with negative units", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "attack_adjacent",
+        sourceTileId: "s",
+        targetTileId: "t",
+        units: { ground: -1, siege: 0, air: 0 },
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "attack_adjacent", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects attack_adjacent sending 0 total units", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "attack_adjacent",
+        sourceTileId: "s",
+        targetTileId: "t",
+        units: { ground: 0, siege: 0, air: 0 },
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "attack_adjacent", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects cast_spell_on_tile with missing tileId or spellId", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        enqueueOrderServer({
+          playerId: "p",
+          kind: "cast_spell_on_tile",
+          params: { kind: "cast_spell_on_tile", tileId: "t", spellId: "" } as QueuedOrderParams,
+        })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects when params.kind doesn't match the requested kind", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        enqueueOrderServer({
+          playerId: "p",
+          kind: "recruit_on_tile",
+          params: {
+            kind: "cast_spell_on_tile",
+            tileId: "t",
+            spellId: "s",
+          } as QueuedOrderParams,
+        })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+  });
+
+  describe("enqueueOrderServer — queue cap + happy path", () => {
+    it("throws QueuedOrderQueueFullError at cap", async () => {
+      const full: QueuedOrder[] = Array(QUEUED_ORDERS_MAX_PER_PLAYER).fill({
+        id: "x",
+        playerId: "p",
+        status: "queued",
+        sequenceIndex: 0,
+      } as unknown as QueuedOrder);
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ queueDocs: full }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        enqueueOrderServer({
+          playerId: "p",
+          kind: "recruit_on_tile",
+          params: {
+            kind: "recruit_on_tile",
+            tileId: "t",
+            unitType: "ground",
+          } as QueuedOrderParams,
+        })
+      ).rejects.toThrow(QueuedOrderQueueFullError);
+    });
+
+    it("persists a new order with sequenceIndex = current queue size", async () => {
+      const sink: { id?: string; data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ queueDocs: [{} as QueuedOrder, {} as QueuedOrder], setSink: sink }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await enqueueOrderServer({
+        playerId: "p",
+        kind: "recruit_on_tile",
+        params: {
+          kind: "recruit_on_tile",
+          tileId: "t",
+          unitType: "ground",
+        } as QueuedOrderParams,
+      });
+      expect(out.sequenceIndex).toBe(2);
+      expect(out.status).toBe("queued");
+      expect(out.playerId).toBe("p");
+      expect(sink.data).toBeDefined();
+    });
+  });
+
+  describe("listOrdersForPlayerServer + readQueuedOrdersForPlayer", () => {
+    it("returns orders sorted by sequenceIndex", async () => {
+      const orders: QueuedOrder[] = [
+        { sequenceIndex: 2 } as unknown as QueuedOrder,
+        { sequenceIndex: 0 } as unknown as QueuedOrder,
+        { sequenceIndex: 1 } as unknown as QueuedOrder,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ queueDocs: orders }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listOrdersForPlayerServer("p", false);
+      expect(out.map((o) => o.sequenceIndex)).toEqual([0, 1, 2]);
+    });
+
+    it("readQueuedOrdersForPlayer returns queued-only sorted", async () => {
+      const orders: QueuedOrder[] = [
+        { sequenceIndex: 1 } as unknown as QueuedOrder,
+        { sequenceIndex: 0 } as unknown as QueuedOrder,
+      ];
+      const db = fakeDb({ queueDocs: orders });
+      const out = await readQueuedOrdersForPlayer(db, "p");
+      expect(out.map((o) => o.sequenceIndex)).toEqual([0, 1]);
+    });
+  });
+
+  describe("cancelOrderServer", () => {
+    it("throws QueuedOrderNotFoundError when the order doesn't exist", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ cancelExists: false }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        cancelOrderServer({ orderId: "o", callerUserId: "p" })
+      ).rejects.toThrow(QueuedOrderNotFoundError);
+    });
+
+    it("throws QueuedOrderForbiddenError when caller is not the owner", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          cancelExists: true,
+          cancelInitial: {
+            id: "o",
+            playerId: "owner",
+            status: "queued",
+          } as unknown as QueuedOrder,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        cancelOrderServer({ orderId: "o", callerUserId: "other" })
+      ).rejects.toThrow(QueuedOrderForbiddenError);
+    });
+
+    it("returns the order unchanged when already non-queued (idempotent)", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          cancelExists: true,
+          cancelInitial: {
+            id: "o",
+            playerId: "p",
+            status: "executed",
+          } as unknown as QueuedOrder,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await cancelOrderServer({ orderId: "o", callerUserId: "p" });
+      expect(out.status).toBe("executed");
+    });
+
+    it("marks the order cancelled when it's currently queued", async () => {
+      const updateSink: { ref?: unknown; updates?: Partial<QueuedOrder> } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          cancelExists: true,
+          cancelInitial: {
+            id: "o",
+            playerId: "p",
+            status: "queued",
+          } as unknown as QueuedOrder,
+          txUpdateSink: updateSink,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await cancelOrderServer({ orderId: "o", callerUserId: "p" });
+      expect(out.status).toBe("cancelled");
+      expect(updateSink.updates?.status).toBe("cancelled");
+      expect(updateSink.updates?.resultSummary).toBe("Cancelled by player");
+    });
+  });
+
+  describe("markOrderResultInTx", () => {
+    it("emits a tx.update with status + resultSummary + executedAt", () => {
+      const updateSink: { ref?: unknown; updates?: Partial<QueuedOrder> } = {};
+      const tx = {
+        update: (ref: unknown, updates: Partial<QueuedOrder>) => {
+          updateSink.ref = ref;
+          updateSink.updates = updates;
+        },
+      } as unknown as Transaction;
+      const db = {
+        collection: () => ({ doc: () => ({ __ref: true }) }),
+      } as unknown as Firestore;
+
+      markOrderResultInTx({
+        tx,
+        db,
+        order: { id: "o" } as QueuedOrder,
+        status: "executed",
+        resultSummary: "done",
+        now: new Date("2026-01-01"),
+      });
+      expect(updateSink.updates?.status).toBe("executed");
+      expect(updateSink.updates?.resultSummary).toBe("done");
+    });
+
+    it("includes resultRefId when provided", () => {
+      const updateSink: { ref?: unknown; updates?: Partial<QueuedOrder> } = {};
+      const tx = {
+        update: (ref: unknown, updates: Partial<QueuedOrder>) => {
+          updateSink.ref = ref;
+          updateSink.updates = updates;
+        },
+      } as unknown as Transaction;
+      const db = {
+        collection: () => ({ doc: () => ({ __ref: true }) }),
+      } as unknown as Firestore;
+      markOrderResultInTx({
+        tx,
+        db,
+        order: { id: "o" } as QueuedOrder,
+        status: "failed",
+        resultSummary: "boom",
+        resultRefId: "ref-1",
+        now: new Date(),
+      });
+      expect(updateSink.updates?.resultRefId).toBe("ref-1");
+    });
+  });
+});

--- a/__tests__/lib/game/pacts.test.ts
+++ b/__tests__/lib/game/pacts.test.ts
@@ -1,0 +1,404 @@
+/**
+ * @jest-environment node
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  MAX_PACT_STATEMENT_LENGTH,
+  PactEmptyError,
+  PactForbiddenError,
+  PactNotFoundError,
+  PactSelfTargetError,
+  PactTargetNotFoundError,
+  PactTooLongError,
+  createPactServer,
+  deletePactServer,
+  findActivePactsBetween,
+  listPactsForPlayerServer,
+  markPactsBrokenInTx,
+} from "@/lib/game/pacts";
+import type { Pact } from "@/lib/game/types";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeText: (s: string) => s.trim(),
+}));
+jest.mock("@/lib/game/community", () => ({
+  logCommunityEventInTx: jest.fn(),
+}));
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logCommunityEventInTx } from "@/lib/game/community";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockLogCommunityEvent = logCommunityEventInTx as jest.MockedFunction<typeof logCommunityEventInTx>;
+
+type CollectionStub = {
+  doc: (id: string) => DocStub;
+  where: (...args: unknown[]) => QueryStub;
+};
+type DocStub = {
+  get: () => Promise<{ exists: boolean; data?: () => unknown; ref?: unknown }>;
+  set: (data: unknown) => Promise<void>;
+  update: (data: unknown) => Promise<void>;
+};
+type QueryStub = {
+  where: (...args: unknown[]) => QueryStub;
+  get: () => Promise<{ docs: Array<{ data: () => unknown; ref: unknown }>; empty: boolean }>;
+};
+
+function fakeDb(opts: {
+  targetDoc?: { exists: boolean; data?: unknown };
+  pactDocs?: Pact[];
+  pactDoc?: { exists: boolean; data?: Pact };
+  updateSink?: { data?: unknown };
+  setSink?: { id?: string; data?: unknown };
+}): Firestore {
+  const mkDoc = (id: string): DocStub => ({
+    get: async () => {
+      const td = opts.targetDoc;
+      const pd = opts.pactDoc;
+      if (id === "player-target") {
+        return { exists: !!td?.exists, data: () => td?.data };
+      }
+      return {
+        exists: !!pd?.exists,
+        data: () => pd?.data,
+        ref: { __ref: id },
+      };
+    },
+    set: async (data: unknown) => {
+      if (opts.setSink) {
+        opts.setSink.id = id;
+        opts.setSink.data = data;
+      }
+    },
+    update: async (data: unknown) => {
+      if (opts.updateSink) {
+        opts.updateSink.data = data;
+      }
+    },
+  });
+  const mkQuery = (): QueryStub => ({
+    where: () => mkQuery(),
+    get: async () => ({
+      docs: (opts.pactDocs ?? []).map((p) => ({
+        data: () => p,
+        ref: { __ref: p.id },
+      })),
+      empty: (opts.pactDocs ?? []).length === 0,
+    }),
+  });
+  const collection = (_name: string): CollectionStub => ({
+    doc: mkDoc,
+    where: () => mkQuery(),
+  });
+  return { collection } as unknown as Firestore;
+}
+
+describe("game/pacts", () => {
+  beforeEach(() => {
+    mockGetAdminDb.mockReset();
+    mockLogCommunityEvent.mockReset();
+  });
+
+  describe("error classes", () => {
+    it("PactEmptyError, PactTooLongError, PactSelfTargetError, PactTargetNotFoundError, PactForbiddenError, PactNotFoundError all have stable names", () => {
+      expect(new PactEmptyError().name).toBe("PactEmptyError");
+      expect(new PactTooLongError().name).toBe("PactTooLongError");
+      expect(new PactSelfTargetError().name).toBe("PactSelfTargetError");
+      expect(new PactTargetNotFoundError().name).toBe("PactTargetNotFoundError");
+      expect(new PactForbiddenError().name).toBe("PactForbiddenError");
+      expect(new PactNotFoundError().name).toBe("PactNotFoundError");
+    });
+
+    it("PactTooLongError message mentions the length cap", () => {
+      expect(new PactTooLongError().message).toContain(String(MAX_PACT_STATEMENT_LENGTH));
+    });
+  });
+
+  describe("createPactServer", () => {
+    const author = { userId: "u-author", displayName: "Alice", caste: "red" as const };
+
+    it("rejects self-target", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createPactServer({ author, targetId: author.userId, rawStatement: "hi" })
+      ).rejects.toThrow(PactSelfTargetError);
+    });
+
+    it("rejects empty statement (after sanitize)", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createPactServer({ author, targetId: "u-other", rawStatement: "   " })
+      ).rejects.toThrow(PactEmptyError);
+    });
+
+    it("rejects too-long statement", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const long = "x".repeat(MAX_PACT_STATEMENT_LENGTH + 1);
+      await expect(
+        createPactServer({ author, targetId: "u-other", rawStatement: long })
+      ).rejects.toThrow(PactTooLongError);
+    });
+
+    it("rejects when target doesn't exist", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ targetDoc: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        createPactServer({ author, targetId: "player-target", rawStatement: "hi" })
+      ).rejects.toThrow(PactTargetNotFoundError);
+    });
+
+    it("creates a pact and returns the full record", async () => {
+      const setSink: { id?: string; data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          targetDoc: {
+            exists: true,
+            data: { displayName: "Bob", caste: "blue" },
+          },
+          setSink,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const pact = await createPactServer({
+        author,
+        targetId: "player-target",
+        rawStatement: "no attack for 7 days",
+      });
+      expect(pact.authorId).toBe("u-author");
+      expect(pact.targetDisplayName).toBe("Bob");
+      expect(pact.statement).toBe("no attack for 7 days");
+      expect(pact.expiresAt instanceof Date).toBe(true);
+    });
+
+    it("falls back to 'Unknown general' when target has no displayName", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ targetDoc: { exists: true, data: {} } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const pact = await createPactServer({
+        author,
+        targetId: "player-target",
+        rawStatement: "hi",
+      });
+      expect(pact.targetDisplayName).toBe("Unknown general");
+      expect(pact.targetCaste).toBeNull();
+    });
+  });
+
+  describe("listPactsForPlayerServer", () => {
+    it("returns deduplicated pacts sorted by expiresAt desc, skipping deleted", async () => {
+      const now = new Date();
+      const pacts: Pact[] = [
+        {
+          id: "p1",
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "p2",
+          expiresAt: new Date(now.getTime() + 50_000),
+        } as unknown as Pact,
+        {
+          id: "p1", // dup
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "p3",
+          deletedAt: now, // skipped
+          expiresAt: new Date(now.getTime() + 200_000),
+        } as unknown as Pact,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ pactDocs: pacts }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPactsForPlayerServer("u1");
+      expect(out.map((p) => p.id)).toEqual(["p1", "p2"]);
+    });
+
+    it("handles timestamp-shaped expiresAt fields (seconds)", async () => {
+      const now = Date.now() / 1000;
+      const pacts: Pact[] = [
+        {
+          id: "tsa",
+          expiresAt: { seconds: now + 200 } as unknown as Date,
+        } as unknown as Pact,
+        {
+          id: "tsb",
+          expiresAt: { seconds: now + 100 } as unknown as Date,
+        } as unknown as Pact,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ pactDocs: pacts }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPactsForPlayerServer("u1");
+      expect(out.map((p) => p.id)).toEqual(["tsa", "tsb"]);
+    });
+  });
+
+  describe("deletePactServer", () => {
+    it("throws PactNotFoundError when pact doesn't exist", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ pactDoc: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deletePactServer({ pactId: "p", callerUserId: "u", callerIsAdmin: false })
+      ).rejects.toThrow(PactNotFoundError);
+    });
+
+    it("throws PactForbiddenError when non-author non-admin caller tries to delete", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          pactDoc: { exists: true, data: { authorId: "other" } as Pact },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deletePactServer({ pactId: "p", callerUserId: "me", callerIsAdmin: false })
+      ).rejects.toThrow(PactForbiddenError);
+    });
+
+    it("allows author to delete (sets deletedByAdmin=false)", async () => {
+      const updateSink: { data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          pactDoc: { exists: true, data: { id: "p", authorId: "me" } as Pact },
+          updateSink,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deletePactServer({
+        pactId: "p",
+        callerUserId: "me",
+        callerIsAdmin: false,
+      });
+      expect(out.deletedAt).toBeInstanceOf(Date);
+      expect(out.deletedByAdmin).toBe(false);
+      expect((updateSink.data as { deletedByAdmin: boolean }).deletedByAdmin).toBe(false);
+    });
+
+    it("allows admin to delete (sets deletedByAdmin=true when not author)", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          pactDoc: { exists: true, data: { id: "p", authorId: "other" } as Pact },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deletePactServer({
+        pactId: "p",
+        callerUserId: "admin",
+        callerIsAdmin: true,
+      });
+      expect(out.deletedByAdmin).toBe(true);
+    });
+  });
+
+  describe("findActivePactsBetween", () => {
+    const now = new Date();
+
+    it("returns [] when no pacts exist", async () => {
+      const db = fakeDb({ pactDocs: [] });
+      expect(
+        await findActivePactsBetween({ db, attackerId: "a", defenderId: "d", now })
+      ).toEqual([]);
+    });
+
+    it("filters out deleted, broken, and expired pacts", async () => {
+      const pacts: Pact[] = [
+        {
+          id: "active",
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "deleted",
+          deletedAt: now,
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "broken",
+          brokenAt: now,
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "expired",
+          expiresAt: new Date(now.getTime() - 1),
+        } as unknown as Pact,
+      ];
+      const db = fakeDb({ pactDocs: pacts });
+      const out = await findActivePactsBetween({
+        db,
+        attackerId: "a",
+        defenderId: "d",
+        now,
+      });
+      expect(out.map((p) => p.id)).toEqual(["active"]);
+    });
+  });
+
+  describe("markPactsBrokenInTx", () => {
+    it("no-ops when there are no matching pacts", async () => {
+      const db = fakeDb({ pactDocs: [] });
+      const tx = { update: jest.fn() } as unknown as Transaction;
+      await markPactsBrokenInTx({
+        tx,
+        db,
+        attackerId: "a",
+        attackerDisplayName: "A",
+        attackerCaste: "red",
+        defenderId: "d",
+        defenderDisplayName: "D",
+        now: new Date(),
+      });
+      expect(tx.update).not.toHaveBeenCalled();
+      expect(mockLogCommunityEvent).not.toHaveBeenCalled();
+    });
+
+    it("updates brokenAt + logs a pact_broken event for each live pact", async () => {
+      const now = new Date();
+      const pacts: Pact[] = [
+        {
+          id: "p1",
+          statement: "no attack",
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+      ];
+      const db = fakeDb({ pactDocs: pacts });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await markPactsBrokenInTx({
+        tx,
+        db,
+        attackerId: "a",
+        attackerDisplayName: "A",
+        attackerCaste: "red",
+        defenderId: "d",
+        defenderDisplayName: "D",
+        now,
+      });
+      expect(updateMock).toHaveBeenCalledTimes(1);
+      expect(updateMock.mock.calls[0][1]).toMatchObject({ brokenAt: now });
+      expect(mockLogCommunityEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips deleted/broken/expired pacts", async () => {
+      const now = new Date();
+      const pacts: Pact[] = [
+        { id: "exp", expiresAt: new Date(now.getTime() - 1) } as unknown as Pact,
+        { id: "del", deletedAt: now, expiresAt: new Date(now.getTime() + 100) } as unknown as Pact,
+        { id: "brk", brokenAt: now, expiresAt: new Date(now.getTime() + 100) } as unknown as Pact,
+      ];
+      const db = fakeDb({ pactDocs: pacts });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await markPactsBrokenInTx({
+        tx,
+        db,
+        attackerId: "a",
+        attackerDisplayName: "A",
+        attackerCaste: null,
+        defenderId: "d",
+        defenderDisplayName: "D",
+        now,
+      });
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/lib/game/prophecies.test.ts
+++ b/__tests__/lib/game/prophecies.test.ts
@@ -1,0 +1,330 @@
+/**
+ * @jest-environment node
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  MAX_PROPHECY_LENGTH,
+  ProphecyEmptyError,
+  ProphecyForbiddenError,
+  ProphecyInvalidSealError,
+  ProphecyNotFoundError,
+  ProphecySealAlreadyBrokenError,
+  ProphecyTooLongError,
+  createProphecyServer,
+  deleteProphecyServer,
+  listPropheciesByAuthorServer,
+  listPropheciesForSealServer,
+  resolveProphesiesForSealInTx,
+} from "@/lib/game/prophecies";
+import type { Prophecy } from "@/lib/game/types";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeText: (s: string) => s.trim(),
+}));
+jest.mock("@/lib/game/community", () => ({
+  logCommunityEventInTx: jest.fn(),
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { increment: (n: number) => ({ __increment: n }) },
+}));
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logCommunityEventInTx } from "@/lib/game/community";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockLog = logCommunityEventInTx as jest.MockedFunction<typeof logCommunityEventInTx>;
+
+function fakeDb(opts: {
+  worldMeta?: { exists: boolean; sealsBroken?: number };
+  propheciesDocs?: Prophecy[];
+  prophecyDoc?: { exists: boolean; data?: Prophecy };
+  setSink?: { id?: string; data?: unknown };
+  updateSink?: { data?: unknown };
+}): Firestore {
+  return {
+    collection: (_name: string) => ({
+      doc: (id: string) => ({
+        get: async () => {
+          if (id === "singleton") {
+            return {
+              exists: !!opts.worldMeta?.exists,
+              data: () => ({ sealsBroken: opts.worldMeta?.sealsBroken ?? 0 }),
+            };
+          }
+          return {
+            exists: !!opts.prophecyDoc?.exists,
+            data: () => opts.prophecyDoc?.data,
+          };
+        },
+        set: async (data: unknown) => {
+          if (opts.setSink) {
+            opts.setSink.id = id;
+            opts.setSink.data = data;
+          }
+        },
+        update: async (data: unknown) => {
+          if (opts.updateSink) opts.updateSink.data = data;
+        },
+      }),
+      where: () => ({
+        where: () => ({ get: async () => ({ docs: [] }) }),
+        orderBy: () => ({
+          get: async () => ({
+            docs: (opts.propheciesDocs ?? []).map((p) => ({
+              data: () => p,
+              ref: { __ref: p.id },
+            })),
+          }),
+        }),
+        get: async () => ({
+          docs: (opts.propheciesDocs ?? []).map((p) => ({
+            data: () => p,
+            ref: { __ref: p.id },
+          })),
+        }),
+      }),
+    }),
+  } as unknown as Firestore;
+}
+
+describe("game/prophecies", () => {
+  beforeEach(() => {
+    mockGetAdminDb.mockReset();
+    mockLog.mockReset();
+  });
+
+  describe("error classes", () => {
+    it("all 6 error classes have stable names", () => {
+      expect(new ProphecyEmptyError().name).toBe("ProphecyEmptyError");
+      expect(new ProphecyTooLongError().name).toBe("ProphecyTooLongError");
+      expect(new ProphecyInvalidSealError().name).toBe("ProphecyInvalidSealError");
+      expect(new ProphecySealAlreadyBrokenError().name).toBe("ProphecySealAlreadyBrokenError");
+      expect(new ProphecyForbiddenError().name).toBe("ProphecyForbiddenError");
+      expect(new ProphecyNotFoundError().name).toBe("ProphecyNotFoundError");
+    });
+    it("TooLongError carries the length cap in the message", () => {
+      expect(new ProphecyTooLongError().message).toContain(String(MAX_PROPHECY_LENGTH));
+    });
+  });
+
+  describe("createProphecyServer", () => {
+    const author = { userId: "u1", displayName: "Alice", caste: "red" as const };
+
+    it.each([
+      ["non-integer (0)", 0],
+      ["non-integer (8)", 8],
+      ["non-integer (-1)", -1],
+    ])("rejects invalid seal number: %s", async (_n, sealNumber) => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createProphecyServer({ author, targetSealNumber: sealNumber, rawPrediction: "x" })
+      ).rejects.toThrow(ProphecyInvalidSealError);
+    });
+
+    it("rejects empty prediction (after sanitize)", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createProphecyServer({ author, targetSealNumber: 1, rawPrediction: "  " })
+      ).rejects.toThrow(ProphecyEmptyError);
+    });
+
+    it("rejects too-long prediction", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const long = "x".repeat(MAX_PROPHECY_LENGTH + 1);
+      await expect(
+        createProphecyServer({ author, targetSealNumber: 1, rawPrediction: long })
+      ).rejects.toThrow(ProphecyTooLongError);
+    });
+
+    it("rejects when the target seal has already broken", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ worldMeta: { exists: true, sealsBroken: 3 } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        createProphecyServer({ author, targetSealNumber: 2, rawPrediction: "the end is nigh" })
+      ).rejects.toThrow(ProphecySealAlreadyBrokenError);
+    });
+
+    it("persists a valid prophecy", async () => {
+      const setSink: { id?: string; data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ worldMeta: { exists: true, sealsBroken: 0 }, setSink }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await createProphecyServer({
+        author,
+        targetSealNumber: 3,
+        rawPrediction: "the third seal breaks tonight",
+      });
+      expect(out.authorId).toBe("u1");
+      expect(out.targetSealNumber).toBe(3);
+      expect(out.prediction).toBe("the third seal breaks tonight");
+      expect(setSink.data).toBeDefined();
+    });
+
+    it("treats a missing world-meta doc as sealsBroken = 0", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ worldMeta: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      // Seal 1 should be valid because no seal has broken yet.
+      const out = await createProphecyServer({
+        author,
+        targetSealNumber: 1,
+        rawPrediction: "first seal soon",
+      });
+      expect(out.targetSealNumber).toBe(1);
+    });
+  });
+
+  describe("listPropheciesForSealServer", () => {
+    it("returns prophecies for a seal, filtering deleted", async () => {
+      const prophecies: Prophecy[] = [
+        { id: "p1", targetSealNumber: 1 } as unknown as Prophecy,
+        { id: "p2", targetSealNumber: 1, deletedAt: new Date() } as unknown as Prophecy,
+        { id: "p3", targetSealNumber: 1 } as unknown as Prophecy,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ propheciesDocs: prophecies }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPropheciesForSealServer(1);
+      expect(out.map((p) => p.id)).toEqual(["p1", "p3"]);
+    });
+  });
+
+  describe("listPropheciesByAuthorServer", () => {
+    it("returns prophecies for an author, filtering deleted", async () => {
+      const prophecies: Prophecy[] = [
+        { id: "p1", authorId: "u1" } as unknown as Prophecy,
+        { id: "p2", authorId: "u1", deletedAt: new Date() } as unknown as Prophecy,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ propheciesDocs: prophecies }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPropheciesByAuthorServer("u1");
+      expect(out.map((p) => p.id)).toEqual(["p1"]);
+    });
+  });
+
+  describe("deleteProphecyServer", () => {
+    it("throws ProphecyNotFoundError when missing", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ prophecyDoc: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deleteProphecyServer({ prophecyId: "p", callerUserId: "u", callerIsAdmin: false })
+      ).rejects.toThrow(ProphecyNotFoundError);
+    });
+
+    it("throws ProphecyForbiddenError for non-author non-admin", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          prophecyDoc: { exists: true, data: { authorId: "other" } as Prophecy },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deleteProphecyServer({ prophecyId: "p", callerUserId: "me", callerIsAdmin: false })
+      ).rejects.toThrow(ProphecyForbiddenError);
+    });
+
+    it("author delete sets deletedByAdmin=false", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          prophecyDoc: { exists: true, data: { id: "p", authorId: "me" } as Prophecy },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deleteProphecyServer({
+        prophecyId: "p",
+        callerUserId: "me",
+        callerIsAdmin: false,
+      });
+      expect(out.deletedByAdmin).toBe(false);
+    });
+
+    it("admin delete (non-author) sets deletedByAdmin=true", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          prophecyDoc: { exists: true, data: { id: "p", authorId: "other" } as Prophecy },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deleteProphecyServer({
+        prophecyId: "p",
+        callerUserId: "admin",
+        callerIsAdmin: true,
+      });
+      expect(out.deletedByAdmin).toBe(true);
+    });
+  });
+
+  describe("resolveProphesiesForSealInTx", () => {
+    const brokenBy = {
+      userId: "u-breaker",
+      displayName: "Breaker",
+      caste: "black" as const,
+    };
+
+    it("no-ops when no prophecies target the broken seal", async () => {
+      const db = fakeDb({ propheciesDocs: [] });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await resolveProphesiesForSealInTx({
+        tx,
+        db,
+        brokenSealNumber: 1,
+        brokenBy,
+        now: new Date(),
+      });
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it("resolves each live prophecy and emits prophecy_fulfilled events", async () => {
+      const now = new Date();
+      const prophecies: Prophecy[] = [
+        {
+          id: "p1",
+          authorId: "u1",
+          authorDisplayName: "Alice",
+          authorCaste: "red",
+          targetSealNumber: 1,
+          prediction: "the bell tolls",
+        } as unknown as Prophecy,
+      ];
+      const db = fakeDb({ propheciesDocs: prophecies });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await resolveProphesiesForSealInTx({
+        tx,
+        db,
+        brokenSealNumber: 1,
+        brokenBy,
+        now,
+      });
+      // Two updates: prophecy doc resolve, player doc bumps.
+      expect(updateMock).toHaveBeenCalledTimes(2);
+      const prophecyUpdate = updateMock.mock.calls[0][1];
+      expect(prophecyUpdate.resolvedAt).toBe(now);
+      expect(prophecyUpdate.fulfilledBy).toEqual(brokenBy);
+      expect(mockLog).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips already-resolved and deleted prophecies", async () => {
+      const prophecies: Prophecy[] = [
+        { id: "deleted", deletedAt: new Date() } as unknown as Prophecy,
+        { id: "resolved", resolvedAt: new Date() } as unknown as Prophecy,
+      ];
+      const db = fakeDb({ propheciesDocs: prophecies });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await resolveProphesiesForSealInTx({
+        tx,
+        db,
+        brokenSealNumber: 1,
+        brokenBy,
+        now: new Date(),
+      });
+      expect(updateMock).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/lib/logger-coverage.test.ts
+++ b/__tests__/lib/logger-coverage.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment node
+ *
+ * Coverage complement for __tests__/lib/logger.test.ts. Targets the
+ * previously-uncovered logRequest, withLogging, logApiError, and the
+ * sanitizeErrorMessage redaction patterns (Bearer tokens, API keys,
+ * emails, /Users/ paths).
+ */
+import {
+  LogLevel,
+  logApiError,
+  logger,
+  withLogging,
+} from "@/lib/logger";
+
+function mkRequest(opts: {
+  url?: string;
+  method?: string;
+  headers?: Record<string, string>;
+}): Request {
+  const headers = new Headers(opts.headers ?? {});
+  return new Request(opts.url ?? "https://example.com/api/x", {
+    method: opts.method ?? "GET",
+    headers,
+  });
+}
+
+describe("lib/logger — additional coverage", () => {
+  beforeEach(() => {
+    console.log = jest.fn();
+    console.error = jest.fn();
+    console.warn = jest.fn();
+    console.debug = jest.fn();
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("logRequest", () => {
+    it("logs at INFO for 2xx", () => {
+      const req = mkRequest({ url: "https://x.com/api/users" });
+      const res = new Response("ok", { status: 200 });
+      logger.logRequest(req, res, 12);
+      expect(console.log).toHaveBeenCalled();
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("[INFO]");
+      expect(msg).toContain("GET /api/users");
+      expect(msg).toContain("[200]");
+      expect(msg).toContain("[12ms]");
+    });
+
+    it("logs at WARN for 4xx", () => {
+      const req = mkRequest({});
+      const res = new Response("nope", { status: 401 });
+      logger.logRequest(req, res, 1);
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("logs at ERROR for 5xx", () => {
+      const req = mkRequest({});
+      const res = new Response("boom", { status: 500 });
+      logger.logRequest(req, res, 1);
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("captures client IP from x-forwarded-for (first entry, trimmed)", () => {
+      const req = mkRequest({
+        headers: { "x-forwarded-for": "203.0.113.5, 10.0.0.1" },
+      });
+      const res = new Response("ok", { status: 200 });
+      logger.logRequest(req, res, 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("203.0.113.5");
+    });
+
+    it("captures IP from x-real-ip when x-forwarded-for is absent", () => {
+      const req = mkRequest({ headers: { "x-real-ip": "198.51.100.7" } });
+      logger.logRequest(req, new Response("ok"), 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("198.51.100.7");
+    });
+
+    it("falls back to cf-connecting-ip", () => {
+      const req = mkRequest({ headers: { "cf-connecting-ip": "192.0.2.9" } });
+      logger.logRequest(req, new Response("ok"), 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("192.0.2.9");
+    });
+
+    it("captures user-agent when present", () => {
+      const req = mkRequest({ headers: { "user-agent": "Mozilla/5.0" } });
+      logger.logRequest(req, new Response("ok"), 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("Mozilla/5.0");
+    });
+  });
+
+  describe("logError redactions", () => {
+    it("redacts Bearer tokens from error messages", () => {
+      logger.logError(new Error("authz failed: Bearer abc123tok-_.token"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("Bearer [REDACTED]");
+      expect(msg).not.toContain("abc123tok");
+    });
+
+    it("redacts common API key prefixes (sk_live_, ghp_, AIza...)", () => {
+      logger.logError(new Error("key sk_live_abcdef and AIzaSyXX-DEMO"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("[REDACTED]");
+      expect(msg).not.toContain("sk_live_abcdef");
+    });
+
+    it("redacts email addresses", () => {
+      logger.logError(new Error("user alice@example.com triggered"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("[EMAIL_REDACTED]");
+      expect(msg).not.toContain("alice@example.com");
+    });
+
+    it("redacts /Users/<name> and /home/<name> paths", () => {
+      logger.logError(new Error("Cannot read /Users/ludwitt/cursor-boston/x.ts"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("/Users/[REDACTED]");
+      expect(msg).not.toContain("/Users/ludwitt");
+    });
+
+    it("returns 'Unknown error' for empty error messages", () => {
+      // Triggers the `if (!message) return "Unknown error";` branch.
+      logger.logError(new Error(""));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("Unknown error");
+    });
+
+    it("handles non-Error values without throwing", () => {
+      logger.logError("string error");
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("preserves common identifier prefixes in the base64-redaction step", () => {
+      // The 40+ char base64 match has an exception for firebase/google/github/discord prefixes.
+      const safe = "firebase" + "A".repeat(40);
+      logger.logError(new Error(`identifier=${safe}`));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain(safe);
+    });
+  });
+
+  describe("withLogging middleware", () => {
+    it("invokes the handler and logs the request on success", async () => {
+      const handler = jest.fn(async (_req: Request) => new Response("ok", { status: 200 }));
+      const wrapped = withLogging(handler);
+      const res = await wrapped(mkRequest({}));
+      expect(res.status).toBe(200);
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it("logs the error and returns a 500 with X-Request-ID when the handler throws", async () => {
+      const handler = jest.fn(async (_req: Request) => {
+        throw new Error("handler boom");
+      });
+      const wrapped = withLogging(handler);
+      const res = await wrapped(mkRequest({}));
+      expect(res.status).toBe(500);
+      expect(res.headers.get("X-Request-ID")).toMatch(/^[0-9a-f-]{8,}$/);
+      const body = await res.json();
+      expect(body.error).toBe("Internal server error");
+      expect(typeof body.requestId).toBe("string");
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("logApiError", () => {
+    it("logs the error with endpoint metadata", () => {
+      logApiError("/api/x", new Error("boom"));
+      expect(console.error).toHaveBeenCalled();
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("/api/x");
+    });
+  });
+
+  describe("LogLevel enum", () => {
+    it("exposes the four levels", () => {
+      expect(LogLevel.DEBUG).toBe("DEBUG");
+      expect(LogLevel.INFO).toBe("INFO");
+      expect(LogLevel.WARN).toBe("WARN");
+      expect(LogLevel.ERROR).toBe("ERROR");
+    });
+  });
+});

--- a/__tests__/lib/mentorship-data.test.ts
+++ b/__tests__/lib/mentorship-data.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ */
+import {
+  getAllActiveMentorshipProfiles,
+  getMentorshipPairingsForUser,
+  getMentorshipProfile,
+} from "@/lib/mentorship/data";
+
+const mockGetDoc = jest.fn();
+const mockGetDocs = jest.fn();
+
+jest.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => ({ __collection: args }),
+  doc: (...args: unknown[]) => ({ __doc: args }),
+  query: (...args: unknown[]) => ({ __query: args }),
+  where: (...args: unknown[]) => ({ __where: args }),
+  orderBy: (...args: unknown[]) => ({ __orderBy: args }),
+  limit: (n: number) => ({ __limit: n }),
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+}));
+
+jest.mock("@/lib/firebase", () => ({
+  db: { __fake: true },
+}));
+
+// Re-importable mock toggle for the db: tests can override.
+jest.mock("@/lib/firebase", () => {
+  let _db: unknown = { __fake: true };
+  return {
+    get db() {
+      return _db;
+    },
+    __setDb(next: unknown) {
+      _db = next;
+    },
+  };
+});
+
+describe("lib/mentorship/data", () => {
+  beforeEach(() => {
+    mockGetDoc.mockReset();
+    mockGetDocs.mockReset();
+  });
+
+  describe("getMentorshipProfile", () => {
+    it("returns null when db is unavailable", async () => {
+      const firebase = jest.requireMock("@/lib/firebase");
+      firebase.__setDb(null);
+      expect(await getMentorshipProfile("u1")).toBeNull();
+      firebase.__setDb({ __fake: true });
+    });
+
+    it("returns null when the doc doesn't exist", async () => {
+      mockGetDoc.mockResolvedValueOnce({ exists: () => false });
+      expect(await getMentorshipProfile("u1")).toBeNull();
+    });
+
+    it("returns the profile with userId injected when it exists", async () => {
+      mockGetDoc.mockResolvedValueOnce({
+        exists: () => true,
+        id: "u-alice",
+        data: () => ({ displayName: "Alice", bio: "Mentor" }),
+      });
+      const p = await getMentorshipProfile("u-alice");
+      expect(p).toEqual({ userId: "u-alice", displayName: "Alice", bio: "Mentor" });
+    });
+  });
+
+  describe("getAllActiveMentorshipProfiles", () => {
+    it("returns [] when db is unavailable", async () => {
+      const firebase = jest.requireMock("@/lib/firebase");
+      firebase.__setDb(null);
+      expect(await getAllActiveMentorshipProfiles()).toEqual([]);
+      firebase.__setDb({ __fake: true });
+    });
+
+    it("maps each doc to a profile with userId injected", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          { id: "u1", data: () => ({ displayName: "A" }) },
+          { id: "u2", data: () => ({ displayName: "B" }) },
+        ],
+      });
+      const out = await getAllActiveMentorshipProfiles();
+      expect(out).toEqual([
+        { userId: "u1", displayName: "A" },
+        { userId: "u2", displayName: "B" },
+      ]);
+    });
+
+    it("returns an empty array when there are no matching profiles", async () => {
+      mockGetDocs.mockResolvedValueOnce({ docs: [] });
+      expect(await getAllActiveMentorshipProfiles()).toEqual([]);
+    });
+  });
+
+  describe("getMentorshipPairingsForUser", () => {
+    it("returns [] when db is unavailable", async () => {
+      const firebase = jest.requireMock("@/lib/firebase");
+      firebase.__setDb(null);
+      expect(await getMentorshipPairingsForUser("u1")).toEqual([]);
+      firebase.__setDb({ __fake: true });
+    });
+
+    it("unions mentor-side and mentee-side pairings, deduped by doc id", async () => {
+      mockGetDocs
+        .mockResolvedValueOnce({
+          docs: [
+            { id: "p-1", data: () => ({ mentorId: "u1", menteeId: "u2" }) },
+            { id: "p-shared", data: () => ({ mentorId: "u1", menteeId: "u-other" }) },
+          ],
+        })
+        .mockResolvedValueOnce({
+          docs: [
+            { id: "p-shared", data: () => ({ mentorId: "u1", menteeId: "u-other" }) }, // duplicate
+            { id: "p-2", data: () => ({ mentorId: "u-other", menteeId: "u1" }) },
+          ],
+        });
+      const out = await getMentorshipPairingsForUser("u1");
+      expect(out.map((p) => p.id).sort()).toEqual(["p-1", "p-2", "p-shared"]);
+    });
+
+    it("returns an empty array when neither query returns docs", async () => {
+      mockGetDocs.mockResolvedValueOnce({ docs: [] }).mockResolvedValueOnce({ docs: [] });
+      expect(await getMentorshipPairingsForUser("u1")).toEqual([]);
+    });
+  });
+});

--- a/__tests__/lib/pair-programming-data.test.ts
+++ b/__tests__/lib/pair-programming-data.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+import {
+  getAllActiveProfiles,
+  getPairProfile,
+  getPairSessionsForUser,
+  updatePairSession,
+} from "@/lib/pair-programming/data";
+
+const mockGetDoc = jest.fn();
+const mockGetDocs = jest.fn();
+const mockUpdateDoc = jest.fn();
+
+jest.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => ({ __collection: args }),
+  doc: (...args: unknown[]) => ({ __doc: args }),
+  query: (...args: unknown[]) => ({ __query: args }),
+  where: (...args: unknown[]) => ({ __where: args }),
+  orderBy: (...args: unknown[]) => ({ __orderBy: args }),
+  limit: (n: number) => ({ __limit: n }),
+  serverTimestamp: () => "SERVER_TS",
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+}));
+
+jest.mock("@/lib/firebase", () => {
+  let _db: unknown = { __fake: true };
+  return {
+    get db() {
+      return _db;
+    },
+    __setDb(next: unknown) {
+      _db = next;
+    },
+  };
+});
+
+describe("lib/pair-programming/data", () => {
+  beforeEach(() => {
+    mockGetDoc.mockReset();
+    mockGetDocs.mockReset();
+    mockUpdateDoc.mockReset();
+  });
+
+  describe("getPairProfile", () => {
+    it("returns null when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      expect(await getPairProfile("u1")).toBeNull();
+      fb.__setDb({ __fake: true });
+    });
+
+    it("returns null when doc doesn't exist", async () => {
+      mockGetDoc.mockResolvedValueOnce({ exists: () => false });
+      expect(await getPairProfile("u1")).toBeNull();
+    });
+
+    it("returns the profile with userId injected", async () => {
+      mockGetDoc.mockResolvedValueOnce({
+        exists: () => true,
+        id: "u-a",
+        data: () => ({ displayName: "A" }),
+      });
+      expect(await getPairProfile("u-a")).toEqual({ userId: "u-a", displayName: "A" });
+    });
+  });
+
+  describe("getAllActiveProfiles", () => {
+    it("returns [] when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      expect(await getAllActiveProfiles()).toEqual([]);
+      fb.__setDb({ __fake: true });
+    });
+
+    it("maps docs to profiles with userId", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          { id: "u1", data: () => ({ displayName: "A" }) },
+          { id: "u2", data: () => ({ displayName: "B" }) },
+        ],
+      });
+      expect(await getAllActiveProfiles()).toEqual([
+        { userId: "u1", displayName: "A" },
+        { userId: "u2", displayName: "B" },
+      ]);
+    });
+  });
+
+  describe("getPairSessionsForUser", () => {
+    it("returns [] when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      expect(await getPairSessionsForUser("u1")).toEqual([]);
+      fb.__setDb({ __fake: true });
+    });
+
+    it("maps docs to sessions with id", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          { id: "s1", data: () => ({ participantIds: ["u1", "u2"] }) },
+          { id: "s2", data: () => ({ participantIds: ["u1", "u3"] }) },
+        ],
+      });
+      const out = await getPairSessionsForUser("u1");
+      expect(out.map((s) => s.id)).toEqual(["s1", "s2"]);
+    });
+  });
+
+  describe("updatePairSession", () => {
+    it("throws when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      await expect(updatePairSession("s1", { status: "completed" } as unknown as Parameters<typeof updatePairSession>[1])).rejects.toThrow(
+        "Firestore not initialized"
+      );
+      fb.__setDb({ __fake: true });
+    });
+
+    it("calls updateDoc with the merged payload + serverTimestamp", async () => {
+      mockUpdateDoc.mockResolvedValueOnce(undefined);
+      await updatePairSession("s1", { status: "completed" } as unknown as Parameters<typeof updatePairSession>[1]);
+      expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+      const [, payload] = mockUpdateDoc.mock.calls[0];
+      expect(payload).toMatchObject({
+        status: "completed",
+        updatedAt: "SERVER_TS",
+      });
+    });
+  });
+});


### PR DESCRIPTION
Promotes 8 commits from develop, all tests-only:

- #1011 push #15 — hero-registry InTx + event builders
- #1013 push #16 — queued-orders
- #1014 push #17 — logger logRequest + sanitize + withLogging
- #1015 push #18 — mentorship/data
- #1016 push #19 — pair-programming/data
- #1017 push #20 — armageddon constants + helpers
- #1018 push #21 — pacts end-to-end
- #1019 push #22 — prophecies end-to-end

~140 new tests across this batch. Cumulative this session: 31.22% → ~34.3% statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)