### PR TITLE
release: OpenSSF Gold Wave A coverage push (5 PRs)

### DIFF
--- a/__tests__/app/api/game/prophecies/prophecyId.route.test.ts
+++ b/__tests__/app/api/game/prophecies/prophecyId.route.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #1 — full coverage of the DELETE handler
+ * on /api/game/prophecies/[prophecyId] (0% → ~100%).
+ */
+import { DELETE } from "@/app/api/game/prophecies/[prophecyId]/route";
+import {
+  ProphecyForbiddenError,
+  ProphecyNotFoundError,
+  deleteProphecyServer,
+} from "@/lib/game/prophecies";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/game/prophecies", () => {
+  const actual = jest.requireActual("@/lib/game/prophecies");
+  return {
+    ...actual,
+    deleteProphecyServer: jest.fn(),
+  };
+});
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockDelete = deleteProphecyServer as jest.MockedFunction<typeof deleteProphecyServer>;
+
+const USER = { uid: "u1", email: "u@test.com", name: "U", isAdmin: false } as never;
+const ADMIN = { uid: "admin1", email: "a@test.com", name: "A", isAdmin: true } as never;
+
+function withParams(prophecyId: string) {
+  return { params: Promise.resolve({ prophecyId }) };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDelete.mockResolvedValue({ id: "p-1", deletedAt: "2026-05-19" } as never);
+});
+
+describe("DELETE /api/game/prophecies/[prophecyId]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await DELETE(
+      makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/p-1" }),
+      withParams("p-1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when prophecyId is empty", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    const res = await DELETE(
+      makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/" }),
+      withParams(""),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with the deleted prophecy on success (author)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    const { status, body } = await readJson(
+      await DELETE(
+        makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/p-1" }),
+        withParams("p-1"),
+      ),
+    );
+    expect(status).toBe(200);
+    expect(body.prophecy).toMatchObject({ id: "p-1" });
+    expect(mockDelete).toHaveBeenCalledWith({
+      prophecyId: "p-1",
+      callerUserId: "u1",
+      callerIsAdmin: false,
+    });
+  });
+
+  it("passes callerIsAdmin=true for admin user", async () => {
+    mockGetVerifiedUser.mockResolvedValue(ADMIN);
+    await DELETE(
+      makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/p-1" }),
+      withParams("p-1"),
+    );
+    expect(mockDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ callerIsAdmin: true }),
+    );
+  });
+
+  it("translates ProphecyNotFoundError to 404", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockDelete.mockRejectedValue(new ProphecyNotFoundError());
+    const { status, body } = await readJson(
+      await DELETE(
+        makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/p-1" }),
+        withParams("p-1"),
+      ),
+    );
+    expect(status).toBe(404);
+    expect(typeof body.error.message).toBe("string");
+  });
+
+  it("translates ProphecyForbiddenError to 403", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockDelete.mockRejectedValue(new ProphecyForbiddenError());
+    const { status, body } = await readJson(
+      await DELETE(
+        makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/p-1" }),
+        withParams("p-1"),
+      ),
+    );
+    expect(status).toBe(403);
+    expect(typeof body.error.message).toBe("string");
+  });
+
+  it("returns 500 for untyped Error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockDelete.mockRejectedValue(new Error("kaboom"));
+    const { status, body } = await readJson(
+      await DELETE(
+        makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/p-1" }),
+        withParams("p-1"),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("kaboom");
+  });
+
+  it("returns 500 'Server error' for non-Error throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockDelete.mockImplementation(() => {
+      throw "string-thrown";
+    });
+    const { status, body } = await readJson(
+      await DELETE(
+        makeAuthedRequest({ method: "DELETE", path: "/api/game/prophecies/p-1" }),
+        withParams("p-1"),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("Server error");
+  });
+});

--- a/__tests__/app/api/game/prophecies/route.test.ts
+++ b/__tests__/app/api/game/prophecies/route.test.ts
@@ -1,21 +1,137 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #1 — full GET + POST coverage for the
+ * prophecies index route. Covers happy paths, validation paths, the
+ * server-configured / rate-limit / player-not-found branches, and every
+ * typed error class that POST translates to a status code.
  */
-import { GET } from "@/app/api/game/prophecies/route";
-import { listPropheciesForSealServer } from "@/lib/game/prophecies";
+import { GET, POST } from "@/app/api/game/prophecies/route";
+import {
+  listPropheciesForSealServer,
+  listPropheciesByAuthorServer,
+  createProphecyServer,
+  ProphecyEmptyError,
+  ProphecyTooLongError,
+  ProphecyInvalidSealError,
+  ProphecySealAlreadyBrokenError,
+  MAX_PROPHECY_LENGTH,
+} from "@/lib/game/prophecies";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import {
+  makeAuthedRequest,
+  makeRequest,
+  readJson,
+} from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/prophecies", () => ({
-  listPropheciesForSealServer: jest.fn().mockResolvedValue([]),
-  listPropheciesByAuthorServer: jest.fn().mockResolvedValue([]),
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/upstash-rate-limit", () => ({
+  checkUpstashRateLimit: jest.fn(),
 }));
+jest.mock("@/lib/game/prophecies", () => {
+  const actual = jest.requireActual("@/lib/game/prophecies");
+  return {
+    ...actual,
+    listPropheciesForSealServer: jest.fn(),
+    listPropheciesByAuthorServer: jest.fn(),
+    createProphecyServer: jest.fn(),
+  };
+});
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockRateLimit = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+const mockListForSeal = listPropheciesForSealServer as jest.MockedFunction<typeof listPropheciesForSealServer>;
+const mockListByAuthor = listPropheciesByAuthorServer as jest.MockedFunction<typeof listPropheciesByAuthorServer>;
+const mockCreate = createProphecyServer as jest.MockedFunction<typeof createProphecyServer>;
+
+const USER = { uid: "u1", email: "u@test.com", name: "U", isAdmin: false } as never;
+
+function fakeDb(playerDoc: { exists: boolean; data?: () => unknown }) {
+  return {
+    collection: jest.fn().mockReturnValue({
+      doc: jest.fn().mockReturnValue({
+        get: jest.fn().mockResolvedValue(playerDoc),
+      }),
+    }),
+  } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListForSeal.mockResolvedValue([]);
+  mockListByAuthor.mockResolvedValue([]);
+  mockCreate.mockResolvedValue({ id: "p-1" } as never);
+  mockRateLimit.mockResolvedValue({ success: true } as never);
+  mockGetAdminDb.mockReturnValue(fakeDb({ exists: false }));
+});
 
 describe("GET /api/game/prophecies", () => {
-  it("returns 200 with prophecies list", async () => {
-    (getVerifiedUser as jest.Mock).mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    const { status } = await readJson(
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await GET(
+      makeRequest({ method: "GET", path: "/api/game/prophecies", searchParams: { seal: "1" } }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 + cache header for valid seal=N", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockListForSeal.mockResolvedValue([{ id: "p-1" }] as never);
+    const res = await GET(
+      makeAuthedRequest({ method: "GET", path: "/api/game/prophecies", searchParams: { seal: "3" } }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toContain("private");
+    expect(mockListForSeal).toHaveBeenCalledWith(3);
+  });
+
+  it.each([
+    ["non-integer", "1.5"],
+    ["below range", "0"],
+    ["above range", "8"],
+    ["NaN", "abc"],
+  ])("returns 400 for %s seal value (%s)", async (_label, sealValue) => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    const res = await GET(
+      makeAuthedRequest({
+        method: "GET",
+        path: "/api/game/prophecies",
+        searchParams: { seal: sealValue },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 for authorId list path", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockListByAuthor.mockResolvedValue([{ id: "p-2" }] as never);
+    const res = await GET(
+      makeAuthedRequest({
+        method: "GET",
+        path: "/api/game/prophecies",
+        searchParams: { authorId: "u2" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockListByAuthor).toHaveBeenCalledWith("u2");
+  });
+
+  it("returns 400 when neither seal nor authorId provided", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    const res = await GET(
+      makeAuthedRequest({ method: "GET", path: "/api/game/prophecies" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when the data layer throws an Error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockListForSeal.mockRejectedValue(new Error("firestore down"));
+    const { status, body } = await readJson(
       await GET(
         makeAuthedRequest({
           method: "GET",
@@ -24,7 +140,187 @@ describe("GET /api/game/prophecies", () => {
         }),
       ),
     );
-    expect(status).toBe(200);
-    expect(listPropheciesForSealServer).toHaveBeenCalled();
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("firestore down");
+  });
+
+  it("returns 500 with generic 'Server error' for non-Error throw", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockListForSeal.mockImplementation(() => {
+      throw "boom";
+    });
+    const { status, body } = await readJson(
+      await GET(
+        makeAuthedRequest({
+          method: "GET",
+          path: "/api/game/prophecies",
+          searchParams: { seal: "1" },
+        }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("Server error");
+  });
+});
+
+describe("POST /api/game/prophecies", () => {
+  const VALID_BODY = { targetSealNumber: 1, prediction: "The sky is falling" };
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when daily rate-limit exceeded (with retryAfter)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockRateLimit.mockResolvedValue({ success: false, retryAfter: 1234 } as never);
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+      ),
+    );
+    expect(status).toBe(429);
+    expect(body.error.message).toContain("1234");
+  });
+
+  it("returns 429 with 3600 fallback when retryAfter missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockRateLimit.mockResolvedValue({ success: false } as never);
+    const { body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+      ),
+    );
+    expect(body.error.message).toContain("3600");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        path: "/api/game/prophecies",
+        body: "not-json",
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on zod validation failure (too-long prediction)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/prophecies",
+        body: { targetSealNumber: 1, prediction: "x".repeat(MAX_PROPHECY_LENGTH + 1) },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on zod validation failure (out-of-range seal)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/prophecies",
+        body: { targetSealNumber: 99, prediction: "fine" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when admin db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockGetAdminDb.mockReturnValue(null as never);
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toContain("Server not configured");
+  });
+
+  it("creates prophecy with 'Unknown general' fallback when player record missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockGetAdminDb.mockReturnValue(fakeDb({ exists: false }));
+    const res = await POST(
+      makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        author: expect.objectContaining({ displayName: "Unknown general", caste: null }),
+      }),
+    );
+  });
+
+  it("uses player.displayName and player.caste when player record exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockGetAdminDb.mockReturnValue(
+      fakeDb({
+        exists: true,
+        data: () => ({ displayName: "  Lord Tomato  ", caste: "warrior" }),
+      }),
+    );
+    const res = await POST(
+      makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        author: expect.objectContaining({ displayName: "Lord Tomato", caste: "warrior" }),
+      }),
+    );
+  });
+
+  it.each([
+    [ProphecyEmptyError, 400],
+    [ProphecyTooLongError, 400],
+    [ProphecyInvalidSealError, 400],
+    [ProphecySealAlreadyBrokenError, 409],
+  ])("translates %p to status %i", async (ErrCls, expectedStatus) => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    // These error classes carry their own canonical messages; instantiate
+    // with the default constructor signature.
+    mockCreate.mockRejectedValue(new (ErrCls as new () => Error)());
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+      ),
+    );
+    expect(status).toBe(expectedStatus);
+    expect(typeof body.error.message).toBe("string");
+  });
+
+  it("returns 500 for an untyped Error", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockCreate.mockRejectedValue(new Error("kaboom"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("kaboom");
+  });
+
+  it("returns 500 'Server error' for non-Error throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue(USER);
+    mockCreate.mockImplementation(() => {
+      throw "string-thrown";
+    });
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/prophecies", body: VALID_BODY }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("Server error");
   });
 });

--- a/__tests__/app/api/game/reactions/route.test.ts
+++ b/__tests__/app/api/game/reactions/route.test.ts
@@ -101,4 +101,85 @@ describe("PUT /api/game/reactions", () => {
       heroId: undefined,
     });
   });
+
+  it("returns 429 with default 30s when retryAfter is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockRateLimit.mockResolvedValue({ success: false } as never);
+    const { body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(String((body as { error?: { message?: string } }).error?.message)).toContain("30s");
+  });
+
+  it("returns 400 for non-JSON request body", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    const res = await PUT(
+      makeRequest({
+        method: "PUT",
+        path: "/api/game/reactions",
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("translates ReactionTargetNotFoundError to 404", async () => {
+    const { ReactionTargetNotFoundError } = jest.requireActual("@/lib/game/reactions");
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockToggle.mockRejectedValue(new ReactionTargetNotFoundError("chat", "msg-missing"));
+    const { status, body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(404);
+    expect(typeof (body as { error: { message: string } }).error.message).toBe("string");
+  });
+
+  it.each([
+    ["ReactionInvalidScopeError"],
+    ["ReactionInvalidEmojiError"],
+    ["ReactionMissingHeroIdError"],
+  ])("translates %s to 400", async (errName) => {
+    const reactions = jest.requireActual("@/lib/game/reactions");
+    const ErrCls = reactions[errName];
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    // These error classes all take a single string arg.
+    mockToggle.mockRejectedValue(new ErrCls("bad"));
+    const { status } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(400);
+  });
+
+  it("returns 500 for untyped Error", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockToggle.mockRejectedValue(new Error("kaboom"));
+    const { status, body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("kaboom");
+  });
+
+  it("returns 500 'Server error' for non-Error throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockToggle.mockImplementation(() => {
+      throw "string-thrown";
+    });
+    const { status, body } = await readJson(
+      await PUT(
+        makeAuthedRequest({ method: "PUT", path: "/api/game/reactions", body: BODY }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.message).toBe("Server error");
+  });
 });

--- a/__tests__/app/api/game/redistribute/route.test.ts
+++ b/__tests__/app/api/game/redistribute/route.test.ts
@@ -1,5 +1,7 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #5 — full coverage for redistribute route.
  */
 import { POST } from "@/app/api/game/redistribute/route";
 import { redistributeUnitsServer } from "@/lib/game/data-server";
@@ -7,38 +9,103 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/data-server", () => ({
-  redistributeUnitsServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return { ...actual, redistributeUnitsServer: jest.fn() };
+});
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockRedistribute = redistributeUnitsServer as jest.MockedFunction<typeof redistributeUnitsServer>;
+
+const VALID = {
+  sourceTileId: "a",
+  destTileId: "b",
+  units: { ground: 5, siege: 0, air: 0 },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" } as never);
+  mockRedistribute.mockResolvedValue({ source: {}, dest: {} } as never);
+});
 
 describe("POST /api/game/redistribute", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    (getVerifiedUser as jest.Mock).mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    (redistributeUnitsServer as jest.Mock).mockResolvedValue({ source: {}, dest: {} });
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ method: "POST", path: "/api/game/redistribute", body: VALID }),
+    );
+    expect(res.status).toBe(401);
   });
 
-  it("returns 400 when moving zero units", async () => {
+  it("returns 400 for non-JSON body", async () => {
     const res = await POST(
-      makeAuthedRequest({
+      makeRequest({
         method: "POST",
         path: "/api/game/redistribute",
-        body: { sourceTileId: "a", destTileId: "b", units: { ground: 0, siege: 0, air: 0 } },
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
       }),
     );
     expect(res.status).toBe(400);
   });
 
-  it("returns 200 on success", async () => {
+  it("returns 400 when zod validation fails (missing fields)", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/redistribute",
+        body: { sourceTileId: "a" } as never,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for negative unit counts (zod min(0) fails)", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/redistribute",
+        body: { ...VALID, units: { ground: -1, siege: 0, air: 0 } },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when moving zero total units", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/redistribute",
+        body: { ...VALID, units: { ground: 0, siege: 0, air: 0 } },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 on success and forwards the parsed body", async () => {
     const { status } = await readJson(
       await POST(
-        makeAuthedRequest({
-          method: "POST",
-          path: "/api/game/redistribute",
-          body: { sourceTileId: "a", destTileId: "b", units: { ground: 5, siege: 0, air: 0 } },
-        }),
+        makeAuthedRequest({ method: "POST", path: "/api/game/redistribute", body: VALID }),
       ),
     );
     expect(status).toBe(200);
+    expect(mockRedistribute).toHaveBeenCalledWith({
+      callerUserId: "u1",
+      sourceTileId: "a",
+      destTileId: "b",
+      units: { ground: 5, siege: 0, air: 0 },
+    });
+  });
+
+  it("returns 500 via mapGameError when redistributeUnitsServer throws", async () => {
+    mockRedistribute.mockRejectedValue(new Error("redistribute failed"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/redistribute", body: VALID }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });

--- a/__tests__/app/api/game/setup/caste/route.test.ts
+++ b/__tests__/app/api/game/setup/caste/route.test.ts
@@ -1,5 +1,7 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #4 — full coverage for setup/caste route.
  */
 import { POST } from "@/app/api/game/setup/caste/route";
 import { chooseCasteServer } from "@/lib/game/data-server";
@@ -7,9 +9,10 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/data-server", () => ({
-  chooseCasteServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return { ...actual, chooseCasteServer: jest.fn() };
+});
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
 const mockChooseCaste = chooseCasteServer as jest.MockedFunction<typeof chooseCasteServer>;
@@ -18,19 +21,58 @@ describe("POST /api/game/setup/caste", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetVerifiedUser.mockResolvedValue(null);
+    mockChooseCaste.mockResolvedValue({ userId: "u1", caste: "red" } as never);
   });
 
   it("returns 401 when unauthenticated", async () => {
-    expect((await POST(makeRequest({ method: "POST", path: "/api/game/setup/caste", body: { caste: "red" } }))).status).toBe(401);
+    const res = await POST(
+      makeRequest({ method: "POST", path: "/api/game/setup/caste", body: { caste: "red" } }),
+    );
+    expect(res.status).toBe(401);
   });
 
-  it("returns 200 on success", async () => {
+  it("returns 400 for non-JSON body", async () => {
     mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    mockChooseCaste.mockResolvedValue({ userId: "u1", caste: "red" } as never);
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        path: "/api/game/setup/caste",
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when caste is missing from body (zod validation fails)", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    const res = await POST(
+      makeAuthedRequest({ method: "POST", path: "/api/game/setup/caste", body: {} }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 on successful caste choice", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
     const { status, body } = await readJson(
-      await POST(makeAuthedRequest({ method: "POST", path: "/api/game/setup/caste", body: { caste: "red" } })),
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/setup/caste", body: { caste: "red" } }),
+      ),
     );
     expect(status).toBe(200);
     expect(body).toMatchObject({ success: true });
+    expect(mockChooseCaste).toHaveBeenCalledWith("u1", "red");
+  });
+
+  it("returns 500 via mapGameError when chooseCasteServer throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    mockChooseCaste.mockRejectedValue(new Error("caste service down"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/setup/caste", body: { caste: "red" } }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });

--- a/__tests__/app/api/game/setup/distribute/route.test.ts
+++ b/__tests__/app/api/game/setup/distribute/route.test.ts
@@ -1,5 +1,7 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #4 — full coverage for setup/distribute route.
  */
 import { POST } from "@/app/api/game/setup/distribute/route";
 import { distributeTileServer } from "@/lib/game/data-server";
@@ -7,38 +9,89 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/data-server", () => ({
-  distributeTileServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return { ...actual, distributeTileServer: jest.fn() };
+});
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockDistribute = distributeTileServer as jest.MockedFunction<typeof distributeTileServer>;
+
+const VALID_BODY = { tileId: "t1", type: "food", count: 1 };
+const SUCCESS = {
+  player: { userId: "u1" },
+  tile: { tileId: "t1" },
+  report: { kind: "distribute" },
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDistribute.mockResolvedValue(SUCCESS);
+});
 
 describe("POST /api/game/setup/distribute", () => {
   it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
     const res = await POST(
-      makeRequest({
-        method: "POST",
-        path: "/api/game/setup/distribute",
-        body: { tileId: "t1", type: "food", count: 1 },
-      }),
+      makeRequest({ method: "POST", path: "/api/game/setup/distribute", body: VALID_BODY }),
     );
     expect(res.status).toBe(401);
   });
 
-  it("returns 200 on success", async () => {
-    (getVerifiedUser as jest.Mock).mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    (distributeTileServer as jest.Mock).mockResolvedValue({
-      player: { userId: "u1" },
-      tile: { tileId: "t1" },
-      report: { kind: "distribute" },
-    });
-    const { status } = await readJson(
+  it("returns 400 for non-JSON body", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        path: "/api/game/setup/distribute",
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when required fields missing", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/setup/distribute",
+        body: { tileId: "t1" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 on successful distribute", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    const { status, body } = await readJson(
       await POST(
         makeAuthedRequest({
           method: "POST",
           path: "/api/game/setup/distribute",
-          body: { tileId: "t1", type: "food", count: 1 },
+          body: VALID_BODY,
         }),
       ),
     );
     expect(status).toBe(200);
+    expect(body).toMatchObject({ success: true });
+    expect(mockDistribute).toHaveBeenCalledWith("u1", "t1", "food");
+  });
+
+  it("returns 500 via mapGameError when distributeTileServer throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    mockDistribute.mockRejectedValue(new Error("distribute failed"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/setup/distribute",
+          body: VALID_BODY,
+        }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });

--- a/__tests__/app/api/game/setup/explore/route.test.ts
+++ b/__tests__/app/api/game/setup/explore/route.test.ts
@@ -1,25 +1,111 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #4 — full coverage for setup/explore route.
  */
 import { POST } from "@/app/api/game/setup/explore/route";
 import { exploreNextTileServer } from "@/lib/game/data-server";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/data-server", () => ({
-  exploreNextTileServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return { ...actual, exploreNextTileServer: jest.fn() };
+});
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockExplore = exploreNextTileServer as jest.MockedFunction<typeof exploreNextTileServer>;
+
+const SUCCESS_RESULT = {
+  player: { userId: "u1" },
+  tile: { tileId: "t1" },
+  report: { kind: "explore" },
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockExplore.mockResolvedValue(SUCCESS_RESULT);
+});
 
 describe("POST /api/game/setup/explore", () => {
-  it("returns 200 on setup explore", async () => {
-    (getVerifiedUser as jest.Mock).mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    (exploreNextTileServer as jest.Mock).mockResolvedValue({
-      player: { userId: "u1" },
-      tile: { tileId: "t1" },
-      report: { kind: "explore" },
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ method: "POST", path: "/api/game/setup/explore", body: { count: 1 } }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("explores once when request body is absent (count=1 default)", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    // No body: content-length header not set, route takes the count=1 default branch.
+    const req = new (require("next/server").NextRequest)("https://example.com/api/game/setup/explore", {
+      method: "POST",
+      headers: { Authorization: "Bearer test" },
     });
+    const { status } = await readJson(await POST(req));
+    expect(status).toBe(200);
+    expect(mockExplore).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 200 on setup explore with explicit count", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
     const { status } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/setup/explore",
+          body: { count: 2 },
+        }),
+      ),
+    );
+    expect(status).toBe(200);
+    // parseBatchCount clamps to >=1; with count=2 we expect 2 calls
+    expect(mockExplore).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid request body shape (with Content-Length set)", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    // Route only parses the body when Content-Length is set; the test
+    // helper doesn't set it automatically, so we construct the request by
+    // hand to exercise the body-parsing branch.
+    const payload = JSON.stringify({ count: "not-a-number" });
+    const NextRequest = require("next/server").NextRequest;
+    const req = new NextRequest("https://example.com/api/game/setup/explore", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test",
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      },
+      body: payload,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-JSON body (with Content-Length set)", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    const payload = "garbage";
+    const NextRequest = require("next/server").NextRequest;
+    const req = new NextRequest("https://example.com/api/game/setup/explore", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test",
+        "Content-Type": "text/plain",
+        "Content-Length": String(payload.length),
+      },
+      body: payload,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 SERVER_ERROR via mapGameError when explore throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
+    mockExplore.mockRejectedValue(new Error("explore failed"));
+    const { status, body } = await readJson(
       await POST(
         makeAuthedRequest({
           method: "POST",
@@ -28,6 +114,7 @@ describe("POST /api/game/setup/explore", () => {
         }),
       ),
     );
-    expect(status).toBe(200);
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });

--- a/__tests__/app/api/game/siege/route.test.ts
+++ b/__tests__/app/api/game/siege/route.test.ts
@@ -1,33 +1,90 @@
 /**
  * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #5 — full coverage for siege route.
  */
 import { POST } from "@/app/api/game/siege/route";
 import { siegeTileServer } from "@/lib/game/data-server";
 import { getVerifiedUser } from "@/lib/server-auth";
-import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
-jest.mock("@/lib/game/data-server", () => ({
-  siegeTileServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return { ...actual, siegeTileServer: jest.fn() };
+});
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockSiege = siegeTileServer as jest.MockedFunction<typeof siegeTileServer>;
+
+const VALID = { sourceTileId: "0_0", targetTileId: "1_0" };
+const SUCCESS = {
+  player: { userId: "u1" },
+  report: { kind: "siege" },
+  siegeTotalMagnitude: 1,
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" } as never);
+  mockSiege.mockResolvedValue(SUCCESS);
+});
 
 describe("POST /api/game/siege", () => {
-  it("returns 200 on siege", async () => {
-    (getVerifiedUser as jest.Mock).mockResolvedValue({ uid: "u1", email: "u@test.com", name: "U" });
-    (siegeTileServer as jest.Mock).mockResolvedValue({
-      player: { userId: "u1" },
-      report: { kind: "siege" },
-      siegeTotalMagnitude: 1,
-    });
-    const { status } = await readJson(
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ method: "POST", path: "/api/game/siege", body: VALID }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for non-JSON body", async () => {
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        path: "/api/game/siege",
+        body: "not-json",
+        headers: { Authorization: "Bearer test", "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod validation fails", async () => {
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/game/siege",
+        body: { sourceTileId: "0_0" } as never,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 on successful siege", async () => {
+    const { status, body } = await readJson(
       await POST(
-        makeAuthedRequest({
-          method: "POST",
-          path: "/api/game/siege",
-          body: { sourceTileId: "0_0", targetTileId: "1_0" },
-        }),
+        makeAuthedRequest({ method: "POST", path: "/api/game/siege", body: VALID }),
       ),
     );
     expect(status).toBe(200);
+    expect(body).toMatchObject({ success: true, siegeTotalMagnitude: 1 });
+    expect(mockSiege).toHaveBeenCalledWith({
+      attackerId: "u1",
+      sourceTileId: "0_0",
+      targetTileId: "1_0",
+    });
+  });
+
+  it("returns 500 via mapGameError when siegeTileServer throws", async () => {
+    mockSiege.mockRejectedValue(new Error("siege failed"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({ method: "POST", path: "/api/game/siege", body: VALID }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });

--- a/__tests__/app/api/game/spell/arm/route.test.ts
+++ b/__tests__/app/api/game/spell/arm/route.test.ts
@@ -12,9 +12,15 @@ jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
 }));
 
-jest.mock("@/lib/game/data-server", () => ({
-  armDefenseSpellServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  // Keep the error classes that mapGameError uses for instanceof checks;
+  // only override the function we need to spy on.
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return {
+    ...actual,
+    armDefenseSpellServer: jest.fn(),
+  };
+});
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
 const mockArmDefense = armDefenseSpellServer as jest.MockedFunction<typeof armDefenseSpellServer>;
@@ -67,5 +73,145 @@ describe("POST /api/game/spell/arm", () => {
     );
     expect(status).toBe(200);
     expect(mockArmDefense).toHaveBeenCalledWith("u1", "mine-1", "ward");
+  });
+
+  it("returns 400 when bulk tileIds exceeds the cap", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    const tileIds = Array.from({ length: 201 }, (_, i) => `tile-${i}`);
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/spell/arm",
+          body: { spellId: "shield", tileIds },
+        }),
+      ),
+    );
+    expect(status).toBe(400);
+    expect(body.error.message).toContain("Too many tileIds");
+  });
+
+  it("returns 200 with armed/failed summary for bulk arm (all succeed)", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockArmDefense
+      .mockResolvedValueOnce({
+        player: { userId: "u1" },
+        tile: { id: "t1" },
+        report: { kind: "arm", tileId: "t1" },
+      } as never)
+      .mockResolvedValueOnce({
+        player: { userId: "u1" },
+        tile: { id: "t2" },
+        report: { kind: "arm", tileId: "t2" },
+      } as never);
+
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/spell/arm",
+          body: { spellId: "ward", tileIds: ["t1", "t2"] },
+        }),
+      ),
+    );
+    expect(status).toBe(200);
+    expect(body.armed).toBe(2);
+    expect(body.failed).toEqual([]);
+    expect(body.reports).toHaveLength(2);
+    expect(mockArmDefense).toHaveBeenCalledTimes(2);
+  });
+
+  it("collects per-tile failures and continues the bulk batch (partial success)", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockArmDefense
+      .mockResolvedValueOnce({
+        player: { userId: "u1" },
+        tile: { id: "t1" },
+        report: { kind: "arm", tileId: "t1" },
+      } as never)
+      .mockRejectedValueOnce(new Error("Insufficient mana"))
+      .mockRejectedValueOnce("non-error-throw");
+
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/spell/arm",
+          body: { spellId: "ward", tileIds: ["t1", "t2", "t3"] },
+        }),
+      ),
+    );
+    expect(status).toBe(200);
+    expect(body.armed).toBe(1);
+    expect(body.failed).toEqual([
+      { tileId: "t2", reason: "Insufficient mana" },
+      { tileId: "t3", reason: "non-error-throw" },
+    ]);
+    expect(body.reports).toHaveLength(1);
+  });
+
+  it("maps to game error when every tile in the bulk batch fails", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockArmDefense.mockRejectedValue(new Error("Tile not owned"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/spell/arm",
+          body: { spellId: "ward", tileIds: ["t1", "t2"] },
+        }),
+      ),
+    );
+    // mapGameError returns a generic 500 SERVER_ERROR for unknown Error
+    // instances (it doesn't surface arbitrary error messages — that's a
+    // security design choice). The point of this test is to exercise the
+    // "all failed → mapGameError fallback" branch in the bulk path.
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
+  });
+
+  it("translates thrown game errors via mapGameError in the single-tile path", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockArmDefense.mockRejectedValue(new Error("Mana too low"));
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/spell/arm",
+          body: { spellId: "ward", tileId: "mine-1" },
+        }),
+      ),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
+  });
+
+  it("returns 400 with zod-issue message for invalid body", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/spell/arm",
+          // spellId is required by the contract
+          body: { tileId: "t1" },
+        }),
+      ),
+    );
+    expect(status).toBe(400);
+    expect(typeof body.error.message).toBe("string");
+  });
+
+  it("returns 400 for invalid JSON request body", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        path: "/api/game/spell/arm",
+        body: "not-json",
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    expect(res.status).toBe(400);
   });
 });

--- a/__tests__/app/api/game/world/route.test.ts
+++ b/__tests__/app/api/game/world/route.test.ts
@@ -7,6 +7,7 @@ import { GET } from "@/app/api/game/world/route";
 import {
   getAllMapTilesServer,
   getAllOwnerSummariesServer,
+  getMapTilesInBoundsServer,
 } from "@/lib/game/data-server";
 import { readWorldSnapshotServer } from "@/lib/game/world-snapshot";
 import { getVerifiedUser } from "@/lib/server-auth";
@@ -16,11 +17,15 @@ jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
 }));
 
-jest.mock("@/lib/game/data-server", () => ({
-  getAllMapTilesServer: jest.fn(),
-  getAllOwnerSummariesServer: jest.fn(),
-  getMapTilesInBoundsServer: jest.fn(),
-}));
+jest.mock("@/lib/game/data-server", () => {
+  const actual = jest.requireActual("@/lib/game/data-server");
+  return {
+    ...actual,
+    getAllMapTilesServer: jest.fn(),
+    getAllOwnerSummariesServer: jest.fn(),
+    getMapTilesInBoundsServer: jest.fn(),
+  };
+});
 
 jest.mock("@/lib/game/world-snapshot", () => ({
   readWorldSnapshotServer: jest.fn(),
@@ -44,6 +49,9 @@ const mockGetAllTiles = getAllMapTilesServer as jest.MockedFunction<
 >;
 const mockGetOwners = getAllOwnerSummariesServer as jest.MockedFunction<
   typeof getAllOwnerSummariesServer
+>;
+const mockGetBbox = getMapTilesInBoundsServer as jest.MockedFunction<
+  typeof getMapTilesInBoundsServer
 >;
 
 describe("GET /api/game/world", () => {
@@ -97,5 +105,123 @@ describe("GET /api/game/world", () => {
       tiles: [{ id: "live-tile" }],
       owners: [{ userId: "u2" }],
     });
+  });
+
+  it("returns bbox-filtered tiles from the snapshot (omits owners)", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockReadSnapshot.mockResolvedValue({
+      snapshot: {
+        tiles: [
+          { id: "t1", q: 0, r: 0 },
+          { id: "t2", q: 5, r: 5 },
+          { id: "t3", q: 10, r: 10 },
+        ],
+        owners: [{ userId: "u1" }],
+        generatedAt: "2026-05-18T00:00:00.000Z",
+      },
+      isStale: false,
+    } as never);
+
+    const { status, body } = await readJson(
+      await GET(
+        makeAuthedRequest({
+          path: "/api/game/world",
+          searchParams: { qMin: "0", qMax: "5", rMin: "0", rMax: "5" },
+        }),
+      ),
+    );
+
+    expect(status).toBe(200);
+    expect(body.tiles).toEqual([
+      { id: "t1", q: 0, r: 0 },
+      { id: "t2", q: 5, r: 5 },
+    ]);
+    expect(body.owners).toBeUndefined();
+  });
+
+  it("sets X-World-Snapshot-Stale header when snapshot is stale", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockReadSnapshot.mockResolvedValue({
+      snapshot: {
+        tiles: [],
+        owners: [],
+        generatedAt: "2026-05-17T00:00:00.000Z",
+      },
+      isStale: true,
+    } as never);
+
+    const res = await GET(makeAuthedRequest({ path: "/api/game/world" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-World-Snapshot-Stale")).toBe("true");
+    expect(res.headers.get("X-World-Snapshot-GeneratedAt")).toBe(
+      "2026-05-17T00:00:00.000Z",
+    );
+  });
+
+  it("falls back to bbox-only live query when snapshot is missing and bbox set", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockReadSnapshot.mockResolvedValue(null);
+    mockGetBbox.mockResolvedValue([{ id: "bbox-tile" }] as never);
+
+    const { status, body } = await readJson(
+      await GET(
+        makeAuthedRequest({
+          path: "/api/game/world",
+          searchParams: { qMin: "0", qMax: "5", rMin: "0", rMax: "5" },
+        }),
+      ),
+    );
+
+    expect(status).toBe(200);
+    expect(body.tiles).toEqual([{ id: "bbox-tile" }]);
+    expect(body.owners).toBeUndefined();
+    expect(mockGetBbox).toHaveBeenCalledWith({
+      qMin: 0,
+      qMax: 5,
+      rMin: 0,
+      rMax: 5,
+    });
+    expect(mockGetAllTiles).not.toHaveBeenCalled();
+  });
+
+  describe("bbox parsing — null bbox when invalid", () => {
+    beforeEach(() => {
+      mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+      mockReadSnapshot.mockResolvedValue({
+        snapshot: {
+          tiles: [{ id: "t-full", q: 0, r: 0 }],
+          owners: [{ userId: "u1" }],
+          generatedAt: "2026-05-18T00:00:00.000Z",
+        },
+        isStale: false,
+      } as never);
+    });
+
+    it.each([
+      ["missing one param", { qMin: "0", qMax: "5", rMin: "0" }],
+      ["non-finite (NaN)", { qMin: "abc", qMax: "5", rMin: "0", rMax: "5" }],
+      ["inverted qMin>qMax", { qMin: "10", qMax: "5", rMin: "0", rMax: "5" }],
+      ["inverted rMin>rMax", { qMin: "0", qMax: "5", rMin: "10", rMax: "5" }],
+    ])("falls through to full-world response when bbox is %s", async (_label, params) => {
+      const { status, body } = await readJson(
+        await GET(
+          makeAuthedRequest({ path: "/api/game/world", searchParams: params }),
+        ),
+      );
+      // With a null bbox the route returns full tiles + owners from the snapshot.
+      expect(status).toBe(200);
+      expect(body.tiles).toEqual([{ id: "t-full", q: 0, r: 0 }]);
+      expect(body.owners).toEqual([{ userId: "u1" }]);
+    });
+  });
+
+  it("returns 500 via mapGameError when the snapshot read throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@test.com", name: "User" });
+    mockReadSnapshot.mockRejectedValue(new Error("snapshot read failed"));
+    const { status, body } = await readJson(
+      await GET(makeAuthedRequest({ path: "/api/game/world" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error.code).toBe("SERVER_ERROR");
   });
 });


### PR DESCRIPTION
## Summary
Phase 6 Wave A of the OpenSSF Best Practices Gold coverage grind. Five PRs each lifting a target game-route file (or bundle) to 100% statement coverage with high branch coverage:

- **#1117** `prophecies` (route + [prophecyId]) — 37/0 → 100/100 stmt; 14/0 → 98/100 branch. _@Ludwitt (with Claude)._
- **#1118** `spell/arm` — 58 → 97.67 stmt; 38 → 87.5 branch. _@Ludwitt (with Claude)._
- **#1119** `world` — 69 → 100 stmt; 36 → 100 branch. _@Ludwitt (with Claude)._
- **#1120** `setup/{caste,distribute,explore}` bundle — caste 85→100, distribute 87→100, explore 64→96 stmt; branches 50→87.5/87.5/80. _@Ludwitt (with Claude)._
- **#1121** `reactions / redistribute / siege` bundle — all to 100 stmt; branches 43→95, 50→90, 37→87. _@Ludwitt (with Claude)._

Global coverage delta from these 5 PRs: ~80.25% → ~80.5%+ statements, ~66.0% → ~66.5%+ branches (per-PR global lift is modest because the repo is large; file-level lifts are substantial).

**Gold tier:** stays at 91% on bestpractices.dev — coverage criteria (`test_statement_coverage90`, `test_branch_coverage80`) still need ~9.5pp / 13.5pp more. The remaining Wave B-E and any follow-on waves will close that gap in future sessions.

## Test plan
- [ ] CI green on main after merge
- [ ] No test regressions on the rest of the suite
- [ ] Coverage floors in `config/jest.config.js` should be re-ratcheted in a follow-up `chore/` PR once enough gains accumulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)