### PR TITLE
chore(openssf-silver): ratchet coverage floors → 42/33/44/35

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -53,11 +53,11 @@ const customJestConfig = {
   // allowlisted lore subcollections — chapters, epitaphs). Registry
   // additions are static data covered transitively by the existing
   // registry self-check test; cascade-test growth lags by ~1pp.
-  // Current totals (2026-05-18 CI, after coverage pushes #23-64): statements ~41.9%,
-  // branches ~32.5%, lines ~43.1%, functions ~34.6%. Pushes #59-64 added
-  // lib/hackathon-{pool-dashboard-server,asprint-2026-award-profile-sync,
-  // showcase-admin}, lib/mentorship/data-server, lib/questions/service (52→96%),
-  // and lib/live-sessions/client (14→96%).
+  // Current totals (2026-05-18 CI, after coverage pushes #23-70): statements ~42.97%,
+  // branches ~33.4%, lines ~44.1%, functions ~35.8%. Pushes #65-70 added
+  // lib/hackathon-showcase (28→100%), lib/pair-programming/data-server
+  // (20→100%), lib/game/heroes-server (18→91%), lib/rate-limit (47→77%),
+  // lib/game/content/heroes (74→83%), and contexts/AuthContext (0→81%).
   // Floors set ~0.5pp below current → any regression fails CI.
   // Ratchet these UP as tests are added; the OSS-readiness lift (Phase 5.4)
   // targets statements ≥80% (OpenSSF Silver `test_statement_coverage80`) by
@@ -65,10 +65,10 @@ const customJestConfig = {
   // layer at lib/game/data-server.ts etc.
   coverageThreshold: {
     global: {
-      branches: 32,
-      functions: 34,
-      lines: 43,
-      statements: 41,
+      branches: 33,
+      functions: 35,
+      lines: 44,
+      statements: 42,
     },
   },
   // Generate JSON summary for CI coverage checks


### PR DESCRIPTION
## Summary
After pushes #65-70 lifted measurable coverage from 41.92% → **42.97%** statements (branches 32.52% → 33.36%, lines 43.08% → 44.09%, functions 34.62% → 35.75%), bump the per-metric floor ~0.5pp below the new current.

New floors:
- `branches: 32 → 33`
- `functions: 34 → 35`
- `lines: 43 → 44`
- `statements: 41 → 42`

## Test plan
- [x] `coverage/coverage-summary.json` shows totals above all four new floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)