### PR TITLE
docs(governance): require 2 reviewers + phishing-resistant 2FA for OpenSSF Gold

### DIFF
--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -164,24 +164,35 @@ All code changes require review before merging.
 
 ### Tiers
 
-- **Minor changes** (typos, docs, small fixes): One maintainer approval.
-- **Standard changes** (features, bug fixes): One maintainer approval, 24-hour waiting period for objections.
-- **Major changes** (architecture, breaking changes): Two maintainer approvals, 72-hour waiting period.
+- **Minor changes** (typos, docs-only edits, dependency bumps with no changelog impact, generated-file refreshes, badge/README link tweaks): **One maintainer approval**. No waiting period.
+- **Standard changes** (features, bug fixes, non-trivial refactors, any change touching `lib/`, `app/api/`, `config/`, or workflows): **Two maintainer approvals**, 24-hour waiting period for objections.
+- **Major changes** (architecture changes, breaking changes, governance edits, security-policy edits): **Two maintainer approvals**, 72-hour waiting period.
+
+The 2-reviewer requirement on Standard and Major changes is enforced at the GitHub level via branch protection on `develop` and `main` (`required_approving_review_count: 2`). See [`docs/BRANCH_PROTECTION.md`](../docs/BRANCH_PROTECTION.md) for the live settings and OpenSSF Best Practices Gold criterion `two_person_review` for the rationale.
 
 ### No self-approval
 
-The author of a PR cannot approve their own changes. A maintainer may merge their own PR **only after** another maintainer has submitted a GitHub "Approve" review on that PR. This rule applies to every PR, including governance/docs PRs and including the Project Lead.
+The author of a PR cannot approve their own changes. A maintainer may merge their own PR **only after** the required number of other maintainer "Approve" reviews have landed. This rule applies to every PR, including governance/docs PRs and including the Project Lead.
 
-This is enforced procedurally (maintainers are expected to follow it) and observably (GitHub's review history on each PR is the audit trail). If the maintainer team observes that the rule is being skipped in practice, the next governance update should move enforcement to a required-status-check on the branch protection rules.
+This is enforced both procedurally (maintainers are expected to follow it) and observably (GitHub's review history on each PR is the audit trail).
 
-### Exception: solo-emergency merges
+### Project Lead bypass
 
-If only one maintainer is reachable and the change is urgent (security patch, production outage), that maintainer may merge without a second reviewer. The merged PR must then be:
+The Project Lead may use `gh pr merge --admin` to bypass the 2-reviewer requirement in two narrow cases:
 
-1. Linked in `#maintainers` on Discord with the reason for the exception.
-2. Reviewed retroactively by a second maintainer within 7 days; any issues found are fixed via a follow-up PR.
+1. **Develop → main release PRs** — `--admin` is the documented mechanism to bypass DCO failures and the `mergeStateStatus=BEHIND` topology quirk that affects rebase-style releases.
+2. **Urgent production fixes** — security patches or live-incident hotfixes when a second reviewer is not reachable within the window the incident allows.
 
-This exception exists so the rule never blocks a security fix, not as a routine path.
+Every bypass is audit-trail-visible in the GitHub merge metadata (the API records which user merged with admin privileges). Bypasses MUST be:
+
+- Linked in `#maintainers` on Discord within 24 hours with the reason.
+- Reviewed retroactively by a second maintainer within 7 days; any issues found are fixed via a follow-up PR.
+
+The bypass exists so the policy never blocks a security fix or a clean release, not as a routine path for feature work.
+
+### Exception: solo-emergency merges (legacy alias)
+
+The "solo-emergency merge" terminology previously documented in this section is now covered by the Project Lead bypass clause above. The mechanics are the same: emergency merge, link in `#maintainers` within 24 hours, retroactive second review within 7 days.
 
 ## Releases
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -68,7 +68,7 @@ If you're deploying Cursor Boston:
    - Test rules thoroughly before production
    - Review rules regularly for security gaps
 3. **Authentication** - Use strong authentication methods
-   - Enable 2FA for admin accounts
+   - Maintainers and committers MUST use **phishing-resistant 2FA** (hardware security keys / FIDO2 / WebAuthn / passkeys). TOTP-only (Authy, Google Authenticator) and SMS are not sufficient for maintainer accounts. The `rogerSuperBuilderAlpha` GitHub organization enforces org-level 2FA — see [`MAINTAINERS.md` § Maintainer account security](../MAINTAINERS.md#maintainer-account-security).
    - Use OAuth providers with proper redirect URIs
    - Regularly review authorized domains in Firebase
 4. **HTTPS** - Always use HTTPS in production

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -40,6 +40,17 @@ Aaron holds the **Community Maintainer** title rather than the standard Maintain
 - [`docs/SUBMISSION_BRANCHES.md`](docs/SUBMISSION_BRANCHES.md) — what the persistent contribution branches are and when they're used
 - [`ROADMAP.md`](ROADMAP.md) — current roadmap and where to file new issues (mirrored at `.github/ACTIVE_ISSUES.md`)
 
+## Maintainer account security
+
+Required for all maintainers and any GitHub account with merge rights on this repository (OpenSSF Best Practices Gold criteria `require_2FA` and `secure_2FA`):
+
+1. **Two-factor authentication is mandatory.** Every maintainer MUST have 2FA enabled on their GitHub account. The `rogerSuperBuilderAlpha` organization enforces this at the org level — accounts without 2FA cannot be members.
+2. **Phishing-resistant 2FA only.** The second factor MUST be either a hardware security key (FIDO2 / WebAuthn — YubiKey, Titan, etc.) or a passkey synced via a platform authenticator (iCloud Keychain, 1Password, Bitwarden, etc.). **TOTP-only (Authy, Google Authenticator) is not sufficient** for maintainer accounts because TOTP codes can be phished. SMS 2FA is explicitly forbidden.
+3. **Recovery codes** stored offline (printed and locked, or in a hardware-backed password manager). Lost-key scenarios are recovered via the maintainer team consensus and the Project Lead, not by SMS reset.
+4. **Local commit signing** is encouraged but not required (DCO sign-off is the enforced minimum).
+
+A maintainer who cannot meet the phishing-resistant 2FA requirement (e.g., no access to a hardware key) should contact the Project Lead. The expectation is that hardware keys or passkeys are obtained within 30 days of joining the maintainer team.
+
 ## Emeritus
 
 Maintainers who have stepped down but whose contributions are recognized. None currently.

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -20,6 +20,7 @@ If the live settings drift from this document, treat the document as the source 
 **Required protections:**
 
 - **Require a pull request before merging.** No direct pushes. Release PRs from `develop` are the only mechanism.
+- **Require 2 approving reviews** (`required_approving_review_count: 2`). Implements OpenSSF Best Practices Gold criterion `two_person_review` for Standard and Major changes per [`.github/GOVERNANCE.md` § Code Review](../.github/GOVERNANCE.md#code-review).
 - **Require status checks to pass before merging:**
   - `CI / lint-and-typecheck`
   - `CI / test` (Jest)
@@ -33,6 +34,7 @@ If the live settings drift from this document, treat the document as the source 
 - **No force pushes.** Disabled.
 - **No deletions.** Disabled.
 - **Restrict who can push.** Only maintainers (currently `@rogerSuperBuilderAlpha`).
+- **`enforce_admins: false`** — admins (Project Lead) are NOT subject to the rules, which makes the documented `gh pr merge --admin` bypass work. The bypass is policy-restricted per GOVERNANCE.md to release PRs and urgent fixes only.
 
 **Admin-bypass case:**
 
@@ -51,6 +53,7 @@ The April 2026 referral-code postmortem ([`docs/security-incident-2026-04-11.md`
 **Required protections:**
 
 - **Require a pull request before merging.** No direct pushes.
+- **Require 2 approving reviews** (`required_approving_review_count: 2`) on every PR — Standard and Major changes per [`.github/GOVERNANCE.md` § Code Review](../.github/GOVERNANCE.md#code-review). Minor changes (typos, docs-only, dependency bumps) still need 1 reviewer per the GitHub setting; the policy distinguishes Minor procedurally via the PR description.
 - **Require status checks to pass before merging:**
   - `CI / lint-and-typecheck`
   - `CI / test`
@@ -63,6 +66,7 @@ The April 2026 referral-code postmortem ([`docs/security-incident-2026-04-11.md`
 - **Require signed-off commits.** Enforced via DCO.
 - **No force pushes.** Disabled.
 - **No deletions.** Disabled.
+- **`enforce_admins: false`** — admins (Project Lead) can use `gh pr merge --admin` for the policy-restricted bypass cases in GOVERNANCE.md (release PRs, urgent fixes). Bypasses are auditable and require retroactive review within 7 days.
 
 `develop` does **not** restrict push permissions beyond the "requires PR" rule — maintainers merge approved PRs but do not push branches directly.
 


### PR DESCRIPTION
## Summary
Closes three OpenSSF Best Practices Gold criteria via governance docs:

- **`require_2FA` + `secure_2FA`** — MAINTAINERS.md gains a "Maintainer account security" section mandating 2FA for all maintainers and requiring **phishing-resistant 2FA** (FIDO2 / WebAuthn / passkeys). TOTP-only and SMS are explicitly forbidden for maintainer accounts. SECURITY.md updated to point at the new section instead of the generic "enable 2FA for admin accounts" line.
- **`two_person_review`** — GOVERNANCE.md § Code Review promotes "Standard changes" from 1 approval to **2 approvals** (24h waiting period unchanged). Major changes stay at 2 approvals + 72h. Minor changes stay at 1 approval. The Project Lead `--admin` bypass clause is now explicit: release PRs + urgent fixes only, audited in `#maintainers` on Discord within 24h, retroactive second review within 7 days.

BRANCH_PROTECTION.md is updated to reflect the new 2-reviewer rule on both `main` and `develop`, with `enforce_admins: false` so the documented `gh pr merge --admin` bypass keeps working. The matching branch-protection API update is applied separately after this PR lands.

## Test plan
- [ ] CI green
- [ ] After merge: `gh api repos/.../branches/develop/protection --jq '.required_pull_request_reviews.required_approving_review_count'` returns `2`
- [ ] After merge: `gh api repos/.../branches/develop/protection --jq '.enforce_admins.enabled'` returns `false`
- [ ] A test PR with 1 approval is blocked from merging; \`gh pr merge --admin\` succeeds for Project Lead
- [ ] bestpractices.dev /gold shows `secure_2FA` and `two_person_review` as Met