### PR TITLE
test(hunt): add path submit validation tests (#571)

### DIFF
--- a/__tests__/app/api/hunt/paths/submit.test.ts
+++ b/__tests__/app/api/hunt/paths/submit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST } from "@/app/api/hunt/paths/[pathId]/submit/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { checkTreasureHuntEligibility } from "@/lib/treasure-hunt-eligibility";
+import { claimTreasureHuntPrize } from "@/lib/treasure-hunt-claim";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/treasure-hunt-eligibility", () => ({
+  checkTreasureHuntEligibility: jest.fn(),
+}));
+
+jest.mock("@/lib/treasure-hunt-claim", () => ({
+  claimTreasureHuntPrize: jest.fn(),
+}));
+
+const mockRateGet = jest.fn();
+const mockRateSet = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({
+      doc: () => ({
+        get: mockRateGet,
+        set: mockRateSet,
+      }),
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCheckEligibility = checkTreasureHuntEligibility as jest.MockedFunction<
+  typeof checkTreasureHuntEligibility
+>;
+const mockClaimPrize = claimTreasureHuntPrize as jest.MockedFunction<typeof claimTreasureHuntPrize>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Hunter", email: "hunter@test.com" };
+
+function submit(pathId: string, body?: Record<string, unknown>, authed = false) {
+  const req = authed
+    ? makeAuthedRequest({
+        method: "POST",
+        path: `/api/hunt/paths/${pathId}/submit`,
+        body: body ?? { answer: "wrong-guess" },
+      })
+    : makeRequest({
+        method: "POST",
+        path: `/api/hunt/paths/${pathId}/submit`,
+        body: body ?? { answer: "wrong-guess" },
+      });
+  return POST(req, { params: Promise.resolve({ pathId }) });
+}
+
+describe("POST /api/hunt/paths/[pathId]/submit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRateGet.mockResolvedValue({ data: () => ({ wrongAt: [] }) });
+    mockCheckEligibility.mockResolvedValue({
+      ok: true,
+      githubLogin: "hunter",
+      discordUsername: "hunter#0001",
+    });
+  });
+
+  describe("pathId validation", () => {
+    it.each([
+      ["unknown-path", "unknown slug"],
+      ["", "empty pathId"],
+      ["../admin", "path traversal"],
+      ["'; DROP TABLE--", "SQL-injection-like characters"],
+      ["code-reader%00", "null-byte suffix"],
+    ])("returns 404 for invalid pathId (%s)", async (pathId) => {
+      const { status, body } = await readJson(await submit(pathId));
+      expect(status).toBe(404);
+      expect(body).toEqual({ error: "Unknown path" });
+      expect(mockGetVerifiedUser).not.toHaveBeenCalled();
+    });
+  });
+
+  it("returns 401 when not authenticated for a known path", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const { status, body } = await readJson(await submit("code-reader"));
+    expect(status).toBe(401);
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 403 when the user is not hunt-eligible", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCheckEligibility.mockResolvedValue({ ok: false, reason: "no_github" });
+
+    const { status, body } = await readJson(await submit("code-reader", { answer: "x" }, true));
+    expect(status).toBe(403);
+    expect(body).toEqual({ ok: false, reason: "no_github" });
+  });
+
+  it("returns 400 when the answer is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const { status, body } = await readJson(await submit("code-reader", {}, true));
+    expect(status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 400 when the answer is empty", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const { status, body } = await readJson(await submit("code-reader", { answer: "" }, true));
+    expect(status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns wrong_answer without leaking internals when verification fails", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const { status, body } = await readJson(
+      await submit("code-reader", { answer: "not-the-function" }, true),
+    );
+    expect(status).toBe(200);
+    expect(body).toEqual({ ok: false, reason: "wrong_answer" });
+    expect(mockRateSet).toHaveBeenCalled();
+    expect(mockClaimPrize).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when too many wrong answers in the last hour", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const now = Date.now();
+    mockRateGet.mockResolvedValue({
+      data: () => ({
+        wrongAt: [now - 1000, now - 2000, now - 3000, now - 4000, now - 5000],
+      }),
+    });
+
+    const { status, body } = await readJson(
+      await submit("code-reader", { answer: "not-the-function" }, true),
+    );
+    expect(status).toBe(429);
+    expect(body).toEqual({ ok: false, reason: "rate_limited" });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `__tests__/app/api/hunt/paths/submit.test.ts` with 11 cases for `POST /api/hunt/paths/[pathId]/submit`.
- Invalid pathIds (unknown, empty, traversal, injection-like) return 404 before auth.
- Auth, eligibility, body validation, wrong-answer response, and hourly rate limit covered.

Fixes #571

## Test plan
- [x] `npm test -- __tests__/app/api/hunt/paths/submit.test.ts` (11/11 passing)

Made with [Cursor](https://cursor.com)