### PR TITLE
release: develop→main — Cohort-1 Week-2 banner + email + 25 coverage pushes

### DIFF
--- a/__tests__/lib/api-schemas/common.test.ts
+++ b/__tests__/lib/api-schemas/common.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment node
+ */
+import {
+  ApiErrorSchema,
+  ErrorCodeEnum,
+  PaginationFieldsSchema,
+  PaginationQuerySchema,
+  RateLimitedErrorSchema,
+  REQUIRES_AUTH,
+  SECURITY_SCHEMES,
+} from "@/lib/api-schemas/common";
+
+describe("lib/api-schemas/common", () => {
+  describe("ErrorCodeEnum", () => {
+    it("accepts every well-known code", () => {
+      for (const v of [
+        "UNAUTHORIZED",
+        "FORBIDDEN",
+        "NOT_FOUND",
+        "VALIDATION_ERROR",
+        "RATE_LIMITED",
+        "CONFLICT",
+        "SERVER_ERROR",
+        "NOT_CONFIGURED",
+      ]) {
+        expect(ErrorCodeEnum.safeParse(v).success).toBe(true);
+      }
+    });
+
+    it("rejects an unknown code", () => {
+      expect(ErrorCodeEnum.safeParse("MYSTERY").success).toBe(false);
+    });
+  });
+
+  describe("ApiErrorSchema", () => {
+    it("accepts the canonical error envelope", () => {
+      const ok = ApiErrorSchema.safeParse({
+        success: false,
+        error: { message: "Bad input", code: "VALIDATION_ERROR" },
+      });
+      expect(ok.success).toBe(true);
+    });
+
+    it("rejects success=true", () => {
+      const r = ApiErrorSchema.safeParse({
+        success: true,
+        error: { message: "x", code: "SERVER_ERROR" },
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it("rejects an unknown error code", () => {
+      const r = ApiErrorSchema.safeParse({
+        success: false,
+        error: { message: "x", code: "MYSTERY" },
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it("rejects a missing error.message", () => {
+      const r = ApiErrorSchema.safeParse({
+        success: false,
+        error: { code: "SERVER_ERROR" },
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe("RateLimitedErrorSchema", () => {
+    it("accepts an error string alone", () => {
+      const r = RateLimitedErrorSchema.safeParse({ error: "too many requests" });
+      expect(r.success).toBe(true);
+    });
+
+    it("accepts an optional non-negative retryAfterSeconds", () => {
+      const r = RateLimitedErrorSchema.safeParse({
+        error: "x",
+        retryAfterSeconds: 30,
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it("rejects a negative retryAfterSeconds", () => {
+      const r = RateLimitedErrorSchema.safeParse({
+        error: "x",
+        retryAfterSeconds: -1,
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it("rejects a non-integer retryAfterSeconds", () => {
+      const r = RateLimitedErrorSchema.safeParse({
+        error: "x",
+        retryAfterSeconds: 2.5,
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe("PaginationQuerySchema", () => {
+    it("accepts an empty object (all fields optional)", () => {
+      expect(PaginationQuerySchema.safeParse({}).success).toBe(true);
+    });
+
+    it("accepts a numeric-string limit", () => {
+      const r = PaginationQuerySchema.safeParse({ limit: "20" });
+      expect(r.success).toBe(true);
+    });
+
+    it("rejects a non-numeric limit", () => {
+      const r = PaginationQuerySchema.safeParse({ limit: "ten" });
+      expect(r.success).toBe(false);
+    });
+
+    it("accepts an opaque string cursor", () => {
+      const r = PaginationQuerySchema.safeParse({
+        cursor: "abc:0:xyz",
+      });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe("PaginationFieldsSchema", () => {
+    it("accepts a populated next page", () => {
+      const r = PaginationFieldsSchema.safeParse({
+        nextCursor: "abc",
+        hasMore: true,
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it("accepts the last page (nextCursor=null)", () => {
+      const r = PaginationFieldsSchema.safeParse({
+        nextCursor: null,
+        hasMore: false,
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it("rejects missing hasMore", () => {
+      const r = PaginationFieldsSchema.safeParse({ nextCursor: "x" });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe("security definitions", () => {
+    it("SECURITY_SCHEMES has bearerAuth + cookieAuth in OpenAPI shape", () => {
+      expect(SECURITY_SCHEMES.bearerAuth).toMatchObject({
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "Firebase ID token",
+      });
+      expect(SECURITY_SCHEMES.cookieAuth).toMatchObject({
+        type: "apiKey",
+        in: "cookie",
+        name: "session",
+      });
+    });
+
+    it("REQUIRES_AUTH lists both auth methods (one of)", () => {
+      expect(REQUIRES_AUTH).toEqual([{ bearerAuth: [] }, { cookieAuth: [] }]);
+    });
+  });
+});

--- a/__tests__/lib/badges/admin-badge-awards.test.ts
+++ b/__tests__/lib/badges/admin-badge-awards.test.ts
@@ -1,0 +1,546 @@
+/**
+ * @jest-environment node
+ */
+const adminDbMock = jest.fn();
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: () => adminDbMock(),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => ({ __ts: "now" }),
+  },
+}));
+
+jest.mock("@/lib/badges/definitions", () => ({
+  BADGE_IDS: [
+    "registered",
+    "displayName",
+    "publicProfile",
+    "bio",
+    "avatar",
+    "discord",
+    "github",
+    "firstEvent",
+    "talkSubmitter",
+    "contributor",
+    "communityVoice",
+    "communityPoster",
+    "hackathonPlayer",
+    "showcase",
+    "mentor",
+  ],
+}));
+
+const mockEvaluate = jest.fn();
+jest.mock("@/lib/badges/eligibility", () => ({
+  evaluateBadgeEligibility: (...args: unknown[]) => mockEvaluate(...args),
+}));
+
+import {
+  buildAdminBadgeEligibilityInput,
+  syncUserBadgesForUser,
+  userBadgeFromFirestoreDoc,
+} from "@/lib/badges/admin-badge-awards";
+
+function tsLike(iso: string) {
+  return { toDate: () => new Date(iso) };
+}
+
+describe("lib/badges/admin-badge-awards", () => {
+  beforeEach(() => {
+    adminDbMock.mockReset();
+    mockEvaluate.mockReset();
+  });
+
+  describe("userBadgeFromFirestoreDoc", () => {
+    const VALID = {
+      badgeId: "registered",
+      userId: "u1",
+      awardSource: "system",
+      awardedAt: "2026-05-01T00:00:00.000Z",
+      awardedBy: "admin",
+      id: "doc-123",
+    };
+
+    it("parses a valid system-awarded badge with ISO awardedAt", () => {
+      const out = userBadgeFromFirestoreDoc("fallback-id", VALID);
+      expect(out).toEqual({
+        id: "doc-123",
+        userId: "u1",
+        badgeId: "registered",
+        awardedAt: "2026-05-01T00:00:00.000Z",
+        awardSource: "system",
+        awardedBy: "admin",
+      });
+    });
+
+    it("uses docId when data.id is missing", () => {
+      const out = userBadgeFromFirestoreDoc("doc-from-arg", {
+        ...VALID,
+        id: undefined,
+      });
+      expect(out?.id).toBe("doc-from-arg");
+    });
+
+    it("accepts a Timestamp-like awardedAt and converts to ISO", () => {
+      const out = userBadgeFromFirestoreDoc("doc-123", {
+        ...VALID,
+        awardedAt: tsLike("2026-04-01T00:00:00.000Z"),
+      });
+      expect(out?.awardedAt).toBe("2026-04-01T00:00:00.000Z");
+    });
+
+    it("rejects when badgeId is not a known BADGE_ID", () => {
+      const out = userBadgeFromFirestoreDoc("doc-123", {
+        ...VALID,
+        badgeId: "not-real",
+      });
+      expect(out).toBeNull();
+    });
+
+    it("rejects when badgeId is not a string", () => {
+      const out = userBadgeFromFirestoreDoc("doc-123", {
+        ...VALID,
+        badgeId: 42,
+      });
+      expect(out).toBeNull();
+    });
+
+    it("rejects when userId is not a string", () => {
+      const out = userBadgeFromFirestoreDoc("doc-123", {
+        ...VALID,
+        userId: 42,
+      });
+      expect(out).toBeNull();
+    });
+
+    it("rejects when awardSource isn't in the trusted set", () => {
+      const out = userBadgeFromFirestoreDoc("doc-123", {
+        ...VALID,
+        awardSource: "self-claim",
+      });
+      expect(out).toBeNull();
+    });
+
+    it("rejects when awardSource is not a string", () => {
+      const out = userBadgeFromFirestoreDoc("doc-123", {
+        ...VALID,
+        awardSource: 42,
+      });
+      expect(out).toBeNull();
+    });
+
+    it("rejects when awardedAt cannot be parsed (null / invalid string)", () => {
+      expect(
+        userBadgeFromFirestoreDoc("doc-123", { ...VALID, awardedAt: "not-a-date" }),
+      ).toBeNull();
+      expect(
+        userBadgeFromFirestoreDoc("doc-123", { ...VALID, awardedAt: null }),
+      ).toBeNull();
+      expect(
+        userBadgeFromFirestoreDoc("doc-123", { ...VALID, awardedAt: 42 }),
+      ).toBeNull();
+    });
+
+    it("omits awardedBy when it isn't a string", () => {
+      const out = userBadgeFromFirestoreDoc("doc-123", {
+        ...VALID,
+        awardedBy: 42,
+      });
+      expect(out?.awardedBy).toBeUndefined();
+    });
+
+    it("accepts each trusted award source (system / migration / manual)", () => {
+      for (const src of ["system", "migration", "manual"]) {
+        const out = userBadgeFromFirestoreDoc("doc", { ...VALID, awardSource: src });
+        expect(out?.awardSource).toBe(src);
+      }
+    });
+  });
+
+  describe("buildAdminBadgeEligibilityInput", () => {
+    it("returns {} when admin db is unavailable", async () => {
+      adminDbMock.mockReturnValueOnce(null);
+      const out = await buildAdminBadgeEligibilityInput("u1");
+      expect(out).toEqual({});
+    });
+
+    function fakeDb(overrides: Record<string, unknown> = {}) {
+      const docs = (arr: Record<string, unknown>[]) => ({
+        size: arr.length,
+        docs: arr.map((d) => ({ data: () => d })),
+        empty: arr.length === 0,
+      });
+      const userSnap = {
+        exists: true,
+        data: () => ({
+          displayName: "Alice",
+          visibility: { isPublic: true },
+          bio: "hi",
+          photoURL: "https://x/a.png",
+          discord: { id: "d1" },
+          github: { login: "alice" },
+          ...overrides,
+        }),
+      };
+
+      const userRef = { get: jest.fn().mockResolvedValue(userSnap) };
+      const eventReg = {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(
+          docs([{ status: "attended" }, { status: "registered" }]),
+        ),
+      };
+      const talks = {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(
+          docs([{ status: "completed" }, { status: "submitted" }]),
+        ),
+      };
+      const messages = {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(
+          docs([{ parentId: null }, { parentId: "p" }, { parentId: null }]),
+        ),
+      };
+      const prs = {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(docs([{}, {}, {}])),
+      };
+      const teams = {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(docs([{}])),
+      };
+      const pool = {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(docs([{}, {}, {}])),
+      };
+      const showcase = {
+        where: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue(
+          docs([{ status: "approved" }, { status: "pending" }]),
+        ),
+      };
+
+      const collection = jest.fn((name: string) => {
+        switch (name) {
+          case "users":
+            return { doc: () => userRef };
+          case "eventRegistrations":
+            return eventReg;
+          case "talkSubmissions":
+            return talks;
+          case "communityMessages":
+            return messages;
+          case "pullRequests":
+            return prs;
+          case "hackathonTeams":
+            return teams;
+          case "hackathonPool":
+            return pool;
+          case "showcaseSubmissions":
+            return showcase;
+          default:
+            throw new Error(`unexpected: ${name}`);
+        }
+      });
+      return {
+        db: { collection, batch: jest.fn() },
+        spies: { userRef, eventReg, talks, messages, prs, teams, pool, showcase },
+      };
+    }
+
+    it("returns a fully-populated input for a normal user", async () => {
+      const { db } = fakeDb();
+      adminDbMock.mockReturnValueOnce(db as unknown as Record<string, unknown>);
+      const out = await buildAdminBadgeEligibilityInput("u1");
+      expect(out).toMatchObject({
+        hasDisplayName: true,
+        isPublicProfile: true,
+        hasBio: true,
+        hasAvatar: true,
+        hasDiscordConnected: true,
+        hasGithubConnected: true,
+        eventsAttendedCount: 1, // 1 attended of 2 regs
+        talksSubmittedCount: 2,
+        talksGivenCount: 1, // 1 completed of 2 talks
+        pullRequestsCount: 3,
+        communityMessagesCount: 3,
+        communityPostsCount: 2, // 2 with no parentId
+        hackathonParticipationCount: 3, // max(teams=1, pool=3)
+        showcaseSubmissionsCount: 1, // 1 approved of 2
+        mentorMatchesCount: 0,
+      });
+    });
+
+    it("returns false for boolean flags when user profile fields are empty", async () => {
+      const { db } = fakeDb({
+        displayName: "",
+        visibility: { isPublic: false },
+        bio: "   ",
+        photoURL: "",
+        discord: null,
+        github: undefined,
+      });
+      adminDbMock.mockReturnValueOnce(db as unknown as Record<string, unknown>);
+      const out = await buildAdminBadgeEligibilityInput("u1");
+      expect(out).toMatchObject({
+        hasDisplayName: false,
+        isPublicProfile: false,
+        hasBio: false,
+        hasAvatar: false,
+        hasDiscordConnected: false,
+        hasGithubConnected: false,
+      });
+    });
+
+    it("treats non-existent user doc as empty user data", async () => {
+      const { db } = fakeDb();
+      // Override userRef.get to return non-existent snap
+      (db.collection("users") as unknown as { doc: () => { get: jest.Mock } })
+        .doc()
+        .get.mockResolvedValueOnce({ exists: false, data: () => undefined });
+      adminDbMock.mockReturnValueOnce(db as unknown as Record<string, unknown>);
+      const out = await buildAdminBadgeEligibilityInput("u1");
+      expect(out.hasDisplayName).toBe(false);
+      expect(out.hasBio).toBe(false);
+    });
+  });
+
+  describe("syncUserBadgesForUser", () => {
+    it("returns empty result when admin db is unavailable", async () => {
+      adminDbMock.mockReturnValueOnce(null);
+      const out = await syncUserBadgesForUser("u1", { awardedBy: "admin" });
+      expect(out).toEqual({ eligibleBadgeIds: [], newlyAwardedBadgeIds: [] });
+    });
+
+    it("awards missing badges + persists earnedBadgeIds, returns both lists", async () => {
+      const eligibilityMap = {
+        registered: { isEligible: true },
+        displayName: { isEligible: true },
+        bio: { isEligible: false },
+      };
+      mockEvaluate.mockReturnValueOnce(eligibilityMap);
+
+      // Existing user_badges already has registered, missing displayName.
+      const existingDocs = [
+        { id: "u1_registered", data: () => ({ badgeId: "registered" }) },
+      ];
+      const finalDocs = [
+        {
+          id: "u1_registered",
+          data: () => ({
+            id: "u1_registered",
+            userId: "u1",
+            badgeId: "registered",
+            awardSource: "migration",
+            awardedAt: "2026-05-01T00:00:00.000Z",
+          }),
+        },
+        {
+          id: "u1_displayName",
+          data: () => ({
+            id: "u1_displayName",
+            userId: "u1",
+            badgeId: "displayName",
+            awardSource: "migration",
+            awardedAt: "2026-05-01T00:00:00.000Z",
+          }),
+        },
+      ];
+
+      const userBadgesGet = jest
+        .fn()
+        .mockResolvedValueOnce({ docs: existingDocs })
+        .mockResolvedValueOnce({ docs: finalDocs });
+      const userBadgesWhere = jest.fn().mockReturnValue({ get: userBadgesGet });
+      const userBadgesDoc = jest.fn().mockImplementation((id: string) => ({
+        __ref: id,
+      }));
+      const userBadgesRef = { where: userBadgesWhere, doc: userBadgesDoc };
+
+      const batchSet = jest.fn();
+      const batchCommit = jest.fn().mockResolvedValue(undefined);
+      const batch = { set: batchSet, commit: batchCommit };
+
+      const usersSet = jest.fn().mockResolvedValue(undefined);
+      const usersDocObj = {
+        set: usersSet,
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => ({ displayName: "Alice" }),
+        }),
+      };
+      const usersDoc = jest.fn().mockReturnValue(usersDocObj);
+      const usersCol = { doc: usersDoc };
+
+      const collection = jest.fn((name: string) => {
+        if (name === "user_badges") return userBadgesRef;
+        if (name === "users") return usersCol;
+        // Other reads inside buildAdminBadgeEligibilityInput
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({ docs: [], size: 0, empty: true }),
+          doc: () => ({
+            get: jest.fn().mockResolvedValue({
+              exists: true,
+              data: () => ({ displayName: "Alice" }),
+            }),
+          }),
+        };
+      });
+
+      const db = {
+        collection,
+        batch: () => batch,
+      };
+      adminDbMock.mockReturnValue(db as unknown as Record<string, unknown>);
+
+      const out = await syncUserBadgesForUser("u1", { awardedBy: "admin" });
+      expect(out.eligibleBadgeIds.sort()).toEqual(["displayName", "registered"]);
+      expect(out.newlyAwardedBadgeIds).toEqual(["displayName"]);
+      expect(batchSet).toHaveBeenCalledTimes(1);
+      expect(batchSet.mock.calls[0][1]).toMatchObject({
+        id: "u1_displayName",
+        userId: "u1",
+        badgeId: "displayName",
+        awardSource: "migration",
+        awardedBy: "admin",
+      });
+      // earnedBadgeIds list reflects what's actually persisted
+      expect(usersSet).toHaveBeenCalledWith(
+        { earnedBadgeIds: ["registered", "displayName"] },
+        { merge: true },
+      );
+    });
+
+    it("skips batch.commit when nothing new is eligible", async () => {
+      mockEvaluate.mockReturnValueOnce({ registered: { isEligible: true } });
+
+      const existingDocs = [
+        {
+          id: "u1_registered",
+          data: () => ({
+            id: "u1_registered",
+            userId: "u1",
+            badgeId: "registered",
+            awardSource: "migration",
+            awardedAt: "2026-05-01T00:00:00.000Z",
+          }),
+        },
+      ];
+      const userBadgesGet = jest.fn().mockResolvedValueOnce({ docs: existingDocs });
+      const userBadgesRef = {
+        where: jest.fn().mockReturnValue({ get: userBadgesGet }),
+        doc: jest.fn(),
+      };
+
+      const batchCommit = jest.fn();
+      const batchSet = jest.fn();
+      const batch = { set: batchSet, commit: batchCommit };
+
+      const usersSet = jest.fn();
+      const collection = jest.fn((name: string) => {
+        if (name === "user_badges") return userBadgesRef;
+        if (name === "users") {
+          return {
+            doc: () => ({
+              set: usersSet,
+              get: jest.fn().mockResolvedValue({
+                exists: true,
+                data: () => ({ displayName: "Alice" }),
+              }),
+            }),
+          };
+        }
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({ docs: [], size: 0, empty: true }),
+          doc: () => ({
+            get: jest
+              .fn()
+              .mockResolvedValue({ exists: true, data: () => ({}) }),
+          }),
+        };
+      });
+
+      adminDbMock.mockReturnValue({
+        collection,
+        batch: () => batch,
+      } as unknown as Record<string, unknown>);
+      const out = await syncUserBadgesForUser("u1", { awardedBy: "admin" });
+      expect(out.newlyAwardedBadgeIds).toEqual([]);
+      expect(batchCommit).not.toHaveBeenCalled();
+      expect(usersSet).toHaveBeenCalledWith(
+        { earnedBadgeIds: ["registered"] },
+        { merge: true },
+      );
+    });
+
+    it("filters out un-string badgeIds when computing existingByBadgeId", async () => {
+      mockEvaluate.mockReturnValueOnce({ registered: { isEligible: true } });
+
+      // existing docs include a row with no badgeId — should not block
+      // the missing-eligible computation
+      const existingDocs = [
+        { id: "weird", data: () => ({}) },
+        { id: "weird2", data: () => ({ badgeId: 42 }) },
+      ];
+      const finalDocs = [
+        {
+          id: "u1_registered",
+          data: () => ({
+            id: "u1_registered",
+            userId: "u1",
+            badgeId: "registered",
+            awardSource: "migration",
+            awardedAt: "2026-05-01T00:00:00.000Z",
+          }),
+        },
+      ];
+      const userBadgesGet = jest
+        .fn()
+        .mockResolvedValueOnce({ docs: existingDocs })
+        .mockResolvedValueOnce({ docs: finalDocs });
+      const userBadgesRef = {
+        where: jest.fn().mockReturnValue({ get: userBadgesGet }),
+        doc: jest.fn().mockImplementation((id: string) => ({ __ref: id })),
+      };
+
+      const batchSet = jest.fn();
+      const batchCommit = jest.fn().mockResolvedValue(undefined);
+      const usersSet = jest.fn();
+      const collection = jest.fn((name: string) => {
+        if (name === "user_badges") return userBadgesRef;
+        if (name === "users") {
+          return {
+            doc: () => ({
+              set: usersSet,
+              get: jest.fn().mockResolvedValue({
+                exists: true,
+                data: () => ({ displayName: "Alice" }),
+              }),
+            }),
+          };
+        }
+        return {
+          where: jest.fn().mockReturnThis(),
+          get: jest.fn().mockResolvedValue({ docs: [], size: 0, empty: true }),
+          doc: () => ({
+            get: jest
+              .fn()
+              .mockResolvedValue({ exists: true, data: () => ({}) }),
+          }),
+        };
+      });
+
+      adminDbMock.mockReturnValue({
+        collection,
+        batch: () => ({ set: batchSet, commit: batchCommit }),
+      } as unknown as Record<string, unknown>);
+      const out = await syncUserBadgesForUser("u1", { awardedBy: "admin" });
+      expect(out.newlyAwardedBadgeIds).toEqual(["registered"]);
+    });
+  });
+});

--- a/__tests__/lib/badges/data.test.ts
+++ b/__tests__/lib/badges/data.test.ts
@@ -1,0 +1,390 @@
+/**
+ * @jest-environment node
+ */
+const mockGetDocs = jest.fn();
+const mockCollection = jest.fn();
+const mockQuery = jest.fn((...args: unknown[]) => ({ __q: args }));
+const mockWhere = jest.fn((...args: unknown[]) => ({ __w: args }));
+
+jest.mock("firebase/firestore", () => ({
+  collection: (...a: unknown[]) => mockCollection(...a),
+  getDocs: (...a: unknown[]) => mockGetDocs(...a),
+  query: (...a: unknown[]) => mockQuery(...a),
+  where: (...a: unknown[]) => mockWhere(...a),
+}));
+
+jest.mock("@/lib/firebase", () => {
+  let _db: unknown = { __fake: "db" };
+  let _auth: { currentUser: { uid: string; getIdToken: () => Promise<string> } | null } = {
+    currentUser: null,
+  };
+  return {
+    get db() {
+      return _db;
+    },
+    get auth() {
+      return _auth;
+    },
+    __setDb(next: unknown) {
+      _db = next;
+    },
+    __setAuth(next: typeof _auth) {
+      _auth = next;
+    },
+  };
+});
+
+import {
+  BADGES_COLLECTION,
+  USER_BADGES_COLLECTION,
+  ensureUserBadgesForEligible,
+  ensureUserBadgesForEligibleWithStatus,
+  getBadgeDocumentId,
+  getUserBadgeDocumentId,
+  getUserBadgeMap,
+  toBadgeDefinitionDocument,
+  toUserBadgeDocument,
+} from "@/lib/badges/data";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const firebaseMod = require("@/lib/firebase") as {
+  __setDb: (db: unknown) => void;
+  __setAuth: (auth: unknown) => void;
+};
+const setDb = firebaseMod.__setDb;
+const setAuth = firebaseMod.__setAuth;
+
+const originalFetch = global.fetch;
+
+function tsLike(iso: string) {
+  return { toDate: () => new Date(iso) };
+}
+
+describe("lib/badges/data", () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset();
+    mockCollection.mockReset();
+    setDb({ __fake: "db" });
+    setAuth({ currentUser: null });
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("constants + pure ID helpers", () => {
+    it("BADGES_COLLECTION + USER_BADGES_COLLECTION are the Firestore collection names", () => {
+      expect(BADGES_COLLECTION).toBe("badges");
+      expect(USER_BADGES_COLLECTION).toBe("user_badges");
+    });
+
+    it("getBadgeDocumentId returns the badgeId verbatim", () => {
+      expect(getBadgeDocumentId("registered")).toBe("registered");
+    });
+
+    it("getUserBadgeDocumentId joins userId + badgeId with an underscore", () => {
+      expect(getUserBadgeDocumentId("u1", "registered")).toBe("u1_registered");
+    });
+  });
+
+  describe("storage-shape mappers", () => {
+    it("toBadgeDefinitionDocument copies the documented fields", () => {
+      const out = toBadgeDefinitionDocument({
+        id: "registered",
+        name: "Registered",
+        description: "desc",
+        category: "profile",
+        howToEarn: "sign up",
+        sortOrder: 1,
+        iconKey: "k",
+      });
+      expect(out).toEqual({
+        id: "registered",
+        name: "Registered",
+        description: "desc",
+        category: "profile",
+        howToEarn: "sign up",
+        sortOrder: 1,
+        iconKey: "k",
+      });
+    });
+
+    it("toUserBadgeDocument copies the documented fields", () => {
+      const out = toUserBadgeDocument({
+        id: "u1_registered",
+        userId: "u1",
+        badgeId: "registered",
+        awardedAt: "2026-05-01T00:00:00.000Z",
+        awardSource: "system",
+        awardedBy: "admin",
+      });
+      expect(out).toEqual({
+        id: "u1_registered",
+        userId: "u1",
+        badgeId: "registered",
+        awardedAt: "2026-05-01T00:00:00.000Z",
+        awardSource: "system",
+        awardedBy: "admin",
+      });
+    });
+  });
+
+  describe("getUserBadgeMap", () => {
+    it("returns {} when db is null", async () => {
+      setDb(null);
+      expect(await getUserBadgeMap("u1")).toEqual({});
+    });
+
+    it("returns {} when userId is empty", async () => {
+      expect(await getUserBadgeMap("")).toEqual({});
+    });
+
+    it("queries user_badges by userId and maps trusted rows into the map", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          {
+            id: "ub-1",
+            data: () => ({
+              id: "ub-1",
+              userId: "u1",
+              badgeId: "registered",
+              awardedAt: "2026-05-01T00:00:00.000Z",
+              awardSource: "system",
+            }),
+          },
+        ],
+      });
+      const out = await getUserBadgeMap("u1");
+      expect(out.registered).toMatchObject({
+        id: "ub-1",
+        userId: "u1",
+        badgeId: "registered",
+        awardSource: "system",
+      });
+      expect(mockWhere).toHaveBeenCalledWith("userId", "==", "u1");
+    });
+
+    it("converts Timestamp + seconds-shape awardedAt to ISO strings", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          {
+            id: "ub-ts",
+            data: () => ({
+              userId: "u1",
+              badgeId: "bio",
+              awardedAt: tsLike("2026-04-01T00:00:00.000Z"),
+              awardSource: "manual",
+            }),
+          },
+          {
+            id: "ub-sec",
+            data: () => ({
+              userId: "u1",
+              badgeId: "displayName",
+              awardedAt: { seconds: 1717000000 },
+              awardSource: "migration",
+            }),
+          },
+        ],
+      });
+      const out = await getUserBadgeMap("u1");
+      expect(out.bio?.awardedAt).toBe("2026-04-01T00:00:00.000Z");
+      expect(out.displayName?.awardedAt).toBe(
+        new Date(1717000000 * 1000).toISOString(),
+      );
+    });
+
+    it("drops rows missing required fields or with untrusted awardSource", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          { id: "x1", data: () => ({}) }, // empty
+          {
+            id: "x2",
+            data: () => ({
+              userId: "u1",
+              badgeId: "registered",
+              awardSource: "self-claim",
+              awardedAt: "2026-05-01T00:00:00.000Z",
+            }),
+          }, // untrusted source
+          {
+            id: "x3",
+            data: () => ({
+              userId: "u1",
+              badgeId: "bio",
+              awardSource: "system",
+            }),
+          }, // missing awardedAt
+        ],
+      });
+      const out = await getUserBadgeMap("u1");
+      expect(out).toEqual({});
+    });
+  });
+
+  describe("ensureUserBadgesForEligibleWithStatus", () => {
+    it("returns failed when userId is empty", async () => {
+      const out = await ensureUserBadgesForEligibleWithStatus("", {});
+      expect(out.status.state).toBe("failed");
+    });
+
+    it("returns complete when no missing-eligible badges remain", async () => {
+      const eligibility = { registered: { isEligible: true } };
+      const existing = {
+        registered: {
+          id: "u1_registered",
+          userId: "u1",
+          badgeId: "registered",
+          awardedAt: "2026-05-01T00:00:00.000Z",
+          awardSource: "system",
+        },
+      } as Parameters<typeof ensureUserBadgesForEligibleWithStatus>[2];
+      const out = await ensureUserBadgesForEligibleWithStatus(
+        "u1",
+        eligibility as Parameters<typeof ensureUserBadgesForEligibleWithStatus>[1],
+        existing,
+      );
+      expect(out.status.state).toBe("complete");
+      expect(out.userBadgeMap).toBe(existing);
+    });
+
+    it("returns degraded when auth.currentUser != target uid (no fetch)", async () => {
+      setAuth({ currentUser: { uid: "OTHER", getIdToken: async () => "t" } });
+      const out = await ensureUserBadgesForEligibleWithStatus(
+        "u1",
+        { registered: { isEligible: true } } as Parameters<
+          typeof ensureUserBadgesForEligibleWithStatus
+        >[1],
+      );
+      expect(out.status.state).toBe("degraded");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns failed when /api/badges/awards responds non-2xx", async () => {
+      setAuth({
+        currentUser: { uid: "u1", getIdToken: async () => "tok" },
+      });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false });
+      const out = await ensureUserBadgesForEligibleWithStatus(
+        "u1",
+        { registered: { isEligible: true } } as Parameters<
+          typeof ensureUserBadgesForEligibleWithStatus
+        >[1],
+      );
+      expect(out.status.state).toBe("failed");
+    });
+
+    it("returns failed when /api/badges/awards returns a non-array shape", async () => {
+      setAuth({
+        currentUser: { uid: "u1", getIdToken: async () => "tok" },
+      });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ notAnArray: true }),
+      });
+      const out = await ensureUserBadgesForEligibleWithStatus(
+        "u1",
+        { registered: { isEligible: true } } as Parameters<
+          typeof ensureUserBadgesForEligibleWithStatus
+        >[1],
+      );
+      expect(out.status.state).toBe("failed");
+    });
+
+    it("returns complete when all eligible badges come back in the response", async () => {
+      setAuth({
+        currentUser: { uid: "u1", getIdToken: async () => "tok" },
+      });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          userBadges: [
+            {
+              id: "u1_registered",
+              userId: "u1",
+              badgeId: "registered",
+              awardedAt: "2026-05-01T00:00:00.000Z",
+              awardSource: "system",
+            },
+          ],
+        }),
+      });
+      const out = await ensureUserBadgesForEligibleWithStatus(
+        "u1",
+        { registered: { isEligible: true } } as Parameters<
+          typeof ensureUserBadgesForEligibleWithStatus
+        >[1],
+      );
+      expect(out.status.state).toBe("complete");
+      expect(out.userBadgeMap.registered?.id).toBe("u1_registered");
+    });
+
+    it("returns degraded when only some eligible badges come back", async () => {
+      setAuth({
+        currentUser: { uid: "u1", getIdToken: async () => "tok" },
+      });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          userBadges: [
+            {
+              id: "u1_registered",
+              userId: "u1",
+              badgeId: "registered",
+              awardedAt: "2026-05-01T00:00:00.000Z",
+              awardSource: "system",
+            },
+          ],
+        }),
+      });
+      const out = await ensureUserBadgesForEligibleWithStatus(
+        "u1",
+        {
+          registered: { isEligible: true },
+          bio: { isEligible: true },
+        } as Parameters<typeof ensureUserBadgesForEligibleWithStatus>[1],
+      );
+      expect(out.status.state).toBe("degraded");
+    });
+
+    it("returns failed when fetch throws", async () => {
+      setAuth({
+        currentUser: { uid: "u1", getIdToken: async () => "tok" },
+      });
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("net down"));
+      const out = await ensureUserBadgesForEligibleWithStatus(
+        "u1",
+        { registered: { isEligible: true } } as Parameters<
+          typeof ensureUserBadgesForEligibleWithStatus
+        >[1],
+      );
+      expect(out.status.state).toBe("failed");
+    });
+
+    it("ensureUserBadgesForEligible delegates and returns only the badge map", async () => {
+      setAuth({
+        currentUser: { uid: "u1", getIdToken: async () => "tok" },
+      });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          userBadges: [
+            {
+              id: "u1_registered",
+              userId: "u1",
+              badgeId: "registered",
+              awardedAt: "2026-05-01T00:00:00.000Z",
+              awardSource: "system",
+            },
+          ],
+        }),
+      });
+      const out = await ensureUserBadgesForEligible(
+        "u1",
+        { registered: { isEligible: true } } as Parameters<typeof ensureUserBadgesForEligible>[1],
+      );
+      expect(out.registered?.id).toBe("u1_registered");
+    });
+  });
+});

--- a/__tests__/lib/discord.test.ts
+++ b/__tests__/lib/discord.test.ts
@@ -1,0 +1,375 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    logError: jest.fn(),
+  },
+}));
+
+const originalFetch = global.fetch;
+
+async function loadDiscord(envWebhook: string | null) {
+  if (envWebhook === null) {
+    delete process.env.DISCORD_WEBHOOK_URL_PR;
+  } else {
+    process.env.DISCORD_WEBHOOK_URL_PR = envWebhook;
+  }
+  let mod: typeof import("@/lib/discord");
+  await jest.isolateModulesAsync(async () => {
+    mod = await import("@/lib/discord");
+  });
+  return mod!;
+}
+
+describe("lib/discord", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    delete process.env.DISCORD_WEBHOOK_URL_PR;
+  });
+
+  describe("DISCORD_COLORS", () => {
+    it("exposes BLUE / GREEN / RED / YELLOW as numeric color codes", async () => {
+      const { DISCORD_COLORS } = await loadDiscord(null);
+      expect(DISCORD_COLORS).toEqual({
+        BLUE: 0x5865f2,
+        GREEN: 0x57f287,
+        RED: 0xed4245,
+        YELLOW: 0xfee75c,
+      });
+    });
+  });
+
+  describe("sendDiscordNotification", () => {
+    it("returns false when no webhook URL is configured (env unset, no override)", async () => {
+      const { sendDiscordNotification } = await loadDiscord(null);
+      const ok = await sendDiscordNotification({ title: "T" });
+      expect(ok).toBe(false);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("uses the env webhook URL when no override is given", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+      });
+      const { sendDiscordNotification } = await loadDiscord("https://discord/env");
+      const ok = await sendDiscordNotification({ title: "Hi" });
+      expect(ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://discord/env",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("accepts an explicit webhookUrl override", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { sendDiscordNotification } = await loadDiscord(null);
+      await sendDiscordNotification(
+        { title: "Hi" },
+        { webhookUrl: "https://discord/override" },
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://discord/override",
+        expect.anything(),
+      );
+    });
+
+    it("sets default username='Cursor Boston Bot' when none provided", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { sendDiscordNotification } = await loadDiscord(null);
+      await sendDiscordNotification(
+        { title: "Hi" },
+        { webhookUrl: "https://discord/x" },
+      );
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.username).toBe("Cursor Boston Bot");
+      expect(body.embeds).toEqual([{ title: "Hi" }]);
+    });
+
+    it("honors explicit username + avatarUrl overrides", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { sendDiscordNotification } = await loadDiscord(null);
+      await sendDiscordNotification(
+        { title: "Hi" },
+        {
+          webhookUrl: "https://discord/x",
+          username: "Tester",
+          avatarUrl: "https://x/a.png",
+        },
+      );
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.username).toBe("Tester");
+      expect(body.avatar_url).toBe("https://x/a.png");
+    });
+
+    it("returns false when the webhook responds non-2xx", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+      });
+      const { sendDiscordNotification } = await loadDiscord(null);
+      const ok = await sendDiscordNotification(
+        { title: "Hi" },
+        { webhookUrl: "https://discord/x" },
+      );
+      expect(ok).toBe(false);
+    });
+
+    it("returns false and logs when fetch throws", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("ECONNRESET"));
+      const { sendDiscordNotification } = await loadDiscord(null);
+      const ok = await sendDiscordNotification(
+        { title: "Hi" },
+        { webhookUrl: "https://discord/x" },
+      );
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe("notifyPROpened", () => {
+    it("builds the BLUE-colored embed with Author + Repository fields", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyPROpened, DISCORD_COLORS } = await loadDiscord("https://d");
+      await notifyPROpened({
+        number: 7,
+        title: "Feat: add X",
+        authorLogin: "alice",
+        url: "https://github.com/x/y/pull/7",
+        repository: "x/y",
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      const embed = body.embeds[0];
+      expect(embed.title).toBe("New Pull Request #7");
+      expect(embed.color).toBe(DISCORD_COLORS.BLUE);
+      expect(embed.fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "Author",
+            value: "[@alice](https://github.com/alice)",
+          }),
+          expect.objectContaining({
+            name: "Repository",
+            value: "[x/y](https://github.com/x/y)",
+          }),
+        ]),
+      );
+      expect(embed.author).toBeUndefined();
+    });
+
+    it("attaches author block when authorAvatarUrl is provided", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyPROpened } = await loadDiscord("https://d");
+      await notifyPROpened({
+        number: 7,
+        title: "T",
+        authorLogin: "alice",
+        authorAvatarUrl: "https://avatar/a.png",
+        url: "https://x",
+        repository: "x/y",
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.embeds[0].author).toEqual({
+        name: "alice",
+        url: "https://github.com/alice",
+        icon_url: "https://avatar/a.png",
+      });
+    });
+  });
+
+  describe("notifyPRMerged", () => {
+    it("builds the GREEN-colored embed and uses prData.mergedAt as the timestamp", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyPRMerged, DISCORD_COLORS } = await loadDiscord("https://d");
+      const mergedAt = "2026-05-01T12:00:00.000Z";
+      await notifyPRMerged({
+        number: 99,
+        title: "M",
+        authorLogin: "bob",
+        url: "https://github.com/x/y/pull/99",
+        repository: "x/y",
+        mergedAt,
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      const embed = body.embeds[0];
+      expect(embed.title).toBe("Pull Request Merged #99");
+      expect(embed.color).toBe(DISCORD_COLORS.GREEN);
+      expect(embed.timestamp).toBe(mergedAt);
+    });
+
+    it("falls back to current time when mergedAt is omitted", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyPRMerged } = await loadDiscord("https://d");
+      await notifyPRMerged({
+        number: 1,
+        title: "T",
+        authorLogin: "a",
+        url: "https://x",
+        repository: "x/y",
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.embeds[0].timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+      );
+    });
+
+    it("attaches author block when authorAvatarUrl is provided", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyPRMerged } = await loadDiscord("https://d");
+      await notifyPRMerged({
+        number: 1,
+        title: "T",
+        authorLogin: "a",
+        authorAvatarUrl: "https://avatar/a.png",
+        url: "https://x",
+        repository: "x/y",
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.embeds[0].author).toMatchObject({ name: "a" });
+    });
+  });
+
+  describe("notifyHackASprintSubmissionMerged", () => {
+    it("emits the submission-style title + emerald color when submissionLogins is non-empty", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyHackASprintSubmissionMerged } = await loadDiscord("https://d");
+      await notifyHackASprintSubmissionMerged({
+        number: 200,
+        title: "merge submission",
+        authorLogin: "bot",
+        url: "https://x",
+        repository: "r",
+        submissionLogins: ["alice", "bob"],
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      const embed = body.embeds[0];
+      expect(embed.title).toBe("Hack-a-Sprint Submission Merged — PR #200");
+      expect(embed.color).toBe(0x10b981);
+      const descLines = embed.description.split("\n");
+      expect(descLines[0]).toContain("submissions from");
+      expect(descLines[0]).toContain("**alice**, **bob**");
+      expect(embed.description).toContain("git rebase upstream/develop");
+      expect(embed.fields.some((f: { name: string }) => f.name === "Submissions")).toBe(true);
+    });
+
+    it("singular description when exactly one submission login", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyHackASprintSubmissionMerged } = await loadDiscord("https://d");
+      await notifyHackASprintSubmissionMerged({
+        number: 201,
+        title: "t",
+        authorLogin: "bot",
+        url: "https://x",
+        repository: "r",
+        submissionLogins: ["alice"],
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.embeds[0].description.split("\n")[0]).toMatch(
+        /^New submission from \*\*alice\*\*/,
+      );
+    });
+
+    it("emits the merged-to-main fallback title + GREEN color when no submissions", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyHackASprintSubmissionMerged, DISCORD_COLORS } =
+        await loadDiscord("https://d");
+      await notifyHackASprintSubmissionMerged({
+        number: 300,
+        title: "regular merge",
+        authorLogin: "bot",
+        url: "https://x",
+        repository: "r",
+        submissionLogins: [],
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      const embed = body.embeds[0];
+      expect(embed.title).toBe("Merged to Main — PR #300");
+      expect(embed.color).toBe(DISCORD_COLORS.GREEN);
+      expect(embed.fields.some((f: { name: string }) => f.name === "Submissions")).toBe(false);
+    });
+
+    it("attaches author block when authorAvatarUrl provided", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+      const { notifyHackASprintSubmissionMerged } = await loadDiscord("https://d");
+      await notifyHackASprintSubmissionMerged({
+        number: 200,
+        title: "T",
+        authorLogin: "bot",
+        authorAvatarUrl: "https://avatar/b.png",
+        url: "https://x",
+        repository: "r",
+        submissionLogins: [],
+      });
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.embeds[0].author).toMatchObject({ name: "bot" });
+    });
+  });
+});

--- a/__tests__/lib/firebase-admin.test.ts
+++ b/__tests__/lib/firebase-admin.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @jest-environment node
+ */
+const mockCert = jest.fn();
+const mockGetApps = jest.fn();
+const mockInitializeApp = jest.fn();
+const mockGetAuth = jest.fn();
+const mockGetDatabase = jest.fn();
+const mockGetFirestore = jest.fn();
+
+jest.mock("firebase-admin/app", () => ({
+  cert: (...a: unknown[]) => mockCert(...a),
+  getApps: () => mockGetApps(),
+  initializeApp: (...a: unknown[]) => mockInitializeApp(...a),
+}));
+
+jest.mock("firebase-admin/auth", () => ({
+  getAuth: (...a: unknown[]) => mockGetAuth(...a),
+}));
+
+jest.mock("firebase-admin/database", () => ({
+  getDatabase: (...a: unknown[]) => mockGetDatabase(...a),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  getFirestore: (...a: unknown[]) => mockGetFirestore(...a),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+async function loadFresh() {
+  let mod: typeof import("@/lib/firebase-admin");
+  await jest.isolateModulesAsync(async () => {
+    mod = await import("@/lib/firebase-admin");
+  });
+  return mod!;
+}
+
+describe("lib/firebase-admin", () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockCert.mockReset();
+    mockGetApps.mockReset();
+    mockInitializeApp.mockReset();
+    mockGetAuth.mockReset();
+    mockGetDatabase.mockReset();
+    mockGetFirestore.mockReset();
+    delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    delete process.env.FIREBASE_DATABASE_URL;
+    delete process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL;
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe("getAdminDb", () => {
+    it("returns null when no credentials are configured", async () => {
+      mockGetApps.mockReturnValue([]);
+      const { getAdminDb } = await loadFresh();
+      expect(getAdminDb()).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("No credentials found"),
+      );
+    });
+
+    it("initializes with a service-account JSON and returns the Firestore instance", async () => {
+      const fakeApp = { name: "fake-app" };
+      const fakeFirestore = {
+        settings: jest.fn(),
+      } as unknown as ReturnType<typeof mockGetFirestore>;
+      process.env.FIREBASE_SERVICE_ACCOUNT_JSON = JSON.stringify({
+        project_id: "demo-project",
+        client_email: "x@y",
+        private_key: "k",
+      });
+      mockGetApps.mockReturnValue([]);
+      mockInitializeApp.mockReturnValue(fakeApp);
+      mockGetFirestore.mockReturnValue(fakeFirestore);
+      mockCert.mockReturnValue("cert-handle");
+
+      const { getAdminDb } = await loadFresh();
+      const db = getAdminDb();
+      expect(db).toBe(fakeFirestore);
+      expect(mockCert).toHaveBeenCalledWith({
+        project_id: "demo-project",
+        client_email: "x@y",
+        private_key: "k",
+      });
+      expect(mockInitializeApp).toHaveBeenCalledWith({
+        credential: "cert-handle",
+        projectId: "demo-project",
+        databaseURL: undefined,
+      });
+      expect(
+        (fakeFirestore as unknown as { settings: jest.Mock }).settings,
+      ).toHaveBeenCalledWith({ ignoreUndefinedProperties: true });
+    });
+
+    it("initializes with GOOGLE_APPLICATION_CREDENTIALS when service-account JSON is unset", async () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/path/sa.json";
+      process.env.FIREBASE_DATABASE_URL = "https://demo.firebaseio.com";
+      mockGetApps.mockReturnValue([]);
+      mockInitializeApp.mockReturnValue({});
+      mockGetFirestore.mockReturnValue({ settings: jest.fn() });
+      const { getAdminDb } = await loadFresh();
+      getAdminDb();
+      expect(mockInitializeApp).toHaveBeenCalledWith({
+        databaseURL: "https://demo.firebaseio.com",
+      });
+    });
+
+    it("falls back to NEXT_PUBLIC_FIREBASE_DATABASE_URL when FIREBASE_DATABASE_URL is unset", async () => {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/path/sa.json";
+      process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL =
+        "https://demo-public.firebaseio.com";
+      mockGetApps.mockReturnValue([]);
+      mockInitializeApp.mockReturnValue({});
+      mockGetFirestore.mockReturnValue({ settings: jest.fn() });
+      const { getAdminDb } = await loadFresh();
+      getAdminDb();
+      expect(mockInitializeApp).toHaveBeenCalledWith({
+        databaseURL: "https://demo-public.firebaseio.com",
+      });
+    });
+
+    it("reuses an existing initialized app from getApps()", async () => {
+      const existingApp = { name: "existing" };
+      mockGetApps.mockReturnValue([existingApp]);
+      mockGetFirestore.mockReturnValue({ settings: jest.fn() });
+      const { getAdminDb } = await loadFresh();
+      getAdminDb();
+      expect(mockInitializeApp).not.toHaveBeenCalled();
+      expect(mockGetFirestore).toHaveBeenCalledWith(existingApp);
+    });
+
+    it("caches the Firestore instance across calls", async () => {
+      mockGetApps.mockReturnValue([{ name: "a" }]);
+      mockGetFirestore.mockReturnValue({ settings: jest.fn() });
+      const { getAdminDb } = await loadFresh();
+      const a = getAdminDb();
+      const b = getAdminDb();
+      expect(a).toBe(b);
+      expect(mockGetFirestore).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows errors from db.settings() when it has already been applied", async () => {
+      mockGetApps.mockReturnValue([{ name: "a" }]);
+      const throwing = {
+        settings: jest.fn(() => {
+          throw new Error("settings already applied");
+        }),
+      };
+      mockGetFirestore.mockReturnValue(throwing);
+      const { getAdminDb } = await loadFresh();
+      const db = getAdminDb();
+      expect(db).toBe(throwing);
+    });
+
+    it("throws a helpful error when FIREBASE_SERVICE_ACCOUNT_JSON is not valid JSON", async () => {
+      process.env.FIREBASE_SERVICE_ACCOUNT_JSON = "{not-json";
+      mockGetApps.mockReturnValue([]);
+      const { getAdminDb } = await loadFresh();
+      expect(() => getAdminDb()).toThrow(
+        "FIREBASE_SERVICE_ACCOUNT_JSON is not valid JSON",
+      );
+    });
+  });
+
+  describe("getAdminAuth", () => {
+    it("returns null when no credentials are configured", async () => {
+      mockGetApps.mockReturnValue([]);
+      const { getAdminAuth } = await loadFresh();
+      expect(getAdminAuth()).toBeNull();
+    });
+
+    it("returns the Auth instance when an app is initialized", async () => {
+      mockGetApps.mockReturnValue([{ name: "a" }]);
+      const fakeAuth = { __auth: 1 };
+      mockGetAuth.mockReturnValue(fakeAuth);
+      const { getAdminAuth } = await loadFresh();
+      expect(getAdminAuth()).toBe(fakeAuth);
+    });
+
+    it("caches the Auth instance across calls", async () => {
+      mockGetApps.mockReturnValue([{ name: "a" }]);
+      mockGetAuth.mockReturnValue({ __auth: 1 });
+      const { getAdminAuth } = await loadFresh();
+      getAdminAuth();
+      getAdminAuth();
+      expect(mockGetAuth).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getAdminRtdb", () => {
+    it("returns null when no credentials are configured", async () => {
+      mockGetApps.mockReturnValue([]);
+      const { getAdminRtdb } = await loadFresh();
+      expect(getAdminRtdb()).toBeNull();
+    });
+
+    it("returns the Database instance when an app is initialized", async () => {
+      mockGetApps.mockReturnValue([{ name: "a" }]);
+      const fakeDb = { __rtdb: 1 };
+      mockGetDatabase.mockReturnValue(fakeDb);
+      const { getAdminRtdb } = await loadFresh();
+      expect(getAdminRtdb()).toBe(fakeDb);
+    });
+
+    it("caches the Database instance across calls", async () => {
+      mockGetApps.mockReturnValue([{ name: "a" }]);
+      mockGetDatabase.mockReturnValue({ __rtdb: 1 });
+      const { getAdminRtdb } = await loadFresh();
+      getAdminRtdb();
+      getAdminRtdb();
+      expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/lib/game/content-armageddon.test.ts
+++ b/__tests__/lib/game/content-armageddon.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import {
+  ARMAGEDDON_TILE_GATE,
+  ARMAGEDDON_TURN_COST,
+  BASE_SUCCESS,
+  SEAL_COUNT,
+  SUCCESS_HARD_CAP,
+  TOP_BY_TILES_SNAPSHOT_COUNT,
+  WINNER_COUNT,
+  computeArmageddonSuccessChanceFromMultiplier,
+  computeLotteryTickets,
+} from "@/lib/game/content/armageddon";
+
+describe("game/content/armageddon", () => {
+  describe("constants", () => {
+    it("ARMAGEDDON_TILE_GATE = 10,000 (unlock gate)", () => {
+      expect(ARMAGEDDON_TILE_GATE).toBe(10_000);
+    });
+
+    it("ARMAGEDDON_TURN_COST = 100 (per cast)", () => {
+      expect(ARMAGEDDON_TURN_COST).toBe(100);
+    });
+
+    it("BASE_SUCCESS, SUCCESS_HARD_CAP form a sensible probability range", () => {
+      expect(BASE_SUCCESS).toBeGreaterThan(0);
+      expect(BASE_SUCCESS).toBeLessThan(1);
+      expect(SUCCESS_HARD_CAP).toBeGreaterThan(BASE_SUCCESS);
+      expect(SUCCESS_HARD_CAP).toBeLessThanOrEqual(1);
+    });
+
+    it("SEAL_COUNT = 7 (biblical), WINNER_COUNT = 10, SNAPSHOT = 50", () => {
+      expect(SEAL_COUNT).toBe(7);
+      expect(WINNER_COUNT).toBe(10);
+      expect(TOP_BY_TILES_SNAPSHOT_COUNT).toBe(50);
+    });
+  });
+
+  describe("computeArmageddonSuccessChanceFromMultiplier", () => {
+    it("returns BASE_SUCCESS when multiplier = 1", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(1)).toBe(BASE_SUCCESS);
+    });
+
+    it("scales linearly with multiplier below the hard cap", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(2)).toBeCloseTo(BASE_SUCCESS * 2, 10);
+      expect(computeArmageddonSuccessChanceFromMultiplier(3)).toBeCloseTo(BASE_SUCCESS * 3, 10);
+    });
+
+    it("clamps at SUCCESS_HARD_CAP for very large multipliers", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(1000)).toBe(SUCCESS_HARD_CAP);
+    });
+
+    it("returns 0 when multiplier is 0", () => {
+      expect(computeArmageddonSuccessChanceFromMultiplier(0)).toBe(0);
+    });
+  });
+
+  describe("computeLotteryTickets", () => {
+    it("returns 0 when tilesHeld is 0 or negative", () => {
+      expect(computeLotteryTickets(0, 5)).toBe(0);
+      expect(computeLotteryTickets(-10, 5)).toBe(0);
+    });
+
+    it("returns tilesHeld with no seals broken (multiplier = 1)", () => {
+      expect(computeLotteryTickets(1000, 0)).toBe(1000);
+    });
+
+    it("scales by (1 + sealsBroken)", () => {
+      expect(computeLotteryTickets(1000, 1)).toBe(2000);
+      expect(computeLotteryTickets(1000, 3)).toBe(4000);
+      expect(computeLotteryTickets(1000, 6)).toBe(7000);
+    });
+
+    it("treats negative sealsBroken as 0 (defensive)", () => {
+      expect(computeLotteryTickets(1000, -1)).toBe(1000);
+    });
+  });
+});

--- a/__tests__/lib/game/content-index.test.ts
+++ b/__tests__/lib/game/content-index.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment node
+ */
+import {
+  ALL_ARTIFACTS,
+  ALL_BUILDINGS,
+  ALL_SPELLS,
+  ALL_UNITS,
+  ALL_UPGRADES,
+  ARTIFACTS_BY_ID,
+  ARTIFACTS_BY_RARITY,
+  BUILDINGS_BY_ID,
+  CASTE_PROFILES,
+  SPELLS_BY_ID,
+  UNITS_BY_ID,
+  UPGRADES_BY_ID,
+  buildingForCasteAndLand,
+  getCasteProfile,
+  getHighestUnlockedSpell,
+  getSpellForCasteAndType,
+  getSpellsForCasteAndType,
+  getUnitForCasteAndType,
+  isSpellUnlocked,
+  upgradesForTarget,
+} from "@/lib/game/content";
+
+const CASTES = ["white", "blue", "black", "red", "green"] as const;
+const UNIT_TYPES = ["ground", "siege", "air"] as const;
+const SPELL_TYPES = [
+  "defense",
+  "offense",
+  "production",
+  "intel",
+  "siege",
+  "disarm",
+  "attrition",
+] as const;
+
+describe("lib/game/content (index)", () => {
+  describe("registries", () => {
+    it("ALL_UNITS contains exactly 15 entries (5 castes × 3 types)", () => {
+      expect(ALL_UNITS).toHaveLength(15);
+    });
+
+    it("UNITS_BY_ID is keyed by id and recovers every unit", () => {
+      expect(UNITS_BY_ID.size).toBe(ALL_UNITS.length);
+      for (const u of ALL_UNITS) {
+        expect(UNITS_BY_ID.get(u.id)).toBe(u);
+      }
+    });
+
+    it("SPELLS_BY_ID is keyed by id and includes every spell from ALL_SPELLS", () => {
+      expect(SPELLS_BY_ID.size).toBe(ALL_SPELLS.length);
+      for (const s of ALL_SPELLS) {
+        expect(SPELLS_BY_ID.get(s.id)).toBe(s);
+      }
+    });
+
+    it("BUILDINGS_BY_ID is keyed by id", () => {
+      expect(BUILDINGS_BY_ID.size).toBe(ALL_BUILDINGS.length);
+    });
+
+    it("UPGRADES_BY_ID is keyed by id", () => {
+      expect(UPGRADES_BY_ID.size).toBe(ALL_UPGRADES.length);
+    });
+
+    it("ALL_SPELLS includes the armageddon spell catalog", () => {
+      const armageddon = ALL_SPELLS.filter((s) => s.type === "armageddon");
+      expect(armageddon.length).toBeGreaterThan(0);
+    });
+
+    it("CASTE_PROFILES + getCasteProfile expose all 5 castes", () => {
+      for (const c of CASTES) {
+        expect(getCasteProfile(c)).toBe(CASTE_PROFILES[c]);
+      }
+    });
+
+    it("ARTIFACTS_BY_ID + ARTIFACTS_BY_RARITY mirror ALL_ARTIFACTS", () => {
+      for (const a of ALL_ARTIFACTS) {
+        expect(ARTIFACTS_BY_ID.get(a.id)).toBe(a);
+      }
+      expect(ARTIFACTS_BY_RARITY).toBeDefined();
+    });
+  });
+
+  describe("getUnitForCasteAndType", () => {
+    it("returns a unit for every (caste, type) combination", () => {
+      for (const caste of CASTES) {
+        for (const type of UNIT_TYPES) {
+          const u = getUnitForCasteAndType(caste, type);
+          expect(u.caste).toBe(caste);
+          expect(u.type).toBe(type);
+        }
+      }
+    });
+
+    it("throws when an unknown caste/type pair is requested", () => {
+      expect(() =>
+        getUnitForCasteAndType("white", "mystery" as unknown as typeof UNIT_TYPES[number]),
+      ).toThrow(/No unit registered/);
+    });
+  });
+
+  describe("getSpellForCasteAndType", () => {
+    it("returns the tier-1 spell for caste/types that have one", () => {
+      let resolved = 0;
+      for (const caste of CASTES) {
+        for (const type of SPELL_TYPES) {
+          try {
+            const s = getSpellForCasteAndType(caste, type);
+            expect(s.caste).toBe(caste);
+            expect(s.type).toBe(type);
+            expect(s.tier).toBe(1);
+            resolved++;
+          } catch {
+            // Some caste/type pairs may not have a tier-1 registered.
+          }
+        }
+      }
+      // Sanity: at least the canonical "white defense" tier-1 is registered.
+      expect(resolved).toBeGreaterThan(0);
+    });
+
+    it("throws when no tier-1 spell exists for a (caste, type)", () => {
+      expect(() =>
+        getSpellForCasteAndType("white", "armageddon"),
+      ).toThrow(/No tier-1 spell/);
+    });
+  });
+
+  describe("getSpellsForCasteAndType", () => {
+    it("returns all tiers sorted ascending", () => {
+      const spells = getSpellsForCasteAndType("white", "defense");
+      expect(spells.length).toBeGreaterThan(0);
+      const tiers = spells.map((s) => s.tier);
+      const sorted = [...tiers].sort((a, b) => a - b);
+      expect(tiers).toEqual(sorted);
+    });
+  });
+
+  describe("getHighestUnlockedSpell / isSpellUnlocked", () => {
+    it("returns the tier-1 spell when tilesHeld is 0", () => {
+      const s = getHighestUnlockedSpell("white", "defense", 0);
+      expect(s.tier).toBe(1);
+    });
+
+    it("returns a higher tier as tilesHeld grows past minTilesRequired", () => {
+      const tiers = getSpellsForCasteAndType("white", "defense");
+      const top = tiers[tiers.length - 1]!;
+      const out = getHighestUnlockedSpell("white", "defense", top.minTilesRequired);
+      expect(out.id).toBe(top.id);
+    });
+
+    it("isSpellUnlocked is true iff tilesHeld >= minTilesRequired", () => {
+      const tiers = getSpellsForCasteAndType("white", "defense");
+      const last = tiers[tiers.length - 1]!;
+      expect(isSpellUnlocked(last, last.minTilesRequired - 1)).toBe(false);
+      expect(isSpellUnlocked(last, last.minTilesRequired)).toBe(true);
+    });
+  });
+
+  describe("buildingForCasteAndLand", () => {
+    it("returns a building for known caste+landType pairs", () => {
+      const first = ALL_BUILDINGS[0];
+      if (!first) return;
+      const b = buildingForCasteAndLand(first.caste, first.landType);
+      expect(b).toBeDefined();
+      expect(b?.caste).toBe(first.caste);
+    });
+
+    it("returns undefined for unknown landType", () => {
+      expect(
+        buildingForCasteAndLand(
+          "white",
+          "moon" as unknown as ReturnType<typeof buildingForCasteAndLand> extends infer R ? R extends { landType: infer L } ? L : never : never,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("upgradesForTarget", () => {
+    it("returns upgrades whose targetId matches", () => {
+      const known = ALL_UPGRADES[0];
+      if (!known) return;
+      const out = upgradesForTarget(known.targetId);
+      expect(out.length).toBeGreaterThan(0);
+      for (const u of out) expect(u.targetId).toBe(known.targetId);
+    });
+
+    it("returns [] when no upgrades match", () => {
+      expect(upgradesForTarget("nonexistent-target-id")).toEqual([]);
+    });
+  });
+});

--- a/__tests__/lib/game/hero-registry-events.test.ts
+++ b/__tests__/lib/game/hero-registry-events.test.ts
@@ -1,0 +1,379 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the heroEvent payload-builder namespace + viewerWasOwner.
+ * The InTx writer helpers (upsertHeroInTx, markHeroDeceasedInTx, etc.)
+ * each take a Transaction; we exercise them via a fake-tx so we can
+ * assert their argument shape without standing up a real Firestore.
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  HEROES_COLLECTION,
+  HERO_EVENTS_SUBCOLLECTION,
+  appendHeroEventInTx,
+  clearHeroForArmageddonInTx,
+  heroEvent,
+  heroEventsCollection,
+  markHeroDeceasedInTx,
+  transferHeroOwnerInTx,
+  upsertHeroInTx,
+  viewerWasOwner,
+} from "@/lib/game/hero-registry";
+import type { GameHero } from "@/lib/game/types";
+
+function fakeRef(): unknown {
+  return { __fakeRef: true };
+}
+
+function fakeDb() {
+  const collectionCalls: string[] = [];
+  const docCalls: string[] = [];
+  const db = {
+    collection: (name: string) => {
+      collectionCalls.push(name);
+      return {
+        doc: (id: string) => {
+          docCalls.push(`${name}/${id}`);
+          return {
+            __fakeRef: true,
+            collection: (sub: string) => {
+              collectionCalls.push(`${name}/${id}/${sub}`);
+              return {
+                doc: (eid: string) => {
+                  docCalls.push(`${name}/${id}/${sub}/${eid}`);
+                  return { __fakeRef: true };
+                },
+                where: () => ({
+                  limit: () => ({
+                    get: async () => ({ empty: false }),
+                  }),
+                }),
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Firestore;
+  return { db, collectionCalls, docCalls };
+}
+
+function fakeTx() {
+  const sets: Array<{ ref: unknown; data: Record<string, unknown>; opts?: unknown }> = [];
+  const tx = {
+    set: (ref: unknown, data: Record<string, unknown>, opts?: unknown) => {
+      sets.push({ ref, data, opts });
+    },
+  } as unknown as Transaction;
+  return { tx, sets };
+}
+
+describe("hero-registry — constants + ref helpers", () => {
+  it("exposes collection + subcollection names", () => {
+    expect(HEROES_COLLECTION).toBe("game_heroes");
+    expect(HERO_EVENTS_SUBCOLLECTION).toBe("events");
+  });
+
+  it("heroEventsCollection points at game_heroes/{id}/events", () => {
+    const { db, collectionCalls } = fakeDb();
+    heroEventsCollection(db, "h-1");
+    expect(collectionCalls).toContain("game_heroes");
+    expect(collectionCalls).toContain("game_heroes/h-1/events");
+  });
+});
+
+describe("hero-registry — InTx writers", () => {
+  const baseHero: GameHero = {
+    id: "h-1",
+    name: "Aria",
+    class: "warrior",
+    specialty: "siege",
+    caste: "red",
+    ownerId: "u-owner",
+    tileId: "tile-1",
+    stamina: 5,
+    staminaMax: 10,
+    emergedAtTurn: 10,
+  } as unknown as GameHero;
+
+  describe("upsertHeroInTx", () => {
+    it("writes a merge: true patch with the hero fields", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      upsertHeroInTx({ tx, db, hero: baseHero, seasonNumber: 3, now: new Date("2026-01-01") });
+      expect(sets).toHaveLength(1);
+      expect(sets[0].opts).toEqual({ merge: true });
+      const data = sets[0].data;
+      expect(data.id).toBe("h-1");
+      expect(data.currentOwnerId).toBe("u-owner");
+      expect(data.currentTileId).toBe("tile-1");
+      expect(data.emergedSeasonNumber).toBe(3);
+      expect(data.isDeceased).toBe(false);
+      expect(data.awaitingResurrection).toBe(false);
+    });
+  });
+
+  describe("appendHeroEventInTx", () => {
+    it("writes the event under the hero's events subcollection and returns the id", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      const id = appendHeroEventInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        event: heroEvent.emerged({ tileId: "t-1", ownerId: "u-1" } as GameHero, 1),
+        now: new Date("2026-01-01"),
+      });
+      expect(typeof id).toBe("string");
+      // Two sets: the event doc, then the parent hero's lastEventAt bump.
+      expect(sets.length).toBeGreaterThanOrEqual(1);
+      const eventWrite = sets[0];
+      const ev = eventWrite.data;
+      expect(ev.id).toBe(id);
+      expect(ev.kind).toBe("emerged");
+      expect(ev.tileId).toBe("t-1");
+    });
+
+    it("strips undefined optional fields from the event payload", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      appendHeroEventInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        event: heroEvent.emerged({ tileId: "t-1", ownerId: "u-1" } as GameHero, 1),
+        now: new Date(),
+      });
+      const ev = sets[0].data;
+      // emerged events have no attackerId / defenderId / outcome
+      expect("attackerId" in ev).toBe(false);
+      expect("defenderId" in ev).toBe(false);
+      expect("outcome" in ev).toBe(false);
+    });
+  });
+
+  describe("markHeroDeceasedInTx", () => {
+    it("sets deceased flags and clears location fields", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      markHeroDeceasedInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        deceasedTileId: "tile-9",
+        now: new Date("2026-01-01"),
+      });
+      const d = sets[0].data;
+      expect(d.isDeceased).toBe(true);
+      expect(d.awaitingResurrection).toBe(false);
+      expect(d.deceasedTileId).toBe("tile-9");
+      expect(d.currentTileId).toBeNull();
+      expect(d.currentOwnerId).toBeNull();
+      expect(d.stamina).toBe(0);
+    });
+  });
+
+  describe("transferHeroOwnerInTx", () => {
+    it("patches ownerId, tileId and stamina with merge: true", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      transferHeroOwnerInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        newOwnerId: "u-new",
+        newTileId: "tile-new",
+        newStamina: 7,
+        now: new Date(),
+      });
+      expect(sets[0].opts).toEqual({ merge: true });
+      expect(sets[0].data.currentOwnerId).toBe("u-new");
+      expect(sets[0].data.currentTileId).toBe("tile-new");
+      expect(sets[0].data.stamina).toBe(7);
+    });
+  });
+
+  describe("clearHeroForArmageddonInTx", () => {
+    it("flips alive heroes to limbo (awaitingResurrection)", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      clearHeroForArmageddonInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        seasonNumber: 4,
+        wasAlive: true,
+        tileIdAtSeasonEnd: "tile-9",
+        ownerIdAtSeasonEnd: "u-9",
+        now: new Date(),
+      });
+      expect(sets[0].data.awaitingResurrection).toBe(true);
+      expect(sets[0].data.currentOwnerId).toBeNull();
+      expect(sets[0].data.currentTileId).toBeNull();
+    });
+
+    it("is a no-op for deceased heroes (no tx.set)", () => {
+      const { db } = fakeDb();
+      const { tx, sets } = fakeTx();
+      clearHeroForArmageddonInTx({
+        tx,
+        db,
+        heroId: "h-1",
+        seasonNumber: 4,
+        wasAlive: false,
+        tileIdAtSeasonEnd: "tile-9",
+        ownerIdAtSeasonEnd: "u-9",
+        now: new Date(),
+      });
+      expect(sets).toHaveLength(0);
+    });
+  });
+});
+
+describe("hero-registry — heroEvent payload builders", () => {
+  it("emerged carries kind + tileId + ownerIdAtTime + seasonNumber", () => {
+    const ev = heroEvent.emerged({ tileId: "t", ownerId: "o" } as GameHero, 5);
+    expect(ev).toMatchObject({
+      kind: "emerged",
+      tileId: "t",
+      ownerIdAtTime: "o",
+      seasonNumber: 5,
+    });
+  });
+
+  it("engagedAttacker carries combat-specific fields", () => {
+    const ev = heroEvent.engagedAttacker({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      defenderId: "d",
+      targetTileId: "tt",
+      outcome: "victory",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({
+      kind: "engaged_attacker",
+      defenderId: "d",
+      targetTileId: "tt",
+      outcome: "victory",
+    });
+  });
+
+  it("engagedDefender carries attackerId + outcome", () => {
+    const ev = heroEvent.engagedDefender({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      attackerId: "a",
+      outcome: "loss",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({
+      kind: "engaged_defender",
+      attackerId: "a",
+      outcome: "loss",
+    });
+  });
+
+  it("slain carries attackerId", () => {
+    const ev = heroEvent.slain({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      attackerId: "a",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "slain", attackerId: "a" });
+  });
+
+  it("defected sets ownerIdAtTime = fromOwnerId", () => {
+    const ev = heroEvent.defected({
+      tileId: "t",
+      fromOwnerId: "f",
+      toOwnerId: "to",
+      seasonNumber: 1,
+    });
+    expect(ev.ownerIdAtTime).toBe("f");
+    expect(ev).toMatchObject({ kind: "defected", fromOwnerId: "f", toOwnerId: "to" });
+  });
+
+  it("movedOnCapture carries fromTileId", () => {
+    const ev = heroEvent.movedOnCapture({
+      tileId: "to",
+      fromTileId: "from",
+      ownerIdAtTime: "o",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "moved_on_capture", fromTileId: "from" });
+  });
+
+  it("spellCast carries spellId + targetTileId", () => {
+    const ev = heroEvent.spellCast({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      spellId: "fireball",
+      targetTileId: "tt",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "spell_cast", spellId: "fireball", targetTileId: "tt" });
+  });
+
+  it("recruited carries unitType + unitsBuilt", () => {
+    const ev = heroEvent.recruited({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      unitType: "ground" as unknown as ReturnType<typeof heroEvent.recruited>["unitType"],
+      unitsBuilt: 25,
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "recruited", unitsBuilt: 25 });
+  });
+
+  it("specialUnitSummoned carries specialUnitDefId", () => {
+    const ev = heroEvent.specialUnitSummoned({
+      tileId: "t",
+      ownerIdAtTime: "o",
+      specialUnitDefId: "dragon",
+      seasonNumber: 1,
+    });
+    expect(ev).toMatchObject({ kind: "special_unit_summoned", specialUnitDefId: "dragon" });
+  });
+
+  it("seasonEnded accepts a null ownerIdAtTime (deceased heroes)", () => {
+    const ev = heroEvent.seasonEnded({ tileId: "t", ownerIdAtTime: null, seasonNumber: 1 });
+    expect(ev).toMatchObject({ kind: "season_ended", ownerIdAtTime: null });
+  });
+});
+
+describe("hero-registry — viewerWasOwner", () => {
+  it("returns true when at least one event has ownerIdAtTime == viewer", async () => {
+    const db = {
+      collection: () => ({
+        doc: () => ({
+          collection: () => ({
+            where: () => ({
+              limit: () => ({
+                get: async () => ({ empty: false }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as Firestore;
+    expect(await viewerWasOwner(db, "h-1", "u-1")).toBe(true);
+  });
+
+  it("returns false when the query returns no events", async () => {
+    const db = {
+      collection: () => ({
+        doc: () => ({
+          collection: () => ({
+            where: () => ({
+              limit: () => ({
+                get: async () => ({ empty: true }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as Firestore;
+    expect(await viewerWasOwner(db, "h-1", "u-1")).toBe(false);
+  });
+});

--- a/__tests__/lib/game/orders.test.ts
+++ b/__tests__/lib/game/orders.test.ts
@@ -1,0 +1,368 @@
+/**
+ * @jest-environment node
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  QueuedOrderForbiddenError,
+  QueuedOrderInvalidParamsError,
+  QueuedOrderNotFoundError,
+  QueuedOrderQueueFullError,
+  cancelOrderServer,
+  enqueueOrderServer,
+  listOrdersForPlayerServer,
+  markOrderResultInTx,
+  readQueuedOrdersForPlayer,
+} from "@/lib/game/orders";
+import type {
+  QueuedOrder,
+  QueuedOrderParams,
+} from "@/lib/game/types";
+import { QUEUED_ORDERS_MAX_PER_PLAYER } from "@/lib/game/types";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+import { getAdminDb } from "@/lib/firebase-admin";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+type QueuedDoc = { data: () => QueuedOrder };
+
+function fakeDb(opts: {
+  queueDocs?: QueuedOrder[];
+  setSink?: { id?: string; data?: unknown };
+  cancelInitial?: QueuedOrder | null;
+  cancelExists?: boolean;
+  txUpdateSink?: { ref?: unknown; updates?: Partial<QueuedOrder> };
+}): Firestore {
+  return {
+    collection: (_name: string) => ({
+      doc: (id: string) => ({
+        set: async (data: unknown) => {
+          if (opts.setSink) {
+            opts.setSink.id = id;
+            opts.setSink.data = data;
+          }
+          return undefined;
+        },
+      }),
+      where: (..._args: unknown[]) => ({
+        where: (..._args2: unknown[]) => ({
+          get: async () => ({
+            size: opts.queueDocs?.length ?? 0,
+            docs: (opts.queueDocs ?? []).map<QueuedDoc>((q) => ({ data: () => q })),
+          }),
+        }),
+        get: async () => ({
+          docs: (opts.queueDocs ?? []).map<QueuedDoc>((q) => ({ data: () => q })),
+        }),
+      }),
+    }),
+    runTransaction: async (cb: (tx: Transaction) => Promise<QueuedOrder>) => {
+      const tx = {
+        get: async (_ref: unknown) => ({
+          exists: opts.cancelExists ?? !!opts.cancelInitial,
+          data: () => opts.cancelInitial,
+        }),
+        update: (ref: unknown, updates: Partial<QueuedOrder>) => {
+          if (opts.txUpdateSink) {
+            opts.txUpdateSink.ref = ref;
+            opts.txUpdateSink.updates = updates;
+          }
+        },
+      } as unknown as Transaction;
+      return cb(tx);
+    },
+  } as unknown as Firestore;
+}
+
+describe("game/orders", () => {
+  beforeEach(() => mockGetAdminDb.mockReset());
+
+  describe("error classes", () => {
+    it("QueuedOrderQueueFullError carries cap in the message", () => {
+      const err = new QueuedOrderQueueFullError(5);
+      expect(err.message).toContain("5");
+      expect(err.cap).toBe(5);
+      expect(err.name).toBe("QueuedOrderQueueFullError");
+    });
+    it("QueuedOrderNotFoundError + QueuedOrderForbiddenError have stable names", () => {
+      expect(new QueuedOrderNotFoundError().name).toBe("QueuedOrderNotFoundError");
+      expect(new QueuedOrderForbiddenError().name).toBe("QueuedOrderForbiddenError");
+    });
+    it("QueuedOrderInvalidParamsError preserves the message", () => {
+      expect(new QueuedOrderInvalidParamsError("bad").message).toBe("bad");
+    });
+  });
+
+  describe("enqueueOrderServer — param validation", () => {
+    it("rejects recruit_on_tile with missing tileId", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "recruit_on_tile",
+        tileId: "",
+        unitType: "ground",
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "recruit_on_tile", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects recruit_on_tile with invalid unitType", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "recruit_on_tile",
+        tileId: "t",
+        unitType: "horse",
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "recruit_on_tile", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects attack_adjacent with missing tile ids", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "attack_adjacent",
+        sourceTileId: "",
+        targetTileId: "",
+        units: { ground: 1, siege: 0, air: 0 },
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "attack_adjacent", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects attack_adjacent with negative units", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "attack_adjacent",
+        sourceTileId: "s",
+        targetTileId: "t",
+        units: { ground: -1, siege: 0, air: 0 },
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "attack_adjacent", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects attack_adjacent sending 0 total units", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const params = {
+        kind: "attack_adjacent",
+        sourceTileId: "s",
+        targetTileId: "t",
+        units: { ground: 0, siege: 0, air: 0 },
+      } as unknown as QueuedOrderParams;
+      await expect(
+        enqueueOrderServer({ playerId: "p", kind: "attack_adjacent", params })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects cast_spell_on_tile with missing tileId or spellId", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        enqueueOrderServer({
+          playerId: "p",
+          kind: "cast_spell_on_tile",
+          params: { kind: "cast_spell_on_tile", tileId: "t", spellId: "" } as QueuedOrderParams,
+        })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+
+    it("rejects when params.kind doesn't match the requested kind", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        enqueueOrderServer({
+          playerId: "p",
+          kind: "recruit_on_tile",
+          params: {
+            kind: "cast_spell_on_tile",
+            tileId: "t",
+            spellId: "s",
+          } as QueuedOrderParams,
+        })
+      ).rejects.toThrow(QueuedOrderInvalidParamsError);
+    });
+  });
+
+  describe("enqueueOrderServer — queue cap + happy path", () => {
+    it("throws QueuedOrderQueueFullError at cap", async () => {
+      const full: QueuedOrder[] = Array(QUEUED_ORDERS_MAX_PER_PLAYER).fill({
+        id: "x",
+        playerId: "p",
+        status: "queued",
+        sequenceIndex: 0,
+      } as unknown as QueuedOrder);
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ queueDocs: full }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        enqueueOrderServer({
+          playerId: "p",
+          kind: "recruit_on_tile",
+          params: {
+            kind: "recruit_on_tile",
+            tileId: "t",
+            unitType: "ground",
+          } as QueuedOrderParams,
+        })
+      ).rejects.toThrow(QueuedOrderQueueFullError);
+    });
+
+    it("persists a new order with sequenceIndex = current queue size", async () => {
+      const sink: { id?: string; data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ queueDocs: [{} as QueuedOrder, {} as QueuedOrder], setSink: sink }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await enqueueOrderServer({
+        playerId: "p",
+        kind: "recruit_on_tile",
+        params: {
+          kind: "recruit_on_tile",
+          tileId: "t",
+          unitType: "ground",
+        } as QueuedOrderParams,
+      });
+      expect(out.sequenceIndex).toBe(2);
+      expect(out.status).toBe("queued");
+      expect(out.playerId).toBe("p");
+      expect(sink.data).toBeDefined();
+    });
+  });
+
+  describe("listOrdersForPlayerServer + readQueuedOrdersForPlayer", () => {
+    it("returns orders sorted by sequenceIndex", async () => {
+      const orders: QueuedOrder[] = [
+        { sequenceIndex: 2 } as unknown as QueuedOrder,
+        { sequenceIndex: 0 } as unknown as QueuedOrder,
+        { sequenceIndex: 1 } as unknown as QueuedOrder,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ queueDocs: orders }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listOrdersForPlayerServer("p", false);
+      expect(out.map((o) => o.sequenceIndex)).toEqual([0, 1, 2]);
+    });
+
+    it("readQueuedOrdersForPlayer returns queued-only sorted", async () => {
+      const orders: QueuedOrder[] = [
+        { sequenceIndex: 1 } as unknown as QueuedOrder,
+        { sequenceIndex: 0 } as unknown as QueuedOrder,
+      ];
+      const db = fakeDb({ queueDocs: orders });
+      const out = await readQueuedOrdersForPlayer(db, "p");
+      expect(out.map((o) => o.sequenceIndex)).toEqual([0, 1]);
+    });
+  });
+
+  describe("cancelOrderServer", () => {
+    it("throws QueuedOrderNotFoundError when the order doesn't exist", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ cancelExists: false }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        cancelOrderServer({ orderId: "o", callerUserId: "p" })
+      ).rejects.toThrow(QueuedOrderNotFoundError);
+    });
+
+    it("throws QueuedOrderForbiddenError when caller is not the owner", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          cancelExists: true,
+          cancelInitial: {
+            id: "o",
+            playerId: "owner",
+            status: "queued",
+          } as unknown as QueuedOrder,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        cancelOrderServer({ orderId: "o", callerUserId: "other" })
+      ).rejects.toThrow(QueuedOrderForbiddenError);
+    });
+
+    it("returns the order unchanged when already non-queued (idempotent)", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          cancelExists: true,
+          cancelInitial: {
+            id: "o",
+            playerId: "p",
+            status: "executed",
+          } as unknown as QueuedOrder,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await cancelOrderServer({ orderId: "o", callerUserId: "p" });
+      expect(out.status).toBe("executed");
+    });
+
+    it("marks the order cancelled when it's currently queued", async () => {
+      const updateSink: { ref?: unknown; updates?: Partial<QueuedOrder> } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          cancelExists: true,
+          cancelInitial: {
+            id: "o",
+            playerId: "p",
+            status: "queued",
+          } as unknown as QueuedOrder,
+          txUpdateSink: updateSink,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await cancelOrderServer({ orderId: "o", callerUserId: "p" });
+      expect(out.status).toBe("cancelled");
+      expect(updateSink.updates?.status).toBe("cancelled");
+      expect(updateSink.updates?.resultSummary).toBe("Cancelled by player");
+    });
+  });
+
+  describe("markOrderResultInTx", () => {
+    it("emits a tx.update with status + resultSummary + executedAt", () => {
+      const updateSink: { ref?: unknown; updates?: Partial<QueuedOrder> } = {};
+      const tx = {
+        update: (ref: unknown, updates: Partial<QueuedOrder>) => {
+          updateSink.ref = ref;
+          updateSink.updates = updates;
+        },
+      } as unknown as Transaction;
+      const db = {
+        collection: () => ({ doc: () => ({ __ref: true }) }),
+      } as unknown as Firestore;
+
+      markOrderResultInTx({
+        tx,
+        db,
+        order: { id: "o" } as QueuedOrder,
+        status: "executed",
+        resultSummary: "done",
+        now: new Date("2026-01-01"),
+      });
+      expect(updateSink.updates?.status).toBe("executed");
+      expect(updateSink.updates?.resultSummary).toBe("done");
+    });
+
+    it("includes resultRefId when provided", () => {
+      const updateSink: { ref?: unknown; updates?: Partial<QueuedOrder> } = {};
+      const tx = {
+        update: (ref: unknown, updates: Partial<QueuedOrder>) => {
+          updateSink.ref = ref;
+          updateSink.updates = updates;
+        },
+      } as unknown as Transaction;
+      const db = {
+        collection: () => ({ doc: () => ({ __ref: true }) }),
+      } as unknown as Firestore;
+      markOrderResultInTx({
+        tx,
+        db,
+        order: { id: "o" } as QueuedOrder,
+        status: "failed",
+        resultSummary: "boom",
+        resultRefId: "ref-1",
+        now: new Date(),
+      });
+      expect(updateSink.updates?.resultRefId).toBe("ref-1");
+    });
+  });
+});

--- a/__tests__/lib/game/pacts.test.ts
+++ b/__tests__/lib/game/pacts.test.ts
@@ -1,0 +1,404 @@
+/**
+ * @jest-environment node
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  MAX_PACT_STATEMENT_LENGTH,
+  PactEmptyError,
+  PactForbiddenError,
+  PactNotFoundError,
+  PactSelfTargetError,
+  PactTargetNotFoundError,
+  PactTooLongError,
+  createPactServer,
+  deletePactServer,
+  findActivePactsBetween,
+  listPactsForPlayerServer,
+  markPactsBrokenInTx,
+} from "@/lib/game/pacts";
+import type { Pact } from "@/lib/game/types";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeText: (s: string) => s.trim(),
+}));
+jest.mock("@/lib/game/community", () => ({
+  logCommunityEventInTx: jest.fn(),
+}));
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logCommunityEventInTx } from "@/lib/game/community";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockLogCommunityEvent = logCommunityEventInTx as jest.MockedFunction<typeof logCommunityEventInTx>;
+
+type CollectionStub = {
+  doc: (id: string) => DocStub;
+  where: (...args: unknown[]) => QueryStub;
+};
+type DocStub = {
+  get: () => Promise<{ exists: boolean; data?: () => unknown; ref?: unknown }>;
+  set: (data: unknown) => Promise<void>;
+  update: (data: unknown) => Promise<void>;
+};
+type QueryStub = {
+  where: (...args: unknown[]) => QueryStub;
+  get: () => Promise<{ docs: Array<{ data: () => unknown; ref: unknown }>; empty: boolean }>;
+};
+
+function fakeDb(opts: {
+  targetDoc?: { exists: boolean; data?: unknown };
+  pactDocs?: Pact[];
+  pactDoc?: { exists: boolean; data?: Pact };
+  updateSink?: { data?: unknown };
+  setSink?: { id?: string; data?: unknown };
+}): Firestore {
+  const mkDoc = (id: string): DocStub => ({
+    get: async () => {
+      const td = opts.targetDoc;
+      const pd = opts.pactDoc;
+      if (id === "player-target") {
+        return { exists: !!td?.exists, data: () => td?.data };
+      }
+      return {
+        exists: !!pd?.exists,
+        data: () => pd?.data,
+        ref: { __ref: id },
+      };
+    },
+    set: async (data: unknown) => {
+      if (opts.setSink) {
+        opts.setSink.id = id;
+        opts.setSink.data = data;
+      }
+    },
+    update: async (data: unknown) => {
+      if (opts.updateSink) {
+        opts.updateSink.data = data;
+      }
+    },
+  });
+  const mkQuery = (): QueryStub => ({
+    where: () => mkQuery(),
+    get: async () => ({
+      docs: (opts.pactDocs ?? []).map((p) => ({
+        data: () => p,
+        ref: { __ref: p.id },
+      })),
+      empty: (opts.pactDocs ?? []).length === 0,
+    }),
+  });
+  const collection = (_name: string): CollectionStub => ({
+    doc: mkDoc,
+    where: () => mkQuery(),
+  });
+  return { collection } as unknown as Firestore;
+}
+
+describe("game/pacts", () => {
+  beforeEach(() => {
+    mockGetAdminDb.mockReset();
+    mockLogCommunityEvent.mockReset();
+  });
+
+  describe("error classes", () => {
+    it("PactEmptyError, PactTooLongError, PactSelfTargetError, PactTargetNotFoundError, PactForbiddenError, PactNotFoundError all have stable names", () => {
+      expect(new PactEmptyError().name).toBe("PactEmptyError");
+      expect(new PactTooLongError().name).toBe("PactTooLongError");
+      expect(new PactSelfTargetError().name).toBe("PactSelfTargetError");
+      expect(new PactTargetNotFoundError().name).toBe("PactTargetNotFoundError");
+      expect(new PactForbiddenError().name).toBe("PactForbiddenError");
+      expect(new PactNotFoundError().name).toBe("PactNotFoundError");
+    });
+
+    it("PactTooLongError message mentions the length cap", () => {
+      expect(new PactTooLongError().message).toContain(String(MAX_PACT_STATEMENT_LENGTH));
+    });
+  });
+
+  describe("createPactServer", () => {
+    const author = { userId: "u-author", displayName: "Alice", caste: "red" as const };
+
+    it("rejects self-target", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createPactServer({ author, targetId: author.userId, rawStatement: "hi" })
+      ).rejects.toThrow(PactSelfTargetError);
+    });
+
+    it("rejects empty statement (after sanitize)", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createPactServer({ author, targetId: "u-other", rawStatement: "   " })
+      ).rejects.toThrow(PactEmptyError);
+    });
+
+    it("rejects too-long statement", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const long = "x".repeat(MAX_PACT_STATEMENT_LENGTH + 1);
+      await expect(
+        createPactServer({ author, targetId: "u-other", rawStatement: long })
+      ).rejects.toThrow(PactTooLongError);
+    });
+
+    it("rejects when target doesn't exist", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ targetDoc: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        createPactServer({ author, targetId: "player-target", rawStatement: "hi" })
+      ).rejects.toThrow(PactTargetNotFoundError);
+    });
+
+    it("creates a pact and returns the full record", async () => {
+      const setSink: { id?: string; data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          targetDoc: {
+            exists: true,
+            data: { displayName: "Bob", caste: "blue" },
+          },
+          setSink,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const pact = await createPactServer({
+        author,
+        targetId: "player-target",
+        rawStatement: "no attack for 7 days",
+      });
+      expect(pact.authorId).toBe("u-author");
+      expect(pact.targetDisplayName).toBe("Bob");
+      expect(pact.statement).toBe("no attack for 7 days");
+      expect(pact.expiresAt instanceof Date).toBe(true);
+    });
+
+    it("falls back to 'Unknown general' when target has no displayName", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ targetDoc: { exists: true, data: {} } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const pact = await createPactServer({
+        author,
+        targetId: "player-target",
+        rawStatement: "hi",
+      });
+      expect(pact.targetDisplayName).toBe("Unknown general");
+      expect(pact.targetCaste).toBeNull();
+    });
+  });
+
+  describe("listPactsForPlayerServer", () => {
+    it("returns deduplicated pacts sorted by expiresAt desc, skipping deleted", async () => {
+      const now = new Date();
+      const pacts: Pact[] = [
+        {
+          id: "p1",
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "p2",
+          expiresAt: new Date(now.getTime() + 50_000),
+        } as unknown as Pact,
+        {
+          id: "p1", // dup
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "p3",
+          deletedAt: now, // skipped
+          expiresAt: new Date(now.getTime() + 200_000),
+        } as unknown as Pact,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ pactDocs: pacts }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPactsForPlayerServer("u1");
+      expect(out.map((p) => p.id)).toEqual(["p1", "p2"]);
+    });
+
+    it("handles timestamp-shaped expiresAt fields (seconds)", async () => {
+      const now = Date.now() / 1000;
+      const pacts: Pact[] = [
+        {
+          id: "tsa",
+          expiresAt: { seconds: now + 200 } as unknown as Date,
+        } as unknown as Pact,
+        {
+          id: "tsb",
+          expiresAt: { seconds: now + 100 } as unknown as Date,
+        } as unknown as Pact,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ pactDocs: pacts }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPactsForPlayerServer("u1");
+      expect(out.map((p) => p.id)).toEqual(["tsa", "tsb"]);
+    });
+  });
+
+  describe("deletePactServer", () => {
+    it("throws PactNotFoundError when pact doesn't exist", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ pactDoc: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deletePactServer({ pactId: "p", callerUserId: "u", callerIsAdmin: false })
+      ).rejects.toThrow(PactNotFoundError);
+    });
+
+    it("throws PactForbiddenError when non-author non-admin caller tries to delete", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          pactDoc: { exists: true, data: { authorId: "other" } as Pact },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deletePactServer({ pactId: "p", callerUserId: "me", callerIsAdmin: false })
+      ).rejects.toThrow(PactForbiddenError);
+    });
+
+    it("allows author to delete (sets deletedByAdmin=false)", async () => {
+      const updateSink: { data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          pactDoc: { exists: true, data: { id: "p", authorId: "me" } as Pact },
+          updateSink,
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deletePactServer({
+        pactId: "p",
+        callerUserId: "me",
+        callerIsAdmin: false,
+      });
+      expect(out.deletedAt).toBeInstanceOf(Date);
+      expect(out.deletedByAdmin).toBe(false);
+      expect((updateSink.data as { deletedByAdmin: boolean }).deletedByAdmin).toBe(false);
+    });
+
+    it("allows admin to delete (sets deletedByAdmin=true when not author)", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          pactDoc: { exists: true, data: { id: "p", authorId: "other" } as Pact },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deletePactServer({
+        pactId: "p",
+        callerUserId: "admin",
+        callerIsAdmin: true,
+      });
+      expect(out.deletedByAdmin).toBe(true);
+    });
+  });
+
+  describe("findActivePactsBetween", () => {
+    const now = new Date();
+
+    it("returns [] when no pacts exist", async () => {
+      const db = fakeDb({ pactDocs: [] });
+      expect(
+        await findActivePactsBetween({ db, attackerId: "a", defenderId: "d", now })
+      ).toEqual([]);
+    });
+
+    it("filters out deleted, broken, and expired pacts", async () => {
+      const pacts: Pact[] = [
+        {
+          id: "active",
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "deleted",
+          deletedAt: now,
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "broken",
+          brokenAt: now,
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+        {
+          id: "expired",
+          expiresAt: new Date(now.getTime() - 1),
+        } as unknown as Pact,
+      ];
+      const db = fakeDb({ pactDocs: pacts });
+      const out = await findActivePactsBetween({
+        db,
+        attackerId: "a",
+        defenderId: "d",
+        now,
+      });
+      expect(out.map((p) => p.id)).toEqual(["active"]);
+    });
+  });
+
+  describe("markPactsBrokenInTx", () => {
+    it("no-ops when there are no matching pacts", async () => {
+      const db = fakeDb({ pactDocs: [] });
+      const tx = { update: jest.fn() } as unknown as Transaction;
+      await markPactsBrokenInTx({
+        tx,
+        db,
+        attackerId: "a",
+        attackerDisplayName: "A",
+        attackerCaste: "red",
+        defenderId: "d",
+        defenderDisplayName: "D",
+        now: new Date(),
+      });
+      expect(tx.update).not.toHaveBeenCalled();
+      expect(mockLogCommunityEvent).not.toHaveBeenCalled();
+    });
+
+    it("updates brokenAt + logs a pact_broken event for each live pact", async () => {
+      const now = new Date();
+      const pacts: Pact[] = [
+        {
+          id: "p1",
+          statement: "no attack",
+          expiresAt: new Date(now.getTime() + 100_000),
+        } as unknown as Pact,
+      ];
+      const db = fakeDb({ pactDocs: pacts });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await markPactsBrokenInTx({
+        tx,
+        db,
+        attackerId: "a",
+        attackerDisplayName: "A",
+        attackerCaste: "red",
+        defenderId: "d",
+        defenderDisplayName: "D",
+        now,
+      });
+      expect(updateMock).toHaveBeenCalledTimes(1);
+      expect(updateMock.mock.calls[0][1]).toMatchObject({ brokenAt: now });
+      expect(mockLogCommunityEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips deleted/broken/expired pacts", async () => {
+      const now = new Date();
+      const pacts: Pact[] = [
+        { id: "exp", expiresAt: new Date(now.getTime() - 1) } as unknown as Pact,
+        { id: "del", deletedAt: now, expiresAt: new Date(now.getTime() + 100) } as unknown as Pact,
+        { id: "brk", brokenAt: now, expiresAt: new Date(now.getTime() + 100) } as unknown as Pact,
+      ];
+      const db = fakeDb({ pactDocs: pacts });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await markPactsBrokenInTx({
+        tx,
+        db,
+        attackerId: "a",
+        attackerDisplayName: "A",
+        attackerCaste: null,
+        defenderId: "d",
+        defenderDisplayName: "D",
+        now,
+      });
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/lib/game/prophecies.test.ts
+++ b/__tests__/lib/game/prophecies.test.ts
@@ -1,0 +1,330 @@
+/**
+ * @jest-environment node
+ */
+import type { Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  MAX_PROPHECY_LENGTH,
+  ProphecyEmptyError,
+  ProphecyForbiddenError,
+  ProphecyInvalidSealError,
+  ProphecyNotFoundError,
+  ProphecySealAlreadyBrokenError,
+  ProphecyTooLongError,
+  createProphecyServer,
+  deleteProphecyServer,
+  listPropheciesByAuthorServer,
+  listPropheciesForSealServer,
+  resolveProphesiesForSealInTx,
+} from "@/lib/game/prophecies";
+import type { Prophecy } from "@/lib/game/types";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+jest.mock("@/lib/sanitize", () => ({
+  sanitizeText: (s: string) => s.trim(),
+}));
+jest.mock("@/lib/game/community", () => ({
+  logCommunityEventInTx: jest.fn(),
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { increment: (n: number) => ({ __increment: n }) },
+}));
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logCommunityEventInTx } from "@/lib/game/community";
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockLog = logCommunityEventInTx as jest.MockedFunction<typeof logCommunityEventInTx>;
+
+function fakeDb(opts: {
+  worldMeta?: { exists: boolean; sealsBroken?: number };
+  propheciesDocs?: Prophecy[];
+  prophecyDoc?: { exists: boolean; data?: Prophecy };
+  setSink?: { id?: string; data?: unknown };
+  updateSink?: { data?: unknown };
+}): Firestore {
+  return {
+    collection: (_name: string) => ({
+      doc: (id: string) => ({
+        get: async () => {
+          if (id === "singleton") {
+            return {
+              exists: !!opts.worldMeta?.exists,
+              data: () => ({ sealsBroken: opts.worldMeta?.sealsBroken ?? 0 }),
+            };
+          }
+          return {
+            exists: !!opts.prophecyDoc?.exists,
+            data: () => opts.prophecyDoc?.data,
+          };
+        },
+        set: async (data: unknown) => {
+          if (opts.setSink) {
+            opts.setSink.id = id;
+            opts.setSink.data = data;
+          }
+        },
+        update: async (data: unknown) => {
+          if (opts.updateSink) opts.updateSink.data = data;
+        },
+      }),
+      where: () => ({
+        where: () => ({ get: async () => ({ docs: [] }) }),
+        orderBy: () => ({
+          get: async () => ({
+            docs: (opts.propheciesDocs ?? []).map((p) => ({
+              data: () => p,
+              ref: { __ref: p.id },
+            })),
+          }),
+        }),
+        get: async () => ({
+          docs: (opts.propheciesDocs ?? []).map((p) => ({
+            data: () => p,
+            ref: { __ref: p.id },
+          })),
+        }),
+      }),
+    }),
+  } as unknown as Firestore;
+}
+
+describe("game/prophecies", () => {
+  beforeEach(() => {
+    mockGetAdminDb.mockReset();
+    mockLog.mockReset();
+  });
+
+  describe("error classes", () => {
+    it("all 6 error classes have stable names", () => {
+      expect(new ProphecyEmptyError().name).toBe("ProphecyEmptyError");
+      expect(new ProphecyTooLongError().name).toBe("ProphecyTooLongError");
+      expect(new ProphecyInvalidSealError().name).toBe("ProphecyInvalidSealError");
+      expect(new ProphecySealAlreadyBrokenError().name).toBe("ProphecySealAlreadyBrokenError");
+      expect(new ProphecyForbiddenError().name).toBe("ProphecyForbiddenError");
+      expect(new ProphecyNotFoundError().name).toBe("ProphecyNotFoundError");
+    });
+    it("TooLongError carries the length cap in the message", () => {
+      expect(new ProphecyTooLongError().message).toContain(String(MAX_PROPHECY_LENGTH));
+    });
+  });
+
+  describe("createProphecyServer", () => {
+    const author = { userId: "u1", displayName: "Alice", caste: "red" as const };
+
+    it.each([
+      ["non-integer (0)", 0],
+      ["non-integer (8)", 8],
+      ["non-integer (-1)", -1],
+    ])("rejects invalid seal number: %s", async (_n, sealNumber) => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createProphecyServer({ author, targetSealNumber: sealNumber, rawPrediction: "x" })
+      ).rejects.toThrow(ProphecyInvalidSealError);
+    });
+
+    it("rejects empty prediction (after sanitize)", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      await expect(
+        createProphecyServer({ author, targetSealNumber: 1, rawPrediction: "  " })
+      ).rejects.toThrow(ProphecyEmptyError);
+    });
+
+    it("rejects too-long prediction", async () => {
+      mockGetAdminDb.mockReturnValue(fakeDb({}) as unknown as ReturnType<typeof getAdminDb>);
+      const long = "x".repeat(MAX_PROPHECY_LENGTH + 1);
+      await expect(
+        createProphecyServer({ author, targetSealNumber: 1, rawPrediction: long })
+      ).rejects.toThrow(ProphecyTooLongError);
+    });
+
+    it("rejects when the target seal has already broken", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ worldMeta: { exists: true, sealsBroken: 3 } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        createProphecyServer({ author, targetSealNumber: 2, rawPrediction: "the end is nigh" })
+      ).rejects.toThrow(ProphecySealAlreadyBrokenError);
+    });
+
+    it("persists a valid prophecy", async () => {
+      const setSink: { id?: string; data?: unknown } = {};
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ worldMeta: { exists: true, sealsBroken: 0 }, setSink }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await createProphecyServer({
+        author,
+        targetSealNumber: 3,
+        rawPrediction: "the third seal breaks tonight",
+      });
+      expect(out.authorId).toBe("u1");
+      expect(out.targetSealNumber).toBe(3);
+      expect(out.prediction).toBe("the third seal breaks tonight");
+      expect(setSink.data).toBeDefined();
+    });
+
+    it("treats a missing world-meta doc as sealsBroken = 0", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ worldMeta: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      // Seal 1 should be valid because no seal has broken yet.
+      const out = await createProphecyServer({
+        author,
+        targetSealNumber: 1,
+        rawPrediction: "first seal soon",
+      });
+      expect(out.targetSealNumber).toBe(1);
+    });
+  });
+
+  describe("listPropheciesForSealServer", () => {
+    it("returns prophecies for a seal, filtering deleted", async () => {
+      const prophecies: Prophecy[] = [
+        { id: "p1", targetSealNumber: 1 } as unknown as Prophecy,
+        { id: "p2", targetSealNumber: 1, deletedAt: new Date() } as unknown as Prophecy,
+        { id: "p3", targetSealNumber: 1 } as unknown as Prophecy,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ propheciesDocs: prophecies }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPropheciesForSealServer(1);
+      expect(out.map((p) => p.id)).toEqual(["p1", "p3"]);
+    });
+  });
+
+  describe("listPropheciesByAuthorServer", () => {
+    it("returns prophecies for an author, filtering deleted", async () => {
+      const prophecies: Prophecy[] = [
+        { id: "p1", authorId: "u1" } as unknown as Prophecy,
+        { id: "p2", authorId: "u1", deletedAt: new Date() } as unknown as Prophecy,
+      ];
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ propheciesDocs: prophecies }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await listPropheciesByAuthorServer("u1");
+      expect(out.map((p) => p.id)).toEqual(["p1"]);
+    });
+  });
+
+  describe("deleteProphecyServer", () => {
+    it("throws ProphecyNotFoundError when missing", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({ prophecyDoc: { exists: false } }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deleteProphecyServer({ prophecyId: "p", callerUserId: "u", callerIsAdmin: false })
+      ).rejects.toThrow(ProphecyNotFoundError);
+    });
+
+    it("throws ProphecyForbiddenError for non-author non-admin", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          prophecyDoc: { exists: true, data: { authorId: "other" } as Prophecy },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      await expect(
+        deleteProphecyServer({ prophecyId: "p", callerUserId: "me", callerIsAdmin: false })
+      ).rejects.toThrow(ProphecyForbiddenError);
+    });
+
+    it("author delete sets deletedByAdmin=false", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          prophecyDoc: { exists: true, data: { id: "p", authorId: "me" } as Prophecy },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deleteProphecyServer({
+        prophecyId: "p",
+        callerUserId: "me",
+        callerIsAdmin: false,
+      });
+      expect(out.deletedByAdmin).toBe(false);
+    });
+
+    it("admin delete (non-author) sets deletedByAdmin=true", async () => {
+      mockGetAdminDb.mockReturnValue(
+        fakeDb({
+          prophecyDoc: { exists: true, data: { id: "p", authorId: "other" } as Prophecy },
+        }) as unknown as ReturnType<typeof getAdminDb>
+      );
+      const out = await deleteProphecyServer({
+        prophecyId: "p",
+        callerUserId: "admin",
+        callerIsAdmin: true,
+      });
+      expect(out.deletedByAdmin).toBe(true);
+    });
+  });
+
+  describe("resolveProphesiesForSealInTx", () => {
+    const brokenBy = {
+      userId: "u-breaker",
+      displayName: "Breaker",
+      caste: "black" as const,
+    };
+
+    it("no-ops when no prophecies target the broken seal", async () => {
+      const db = fakeDb({ propheciesDocs: [] });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await resolveProphesiesForSealInTx({
+        tx,
+        db,
+        brokenSealNumber: 1,
+        brokenBy,
+        now: new Date(),
+      });
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it("resolves each live prophecy and emits prophecy_fulfilled events", async () => {
+      const now = new Date();
+      const prophecies: Prophecy[] = [
+        {
+          id: "p1",
+          authorId: "u1",
+          authorDisplayName: "Alice",
+          authorCaste: "red",
+          targetSealNumber: 1,
+          prediction: "the bell tolls",
+        } as unknown as Prophecy,
+      ];
+      const db = fakeDb({ propheciesDocs: prophecies });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await resolveProphesiesForSealInTx({
+        tx,
+        db,
+        brokenSealNumber: 1,
+        brokenBy,
+        now,
+      });
+      // Two updates: prophecy doc resolve, player doc bumps.
+      expect(updateMock).toHaveBeenCalledTimes(2);
+      const prophecyUpdate = updateMock.mock.calls[0][1];
+      expect(prophecyUpdate.resolvedAt).toBe(now);
+      expect(prophecyUpdate.fulfilledBy).toEqual(brokenBy);
+      expect(mockLog).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips already-resolved and deleted prophecies", async () => {
+      const prophecies: Prophecy[] = [
+        { id: "deleted", deletedAt: new Date() } as unknown as Prophecy,
+        { id: "resolved", resolvedAt: new Date() } as unknown as Prophecy,
+      ];
+      const db = fakeDb({ propheciesDocs: prophecies });
+      const updateMock = jest.fn();
+      const tx = { update: updateMock } as unknown as Transaction;
+      await resolveProphesiesForSealInTx({
+        tx,
+        db,
+        brokenSealNumber: 1,
+        brokenBy,
+        now: new Date(),
+      });
+      expect(updateMock).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/lib/github-open-pr-review-status.test.ts
+++ b/__tests__/lib/github-open-pr-review-status.test.ts
@@ -1,0 +1,352 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: () => ({ owner: "acme", repo: "demo" }),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { fetchOpenPrsWithReviewStatusForAuthors } from "@/lib/github-open-pr-review-status";
+
+const originalFetch = global.fetch;
+
+type FetchFn = (url: string) => Promise<Response>;
+
+function mkRes(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function makePr(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 1,
+    title: "fix",
+    html_url: "https://github.com/acme/demo/pull/1",
+    draft: false,
+    user: { login: "alice" },
+    ...overrides,
+  };
+}
+
+function makeReview(state: string, submittedAt: string | null = "2026-05-01T00:00:00Z") {
+  return { state, submitted_at: submittedAt };
+}
+
+describe("lib/github-open-pr-review-status", () => {
+  beforeEach(() => {
+    delete process.env.GITHUB_TOKEN;
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  function setFetch(handler: FetchFn) {
+    (global.fetch as jest.Mock).mockImplementation((url: string) =>
+      handler(url),
+    );
+  }
+
+  it("returns an empty map when the input set is empty (skips all network)", async () => {
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set());
+    expect(out.size).toBe(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("includes Authorization: Bearer <token> when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghs_test";
+    setFetch((url) => {
+      if (url.includes("/pulls/1/reviews")) return Promise.resolve(mkRes([]));
+      if (url.includes("/pulls?state=open") || url.includes("&state=open") || url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(mkRes([]));
+    });
+    await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe("Bearer ghs_test");
+  });
+
+  it("returns empty map when first-page list fails (e.g. 401)", async () => {
+    setFetch(() => Promise.resolve(mkRes({}, false, 401)));
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.size).toBe(0);
+  });
+
+  it("filters out PRs whose author is not in the requested set", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(
+          mkRes([
+            makePr({ number: 1, user: { login: "alice" } }),
+            makePr({ number: 2, user: { login: "carol" } }),
+          ]),
+        );
+      }
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.has("alice")).toBe(true);
+    expect(out.has("carol")).toBe(false);
+    expect(out.get("alice")?.[0]?.number).toBe(1);
+  });
+
+  it("drops malformed list entries (missing number/title/html_url/user)", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(
+          mkRes([
+            makePr({ number: "not-a-number" as unknown as number }),
+            makePr({ title: null }),
+            makePr({ html_url: 42 as unknown as string }),
+            makePr({ user: null }),
+            makePr({ user: { login: 99 } }),
+            makePr({ number: 5 }),
+          ]),
+        );
+      }
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.map((p) => p.number)).toEqual([5]);
+  });
+
+  it("lowercases author login for matching", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(
+          mkRes([makePr({ user: { login: "AliCe" }, number: 7 })]),
+        );
+      }
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.number).toBe(7);
+  });
+
+  it("sorts each author's PRs by number descending", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(
+          mkRes([
+            makePr({ number: 11 }),
+            makePr({ number: 22 }),
+            makePr({ number: 9 }),
+          ]),
+        );
+      }
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.map((p) => p.number)).toEqual([22, 11, 9]);
+  });
+
+  it("draft PRs get the 'Draft — mark Ready for review…' summary regardless of reviews", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(
+          mkRes([makePr({ number: 5, draft: true })]),
+        );
+      }
+      return Promise.resolve(mkRes([makeReview("APPROVED")]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/^Draft —/);
+    expect(out.get("alice")?.[0]?.isDraft).toBe(true);
+  });
+
+  it("APPROVED wins over earlier COMMENTED (latest-submitted review applies)", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(
+        mkRes([
+          makeReview("COMMENTED", "2026-05-01T00:00:00Z"),
+          makeReview("APPROVED", "2026-05-02T00:00:00Z"),
+        ]),
+      );
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/^Approved —/);
+  });
+
+  it("CHANGES_REQUESTED summary fires when latest review requested changes", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(mkRes([makeReview("CHANGES_REQUESTED")]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/^Changes requested —/);
+  });
+
+  it("COMMENTED summary fires when only commented review exists", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(mkRes([makeReview("COMMENTED")]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/^Review comment/);
+  });
+
+  it("DISMISSED is skipped — falls through to next decisive review", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(
+        mkRes([
+          makeReview("DISMISSED", "2026-05-03T00:00:00Z"),
+          makeReview("APPROVED", "2026-05-02T00:00:00Z"),
+        ]),
+      );
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/^Approved —/);
+  });
+
+  it("returns the 'no reviews yet' summary when reviews list is empty", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/no reviews yet/);
+  });
+
+  it("returns the 'check the PR conversation' summary when only undated/unknown-state reviews exist", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(
+        mkRes([
+          // submitted_at not a string → filtered out of the dated list,
+          // but reviews.length > 0 so we hit the final fallback
+          { state: "MUMBLED", submitted_at: null },
+        ]),
+      );
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(
+      /check the PR conversation/,
+    );
+  });
+
+  it("returns [] for an unknown review-state in dated reviews (falls through to fallback)", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      return Promise.resolve(mkRes([makeReview("MUMBLE")]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(
+      /check the PR conversation/,
+    );
+  });
+
+  it("returns empty review list when the reviews fetch fails (e.g. 403)", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      if (url.includes("/reviews")) return Promise.resolve(mkRes({}, false, 403));
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/no reviews yet/);
+  });
+
+  it("returns empty review list when the reviews body is not an array", async () => {
+    setFetch((url) => {
+      if (url.includes("/pulls?")) {
+        return Promise.resolve(mkRes([makePr({ number: 1 })]));
+      }
+      if (url.includes("/reviews"))
+        return Promise.resolve(mkRes({ msg: "weird" }));
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.[0]?.reviewSummary).toMatch(/no reviews yet/);
+  });
+
+  it("paginates open PRs across multiple pages until a short page is returned", async () => {
+    const fullPage = (start: number) =>
+      Array.from({ length: 100 }, (_, i) =>
+        makePr({
+          number: start + i,
+          html_url: `https://github.com/x/y/pull/${start + i}`,
+          user: { login: "alice" },
+        }),
+      );
+    const responses: Record<string, Response> = {};
+    setFetch((url) => {
+      const u = new URL(url);
+      const page = u.searchParams.get("page");
+      if (u.pathname.endsWith("/reviews")) return Promise.resolve(mkRes([]));
+      if (page === "1") return Promise.resolve(mkRes(fullPage(1)));
+      if (page === "2") return Promise.resolve(mkRes(fullPage(101)));
+      if (page === "3") return Promise.resolve(mkRes(fullPage(201).slice(0, 50)));
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    // 100 + 100 + 50 = 250 PRs
+    expect(out.get("alice")?.length).toBe(250);
+  });
+
+  it("stops pagination when a page returns 0 items (empty array short-circuit)", async () => {
+    setFetch((url) => {
+      const u = new URL(url);
+      const page = u.searchParams.get("page");
+      if (u.pathname.endsWith("/reviews")) return Promise.resolve(mkRes([]));
+      if (page === "1")
+        return Promise.resolve(mkRes([makePr({ number: 7 })]));
+      if (page === "2") return Promise.resolve(mkRes([]));
+      return Promise.resolve(mkRes([]));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.length).toBe(1);
+  });
+
+  it("returns partial results when a later page fetch fails (page>1 short-circuit)", async () => {
+    setFetch((url) => {
+      const u = new URL(url);
+      const page = u.searchParams.get("page");
+      if (u.pathname.endsWith("/reviews")) return Promise.resolve(mkRes([]));
+      if (page === "1") {
+        return Promise.resolve(
+          mkRes(
+            Array.from({ length: 100 }, (_, i) =>
+              makePr({
+                number: i + 1,
+                html_url: `https://x/${i + 1}`,
+              }),
+            ),
+          ),
+        );
+      }
+      return Promise.resolve(mkRes({}, false, 500));
+    });
+    const out = await fetchOpenPrsWithReviewStatusForAuthors(new Set(["alice"]));
+    expect(out.get("alice")?.length).toBe(100);
+  });
+});

--- a/__tests__/lib/github-recent-merged-prs.test.ts
+++ b/__tests__/lib/github-recent-merged-prs.test.ts
@@ -1,0 +1,238 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import {
+  fetchRecentMergedPullRequests,
+  getGithubRepoPair,
+  getGithubRepoWebBaseUrl,
+} from "@/lib/github-recent-merged-prs";
+
+const originalFetch = global.fetch;
+
+function mockJsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function pr(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 1,
+    title: "fix: thing",
+    html_url: "https://github.com/x/y/pull/1",
+    merged_at: "2026-05-01T12:00:00Z",
+    user: { login: "alice" },
+    ...overrides,
+  };
+}
+
+describe("lib/github-recent-merged-prs", () => {
+  beforeEach(() => {
+    delete process.env.GITHUB_REPO_OWNER;
+    delete process.env.GITHUB_REPO_NAME;
+    delete process.env.GITHUB_TOKEN;
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("getGithubRepoPair", () => {
+    it("returns the default owner/repo when env vars are unset", () => {
+      expect(getGithubRepoPair()).toEqual({
+        owner: "rogerSuperBuilderAlpha",
+        repo: "cursor-boston",
+      });
+    });
+
+    it("honors GITHUB_REPO_OWNER / GITHUB_REPO_NAME overrides", () => {
+      process.env.GITHUB_REPO_OWNER = "acme";
+      process.env.GITHUB_REPO_NAME = "demo";
+      expect(getGithubRepoPair()).toEqual({ owner: "acme", repo: "demo" });
+    });
+  });
+
+  describe("getGithubRepoWebBaseUrl", () => {
+    it("produces the public https URL for the default repo", () => {
+      expect(getGithubRepoWebBaseUrl()).toBe(
+        "https://github.com/rogerSuperBuilderAlpha/cursor-boston",
+      );
+    });
+
+    it("reflects env overrides", () => {
+      process.env.GITHUB_REPO_OWNER = "x";
+      process.env.GITHUB_REPO_NAME = "y";
+      expect(getGithubRepoWebBaseUrl()).toBe("https://github.com/x/y");
+    });
+  });
+
+  describe("fetchRecentMergedPullRequests", () => {
+    it("hits the GitHub pulls API with the expected query params", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockJsonResponse([pr()]),
+      );
+      await fetchRecentMergedPullRequests();
+      const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      const u = new URL(url);
+      expect(u.host).toBe("api.github.com");
+      expect(u.pathname).toBe(
+        "/repos/rogerSuperBuilderAlpha/cursor-boston/pulls",
+      );
+      expect(u.searchParams.get("state")).toBe("closed");
+      expect(u.searchParams.get("sort")).toBe("updated");
+      expect(u.searchParams.get("direction")).toBe("desc");
+      expect(u.searchParams.get("per_page")).toBe("40");
+    });
+
+    it("sends GitHub API headers without Authorization when GITHUB_TOKEN is unset", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(mockJsonResponse([]));
+      await fetchRecentMergedPullRequests();
+      const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Accept"]).toBe("application/vnd.github+json");
+      expect(headers["X-GitHub-Api-Version"]).toBe("2022-11-28");
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+
+    it("adds Authorization: Bearer <token> when GITHUB_TOKEN is set", async () => {
+      process.env.GITHUB_TOKEN = "ghs_test";
+      (global.fetch as jest.Mock).mockResolvedValueOnce(mockJsonResponse([]));
+      await fetchRecentMergedPullRequests();
+      const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer ghs_test");
+    });
+
+    it("returns mapped PRs when the upstream call succeeds", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockJsonResponse([
+          pr({ number: 10, title: "fix #10", html_url: "https://x/10", merged_at: "2026-04-01T00:00:00Z", user: { login: "alice" } }),
+          pr({ number: 11, title: "feat #11", html_url: "https://x/11", merged_at: "2026-04-02T00:00:00Z", user: { login: "bob" } }),
+        ]),
+      );
+      const out = await fetchRecentMergedPullRequests();
+      expect(out.error).toBeUndefined();
+      expect(out.prs).toEqual([
+        {
+          number: 10,
+          title: "fix #10",
+          htmlUrl: "https://x/10",
+          mergedAt: "2026-04-01T00:00:00Z",
+          authorLogin: "alice",
+        },
+        {
+          number: 11,
+          title: "feat #11",
+          htmlUrl: "https://x/11",
+          mergedAt: "2026-04-02T00:00:00Z",
+          authorLogin: "bob",
+        },
+      ]);
+      expect(out.repoUrl).toBe(
+        "https://github.com/rogerSuperBuilderAlpha/cursor-boston",
+      );
+    });
+
+    it("filters out items with no merged_at (closed-but-not-merged PRs)", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockJsonResponse([
+          pr({ number: 1, merged_at: null }),
+          pr({ number: 2, merged_at: "" }),
+          pr({ number: 3 }),
+        ]),
+      );
+      const out = await fetchRecentMergedPullRequests();
+      expect(out.prs.map((p) => p.number)).toEqual([3]);
+    });
+
+    it("drops items missing number, title, or html_url", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockJsonResponse([
+          pr({ number: "not-a-number" as unknown as number }),
+          pr({ title: null }),
+          pr({ html_url: 42 as unknown as string }),
+          pr({ number: 99 }),
+        ]),
+      );
+      const out = await fetchRecentMergedPullRequests();
+      expect(out.prs.map((p) => p.number)).toEqual([99]);
+    });
+
+    it("falls back authorLogin='unknown' when user.login is absent", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockJsonResponse([
+          pr({ number: 5, user: null }),
+          pr({ number: 6, user: { login: 42 } }),
+        ]),
+      );
+      const out = await fetchRecentMergedPullRequests();
+      expect(out.prs.map((p) => p.authorLogin)).toEqual(["unknown", "unknown"]);
+    });
+
+    it("respects the limit parameter (default 8, custom value)", async () => {
+      const many = Array.from({ length: 30 }, (_, i) =>
+        pr({
+          number: i,
+          html_url: `https://x/${i}`,
+          merged_at: "2026-04-01T00:00:00Z",
+        }),
+      );
+      (global.fetch as jest.Mock).mockResolvedValueOnce(mockJsonResponse(many));
+      const out = await fetchRecentMergedPullRequests();
+      expect(out.prs).toHaveLength(8);
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce(mockJsonResponse(many));
+      const out3 = await fetchRecentMergedPullRequests(3);
+      expect(out3.prs).toHaveLength(3);
+    });
+
+    it("returns error:true when the upstream response is not ok", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockJsonResponse({}, false, 403),
+      );
+      const out = await fetchRecentMergedPullRequests();
+      expect(out).toEqual({
+        prs: [],
+        repoUrl: "https://github.com/rogerSuperBuilderAlpha/cursor-boston",
+        error: true,
+      });
+    });
+
+    it("returns error:true when the JSON body is not an array", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockJsonResponse({ message: "rate limited" }),
+      );
+      const out = await fetchRecentMergedPullRequests();
+      expect(out.error).toBe(true);
+      expect(out.prs).toEqual([]);
+    });
+
+    it("returns error:true and empty prs when fetch throws", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("ECONNRESET"));
+      const out = await fetchRecentMergedPullRequests();
+      expect(out.error).toBe(true);
+      expect(out.prs).toEqual([]);
+    });
+
+    it("includes the Next.js revalidate option on the fetch call", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(mockJsonResponse([]));
+      await fetchRecentMergedPullRequests();
+      const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit & {
+        next?: { revalidate: number };
+      };
+      expect(init.next).toEqual({ revalidate: 300 });
+    });
+  });
+});

--- a/__tests__/lib/hackathon-team-dashboard-server.test.ts
+++ b/__tests__/lib/hackathon-team-dashboard-server.test.ts
@@ -1,0 +1,341 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("firebase-admin/firestore", () => ({
+  FieldPath: {
+    documentId: () => "__name__",
+  },
+}));
+
+import { loadHackathonTeamDashboard } from "@/lib/hackathon-team-dashboard-server";
+
+type DocSnap = { id: string; data: () => Record<string, unknown> };
+
+function makeDoc(id: string, data: Record<string, unknown>): DocSnap {
+  return { id, data: () => data };
+}
+
+function tsLike(iso: string) {
+  return { toDate: () => new Date(iso) };
+}
+
+function buildFakeDb(opts: {
+  myTeams?: DocSnap[];
+  invites?: DocSnap[];
+  users?: DocSnap[];
+  submissions?: DocSnap[];
+  joinRequests?: DocSnap[];
+}) {
+  const teamsGet = jest.fn().mockResolvedValue({ docs: opts.myTeams ?? [] });
+  const invitesGet = jest.fn().mockResolvedValue({ docs: opts.invites ?? [] });
+  const usersGet = jest.fn().mockResolvedValue({ docs: opts.users ?? [] });
+  const subGet = jest.fn().mockResolvedValue({ docs: opts.submissions ?? [] });
+  const reqGet = jest.fn().mockResolvedValue({ docs: opts.joinRequests ?? [] });
+
+  const teamsChain = {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: teamsGet,
+  };
+  const invitesChain = {
+    where: jest.fn().mockReturnThis(),
+    get: invitesGet,
+  };
+  const usersChain = {
+    where: jest.fn().mockReturnThis(),
+    get: usersGet,
+  };
+  const subChain = {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: subGet,
+  };
+  const reqChain = {
+    where: jest.fn().mockReturnThis(),
+    get: reqGet,
+  };
+
+  const collection = jest.fn((name: string) => {
+    switch (name) {
+      case "hackathonTeams":
+        return teamsChain;
+      case "hackathonInvites":
+        return invitesChain;
+      case "users":
+        return usersChain;
+      case "hackathonSubmissions":
+        return subChain;
+      case "hackathonJoinRequests":
+        return reqChain;
+      default:
+        throw new Error(`unexpected: ${name}`);
+    }
+  });
+
+  return {
+    db: { collection } as unknown as Parameters<typeof loadHackathonTeamDashboard>[0],
+    spies: { teamsChain, invitesChain, usersChain, subChain, reqChain },
+  };
+}
+
+describe("lib/hackathon-team-dashboard-server", () => {
+  it("returns empty dashboard when user is on no team", async () => {
+    const { db } = buildFakeDb({});
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out).toEqual({
+      myTeam: null,
+      memberProfiles: {},
+      submission: null,
+      myInvites: [],
+      requestsToMyTeam: [],
+    });
+  });
+
+  it("queries hackathonTeams scoped to this hackathon AND member uid", async () => {
+    const { db, spies } = buildFakeDb({});
+    await loadHackathonTeamDashboard(db, "alice", "hack-x");
+    expect(spies.teamsChain.where).toHaveBeenCalledWith("hackathonId", "==", "hack-x");
+    expect(spies.teamsChain.where).toHaveBeenCalledWith(
+      "memberIds",
+      "array-contains",
+      "alice",
+    );
+    expect(spies.teamsChain.limit).toHaveBeenCalledWith(1);
+  });
+
+  it("maps myTeam doc into PoolDashboardTeam (Timestamp → ISO)", async () => {
+    const { db } = buildFakeDb({
+      myTeams: [
+        makeDoc("team-x", {
+          hackathonId: "h1",
+          memberIds: ["alice"],
+          name: "Team X",
+          logoUrl: "https://x/l.png",
+          wins: 3,
+          createdBy: "alice",
+          createdAt: tsLike("2026-05-01T00:00:00.000Z"),
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out.myTeam).toEqual({
+      id: "team-x",
+      hackathonId: "h1",
+      memberIds: ["alice"],
+      name: "Team X",
+      logoUrl: "https://x/l.png",
+      wins: 3,
+      createdBy: "alice",
+      createdAt: "2026-05-01T00:00:00.000Z",
+    });
+  });
+
+  it("maps pending invites with optional expiresAt (Timestamp or omitted)", async () => {
+    const { db } = buildFakeDb({
+      invites: [
+        makeDoc("inv-1", {
+          fromUserId: "bob",
+          toUserId: "alice",
+          teamId: "team-x",
+          status: "pending",
+          createdAt: tsLike("2026-05-01T10:00:00.000Z"),
+          expiresAt: tsLike("2026-05-10T10:00:00.000Z"),
+        }),
+        makeDoc("inv-2", {
+          fromUserId: "carol",
+          toUserId: "alice",
+          teamId: "team-y",
+          status: "pending",
+          createdAt: tsLike("2026-05-02T10:00:00.000Z"),
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out.myInvites).toEqual([
+      {
+        id: "inv-1",
+        fromUserId: "bob",
+        toUserId: "alice",
+        teamId: "team-x",
+        status: "pending",
+        createdAt: "2026-05-01T10:00:00.000Z",
+        expiresAt: "2026-05-10T10:00:00.000Z",
+      },
+      {
+        id: "inv-2",
+        fromUserId: "carol",
+        toUserId: "alice",
+        teamId: "team-y",
+        status: "pending",
+        createdAt: "2026-05-02T10:00:00.000Z",
+        expiresAt: undefined,
+      },
+    ]);
+  });
+
+  it("hydrates member profiles in chunks of 10", async () => {
+    const memberIds = Array.from({ length: 17 }, (_, i) => `u${i}`);
+    const { db, spies } = buildFakeDb({
+      myTeams: [
+        makeDoc("team-x", {
+          hackathonId: "h1",
+          memberIds,
+          createdBy: "u0",
+        }),
+      ],
+      users: [
+        makeDoc("u0", {
+          displayName: "U0",
+          photoURL: "https://x/0",
+          discord: { id: "d0" },
+          github: { login: "u0" },
+        }),
+        makeDoc("u1", {
+          discord: undefined,
+          github: undefined,
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "u0", "h1");
+    // 17 ids → 2 chunks: 10 + 7
+    expect(spies.usersChain.where).toHaveBeenCalledTimes(2);
+    expect(spies.usersChain.where.mock.calls[0][2]).toHaveLength(10);
+    expect(spies.usersChain.where.mock.calls[1][2]).toHaveLength(7);
+    // Profile mapping respects displayName/photoURL null fallbacks
+    expect(out.memberProfiles.u0).toEqual({
+      uid: "u0",
+      displayName: "U0",
+      photoURL: "https://x/0",
+      discord: { id: "d0" },
+      github: { login: "u0" },
+    });
+    expect(out.memberProfiles.u1).toEqual({
+      uid: "u1",
+      displayName: null,
+      photoURL: null,
+      discord: undefined,
+      github: undefined,
+    });
+  });
+
+  it("loads team submission when one exists, mapping every optional timestamp", async () => {
+    const { db } = buildFakeDb({
+      myTeams: [
+        makeDoc("team-x", {
+          hackathonId: "h1",
+          memberIds: ["alice"],
+          createdBy: "alice",
+        }),
+      ],
+      submissions: [
+        makeDoc("sub-1", {
+          hackathonId: "h1",
+          teamId: "team-x",
+          repoUrl: "https://github.com/x/y",
+          registeredBy: "alice",
+          registeredAt: tsLike("2026-05-01T00:00:00.000Z"),
+          submittedAt: tsLike("2026-05-02T00:00:00.000Z"),
+          cutoffAt: tsLike("2026-05-03T00:00:00.000Z"),
+          disqualified: false,
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out.submission).toEqual({
+      id: "sub-1",
+      hackathonId: "h1",
+      teamId: "team-x",
+      repoUrl: "https://github.com/x/y",
+      registeredBy: "alice",
+      registeredAt: "2026-05-01T00:00:00.000Z",
+      submittedAt: "2026-05-02T00:00:00.000Z",
+      cutoffAt: "2026-05-03T00:00:00.000Z",
+      disqualified: false,
+      disqualifiedReason: undefined,
+    });
+  });
+
+  it("submission omits optional submittedAt/cutoffAt when their Timestamps are missing", async () => {
+    const { db } = buildFakeDb({
+      myTeams: [
+        makeDoc("team-x", {
+          hackathonId: "h1",
+          memberIds: ["alice"],
+          createdBy: "alice",
+        }),
+      ],
+      submissions: [
+        makeDoc("sub-2", {
+          hackathonId: "h1",
+          teamId: "team-x",
+          repoUrl: "https://github.com/x/y",
+          registeredBy: "alice",
+          registeredAt: tsLike("2026-05-01T00:00:00.000Z"),
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out.submission?.submittedAt).toBeUndefined();
+    expect(out.submission?.cutoffAt).toBeUndefined();
+  });
+
+  it("submission is null when no submission doc matches", async () => {
+    const { db } = buildFakeDb({
+      myTeams: [
+        makeDoc("team-x", {
+          hackathonId: "h1",
+          memberIds: ["alice"],
+          createdBy: "alice",
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out.submission).toBeNull();
+  });
+
+  it("loads pending join requests into requestsToMyTeam", async () => {
+    const { db } = buildFakeDb({
+      myTeams: [
+        makeDoc("team-x", {
+          hackathonId: "h1",
+          memberIds: ["alice"],
+          createdBy: "alice",
+        }),
+      ],
+      joinRequests: [
+        makeDoc("req-1", {
+          fromUserId: "bob",
+          teamId: "team-x",
+          status: "pending",
+          createdAt: tsLike("2026-05-04T00:00:00.000Z"),
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out.requestsToMyTeam).toEqual([
+      {
+        id: "req-1",
+        fromUserId: "bob",
+        teamId: "team-x",
+        status: "pending",
+        createdAt: "2026-05-04T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("treats invalid Timestamps (NaN dates) as null in tsIso", async () => {
+    const badTs = { toDate: () => new Date(NaN) };
+    const { db } = buildFakeDb({
+      myTeams: [
+        makeDoc("team-x", {
+          hackathonId: "h1",
+          memberIds: ["alice"],
+          createdBy: "alice",
+          createdAt: badTs,
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamDashboard(db, "alice", "h1");
+    expect(out.myTeam?.createdAt).toBeNull();
+  });
+});

--- a/__tests__/lib/hackathon-teams-board-server.test.ts
+++ b/__tests__/lib/hackathon-teams-board-server.test.ts
@@ -1,0 +1,310 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("firebase-admin/firestore", () => ({
+  FieldPath: {
+    documentId: () => "__name__",
+  },
+}));
+
+import { loadHackathonTeamsBoard } from "@/lib/hackathon-teams-board-server";
+
+type DocSnap = { id: string; data: () => Record<string, unknown>; exists?: boolean };
+
+function makeDoc(id: string, data: Record<string, unknown>): DocSnap {
+  return { id, data: () => data, exists: true };
+}
+
+function tsLike(iso: string) {
+  return { toDate: () => new Date(iso) };
+}
+
+function buildFakeDb(opts: {
+  teams?: DocSnap[];
+  users?: DocSnap[];
+  submissions?: DocSnap[];
+  poolExists?: boolean;
+  joinRequests?: DocSnap[];
+}) {
+  const teamsGet = jest.fn().mockResolvedValue({ docs: opts.teams ?? [] });
+  const usersGet = jest.fn().mockResolvedValue({ docs: opts.users ?? [] });
+  const subGet = jest.fn().mockResolvedValue({ docs: opts.submissions ?? [] });
+  const poolGet = jest.fn().mockResolvedValue({ exists: !!opts.poolExists });
+  const reqGet = jest.fn().mockResolvedValue({ docs: opts.joinRequests ?? [] });
+
+  const teamsChain = {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: teamsGet,
+  };
+  const usersChain = {
+    where: jest.fn().mockReturnThis(),
+    get: usersGet,
+  };
+  const subChain = {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: subGet,
+  };
+  const poolDoc = { get: poolGet };
+  const poolChain = { doc: jest.fn().mockReturnValue(poolDoc) };
+  const reqChain = {
+    where: jest.fn().mockReturnThis(),
+    get: reqGet,
+  };
+
+  const collection = jest.fn((name: string) => {
+    if (name === "hackathonTeams") return teamsChain;
+    if (name === "users") return usersChain;
+    if (name === "hackathonSubmissions") return subChain;
+    if (name === "hackathonPool") return poolChain;
+    if (name === "hackathonJoinRequests") return reqChain;
+    throw new Error(`unexpected collection: ${name}`);
+  });
+
+  return {
+    db: { collection } as unknown as Parameters<typeof loadHackathonTeamsBoard>[0],
+    teamsChain,
+    usersChain,
+    subChain,
+    poolChain,
+    reqChain,
+    teamsGet,
+    usersGet,
+  };
+}
+
+describe("lib/hackathon-teams-board-server", () => {
+  it("returns empty payload when no teams + uid=null", async () => {
+    const { db } = buildFakeDb({});
+    const out = await loadHackathonTeamsBoard(db, null, "h1");
+    expect(out).toEqual({
+      teams: [],
+      memberProfiles: {},
+      successfulSubmissionsByTeam: {},
+      myTeamId: null,
+      inPool: false,
+      myPendingRequestTeamIds: [],
+    });
+  });
+
+  it("queries hackathonTeams with the right where + limit", async () => {
+    const { db, teamsChain } = buildFakeDb({});
+    await loadHackathonTeamsBoard(db, null, "hack-x");
+    expect(teamsChain.where).toHaveBeenCalledWith("hackathonId", "==", "hack-x");
+    expect(teamsChain.limit).toHaveBeenCalledWith(200);
+  });
+
+  it("maps teams with createdAt Timestamp → ISO string", async () => {
+    const { db } = buildFakeDb({
+      teams: [
+        makeDoc("team-1", {
+          hackathonId: "h1",
+          memberIds: ["u1", "u2"],
+          name: "Team One",
+          logoUrl: "https://example.com/logo.png",
+          wins: 2,
+          createdBy: "u1",
+          createdAt: tsLike("2026-05-01T10:00:00.000Z"),
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamsBoard(db, null, "h1");
+    expect(out.teams).toHaveLength(1);
+    expect(out.teams[0]).toEqual({
+      id: "team-1",
+      hackathonId: "h1",
+      memberIds: ["u1", "u2"],
+      name: "Team One",
+      logoUrl: "https://example.com/logo.png",
+      wins: 2,
+      createdBy: "u1",
+      createdAt: "2026-05-01T10:00:00.000Z",
+    });
+  });
+
+  it("treats invalid/missing createdAt as null", async () => {
+    const { db } = buildFakeDb({
+      teams: [
+        makeDoc("team-no-ts", {
+          hackathonId: "h1",
+          memberIds: [],
+          createdBy: "u1",
+        }),
+        makeDoc("team-bad-ts", {
+          hackathonId: "h1",
+          memberIds: [],
+          createdBy: "u1",
+          createdAt: { toDate: () => new Date(NaN) },
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamsBoard(db, null, "h1");
+    expect(out.teams[0]?.createdAt).toBeNull();
+    expect(out.teams[1]?.createdAt).toBeNull();
+  });
+
+  it("hydrates public user profiles for real (non-placeholder) member ids", async () => {
+    const { db, usersChain } = buildFakeDb({
+      teams: [
+        makeDoc("team-1", {
+          hackathonId: "h1",
+          memberIds: ["u1", "u2", "mock-member-x"],
+          createdBy: "u1",
+        }),
+      ],
+      users: [
+        makeDoc("u1", {
+          displayName: "Alice",
+          photoURL: "https://example.com/a.png",
+          visibility: { isPublic: true },
+        }),
+        makeDoc("u2", {
+          displayName: "Bob",
+          photoURL: null,
+          visibility: { isPublic: false },
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamsBoard(db, null, "h1");
+    expect(usersChain.where).toHaveBeenCalledWith(
+      "__name__",
+      "in",
+      ["u1", "u2"],
+    );
+    expect(out.memberProfiles).toEqual({
+      u1: { uid: "u1", displayName: "Alice", photoURL: "https://example.com/a.png" },
+    });
+  });
+
+  it("falls back to null displayName/photoURL when fields are missing", async () => {
+    const { db } = buildFakeDb({
+      teams: [makeDoc("team-1", { hackathonId: "h1", memberIds: ["u1"], createdBy: "u1" })],
+      users: [makeDoc("u1", { visibility: { isPublic: true } })],
+    });
+    const out = await loadHackathonTeamsBoard(db, null, "h1");
+    expect(out.memberProfiles.u1).toEqual({
+      uid: "u1",
+      displayName: null,
+      photoURL: null,
+    });
+  });
+
+  it("filters out mock-* placeholder ids before fetching users", async () => {
+    const { db, usersChain } = buildFakeDb({
+      teams: [
+        makeDoc("team-1", {
+          hackathonId: "h1",
+          memberIds: ["mock-member-1", "mock-foo"],
+          createdBy: "mock-foo",
+        }),
+      ],
+    });
+    await loadHackathonTeamsBoard(db, null, "h1");
+    // No real members → no users query at all (every chunk is empty).
+    expect(usersChain.where).not.toHaveBeenCalled();
+  });
+
+  it("chunks member ids into batches of 10 for the 'in' query", async () => {
+    const ids = Array.from({ length: 23 }, (_, i) => `u${i}`);
+    const { db, usersChain } = buildFakeDb({
+      teams: [
+        makeDoc("team-1", { hackathonId: "h1", memberIds: ids, createdBy: "u0" }),
+      ],
+    });
+    await loadHackathonTeamsBoard(db, null, "h1");
+    // 23 ids → 3 chunks: 10, 10, 3
+    expect(usersChain.where).toHaveBeenCalledTimes(3);
+    expect(usersChain.where.mock.calls[0][2]).toHaveLength(10);
+    expect(usersChain.where.mock.calls[1][2]).toHaveLength(10);
+    expect(usersChain.where.mock.calls[2][2]).toHaveLength(3);
+  });
+
+  it("tallies successful (non-disqualified, submittedAt set) submissions per team", async () => {
+    const { db } = buildFakeDb({
+      submissions: [
+        makeDoc("s1", { teamId: "team-a", submittedAt: tsLike("2026-05-01T00:00:00Z") }),
+        makeDoc("s2", { teamId: "team-a", submittedAt: tsLike("2026-05-02T00:00:00Z") }),
+        makeDoc("s3", { teamId: "team-b", submittedAt: tsLike("2026-05-01T00:00:00Z") }),
+        makeDoc("s4", { teamId: "team-b", submittedAt: tsLike("2026-05-02T00:00:00Z"), disqualified: true }),
+        makeDoc("s5", { teamId: "team-c" /* no submittedAt */ }),
+        makeDoc("s6", { submittedAt: tsLike("2026-05-01T00:00:00Z") /* no teamId */ }),
+      ],
+    });
+    const out = await loadHackathonTeamsBoard(db, null, "h1");
+    expect(out.successfulSubmissionsByTeam).toEqual({
+      "team-a": 2,
+      "team-b": 1,
+    });
+  });
+
+  it("resolves myTeamId when uid is a member of a team", async () => {
+    const { db } = buildFakeDb({
+      teams: [
+        makeDoc("team-a", {
+          hackathonId: "h1",
+          memberIds: ["alice"],
+          createdBy: "alice",
+        }),
+        makeDoc("team-b", {
+          hackathonId: "h1",
+          memberIds: ["bob", "carol"],
+          createdBy: "bob",
+        }),
+      ],
+    });
+    const out = await loadHackathonTeamsBoard(db, "carol", "h1");
+    expect(out.myTeamId).toBe("team-b");
+  });
+
+  it("returns myTeamId=null when uid is not on any team", async () => {
+    const { db } = buildFakeDb({
+      teams: [
+        makeDoc("team-a", { hackathonId: "h1", memberIds: ["alice"], createdBy: "alice" }),
+      ],
+    });
+    const out = await loadHackathonTeamsBoard(db, "stranger", "h1");
+    expect(out.myTeamId).toBeNull();
+  });
+
+  it("reads inPool from hackathonPool/{uid}_{hackathonId}", async () => {
+    const { db, poolChain } = buildFakeDb({ poolExists: true });
+    const out = await loadHackathonTeamsBoard(db, "alice", "hack-x");
+    expect(poolChain.doc).toHaveBeenCalledWith("alice_hack-x");
+    expect(out.inPool).toBe(true);
+  });
+
+  it("returns pending join request team ids when uid is provided", async () => {
+    const { db, reqChain } = buildFakeDb({
+      joinRequests: [
+        makeDoc("r1", { teamId: "team-x" }),
+        makeDoc("r2", { teamId: "team-y" }),
+        makeDoc("r3", { /* no teamId */ }),
+      ],
+    });
+    const out = await loadHackathonTeamsBoard(db, "alice", "h1");
+    expect(reqChain.where).toHaveBeenCalledWith("fromUserId", "==", "alice");
+    expect(reqChain.where).toHaveBeenCalledWith("status", "==", "pending");
+    expect(out.myPendingRequestTeamIds).toEqual(["team-x", "team-y"]);
+  });
+
+  it("does not call uid-scoped queries when uid is null", async () => {
+    const { db, poolChain, reqChain } = buildFakeDb({});
+    await loadHackathonTeamsBoard(db, null, "h1");
+    expect(poolChain.doc).not.toHaveBeenCalled();
+    expect(reqChain.where).not.toHaveBeenCalled();
+  });
+
+  it("dedupes member ids across teams before fetching users", async () => {
+    const { db, usersChain } = buildFakeDb({
+      teams: [
+        makeDoc("t1", { hackathonId: "h1", memberIds: ["u1", "u2"], createdBy: "u1" }),
+        makeDoc("t2", { hackathonId: "h1", memberIds: ["u1", "u3"], createdBy: "u1" }),
+      ],
+    });
+    await loadHackathonTeamsBoard(db, null, "h1");
+    expect(usersChain.where).toHaveBeenCalledTimes(1);
+    const idsArg = usersChain.where.mock.calls[0][2];
+    expect(new Set(idsArg)).toEqual(new Set(["u1", "u2", "u3"]));
+  });
+});

--- a/__tests__/lib/hiring-partners.test.ts
+++ b/__tests__/lib/hiring-partners.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment node
+ */
+import {
+  HIRING_PARTNERS_CALENDLY_URL,
+  HIRING_PARTNERS_COLLECTION,
+  HIRING_PARTNERS_MAX,
+  HIRING_PARTNERS_NOTIFY_EMAIL,
+  HIRING_PARTNERS_RETURN_TO,
+  PARTNER_ENGINEER_EXPECTATION_ITEMS,
+  sanitizeEngineerExpectations,
+} from "@/lib/hiring-partners";
+
+describe("lib/hiring-partners", () => {
+  describe("constants", () => {
+    it("HIRING_PARTNERS_COLLECTION names the Firestore collection", () => {
+      expect(HIRING_PARTNERS_COLLECTION).toBe("hiringPartnerApplications");
+    });
+
+    it("HIRING_PARTNERS_NOTIFY_EMAIL is a non-empty array of strings", () => {
+      expect(Array.isArray(HIRING_PARTNERS_NOTIFY_EMAIL)).toBe(true);
+      expect(HIRING_PARTNERS_NOTIFY_EMAIL.length).toBeGreaterThan(0);
+      for (const e of HIRING_PARTNERS_NOTIFY_EMAIL) {
+        expect(typeof e).toBe("string");
+        expect(e).toMatch(/@/);
+      }
+    });
+
+    it("HIRING_PARTNERS_CALENDLY_URL is an https calendly URL", () => {
+      expect(HIRING_PARTNERS_CALENDLY_URL).toMatch(/^https:\/\/calendly\.com\//);
+    });
+
+    it("HIRING_PARTNERS_RETURN_TO is a site-relative path", () => {
+      expect(HIRING_PARTNERS_RETURN_TO.startsWith("/")).toBe(true);
+    });
+
+    it("HIRING_PARTNERS_MAX exposes positive length caps for each input", () => {
+      for (const [, v] of Object.entries(HIRING_PARTNERS_MAX)) {
+        expect(typeof v).toBe("number");
+        expect(v).toBeGreaterThan(0);
+      }
+    });
+
+    it("PARTNER_ENGINEER_EXPECTATION_ITEMS has unique keys + non-empty labels", () => {
+      const keys = PARTNER_ENGINEER_EXPECTATION_ITEMS.map((i) => i.key);
+      expect(new Set(keys).size).toBe(keys.length);
+      for (const item of PARTNER_ENGINEER_EXPECTATION_ITEMS) {
+        expect(typeof item.label).toBe("string");
+        expect(item.label.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("sanitizeEngineerExpectations", () => {
+    it("returns an empty map for null", () => {
+      expect(sanitizeEngineerExpectations(null)).toEqual({});
+    });
+
+    it("returns an empty map for undefined", () => {
+      expect(sanitizeEngineerExpectations(undefined)).toEqual({});
+    });
+
+    it("returns an empty map for a string", () => {
+      expect(sanitizeEngineerExpectations("not-an-object")).toEqual({});
+    });
+
+    it("returns an empty map for a number", () => {
+      expect(sanitizeEngineerExpectations(42)).toEqual({});
+    });
+
+    it("returns an empty map for an empty object", () => {
+      expect(sanitizeEngineerExpectations({})).toEqual({});
+    });
+
+    it("keeps every valid key in the expected 1..7 range", () => {
+      const all = Object.fromEntries(
+        PARTNER_ENGINEER_EXPECTATION_ITEMS.map((i, idx) => [
+          i.key,
+          ((idx % 7) + 1) as number,
+        ]),
+      );
+      const out = sanitizeEngineerExpectations(all);
+      expect(Object.keys(out).sort()).toEqual(
+        PARTNER_ENGINEER_EXPECTATION_ITEMS.map((i) => i.key).sort(),
+      );
+    });
+
+    it("drops keys not in the known set", () => {
+      const out = sanitizeEngineerExpectations({
+        yearsExperience: 5,
+        notARealKey: 3,
+        anotherBogus: 7,
+      });
+      expect(out).toEqual({ yearsExperience: 5 });
+    });
+
+    it("drops non-number values (string, boolean, null, object)", () => {
+      const out = sanitizeEngineerExpectations({
+        yearsExperience: "5",
+        csFundamentals: true,
+        systemDesign: null,
+        aiToolFluency: {},
+      });
+      expect(out).toEqual({});
+    });
+
+    it("drops non-finite numbers (NaN, Infinity, -Infinity)", () => {
+      const out = sanitizeEngineerExpectations({
+        yearsExperience: NaN,
+        csFundamentals: Infinity,
+        systemDesign: -Infinity,
+      });
+      expect(out).toEqual({});
+    });
+
+    it("drops out-of-range values (0 and 8)", () => {
+      const out = sanitizeEngineerExpectations({
+        yearsExperience: 0,
+        csFundamentals: 8,
+        systemDesign: -3,
+        aiToolFluency: 100,
+      });
+      expect(out).toEqual({});
+    });
+
+    it("rounds non-integer values into integers within range", () => {
+      const out = sanitizeEngineerExpectations({
+        yearsExperience: 3.4, // rounds to 3
+        csFundamentals: 4.7, // rounds to 5
+        systemDesign: 6.5, // rounds to 7
+      });
+      expect(out).toEqual({ yearsExperience: 3, csFundamentals: 5, systemDesign: 7 });
+    });
+
+    it("accepts the boundary values 1 and 7", () => {
+      const out = sanitizeEngineerExpectations({
+        yearsExperience: 1,
+        csFundamentals: 7,
+      });
+      expect(out).toEqual({ yearsExperience: 1, csFundamentals: 7 });
+    });
+
+    it("rounds a value that would round to 0 (e.g. 0.4) and drops it as out-of-range", () => {
+      const out = sanitizeEngineerExpectations({ yearsExperience: 0.4 });
+      expect(out).toEqual({});
+    });
+
+    it("rounds a value that would round to 8 (e.g. 7.6) and drops it as out-of-range", () => {
+      const out = sanitizeEngineerExpectations({ yearsExperience: 7.6 });
+      expect(out).toEqual({});
+    });
+
+    it("ignores arrays (typeof object) at the top level by simply iterating their string indices", () => {
+      // arrays *are* objects, but their entries are indexed strings — none of
+      // the indexes (0, 1, ...) match a known key, so the result is empty.
+      const out = sanitizeEngineerExpectations([5, 6, 7]);
+      expect(out).toEqual({});
+    });
+  });
+});

--- a/__tests__/lib/live-sessions/client.test.ts
+++ b/__tests__/lib/live-sessions/client.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ *
+ * Pure-helper tests for lib/live-sessions/client.ts. The React hooks
+ * (useLiveSession, useLiveTimerAudioAlerts) are exercised end-to-end
+ * via the live-session admin page Playwright tests; this file pins
+ * getLiveRemainingSeconds, which is a pure function safe to test in
+ * isolation.
+ */
+import { getLiveRemainingSeconds } from "@/lib/live-sessions/client";
+import type { LiveSessionRealtimeRecord } from "@/lib/live-sessions/types";
+
+type Timer = LiveSessionRealtimeRecord["timer"];
+
+function mkSession(timer: Partial<Timer> & { status: Timer["status"] }): LiveSessionRealtimeRecord {
+  return {
+    timer: {
+      remainingSeconds: 0,
+      ...timer,
+    } as Timer,
+  } as unknown as LiveSessionRealtimeRecord;
+}
+
+describe("lib/live-sessions/client — getLiveRemainingSeconds", () => {
+  it("returns 0 when session is null", () => {
+    expect(getLiveRemainingSeconds(null)).toBe(0);
+  });
+
+  it("returns remainingSeconds verbatim when status is 'idle'", () => {
+    expect(
+      getLiveRemainingSeconds(mkSession({ status: "idle", remainingSeconds: 300 }))
+    ).toBe(300);
+  });
+
+  it("returns remainingSeconds verbatim when status is 'completed'", () => {
+    expect(
+      getLiveRemainingSeconds(mkSession({ status: "completed", remainingSeconds: 42 }))
+    ).toBe(42);
+  });
+
+  it("returns remainingSeconds verbatim when status is 'paused'", () => {
+    expect(
+      getLiveRemainingSeconds(mkSession({ status: "paused", remainingSeconds: 120 }))
+    ).toBe(120);
+  });
+
+  it("returns remainingSeconds verbatim when running but startedAtMs is missing", () => {
+    expect(
+      getLiveRemainingSeconds(
+        mkSession({ status: "running", remainingSeconds: 300, startedAtMs: undefined })
+      )
+    ).toBe(300);
+  });
+
+  it("decrements by elapsed seconds when running with startedAtMs", () => {
+    const now = Date.now();
+    const remaining = getLiveRemainingSeconds(
+      mkSession({
+        status: "running",
+        remainingSeconds: 300,
+        startedAtMs: now - 30_000, // 30 seconds ago
+      })
+    );
+    // Allow ±2s for jitter
+    expect(remaining).toBeGreaterThanOrEqual(268);
+    expect(remaining).toBeLessThanOrEqual(272);
+  });
+
+  it("clamps to 0 when elapsed time exceeds remainingSeconds", () => {
+    const remaining = getLiveRemainingSeconds(
+      mkSession({
+        status: "running",
+        remainingSeconds: 5,
+        startedAtMs: Date.now() - 60_000,
+      })
+    );
+    expect(remaining).toBe(0);
+  });
+
+  it("clamps to 0 if startedAtMs is in the future (negative elapsed)", () => {
+    const remaining = getLiveRemainingSeconds(
+      mkSession({
+        status: "running",
+        remainingSeconds: 60,
+        startedAtMs: Date.now() + 60_000,
+      })
+    );
+    // Future-start = max(0, elapsed)=0, so remaining = 60 - 0 = 60.
+    expect(remaining).toBe(60);
+  });
+});

--- a/__tests__/lib/logger-coverage.test.ts
+++ b/__tests__/lib/logger-coverage.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment node
+ *
+ * Coverage complement for __tests__/lib/logger.test.ts. Targets the
+ * previously-uncovered logRequest, withLogging, logApiError, and the
+ * sanitizeErrorMessage redaction patterns (Bearer tokens, API keys,
+ * emails, /Users/ paths).
+ */
+import {
+  LogLevel,
+  logApiError,
+  logger,
+  withLogging,
+} from "@/lib/logger";
+
+function mkRequest(opts: {
+  url?: string;
+  method?: string;
+  headers?: Record<string, string>;
+}): Request {
+  const headers = new Headers(opts.headers ?? {});
+  return new Request(opts.url ?? "https://example.com/api/x", {
+    method: opts.method ?? "GET",
+    headers,
+  });
+}
+
+describe("lib/logger — additional coverage", () => {
+  beforeEach(() => {
+    console.log = jest.fn();
+    console.error = jest.fn();
+    console.warn = jest.fn();
+    console.debug = jest.fn();
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("logRequest", () => {
+    it("logs at INFO for 2xx", () => {
+      const req = mkRequest({ url: "https://x.com/api/users" });
+      const res = new Response("ok", { status: 200 });
+      logger.logRequest(req, res, 12);
+      expect(console.log).toHaveBeenCalled();
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("[INFO]");
+      expect(msg).toContain("GET /api/users");
+      expect(msg).toContain("[200]");
+      expect(msg).toContain("[12ms]");
+    });
+
+    it("logs at WARN for 4xx", () => {
+      const req = mkRequest({});
+      const res = new Response("nope", { status: 401 });
+      logger.logRequest(req, res, 1);
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("logs at ERROR for 5xx", () => {
+      const req = mkRequest({});
+      const res = new Response("boom", { status: 500 });
+      logger.logRequest(req, res, 1);
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("captures client IP from x-forwarded-for (first entry, trimmed)", () => {
+      const req = mkRequest({
+        headers: { "x-forwarded-for": "203.0.113.5, 10.0.0.1" },
+      });
+      const res = new Response("ok", { status: 200 });
+      logger.logRequest(req, res, 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("203.0.113.5");
+    });
+
+    it("captures IP from x-real-ip when x-forwarded-for is absent", () => {
+      const req = mkRequest({ headers: { "x-real-ip": "198.51.100.7" } });
+      logger.logRequest(req, new Response("ok"), 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("198.51.100.7");
+    });
+
+    it("falls back to cf-connecting-ip", () => {
+      const req = mkRequest({ headers: { "cf-connecting-ip": "192.0.2.9" } });
+      logger.logRequest(req, new Response("ok"), 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("192.0.2.9");
+    });
+
+    it("captures user-agent when present", () => {
+      const req = mkRequest({ headers: { "user-agent": "Mozilla/5.0" } });
+      logger.logRequest(req, new Response("ok"), 1);
+      const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("Mozilla/5.0");
+    });
+  });
+
+  describe("logError redactions", () => {
+    it("redacts Bearer tokens from error messages", () => {
+      logger.logError(new Error("authz failed: Bearer abc123tok-_.token"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("Bearer [REDACTED]");
+      expect(msg).not.toContain("abc123tok");
+    });
+
+    it("redacts common API key prefixes (sk_live_, ghp_, AIza...)", () => {
+      logger.logError(new Error("key sk_live_abcdef and AIzaSyXX-DEMO"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("[REDACTED]");
+      expect(msg).not.toContain("sk_live_abcdef");
+    });
+
+    it("redacts email addresses", () => {
+      logger.logError(new Error("user alice@example.com triggered"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("[EMAIL_REDACTED]");
+      expect(msg).not.toContain("alice@example.com");
+    });
+
+    it("redacts /Users/<name> and /home/<name> paths", () => {
+      logger.logError(new Error("Cannot read /Users/ludwitt/cursor-boston/x.ts"));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("/Users/[REDACTED]");
+      expect(msg).not.toContain("/Users/ludwitt");
+    });
+
+    it("returns 'Unknown error' for empty error messages", () => {
+      // Triggers the `if (!message) return "Unknown error";` branch.
+      logger.logError(new Error(""));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("Unknown error");
+    });
+
+    it("handles non-Error values without throwing", () => {
+      logger.logError("string error");
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("preserves common identifier prefixes in the base64-redaction step", () => {
+      // The 40+ char base64 match has an exception for firebase/google/github/discord prefixes.
+      const safe = "firebase" + "A".repeat(40);
+      logger.logError(new Error(`identifier=${safe}`));
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain(safe);
+    });
+  });
+
+  describe("withLogging middleware", () => {
+    it("invokes the handler and logs the request on success", async () => {
+      const handler = jest.fn(async (_req: Request) => new Response("ok", { status: 200 }));
+      const wrapped = withLogging(handler);
+      const res = await wrapped(mkRequest({}));
+      expect(res.status).toBe(200);
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it("logs the error and returns a 500 with X-Request-ID when the handler throws", async () => {
+      const handler = jest.fn(async (_req: Request) => {
+        throw new Error("handler boom");
+      });
+      const wrapped = withLogging(handler);
+      const res = await wrapped(mkRequest({}));
+      expect(res.status).toBe(500);
+      expect(res.headers.get("X-Request-ID")).toMatch(/^[0-9a-f-]{8,}$/);
+      const body = await res.json();
+      expect(body.error).toBe("Internal server error");
+      expect(typeof body.requestId).toBe("string");
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("logApiError", () => {
+    it("logs the error with endpoint metadata", () => {
+      logApiError("/api/x", new Error("boom"));
+      expect(console.error).toHaveBeenCalled();
+      const msg = (console.error as jest.Mock).mock.calls[0][0] as string;
+      expect(msg).toContain("/api/x");
+    });
+  });
+
+  describe("LogLevel enum", () => {
+    it("exposes the four levels", () => {
+      expect(LogLevel.DEBUG).toBe("DEBUG");
+      expect(LogLevel.INFO).toBe("INFO");
+      expect(LogLevel.WARN).toBe("WARN");
+      expect(LogLevel.ERROR).toBe("ERROR");
+    });
+  });
+});

--- a/__tests__/lib/ludwitt-tokens.test.ts
+++ b/__tests__/lib/ludwitt-tokens.test.ts
@@ -1,0 +1,400 @@
+/**
+ * @jest-environment node
+ */
+const adminDbMock = jest.fn();
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: () => adminDbMock(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mockFetchLudwitt = jest.fn();
+const mockGetClientId = jest.fn();
+const mockGetClientSecret = jest.fn();
+
+jest.mock("@/lib/ludwitt-config", () => ({
+  LUDWITT_TOKEN_URL: "https://example.com/oauth/token",
+  LUDWITT_TOKENS_COLLECTION: "ludwittTokens",
+  fetchLudwittWithTimeout: (...a: unknown[]) => mockFetchLudwitt(...a),
+  getLudwittClientId: () => mockGetClientId(),
+  getLudwittClientSecret: () => mockGetClientSecret(),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => ({ __ts: "now" }),
+    delete: () => ({ __delete: true }),
+  },
+}));
+
+// crypto.randomBytes is deterministic per test by replacing the export
+jest.mock("crypto", () => {
+  const actual = jest.requireActual<typeof import("crypto")>("crypto");
+  return {
+    ...actual,
+    randomBytes: jest.fn((n: number) => actual.randomBytes(n)),
+  };
+});
+
+import {
+  deleteLudwittTokens,
+  getLudwittTokens,
+  refreshLudwittTokens,
+  saveLudwittTokens,
+  withFreshLudwittAccessToken,
+} from "@/lib/ludwitt-tokens";
+
+function tsLikeMs(ms: number) {
+  return {
+    toMillis: () => ms,
+    toDate: () => new Date(ms),
+  };
+}
+
+function tokenSnap(data: Record<string, unknown> | null) {
+  return {
+    exists: !!data,
+    data: () => data ?? undefined,
+  };
+}
+
+describe("lib/ludwitt-tokens", () => {
+  beforeEach(() => {
+    adminDbMock.mockReset();
+    mockFetchLudwitt.mockReset();
+    mockGetClientId.mockReturnValue("CID");
+    mockGetClientSecret.mockReturnValue("CS");
+  });
+
+  function fakeTokenDb(initialSnap: ReturnType<typeof tokenSnap>) {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const set = jest.fn().mockResolvedValue(undefined);
+    const deleteFn = jest.fn().mockResolvedValue(undefined);
+    const get = jest.fn().mockResolvedValue(initialSnap);
+
+    const doc = { get, set, update, delete: deleteFn };
+    const collection = jest.fn().mockReturnValue({
+      doc: jest.fn().mockReturnValue(doc),
+    });
+    const runTransaction = jest.fn(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        get: jest.fn().mockResolvedValue(initialSnap),
+        update: jest.fn(),
+        set: jest.fn(),
+      };
+      return fn(tx);
+    });
+    return {
+      db: { collection, runTransaction },
+      doc,
+      get,
+      set,
+      update,
+      deleteFn,
+    };
+  }
+
+  describe("getLudwittTokens", () => {
+    it("returns null when admin db is unavailable", async () => {
+      adminDbMock.mockReturnValueOnce(null);
+      await expect(getLudwittTokens("u1")).rejects.toThrow("Firebase Admin not configured");
+    });
+
+    it("returns null when doc does not exist", async () => {
+      const { db } = fakeTokenDb(tokenSnap(null));
+      adminDbMock.mockReturnValueOnce(db);
+      expect(await getLudwittTokens("u1")).toBeNull();
+    });
+
+    it("returns null when accessToken/refreshToken are missing", async () => {
+      const { db } = fakeTokenDb(tokenSnap({}));
+      adminDbMock.mockReturnValueOnce(db);
+      expect(await getLudwittTokens("u1")).toBeNull();
+    });
+
+    it("returns the parsed tokens when doc has accessToken + refreshToken", async () => {
+      const { db } = fakeTokenDb(
+        tokenSnap({
+          accessToken: "AT",
+          refreshToken: "RT",
+          scope: "read write",
+          accessExpiresAt: tsLikeMs(1_700_000_000_000),
+        }),
+      );
+      adminDbMock.mockReturnValueOnce(db);
+      const out = await getLudwittTokens("u1");
+      expect(out).toEqual({
+        accessToken: "AT",
+        refreshToken: "RT",
+        scope: "read write",
+        accessExpiresAt: new Date(1_700_000_000_000),
+      });
+    });
+
+    it("defaults scope to '' and falls back to epoch 0 when timestamps missing", async () => {
+      const { db } = fakeTokenDb(
+        tokenSnap({ accessToken: "AT", refreshToken: "RT" }),
+      );
+      adminDbMock.mockReturnValueOnce(db);
+      const out = await getLudwittTokens("u1");
+      expect(out?.scope).toBe("");
+      expect(out?.accessExpiresAt).toEqual(new Date(0));
+    });
+  });
+
+  describe("saveLudwittTokens", () => {
+    it("writes the raw token payload + computed accessExpiresAt", async () => {
+      const { db, set } = fakeTokenDb(tokenSnap(null));
+      adminDbMock.mockReturnValueOnce(db);
+      const now = Date.now();
+      jest.spyOn(Date, "now").mockReturnValueOnce(now);
+      await saveLudwittTokens("u1", {
+        access_token: "AT",
+        refresh_token: "RT",
+        expires_in: 3600,
+        token_type: "Bearer",
+        scope: "read",
+      });
+      const [payload, opts] = set.mock.calls[0];
+      expect(payload).toMatchObject({
+        accessToken: "AT",
+        refreshToken: "RT",
+        scope: "read",
+        tokenType: "Bearer",
+      });
+      expect((payload.accessExpiresAt as Date).getTime()).toBe(now + 3600 * 1000);
+      expect(opts).toEqual({ merge: true });
+    });
+  });
+
+  describe("deleteLudwittTokens", () => {
+    it("deletes the token doc", async () => {
+      const { db, deleteFn } = fakeTokenDb(tokenSnap(null));
+      adminDbMock.mockReturnValueOnce(db);
+      await deleteLudwittTokens("u1");
+      expect(deleteFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("refreshLudwittTokens", () => {
+    it("throws ludwitt_tokens_missing when no doc exists", async () => {
+      const initial = tokenSnap(null);
+      const { db } = fakeTokenDb(initial);
+      adminDbMock.mockReturnValueOnce(db);
+      await expect(refreshLudwittTokens("u1")).rejects.toThrow("ludwitt_tokens_missing");
+    });
+
+    it("claims the lock, posts refresh, and writes new tokens", async () => {
+      const initial = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        scope: "read",
+        tokenType: "Bearer",
+        accessExpiresAt: tsLikeMs(1_700_000_000_000),
+      });
+
+      const update = jest.fn().mockResolvedValue(undefined);
+      const get = jest.fn().mockResolvedValue(initial);
+      const docRef = { get, update };
+      const collection = jest.fn().mockReturnValue({
+        doc: jest.fn().mockReturnValue(docRef),
+      });
+      const runTransaction = jest.fn(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          get: jest.fn().mockResolvedValue(initial),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+      const db = { collection, runTransaction };
+      adminDbMock.mockReturnValueOnce(db);
+
+      mockFetchLudwitt.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "AT1",
+          refresh_token: "RT1",
+          expires_in: 7200,
+          token_type: "Bearer",
+          scope: "read write",
+        }),
+        text: async () => "",
+      });
+
+      const out = await refreshLudwittTokens("u1");
+      expect(out.accessToken).toBe("AT1");
+      expect(out.refreshToken).toBe("RT1");
+      expect(out.scope).toBe("read write");
+      expect(update).toHaveBeenCalled();
+    });
+
+    it("throws when refresh fails (non-2xx)", async () => {
+      const initial = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+      });
+      const update = jest.fn().mockResolvedValue(undefined);
+      const get = jest.fn().mockResolvedValue(initial);
+      const docRef = { get, update };
+      const collection = jest.fn().mockReturnValue({
+        doc: jest.fn().mockReturnValue(docRef),
+      });
+      const runTransaction = jest.fn(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          get: jest.fn().mockResolvedValue(initial),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+      const db = { collection, runTransaction };
+      adminDbMock.mockReturnValueOnce(db);
+
+      mockFetchLudwitt.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+        text: async () => "bad token",
+      });
+
+      await expect(refreshLudwittTokens("u1")).rejects.toThrow("refresh_failed:401");
+      // Lock cleanup attempted
+      expect(update).toHaveBeenCalled();
+    });
+
+    it("throws when client credentials aren't configured", async () => {
+      mockGetClientId.mockReturnValueOnce("");
+      const initial = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+      });
+      const update = jest.fn().mockResolvedValue(undefined);
+      const docRef = { get: jest.fn().mockResolvedValue(initial), update };
+      const collection = jest.fn().mockReturnValue({
+        doc: jest.fn().mockReturnValue(docRef),
+      });
+      const runTransaction = jest.fn(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          get: jest.fn().mockResolvedValue(initial),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+      const db = { collection, runTransaction };
+      adminDbMock.mockReturnValueOnce(db);
+      await expect(refreshLudwittTokens("u1")).rejects.toThrow("Ludwitt OAuth not configured");
+    });
+  });
+
+  describe("withFreshLudwittAccessToken", () => {
+    it("throws ludwitt_not_connected when no tokens stored", async () => {
+      const { db } = fakeTokenDb(tokenSnap(null));
+      adminDbMock.mockReturnValueOnce(db);
+      await expect(
+        withFreshLudwittAccessToken("u1", async () => ({
+          status: 200,
+          body: {},
+          headers: new Headers(),
+        })),
+      ).rejects.toThrow("ludwitt_not_connected");
+    });
+
+    it("returns the first call result when status !== 401", async () => {
+      const { db } = fakeTokenDb(
+        tokenSnap({
+          accessToken: "AT",
+          refreshToken: "RT",
+          scope: "",
+          accessExpiresAt: tsLikeMs(0),
+        }),
+      );
+      adminDbMock.mockReturnValueOnce(db);
+      const call = jest.fn().mockResolvedValueOnce({
+        status: 200,
+        body: { ok: true },
+        headers: new Headers(),
+      });
+      const out = await withFreshLudwittAccessToken("u1", call);
+      expect(out.status).toBe(200);
+      expect(call).toHaveBeenCalledTimes(1);
+      expect(call).toHaveBeenCalledWith("AT");
+    });
+
+    it("retries the call after a 401, using the refreshed access token", async () => {
+      // First, getLudwittTokens needs admin db
+      const dbForGet = fakeTokenDb(
+        tokenSnap({
+          accessToken: "AT0",
+          refreshToken: "RT0",
+          scope: "",
+          accessExpiresAt: tsLikeMs(0),
+        }),
+      );
+      // refreshLudwittTokens also needs admin db (called second time)
+      const initialForRefresh = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+      });
+      const updateRefresh = jest.fn().mockResolvedValue(undefined);
+      const docRefRefresh = {
+        get: jest.fn().mockResolvedValue(initialForRefresh),
+        update: updateRefresh,
+      };
+      const collRefresh = jest.fn().mockReturnValue({
+        doc: jest.fn().mockReturnValue(docRefRefresh),
+      });
+      const txnRefresh = jest.fn(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          get: jest.fn().mockResolvedValue(initialForRefresh),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+      const dbRefresh = { collection: collRefresh, runTransaction: txnRefresh };
+
+      adminDbMock
+        .mockReturnValueOnce(dbForGet.db)
+        .mockReturnValueOnce(dbRefresh);
+
+      mockFetchLudwitt.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "AT1",
+          refresh_token: "RT1",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "",
+        }),
+        text: async () => "",
+      });
+
+      const call = jest
+        .fn()
+        .mockResolvedValueOnce({
+          status: 401,
+          body: { err: "auth" },
+          headers: new Headers(),
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          body: { ok: true },
+          headers: new Headers(),
+        });
+
+      const out = await withFreshLudwittAccessToken("u1", call);
+      expect(out.status).toBe(200);
+      expect(call.mock.calls).toEqual([["AT0"], ["AT1"]]);
+    });
+  });
+});

--- a/__tests__/lib/mailgun-suppressions.test.ts
+++ b/__tests__/lib/mailgun-suppressions.test.ts
@@ -1,0 +1,373 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => ({ __ts: "now" }),
+  },
+}));
+
+import {
+  __resetMailgunSuppressionsMemo,
+  syncMailgunSuppressions,
+} from "@/lib/mailgun-suppressions";
+
+const originalFetch = global.fetch;
+
+function mkRes(body: unknown, ok = true, status = 200, text = ""): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => text,
+  } as unknown as Response;
+}
+
+interface FakeDocSnap {
+  id: string;
+  exists: boolean;
+  data: () => Record<string, unknown> | undefined;
+}
+
+function buildFakeDb(opts: {
+  eventContacts?: Record<string, Record<string, unknown>>;
+  // direct doc lookup by email
+  eventContactsByEmail?: Record<string, FakeDocSnap>;
+  // query: where("email", "==", email).limit(1) → match
+  eventContactsByQuery?: Record<string, FakeDocSnap>;
+  usersByEmail?: Record<string, FakeDocSnap>;
+}) {
+  const eventContactDocSet = jest.fn().mockResolvedValue(undefined);
+  const usersDocSet = jest.fn().mockResolvedValue(undefined);
+
+  function chainOf(getMap: Record<string, FakeDocSnap>) {
+    const where = jest.fn();
+    const limit = jest.fn();
+    const get = jest.fn(() => {
+      const email = where.mock.calls.at(-1)?.[2];
+      const match = email ? getMap[email] : undefined;
+      return Promise.resolve({
+        empty: !match,
+        docs: match ? [match] : [],
+      });
+    });
+    where.mockReturnValue({ where, limit, get });
+    limit.mockReturnValue({ where, limit, get });
+    return { where, limit, get };
+  }
+
+  const eventContactsChain = chainOf(opts.eventContactsByQuery ?? {});
+  const usersChain = chainOf(opts.usersByEmail ?? {});
+
+  const eventContactsCol = {
+    doc: jest.fn((email: string) => {
+      const snap = opts.eventContactsByEmail?.[email];
+      return {
+        get: jest.fn().mockResolvedValue(
+          snap ?? { id: email, exists: false, data: () => undefined },
+        ),
+        set: eventContactDocSet,
+      };
+    }),
+    where: eventContactsChain.where,
+  };
+  const usersCol = {
+    doc: jest.fn(() => ({ set: usersDocSet })),
+    where: usersChain.where,
+  };
+
+  const collection = jest.fn((name: string) => {
+    if (name === "eventContacts") return eventContactsCol;
+    if (name === "users") return usersCol;
+    throw new Error(`unexpected: ${name}`);
+  });
+
+  return {
+    db: { collection } as unknown as Parameters<typeof syncMailgunSuppressions>[0],
+    spies: { eventContactDocSet, usersDocSet, eventContactsChain, usersChain },
+  };
+}
+
+describe("lib/mailgun-suppressions", () => {
+  beforeEach(() => {
+    __resetMailgunSuppressionsMemo();
+    global.fetch = jest.fn();
+    delete process.env.MAILGUN_PRIVATE_API_KEY;
+    delete process.env.MAILGUN_DOMAIN;
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("skips when MAILGUN_PRIVATE_API_KEY is missing", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    const { db } = buildFakeDb({});
+    const out = await syncMailgunSuppressions(db);
+    expect(out.skipped).toBe(true);
+    expect(out.skippedReason).toMatch(/MAILGUN_PRIVATE_API_KEY/);
+    expect(out.allSuppressed.size).toBe(0);
+  });
+
+  it("skips when MAILGUN_DOMAIN is missing", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "x";
+    const { db } = buildFakeDb({});
+    const out = await syncMailgunSuppressions(db);
+    expect(out.skipped).toBe(true);
+    expect(out.skippedReason).toMatch(/MAILGUN_DOMAIN/);
+  });
+
+  it("returns no-op result when bounce + complaint lists are empty", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mkRes({ items: [], paging: { next: null } }),
+    );
+    const { db } = buildFakeDb({});
+    const out = await syncMailgunSuppressions(db);
+    expect(out.skipped).toBe(false);
+    expect(out.allSuppressed.size).toBe(0);
+    expect(out.flaggedEventContacts).toBe(0);
+    expect(out.flaggedUsers).toBe(0);
+  });
+
+  it("merges bounces + complaints into allSuppressed (lowercase, deduped — bounce wins on conflict)", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("/bounces")) {
+        return Promise.resolve(
+          mkRes({
+            items: [
+              { address: "Alice@x.com", code: 550, error: "blocked" },
+              { address: "", code: 0 },
+            ],
+          }),
+        );
+      }
+      if (url.includes("/complaints")) {
+        return Promise.resolve(
+          mkRes({
+            items: [
+              { address: "alice@X.com", code: 999, error: "complained" },
+              { address: "bob@y.com", code: 999 },
+              { address: "  ", code: 0 },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(mkRes({ items: [] }));
+    });
+    const { db } = buildFakeDb({});
+    const out = await syncMailgunSuppressions(db);
+    expect([...out.allSuppressed].sort()).toEqual([
+      "alice@x.com",
+      "bob@y.com",
+    ]);
+    expect(out.bouncedCount).toBe(2);
+    expect(out.complaintsCount).toBe(3);
+  });
+
+  it("writes flags onto eventContacts (direct id) and users (queried by email)", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("/bounces")) {
+        return Promise.resolve(
+          mkRes({
+            items: [{ address: "alice@x.com", code: 550, error: "blocked" }],
+          }),
+        );
+      }
+      return Promise.resolve(mkRes({ items: [] }));
+    });
+    const { db, spies } = buildFakeDb({
+      eventContactsByEmail: {
+        "alice@x.com": {
+          id: "alice@x.com",
+          exists: true,
+          data: () => ({ email: "alice@x.com" }),
+        },
+      },
+      usersByEmail: {
+        "alice@x.com": {
+          id: "user-1",
+          exists: true,
+          data: () => ({ email: "alice@x.com" }),
+        },
+      },
+    });
+    const out = await syncMailgunSuppressions(db);
+    expect(out.flaggedEventContacts).toBe(1);
+    expect(out.flaggedUsers).toBe(1);
+    expect(spies.eventContactDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unsubscribed: true,
+        suppressionReason: "mailgun-bounce",
+        suppressionCode: "550",
+        suppressionError: "blocked",
+      }),
+      { merge: true },
+    );
+    expect(spies.usersDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unsubscribed: true,
+        unsubscribedReason: "mailgun-suppression",
+      }),
+      { merge: true },
+    );
+  });
+
+  it("uses mailgun-complaint reason for complaint-sourced flags + null payload for empty code/error", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("/complaints")) {
+        return Promise.resolve(
+          mkRes({ items: [{ address: "carol@x.com" }] }),
+        );
+      }
+      return Promise.resolve(mkRes({ items: [] }));
+    });
+    const { db, spies } = buildFakeDb({
+      eventContactsByEmail: {
+        "carol@x.com": {
+          id: "carol@x.com",
+          exists: true,
+          data: () => ({}),
+        },
+      },
+    });
+    await syncMailgunSuppressions(db);
+    expect(spies.eventContactDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        suppressionReason: "mailgun-complaint",
+        suppressionCode: null,
+        suppressionError: null,
+      }),
+      { merge: true },
+    );
+  });
+
+  it("skips event contacts already unsubscribed with bouncedAt", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("/bounces")) {
+        return Promise.resolve(
+          mkRes({ items: [{ address: "dave@x.com" }] }),
+        );
+      }
+      return Promise.resolve(mkRes({ items: [] }));
+    });
+    const { db, spies } = buildFakeDb({
+      eventContactsByEmail: {
+        "dave@x.com": {
+          id: "dave@x.com",
+          exists: true,
+          data: () => ({ unsubscribed: true, bouncedAt: { x: 1 } }),
+        },
+      },
+    });
+    const out = await syncMailgunSuppressions(db);
+    expect(out.flaggedEventContacts).toBe(0);
+    expect(spies.eventContactDocSet).not.toHaveBeenCalled();
+  });
+
+  it("falls back to eventContacts where('email','==',email) query when direct doc id misses", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("/bounces")) {
+        return Promise.resolve(
+          mkRes({ items: [{ address: "eve@x.com" }] }),
+        );
+      }
+      return Promise.resolve(mkRes({ items: [] }));
+    });
+    const { db } = buildFakeDb({
+      eventContactsByQuery: {
+        "eve@x.com": {
+          id: "ec-eve",
+          exists: true,
+          data: () => ({ email: "eve@x.com" }),
+        },
+      },
+    });
+    const out = await syncMailgunSuppressions(db);
+    expect(out.flaggedEventContacts).toBe(1);
+  });
+
+  it("memoizes the result and skips refetch on second call without force:true", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockResolvedValue(mkRes({ items: [] }));
+    const { db } = buildFakeDb({});
+    const a = await syncMailgunSuppressions(db);
+    const b = await syncMailgunSuppressions(db);
+    expect(a).toBe(b);
+    expect(global.fetch).toHaveBeenCalledTimes(2); // first call hits twice (bounces + complaints), second call memoized
+  });
+
+  it("refetches when force:true is passed", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockResolvedValue(mkRes({ items: [] }));
+    const { db } = buildFakeDb({});
+    await syncMailgunSuppressions(db);
+    await syncMailgunSuppressions(db, { force: true });
+    expect(global.fetch).toHaveBeenCalledTimes(4); // 2 (first run) + 2 (forced re-run)
+  });
+
+  it("clears memo on transport error so a retry is possible", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mkRes({}, false, 500, "internal"),
+    );
+    const { db } = buildFakeDb({});
+    await expect(syncMailgunSuppressions(db)).rejects.toThrow(
+      /Mailgun .* fetch failed/,
+    );
+    // Second call should attempt fresh fetch (memo was cleared)
+    (global.fetch as jest.Mock).mockResolvedValue(mkRes({ items: [] }));
+    const out = await syncMailgunSuppressions(db);
+    expect(out.skipped).toBe(false);
+  });
+
+  it("follows paging.next until items=0 (caps at 50 pages)", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    let bounceCalls = 0;
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes("/bounces")) {
+        bounceCalls++;
+        if (bounceCalls === 1) {
+          return Promise.resolve(
+            mkRes({
+              items: [{ address: "a@x.com" }],
+              paging: { next: `${url}&page=2` },
+            }),
+          );
+        }
+        return Promise.resolve(mkRes({ items: [] }));
+      }
+      return Promise.resolve(mkRes({ items: [] }));
+    });
+    const { db } = buildFakeDb({});
+    await syncMailgunSuppressions(db);
+    expect(bounceCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("respects verbose:false (no console.log lines emitted)", async () => {
+    process.env.MAILGUN_PRIVATE_API_KEY = "key";
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    (global.fetch as jest.Mock).mockResolvedValue(mkRes({ items: [] }));
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    logSpy.mockClear();
+    const { db } = buildFakeDb({});
+    await syncMailgunSuppressions(db, { verbose: false });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/mailgun.test.ts
+++ b/__tests__/lib/mailgun.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment node
+ */
+
+const mockCreate = jest.fn();
+const mockClient = jest.fn(() => ({ messages: { create: mockCreate } }));
+const MockMailgun = jest.fn().mockImplementation(() => ({ client: mockClient }));
+
+jest.mock("mailgun.js", () => ({
+  __esModule: true,
+  default: MockMailgun,
+}));
+
+jest.mock("form-data", () => ({
+  __esModule: true,
+  default: class FormDataStub {},
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+async function loadFreshModule() {
+  let mod: typeof import("@/lib/mailgun");
+  await jest.isolateModulesAsync(async () => {
+    mod = await import("@/lib/mailgun");
+  });
+  return mod!;
+}
+
+describe("lib/mailgun", () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockClient.mockClear();
+    MockMailgun.mockClear();
+    delete process.env.MAILGUN_API_KEY;
+    delete process.env.MAILGUN_DOMAIN;
+    delete process.env.MAILGUN_FROM;
+    delete process.env.MAILGUN_EU;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("throws when MAILGUN_DOMAIN is unset", async () => {
+    const { sendEmail } = await loadFreshModule();
+    await expect(
+      sendEmail({ to: "x@y.com", subject: "s", text: "t" }),
+    ).rejects.toThrow("MAILGUN_DOMAIN is not set");
+  });
+
+  it("throws when neither text nor html is provided", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    const { sendEmail } = await loadFreshModule();
+    await expect(
+      sendEmail({ to: "x@y.com", subject: "s" }),
+    ).rejects.toThrow("Either text or html is required for sendEmail");
+  });
+
+  it("throws when MAILGUN_API_KEY is unset (client init)", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    const { sendEmail } = await loadFreshModule();
+    await expect(
+      sendEmail({ to: "x@y.com", subject: "s", text: "t" }),
+    ).rejects.toThrow("MAILGUN_API_KEY and MAILGUN_DOMAIN must be set");
+  });
+
+  it("sends with text payload and default noreply from", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    mockCreate.mockResolvedValueOnce({ id: "msg-1" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({ to: "user@x.com", subject: "hi", text: "hello" });
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const [domain, payload] = mockCreate.mock.calls[0];
+    expect(domain).toBe("mg.example.com");
+    expect(payload).toEqual({
+      from: "noreply@mg.example.com",
+      to: ["user@x.com"],
+      subject: "hi",
+      text: "hello",
+    });
+  });
+
+  it("sends with html payload only (no text)", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    mockCreate.mockResolvedValueOnce({ id: "msg-2" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({ to: "user@x.com", subject: "hi", html: "<p>hello</p>" });
+    const [, payload] = mockCreate.mock.calls[0];
+    expect(payload).toEqual({
+      from: "noreply@mg.example.com",
+      to: ["user@x.com"],
+      subject: "hi",
+      html: "<p>hello</p>",
+    });
+    expect(payload).not.toHaveProperty("text");
+  });
+
+  it("includes both text and html when both are provided", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    mockCreate.mockResolvedValueOnce({ id: "msg-3" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({
+      to: "user@x.com",
+      subject: "hi",
+      text: "plain",
+      html: "<p>rich</p>",
+    });
+    const [, payload] = mockCreate.mock.calls[0];
+    expect(payload.text).toBe("plain");
+    expect(payload.html).toBe("<p>rich</p>");
+  });
+
+  it("normalizes a single-string to into an array", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    mockCreate.mockResolvedValueOnce({ id: "msg-4" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({ to: "solo@x.com", subject: "s", text: "t" });
+    const [, payload] = mockCreate.mock.calls[0];
+    expect(payload.to).toEqual(["solo@x.com"]);
+  });
+
+  it("preserves an array-shaped to without re-wrapping", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    mockCreate.mockResolvedValueOnce({ id: "msg-5" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({
+      to: ["a@x.com", "b@x.com"],
+      subject: "s",
+      text: "t",
+    });
+    const [, payload] = mockCreate.mock.calls[0];
+    expect(payload.to).toEqual(["a@x.com", "b@x.com"]);
+  });
+
+  it("uses explicit options.from when provided", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    process.env.MAILGUN_FROM = "fallback@mg.example.com";
+    mockCreate.mockResolvedValueOnce({ id: "msg-6" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({
+      to: "u@x.com",
+      subject: "s",
+      text: "t",
+      from: "explicit@mg.example.com",
+    });
+    const [, payload] = mockCreate.mock.calls[0];
+    expect(payload.from).toBe("explicit@mg.example.com");
+  });
+
+  it("falls back to MAILGUN_FROM env when options.from is omitted", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    process.env.MAILGUN_FROM = "fallback@mg.example.com";
+    mockCreate.mockResolvedValueOnce({ id: "msg-7" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({ to: "u@x.com", subject: "s", text: "t" });
+    const [, payload] = mockCreate.mock.calls[0];
+    expect(payload.from).toBe("fallback@mg.example.com");
+  });
+
+  it("configures EU region URL when MAILGUN_EU=true", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    process.env.MAILGUN_EU = "true";
+    mockCreate.mockResolvedValueOnce({ id: "msg-8" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({ to: "u@x.com", subject: "s", text: "t" });
+    expect(mockClient).toHaveBeenCalledTimes(1);
+    expect(mockClient.mock.calls[0][0]).toEqual({
+      username: "api",
+      key: "key-test",
+      url: "https://api.eu.mailgun.net",
+    });
+  });
+
+  it("omits EU URL when MAILGUN_EU is not exactly 'true'", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    process.env.MAILGUN_EU = "1";
+    mockCreate.mockResolvedValueOnce({ id: "msg-9" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({ to: "u@x.com", subject: "s", text: "t" });
+    const opts = mockClient.mock.calls[0][0];
+    expect(opts).toEqual({ username: "api", key: "key-test" });
+    expect(opts).not.toHaveProperty("url");
+  });
+
+  it("constructs Mailgun with FormData and caches the client across calls", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    mockCreate.mockResolvedValue({ id: "msg-cache" });
+    const { sendEmail } = await loadFreshModule();
+    await sendEmail({ to: "u@x.com", subject: "s", text: "t" });
+    await sendEmail({ to: "u@x.com", subject: "s", text: "t" });
+    expect(MockMailgun).toHaveBeenCalledTimes(1);
+    expect(mockClient).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates errors thrown by mg.messages.create", async () => {
+    process.env.MAILGUN_DOMAIN = "mg.example.com";
+    process.env.MAILGUN_API_KEY = "key-test";
+    mockCreate.mockRejectedValueOnce(new Error("upstream 401"));
+    const { sendEmail } = await loadFreshModule();
+    await expect(
+      sendEmail({ to: "u@x.com", subject: "s", text: "t" }),
+    ).rejects.toThrow("upstream 401");
+  });
+});

--- a/__tests__/lib/members-public-snapshot.test.ts
+++ b/__tests__/lib/members-public-snapshot.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @jest-environment node
+ */
+import {
+  MEMBERS_SNAPSHOT_CACHE_TTL_MS,
+  computePublicMembersSnapshot,
+} from "@/lib/members-public-snapshot";
+
+type DocLike = { id: string; data: () => Record<string, unknown> };
+
+function buildFakeDb(usersDocs: DocLike[], agentsDocs: DocLike[]) {
+  // Build query chains that ignore filter args and return the docs.
+  const usersGet = jest.fn().mockResolvedValue({ docs: usersDocs });
+  const agentsGet = jest.fn().mockResolvedValue({ docs: agentsDocs });
+
+  const usersChain = {
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    get: usersGet,
+  };
+  const agentsChain = {
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    get: agentsGet,
+  };
+
+  const collection = jest.fn((name: string) => {
+    if (name === "users") return usersChain;
+    if (name === "agents") return agentsChain;
+    throw new Error(`unexpected collection: ${name}`);
+  });
+
+  return {
+    db: { collection } as unknown as Parameters<typeof computePublicMembersSnapshot>[0],
+    usersChain,
+    agentsChain,
+    collection,
+  };
+}
+
+function doc(id: string, data: Record<string, unknown>): DocLike {
+  return { id, data: () => data };
+}
+
+function tsLike(iso: string) {
+  return { toDate: () => new Date(iso) };
+}
+
+describe("lib/members-public-snapshot", () => {
+  it("exports a 6-hour cache TTL constant", () => {
+    expect(MEMBERS_SNAPSHOT_CACHE_TTL_MS).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it("returns an empty array when both collections are empty", async () => {
+    const { db } = buildFakeDb([], []);
+    const out = await computePublicMembersSnapshot(db);
+    expect(out).toEqual([]);
+  });
+
+  it("queries users by visibility.isPublic and agents by isPublic+claimed", async () => {
+    const { db, usersChain, agentsChain, collection } = buildFakeDb([], []);
+    await computePublicMembersSnapshot(db);
+    expect(collection).toHaveBeenCalledWith("users");
+    expect(collection).toHaveBeenCalledWith("agents");
+    expect(usersChain.where).toHaveBeenCalledWith(
+      "visibility.isPublic",
+      "==",
+      true,
+    );
+    expect(usersChain.orderBy).toHaveBeenCalledWith("createdAt", "desc");
+    expect(agentsChain.where).toHaveBeenCalledWith(
+      "visibility.isPublic",
+      "==",
+      true,
+    );
+    expect(agentsChain.where).toHaveBeenCalledWith("status", "==", "claimed");
+  });
+
+  it("maps human users with uid + memberType='human' and serializes Timestamp createdAt to ISO", async () => {
+    const ts = tsLike("2026-05-01T10:00:00.000Z");
+    const { db } = buildFakeDb(
+      [doc("u1", { displayName: "Alice", createdAt: ts, visibility: { isPublic: true } })],
+      [],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      uid: "u1",
+      memberType: "human",
+      displayName: "Alice",
+      createdAt: "2026-05-01T10:00:00.000Z",
+    });
+  });
+
+  it("maps agents into a normalized shape (name→displayName, description→bio, avatarUrl→photoURL)", async () => {
+    const ts = tsLike("2026-05-02T10:00:00.000Z");
+    const { db } = buildFakeDb(
+      [],
+      [
+        doc("a1", {
+          name: "GPT-Sage",
+          avatarUrl: "https://example.com/a.png",
+          description: "An AI helper",
+          createdAt: ts,
+          visibility: { isPublic: true, showOwner: false },
+          ownerDisplayName: "Bob",
+          ownerEmail: "bob@example.com",
+        }),
+      ],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      uid: "a1",
+      memberType: "agent",
+      displayName: "GPT-Sage",
+      photoURL: "https://example.com/a.png",
+      bio: "An AI helper",
+      visibility: { isPublic: true, showOwner: false, showBio: true, showMemberSince: true },
+      createdAt: "2026-05-02T10:00:00.000Z",
+    });
+    // owner hidden when showOwner is falsy
+    expect((out[0] as Record<string, unknown>).owner).toBeUndefined();
+  });
+
+  it("includes agent owner block only when visibility.showOwner is truthy", async () => {
+    const ts = tsLike("2026-05-02T10:00:00.000Z");
+    const { db } = buildFakeDb(
+      [],
+      [
+        doc("a2", {
+          name: "ClaudePilot",
+          avatarUrl: null,
+          description: "Pilot agent",
+          createdAt: ts,
+          visibility: { isPublic: true, showOwner: true },
+          ownerDisplayName: "Carol",
+          ownerEmail: "carol@example.com",
+        }),
+      ],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect((out[0] as Record<string, unknown>).owner).toEqual({
+      displayName: "Carol",
+      email: "carol@example.com",
+    });
+  });
+
+  it("falls back to photoURL=null when agent has no avatarUrl", async () => {
+    const { db } = buildFakeDb(
+      [],
+      [
+        doc("a3", {
+          name: "X",
+          description: "x",
+          createdAt: tsLike("2026-05-02T10:00:00.000Z"),
+          visibility: { isPublic: true },
+        }),
+      ],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out[0]?.photoURL).toBeNull();
+  });
+
+  it("sorts the merged result by createdAt descending across humans + agents", async () => {
+    const { db } = buildFakeDb(
+      [
+        doc("u-old", {
+          displayName: "Old Human",
+          createdAt: tsLike("2026-01-01T00:00:00.000Z"),
+          visibility: { isPublic: true },
+        }),
+        doc("u-mid", {
+          displayName: "Mid Human",
+          // ISO-string createdAt path
+          createdAt: "2026-03-01T00:00:00.000Z",
+          visibility: { isPublic: true },
+        }),
+      ],
+      [
+        doc("a-new", {
+          name: "New Agent",
+          description: "newest",
+          createdAt: tsLike("2026-04-01T00:00:00.000Z"),
+          visibility: { isPublic: true },
+        }),
+      ],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out.map((m) => m.uid)).toEqual(["a-new", "u-mid", "u-old"]);
+  });
+
+  it("treats invalid Timestamps (NaN dates) as null in the output", async () => {
+    const badTs = { toDate: () => new Date(NaN) };
+    const { db } = buildFakeDb(
+      [
+        doc("u-bad", {
+          displayName: "Bad Date",
+          createdAt: badTs,
+          visibility: { isPublic: true },
+        }),
+      ],
+      [],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out[0]?.createdAt).toBeNull();
+  });
+
+  it("recursively serializes nested Timestamps inside the visibility blob", async () => {
+    const { db } = buildFakeDb(
+      [
+        doc("u-nest", {
+          displayName: "Nest",
+          createdAt: tsLike("2026-05-01T00:00:00.000Z"),
+          visibility: {
+            isPublic: true,
+            verifiedAt: tsLike("2026-04-01T00:00:00.000Z"),
+            tags: ["a", "b"],
+          },
+        }),
+      ],
+      [],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    const v = (out[0] as Record<string, unknown>).visibility as Record<string, unknown>;
+    expect(v.verifiedAt).toBe("2026-04-01T00:00:00.000Z");
+    expect(v.tags).toEqual(["a", "b"]);
+  });
+
+  it("preserves null and undefined leaf values verbatim", async () => {
+    const { db } = buildFakeDb(
+      [
+        doc("u-null", {
+          displayName: null,
+          bio: undefined,
+          createdAt: tsLike("2026-05-01T00:00:00.000Z"),
+          visibility: { isPublic: true },
+        }),
+      ],
+      [],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out[0]?.displayName).toBeNull();
+    expect((out[0] as Record<string, unknown>).bio).toBeUndefined();
+  });
+
+  it("sorts humans missing a usable createdAt to the bottom (treated as epoch 0)", async () => {
+    const { db } = buildFakeDb(
+      [
+        doc("u-no-ts", {
+          displayName: "No TS Human",
+          visibility: { isPublic: true },
+        }),
+        doc("u-new", {
+          displayName: "New Human",
+          createdAt: tsLike("2026-04-01T00:00:00.000Z"),
+          visibility: { isPublic: true },
+        }),
+      ],
+      [],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out.map((m) => m.uid)).toEqual(["u-new", "u-no-ts"]);
+  });
+
+  it("sorts agents missing a usable createdAt to the bottom (treated as epoch 0)", async () => {
+    const { db } = buildFakeDb(
+      [],
+      [
+        doc("a-no-ts", {
+          name: "No TS",
+          description: "no createdAt at all",
+          visibility: { isPublic: true },
+        }),
+        doc("a-new", {
+          name: "New",
+          description: "new",
+          createdAt: tsLike("2026-04-01T00:00:00.000Z"),
+          visibility: { isPublic: true },
+        }),
+      ],
+    );
+    const out = await computePublicMembersSnapshot(db);
+    expect(out.map((m) => m.uid)).toEqual(["a-new", "a-no-ts"]);
+  });
+});

--- a/__tests__/lib/mentorship-data.test.ts
+++ b/__tests__/lib/mentorship-data.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ */
+import {
+  getAllActiveMentorshipProfiles,
+  getMentorshipPairingsForUser,
+  getMentorshipProfile,
+} from "@/lib/mentorship/data";
+
+const mockGetDoc = jest.fn();
+const mockGetDocs = jest.fn();
+
+jest.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => ({ __collection: args }),
+  doc: (...args: unknown[]) => ({ __doc: args }),
+  query: (...args: unknown[]) => ({ __query: args }),
+  where: (...args: unknown[]) => ({ __where: args }),
+  orderBy: (...args: unknown[]) => ({ __orderBy: args }),
+  limit: (n: number) => ({ __limit: n }),
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+}));
+
+jest.mock("@/lib/firebase", () => ({
+  db: { __fake: true },
+}));
+
+// Re-importable mock toggle for the db: tests can override.
+jest.mock("@/lib/firebase", () => {
+  let _db: unknown = { __fake: true };
+  return {
+    get db() {
+      return _db;
+    },
+    __setDb(next: unknown) {
+      _db = next;
+    },
+  };
+});
+
+describe("lib/mentorship/data", () => {
+  beforeEach(() => {
+    mockGetDoc.mockReset();
+    mockGetDocs.mockReset();
+  });
+
+  describe("getMentorshipProfile", () => {
+    it("returns null when db is unavailable", async () => {
+      const firebase = jest.requireMock("@/lib/firebase");
+      firebase.__setDb(null);
+      expect(await getMentorshipProfile("u1")).toBeNull();
+      firebase.__setDb({ __fake: true });
+    });
+
+    it("returns null when the doc doesn't exist", async () => {
+      mockGetDoc.mockResolvedValueOnce({ exists: () => false });
+      expect(await getMentorshipProfile("u1")).toBeNull();
+    });
+
+    it("returns the profile with userId injected when it exists", async () => {
+      mockGetDoc.mockResolvedValueOnce({
+        exists: () => true,
+        id: "u-alice",
+        data: () => ({ displayName: "Alice", bio: "Mentor" }),
+      });
+      const p = await getMentorshipProfile("u-alice");
+      expect(p).toEqual({ userId: "u-alice", displayName: "Alice", bio: "Mentor" });
+    });
+  });
+
+  describe("getAllActiveMentorshipProfiles", () => {
+    it("returns [] when db is unavailable", async () => {
+      const firebase = jest.requireMock("@/lib/firebase");
+      firebase.__setDb(null);
+      expect(await getAllActiveMentorshipProfiles()).toEqual([]);
+      firebase.__setDb({ __fake: true });
+    });
+
+    it("maps each doc to a profile with userId injected", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          { id: "u1", data: () => ({ displayName: "A" }) },
+          { id: "u2", data: () => ({ displayName: "B" }) },
+        ],
+      });
+      const out = await getAllActiveMentorshipProfiles();
+      expect(out).toEqual([
+        { userId: "u1", displayName: "A" },
+        { userId: "u2", displayName: "B" },
+      ]);
+    });
+
+    it("returns an empty array when there are no matching profiles", async () => {
+      mockGetDocs.mockResolvedValueOnce({ docs: [] });
+      expect(await getAllActiveMentorshipProfiles()).toEqual([]);
+    });
+  });
+
+  describe("getMentorshipPairingsForUser", () => {
+    it("returns [] when db is unavailable", async () => {
+      const firebase = jest.requireMock("@/lib/firebase");
+      firebase.__setDb(null);
+      expect(await getMentorshipPairingsForUser("u1")).toEqual([]);
+      firebase.__setDb({ __fake: true });
+    });
+
+    it("unions mentor-side and mentee-side pairings, deduped by doc id", async () => {
+      mockGetDocs
+        .mockResolvedValueOnce({
+          docs: [
+            { id: "p-1", data: () => ({ mentorId: "u1", menteeId: "u2" }) },
+            { id: "p-shared", data: () => ({ mentorId: "u1", menteeId: "u-other" }) },
+          ],
+        })
+        .mockResolvedValueOnce({
+          docs: [
+            { id: "p-shared", data: () => ({ mentorId: "u1", menteeId: "u-other" }) }, // duplicate
+            { id: "p-2", data: () => ({ mentorId: "u-other", menteeId: "u1" }) },
+          ],
+        });
+      const out = await getMentorshipPairingsForUser("u1");
+      expect(out.map((p) => p.id).sort()).toEqual(["p-1", "p-2", "p-shared"]);
+    });
+
+    it("returns an empty array when neither query returns docs", async () => {
+      mockGetDocs.mockResolvedValueOnce({ docs: [] }).mockResolvedValueOnce({ docs: [] });
+      expect(await getMentorshipPairingsForUser("u1")).toEqual([]);
+    });
+  });
+});

--- a/__tests__/lib/pair-programming-data.test.ts
+++ b/__tests__/lib/pair-programming-data.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+import {
+  getAllActiveProfiles,
+  getPairProfile,
+  getPairSessionsForUser,
+  updatePairSession,
+} from "@/lib/pair-programming/data";
+
+const mockGetDoc = jest.fn();
+const mockGetDocs = jest.fn();
+const mockUpdateDoc = jest.fn();
+
+jest.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => ({ __collection: args }),
+  doc: (...args: unknown[]) => ({ __doc: args }),
+  query: (...args: unknown[]) => ({ __query: args }),
+  where: (...args: unknown[]) => ({ __where: args }),
+  orderBy: (...args: unknown[]) => ({ __orderBy: args }),
+  limit: (n: number) => ({ __limit: n }),
+  serverTimestamp: () => "SERVER_TS",
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+}));
+
+jest.mock("@/lib/firebase", () => {
+  let _db: unknown = { __fake: true };
+  return {
+    get db() {
+      return _db;
+    },
+    __setDb(next: unknown) {
+      _db = next;
+    },
+  };
+});
+
+describe("lib/pair-programming/data", () => {
+  beforeEach(() => {
+    mockGetDoc.mockReset();
+    mockGetDocs.mockReset();
+    mockUpdateDoc.mockReset();
+  });
+
+  describe("getPairProfile", () => {
+    it("returns null when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      expect(await getPairProfile("u1")).toBeNull();
+      fb.__setDb({ __fake: true });
+    });
+
+    it("returns null when doc doesn't exist", async () => {
+      mockGetDoc.mockResolvedValueOnce({ exists: () => false });
+      expect(await getPairProfile("u1")).toBeNull();
+    });
+
+    it("returns the profile with userId injected", async () => {
+      mockGetDoc.mockResolvedValueOnce({
+        exists: () => true,
+        id: "u-a",
+        data: () => ({ displayName: "A" }),
+      });
+      expect(await getPairProfile("u-a")).toEqual({ userId: "u-a", displayName: "A" });
+    });
+  });
+
+  describe("getAllActiveProfiles", () => {
+    it("returns [] when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      expect(await getAllActiveProfiles()).toEqual([]);
+      fb.__setDb({ __fake: true });
+    });
+
+    it("maps docs to profiles with userId", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          { id: "u1", data: () => ({ displayName: "A" }) },
+          { id: "u2", data: () => ({ displayName: "B" }) },
+        ],
+      });
+      expect(await getAllActiveProfiles()).toEqual([
+        { userId: "u1", displayName: "A" },
+        { userId: "u2", displayName: "B" },
+      ]);
+    });
+  });
+
+  describe("getPairSessionsForUser", () => {
+    it("returns [] when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      expect(await getPairSessionsForUser("u1")).toEqual([]);
+      fb.__setDb({ __fake: true });
+    });
+
+    it("maps docs to sessions with id", async () => {
+      mockGetDocs.mockResolvedValueOnce({
+        docs: [
+          { id: "s1", data: () => ({ participantIds: ["u1", "u2"] }) },
+          { id: "s2", data: () => ({ participantIds: ["u1", "u3"] }) },
+        ],
+      });
+      const out = await getPairSessionsForUser("u1");
+      expect(out.map((s) => s.id)).toEqual(["s1", "s2"]);
+    });
+  });
+
+  describe("updatePairSession", () => {
+    it("throws when db is unavailable", async () => {
+      const fb = jest.requireMock("@/lib/firebase");
+      fb.__setDb(null);
+      await expect(updatePairSession("s1", { status: "completed" } as unknown as Parameters<typeof updatePairSession>[1])).rejects.toThrow(
+        "Firestore not initialized"
+      );
+      fb.__setDb({ __fake: true });
+    });
+
+    it("calls updateDoc with the merged payload + serverTimestamp", async () => {
+      mockUpdateDoc.mockResolvedValueOnce(undefined);
+      await updatePairSession("s1", { status: "completed" } as unknown as Parameters<typeof updatePairSession>[1]);
+      expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+      const [, payload] = mockUpdateDoc.mock.calls[0];
+      expect(payload).toMatchObject({
+        status: "completed",
+        updatedAt: "SERVER_TS",
+      });
+    });
+  });
+});

--- a/__tests__/lib/profile-bundle-server.test.ts
+++ b/__tests__/lib/profile-bundle-server.test.ts
@@ -1,0 +1,383 @@
+/**
+ * @jest-environment node
+ */
+const mockGetBaseInput = jest.fn();
+const mockBuildStatus = jest.fn();
+
+jest.mock("@/lib/badges/getBadgeEligibilityInput", () => ({
+  getBaseBadgeEligibilityInput: (...a: unknown[]) => mockGetBaseInput(...a),
+  buildBadgeDataStatus: (...a: unknown[]) => mockBuildStatus(...a),
+}));
+
+import { fetchProfileDataBundleJson } from "@/lib/profile-bundle-server";
+
+function tsLike(iso: string) {
+  return { toDate: () => new Date(iso) };
+}
+
+type DocSnap = { id: string; data: () => Record<string, unknown> };
+function makeDoc(id: string, data: Record<string, unknown>): DocSnap {
+  return { id, data: () => data };
+}
+
+function buildDb(opts: {
+  user?: { exists: boolean; data?: Record<string, unknown> };
+  registrations?: DocSnap[];
+  talks?: DocSnap[];
+  mergedPrs?: DocSnap[];
+  showcase?: DocSnap[];
+  messages?: DocSnap[];
+  teams?: DocSnap[];
+  pool?: DocSnap[];
+  userBadges?: DocSnap[];
+}) {
+  const userGet = jest.fn().mockResolvedValue({
+    exists: opts.user?.exists ?? true,
+    data: () => opts.user?.data ?? {},
+  });
+  const userRef = { get: userGet };
+
+  function chain(docs: DocSnap[]) {
+    const get = jest
+      .fn()
+      .mockResolvedValue({ docs, size: docs.length, empty: docs.length === 0 });
+    return {
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      get,
+    };
+  }
+
+  const collection = jest.fn((name: string) => {
+    switch (name) {
+      case "users":
+        return { doc: () => userRef };
+      case "eventRegistrations":
+        return chain(opts.registrations ?? []);
+      case "talkSubmissions":
+        return chain(opts.talks ?? []);
+      case "pullRequests":
+        return chain(opts.mergedPrs ?? []);
+      case "showcaseSubmissions":
+        return chain(opts.showcase ?? []);
+      case "communityMessages":
+        return chain(opts.messages ?? []);
+      case "hackathonTeams":
+        return chain(opts.teams ?? []);
+      case "hackathonPool":
+        return chain(opts.pool ?? []);
+      case "user_badges":
+        return chain(opts.userBadges ?? []);
+      default:
+        throw new Error(`unexpected collection: ${name}`);
+    }
+  });
+  return { db: { collection } as unknown as Parameters<typeof fetchProfileDataBundleJson>[0] };
+}
+
+describe("lib/profile-bundle-server", () => {
+  beforeEach(() => {
+    mockGetBaseInput.mockReset();
+    mockBuildStatus.mockReset();
+    mockGetBaseInput.mockImplementation((input: Record<string, unknown>) => ({
+      ...input,
+      __base: true,
+    }));
+    mockBuildStatus.mockImplementation((s: Record<string, string>) => ({
+      __status: true,
+      sources: s,
+    }));
+  });
+
+  it("returns a zero-shaped bundle for a non-existent user with no related docs", async () => {
+    const { db } = buildDb({
+      user: { exists: false },
+    });
+    const out = await fetchProfileDataBundleJson(db, "uX");
+    expect(out.stats).toEqual({
+      eventsRegistered: 0,
+      eventsAttended: 0,
+      talksSubmitted: 0,
+      talksGiven: 0,
+      pullRequestsCount: 0,
+    });
+    expect(out.registrations).toEqual([]);
+    expect(out.talks).toEqual([]);
+    expect(out.userBadgeMap).toEqual({});
+    expect(mockGetBaseInput).toHaveBeenCalledWith({
+      displayName: null,
+      visibility: null,
+      bio: null,
+      photoURL: null,
+      discord: undefined,
+      github: undefined,
+    });
+  });
+
+  it("passes user profile fields into getBaseBadgeEligibilityInput", async () => {
+    const { db } = buildDb({
+      user: {
+        exists: true,
+        data: {
+          displayName: "Alice",
+          visibility: { isPublic: true },
+          bio: "hi",
+          photoURL: "https://x/a.png",
+          discord: { id: "d1" },
+          github: { login: "alice" },
+        },
+      },
+    });
+    await fetchProfileDataBundleJson(db, "u1");
+    expect(mockGetBaseInput).toHaveBeenCalledWith({
+      displayName: "Alice",
+      visibility: { isPublic: true },
+      bio: "hi",
+      photoURL: "https://x/a.png",
+      discord: { id: "d1" },
+      github: { login: "alice" },
+    });
+  });
+
+  it("maps registrations and computes registered/attended counts", async () => {
+    const { db } = buildDb({
+      registrations: [
+        makeDoc("r1", {
+          eventId: "e1",
+          eventTitle: "E1",
+          userId: "u1",
+          userEmail: "u@x.com",
+          status: "attended",
+          registeredAt: tsLike("2026-05-01T00:00:00.000Z"),
+          source: "luma",
+        }),
+        makeDoc("r2", {
+          eventId: "e2",
+          eventTitle: "E2",
+          userId: "u1",
+          userEmail: "u@x.com",
+          status: "registered",
+          createdAt: tsLike("2026-05-02T00:00:00.000Z"),
+          source: "form",
+        }),
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.stats.eventsRegistered).toBe(2);
+    expect(out.stats.eventsAttended).toBe(1);
+    expect(out.registrations[0]?.registeredAt).toBe("2026-05-01T00:00:00.000Z");
+    // r2 uses createdAt fallback when registeredAt is missing
+    expect(out.registrations[1]?.registeredAt).toBe("2026-05-02T00:00:00.000Z");
+  });
+
+  it("uses doc.id when registration data.id is missing", async () => {
+    const { db } = buildDb({
+      registrations: [
+        makeDoc("doc-r1", {
+          eventId: "e",
+          eventTitle: "E",
+          userId: "u",
+          userEmail: "u@x",
+        }),
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.registrations[0]?.id).toBe("doc-r1");
+  });
+
+  it("counts talksSubmitted/talksGiven and maps talks with status='completed'", async () => {
+    const { db } = buildDb({
+      talks: [
+        makeDoc("t1", {
+          title: "T1",
+          status: "completed",
+          submittedAt: tsLike("2026-04-01T00:00:00.000Z"),
+        }),
+        makeDoc("t2", { title: "T2", status: "submitted" }),
+        makeDoc("t3", { status: "completed" }),
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.stats.talksSubmitted).toBe(3);
+    expect(out.stats.talksGiven).toBe(2);
+    expect(out.talks[0]).toEqual({
+      id: "t1",
+      title: "T1",
+      status: "completed",
+      submittedAt: "2026-04-01T00:00:00.000Z",
+    });
+    // talk 3 has no title → falls back to ""
+    expect(out.talks[2]?.title).toBe("");
+  });
+
+  it("counts mergedPrSnap → stats.pullRequestsCount", async () => {
+    const { db } = buildDb({
+      mergedPrs: [makeDoc("p1", {}), makeDoc("p2", {}), makeDoc("p3", {})],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.stats.pullRequestsCount).toBe(3);
+  });
+
+  it("filters showcase submissions to status='approved' for badge input", async () => {
+    const baseInput: Record<string, unknown> = {};
+    mockGetBaseInput.mockReturnValueOnce(baseInput);
+    const { db } = buildDb({
+      showcase: [
+        makeDoc("s1", { status: "approved" }),
+        makeDoc("s2", { status: "pending" }),
+        makeDoc("s3", { status: "approved" }),
+      ],
+    });
+    await fetchProfileDataBundleJson(db, "u1");
+    expect(baseInput.showcaseSubmissionsCount).toBe(2);
+  });
+
+  it("counts communityMessagesCount + filters posts (no parentId)", async () => {
+    const baseInput: Record<string, unknown> = {};
+    mockGetBaseInput.mockReturnValueOnce(baseInput);
+    const { db } = buildDb({
+      messages: [
+        makeDoc("m1", { parentId: null }),
+        makeDoc("m2", { parentId: "p" }),
+        makeDoc("m3", { parentId: null }),
+      ],
+    });
+    await fetchProfileDataBundleJson(db, "u1");
+    expect(baseInput.communityMessagesCount).toBe(3);
+    expect(baseInput.communityPostsCount).toBe(2);
+  });
+
+  it("hackathonParticipationCount = max(teamsSnap.size, poolSnap.size)", async () => {
+    const baseInput: Record<string, unknown> = {};
+    mockGetBaseInput.mockReturnValueOnce(baseInput);
+    const { db } = buildDb({
+      teams: [makeDoc("t1", {}), makeDoc("t2", {})],
+      pool: [makeDoc("p1", {}), makeDoc("p2", {}), makeDoc("p3", {})],
+    });
+    await fetchProfileDataBundleJson(db, "u1");
+    expect(baseInput.hackathonParticipationCount).toBe(3);
+  });
+
+  it("parses trusted user_badges into userBadgeMap keyed by badgeId", async () => {
+    const { db } = buildDb({
+      userBadges: [
+        makeDoc("ub-1", {
+          id: "ub-1",
+          userId: "u1",
+          badgeId: "registered",
+          awardSource: "system",
+          awardedAt: "2026-05-01T00:00:00.000Z",
+          awardedBy: "admin",
+        }),
+        makeDoc("ub-2", {
+          id: "ub-2",
+          userId: "u1",
+          badgeId: "displayName",
+          awardSource: "manual",
+          awardedAt: tsLike("2026-05-02T00:00:00.000Z"),
+        }),
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.userBadgeMap.registered).toMatchObject({
+      id: "ub-1",
+      userId: "u1",
+      badgeId: "registered",
+      awardSource: "system",
+      awardedAt: "2026-05-01T00:00:00.000Z",
+      awardedBy: "admin",
+    });
+    expect(out.userBadgeMap.displayName?.awardedAt).toBe(
+      "2026-05-02T00:00:00.000Z",
+    );
+  });
+
+  it("parses user_badges with Timestamp-with-seconds awardedAt", async () => {
+    const { db } = buildDb({
+      userBadges: [
+        makeDoc("ub-3", {
+          userId: "u1",
+          badgeId: "bio",
+          awardSource: "migration",
+          awardedAt: { seconds: 1717000000 },
+        }),
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.userBadgeMap.bio?.awardedAt).toBe(
+      new Date(1717000000 * 1000).toISOString(),
+    );
+  });
+
+  it("drops untrusted-source badges from userBadgeMap", async () => {
+    const { db } = buildDb({
+      userBadges: [
+        makeDoc("ub-1", {
+          userId: "u1",
+          badgeId: "registered",
+          awardSource: "self-claim",
+          awardedAt: "2026-05-01T00:00:00.000Z",
+        }),
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.userBadgeMap).toEqual({});
+  });
+
+  it("drops badges missing required fields (userId / badgeId / awardSource / awardedAt)", async () => {
+    const { db } = buildDb({
+      userBadges: [
+        makeDoc("ub-1", {
+          badgeId: "registered",
+          awardSource: "system",
+          awardedAt: "2026-05-01T00:00:00.000Z",
+        }), // missing userId
+        makeDoc("ub-2", {
+          userId: "u1",
+          awardSource: "system",
+          awardedAt: "2026-05-01T00:00:00.000Z",
+        }), // missing badgeId
+        makeDoc("ub-3", {
+          userId: "u1",
+          badgeId: "registered",
+          awardSource: "system",
+        }), // missing awardedAt
+        makeDoc("ub-4", {
+          userId: "u1",
+          badgeId: "registered",
+          awardedAt: "2026-05-01T00:00:00.000Z",
+        }), // missing awardSource
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.userBadgeMap).toEqual({});
+  });
+
+  it("uses badge doc.id when data.id is missing", async () => {
+    const { db } = buildDb({
+      userBadges: [
+        makeDoc("doc-id-only", {
+          userId: "u1",
+          badgeId: "registered",
+          awardSource: "system",
+          awardedAt: "2026-05-01T00:00:00.000Z",
+        }),
+      ],
+    });
+    const out = await fetchProfileDataBundleJson(db, "u1");
+    expect(out.userBadgeMap.registered?.id).toBe("doc-id-only");
+  });
+
+  it("calls buildBadgeDataStatus with all five source states set to 'ok' on happy path", async () => {
+    const { db } = buildDb({});
+    await fetchProfileDataBundleJson(db, "u1");
+    expect(mockBuildStatus).toHaveBeenCalledTimes(1);
+    expect(mockBuildStatus.mock.calls[0][0]).toEqual({
+      stats: "ok",
+      showcaseSubmissions: "ok",
+      communityMessages: "ok",
+      pullRequests: "ok",
+      hackathonParticipation: "ok",
+    });
+  });
+});

--- a/__tests__/lib/pydata-2026.test.ts
+++ b/__tests__/lib/pydata-2026.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @jest-environment node
+ */
+import {
+  PYDATA_2026_CAPACITY,
+  PYDATA_2026_EVENT_ID,
+  PYDATA_2026_EVENT_SLUG,
+  PYDATA_2026_LIMITS,
+  PYDATA_2026_LUMA_EVENT_NAME,
+  PYDATA_2026_LUMA_URL,
+  PYDATA_2026_REGISTRATION_OPEN,
+  PYDATA_2026_REGISTRATION_PATH,
+  PYDATA_2026_REGISTRATIONS_COLLECTION,
+  validatePydataRegistration,
+} from "@/lib/pydata-2026";
+
+const VALID = {
+  firstName: "Ada",
+  lastName: "Lovelace",
+  email: "ada@example.com",
+  phone: "+1 555 0100",
+  organization: "Analytical",
+  attendingConfirmed: true,
+};
+
+describe("lib/pydata-2026", () => {
+  describe("constants", () => {
+    it("PYDATA_2026_EVENT_ID and SLUG are the canonical strings", () => {
+      expect(PYDATA_2026_EVENT_ID).toBe("cursor-boston-pydata-2026");
+      expect(PYDATA_2026_EVENT_SLUG).toBe("cursor-boston-pydata-2026");
+    });
+
+    it("PYDATA_2026_LUMA_URL is the Luma event URL", () => {
+      expect(PYDATA_2026_LUMA_URL).toMatch(/^https:\/\/luma\.com\//);
+    });
+
+    it("PYDATA_2026_REGISTRATION_PATH is derived from the slug", () => {
+      expect(PYDATA_2026_REGISTRATION_PATH).toBe(
+        "/events/cursor-boston-pydata-2026/register",
+      );
+    });
+
+    it("PYDATA_2026_REGISTRATIONS_COLLECTION is the Firestore collection", () => {
+      expect(PYDATA_2026_REGISTRATIONS_COLLECTION).toBe(
+        "pydataHack2026Registrations",
+      );
+    });
+
+    it("PYDATA_2026_REGISTRATION_OPEN is a boolean (closed by post-event)", () => {
+      expect(typeof PYDATA_2026_REGISTRATION_OPEN).toBe("boolean");
+    });
+
+    it("PYDATA_2026_LUMA_EVENT_NAME matches Luma exactly", () => {
+      expect(PYDATA_2026_LUMA_EVENT_NAME).toBe(
+        "Cursor Boston-PyData Data Science Hack",
+      );
+    });
+
+    it("PYDATA_2026_CAPACITY is the door cap (150)", () => {
+      expect(PYDATA_2026_CAPACITY).toBe(150);
+    });
+
+    it("PYDATA_2026_LIMITS exposes positive caps + nameMin", () => {
+      for (const [, v] of Object.entries(PYDATA_2026_LIMITS)) {
+        expect(typeof v).toBe("number");
+        expect(v).toBeGreaterThan(0);
+      }
+      expect(PYDATA_2026_LIMITS.nameMin).toBe(2);
+    });
+  });
+
+  describe("validatePydataRegistration — happy path", () => {
+    it("accepts a fully valid payload and returns the trimmed/lowercased data", () => {
+      const out = validatePydataRegistration({
+        ...VALID,
+        firstName: "  Ada  ",
+        email: "Ada@Example.COM",
+      });
+      expect(out.ok).toBe(true);
+      if (out.ok) {
+        expect(out.data).toEqual({
+          firstName: "Ada",
+          lastName: "Lovelace",
+          email: "ada@example.com",
+          phone: "+1 555 0100",
+          organization: "Analytical",
+          attendingConfirmed: true,
+        });
+      }
+    });
+
+    it("clamps oversized inputs to the documented max lengths", () => {
+      const longFirst = "a".repeat(PYDATA_2026_LIMITS.firstName + 10);
+      const longOrg = "z".repeat(PYDATA_2026_LIMITS.organization + 20);
+      const out = validatePydataRegistration({
+        ...VALID,
+        firstName: longFirst,
+        organization: longOrg,
+      });
+      expect(out.ok).toBe(true);
+      if (out.ok) {
+        expect(out.data.firstName.length).toBe(PYDATA_2026_LIMITS.firstName);
+        expect(out.data.organization.length).toBe(PYDATA_2026_LIMITS.organization);
+      }
+    });
+  });
+
+  describe("validatePydataRegistration — rejection paths", () => {
+    it("returns errors=[] when raw is not an object (string)", () => {
+      const out = validatePydataRegistration("not-an-object");
+      expect(out.ok).toBe(false);
+      if (!out.ok) {
+        // every field is empty → required errors fire
+        expect(out.errors).toEqual(
+          expect.arrayContaining([
+            "firstName-required",
+            "lastName-required",
+            "email-required",
+            "organization-required",
+            "must-confirm-attendance",
+          ]),
+        );
+      }
+    });
+
+    it("flags firstName-required when missing", () => {
+      const out = validatePydataRegistration({ ...VALID, firstName: "" });
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.errors).toContain("firstName-required");
+    });
+
+    it("flags firstName-too-short for single-letter first name", () => {
+      const out = validatePydataRegistration({ ...VALID, firstName: "A" });
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.errors).toContain("firstName-too-short");
+    });
+
+    it("flags lastName-required when missing", () => {
+      const out = validatePydataRegistration({ ...VALID, lastName: "" });
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.errors).toContain("lastName-required");
+    });
+
+    it("flags lastName-too-short for single-letter last name", () => {
+      const out = validatePydataRegistration({ ...VALID, lastName: "B" });
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.errors).toContain("lastName-too-short");
+    });
+
+    it("flags email-required when missing", () => {
+      const out = validatePydataRegistration({ ...VALID, email: "" });
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.errors).toContain("email-required");
+    });
+
+    it("flags email-invalid on malformed input", () => {
+      for (const bad of ["nope", "a@b", "a b@c.d", "@c.d", "no-at.com"]) {
+        const out = validatePydataRegistration({ ...VALID, email: bad });
+        expect(out.ok).toBe(false);
+        if (!out.ok) expect(out.errors).toContain("email-invalid");
+      }
+    });
+
+    it("flags organization-required when missing", () => {
+      const out = validatePydataRegistration({ ...VALID, organization: "" });
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.errors).toContain("organization-required");
+    });
+
+    it("flags must-confirm-attendance when attendingConfirmed !== true", () => {
+      for (const bad of [false, "true", 1, undefined]) {
+        const out = validatePydataRegistration({
+          ...VALID,
+          attendingConfirmed: bad as unknown as true,
+        });
+        expect(out.ok).toBe(false);
+        if (!out.ok) expect(out.errors).toContain("must-confirm-attendance");
+      }
+    });
+
+    it("treats non-string fields as empty strings (clamp returns '')", () => {
+      const out = validatePydataRegistration({
+        firstName: 123,
+        lastName: { x: 1 },
+        email: null,
+        phone: undefined,
+        organization: [],
+        attendingConfirmed: true,
+      });
+      expect(out.ok).toBe(false);
+      if (!out.ok) {
+        expect(out.errors).toEqual(
+          expect.arrayContaining([
+            "firstName-required",
+            "lastName-required",
+            "email-required",
+            "organization-required",
+          ]),
+        );
+      }
+    });
+
+    it("accumulates multiple errors in one pass", () => {
+      const out = validatePydataRegistration({});
+      expect(out.ok).toBe(false);
+      if (!out.ok) {
+        expect(new Set(out.errors)).toEqual(
+          new Set([
+            "firstName-required",
+            "lastName-required",
+            "email-required",
+            "organization-required",
+            "must-confirm-attendance",
+          ]),
+        );
+      }
+    });
+  });
+});

--- a/__tests__/lib/rate-limit-server.test.ts
+++ b/__tests__/lib/rate-limit-server.test.ts
@@ -1,0 +1,383 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(),
+  getClientIdentifier: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  Timestamp: {
+    now: () => ({ __ts: "now" }),
+    fromMillis: (ms: number) => ({ __ts: ms }),
+  },
+}));
+
+import {
+  buildRateLimitHeaders,
+  checkServerRateLimit,
+  type ServerRateLimitResult,
+} from "@/lib/rate-limit-server";
+
+import { getAdminDb } from "@/lib/firebase-admin";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+
+const getAdminDbMock = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const checkRateLimitMock = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+const getClientIdentifierMock = getClientIdentifier as jest.MockedFunction<typeof getClientIdentifier>;
+const loggerWarn = (logger as unknown as { warn: jest.Mock }).warn;
+const loggerInfo = (logger as unknown as { info: jest.Mock }).info;
+
+function buildAllowingTx() {
+  return jest.fn().mockImplementation(async (fn) => {
+    const tx = {
+      get: jest.fn().mockResolvedValue({ exists: false, data: () => undefined }),
+      set: jest.fn(),
+    };
+    return fn(tx);
+  });
+}
+
+function buildExistingTx(currentCount: number) {
+  return jest.fn().mockImplementation(async (fn) => {
+    const tx = {
+      get: jest.fn().mockResolvedValue({
+        exists: true,
+        data: () => ({ count: currentCount }),
+      }),
+      set: jest.fn(),
+    };
+    return fn(tx);
+  });
+}
+
+function buildThrowingTx(err: unknown) {
+  return jest.fn().mockRejectedValue(err);
+}
+
+function makeRequest(): Request {
+  return new Request("https://example.com/api/x");
+}
+
+describe("lib/rate-limit-server", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getClientIdentifierMock.mockReturnValue("client-A");
+    checkRateLimitMock.mockReturnValue({
+      success: true,
+      remaining: 5,
+      resetTime: 999_999,
+    });
+  });
+
+  describe("buildRateLimitHeaders", () => {
+    it("emits the four canonical X-RateLimit headers", () => {
+      const result: ServerRateLimitResult = {
+        success: true,
+        remaining: 4,
+        resetTime: 1000,
+        source: "firestore",
+      };
+      expect(buildRateLimitHeaders(result, 10)).toEqual({
+        "X-RateLimit-Limit": "10",
+        "X-RateLimit-Remaining": "4",
+        "X-RateLimit-Reset": "1000",
+        "X-RateLimit-Source": "firestore",
+      });
+    });
+
+    it("appends Retry-After when retryAfter is set", () => {
+      const result: ServerRateLimitResult = {
+        success: false,
+        remaining: 0,
+        resetTime: 1000,
+        retryAfter: 30,
+        source: "firestore",
+      };
+      expect(buildRateLimitHeaders(result, 10)["Retry-After"]).toBe("30");
+    });
+
+    it("does NOT append Retry-After when retryAfter is missing or 0", () => {
+      const result: ServerRateLimitResult = {
+        success: true,
+        remaining: 4,
+        resetTime: 1000,
+        source: "memory-fallback",
+      };
+      expect(buildRateLimitHeaders(result, 10)).not.toHaveProperty("Retry-After");
+    });
+  });
+
+  describe("checkServerRateLimit — no admin db", () => {
+    beforeEach(() => {
+      getAdminDbMock.mockReturnValue(null as unknown as ReturnType<typeof getAdminDb>);
+    });
+
+    it("falls back to memory and logs an observation with reason='admin_db_unavailable'", async () => {
+      checkRateLimitMock.mockReturnValueOnce({
+        success: true,
+        remaining: 9,
+        resetTime: 5000,
+      });
+      const res = await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+      });
+      expect(res).toMatchObject({
+        success: true,
+        remaining: 9,
+        source: "memory-fallback",
+      });
+      expect(loggerWarn).toHaveBeenCalledWith(
+        "rate_limit_observation",
+        expect.objectContaining({ reason: "admin_db_unavailable" }),
+      );
+    });
+
+    it("with fallbackMode='deny' returns fail-closed 503 result", async () => {
+      const res = await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+        fallbackMode: "deny",
+      });
+      expect(res.source).toBe("fail-closed");
+      expect(res.statusCode).toBe(503);
+      expect(res.success).toBe(false);
+      expect(res.retryAfter).toBeGreaterThanOrEqual(1);
+    });
+
+    it("uses tighter limits under 'strict-memory' fallback (min(max,10))", async () => {
+      await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 100, // strict-memory clamps to 10
+      });
+      const args = checkRateLimitMock.mock.calls[0][1];
+      expect(args.maxRequests).toBe(10);
+    });
+
+    it("respects an explicit fallbackMaxRequests override", async () => {
+      await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 100,
+        fallbackMaxRequests: 25,
+      });
+      const args = checkRateLimitMock.mock.calls[0][1];
+      expect(args.maxRequests).toBe(25);
+    });
+
+    it("uses full max under 'memory' fallback mode", async () => {
+      await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 50,
+        fallbackMode: "memory",
+      });
+      const args = checkRateLimitMock.mock.calls[0][1];
+      expect(args.maxRequests).toBe(50);
+    });
+
+    it("uses explicit options.identifier when provided", async () => {
+      await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+        identifier: "explicit-id",
+      });
+      expect(getClientIdentifierMock).not.toHaveBeenCalled();
+      const key = checkRateLimitMock.mock.calls[0][0];
+      expect(key).toContain("explicit-id");
+    });
+
+    it("falls back to 'unknown' identifier when no header + no override", async () => {
+      getClientIdentifierMock.mockReturnValueOnce("");
+      await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+      });
+      const key = checkRateLimitMock.mock.calls[0][0];
+      expect(key).toContain("unknown");
+    });
+  });
+
+  describe("checkServerRateLimit — firestore happy path", () => {
+    it("allows the request, writes count=1 + metadata on new bucket", async () => {
+      const tx = buildAllowingTx();
+      const setSpy = jest.fn();
+      tx.mockImplementationOnce(async (fn) => {
+        const txObj = {
+          get: jest.fn().mockResolvedValue({ exists: false, data: () => undefined }),
+          set: setSpy,
+        };
+        return fn(txObj);
+      });
+      getAdminDbMock.mockReturnValueOnce({
+        collection: () => ({ doc: () => ({}) }),
+        runTransaction: tx,
+      } as unknown as ReturnType<typeof getAdminDb>);
+      const res = await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+      });
+      expect(res.success).toBe(true);
+      expect(res.source).toBe("firestore");
+      expect(res.remaining).toBe(9);
+      const payload = setSpy.mock.calls[0][1];
+      expect(payload).toMatchObject({
+        count: 1,
+        scope: "foo",
+        windowMs: 60_000,
+      });
+    });
+
+    it("allows the request, writes count++ only when bucket already exists", async () => {
+      const setSpy = jest.fn();
+      const tx = jest.fn().mockImplementation(async (fn) => {
+        const txObj = {
+          get: jest.fn().mockResolvedValue({
+            exists: true,
+            data: () => ({ count: 3 }),
+          }),
+          set: setSpy,
+        };
+        return fn(txObj);
+      });
+      getAdminDbMock.mockReturnValueOnce({
+        collection: () => ({ doc: () => ({}) }),
+        runTransaction: tx,
+      } as unknown as ReturnType<typeof getAdminDb>);
+      const res = await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+      });
+      expect(res.success).toBe(true);
+      expect(res.remaining).toBe(6); // 10 - 4
+      // Existing bucket → merge with only count + updatedAt
+      const [, payload, opts] = setSpy.mock.calls[0];
+      expect(payload).toEqual({ count: 4, updatedAt: { __ts: "now" } });
+      expect(opts).toEqual({ merge: true });
+    });
+
+    it("denies once currentCount >= maxRequests with retry-after", async () => {
+      const tx = buildExistingTx(10);
+      getAdminDbMock.mockReturnValueOnce({
+        collection: () => ({ doc: () => ({}) }),
+        runTransaction: tx,
+      } as unknown as ReturnType<typeof getAdminDb>);
+      const res = await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+      });
+      expect(res.success).toBe(false);
+      expect(res.source).toBe("firestore");
+      expect(res.retryAfter).toBeGreaterThan(0);
+      expect(loggerWarn).toHaveBeenCalledWith(
+        "rate_limit_observation",
+        expect.objectContaining({
+          reason: "quota_exceeded",
+          statusCode: 429,
+        }),
+      );
+    });
+
+    it("emits success observation log when sampleRate is 1 (every request)", async () => {
+      const tx = buildAllowingTx();
+      getAdminDbMock.mockReturnValueOnce({
+        collection: () => ({ doc: () => ({}) }),
+        runTransaction: tx,
+      } as unknown as ReturnType<typeof getAdminDb>);
+      await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+        successSampleRate: 1,
+      });
+      expect(loggerInfo).toHaveBeenCalledWith(
+        "rate_limit_observation",
+        expect.objectContaining({ reason: "allowed_sampled" }),
+      );
+    });
+  });
+
+  describe("checkServerRateLimit — firestore transaction throws", () => {
+    it("falls back to memory and logs reason='firestore_transaction_error'", async () => {
+      checkRateLimitMock.mockReturnValueOnce({
+        success: true,
+        remaining: 9,
+        resetTime: 5000,
+      });
+      const tx = buildThrowingTx(new Error("aborted"));
+      getAdminDbMock.mockReturnValueOnce({
+        collection: () => ({ doc: () => ({}) }),
+        runTransaction: tx,
+      } as unknown as ReturnType<typeof getAdminDb>);
+      const res = await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+      });
+      expect(res.source).toBe("memory-fallback");
+      expect(loggerWarn).toHaveBeenCalledWith(
+        "rate_limit_observation",
+        expect.objectContaining({
+          reason: "firestore_transaction_error",
+          error: "aborted",
+        }),
+      );
+    });
+
+    it("coerces non-Error throws to a string in the log", async () => {
+      const tx = buildThrowingTx("string-thrown");
+      getAdminDbMock.mockReturnValueOnce({
+        collection: () => ({ doc: () => ({}) }),
+        runTransaction: tx,
+      } as unknown as ReturnType<typeof getAdminDb>);
+      await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+      });
+      expect(loggerWarn).toHaveBeenCalledWith(
+        "rate_limit_observation",
+        expect.objectContaining({ error: "string-thrown" }),
+      );
+    });
+
+    it("with fallbackMode='deny' returns fail-closed when transaction throws", async () => {
+      const tx = buildThrowingTx(new Error("aborted"));
+      getAdminDbMock.mockReturnValueOnce({
+        collection: () => ({ doc: () => ({}) }),
+        runTransaction: tx,
+      } as unknown as ReturnType<typeof getAdminDb>);
+      const res = await checkServerRateLimit(makeRequest(), {
+        scope: "foo",
+        windowMs: 60_000,
+        maxRequests: 10,
+        fallbackMode: "deny",
+      });
+      expect(res.source).toBe("fail-closed");
+      expect(res.statusCode).toBe(503);
+    });
+  });
+});

--- a/__tests__/lib/submissions.test.ts
+++ b/__tests__/lib/submissions.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment node
+ */
+const mockAddDoc = jest.fn();
+const mockCollection = jest.fn();
+const mockServerTimestamp = jest.fn(() => "ST" as unknown as Date);
+
+jest.mock("firebase/firestore", () => ({
+  collection: (...args: unknown[]) => mockCollection(...args),
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+}));
+
+jest.mock("@/lib/firebase", () => {
+  let _db: unknown = { __fake: "db" };
+  return {
+    get db() {
+      return _db;
+    },
+    __setDb(next: unknown) {
+      _db = next;
+    },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const firebaseMod = require("@/lib/firebase") as { __setDb: (db: unknown) => void };
+const setDb = firebaseMod.__setDb;
+
+import {
+  submitEventRequest,
+  submitTalkProposal,
+} from "@/lib/submissions";
+
+const originalFetch = global.fetch;
+
+describe("lib/submissions", () => {
+  beforeEach(() => {
+    mockAddDoc.mockReset();
+    mockCollection.mockReset();
+    mockServerTimestamp.mockClear();
+    setDb({ __fake: "db" });
+    global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+    mockCollection.mockImplementation((db, name) => ({ __collRef: name }));
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("submitTalkProposal", () => {
+    const baseTalk = {
+      name: "A",
+      email: "a@x.com",
+      title: "T",
+      description: "D",
+      category: "AI",
+      duration: "15-20 min",
+      experience: "intermediate",
+    };
+
+    it("throws when db is unset", async () => {
+      setDb(null);
+      await expect(submitTalkProposal(baseTalk)).rejects.toThrow(
+        "Firebase is not configured",
+      );
+    });
+
+    it("stores the submission in talkSubmissions and returns the new doc id", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "talk-123" });
+      const id = await submitTalkProposal(baseTalk, "uid-7");
+      expect(id).toBe("talk-123");
+      expect(mockCollection).toHaveBeenCalledWith({ __fake: "db" }, "talkSubmissions");
+      expect(mockAddDoc).toHaveBeenCalledTimes(1);
+      const [, payload] = mockAddDoc.mock.calls[0];
+      expect(payload).toEqual({
+        ...baseTalk,
+        userId: "uid-7",
+        status: "pending",
+        createdAt: "ST",
+      });
+    });
+
+    it("defaults userId to null when not provided", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "talk-456" });
+      await submitTalkProposal(baseTalk);
+      const [, payload] = mockAddDoc.mock.calls[0];
+      expect(payload.userId).toBeNull();
+    });
+
+    it("POSTs to /api/notify-admin/talk with the submissionId", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "talk-id" });
+      await submitTalkProposal(baseTalk, "uid");
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/notify-admin/talk",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.submissionId).toBe("talk-id");
+      expect(body.title).toBe("T");
+    });
+
+    it("swallows fetch failures (submission is already saved)", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "talk-id-ok" });
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("net down"));
+      const id = await submitTalkProposal(baseTalk);
+      expect(id).toBe("talk-id-ok");
+    });
+
+    it("propagates errors from addDoc (write failure surfaces)", async () => {
+      mockAddDoc.mockRejectedValueOnce(new Error("firestore write failed"));
+      await expect(submitTalkProposal(baseTalk)).rejects.toThrow(
+        "firestore write failed",
+      );
+    });
+  });
+
+  describe("submitEventRequest", () => {
+    const baseEvent = {
+      name: "B",
+      email: "b@x.com",
+      eventType: "workshop",
+      title: "Title",
+      description: "Desc",
+      expectedAttendees: "30",
+    };
+
+    it("throws when db is unset", async () => {
+      setDb(null);
+      await expect(submitEventRequest(baseEvent)).rejects.toThrow(
+        "Firebase is not configured",
+      );
+    });
+
+    it("stores the request in eventRequests and returns the new doc id", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "ev-1" });
+      const id = await submitEventRequest(baseEvent, "uid-9");
+      expect(id).toBe("ev-1");
+      expect(mockCollection).toHaveBeenCalledWith({ __fake: "db" }, "eventRequests");
+      const [, payload] = mockAddDoc.mock.calls[0];
+      expect(payload).toEqual({
+        ...baseEvent,
+        userId: "uid-9",
+        status: "pending",
+        createdAt: "ST",
+      });
+    });
+
+    it("defaults userId to null when not provided", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "ev-2" });
+      await submitEventRequest(baseEvent);
+      const [, payload] = mockAddDoc.mock.calls[0];
+      expect(payload.userId).toBeNull();
+    });
+
+    it("POSTs to /api/notify-admin/event with the requestId", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "ev-id" });
+      await submitEventRequest(baseEvent);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/notify-admin/event",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string,
+      );
+      expect(body.requestId).toBe("ev-id");
+      expect(body.eventType).toBe("workshop");
+    });
+
+    it("swallows fetch failures (request is already saved)", async () => {
+      mockAddDoc.mockResolvedValueOnce({ id: "ev-ok" });
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("dns fail"));
+      const id = await submitEventRequest(baseEvent);
+      expect(id).toBe("ev-ok");
+    });
+
+    it("propagates errors from addDoc", async () => {
+      mockAddDoc.mockRejectedValueOnce(new Error("perm denied"));
+      await expect(submitEventRequest(baseEvent)).rejects.toThrow("perm denied");
+    });
+  });
+});

--- a/__tests__/lib/summer-cohort-auto-admit.test.ts
+++ b/__tests__/lib/summer-cohort-auto-admit.test.ts
@@ -1,0 +1,324 @@
+/**
+ * @jest-environment node
+ */
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/summer-cohort", () => ({
+  SUMMER_COHORT_C1_AUTO_ADMIT_DEADLINE_MS: 9_999_999_999_999,
+  SUMMER_COHORT_C1_CAP: 200,
+  SUMMER_COHORT_COLLECTION: "summerCohortApplications",
+  isWithinSummerCohortC1AutoAdmitWindow: jest.fn(() => true),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => ({ __ts: "now" }),
+  },
+}));
+
+import { maybeAutoAdmitOnPRMerge } from "@/lib/summer-cohort-auto-admit";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { isWithinSummerCohortC1AutoAdmitWindow } from "@/lib/summer-cohort";
+
+const getAdminDbMock = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const inWindowMock = isWithinSummerCohortC1AutoAdmitWindow as jest.MockedFunction<typeof isWithinSummerCohortC1AutoAdmitWindow>;
+
+type UserDoc = { id: string };
+
+function mkUsersSnap(docs: UserDoc[]) {
+  return { docs };
+}
+
+interface AppFixture {
+  exists?: boolean;
+  status?: string;
+  cohorts?: unknown;
+}
+
+function buildDb(opts: {
+  primaryUsers?: UserDoc[];
+  fallbackUsers?: UserDoc[];
+  appByUid?: Record<string, AppFixture>;
+  admittedCount?: number;
+  // Force isWithinSummerCohortC1AutoAdmitWindow to flip during the transaction
+  windowClosesMidTx?: boolean;
+}) {
+  const updateSpy = jest.fn();
+  const txnInsideWindowAfter = !opts.windowClosesMidTx;
+  const usersGet = jest
+    .fn()
+    .mockResolvedValueOnce(mkUsersSnap(opts.primaryUsers ?? []))
+    .mockResolvedValueOnce(mkUsersSnap(opts.fallbackUsers ?? []));
+
+  const usersChain = {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: usersGet,
+  };
+
+  const countAgg = {
+    get: jest.fn().mockResolvedValue({
+      data: () => ({ count: opts.admittedCount ?? 0 }),
+    }),
+  };
+  const cohortChain = {
+    where: jest.fn().mockReturnThis(),
+    count: jest.fn().mockReturnValue(countAgg),
+  };
+
+  const cohortDocMap: Record<string, { update: jest.Mock; appRef: { __uid: string } }> = {};
+  const cohortCollection = {
+    doc: jest.fn((uid: string) => {
+      const ref = (cohortDocMap[uid] ??= {
+        update: updateSpy,
+        appRef: { __uid: uid },
+      });
+      return ref.appRef;
+    }),
+    where: cohortChain.where,
+    count: cohortChain.count,
+  } as unknown as ReturnType<typeof getAdminDbMock>;
+
+  // Provide a where(...).where(...).count() chain when count() is called via
+  // db.collection(...).where(...).where(...).count()
+  Object.assign(cohortCollection, cohortChain);
+
+  const runTransaction = jest.fn(async (fn) => {
+    const tx = {
+      get: jest.fn((ref: { __uid: string }) => {
+        const f = opts.appByUid?.[ref.__uid];
+        if (!f || f.exists === false) {
+          return Promise.resolve({ exists: false, data: () => undefined });
+        }
+        return Promise.resolve({
+          exists: true,
+          data: () => ({ status: f.status, cohorts: f.cohorts }),
+        });
+      }),
+      update: updateSpy,
+    };
+    if (opts.windowClosesMidTx) {
+      // Outer guard already fired with the default (true).
+      // Force the in-txn re-check to return false.
+      inWindowMock.mockImplementationOnce(() => false);
+    }
+    return fn(tx);
+  });
+
+  const collection = jest.fn((name: string) => {
+    if (name === "users") return usersChain;
+    if (name === "summerCohortApplications") return cohortCollection;
+    throw new Error(`unexpected collection: ${name}`);
+  });
+
+  return {
+    db: { collection, runTransaction } as unknown as ReturnType<typeof getAdminDb>,
+    updateSpy,
+    usersChain,
+    cohortChain,
+    runTransaction,
+    txnInsideWindowAfter,
+  };
+}
+
+describe("lib/summer-cohort-auto-admit", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    inWindowMock.mockReturnValue(true);
+  });
+
+  it("skips when authorLogin is empty", async () => {
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "", prNumber: 1 });
+    expect(out).toEqual({ kind: "skipped", reason: "no-author-login" });
+  });
+
+  it("skips when outside the auto-admit window", async () => {
+    inWindowMock.mockReturnValueOnce(false);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out.kind).toBe("skipped");
+    if (out.kind === "skipped") expect(out.reason).toBe("outside-auto-admit-window");
+  });
+
+  it("skips when admin db is null", async () => {
+    getAdminDbMock.mockReturnValueOnce(null as unknown as ReturnType<typeof getAdminDb>);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({ kind: "skipped", reason: "no-admin-db" });
+  });
+
+  it("skips when no user has that github.login (and no lowercase fallback because login is already lowercase)", async () => {
+    const { db, usersChain } = buildDb({});
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({
+      kind: "skipped",
+      reason: "no-user-with-this-github-login",
+    });
+    // Only the primary lookup happened (login is already lowercase).
+    expect(usersChain.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to lowercase login lookup when mixed-case primary misses", async () => {
+    const { db, usersChain } = buildDb({
+      primaryUsers: [],
+      fallbackUsers: [{ id: "uA" }],
+      appByUid: { uA: { exists: false } },
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "AliCe", prNumber: 5 });
+    expect(usersChain.get).toHaveBeenCalledTimes(2);
+    expect(out.kind).toBe("skipped");
+  });
+
+  it("returns no-eligible-application when no candidate user has a pending cohort-1 app", async () => {
+    const { db } = buildDb({
+      primaryUsers: [{ id: "u1" }],
+      appByUid: { u1: { exists: false } },
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({
+      kind: "skipped",
+      reason: "no-eligible-application",
+    });
+  });
+
+  it("skips a user whose application is not pending", async () => {
+    const { db } = buildDb({
+      primaryUsers: [{ id: "u1" }],
+      appByUid: { u1: { exists: true, status: "rejected", cohorts: ["cohort-1"] } },
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({
+      kind: "skipped",
+      reason: "no-eligible-application",
+    });
+  });
+
+  it("skips a user whose application is missing cohort-1", async () => {
+    const { db } = buildDb({
+      primaryUsers: [{ id: "u1" }],
+      appByUid: { u1: { exists: true, status: "pending", cohorts: ["cohort-2"] } },
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({
+      kind: "skipped",
+      reason: "no-eligible-application",
+    });
+  });
+
+  it("skips when the cohort-1 cap has already been reached", async () => {
+    const { db, updateSpy } = buildDb({
+      primaryUsers: [{ id: "u1" }],
+      appByUid: { u1: { exists: true, status: "pending", cohorts: ["cohort-1"] } },
+      admittedCount: 200,
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 9 });
+    expect(out).toEqual({
+      kind: "skipped",
+      reason: "no-eligible-application",
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips when the deadline elapsed between guard and transaction body", async () => {
+    const { db, updateSpy } = buildDb({
+      primaryUsers: [{ id: "u1" }],
+      appByUid: { u1: { exists: true, status: "pending", cohorts: ["cohort-1"] } },
+      windowClosesMidTx: true,
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({
+      kind: "skipped",
+      reason: "no-eligible-application",
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("promotes a pending cohort-1 user when all gates pass", async () => {
+    const { db, updateSpy } = buildDb({
+      primaryUsers: [{ id: "uX" }],
+      appByUid: { uX: { exists: true, status: "pending", cohorts: ["cohort-1"] } },
+      admittedCount: 10,
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 42 });
+    expect(out).toEqual({
+      kind: "promoted",
+      userId: "uX",
+      applicationId: "uX",
+    });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const updatePayload = updateSpy.mock.calls[0][1];
+    expect(updatePayload).toMatchObject({
+      status: "admitted",
+      admittedVia: "pr-merge",
+      admittedFromPR: 42,
+    });
+  });
+
+  it("treats non-string status as 'pending' (Firestore data is loose)", async () => {
+    const { db, updateSpy } = buildDb({
+      primaryUsers: [{ id: "uX" }],
+      appByUid: { uX: { exists: true, status: undefined, cohorts: ["cohort-1"] } },
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out.kind).toBe("promoted");
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats non-array cohorts as []", async () => {
+    const { db } = buildDb({
+      primaryUsers: [{ id: "uX" }],
+      appByUid: { uX: { exists: true, status: "pending", cohorts: "not-array" } },
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out.kind).toBe("skipped");
+  });
+
+  it("returns 'exception' (non-fatal) when the transaction throws", async () => {
+    const { db } = buildDb({
+      primaryUsers: [{ id: "u1" }],
+      appByUid: { u1: { exists: true, status: "pending", cohorts: ["cohort-1"] } },
+    });
+    (db as unknown as { runTransaction: jest.Mock }).runTransaction =
+      jest.fn().mockRejectedValueOnce(new Error("aborted"));
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({ kind: "skipped", reason: "exception" });
+  });
+
+  it("stops scanning after the first user is promoted (multi-user case)", async () => {
+    const { db, updateSpy } = buildDb({
+      primaryUsers: [{ id: "u1" }, { id: "u2" }],
+      appByUid: {
+        u1: { exists: true, status: "pending", cohorts: ["cohort-1"] },
+        u2: { exists: true, status: "pending", cohorts: ["cohort-1"] },
+      },
+    });
+    getAdminDbMock.mockReturnValueOnce(db);
+    const out = await maybeAutoAdmitOnPRMerge({ authorLogin: "alice", prNumber: 1 });
+    expect(out).toEqual({
+      kind: "promoted",
+      userId: "u1",
+      applicationId: "u1",
+    });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/treasure-hunt-claim.test.ts
+++ b/__tests__/lib/treasure-hunt-claim.test.ts
@@ -1,0 +1,330 @@
+/**
+ * @jest-environment node
+ */
+const mockEmailAlreadyWon = jest.fn();
+jest.mock("@/lib/treasure-hunt-eligibility", () => ({
+  emailAlreadyWon: (...a: unknown[]) => mockEmailAlreadyWon(...a),
+}));
+
+const mockSendEmail = jest.fn();
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: (...a: unknown[]) => mockSendEmail(...a),
+}));
+
+const afterCallbacks: Array<() => Promise<void>> = [];
+jest.mock("next/server", () => ({
+  after: (cb: () => Promise<void>) => {
+    afterCallbacks.push(cb);
+  },
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => ({ __ts: "now" }),
+    arrayUnion: (...vals: unknown[]) => ({ __arrayUnion: vals }),
+  },
+}));
+
+import { claimTreasureHuntPrize } from "@/lib/treasure-hunt-claim";
+
+function buildDb(opts: {
+  progressExists?: boolean;
+  progressHasPrize?: boolean;
+  pathWinnerExists?: boolean;
+  prizeDocs?: Array<{
+    id: string;
+    data: () => Record<string, unknown>;
+    ref: Record<string, unknown>;
+  }>;
+  runtimeFails?: boolean;
+}) {
+  const progressRefUpdate = jest.fn();
+  const progressRefSet = jest.fn().mockResolvedValue(undefined);
+  const progressRef = {
+    update: progressRefUpdate,
+    set: progressRefSet,
+  };
+
+  const pathWinnerRef = {};
+  const prizesQuery = { docs: opts.prizeDocs ?? [], empty: (opts.prizeDocs ?? []).length === 0 };
+  const prizesChain = {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+  };
+
+  const txGetMap = new Map<unknown, unknown>([
+    [progressRef, opts.progressExists
+      ? { exists: true, data: () => ({ prizeCodeId: opts.progressHasPrize ? "X" : null }) }
+      : { exists: false, data: () => undefined }],
+    [pathWinnerRef, { exists: !!opts.pathWinnerExists }],
+    [prizesChain, prizesQuery],
+  ]);
+
+  const runtimeDoc = {
+    set: opts.runtimeFails
+      ? jest.fn().mockRejectedValue(new Error("runtime write failed"))
+      : jest.fn().mockResolvedValue(undefined),
+  };
+  const runtimeChain = {
+    doc: jest.fn().mockReturnValue(runtimeDoc),
+  };
+
+  const txUpdate = jest.fn();
+  const txSet = jest.fn();
+  const tx = {
+    get: jest.fn(async (ref: unknown) => {
+      // Reproduce the Promise.all([tx.get(progressRef), tx.get(pathWinnerRef)])
+      // and the tx.get(query) calls — match by reference identity.
+      return txGetMap.get(ref) ?? { exists: false, data: () => undefined };
+    }),
+    update: txUpdate,
+    set: txSet,
+  };
+
+  const runTransaction = jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(tx));
+
+  const collection = jest.fn((name: string) => {
+    switch (name) {
+      case "treasureHuntProgress":
+        return { doc: () => progressRef };
+      case "treasureHuntPathWinners":
+        return { doc: () => pathWinnerRef };
+      case "treasureHuntPrizes":
+        return prizesChain;
+      case "treasureHuntRuntime":
+        return runtimeChain;
+      default:
+        throw new Error(`unexpected: ${name}`);
+    }
+  });
+
+  return {
+    db: { collection, runTransaction } as unknown as Parameters<typeof claimTreasureHuntPrize>[0],
+    spies: { progressRef, txUpdate, txSet, runtimeDoc },
+  };
+}
+
+describe("lib/treasure-hunt-claim", () => {
+  beforeEach(() => {
+    mockEmailAlreadyWon.mockReset();
+    mockEmailAlreadyWon.mockResolvedValue(false);
+    mockSendEmail.mockReset();
+    mockSendEmail.mockResolvedValue(undefined);
+    afterCallbacks.length = 0;
+  });
+
+  it("rejects with no_email when email is blank/whitespace", async () => {
+    const { db } = buildDb({});
+    const out = await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "   ",
+      displayName: "Alice",
+      pathId: "path-a",
+    });
+    expect(out).toEqual({ ok: false, reason: "no_email" });
+  });
+
+  it("rejects when the email has already won under a different uid", async () => {
+    mockEmailAlreadyWon.mockResolvedValueOnce(true);
+    const { db } = buildDb({});
+    const out = await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "user@x.com",
+      displayName: "Alice",
+      pathId: "path-a",
+    });
+    expect(out).toEqual({ ok: false, reason: "email_already_won" });
+    expect(mockEmailAlreadyWon).toHaveBeenCalledWith(expect.anything(), "user@x.com");
+  });
+
+  it("rejects with already_won when this uid already has a prizeCodeId", async () => {
+    const { db } = buildDb({
+      progressExists: true,
+      progressHasPrize: true,
+    });
+    const out = await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "user@x.com",
+      displayName: "Alice",
+      pathId: "path-a",
+    });
+    expect(out).toEqual({ ok: false, reason: "already_won" });
+  });
+
+  it("rejects with path_taken when the pathWinner index doc already exists", async () => {
+    const { db } = buildDb({
+      pathWinnerExists: true,
+    });
+    const out = await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "user@x.com",
+      displayName: "Alice",
+      pathId: "path-a",
+    });
+    expect(out).toEqual({ ok: false, reason: "path_taken" });
+  });
+
+  it("rejects with pool_empty when no available prize matches the query", async () => {
+    const { db } = buildDb({ prizeDocs: [] });
+    const out = await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "user@x.com",
+      displayName: "Alice",
+      pathId: "path-a",
+    });
+    expect(out).toEqual({ ok: false, reason: "pool_empty" });
+  });
+
+  it("awards the first available prize and returns code + creditUrl + pathId", async () => {
+    const prizeRef = {};
+    const { db, spies } = buildDb({
+      prizeDocs: [
+        {
+          id: "PRIZE-1",
+          data: () => ({ creditUrl: "https://cursor.com/credit/abc" }),
+          ref: prizeRef,
+        },
+      ],
+    });
+    const out = await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "User@X.com",
+      displayName: "  Alice  ",
+      pathId: "path-a",
+    });
+    expect(out).toEqual({
+      ok: true,
+      code: "PRIZE-1",
+      creditUrl: "https://cursor.com/credit/abc",
+      pathId: "path-a",
+    });
+    // Tx wrote claim payload onto the prize ref
+    expect(spies.txUpdate).toHaveBeenCalledWith(
+      prizeRef,
+      expect.objectContaining({
+        status: "claimed",
+        claimedByUid: "u1",
+        claimedByEmail: "User@X.com",
+        claimedPath: "path-a",
+      }),
+    );
+    // Path winner index written
+    expect(spies.txSet).toHaveBeenCalledTimes(2);
+    const [winnerRef, winnerPayload] = spies.txSet.mock.calls[0];
+    expect(winnerRef).toBeDefined();
+    expect(winnerPayload).toMatchObject({
+      pathId: "path-a",
+      winnerUid: "u1",
+      winnerEmail: "User@X.com",
+      prizeCodeId: "PRIZE-1",
+    });
+    // Progress doc upsert with arrayUnion + null prizeEmailSentAt
+    const progressPayload = spies.txSet.mock.calls[1][1];
+    expect(progressPayload).toMatchObject({
+      uid: "u1",
+      winnerEmail: "User@X.com",
+      winnerEmailLower: "user@x.com",
+      prizeCodeId: "PRIZE-1",
+      prizeCreditUrl: "https://cursor.com/credit/abc",
+      prizeEmailSentAt: null,
+    });
+  });
+
+  it("clears the email-retry 'queue empty' marker (best-effort)", async () => {
+    const { db, spies } = buildDb({
+      prizeDocs: [
+        { id: "PRIZE", data: () => ({ creditUrl: "https://x" }), ref: {} },
+      ],
+    });
+    await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "u@x.com",
+      displayName: "Alice",
+      pathId: "p1",
+    });
+    expect(spies.runtimeDoc.set).toHaveBeenCalledWith(
+      expect.objectContaining({ queueEmpty: false }),
+      { merge: true },
+    );
+  });
+
+  it("ignores a failed runtime marker write (try/catch)", async () => {
+    const { db } = buildDb({
+      prizeDocs: [{ id: "PRIZE", data: () => ({ creditUrl: "https://x" }), ref: {} }],
+      runtimeFails: true,
+    });
+    const out = await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "u@x.com",
+      displayName: "Alice",
+      pathId: "p1",
+    });
+    expect(out.ok).toBe(true);
+  });
+
+  it("queues an after() callback that sends the prize email", async () => {
+    const { db, spies } = buildDb({
+      prizeDocs: [
+        { id: "PRIZE-1", data: () => ({ creditUrl: "https://x/credit" }), ref: {} },
+      ],
+    });
+    await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "user@x.com",
+      displayName: "Alice",
+      pathId: "path-a",
+    });
+    expect(afterCallbacks).toHaveLength(1);
+    // Invoke the queued callback
+    await afterCallbacks[0]!();
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.to).toBe("user@x.com");
+    expect(args.subject).toContain("Cursor credit");
+    expect(args.text).toContain("path-a");
+    expect(args.html).toContain("https://x/credit");
+    // Progress doc was patched with prizeEmailSentAt after send succeeded
+    expect(spies.progressRef.set).toHaveBeenCalledWith(
+      { prizeEmailSentAt: { __ts: "now" } },
+      { merge: true },
+    );
+  });
+
+  it("falls back to 'there' when displayName is blank", async () => {
+    const { db } = buildDb({
+      prizeDocs: [
+        { id: "PRIZE-1", data: () => ({ creditUrl: "https://x/credit" }), ref: {} },
+      ],
+    });
+    await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "user@x.com",
+      displayName: "   ",
+      pathId: "path-a",
+    });
+    await afterCallbacks[0]!();
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.text).toContain("Hi there,");
+  });
+
+  it("swallows a failed email send (logs but doesn't throw)", async () => {
+    mockSendEmail.mockRejectedValueOnce(new Error("upstream 502"));
+    const consoleErrSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { db } = buildDb({
+      prizeDocs: [
+        { id: "PRIZE-1", data: () => ({ creditUrl: "https://x" }), ref: {} },
+      ],
+    });
+    await claimTreasureHuntPrize(db, {
+      uid: "u1",
+      email: "u@x.com",
+      displayName: "Alice",
+      pathId: "p1",
+    });
+    await afterCallbacks[0]!();
+    expect(consoleErrSpy).toHaveBeenCalled();
+    consoleErrSpy.mockRestore();
+  });
+});

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -504,6 +504,13 @@ function SummerCohortPageInner() {
    *  expanding shows the editable form. */
   const [editingDetails, setEditingDetails] = useState(false);
 
+  // Tonight's (Mon May 18 2026) 6pm EST Zoom call banner — auto-hides after
+  // the cutoff. Captured once at mount via lazy initializer to keep render
+  // pure (react-hooks/purity).
+  const [showTonightZoomBanner] = useState(
+    () => Date.now() < new Date("2026-05-19T04:00:00Z").getTime()
+  );
+
   const [activeTab, setActiveTab] = useState<CohortTabId>(
     SUMMER_COHORT_C1_DEFAULT_TAB
   );
@@ -1098,6 +1105,41 @@ function SummerCohortPageInner() {
                       Take it →
                     </span>
                   </button>
+                ) : null}
+                {isCohort1Selected && showTonightZoomBanner ? (
+                  <div className="mt-6 rounded-xl border border-sky-300 bg-sky-50 p-4 dark:border-sky-800 dark:bg-sky-950/30">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-sky-900 dark:text-sky-100">
+                          Tonight · Mon May 18 · 6 pm EST — Week 1 review + Week 2 kickoff
+                        </p>
+                        <p className="mt-0.5 text-xs text-sky-800 dark:text-sky-200">
+                          Hop on Zoom — we&apos;ll walk through what people shipped in Week 1, then kick off Week 2 (Comms build).
+                        </p>
+                        <p className="mt-1 text-xs text-sky-700 dark:text-sky-300">
+                          Meeting ID:{" "}
+                          <strong className="font-semibold">924 1507 7928</strong>
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 flex-wrap gap-2">
+                        <a
+                          href="https://bentley.zoom.us/j/92415077928"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center rounded-lg bg-sky-600 px-3 py-2 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-sky-700"
+                        >
+                          Join Zoom →
+                        </a>
+                        <button
+                          type="button"
+                          onClick={() => setActiveTab("week-2")}
+                          className="inline-flex items-center rounded-lg border border-sky-300 bg-white px-3 py-2 text-xs font-semibold text-sky-800 transition-colors hover:bg-sky-100 dark:border-sky-700 dark:bg-neutral-900 dark:text-sky-200 dark:hover:bg-sky-900/40"
+                        >
+                          Open Week 2 →
+                        </button>
+                      </div>
+                    </div>
+                  </div>
                 ) : null}
                 <CohortTabs
                   activeTab={activeTab}

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -53,8 +53,8 @@ const customJestConfig = {
   // allowlisted lore subcollections — chapters, epitaphs). Registry
   // additions are static data covered transitively by the existing
   // registry self-check test; cascade-test growth lags by ~1pp.
-  // Current totals (2026-05-18 CI, after coverage pushes #23-37): statements ~36.3%,
-  // branches ~27.1%, lines ~37.5%, functions ~29.1%.
+  // Current totals (2026-05-18 CI, after coverage pushes #23-44): statements ~37.5%,
+  // branches ~28.2%, lines ~38.7%, functions ~30.1%.
   // Floors set ~0.5pp below current → any regression fails CI.
   // Ratchet these UP as tests are added; the OSS-readiness lift (Phase 5.4)
   // targets statements ≥80% (OpenSSF Silver `test_statement_coverage80`) by
@@ -62,10 +62,10 @@ const customJestConfig = {
   // layer at lib/game/data-server.ts etc.
   coverageThreshold: {
     global: {
-      branches: 26,
-      functions: 28,
-      lines: 37,
-      statements: 35,
+      branches: 27,
+      functions: 29,
+      lines: 38,
+      statements: 37,
     },
   },
   // Generate JSON summary for CI coverage checks

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -53,8 +53,8 @@ const customJestConfig = {
   // allowlisted lore subcollections — chapters, epitaphs). Registry
   // additions are static data covered transitively by the existing
   // registry self-check test; cascade-test growth lags by ~1pp.
-  // Current totals (2026-05-18 CI, after coverage pushes #1-5): statements ~32.4%,
-  // branches ~24.4%, lines ~33.6%, functions ~25.8%.
+  // Current totals (2026-05-18 CI, after coverage pushes #23-37): statements ~36.3%,
+  // branches ~27.1%, lines ~37.5%, functions ~29.1%.
   // Floors set ~0.5pp below current → any regression fails CI.
   // Ratchet these UP as tests are added; the OSS-readiness lift (Phase 5.4)
   // targets statements ≥80% (OpenSSF Silver `test_statement_coverage80`) by
@@ -62,10 +62,10 @@ const customJestConfig = {
   // layer at lib/game/data-server.ts etc.
   coverageThreshold: {
     global: {
-      branches: 24,
-      functions: 25,
-      lines: 33,
-      statements: 32,
+      branches: 26,
+      functions: 28,
+      lines: 37,
+      statements: 35,
     },
   },
   // Generate JSON summary for CI coverage checks

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     command: 'npm run build && npm run start',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    timeout: 300_000,
     env: {
       NEXT_PUBLIC_FIREBASE_API_KEY: 'test-api-key',
       NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: 'test-project.firebaseapp.com',

--- a/scripts/send-cohort1-week2-kickoff.ts
+++ b/scripts/send-cohort1-week2-kickoff.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Mon May 18, 2026 6pm EST Zoom invite to every admitted Cohort 1 applicant.
+ * The call has two halves: a relaxed walk-through of what people shipped in
+ * Week 1, then the Week 2 (Comms build) kickoff. Tone: warm + excited — show
+ * up even if you didn't ship last week.
+ *
+ * Idempotent via `cohort1Week2KickoffEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week2-kickoff.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week2-kickoff.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week2-kickoff.ts --send
+ *   npx tsx scripts/send-cohort1-week2-kickoff.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week2KickoffEmailedAt";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/92415077928";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/92415077928";
+const ZOOM_MEETING_ID = "924 1507 7928";
+const ZOOM_ONE_TAP_1 = "+13017158592,,92415077928# US (Washington DC)";
+const ZOOM_ONE_TAP_2 = "+13052241968,,92415077928# US";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Tonight 6pm EST — Week 1 review + Week 2 kickoff 🚀";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Quick one — tonight at 6pm EST we&apos;re back on Zoom.</strong> Two things on the agenda:</p>
+
+<ol style="padding-left:20px;">
+  <li style="margin-bottom:8px;"><strong>Week 1 review.</strong> We&apos;ll walk through what people built — PM tools, dashboards, you name it. Come look at each other&apos;s work, ask questions, swap notes.</li>
+  <li style="margin-bottom:8px;"><strong>Week 2 kickoff.</strong> Week 2 is the <strong>Comms build</strong> — everyone ships a cohort comms platform, same vote-and-pick-a-winner format. We&apos;ll talk through the prompt live on the call.</li>
+</ol>
+
+<p>Even if you didn&apos;t ship in Week 1, come hang out. The point is the room — meet the people, see what&apos;s shipping, trade ideas for Week 2.</p>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<p style="margin-top:8px;font-size:13px;color:#555;">
+  The Week 2 prompt + submission form is live now under the <strong>&quot;Week 2: Comms&quot;</strong> tab. Take a peek before the call if you want a head start.
+</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>Zoom — tonight, Mon May 18 · 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<p>See you at 6.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick one — tonight at 6pm EST we're back on Zoom. Two things on the agenda:
+
+  1. Week 1 review. We'll walk through what people built — PM tools, dashboards, you name it. Come look at each other's work, ask questions, swap notes.
+
+  2. Week 2 kickoff. Week 2 is the Comms build — everyone ships a cohort comms platform, same vote-and-pick-a-winner format. We'll talk through the prompt live on the call.
+
+Even if you didn't ship in Week 1, come hang out. The point is the room — meet the people, see what's shipping, trade ideas for Week 2.
+
+Open the cohort page: ${COHORT_URL}
+The Week 2 prompt + submission form is live now under the "Week 2: Comms" tab. Take a peek before the call if you want a head start.
+
+ZOOM — TONIGHT, MON MAY 18 · 6:00 PM EST
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+See you at 6.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Routine develop→main release. Headline: tonight's Cohort-1 Week-2 kickoff banner (above tabs on `/summer-cohort`) + the mailer that already went to 97 admitted cohort-1 applicants. Rest is the OpenSSF Silver test-coverage push series.

## Included PRs (all @Ludwitt)

**Feature**
- #1020 — feat(summer-cohort): tonight's Zoom banner + Week 2 kickoff email

**Coverage push (OpenSSF Silver)**
- #1011 — hero-registry InTx writers + event payload builders (#15)
- #1013 — game queued-orders (#16)
- #1014 — logger logRequest + sanitize + withLogging (#17)
- #1015 — mentorship data.ts client-Firestore helpers (#18)
- #1016 — pair-programming data.ts client-Firestore helpers (#19)
- #1017 — game/content armageddon constants + pure helpers (#20)
- #1018 — game pacts end-to-end (#21)
- #1019 — game prophecies end-to-end (#22)
- #1021 — live-sessions getLiveRemainingSeconds pure helper (#23)
- #1023 — mailgun full sendEmail coverage (#24)
- #1024 — members-public-snapshot computePublicMembersSnapshot (#25)
- #1025 — hiring-partners constants + sanitizeEngineerExpectations (#26)
- #1026 — submissions: talk + event flows (#27)
- #1027 — github-recent-merged-prs (#28)
- #1028 — hackathon-teams-board-server loadHackathonTeamsBoard (#29)
- #1029 — api-schemas/common zod fragments + security schemes (#30)
- #1030 — rate-limit-server checkServerRateLimit + buildRateLimitHeaders (#31)
- #1031 — pydata-2026 constants + validatePydataRegistration (#32)
- #1032 — github-open-pr-review-status (#33)
- #1034 — summer-cohort-auto-admit maybeAutoAdmitOnPRMerge (#34)
- #1035 — badges/admin-badge-awards (#35)
- #1036 — firebase-admin full singleton + init coverage (#36)
- #1037 — hackathon-team-dashboard-server (#37)
- #1039 — profile-bundle-server fetchProfileDataBundleJson (#38)
- #1040 — ludwitt-tokens OAuth token CRUD + refresh (#39)
- #1041 — treasure-hunt-claim claimTreasureHuntPrize (#40)

**Chore**
- #1038 — chore(jest): ratchet coverage thresholds to lock in pushes #23-37

## Test plan
- [x] Local production build (`npm run build && npm start`) verified — banner renders above tabs on `/summer-cohort` for cohort-1 users
- [x] Cohort-1 Week-2 kickoff email sent to 97 admitted applicants (0 failures) before this PR opened
- [x] Coverage thresholds ratcheted to lock in the new floor — no future regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)