### PR TITLE
test(game): coverage for reactions/redistribute/siege (Gold coverage push #5)

### DIFF
--- a/__tests__/app/api/game/reactions/route.test.ts
+++ b/__tests__/app/api/game/reactions/route.test.ts
@@ -101,4 +101,85 @@ describe("PUT /api/game/reactions", () => {
       heroId: undefined,
     });
   });
+
+  it("returns 429 with default 30s when retryAfter is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockRateLimit.mockResolvedValue({ success: false } as never);
+    const { body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(String((body as { error?: { message?: string } }).error?.message)).toContain("30s");
+  });
+
+  it("returns 400 for non-JSON request body", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    const res = await PUT(
+      makeRequest({
+        method: "PUT",
+        path: "/api/game/reactions",
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("translates ReactionTargetNotFoundError to 404", async () => {
+    const { ReactionTargetNotFoundError } = jest.requireActual("@/lib/game/reactions");
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockToggle.mockRejectedValue(new ReactionTargetNotFoundError("chat", "msg-missing"));
+    const { status, body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(404);
+    expect(typeof (body as { error: { message: string } }).error.message).toBe("string");
+  });
+
+  it.each([
+    ["ReactionInvalidScopeError"],
+    ["ReactionInvalidEmojiError"],
+    ["ReactionMissingHeroIdError"],
+  ])("translates %s to 400", async (errName) => {
+    const reactions = jest.requireActual("@/lib/game/reactions");
+    const ErrCls = reactions[errName];
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    // These error classes all take a single string arg.
+    mockToggle.mockRejectedValue(new ErrCls("bad"));
+    const { status } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(400);
+  });
+
+  it("returns 500 for untyped Error", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockToggle.mockRejectedValue(new Error("kaboom"));
+    const { status, body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("kaboom");
+  });
+
+  it("returns 500 'Server error' for non-Error throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockToggle.mockImplementation(() => {
+      throw "string-thrown";
+    });
+    const { status, body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("Server error");
+  });
 });

--- a/__tests__/app/api/game/redistribute/route.test.ts
+++ b/__tests__/app/api/game/redistribute/route.test.ts
@@ -1,5 +1,7 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #5 — full coverage for redistribute route.
  */
 import { POST } from "@/app/api/game/redistribute/route";
 import { redistributeUnitsServer } from "@/lib/game/data-server";
@@ -7,38 +9,103 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/data-server", () => ({
-  redistributeUnitsServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return { ...actual, redistributeUnitsServer: jest.fn() };
+});
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockRedistribute = redistributeUnitsServer as jest.MockedFunction<typeof redistributeUnitsServer>;
+
+const VALID = {
+  sourceTileId: "a",
+  destTileId: "b",
+  units: { ground: 5, siege: 0, air: 0 },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" } as never);
+  mockRedistribute.mockResolvedValue({ source: {}, dest: {} } as never);
+});
 
 describe("POST /api/game/redistribute", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    (getVerifiedUser as jest.Mock).mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    (redistributeUnitsServer as jest.Mock).mockResolvedValue({ source: {}, dest: {} });
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ method: "POST", path: "/api/game/redistribute", body: VALID }),
+    );
+    expect(res.status).toBe(401);
   });
 
-  it("returns 400 when moving zero units", async () => {
+  it("returns 400 for non-JSON body", async () => {
     const res = await POST(
-      makeAuthedRequest({
+      makeRequest({
         method: "POST",
         path: "/api/game/redistribute",
-        body: { sourceTileId: "a", destTileId: "b", units: { ground: 0, siege: 0, air: 0 } },
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
       }),
     );
     expect(res.status).toBe(400);
   });
 
-  it("returns 200 on success", async () => {
+  it("returns 400 when zod validation fails (missing fields)", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/redistribute",
+        body: { sourceTileId: "a" } as never,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for negative unit counts (zod min(0) fails)", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/redistribute",
+        body: { ...VALID, units: { ground: -1, siege: 0, air: 0 } },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when moving zero total units", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/redistribute",
+        body: { ...VALID, units: { ground: 0, siege: 0, air: 0 } },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 on success and forwards the parsed body", async () => {
     const { status } = await readJson(
       await POST(
-        makeAuthedRequest({
-          method: "POST",
-          path: "/api/game/redistribute",
-          body: { sourceTileId: "a", destTileId: "b", units: { ground: 5, siege: 0, air: 0 } },
-        }),
+        makeAuthedRequest({ method: "POST", path: "/api/game/redistribute", body: VALID }),
       ),
     );
     expect(status).toBe(200);
+    expect(mockRedistribute).toHaveBeenCalledWith({
+      callerUserId: "u1",
+      sourceTileId: "a",
+      destTileId: "b",
+      units: { ground: 5, siege: 0, air: 0 },
+    });
+  });
+
+  it("returns 500 via mapGameError when redistributeUnitsServer throws", async () => {
+    mockRedistribute.mockRejectedValue(new Error("redistribute failed"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/redistribute", body: VALID }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });

--- a/__tests__/app/api/game/siege/route.test.ts
+++ b/__tests__/app/api/game/siege/route.test.ts
@@ -1,33 +1,90 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #5 — full coverage for siege route.
  */
 import { POST } from "@/app/api/game/siege/route";
 import { siegeTileServer } from "@/lib/game/data-server";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/data-server", () => ({
-  siegeTileServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return { ...actual, siegeTileServer: jest.fn() };
+});
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockSiege = siegeTileServer as jest.MockedFunction<typeof siegeTileServer>;
+
+const VALID = { sourceTileId: "0_0", targetTileId: "1_0" };
+const SUCCESS = {
+  player: { userId: "u1" },
+  report: { kind: "siege" },
+  siegeTotalMagnitude: 1,
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" } as never);
+  mockSiege.mockResolvedValue(SUCCESS);
+});
 
 describe("POST /api/game/siege", () => {
-  it("returns 200 on siege", async () => {
-    (getVerifiedUser as jest.Mock).mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    (siegeTileServer as jest.Mock).mockResolvedValue({
-      player: { userId: "u1" },
-      report: { kind: "siege" },
-      siegeTotalMagnitude: 1,
-    });
-    const { status } = await readJson(
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ method: "POST", path: "/api/game/siege", body: VALID }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for non-JSON body", async () => {
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        path: "/api/game/siege",
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod validation fails", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/siege",
+        body: { sourceTileId: "0_0" } as never,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 on successful siege", async () => {
+    const { status, body } = await readJson(
       await POST(
-        makeAuthedRequest({
-          method: "POST",
-          path: "/api/game/siege",
-          body: { sourceTileId: "0_0", targetTileId: "1_0" },
-        }),
+        makeAuthedRequest({ method: "POST", path: "/api/game/siege", body: VALID }),
       ),
     );
     expect(status).toBe(200);
+    expect(body).toMatchObject({ success: true, siegeTotalMagnitude: 1 });
+    expect(mockSiege).toHaveBeenCalledWith({
+      attackerId: "u1",
+      sourceTileId: "0_0",
+      targetTileId: "1_0",
+    });
+  });
+
+  it("returns 500 via mapGameError when siegeTileServer throws", async () => {
+    mockSiege.mockRejectedValue(new Error("siege failed"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/siege", body: VALID }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });


### PR DESCRIPTION
## Summary
Fifth coverage push, Wave A bundle.

| Route | Before | After |
|---|---|---|
| `app/api/game/reactions/route.ts` | 79 / 43 | **100 / 95.23** |
| `app/api/game/redistribute/route.ts` | 84 / 50 | **100 / 90** |
| `app/api/game/siege/route.ts` | 80 / 37.5 | **100 / 87.5** |

24 tests total (24/24 pass).

## Test plan
- [x] Local coverage as above; 24 tests pass
- [ ] CI green