### PR TITLE
test(_helpers): Wave 0 — shared mock fixtures for the Silver coverage grind

### DIFF
--- a/__tests__/_helpers/_helpers-smoke.test.ts
+++ b/__tests__/_helpers/_helpers-smoke.test.ts
@@ -1,0 +1,269 @@
+/**
+ * @jest-environment node
+ *
+ * Smoke test for __tests__/_helpers/* — makes sure the shared mocks
+ * import cleanly, compose with each other, and return the shapes the
+ * Wave 1-5 backlog will rely on. If this file breaks, every downstream
+ * coverage push will break with it.
+ */
+import {
+  makeChain,
+  makeDoc,
+  makeDocRef,
+  makeFakeDb,
+  makeQuerySnap,
+  tsLike,
+  tsLikeMs,
+  withFakeAdminDb,
+} from "@/__tests__/_helpers/firebase-admin-mock";
+import {
+  createFirestoreClientModule,
+  createSwappableFirebaseModule,
+  makeFirestoreClientSpies,
+} from "@/__tests__/_helpers/firebase-client-mock";
+import {
+  createServerAuthModule,
+  clearCronSecret,
+  makeServerAuthSpies,
+  withCronSecret,
+} from "@/__tests__/_helpers/server-auth-mock";
+import {
+  makeAuthedRequest,
+  makeCronRequest,
+  makeRequest,
+  readJson,
+} from "@/__tests__/_helpers/route-test-utils";
+
+describe("__tests__/_helpers (smoke)", () => {
+  describe("firebase-admin-mock", () => {
+    it("makeDoc → exists:true when data is provided", () => {
+      const d = makeDoc("u1", { displayName: "Alice" });
+      expect(d.exists).toBe(true);
+      expect(d.id).toBe("u1");
+      expect(d.data()).toEqual({ displayName: "Alice" });
+    });
+
+    it("makeDoc → exists:false when data is undefined", () => {
+      const d = makeDoc("u1", undefined);
+      expect(d.exists).toBe(false);
+      expect(d.data()).toBeUndefined();
+    });
+
+    it("makeQuerySnap exposes docs/size/empty", () => {
+      const empty = makeQuerySnap([]);
+      expect(empty).toEqual({ docs: [], size: 0, empty: true });
+      const filled = makeQuerySnap([makeDoc("a", {}), makeDoc("b", {})]);
+      expect(filled.size).toBe(2);
+      expect(filled.empty).toBe(false);
+    });
+
+    it("tsLike + tsLikeMs match Firestore Timestamp shape", () => {
+      const a = tsLike("2026-05-01T00:00:00.000Z");
+      expect(a.toDate()).toEqual(new Date("2026-05-01T00:00:00.000Z"));
+      expect(a.toMillis()).toBe(Date.parse("2026-05-01T00:00:00.000Z"));
+
+      const b = tsLikeMs(1717000000000);
+      expect(b.toMillis()).toBe(1717000000000);
+      expect(b.toDate()).toEqual(new Date(1717000000000));
+    });
+
+    it("makeChain returns a chainable mock with where/orderBy/limit/get/count", async () => {
+      const chain = makeChain({ docs: [makeDoc("a", { v: 1 })] });
+      const result = await chain.where("x", "==", 1).orderBy("y").limit(10).get();
+      expect(result.size).toBe(1);
+      expect(chain.where).toHaveBeenCalledWith("x", "==", 1);
+      expect(chain.orderBy).toHaveBeenCalledWith("y");
+      expect(chain.limit).toHaveBeenCalledWith(10);
+      // count() returns aggregate
+      const agg = await chain.count().get();
+      expect(agg.data()).toEqual({ count: 1 });
+    });
+
+    it("makeDocRef provides get/set/update/delete spies + snap", async () => {
+      const ref = makeDocRef("d1", { snap: makeDoc("d1", { v: 2 }) });
+      const snap = await ref.get();
+      expect(snap.exists).toBe(true);
+      expect(snap.data()).toEqual({ v: 2 });
+      await ref.set({ x: 1 });
+      expect(ref.set).toHaveBeenCalledWith({ x: 1 });
+    });
+
+    it("makeFakeDb routes collection() calls to per-name chains", async () => {
+      const { db, collectionSpies } = makeFakeDb({
+        collections: {
+          users: [makeDoc("u1", { name: "A" })],
+          orders: [],
+        },
+      });
+      const usersSnap = await db.collection("users").where("x", "==", 1).get();
+      expect(usersSnap.size).toBe(1);
+      expect(collectionSpies.get("users")).toBeDefined();
+      const ordersSnap = await db.collection("orders").get();
+      expect(ordersSnap.empty).toBe(true);
+    });
+
+    it("makeFakeDb supports byId doc lookups", async () => {
+      const { db } = makeFakeDb({
+        collections: {
+          users: {
+            byId: { u1: makeDoc("u1", { name: "Alice" }) },
+          },
+        },
+      });
+      const refExists = (db.collection("users") as unknown as { doc: (id: string) => { get: () => Promise<unknown> } }).doc("u1");
+      const refMiss = (db.collection("users") as unknown as { doc: (id: string) => { get: () => Promise<unknown> } }).doc("nope");
+      const snapExists = (await refExists.get()) as { exists: boolean; data: () => unknown };
+      const snapMiss = (await refMiss.get()) as { exists: boolean };
+      expect(snapExists.exists).toBe(true);
+      expect(snapExists.data()).toEqual({ name: "Alice" });
+      expect(snapMiss.exists).toBe(false);
+    });
+
+    it("makeFakeDb.runTransaction proxies to a tx object with get/set/update", async () => {
+      const { db } = makeFakeDb({});
+      const txReturn = await db.runTransaction(async (tx) => {
+        const t = tx as { set: jest.Mock };
+        t.set({ __ref: 1 }, { x: 1 });
+        return "done";
+      });
+      expect(txReturn).toBe("done");
+    });
+
+    it("withFakeAdminDb wires a getAdminDb spy to a fresh fakeDb", () => {
+      const getAdminDb = jest.fn();
+      const { db } = withFakeAdminDb(getAdminDb, {
+        collections: { users: [] },
+      });
+      expect(getAdminDb()).toBe(db);
+    });
+  });
+
+  describe("firebase-client-mock", () => {
+    it("makeFirestoreClientSpies returns a complete spy bag", () => {
+      const spies = makeFirestoreClientSpies();
+      expect(typeof spies.collection).toBe("function");
+      expect(typeof spies.addDoc).toBe("function");
+      expect(typeof spies.onSnapshot).toBe("function");
+    });
+
+    it("createFirestoreClientModule binds the spies to module exports", async () => {
+      const spies = makeFirestoreClientSpies();
+      const mod = createFirestoreClientModule(spies);
+      spies.addDoc.mockResolvedValueOnce({ id: "new-1" });
+      const out = await mod.addDoc({}, { x: 1 });
+      expect(out).toEqual({ id: "new-1" });
+      expect(spies.addDoc).toHaveBeenCalledWith({}, { x: 1 });
+      expect(mod.Timestamp.now()).toEqual({ __ts: "now" });
+    });
+
+    it("createSwappableFirebaseModule exposes db/auth + __setters that swap values", () => {
+      const mod = createSwappableFirebaseModule();
+      expect(mod.db).toEqual({ __fake: "db" });
+      mod.__setDb({ __my: 1 });
+      expect(mod.db).toEqual({ __my: 1 });
+      mod.__setAuth({ currentUser: { uid: "u1" } });
+      expect((mod.auth as { currentUser: { uid: string } }).currentUser.uid).toBe(
+        "u1",
+      );
+    });
+  });
+
+  describe("server-auth-mock", () => {
+    afterEach(() => clearCronSecret());
+
+    it("makeServerAuthSpies → getVerifiedUser returns null by default", async () => {
+      const spies = makeServerAuthSpies();
+      expect(await spies.getVerifiedUser({} as never)).toBeNull();
+    });
+
+    it("mockVerifiedUser one-shots a user", async () => {
+      const spies = makeServerAuthSpies();
+      spies.mockVerifiedUser({ uid: "u1", email: "u@x.com" });
+      const u = (await spies.getVerifiedUser({} as never)) as { uid: string; email: string };
+      expect(u.uid).toBe("u1");
+      expect(u.email).toBe("u@x.com");
+      // Next call falls back to null again
+      expect(await spies.getVerifiedUser({} as never)).toBeNull();
+    });
+
+    it("mockUnauthenticated → null", async () => {
+      const spies = makeServerAuthSpies();
+      spies.mockUnauthenticated();
+      expect(await spies.getVerifiedUser({} as never)).toBeNull();
+    });
+
+    it("mockAuthError → rejects", async () => {
+      const spies = makeServerAuthSpies();
+      spies.mockAuthError(new Error("expired"));
+      await expect(spies.getVerifiedUser({} as never)).rejects.toThrow("expired");
+    });
+
+    it("createServerAuthModule binds spies to module exports", async () => {
+      const spies = makeServerAuthSpies();
+      const mod = createServerAuthModule(spies);
+      spies.mockVerifiedUser({ uid: "u9" });
+      const u = (await mod.getVerifiedUser({} as never)) as { uid: string };
+      expect(u.uid).toBe("u9");
+    });
+
+    it("withCronSecret + clearCronSecret manage process.env", () => {
+      withCronSecret("hello");
+      expect(process.env.CRON_SECRET).toBe("hello");
+      clearCronSecret();
+      expect(process.env.CRON_SECRET).toBeUndefined();
+    });
+  });
+
+  describe("route-test-utils", () => {
+    it("makeRequest defaults to GET with content-type json", async () => {
+      const req = makeRequest({ path: "/api/x" });
+      expect(req.method).toBe("GET");
+      expect(req.url).toContain("/api/x");
+      expect(req.headers.get("content-type")).toBe("application/json");
+    });
+
+    it("makeRequest JSON-stringifies object bodies on POST", async () => {
+      const req = makeRequest({ method: "POST", body: { foo: 1 } });
+      const body = await req.json();
+      expect(body).toEqual({ foo: 1 });
+    });
+
+    it("makeRequest leaves string bodies untouched", async () => {
+      const req = makeRequest({ method: "POST", body: '{"raw":true}' });
+      const body = await req.json();
+      expect(body).toEqual({ raw: true });
+    });
+
+    it("makeRequest applies searchParams", () => {
+      const req = makeRequest({
+        path: "/api/x",
+        searchParams: { a: "1", b: "two" },
+      });
+      const url = new URL(req.url);
+      expect(url.searchParams.get("a")).toBe("1");
+      expect(url.searchParams.get("b")).toBe("two");
+    });
+
+    it("makeAuthedRequest sets Authorization: Bearer", () => {
+      const req = makeAuthedRequest({ token: "abc" });
+      expect(req.headers.get("authorization")).toBe("Bearer abc");
+    });
+
+    it("makeAuthedRequest defaults to 'Bearer test-token'", () => {
+      const req = makeAuthedRequest();
+      expect(req.headers.get("authorization")).toBe("Bearer test-token");
+    });
+
+    it("makeCronRequest sets x-cron-secret", () => {
+      const req = makeCronRequest({ secret: "s3cret" });
+      expect(req.headers.get("x-cron-secret")).toBe("s3cret");
+    });
+
+    it("readJson returns { status, body }", async () => {
+      const fakeRes = new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const { status, body } = await readJson<{ ok: boolean }>(fakeRes);
+      expect(status).toBe(200);
+      expect(body).toEqual({ ok: true });
+    });
+  });
+});

--- a/__tests__/_helpers/component-test-utils.ts
+++ b/__tests__/_helpers/component-test-utils.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import * as React from "react";
+import { render, type RenderOptions } from "@testing-library/react";
+
+/**
+ * Render helpers for React component tests.
+ *
+ * The `useAuth()` mock is registered per-test via jest.mock() — see
+ * __tests__/components/AppShell.test.tsx for the canonical pattern.
+ *
+ * This helper provides the *wrapper* shape so multiple tests don't have
+ * to re-stub the same provider tree. Use it like:
+ *
+ * ```ts
+ * jest.mock("@/contexts/AuthContext", () => ({
+ *   useAuth: () => mockUseAuth(),
+ * }));
+ * const mockUseAuth = jest.fn();
+ *
+ * render(<MyComponent />, { wrapper: AllProviders });
+ * ```
+ */
+
+export interface MockUser {
+  uid: string;
+  email?: string | null;
+  displayName?: string | null;
+  photoURL?: string | null;
+}
+
+/**
+ * Pre-built useAuth() return shapes for common scenarios.
+ */
+export const authStates = {
+  loading: () => ({ user: null, loading: true }),
+  signedOut: () => ({ user: null, loading: false }),
+  signedIn: (overrides: Partial<MockUser> = {}) => ({
+    user: {
+      uid: "u1",
+      email: "u1@example.com",
+      displayName: "Test User",
+      photoURL: null,
+      ...overrides,
+    },
+    loading: false,
+  }),
+};
+
+/**
+ * Optional all-providers wrapper. Re-export RTL so tests have one import
+ * surface.
+ */
+export function AllProviders({ children }: { children: React.ReactNode }) {
+  return React.createElement(React.Fragment, null, children);
+}
+
+/** Convenience render that uses AllProviders. */
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, "wrapper">,
+) {
+  return render(ui, { wrapper: AllProviders, ...options });
+}
+
+/**
+ * Build a deterministic Firestore-User-like object for use in
+ * `mockUseAuth.mockReturnValue({ user: makeMockUser(), loading: false })`.
+ */
+export function makeMockUser(overrides: Partial<MockUser> = {}): MockUser {
+  return {
+    uid: "u-test",
+    email: "test@example.com",
+    displayName: "Test User",
+    photoURL: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Re-export common RTL primitives so consumers only need one import.
+ */
+export { render, screen, fireEvent, waitFor, within, act } from "@testing-library/react";
+export { default as userEvent } from "@testing-library/user-event";

--- a/__tests__/_helpers/firebase-admin-mock.ts
+++ b/__tests__/_helpers/firebase-admin-mock.ts
@@ -1,0 +1,243 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Reusable Firestore Admin SDK mock builders.
+ *
+ * Consolidates the per-test fakeDb builders that pushes #23-44 grew inline
+ * (e.g. __tests__/lib/hackathon-teams-board-server.test.ts:14-71,
+ *  __tests__/lib/profile-bundle-server.test.ts:23-77,
+ *  __tests__/lib/summer-cohort-auto-admit.test.ts:44-99).
+ *
+ * Coverage tests should reach for these helpers before rolling new mocks.
+ */
+
+export type FakeDocSnap = {
+  id: string;
+  exists: boolean;
+  data: () => Record<string, unknown> | undefined;
+  ref?: unknown;
+};
+
+export type FakeQuerySnap = {
+  docs: FakeDocSnap[];
+  size: number;
+  empty: boolean;
+};
+
+/**
+ * Snap-shape factory. Mirrors a real Firestore DocumentSnapshot for both
+ * existing-doc reads (`exists:true, data() → record`) and the get-by-doc-id
+ * miss path (`exists:false, data() → undefined`).
+ */
+export function makeDoc(id: string, data: Record<string, unknown> | undefined): FakeDocSnap {
+  if (data === undefined) {
+    return { id, exists: false, data: () => undefined };
+  }
+  return { id, exists: true, data: () => data };
+}
+
+/** Query-snap factory — wraps an array of `makeDoc()` results. */
+export function makeQuerySnap(docs: FakeDocSnap[]): FakeQuerySnap {
+  return { docs, size: docs.length, empty: docs.length === 0 };
+}
+
+/**
+ * Timestamp-like proxy. Firestore Timestamps expose `.toDate()` and
+ * `.toMillis()`; this matches both so the production code's narrowing
+ * (`"toDate" in v`) and direct millis access work transparently.
+ */
+export function tsLike(iso: string) {
+  const date = new Date(iso);
+  return {
+    toDate: () => date,
+    toMillis: () => date.getTime(),
+  };
+}
+
+/** Reverse Timestamp helper for tests that want to feed milliseconds. */
+export function tsLikeMs(ms: number) {
+  return {
+    toDate: () => new Date(ms),
+    toMillis: () => ms,
+  };
+}
+
+/**
+ * Chain builder for `.where(...).orderBy(...).limit(...).get()` style reads.
+ * Every chain method returns the same chain so tests can compose any order.
+ *
+ * Pass either:
+ * - `{ docs: [...] }` for one-shot reads (most common)
+ * - `{ get: jest.fn().mockResolvedValueOnce(...).mockResolvedValueOnce(...) }`
+ *   when a single chain is reused across multiple calls inside a single
+ *   function under test.
+ */
+export interface ChainOpts {
+  docs?: FakeDocSnap[];
+  get?: jest.Mock;
+}
+
+export function makeChain(opts: ChainOpts = {}) {
+  const get =
+    opts.get ??
+    jest.fn().mockResolvedValue(makeQuerySnap(opts.docs ?? []));
+
+  const chain: Record<string, jest.Mock> = {};
+  chain.where = jest.fn().mockReturnValue(chain);
+  chain.orderBy = jest.fn().mockReturnValue(chain);
+  chain.limit = jest.fn().mockReturnValue(chain);
+  chain.startAfter = jest.fn().mockReturnValue(chain);
+  chain.endBefore = jest.fn().mockReturnValue(chain);
+  chain.select = jest.fn().mockReturnValue(chain);
+  chain.get = get;
+  // count() returns an aggregate query whose .get() returns { data: () => ({ count }) }
+  chain.count = jest.fn().mockReturnValue({
+    get: jest.fn().mockResolvedValue({ data: () => ({ count: opts.docs?.length ?? 0 }) }),
+  });
+  return chain;
+}
+
+/** Doc-ref builder for `.collection(...).doc(...)` style reads. */
+export interface DocRefOpts {
+  snap?: FakeDocSnap | null;
+  get?: jest.Mock;
+  set?: jest.Mock;
+  update?: jest.Mock;
+  delete?: jest.Mock;
+}
+
+export function makeDocRef(id: string, opts: DocRefOpts = {}) {
+  const snap = opts.snap ?? makeDoc(id, undefined);
+  return {
+    id,
+    get: opts.get ?? jest.fn().mockResolvedValue(snap),
+    set: opts.set ?? jest.fn().mockResolvedValue(undefined),
+    update: opts.update ?? jest.fn().mockResolvedValue(undefined),
+    delete: opts.delete ?? jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * Top-level fake Firestore Admin DB builder.
+ *
+ * `opts.collections` maps collection name → either:
+ * - a `Record<docId, FakeDocSnap>` (looked up via `db.collection(x).doc(id)`)
+ * - an array of `FakeDocSnap[]` (returned by `db.collection(x).where(...).get()`)
+ * - a custom chain object (full control)
+ *
+ * Returns the db + a per-collection spy map so tests can assert on the
+ * `.where()`, `.limit()`, etc. calls each route made.
+ */
+export interface FakeDbOpts {
+  collections?: Record<
+    string,
+    | FakeDocSnap[]
+    | { docs?: FakeDocSnap[]; byId?: Record<string, FakeDocSnap> }
+    | ReturnType<typeof makeChain>
+  >;
+  runTransaction?: jest.Mock;
+  batch?: jest.Mock;
+  getAll?: jest.Mock;
+}
+
+export function makeFakeDb(opts: FakeDbOpts = {}) {
+  const collectionSpies = new Map<
+    string,
+    {
+      chain: ReturnType<typeof makeChain>;
+      docs: Record<string, ReturnType<typeof makeDocRef>>;
+    }
+  >();
+
+  const collection = jest.fn((name: string) => {
+    let entry = collectionSpies.get(name);
+    if (!entry) {
+      const collDef = opts.collections?.[name];
+      let docs: FakeDocSnap[] = [];
+      let byId: Record<string, FakeDocSnap> = {};
+
+      if (Array.isArray(collDef)) {
+        docs = collDef;
+      } else if (collDef && typeof collDef === "object" && "where" in collDef) {
+        // Already a fully-built chain — use as-is.
+        entry = {
+          chain: collDef as ReturnType<typeof makeChain>,
+          docs: {},
+        };
+        collectionSpies.set(name, entry);
+        return entry.chain;
+      } else if (collDef && typeof collDef === "object") {
+        docs = collDef.docs ?? [];
+        byId = collDef.byId ?? {};
+      }
+
+      const chain = makeChain({ docs });
+      const docMap: Record<string, ReturnType<typeof makeDocRef>> = {};
+      // Pre-build doc refs for known byId entries; lazy-build others.
+      for (const [docId, snap] of Object.entries(byId)) {
+        docMap[docId] = makeDocRef(docId, { snap });
+      }
+      // collection().doc(id) lookup → reuses pre-built or makes a new "exists:false" miss
+      (chain as Record<string, unknown>).doc = jest.fn((docId: string) => {
+        if (!docMap[docId]) {
+          docMap[docId] = makeDocRef(docId, { snap: makeDoc(docId, undefined) });
+        }
+        return docMap[docId];
+      });
+      entry = { chain, docs: docMap };
+      collectionSpies.set(name, entry);
+    }
+    return entry.chain;
+  });
+
+  const db = {
+    collection,
+    runTransaction:
+      opts.runTransaction ??
+      jest.fn(async (fn: (tx: unknown) => unknown) => {
+        // Default transaction: tx.get(ref) reads via ref.get(); tx.update/set/delete are spies.
+        const tx = {
+          get: jest.fn(async (ref: { get?: () => Promise<unknown> }) =>
+            ref.get ? ref.get() : { exists: false, data: () => undefined },
+          ),
+          set: jest.fn(),
+          update: jest.fn(),
+          delete: jest.fn(),
+        };
+        return fn(tx);
+      }),
+    batch:
+      opts.batch ??
+      jest.fn(() => ({
+        set: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+        commit: jest.fn().mockResolvedValue(undefined),
+      })),
+    getAll:
+      opts.getAll ??
+      jest.fn(async (...refs: Array<{ get?: () => Promise<unknown> }>) => {
+        return Promise.all(
+          refs.map((r) =>
+            r.get ? r.get() : { exists: false, data: () => undefined },
+          ),
+        );
+      }),
+  };
+
+  return { db, collection, collectionSpies };
+}
+
+/** Convenience helper for tests that just want `getAdminDb` to return a fake. */
+export function withFakeAdminDb<T>(
+  mockGetAdminDb: jest.Mock,
+  opts: FakeDbOpts = {},
+): { db: ReturnType<typeof makeFakeDb>["db"]; collectionSpies: ReturnType<typeof makeFakeDb>["collectionSpies"] } & T {
+  const { db, collectionSpies } = makeFakeDb(opts);
+  mockGetAdminDb.mockReturnValue(db);
+  return { db, collectionSpies } as ReturnType<typeof makeFakeDb> & T;
+}

--- a/__tests__/_helpers/firebase-client-mock.ts
+++ b/__tests__/_helpers/firebase-client-mock.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Reusable client-side Firebase mocks (firebase/firestore + firebase/auth +
+ * @/lib/firebase swappable singleton).
+ *
+ * Consolidates patterns from:
+ * - __tests__/lib/mentorship-data.test.ts (swappable db)
+ * - __tests__/lib/badges/data.test.ts (swappable db + auth)
+ * - __tests__/lib/submissions.test.ts (firebase/firestore module mock)
+ *
+ * Call `mockFirestoreClient()` (or `mockFirebaseAll()`) at the TOP of a test
+ * file — these helpers register jest.mock() calls which Jest hoists.
+ */
+
+/**
+ * Builder for `firebase/firestore` client SDK mock.
+ *
+ * After calling, the firebase/firestore module is mocked so that:
+ * - collection / addDoc / getDocs / query / where / serverTimestamp /
+ *   onSnapshot / doc / setDoc / updateDoc / deleteDoc / orderBy / limit /
+ *   startAfter / Timestamp.now()
+ *
+ * are all jest.fn()s that return predictable shapes. Tests can grab the
+ * returned spies map and configure mockResolvedValue/mockReturnValue as
+ * needed.
+ *
+ * NOTE: jest.mock() is hoisted by Jest's babel transform, so this function
+ * must be called at the top level of the test file (before any imports
+ * from the module under test).
+ */
+export interface FirestoreClientSpies {
+  collection: jest.Mock;
+  doc: jest.Mock;
+  addDoc: jest.Mock;
+  setDoc: jest.Mock;
+  updateDoc: jest.Mock;
+  deleteDoc: jest.Mock;
+  getDoc: jest.Mock;
+  getDocs: jest.Mock;
+  query: jest.Mock;
+  where: jest.Mock;
+  orderBy: jest.Mock;
+  limit: jest.Mock;
+  startAfter: jest.Mock;
+  onSnapshot: jest.Mock;
+  serverTimestamp: jest.Mock;
+}
+
+/**
+ * Returns a fresh spy bag. Tests must register the mock themselves at
+ * file top:
+ *
+ * ```ts
+ * const fsSpies = makeFirestoreClientSpies();
+ * jest.mock("firebase/firestore", () => createFirestoreClientModule(fsSpies));
+ * ```
+ *
+ * This split lets the spies be referenced inside the factory while keeping
+ * jest.mock() hoist-safe.
+ */
+export function makeFirestoreClientSpies(): FirestoreClientSpies {
+  return {
+    collection: jest.fn((_db: unknown, name: string) => ({ __coll: name })),
+    doc: jest.fn((_db: unknown, ...path: string[]) => ({ __doc: path.join("/") })),
+    addDoc: jest.fn(async () => ({ id: "doc-new" })),
+    setDoc: jest.fn(async () => undefined),
+    updateDoc: jest.fn(async () => undefined),
+    deleteDoc: jest.fn(async () => undefined),
+    getDoc: jest.fn(async () => ({ exists: () => false, data: () => undefined })),
+    getDocs: jest.fn(async () => ({ docs: [], size: 0, empty: true })),
+    query: jest.fn((...args: unknown[]) => ({ __q: args })),
+    where: jest.fn((...args: unknown[]) => ({ __w: args })),
+    orderBy: jest.fn((...args: unknown[]) => ({ __o: args })),
+    limit: jest.fn((...args: unknown[]) => ({ __l: args })),
+    startAfter: jest.fn((...args: unknown[]) => ({ __s: args })),
+    onSnapshot: jest.fn(() => () => {}),
+    serverTimestamp: jest.fn(() => ({ __ts: "now" })),
+  };
+}
+
+/**
+ * Module factory for the jest.mock("firebase/firestore", ...) call. Use
+ * with `makeFirestoreClientSpies()` above.
+ */
+export function createFirestoreClientModule(spies: FirestoreClientSpies) {
+  return {
+    collection: (...a: unknown[]) => spies.collection(...a),
+    doc: (...a: unknown[]) => spies.doc(...a),
+    addDoc: (...a: unknown[]) => spies.addDoc(...a),
+    setDoc: (...a: unknown[]) => spies.setDoc(...a),
+    updateDoc: (...a: unknown[]) => spies.updateDoc(...a),
+    deleteDoc: (...a: unknown[]) => spies.deleteDoc(...a),
+    getDoc: (...a: unknown[]) => spies.getDoc(...a),
+    getDocs: (...a: unknown[]) => spies.getDocs(...a),
+    query: (...a: unknown[]) => spies.query(...a),
+    where: (...a: unknown[]) => spies.where(...a),
+    orderBy: (...a: unknown[]) => spies.orderBy(...a),
+    limit: (...a: unknown[]) => spies.limit(...a),
+    startAfter: (...a: unknown[]) => spies.startAfter(...a),
+    onSnapshot: (...a: unknown[]) => spies.onSnapshot(...a),
+    serverTimestamp: () => spies.serverTimestamp(),
+    Timestamp: {
+      now: () => ({ __ts: "now" }),
+      fromMillis: (ms: number) => ({ __ts: ms }),
+      fromDate: (d: Date) => ({ __ts: d.getTime() }),
+    },
+  };
+}
+
+/**
+ * `@/lib/firebase` swappable singleton mock. Pattern from
+ * __tests__/lib/mentorship-data.test.ts:
+ *
+ * ```ts
+ * jest.mock("@/lib/firebase", () => createSwappableFirebaseModule());
+ * const { setDb, setAuth } = getSwappableFirebaseHandles();
+ * setDb(myFakeDb);
+ * ```
+ *
+ * Provides `db`, `auth`, `storage` getters that return whatever was last
+ * passed to `__setDb()` / `__setAuth()` / `__setStorage()`.
+ */
+export function createSwappableFirebaseModule() {
+  let _db: unknown = { __fake: "db" };
+  let _auth: unknown = { currentUser: null };
+  let _storage: unknown = { __fake: "storage" };
+  return {
+    get db() {
+      return _db;
+    },
+    get auth() {
+      return _auth;
+    },
+    get storage() {
+      return _storage;
+    },
+    __setDb(next: unknown) {
+      _db = next;
+    },
+    __setAuth(next: unknown) {
+      _auth = next;
+    },
+    __setStorage(next: unknown) {
+      _storage = next;
+    },
+  };
+}
+
+/**
+ * After registering the swappable module via jest.mock(),
+ * call this to get typed handles to the setters.
+ *
+ * ```ts
+ * jest.mock("@/lib/firebase", () => createSwappableFirebaseModule());
+ * const { setDb, setAuth } = getSwappableFirebaseHandles();
+ * ```
+ */
+export function getSwappableFirebaseHandles(): {
+  setDb: (next: unknown) => void;
+  setAuth: (next: unknown) => void;
+  setStorage: (next: unknown) => void;
+} {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require("@/lib/firebase") as {
+    __setDb: (next: unknown) => void;
+    __setAuth: (next: unknown) => void;
+    __setStorage: (next: unknown) => void;
+  };
+  return {
+    setDb: mod.__setDb,
+    setAuth: mod.__setAuth,
+    setStorage: mod.__setStorage,
+  };
+}

--- a/__tests__/_helpers/route-test-utils.ts
+++ b/__tests__/_helpers/route-test-utils.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+
+/**
+ * Request factories for App Router route-handler tests.
+ *
+ * Consolidates the boilerplate `new NextRequest("http://localhost/api/x",
+ * { method, headers, body: JSON.stringify(...) })` from the 79 existing
+ * route tests so future tests only need to think about the auth context
+ * and the body shape.
+ */
+
+export interface MakeRequestOpts {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
+  /** Path relative to localhost; defaults to "/api/route". */
+  path?: string;
+  /** Plain object — will be JSON.stringify'd. Skipped on GET/HEAD. */
+  body?: unknown;
+  /** Searchparams object. */
+  searchParams?: Record<string, string>;
+  /** Extra headers to merge in. */
+  headers?: Record<string, string>;
+}
+
+const BASE_URL = "http://localhost:3000";
+
+function buildUrl(path = "/api/route", searchParams?: Record<string, string>): string {
+  const url = new URL(path, BASE_URL);
+  if (searchParams) {
+    for (const [k, v] of Object.entries(searchParams)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return url.toString();
+}
+
+/** Plain request, no auth. */
+export function makeRequest(opts: MakeRequestOpts = {}): NextRequest {
+  const method = opts.method ?? "GET";
+  const headers = new Headers({
+    "content-type": "application/json",
+    ...(opts.headers ?? {}),
+  });
+  const init: RequestInit = { method, headers };
+  if (opts.body !== undefined && method !== "GET" && method !== "HEAD") {
+    init.body = typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
+  }
+  return new NextRequest(buildUrl(opts.path, opts.searchParams), init);
+}
+
+/**
+ * Authed request — adds `Authorization: Bearer dummy-token` so the route's
+ * `getVerifiedUser()` call will hit a token; the test must pair this with
+ * a `mockVerifiedUser(...)` call on the server-auth spies bag.
+ */
+export function makeAuthedRequest(
+  opts: MakeRequestOpts & { token?: string } = {},
+): NextRequest {
+  return makeRequest({
+    ...opts,
+    headers: {
+      Authorization: `Bearer ${opts.token ?? "test-token"}`,
+      ...(opts.headers ?? {}),
+    },
+  });
+}
+
+/**
+ * Cron-secret request — sets the `x-cron-secret` header. Pair with
+ * `withCronSecret("...")` in your beforeEach to populate the env.
+ */
+export function makeCronRequest(
+  opts: MakeRequestOpts & { secret?: string } = {},
+): NextRequest {
+  return makeRequest({
+    ...opts,
+    headers: {
+      "x-cron-secret": opts.secret ?? "test-cron-secret",
+      ...(opts.headers ?? {}),
+    },
+  });
+}
+
+/**
+ * Reads the JSON body off a Response (most route handlers return
+ * `NextResponse.json(...)`). Returns `{ status, body }` for easy
+ * assertion.
+ */
+export async function readJson<T = unknown>(res: Response): Promise<{ status: number; body: T }> {
+  const status = res.status;
+  const body = (await res.json()) as T;
+  return { status, body };
+}

--- a/__tests__/_helpers/server-auth-mock.ts
+++ b/__tests__/_helpers/server-auth-mock.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Helpers for mocking @/lib/server-auth — the verifier used by 161 Next.js
+ * App Router API routes. Plus a tiny CRON_SECRET helper for the 5 internal
+ * cron endpoints.
+ *
+ * Pattern (registered at file top, hoisted by Jest):
+ *
+ * ```ts
+ * const auth = makeServerAuthSpies();
+ * jest.mock("@/lib/server-auth", () => createServerAuthModule(auth));
+ * // ...
+ * auth.mockVerifiedUser({ uid: "u1", email: "u@x.com" });
+ * await POST(makeAuthedRequest({ uid: "u1" }));
+ * ```
+ */
+
+import type { VerifiedUser } from "@/lib/server-auth";
+
+export interface ServerAuthSpies {
+  getVerifiedUser: jest.Mock;
+  getOptionalVerifiedUser: jest.Mock;
+  /** Pre-seed `getVerifiedUser` to return the given user on the next call. */
+  mockVerifiedUser: (user: Partial<VerifiedUser> & { uid: string }) => void;
+  /** Pre-seed `getVerifiedUser` to return null (unauth) on the next call. */
+  mockUnauthenticated: () => void;
+  /** Pre-seed `getVerifiedUser` to throw on the next call (token verify fail). */
+  mockAuthError: (err?: Error) => void;
+}
+
+export function makeServerAuthSpies(): ServerAuthSpies {
+  const getVerifiedUser = jest.fn().mockResolvedValue(null);
+  const getOptionalVerifiedUser = jest.fn().mockResolvedValue(null);
+
+  return {
+    getVerifiedUser,
+    getOptionalVerifiedUser,
+    mockVerifiedUser(user) {
+      getVerifiedUser.mockResolvedValueOnce({
+        email: undefined,
+        name: undefined,
+        picture: undefined,
+        isAdmin: false,
+        ...user,
+      });
+      getOptionalVerifiedUser.mockResolvedValueOnce({
+        email: undefined,
+        name: undefined,
+        picture: undefined,
+        isAdmin: false,
+        ...user,
+      });
+    },
+    mockUnauthenticated() {
+      getVerifiedUser.mockResolvedValueOnce(null);
+      getOptionalVerifiedUser.mockResolvedValueOnce(null);
+    },
+    mockAuthError(err = new Error("token verify failed")) {
+      getVerifiedUser.mockRejectedValueOnce(err);
+      getOptionalVerifiedUser.mockRejectedValueOnce(err);
+    },
+  };
+}
+
+export function createServerAuthModule(spies: ServerAuthSpies) {
+  return {
+    getVerifiedUser: (...a: unknown[]) => spies.getVerifiedUser(...a),
+    getOptionalVerifiedUser: (...a: unknown[]) =>
+      spies.getOptionalVerifiedUser(...a),
+  };
+}
+
+/**
+ * CRON_SECRET env helper. The 5 internal cron routes all read
+ * `process.env.CRON_SECRET` at request time and compare against either
+ * `x-cron-secret` header or `Authorization: Bearer <secret>`.
+ *
+ * Use in beforeEach: `withCronSecret("test-secret-123")`. Returns the
+ * secret string so tests can also use it when constructing the request.
+ */
+export function withCronSecret(secret = "test-cron-secret"): string {
+  process.env.CRON_SECRET = secret;
+  return secret;
+}
+
+/** Test cleanup helper. */
+export function clearCronSecret(): void {
+  delete process.env.CRON_SECRET;
+}


### PR DESCRIPTION
## Summary

**Wave 0 of the Silver-coverage backlog** (see /Users/ludwitt/.claude/plans/i-need-an-end-streamed-mccarthy.md). Builds five reusable test helpers under `__tests__/_helpers/` that consolidate the inline mocks pushes #23-44 grew per-test. Future Wave 1-5 coverage PRs (~115 total) will import these instead of rolling new mocks per file.

No production code touched. 27 smoke tests pass and confirm every helper composes.

### What's in here

| File | LOC | Consolidates from |
|------|-----|-------------------|
| `firebase-admin-mock.ts` | 260 | hackathon-teams-board-server, profile-bundle-server, summer-cohort-auto-admit (~5 inline copies) |
| `firebase-client-mock.ts` | 170 | badges/data, mentorship-data, submissions (~4 inline copies) |
| `server-auth-mock.ts` | 100 | Net-new — unlocks 161 route tests that all use `getVerifiedUser` |
| `route-test-utils.ts` | 90 | 79 existing route tests that hand-roll NextRequest |
| `component-test-utils.ts` | 75 | AppShell, SummerCohortModal, and ~9 other component tests |
| `_helpers-smoke.test.ts` | 270 | New — 27 tests proving every helper composes |

### Exports

- `firebase-admin-mock`: `makeDoc`, `makeQuerySnap`, `tsLike`, `tsLikeMs`, `makeChain` (where/orderBy/limit/get/count chain), `makeDocRef`, `makeFakeDb` (full collection routing + byId lookup), `withFakeAdminDb` (one-line `getAdminDb` wiring)
- `firebase-client-mock`: `makeFirestoreClientSpies` + `createFirestoreClientModule` (for `jest.mock("firebase/firestore", ...)`); `createSwappableFirebaseModule` (db/auth/storage getters + `__setDb` / `__setAuth` setters); `getSwappableFirebaseHandles`
- `server-auth-mock`: `makeServerAuthSpies` (with one-shot helpers `mockVerifiedUser`, `mockUnauthenticated`, `mockAuthError`); `createServerAuthModule`; `withCronSecret` / `clearCronSecret`
- `route-test-utils`: `makeRequest`, `makeAuthedRequest`, `makeCronRequest`, `readJson`
- `component-test-utils`: `authStates`, `makeMockUser`, `AllProviders`, `renderWithProviders` + RTL re-exports

### Why now

Inline mocks are growing combinatorially: ~30 PRs each duplicated ~50 LOC of fakeDb plumbing. Extracting one canonical set:

1. Removes ~1,500 LOC of forthcoming duplication.
2. Makes each downstream coverage PR ~3-4× faster (the boilerplate becomes 2-3 imports instead of 50 LOC of inline setup).
3. Locks in one shape for `getVerifiedUser` / `getAdminDb` mocking so contributors don't reinvent it.

Refs #54 (`test_statement_coverage80` Silver criterion). First PR in Wave 0 of the documented plan; Wave 1a chunks 1-3 (data-server.ts coverage) follow immediately and validate the abstraction.

## Test plan
- [x] `npx jest __tests__/_helpers/_helpers-smoke.test.ts` — 27/27 pass
- [x] No production code modified; CI should be unaffected aside from new test-only files