### PR TITLE
chore(jest): ratchet coverage floors again after pushes #38-44

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -53,8 +53,8 @@ const customJestConfig = {
   // allowlisted lore subcollections — chapters, epitaphs). Registry
   // additions are static data covered transitively by the existing
   // registry self-check test; cascade-test growth lags by ~1pp.
-  // Current totals (2026-05-18 CI, after coverage pushes #23-37): statements ~36.3%,
-  // branches ~27.1%, lines ~37.5%, functions ~29.1%.
+  // Current totals (2026-05-18 CI, after coverage pushes #23-44): statements ~37.5%,
+  // branches ~28.2%, lines ~38.7%, functions ~30.1%.
   // Floors set ~0.5pp below current → any regression fails CI.
   // Ratchet these UP as tests are added; the OSS-readiness lift (Phase 5.4)
   // targets statements ≥80% (OpenSSF Silver `test_statement_coverage80`) by
@@ -62,10 +62,10 @@ const customJestConfig = {
   // layer at lib/game/data-server.ts etc.
   coverageThreshold: {
     global: {
-      branches: 26,
-      functions: 28,
-      lines: 37,
-      statements: 35,
+      branches: 27,
+      functions: 29,
+      lines: 38,
+      statements: 37,
     },
   },
   // Generate JSON summary for CI coverage checks


### PR DESCRIPTION
## Summary

Second-pass ratchet, locking in pushes #38-44 (profile-bundle-server, ludwitt-tokens, treasure-hunt-claim, game/content index, mailgun-suppressions, discord, badges/data).

| metric     | old floor | new floor | current |
|------------|-----------|-----------|---------|
| statements | 35        | **37**    | 37.45   |
| branches   | 26        | **27**    | 28.23   |
| lines      | 37        | **38**    | 38.71   |
| functions  | 28        | **29**    | 30.1    |

Each floor sits 0.5–1pp below current. test_statement_coverage80 remains the long-haul goal (~42.5pp to go).

Refs #54.