### PR TITLE
test(questions): vote route tests and self-vote guard (#595)

### DIFF
--- a/__tests__/app/api/questions/vote/route.test.ts
+++ b/__tests__/app/api/questions/vote/route.test.ts
@@ -37,6 +37,12 @@ jest.mock("@/lib/questions/service", () => ({
   AnswerNotFoundError: class extends Error {
     constructor() { super("Answer not found"); this.name = "AnswerNotFoundError"; }
   },
+  UnauthorizedError: class extends Error {
+    constructor(msg = "Unauthorized") {
+      super(msg);
+      this.name = "UnauthorizedError";
+    }
+  },
 }));
 
 const { getVerifiedUser } = jest.requireMock("@/lib/server-auth") as {
@@ -100,6 +106,96 @@ describe("POST /api/questions/vote", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.action).toBe("added");
+    expect(mockVote).toHaveBeenCalledWith("question", "q1", "u1", "up", undefined);
+  });
+
+  it("adds a downvote", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockVote.mockResolvedValue({
+      action: "added", type: "down", upCount: 0, downCount: 1, netScore: -1,
+    });
+
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "q1", type: "down" })
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).action).toBe("added");
+  });
+
+  it("switches vote from up to down", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockVote.mockResolvedValue({
+      action: "switched",
+      type: "down",
+      previousType: "up",
+      upCount: 0,
+      downCount: 1,
+      netScore: -1,
+    });
+
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "q1", type: "down" })
+    );
+    const data = await res.json();
+    expect(data.action).toBe("switched");
+    expect(data.previousType).toBe("up");
+  });
+
+  it("removes vote when toggling same type (unvote)", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockVote.mockResolvedValue({
+      action: "removed", type: "up", upCount: 0, downCount: 0, netScore: 0,
+    });
+
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "q1", type: "up" })
+    );
+    const data = await res.json();
+    expect(data.action).toBe("removed");
+    expect(data.upCount).toBe(0);
+  });
+
+  it("votes on an answer with questionId", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    mockVote.mockResolvedValue({
+      action: "added", type: "up", upCount: 1, downCount: 0, netScore: 1,
+    });
+
+    const res = await POST(
+      makePostRequest({
+        targetType: "answer",
+        targetId: "a1",
+        questionId: "q1",
+        type: "up",
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockVote).toHaveBeenCalledWith("answer", "a1", "u1", "up", "q1");
+  });
+
+  it("returns 404 when question not found", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const { QuestionNotFoundError } = jest.requireMock("@/lib/questions/service");
+    mockVote.mockRejectedValue(new QuestionNotFoundError());
+
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "missing", type: "up" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when voting on own content", async () => {
+    getVerifiedUser.mockResolvedValue(testUser);
+    const { UnauthorizedError } = jest.requireMock("@/lib/questions/service");
+    mockVote.mockRejectedValue(
+      new UnauthorizedError("You cannot vote on your own content")
+    );
+
+    const res = await POST(
+      makePostRequest({ targetType: "question", targetId: "q1", type: "up" })
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("You cannot vote on your own content");
   });
 });
 

--- a/__tests__/lib/questions/service.test.ts
+++ b/__tests__/lib/questions/service.test.ts
@@ -241,6 +241,24 @@ describe("QuestionsService", () => {
       expect(result.downCount).toBe(1);
     });
 
+    it("throws UnauthorizedError when voting on own content", async () => {
+      mockRunTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          get: jest.fn()
+            .mockResolvedValueOnce({
+              exists: true,
+              data: () => ({ authorId: "u1", upCount: 0, downCount: 0 }),
+            })
+            .mockResolvedValueOnce({ exists: false }),
+        };
+        return fn(tx);
+      });
+
+      await expect(service.vote("question", "q1", "u1", "up")).rejects.toThrow(
+        UnauthorizedError
+      );
+    });
+
     it("throws QuestionNotFoundError when target does not exist", async () => {
       mockRunTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
         const tx = {

--- a/app/api/questions/vote/route.ts
+++ b/app/api/questions/vote/route.ts
@@ -11,6 +11,7 @@ import {
   getQuestionsService,
   QuestionNotFoundError,
   AnswerNotFoundError,
+  UnauthorizedError,
 } from "@/lib/questions/service";
 import { logger } from "@/lib/logger";
 import { getClientIdentifier } from "@/lib/rate-limit";
@@ -74,6 +75,9 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     if (error instanceof QuestionNotFoundError || error instanceof AnswerNotFoundError) {
       return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
     }
     logger.logError(error, { endpoint: "POST /api/questions/vote" });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/lib/questions/service.ts
+++ b/lib/questions/service.ts
@@ -366,6 +366,10 @@ export class QuestionsService {
       }
 
       const targetData = targetSnap.data()!;
+      if (targetData.authorId === userId) {
+        throw new UnauthorizedError("You cannot vote on your own content");
+      }
+
       const upCount = Number(targetData.upCount ?? 0);
       const downCount = Number(targetData.downCount ?? 0);
 


### PR DESCRIPTION
## Summary
- Expands POST `/api/questions/vote` tests for upvote, downvote, vote switch, unvote, answer votes, 404, and 403 self-vote.
- Prevents voting on your own question or answer in `QuestionsService.vote`.

Closes #595.

## Test plan
- [x] `npm test -- --testPathPatterns="questions/vote|lib/questions/service.test"`

Made with [Cursor](https://cursor.com)