### PR TITLE
feat(certificate): cohort weekly winner LinkedIn certificates

### DIFF
--- a/__tests__/app/api/certificate/claim.test.ts
+++ b/__tests__/app/api/certificate/claim.test.ts
@@ -166,6 +166,7 @@ describe("POST /api/certificate/claim", () => {
         issuedAt: { toDate: () => new Date("2026-01-01") },
         certName: "Cursor Boston Open Source Contributor",
         certUrl: "https://cursorboston.com/certificates/cert-u1",
+        kind: "contributor",
       },
     });
     mockGetAdminDb.mockReturnValue(db);
@@ -204,6 +205,7 @@ describe("POST /api/certificate/claim", () => {
         issuedAt: { toDate: () => new Date("2026-05-12") },
         certName: "Cursor Boston Open Source Contributor",
         certUrl: "https://cursorboston.com/certificates/cert-u1",
+        kind: "contributor",
       },
     });
     mockGetAdminDb.mockReturnValue(db);
@@ -219,6 +221,7 @@ describe("POST /api/certificate/claim", () => {
     expect(payload.githubLogin).toBe("octocat");
     expect(payload.displayName).toBe("Pat Dev");
     expect(payload.pullRequestsCount).toBe(15);
+    expect(payload.kind).toBe("contributor");
   });
 
   it("returns 500 when the read-back of the created certificate fails to parse", async () => {

--- a/__tests__/app/api/certificate/mine.test.ts
+++ b/__tests__/app/api/certificate/mine.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/certificate/mine/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+
+function mineRequest() {
+  return new NextRequest("http://localhost/api/certificate/mine", {
+    method: "GET",
+  });
+}
+
+describe("GET /api/certificate/mine", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(mineRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when admin DB is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1" } as any);
+    mockGetAdminDb.mockReturnValue(null as any);
+    const res = await GET(mineRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns contributor and cohort winner certificates for the user", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1" } as any);
+
+    const docs = [
+      {
+        id: "cert_u1",
+        data: () => ({
+          id: "cert_u1",
+          userId: "u1",
+          displayName: "Pat",
+          githubLogin: "pat",
+          pullRequestsCount: 12,
+          issuedAt: { toDate: () => new Date("2026-04-01") },
+          certName: "Cursor Boston Open Source Contributor",
+          certUrl: "https://cursorboston.com/certificate/verify/cert_u1",
+          kind: "contributor",
+        }),
+      },
+      {
+        id: "cert_cohort-1_week-1_u1",
+        data: () => ({
+          id: "cert_cohort-1_week-1_u1",
+          userId: "u1",
+          displayName: "Pat",
+          githubLogin: "pat",
+          issuedAt: { toDate: () => new Date("2026-05-18") },
+          certName: "Cohort 1 Week 1 Best Project Management Tool",
+          certUrl:
+            "https://cursorboston.com/certificate/verify/cert_cohort-1_week-1_u1",
+          kind: "cohort-winner",
+          cohortId: "cohort-1",
+          weekId: "week-1",
+          voteCount: 9,
+        }),
+      },
+    ];
+
+    const db: any = {
+      collection: jest.fn(() => ({
+        where: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue({ docs }),
+        })),
+      })),
+    };
+    mockGetAdminDb.mockReturnValue(db);
+
+    const res = await GET(mineRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.certificates).toHaveLength(2);
+    expect(json.certificates[0].certificate.kind).toBe("cohort-winner");
+    expect(json.certificates[0].certificate.certName).toBe(
+      "Cohort 1 Week 1 Best Project Management Tool"
+    );
+    expect(json.certificates[0].linkedInAddToProfileUrl).toContain("linkedin.com");
+    expect(json.certificates[1].certificate.kind).toBe("contributor");
+  });
+});

--- a/__tests__/lib/certificate-cohort-winner.test.ts
+++ b/__tests__/lib/certificate-cohort-winner.test.ts
@@ -1,0 +1,109 @@
+import {
+  COHORT_WINNER_CERT_NAMES,
+  buildLinkedInAddToProfileUrl,
+  getCohortWinnerCertDocId,
+  getCohortWinnerCertName,
+  listCertificatesForUser,
+  parseCertificateFromFirestore,
+} from "@/lib/certificate";
+
+describe("cohort winner certificates", () => {
+  it("maps cohort-1 week-1 to the PM winner LinkedIn title", () => {
+    expect(getCohortWinnerCertName("cohort-1", "week-1")).toBe(
+      COHORT_WINNER_CERT_NAMES["cohort-1"]?.["week-1"]
+    );
+    expect(getCohortWinnerCertName("cohort-1", "week-1")).toBe(
+      "Cohort 1 Week 1 Best Project Management Tool"
+    );
+  });
+
+  it("builds a unique doc id per cohort/week/user", () => {
+    expect(getCohortWinnerCertDocId("cohort-1", "week-1", "uid123")).toBe(
+      "cert_cohort-1_week-1_uid123"
+    );
+  });
+
+  it("parses cohort winner certificates without pullRequestsCount", () => {
+    const cert = parseCertificateFromFirestore("cert_cohort-1_week-1_uid123", {
+      id: "cert_cohort-1_week-1_uid123",
+      userId: "uid123",
+      displayName: "Ying Chen",
+      githubLogin: "ProductChameleon",
+      issuedAt: "2026-05-18T00:00:00.000Z",
+      certName: "Cohort 1 Week 1 Best Project Management Tool",
+      certUrl: "https://cursorboston.com/certificate/verify/cert_cohort-1_week-1_uid123",
+      kind: "cohort-winner",
+      cohortId: "cohort-1",
+      weekId: "week-1",
+      voteCount: 9,
+    });
+
+    expect(cert).toMatchObject({
+      kind: "cohort-winner",
+      voteCount: 9,
+      cohortId: "cohort-1",
+      weekId: "week-1",
+    });
+    expect(cert?.pullRequestsCount).toBeUndefined();
+  });
+
+  it("builds a LinkedIn add-to-profile URL for cohort winner certs", () => {
+    const linkedInUrl = buildLinkedInAddToProfileUrl({
+      id: "cert_cohort-1_week-1_uid123",
+      userId: "uid123",
+      displayName: "Ying Chen",
+      githubLogin: "ProductChameleon",
+      issuedAt: "2026-05-18T00:00:00.000Z",
+      certName: "Cohort 1 Week 1 Best Project Management Tool",
+      certUrl: "https://cursorboston.com/certificate/verify/cert_cohort-1_week-1_uid123",
+      kind: "cohort-winner",
+      cohortId: "cohort-1",
+      weekId: "week-1",
+      voteCount: 9,
+    });
+
+    expect(linkedInUrl).toContain("linkedin.com/profile/add");
+    expect(linkedInUrl).toContain("name=Cohort+1+Week+1+Best+Project+Management+Tool");
+  });
+
+  it("sorts cohort winner certificates ahead of contributor certificates", async () => {
+    const db: any = {
+      collection: jest.fn(() => ({
+        where: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue({
+            docs: [
+              {
+                id: "cert_u1",
+                data: () => ({
+                  userId: "u1",
+                  displayName: "Pat",
+                  githubLogin: "pat",
+                  pullRequestsCount: 12,
+                  issuedAt: "2026-04-01T00:00:00.000Z",
+                  kind: "contributor",
+                }),
+              },
+              {
+                id: "cert_cohort-1_week-1_u1",
+                data: () => ({
+                  userId: "u1",
+                  displayName: "Pat",
+                  githubLogin: "pat",
+                  issuedAt: "2026-05-18T00:00:00.000Z",
+                  certName: "Cohort 1 Week 1 Best Project Management Tool",
+                  kind: "cohort-winner",
+                  cohortId: "cohort-1",
+                  weekId: "week-1",
+                  voteCount: 9,
+                }),
+              },
+            ],
+          }),
+        })),
+      })),
+    };
+
+    const certs = await listCertificatesForUser(db, "u1");
+    expect(certs.map((c) => c.kind)).toEqual(["cohort-winner", "contributor"]);
+  });
+});

--- a/app/api/certificate/claim/route.ts
+++ b/app/api/certificate/claim/route.ts
@@ -120,6 +120,7 @@ export async function POST(request: NextRequest) {
       issuedAt: FieldValue.serverTimestamp(),
       certName: CERTIFICATE_NAME,
       certUrl,
+      kind: "contributor",
     });
 
     // Read back to get the server timestamp resolved

--- a/app/api/certificate/mine/route.ts
+++ b/app/api/certificate/mine/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  buildLinkedInAddToProfileUrl,
+  listCertificatesForUser,
+} from "@/lib/certificate";
+import { logger } from "@/lib/logger";
+
+// @contracts: certificateContract.mine (lib/api-schemas/certificate.ts)
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const certificates = await listCertificatesForUser(db, user.uid);
+
+    return NextResponse.json({
+      certificates: certificates.map((certificate) => ({
+        certificate,
+        linkedInAddToProfileUrl: buildLinkedInAddToProfileUrl(certificate),
+      })),
+    });
+  } catch (error) {
+    logger.logError(error, {
+      endpoint: "/api/certificate/mine",
+      method: "GET",
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/certificate/_components/CertificateCard.tsx
+++ b/app/certificate/_components/CertificateCard.tsx
@@ -47,10 +47,20 @@ export function CertificateCard({ certificate, linkedInAddToProfileUrl }: Certif
           <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4">
             @{certificate.githubLogin}
           </p>
-          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
-            <span className="text-emerald-700 dark:text-emerald-300 font-medium">
-              {certificate.pullRequestsCount} merged PRs
-            </span>
+          <div className="flex justify-center">
+            {certificate.kind === "cohort-winner" ? (
+              <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
+                <span className="text-emerald-700 dark:text-emerald-300 font-medium">
+                  {certificate.voteCount ?? 0} cohort votes
+                </span>
+              </div>
+            ) : (
+              <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
+                <span className="text-emerald-700 dark:text-emerald-300 font-medium">
+                  {certificate.pullRequestsCount ?? 0} merged PRs
+                </span>
+              </div>
+            )}
           </div>
           <p className="mt-4 text-xs text-neutral-400 dark:text-neutral-500">
             Issued {formattedDate}

--- a/app/certificate/page.tsx
+++ b/app/certificate/page.tsx
@@ -12,7 +12,11 @@ import { Award } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { CERTIFICATE_PR_THRESHOLD } from "@/lib/certificate";
 import type { ProfileDataApiResponse } from "@/lib/profile-data-types";
-import type { Certificate, CertificateClaimResponse } from "@/types/certificate";
+import type {
+  CertificateClaimResponse,
+  CertificateEntry,
+  CertificateListResponse,
+} from "@/types/certificate";
 import { CertificateCard } from "./_components/CertificateCard";
 import { CertificateProgress } from "./_components/CertificateProgress";
 import { SectionHelp } from "@/components/SectionHelp";
@@ -24,8 +28,7 @@ export default function CertificatePage() {
   const [loadingData, setLoadingData] = useState(true);
   const [claiming, setClaiming] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [certificate, setCertificate] = useState<Certificate | null>(null);
-  const [linkedInUrl, setLinkedInUrl] = useState<string | null>(null);
+  const [certificates, setCertificates] = useState<CertificateEntry[]>([]);
 
   useEffect(() => {
     if (!loading && !user) {
@@ -33,7 +36,6 @@ export default function CertificatePage() {
     }
   }, [loading, user, router]);
 
-  // Fetch PR count and check for existing certificate
   useEffect(() => {
     if (!user) return;
 
@@ -41,14 +43,16 @@ export default function CertificatePage() {
       try {
         const headers = { Authorization: `Bearer ${await user.getIdToken()}` };
 
-        // Fetch profile data (includes PR count)
-        const res = await fetch("/api/profile/data", { headers });
-        if (!res.ok) throw new Error(`Profile data failed: ${res.status}`);
-        const json = (await res.json()) as ProfileDataApiResponse;
+        const [profileRes, mineRes] = await Promise.all([
+          fetch("/api/profile/data", { headers }),
+          fetch("/api/certificate/mine", { headers }),
+        ]);
 
+        if (!profileRes.ok) throw new Error(`Profile data failed: ${profileRes.status}`);
+
+        const json = (await profileRes.json()) as ProfileDataApiResponse;
         let prCount = json.stats.pullRequestsCount ?? 0;
 
-        // If GitHub connected but 0 PRs, try reconciliation
         const githubLogin =
           userProfile?.github &&
           typeof userProfile.github === "object" &&
@@ -69,8 +73,17 @@ export default function CertificatePage() {
 
         setPullRequestsCount(prCount);
 
-        // Try to claim to check if already claimed (idempotent endpoint)
-        if (prCount >= CERTIFICATE_PR_THRESHOLD) {
+        let issued: CertificateEntry[] = [];
+        if (mineRes.ok) {
+          const mine = (await mineRes.json()) as CertificateListResponse;
+          issued = mine.certificates ?? [];
+        }
+
+        const hasContributorCert = issued.some(
+          (entry) => entry.certificate.kind === "contributor"
+        );
+
+        if (prCount >= CERTIFICATE_PR_THRESHOLD && !hasContributorCert) {
           const claimRes = await fetch("/api/certificate/claim", {
             method: "POST",
             headers: {
@@ -80,10 +93,17 @@ export default function CertificatePage() {
           });
           if (claimRes.ok) {
             const claimData = (await claimRes.json()) as CertificateClaimResponse;
-            setCertificate(claimData.certificate);
-            setLinkedInUrl(claimData.linkedInAddToProfileUrl);
+            issued = [
+              ...issued,
+              {
+                certificate: claimData.certificate,
+                linkedInAddToProfileUrl: claimData.linkedInAddToProfileUrl,
+              },
+            ];
           }
         }
+
+        setCertificates(issued);
       } catch (err) {
         console.error("Error loading certificate data:", err);
       } finally {
@@ -113,8 +133,18 @@ export default function CertificatePage() {
       }
 
       const data = (await res.json()) as CertificateClaimResponse;
-      setCertificate(data.certificate);
-      setLinkedInUrl(data.linkedInAddToProfileUrl);
+      setCertificates((prev) => {
+        const withoutContributor = prev.filter(
+          (entry) => entry.certificate.kind !== "contributor"
+        );
+        return [
+          ...withoutContributor,
+          {
+            certificate: data.certificate,
+            linkedInAddToProfileUrl: data.linkedInAddToProfileUrl,
+          },
+        ];
+      });
     } catch {
       setError("Something went wrong. Please try again.");
     } finally {
@@ -131,93 +161,147 @@ export default function CertificatePage() {
   }
 
   const isEligible = pullRequestsCount >= CERTIFICATE_PR_THRESHOLD;
+  const hasContributorCert = certificates.some(
+    (entry) => entry.certificate.kind === "contributor"
+  );
+  const cohortWinnerCerts = certificates.filter(
+    (entry) => entry.certificate.kind === "cohort-winner"
+  );
+  const contributorCert = certificates.find(
+    (entry) => entry.certificate.kind === "contributor"
+  );
 
   return (
     <div className="min-h-[80vh] px-6 py-8 md:py-12">
       <div className="max-w-2xl mx-auto">
         <section className="mb-6">
           <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-2">
-            LinkedIn Certificate
+            LinkedIn Certificates
           </h1>
           <p className="text-neutral-600 dark:text-neutral-400 max-w-2xl">
-            Earn your Cursor Boston Open Source Contributor certificate by merging{" "}
-            {CERTIFICATE_PR_THRESHOLD} pull requests, then add it to your LinkedIn profile.
+            View certificates you&apos;ve earned — Summer Cohort weekly wins and
+            the Open Source Contributor award after {CERTIFICATE_PR_THRESHOLD}{" "}
+            merged pull requests.
           </p>
         </section>
-
-        <SectionHelp
-          title="About the certificate"
-          intro={
-            <>
-              After {CERTIFICATE_PR_THRESHOLD} merged PRs against this repo,
-              you can claim a LinkedIn-compatible Cursor Boston Open Source
-              Contributor certificate. The merge count is auto-detected from
-              your linked GitHub account.
-            </>
-          }
-          faq={[
-            {
-              q: "Which PRs count?",
-              a: "Any merged PR into this repo that has your linked GitHub login as the author. Closed/unmerged PRs don't count.",
-            },
-            {
-              q: "Why isn't my count updating?",
-              a: "Make sure your GitHub account is linked from your profile. The page will trigger a reconciliation; if it stays at 0, check that the GitHub username on your profile is correct.",
-            },
-            {
-              q: "Can I add it to LinkedIn?",
-              a: "Yes — after claiming, the Add-to-Profile button generates a one-click LinkedIn link with the certificate details prefilled.",
-            },
-          ]}
-          links={[
-            { label: "Your profile / link GitHub", href: "/profile" },
-            { label: "First contribution guide", href: "/open-source" },
-          ]}
-        />
 
         {loadingData ? (
           <div className="flex items-center justify-center py-12">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-neutral-900 dark:border-white" />
           </div>
-        ) : certificate && linkedInUrl ? (
-          <CertificateCard certificate={certificate} linkedInAddToProfileUrl={linkedInUrl} />
-        ) : isEligible ? (
-          <div className="rounded-2xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-6 text-center">
-            <div className="flex justify-center mb-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
-                <Award className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-              </div>
-            </div>
-            <h2 className="text-xl font-semibold text-foreground mb-2">
-              You&apos;re eligible!
-            </h2>
-            <p className="text-neutral-600 dark:text-neutral-400 mb-4">
-              You have {pullRequestsCount} merged PRs. Claim your certificate to add it to
-              your LinkedIn profile.
-            </p>
-            {error && (
-              <p className="text-sm text-red-600 dark:text-red-400 mb-4">{error}</p>
-            )}
-            <button
-              onClick={handleClaim}
-              disabled={claiming}
-              className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {claiming ? (
-                <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-white" />
-                  Claiming...
-                </>
-              ) : (
-                <>
-                  <Award className="h-4 w-4" />
-                  Claim Your Certificate
-                </>
-              )}
-            </button>
-          </div>
         ) : (
-          <CertificateProgress pullRequestsCount={pullRequestsCount} />
+          <div className="space-y-10">
+            {certificates.length > 0 ? (
+              <section className="space-y-6">
+                <h2 className="text-lg font-semibold text-foreground">
+                  Your certificates
+                </h2>
+                {cohortWinnerCerts.map((entry) => (
+                  <CertificateCard
+                    key={entry.certificate.id}
+                    certificate={entry.certificate}
+                    linkedInAddToProfileUrl={entry.linkedInAddToProfileUrl}
+                  />
+                ))}
+                {contributorCert ? (
+                  <CertificateCard
+                    certificate={contributorCert.certificate}
+                    linkedInAddToProfileUrl={contributorCert.linkedInAddToProfileUrl}
+                  />
+                ) : null}
+              </section>
+            ) : null}
+
+            <section className="space-y-6">
+              <div>
+                <h2 className="text-lg font-semibold text-foreground mb-1">
+                  Open Source Contributor
+                </h2>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                  Merge {CERTIFICATE_PR_THRESHOLD} pull requests into this repo to
+                  claim a LinkedIn-ready contributor certificate.
+                </p>
+              </div>
+
+              <SectionHelp
+                title="About the contributor certificate"
+                intro={
+                  <>
+                    After {CERTIFICATE_PR_THRESHOLD} merged PRs against this repo,
+                    you can claim a LinkedIn-compatible Cursor Boston Open Source
+                    Contributor certificate. The merge count is auto-detected from
+                    your linked GitHub account.
+                  </>
+                }
+                faq={[
+                  {
+                    q: "Which PRs count?",
+                    a: "Any merged PR into this repo that has your linked GitHub login as the author. Closed/unmerged PRs don't count.",
+                  },
+                  {
+                    q: "Why isn't my count updating?",
+                    a: "Make sure your GitHub account is linked from your profile. The page will trigger a reconciliation; if it stays at 0, check that the GitHub username on your profile is correct.",
+                  },
+                  {
+                    q: "Can I add it to LinkedIn?",
+                    a: "Yes — after claiming, the Add-to-Profile button generates a one-click LinkedIn link with the certificate details prefilled.",
+                  },
+                  {
+                    q: "What about cohort winner certificates?",
+                    a: "If you win a Summer Cohort weekly vote, your certificate appears automatically at the top of this page once it is issued.",
+                  },
+                ]}
+                links={[
+                  { label: "Your profile / link GitHub", href: "/profile" },
+                  { label: "First contribution guide", href: "/open-source" },
+                  { label: "Summer Cohort", href: "/summer-cohort" },
+                ]}
+              />
+
+              {hasContributorCert ? (
+                <p className="text-sm text-emerald-700 dark:text-emerald-300">
+                  Your Open Source Contributor certificate is listed above.
+                </p>
+              ) : isEligible ? (
+                <div className="rounded-2xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-neutral-900 p-6 text-center">
+                  <div className="flex justify-center mb-4">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/50">
+                      <Award className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+                    </div>
+                  </div>
+                  <h3 className="text-xl font-semibold text-foreground mb-2">
+                    You&apos;re eligible!
+                  </h3>
+                  <p className="text-neutral-600 dark:text-neutral-400 mb-4">
+                    You have {pullRequestsCount} merged PRs. Claim your certificate to
+                    add it to your LinkedIn profile.
+                  </p>
+                  {error && (
+                    <p className="text-sm text-red-600 dark:text-red-400 mb-4">{error}</p>
+                  )}
+                  <button
+                    onClick={handleClaim}
+                    disabled={claiming}
+                    className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {claiming ? (
+                      <>
+                        <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-white" />
+                        Claiming...
+                      </>
+                    ) : (
+                      <>
+                        <Award className="h-4 w-4" />
+                        Claim Contributor Certificate
+                      </>
+                    )}
+                  </button>
+                </div>
+              ) : (
+                <CertificateProgress pullRequestsCount={pullRequestsCount} />
+              )}
+            </section>
+          </div>
         )}
       </div>
     </div>

--- a/app/certificate/verify/[certId]/page.tsx
+++ b/app/certificate/verify/[certId]/page.tsx
@@ -39,12 +39,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return { title: "Certificate Not Found | Cursor Boston" };
   }
 
+  const isCohortWinner = cert.kind === "cohort-winner";
+  const description = isCohortWinner
+    ? `${cert.displayName} (@${cert.githubLogin}) earned the ${cert.certName} certificate with ${cert.voteCount ?? 0} cohort votes.`
+    : `${cert.displayName} (@${cert.githubLogin}) earned the ${cert.certName} certificate with ${cert.pullRequestsCount ?? 0} merged pull requests.`;
+
   return {
     title: `${cert.displayName} - ${cert.certName} | Cursor Boston`,
-    description: `${cert.displayName} (@${cert.githubLogin}) earned the ${cert.certName} certificate with ${cert.pullRequestsCount} merged pull requests.`,
+    description,
     openGraph: {
       title: `${cert.displayName} - ${cert.certName}`,
-      description: `Verified open source contributor with ${cert.pullRequestsCount} merged PRs to Cursor Boston.`,
+      description: isCohortWinner
+        ? `Verified Summer Cohort weekly winner at Cursor Boston.`
+        : `Verified open source contributor with ${cert.pullRequestsCount ?? 0} merged PRs to Cursor Boston.`,
       type: "profile",
     },
   };
@@ -64,6 +71,8 @@ export default async function CertificateVerifyPage({ params }: Props) {
     month: "long",
     day: "numeric",
   });
+
+  const isCohortWinner = cert.kind === "cohort-winner";
 
   return (
     <div className="min-h-[80vh] px-6 py-8 md:py-12">
@@ -109,7 +118,9 @@ export default async function CertificateVerifyPage({ params }: Props) {
             <div className="flex justify-center">
               <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 text-sm">
                 <span className="text-emerald-700 dark:text-emerald-300 font-medium">
-                  {cert.pullRequestsCount} merged PRs
+                  {isCohortWinner
+                    ? `${cert.voteCount ?? 0} cohort votes`
+                    : `${cert.pullRequestsCount ?? 0} merged PRs`}
                 </span>
               </div>
             </div>
@@ -136,9 +147,25 @@ export default async function CertificateVerifyPage({ params }: Props) {
               <dd className="text-foreground">{formattedDate}</dd>
             </div>
             <div className="flex justify-between">
-              <dt className="text-neutral-500 dark:text-neutral-400">Merged PRs at Issuance</dt>
-              <dd className="text-foreground">{cert.pullRequestsCount}</dd>
+              <dt className="text-neutral-500 dark:text-neutral-400">
+                {isCohortWinner ? "Cohort votes at issuance" : "Merged PRs at Issuance"}
+              </dt>
+              <dd className="text-foreground">
+                {isCohortWinner ? cert.voteCount ?? 0 : cert.pullRequestsCount ?? 0}
+              </dd>
             </div>
+            {isCohortWinner && cert.cohortId && cert.weekId ? (
+              <>
+                <div className="flex justify-between">
+                  <dt className="text-neutral-500 dark:text-neutral-400">Cohort</dt>
+                  <dd className="text-foreground">{cert.cohortId}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-neutral-500 dark:text-neutral-400">Week</dt>
+                  <dd className="text-foreground">{cert.weekId}</dd>
+                </div>
+              </>
+            ) : null}
           </dl>
         </div>
 
@@ -149,17 +176,31 @@ export default async function CertificateVerifyPage({ params }: Props) {
             className="hover:underline"
           >
             Cursor Boston
-          </a>{" "}
-          for open source contributions to the{" "}
-          <a
-            href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:underline"
-          >
-            cursor-boston
-          </a>{" "}
-          repository.
+          </a>
+          {isCohortWinner ? (
+            <>
+              {" "}
+              for winning the cohort weekly vote on{" "}
+              <a href="https://cursorboston.com/summer-cohort" className="hover:underline">
+                Summer Cohort
+              </a>
+              .
+            </>
+          ) : (
+            <>
+              {" "}
+              for open source contributions to the{" "}
+              <a
+                href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                cursor-boston
+              </a>{" "}
+              repository.
+            </>
+          )}
         </p>
       </div>
     </div>

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -35,6 +35,12 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/__tests__/config/firebase/firestore.rules.test.ts',
     '<rootDir>/e2e/',
+    // next/jest testMatch includes every file under __tests__/; exclude shared fixtures.
+    '<rootDir>/__tests__/_helpers/firebase-admin-mock.ts',
+    '<rootDir>/__tests__/_helpers/firebase-client-mock.ts',
+    '<rootDir>/__tests__/_helpers/route-test-utils.ts',
+    '<rootDir>/__tests__/_helpers/server-auth-mock.ts',
+    '<rootDir>/__tests__/_helpers/component-test-utils.ts',
   ],
   // Global thresholds — kept just below current CI totals so new UI without tests fails CI loudly.
   // Re-aligned 2026-05-12 after the PyData hackathon hub + access-gate

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**178 paths, 214 operations across 32 areas.**
+**179 paths, 215 operations across 32 areas.**
 
 ---
 
@@ -69,6 +69,7 @@ _Verifiable merged-PR certificates._
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | POST | `/api/certificate/claim` | Yes | Claim a Cursor Boston merged-PR certificate |
+| GET | `/api/certificate/mine` | Yes | List LinkedIn certificates issued to the signed-in user |
 
 ## Cfp
 

--- a/lib/api-schemas/certificate.ts
+++ b/lib/api-schemas/certificate.ts
@@ -20,6 +20,19 @@ const PassthroughOk = z.object({}).passthrough();
 
 export const certificateContract = c.router(
   {
+    mine: {
+      method: "GET",
+      path: "/api/certificate/mine",
+      summary: "List LinkedIn certificates issued to the signed-in user",
+      responses: {
+        200: PassthroughOk,
+        401: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: ["UNAUTHORIZED", "SERVER_ERROR"] as const,
+      },
+    },
     claim: {
       method: "POST",
       path: "/api/certificate/claim",

--- a/lib/certificate.ts
+++ b/lib/certificate.ts
@@ -4,12 +4,30 @@
  * See LICENSE file for details.
  */
 
-import type { Certificate } from "@/types/certificate";
+import type { Firestore } from "firebase-admin/firestore";
+import type { Certificate, CertificateKind } from "@/types/certificate";
+import type { SummerCohortId } from "@/lib/summer-cohort";
 
 export const CERTIFICATES_COLLECTION = "certificates";
 export const CERTIFICATE_PR_THRESHOLD = 10;
 export const CERTIFICATE_NAME = "Cursor Boston Open Source Contributor";
 export const LINKEDIN_ORGANIZATION_ID = "112955918";
+
+/** LinkedIn certification titles for cohort weekly vote winners. */
+export const COHORT_WINNER_CERT_NAMES: Partial<
+  Record<SummerCohortId, Partial<Record<string, string>>>
+> = {
+  "cohort-1": {
+    "week-1": "Cohort 1 Week 1 Best Project Management Tool",
+    "week-2": "Cohort 1 Week 2 Best Communications Platform",
+    "week-3": "Cohort 1 Week 3 Best Marketing Platform",
+  },
+  "cohort-2": {
+    "week-1": "Cohort 2 Week 1 Best Project Management Tool",
+    "week-2": "Cohort 2 Week 2 Best Communications Platform",
+    "week-3": "Cohort 2 Week 3 Best Marketing Platform",
+  },
+};
 
 function getSiteOrigin(): string {
   return process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com";
@@ -17,6 +35,25 @@ function getSiteOrigin(): string {
 
 export function getCertificateDocId(userId: string): string {
   return `cert_${userId}`;
+}
+
+export function getCohortWinnerCertDocId(
+  cohortId: SummerCohortId,
+  weekId: string,
+  userId: string
+): string {
+  return `cert_${cohortId}_${weekId}_${userId}`;
+}
+
+export function getCohortWinnerCertName(
+  cohortId: SummerCohortId,
+  weekId: string
+): string | null {
+  return COHORT_WINNER_CERT_NAMES[cohortId]?.[weekId] ?? null;
+}
+
+function readCertificateKind(data: Record<string, unknown>): CertificateKind {
+  return data.kind === "cohort-winner" ? "cohort-winner" : "contributor";
 }
 
 export function getCertVerifyUrl(certId: string): string {
@@ -55,13 +92,33 @@ export function parseCertificateFromFirestore(
     issuedAt = new Date(rawIssuedAt.seconds * 1000).toISOString();
   }
 
-  if (
-    !data.userId ||
-    !data.displayName ||
-    !data.githubLogin ||
-    !issuedAt ||
-    typeof data.pullRequestsCount !== "number"
-  ) {
+  if (!data.userId || !data.displayName || !data.githubLogin || !issuedAt) {
+    return null;
+  }
+
+  const kind = readCertificateKind(data);
+
+  if (kind === "contributor") {
+    if (typeof data.pullRequestsCount !== "number") {
+      return null;
+    }
+    return {
+      id: (data.id as string) || docId,
+      userId: data.userId as string,
+      displayName: data.displayName as string,
+      githubLogin: data.githubLogin as string,
+      pullRequestsCount: data.pullRequestsCount as number,
+      issuedAt,
+      certName: (data.certName as string) || CERTIFICATE_NAME,
+      certUrl: (data.certUrl as string) || getCertVerifyUrl(docId),
+      kind,
+    };
+  }
+
+  const cohortId =
+    typeof data.cohortId === "string" ? data.cohortId : undefined;
+  const weekId = typeof data.weekId === "string" ? data.weekId : undefined;
+  if (!cohortId || !weekId) {
     return null;
   }
 
@@ -70,9 +127,41 @@ export function parseCertificateFromFirestore(
     userId: data.userId as string,
     displayName: data.displayName as string,
     githubLogin: data.githubLogin as string,
-    pullRequestsCount: data.pullRequestsCount as number,
     issuedAt,
-    certName: (data.certName as string) || CERTIFICATE_NAME,
+    certName: (data.certName as string) || getCohortWinnerCertName(cohortId as SummerCohortId, weekId) || "Cohort Winner",
     certUrl: (data.certUrl as string) || getCertVerifyUrl(docId),
+    kind,
+    cohortId,
+    weekId,
+    voteCount: typeof data.voteCount === "number" ? data.voteCount : undefined,
   };
+}
+
+/** All LinkedIn certificates issued to a user (contributor + cohort winners). */
+export async function listCertificatesForUser(
+  db: Firestore,
+  userId: string
+): Promise<Certificate[]> {
+  const snap = await db
+    .collection(CERTIFICATES_COLLECTION)
+    .where("userId", "==", userId)
+    .get();
+
+  const certificates: Certificate[] = [];
+  for (const doc of snap.docs) {
+    const parsed = parseCertificateFromFirestore(
+      doc.id,
+      doc.data() as Record<string, unknown>
+    );
+    if (parsed) {
+      certificates.push(parsed);
+    }
+  }
+
+  return certificates.sort((a, b) => {
+    if (a.kind !== b.kind) {
+      return a.kind === "cohort-winner" ? -1 : 1;
+    }
+    return new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime();
+  });
 }

--- a/scripts/issue-cohort-winner-certificate.ts
+++ b/scripts/issue-cohort-winner-certificate.ts
@@ -1,0 +1,244 @@
+/**
+ * Issue a LinkedIn-ready Summer Cohort weekly winner certificate.
+ *
+ * Tallies votes for the given cohort/week (or accepts --handle override),
+ * resolves the winner's Firebase user profile, and writes a unique certificate
+ * doc to Firestore.
+ *
+ * Usage:
+ *   npx tsx scripts/issue-cohort-winner-certificate.ts --cohort-id=cohort-1 --week-id=week-1 --dry-run
+ *   npx tsx scripts/issue-cohort-winner-certificate.ts --cohort-id=cohort-1 --week-id=week-1 --apply
+ *   npx tsx scripts/issue-cohort-winner-certificate.ts --cohort-id=cohort-1 --week-id=week-1 --handle=productchameleon --apply
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import {
+  CERTIFICATES_COLLECTION,
+  buildLinkedInAddToProfileUrl,
+  getCertVerifyUrl,
+  getCohortWinnerCertDocId,
+  getCohortWinnerCertName,
+  parseCertificateFromFirestore,
+} from "../lib/certificate";
+import {
+  SUMMER_COHORT_VOTES_COLLECTION,
+  isValidCohortId,
+  type SummerCohortId,
+} from "../lib/summer-cohort";
+
+const VALID_WEEK_IDS = new Set(["week-1", "week-2", "week-3"]);
+
+function readArg(name: string): string | null {
+  const prefix = `--${name}=`;
+  const hit = process.argv.find((a) => a.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : null;
+}
+
+function voteDocMatchesCohort(
+  data: Record<string, unknown>,
+  cohortId: SummerCohortId
+): boolean {
+  const docCohort =
+    typeof data.cohortId === "string" ? data.cohortId : "cohort-1";
+  return docCohort === cohortId;
+}
+
+async function tallyVotes(
+  cohortId: SummerCohortId,
+  weekId: string
+): Promise<Array<[handle: string, count: number]>> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not configured");
+
+  const snap = await db
+    .collection(SUMMER_COHORT_VOTES_COLLECTION)
+    .where("weekId", "==", weekId)
+    .get();
+
+  const counts: Record<string, number> = {};
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (!voteDocMatchesCohort(data, cohortId)) continue;
+    const handle =
+      typeof data.submitterHandle === "string"
+        ? data.submitterHandle.toLowerCase()
+        : null;
+    if (!handle) continue;
+    counts[handle] = (counts[handle] ?? 0) + 1;
+  }
+
+  return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+}
+
+async function findUserByGithubHandle(handle: string) {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not configured");
+
+  const target = handle.toLowerCase();
+  const snap = await db.collection("users").get();
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const login =
+      data.github &&
+      typeof data.github === "object" &&
+      typeof (data.github as { login?: string }).login === "string"
+        ? (data.github as { login: string }).login.trim().toLowerCase()
+        : "";
+    if (login === target) {
+      return { uid: doc.id, data };
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const apply = process.argv.includes("--apply");
+  if (dryRun === apply) {
+    console.error("Pass exactly one of --dry-run or --apply");
+    process.exit(1);
+  }
+
+  const rawCohort = readArg("cohort-id") ?? "cohort-1";
+  if (!isValidCohortId(rawCohort)) {
+    console.error("cohort-id must be cohort-1 or cohort-2");
+    process.exit(1);
+  }
+  const cohortId = rawCohort;
+
+  const weekId = readArg("week-id");
+  if (!weekId || !VALID_WEEK_IDS.has(weekId)) {
+    console.error("week-id must be one of week-1, week-2, week-3");
+    process.exit(1);
+  }
+
+  const certName = getCohortWinnerCertName(cohortId, weekId);
+  if (!certName) {
+    console.error(`No LinkedIn cert name configured for ${cohortId} ${weekId}`);
+    process.exit(1);
+  }
+
+  const handleOverride = readArg("handle")?.trim().toLowerCase() ?? null;
+  const ranked = await tallyVotes(cohortId, weekId);
+  const winnerHandle = handleOverride ?? ranked[0]?.[0] ?? null;
+  const voteCount =
+    ranked.find(([handle]) => handle === winnerHandle)?.[1] ?? ranked[0]?.[1] ?? 0;
+
+  if (!winnerHandle) {
+    console.error("No votes found for this cohort/week");
+    process.exit(1);
+  }
+
+  const user = await findUserByGithubHandle(winnerHandle);
+  if (!user) {
+    console.error(
+      `Winner @${winnerHandle} has no linked Firebase user — they must sign in and connect GitHub first`
+    );
+    process.exit(1);
+  }
+
+  const githubLogin =
+    user.data.github &&
+    typeof user.data.github === "object" &&
+    typeof (user.data.github as { login?: string }).login === "string"
+      ? (user.data.github as { login: string }).login.trim()
+      : winnerHandle;
+  const displayName =
+    (typeof user.data.displayName === "string" && user.data.displayName.trim()) ||
+    githubLogin;
+
+  const certDocId = getCohortWinnerCertDocId(cohortId, weekId, user.uid);
+  const certUrl = getCertVerifyUrl(certDocId);
+
+  const payload = {
+    id: certDocId,
+    userId: user.uid,
+    displayName,
+    githubLogin,
+    issuedAt: FieldValue.serverTimestamp(),
+    certName,
+    certUrl,
+    kind: "cohort-winner" as const,
+    cohortId,
+    weekId,
+    voteCount,
+  };
+
+  const summary = {
+    mode: dryRun ? "dry-run" : "apply",
+    cohortId,
+    weekId,
+    certName,
+    winnerHandle,
+    voteCount,
+    displayName,
+    githubLogin,
+    userId: user.uid,
+    certDocId,
+    certUrl,
+    voteTally: ranked,
+  };
+
+  if (dryRun) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured");
+    process.exit(1);
+  }
+
+  const existing = await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).get();
+  if (existing.exists) {
+    const parsed = parseCertificateFromFirestore(
+      certDocId,
+      existing.data() as Record<string, unknown>
+    );
+    if (parsed) {
+      console.log(
+        JSON.stringify(
+          {
+            ...summary,
+            alreadyIssued: true,
+            linkedInAddToProfileUrl: buildLinkedInAddToProfileUrl(parsed),
+          },
+          null,
+          2
+        )
+      );
+      return;
+    }
+  }
+
+  await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).set(payload);
+  const created = await db.collection(CERTIFICATES_COLLECTION).doc(certDocId).get();
+  const certificate = parseCertificateFromFirestore(
+    certDocId,
+    created.data() as Record<string, unknown>
+  );
+  if (!certificate) {
+    console.error("Certificate write succeeded but read-back failed");
+    process.exit(1);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ...summary,
+        alreadyIssued: false,
+        linkedInAddToProfileUrl: buildLinkedInAddToProfileUrl(certificate),
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/types/certificate.ts
+++ b/types/certificate.ts
@@ -4,20 +4,37 @@
  * See LICENSE file for details.
  */
 
+export type CertificateKind = "contributor" | "cohort-winner";
+
 export interface Certificate {
   id: string;
   userId: string;
   displayName: string;
   githubLogin: string;
-  pullRequestsCount: number;
   issuedAt: string;
   certName: string;
   certUrl: string;
+  kind: CertificateKind;
+  /** Present on contributor certificates (merged-PR threshold). */
+  pullRequestsCount?: number;
+  /** Present on cohort weekly winner certificates. */
+  cohortId?: string;
+  weekId?: string;
+  voteCount?: number;
 }
 
 export interface CertificateClaimResponse {
   certificate: Certificate;
   linkedInAddToProfileUrl: string;
+}
+
+export interface CertificateEntry {
+  certificate: Certificate;
+  linkedInAddToProfileUrl: string;
+}
+
+export interface CertificateListResponse {
+  certificates: CertificateEntry[];
 }
 
 export interface CertificateClaimErrorResponse {


### PR DESCRIPTION
## Summary
- Add a distinct `cohort-winner` certificate type with unique Firestore doc IDs per cohort/week/user
- Add `GET /api/certificate/mine` so signed-in users see awarded certs on `/certificate`
- Add maintainer script `scripts/issue-cohort-winner-certificate.ts` to issue certs from vote tallies
- Update verify page + certificate card UI for cohort winner metadata

## Test plan
- [x] `npm run build`
- [x] Unit tests for certificate helpers, `/api/certificate/mine`, and claim route
- [x] Issued Cohort 1 Week 1 cert to @ProductChameleon in Firestore (9 votes)


Made with [Cursor](https://cursor.com)