### PR TITLE
docs: reflect OpenSSF Best Practices Silver badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.bestpractices.dev/projects/12883"><img src="https://www.bestpractices.dev/projects/12883/badge" alt="OpenSSF Best Practices" height="28" /></a>
+  <a href="https://www.bestpractices.dev/projects/12883/silver"><img src="https://www.bestpractices.dev/projects/12883/badge" alt="OpenSSF Best Practices Silver" height="28" /></a>
 </p>
 
 <p align="center">

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -208,7 +208,7 @@ We argue, OWASP Top 10 (2021) item by item, that the corresponding weakness clas
 
 External attestations:
 
-- OpenSSF Best Practices Passing badge: https://www.bestpractices.dev/projects/12883
+- OpenSSF Best Practices Silver badge (awarded 2026-05-19): https://www.bestpractices.dev/projects/12883/silver
 - OpenSSF Scorecard: https://scorecard.dev/viewer/?uri=github.com/rogerSuperBuilderAlpha/cursor-boston
 - Sigstore-signed release artifacts: see https://github.com/rogerSuperBuilderAlpha/cursor-boston/releases — every release after v0.2.2 includes `.cosign.bundle` and SLSA provenance.
 
@@ -218,7 +218,7 @@ External attestations:
 
 Honesty matters more than a clean score. The following gaps are tracked in [`docs/REVIEW_ACTION_PLAN.md`](REVIEW_ACTION_PLAN.md):
 
-1. **Test statement coverage** (**~80.25%** statements as of 2026-05-19 OpenSSF sprint wave 15: 27,092 / 33,762 covered; branches ~66.0%, lines ~83.2%, functions ~72.9%; 4,914 Jest tests) — meets the 80% OpenSSF Silver target (`test_statement_coverage80`). Waves 10–15 pushed `lib/game/data-server.ts` to ~95% line coverage; gap-fill waves 2–6 and deep page/hook/route tests covered summer-cohort, hackathons, mentorship/pair, game UI, and API admin routes. Jest floors are ratcheted to 79.5% statements in `config/jest.config.js`. **Next:** update [bestpractices.dev #12883](https://www.bestpractices.dev/projects/12883/edit) to claim `test_statement_coverage80`, then keep floors aligned on each release.
+1. **Test statement coverage** (**~80.25%** statements as of 2026-05-19 OpenSSF sprint wave 15: 27,092 / 33,762 covered; branches ~66.0%, lines ~83.2%, functions ~72.9%; 4,914 Jest tests) — meets the 80% OpenSSF Silver target (`test_statement_coverage80`). Waves 10–15 pushed `lib/game/data-server.ts` to ~95% line coverage; gap-fill waves 2–6 and deep page/hook/route tests covered summer-cohort, hackathons, mentorship/pair, game UI, and API admin routes. Jest floors are ratcheted to 79.5% statements in `config/jest.config.js`. The OpenSSF Silver badge was awarded 2026-05-19 — see [bestpractices.dev #12883/silver](https://www.bestpractices.dev/projects/12883/silver). Branch coverage (~66%) is the long-tail gap toward Gold.
 2. **Production observability** — application-level error tracking (Sentry) is planned but not shipped. Platform-level logs are available in Vercel + Firebase.
 3. **Signed git tags** — release artifacts are Sigstore-signed; git tags themselves are migrating to signed tags from v0.3.0 onward.
 4. **Independent security audit** — no external auditor has reviewed the codebase. The OpenSSF Best Practices + Scorecard + the maintainer review process are the current substitute.


### PR DESCRIPTION
## Summary
- Award announcement: OpenSSF Best Practices **Silver** badge awarded 2026-05-19 — [bestpractices.dev/projects/12883/silver](https://www.bestpractices.dev/projects/12883/silver) (100% progress, all 55 criteria satisfied).
- README badge now links to `/silver` and the alt text reflects the Silver tier. The image URL is unchanged — `bestpractices.dev`'s `/badge` endpoint auto-renders the highest tier achieved.
- `docs/ASSURANCE_CASE.md` updated: external-attestation entry says Silver with the award date, and the §8 gap on `test_statement_coverage80` is replaced with a Silver-awarded note (next ratchet is branch coverage toward Gold).

The Silver gap was closed by sprint #1108 ("coverage/sprint-80", commit 2aace0a) which lifted statement coverage from ~32% to ~80.25%. The badge was unblocked by also adding URLs to three other criteria whose justifications were missing the `met_url_required` link (`access_continuity`, `coding_standards`, `external_dependencies`).

## Test plan
- [ ] CI green
- [ ] README renders the silver badge image in GitHub's preview (it auto-resolves to the highest tier)
- [ ] Clicking the badge in README navigates to `/silver` view