### PR TITLE
fix(questions): add error boundary to questions page (#580)

### DIFF
--- a/__tests__/components/ui/ErrorBoundary.test.tsx
+++ b/__tests__/components/ui/ErrorBoundary.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { logger } from "@/lib/logger";
+
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    logError: jest.fn(),
+  },
+}));
 
 // A component that throws on demand
 function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
@@ -11,6 +18,7 @@ function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
 // Suppress noisy console.error from React & componentDidCatch during boundary tests
 beforeEach(() => {
   jest.spyOn(console, "error").mockImplementation(() => {});
+  jest.mocked(logger.logError).mockClear();
 });
 afterEach(() => {
   jest.restoreAllMocks();
@@ -76,18 +84,33 @@ describe("ErrorBoundary", () => {
   });
 
   it("calls componentDidCatch and logs the error", () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-
     render(
       <ErrorBoundary>
         <ThrowingChild shouldThrow={true} />
       </ErrorBoundary>,
     );
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      "ErrorBoundary caught an error:",
+    expect(logger.logError).toHaveBeenCalledWith(
       expect.any(Error),
-      expect.objectContaining({ componentStack: expect.any(String) }),
+      expect.objectContaining({
+        boundary: "ErrorBoundary",
+        componentStack: expect.any(String),
+      }),
     );
+  });
+
+  it("renders custom title and description when provided", () => {
+    render(
+      <ErrorBoundary
+        title="Failed to load questions"
+        description="Failed to load questions. Please refresh."
+      >
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Failed to load questions")).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed to load questions. Please refresh."),
+    ).toBeInTheDocument();
   });
 });

--- a/app/questions/page.tsx
+++ b/app/questions/page.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Metadata } from "next";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { QuestionsListing } from "@/components/questions/QuestionsListing";
 import { SectionHelp } from "@/components/SectionHelp";
 
@@ -50,7 +51,12 @@ export default function QuestionsPage() {
           },
         ]}
       />
-      <QuestionsListing />
+      <ErrorBoundary
+        title="Failed to load questions"
+        description="Failed to load questions. Please refresh."
+      >
+        <QuestionsListing />
+      </ErrorBoundary>
     </main>
   );
 }

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -7,10 +7,13 @@
 "use client";
 
 import { Component, ReactNode } from "react";
+import { logger } from "@/lib/logger";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
+  title?: string;
+  description?: string;
 }
 
 interface ErrorBoundaryState {
@@ -28,7 +31,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("ErrorBoundary caught an error:", error, errorInfo);
+    logger.logError(error, {
+      componentStack: errorInfo.componentStack,
+      boundary: "ErrorBoundary",
+    });
   }
 
   render() {
@@ -41,10 +47,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         <div role="alert" className="min-h-[60vh] flex items-center justify-center p-8">
           <div className="text-center max-w-md">
             <h2 className="text-xl font-semibold text-foreground mb-2">
-              Something went wrong
+              {this.props.title ?? "Something went wrong"}
             </h2>
             <p className="text-neutral-600 dark:text-neutral-400 mb-6">
-              An unexpected error occurred. You can try again or reload the page.
+              {this.props.description ??
+                "An unexpected error occurred. You can try again or reload the page."}
             </p>
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
               <button


### PR DESCRIPTION
## Summary
- Wrap `QuestionsListing` in the shared `ErrorBoundary` on `/questions`.
- Add optional `title` / `description` props so questions gets the audit copy without losing Try again / Reload.
- Log boundary errors via `logger.logError` in `componentDidCatch`.

Fixes #580

## Test plan
- [x] `npm test -- __tests__/components/ui/ErrorBoundary.test.tsx`
- [ ] Load `/questions`; confirm page renders normally

Made with [Cursor](https://cursor.com)