### PR TITLE
fix(ci): exclude __tests__/_helpers from Jest runs

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -35,6 +35,12 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/__tests__/config/firebase/firestore.rules.test.ts',
     '<rootDir>/e2e/',
+    // next/jest testMatch includes every file under __tests__/; exclude shared fixtures.
+    '<rootDir>/__tests__/_helpers/firebase-admin-mock.ts',
+    '<rootDir>/__tests__/_helpers/firebase-client-mock.ts',
+    '<rootDir>/__tests__/_helpers/route-test-utils.ts',
+    '<rootDir>/__tests__/_helpers/server-auth-mock.ts',
+    '<rootDir>/__tests__/_helpers/component-test-utils.ts',
   ],
   // Global thresholds — kept just below current CI totals so new UI without tests fails CI loudly.
   // Re-aligned 2026-05-12 after the PyData hackathon hub + access-gate


### PR DESCRIPTION
## Summary
- Adds `testPathIgnorePatterns` for shared `__tests__/_helpers/*` mock modules
- Fixes CI **Test** failures where next/jest’s merged `testMatch` treated fixtures as empty test suites

## Test plan
- [x] `npm test` locally (290 suites green)

Made with [Cursor](https://cursor.com)