### PR TITLE
Add c1w1pm submission for bradAGI

### DIFF
--- a/content/summer-cohort/c1/w1-pm/submissions/bradAGI.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/bradAGI.json
@@ -6,5 +6,5 @@
   "liveUrl": "https://cohort-tracker.fly.dev",
   "loomUrl": "https://www.loom.com/share/PLACEHOLDER",
   "pitch": "A live cohort tracker built for cohorts like this one — admins run weekly rounds, builders submit projects, and the cohort votes the winner; deployed end-to-end on Fly.io this week.",
-  "competeForWin": true
+  "competeForWin": false
 }

--- a/content/summer-cohort/c1/w1-pm/submissions/bradAGI.json
+++ b/content/summer-cohort/c1/w1-pm/submissions/bradAGI.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "bradAGI",
+  "name": "Brad Egan",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocIC-U9ZMsY6U_D0bkeaoiX_7F8Tfp7v07O0hkwyduAZPbb-Ow=s96-c",
+  "repoUrl": "https://github.com/bradAGI/project_management_cursor",
+  "liveUrl": "https://cohort-tracker.fly.dev",
+  "loomUrl": "https://www.loom.com/share/PLACEHOLDER",
+  "pitch": "A live cohort tracker built for cohorts like this one — admins run weekly rounds, builders submit projects, and the cohort votes the winner; deployed end-to-end on Fly.io this week.",
+  "competeForWin": true
+}


### PR DESCRIPTION
## Summary
- Adds `content/summer-cohort/c1/w1-pm/submissions/bradAGI.json`
- Live: https://cohort-tracker.fly.dev
- Repo: https://github.com/bradAGI/project_management_cursor
- Loom: placeholder, will update

Signed off (DCO).