### PR TITLE
release: develop → main 2026-05-19

### DIFF
--- a/__tests__/app/api/hunt/oracle/route.test.ts
+++ b/__tests__/app/api/hunt/oracle/route.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+
+import { createHash } from "crypto";
+import { GET as getOracle } from "@/app/api/hunt/oracle/route";
+import { GET as getKonami } from "@/app/api/hunt/oracle/konami/route";
+import { getKonamiToken, getOracleAnswer } from "@/lib/treasure-hunt-paths";
+
+const KONAMI_SEQUENCE = "UUDDLRLRBA";
+
+function konamiRequest(sequence?: string) {
+  const headers: Record<string, string> = {};
+  if (sequence !== undefined) {
+    headers["X-Konami-Sequence"] = sequence;
+  }
+  return new Request("http://localhost/api/hunt/oracle/konami", { headers });
+}
+
+describe("GET /api/hunt/oracle", () => {
+  it("returns 200 with riddle, dateUtc, and answerFingerprint", async () => {
+    const res = await getOracle();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(typeof body.riddle).toBe("string");
+    expect(body.riddle.length).toBeGreaterThan(0);
+    expect(body.dateUtc).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(typeof body.answerFingerprint).toBe("string");
+    expect(body.answerFingerprint).toHaveLength(16);
+  });
+
+  it("uses today's UTC date", async () => {
+    const res = await getOracle();
+    const body = await res.json();
+    const expected = new Date().toISOString().slice(0, 10);
+    expect(body.dateUtc).toBe(expected);
+  });
+
+  it("fingerprints the daily oracle answer (first 16 hex of sha256)", async () => {
+    const res = await getOracle();
+    const body = await res.json();
+    const expected = createHash("sha256")
+      .update(getOracleAnswer())
+      .digest("hex")
+      .slice(0, 16);
+    expect(body.answerFingerprint).toBe(expected);
+  });
+
+  it("does not expose the full oracle answer in the response", async () => {
+    const res = await getOracle();
+    const body = await res.json();
+    const fullAnswer = getOracleAnswer();
+    expect(body).not.toHaveProperty("answer", fullAnswer);
+    expect(body).not.toHaveProperty("token", fullAnswer);
+  });
+});
+
+describe("GET /api/hunt/oracle/konami", () => {
+  it("returns 404 when X-Konami-Sequence header is missing", async () => {
+    const res = await getKonami(konamiRequest());
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Not found");
+  });
+
+  it("returns 404 for an incorrect sequence", async () => {
+    const res = await getKonami(konamiRequest("WRONG"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the daily token when sequence is correct", async () => {
+    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.token).toBe(getKonamiToken());
+    expect(body.token).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it("is case-sensitive for the Konami sequence header", async () => {
+    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE.toLowerCase()));
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/app/api/hunt/paths/submit.test.ts
+++ b/__tests__/app/api/hunt/paths/submit.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST } from "@/app/api/hunt/paths/[pathId]/submit/route";
+import type { VerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { checkTreasureHuntEligibility } from "@/lib/treasure-hunt-eligibility";
+import { claimTreasureHuntPrize } from "@/lib/treasure-hunt-claim";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/treasure-hunt-eligibility", () => ({
+  checkTreasureHuntEligibility: jest.fn(),
+}));
+
+jest.mock("@/lib/treasure-hunt-claim", () => ({
+  claimTreasureHuntPrize: jest.fn(),
+}));
+
+const mockRateGet = jest.fn();
+const mockRateSet = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({
+      doc: () => ({
+        get: mockRateGet,
+        set: mockRateSet,
+      }),
+    }),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockCheckEligibility = checkTreasureHuntEligibility as jest.MockedFunction<
+  typeof checkTreasureHuntEligibility
+>;
+const mockClaimPrize = claimTreasureHuntPrize as jest.MockedFunction<typeof claimTreasureHuntPrize>;
+
+const testUser: VerifiedUser = { uid: "u1", name: "Hunter", email: "hunter@test.com" };
+
+function submit(pathId: string, body?: Record<string, unknown>, authed = false) {
+  const req = authed
+    ? makeAuthedRequest({
+        method: "POST",
+        path: `/api/hunt/paths/${pathId}/submit`,
+        body: body ?? { answer: "wrong-guess" },
+      })
+    : makeRequest({
+        method: "POST",
+        path: `/api/hunt/paths/${pathId}/submit`,
+        body: body ?? { answer: "wrong-guess" },
+      });
+  return POST(req, { params: Promise.resolve({ pathId }) });
+}
+
+describe("POST /api/hunt/paths/[pathId]/submit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRateGet.mockResolvedValue({ data: () => ({ wrongAt: [] }) });
+    mockCheckEligibility.mockResolvedValue({
+      ok: true,
+      githubLogin: "hunter",
+      discordUsername: "hunter#0001",
+    });
+  });
+
+  describe("pathId validation", () => {
+    it.each([
+      ["unknown-path", "unknown slug"],
+      ["", "empty pathId"],
+      ["../admin", "path traversal"],
+      ["'; DROP TABLE--", "SQL-injection-like characters"],
+      ["code-reader%00", "null-byte suffix"],
+    ])("returns 404 for invalid pathId (%s)", async (pathId) => {
+      const { status, body } = await readJson(await submit(pathId));
+      expect(status).toBe(404);
+      expect(body).toEqual({ error: "Unknown path" });
+      expect(mockGetVerifiedUser).not.toHaveBeenCalled();
+    });
+  });
+
+  it("returns 401 when not authenticated for a known path", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const { status, body } = await readJson(await submit("code-reader"));
+    expect(status).toBe(401);
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 403 when the user is not hunt-eligible", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockCheckEligibility.mockResolvedValue({ ok: false, reason: "no_github" });
+
+    const { status, body } = await readJson(await submit("code-reader", { answer: "x" }, true));
+    expect(status).toBe(403);
+    expect(body).toEqual({ ok: false, reason: "no_github" });
+  });
+
+  it("returns 400 when the answer is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const { status, body } = await readJson(await submit("code-reader", {}, true));
+    expect(status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 400 when the answer is empty", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const { status, body } = await readJson(await submit("code-reader", { answer: "" }, true));
+    expect(status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns wrong_answer without leaking internals when verification fails", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+
+    const { status, body } = await readJson(
+      await submit("code-reader", { answer: "not-the-function" }, true),
+    );
+    expect(status).toBe(200);
+    expect(body).toEqual({ ok: false, reason: "wrong_answer" });
+    expect(mockRateSet).toHaveBeenCalled();
+    expect(mockClaimPrize).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when too many wrong answers in the last hour", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const now = Date.now();
+    mockRateGet.mockResolvedValue({
+      data: () => ({
+        wrongAt: [now - 1000, now - 2000, now - 3000, now - 4000, now - 5000],
+      }),
+    });
+
+    const { status, body } = await readJson(
+      await submit("code-reader", { answer: "not-the-function" }, true),
+    );
+    expect(status).toBe(429);
+    expect(body).toEqual({ ok: false, reason: "rate_limited" });
+  });
+});


### PR DESCRIPTION
## Summary
- #1104 — hunt oracle + Konami route tests (#548)
- #1106 — hunt path submit validation tests (#571)

## Test plan
- [x] `npm run build` on develop (local, green)

Made with [Cursor](https://cursor.com)