### PR TITLE
test(profile): useGoogleConnection + useEmailManagement (Gold push #7)

### DIFF
--- a/__tests__/app/(auth)/profile/_hooks/useEmailManagement.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useEmailManagement.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #7 — useEmailManagement (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useEmailManagement } from "@/app/(auth)/profile/_hooks/useEmailManagement";
+
+const USER = { uid: "u1" } as unknown as User;
+
+function setup(overrides: Partial<{
+  sendAddEmailVerification: jest.Mock;
+  removeAdditionalEmail: jest.Mock;
+  changePrimaryEmail: jest.Mock;
+}> = {}) {
+  const sendAddEmailVerification = overrides.sendAddEmailVerification ?? jest.fn().mockResolvedValue(undefined);
+  const removeAdditionalEmail = overrides.removeAdditionalEmail ?? jest.fn().mockResolvedValue(undefined);
+  const changePrimaryEmail = overrides.changePrimaryEmail ?? jest.fn().mockResolvedValue(undefined);
+  return {
+    sendAddEmailVerification,
+    removeAdditionalEmail,
+    changePrimaryEmail,
+    hook: renderHook(() =>
+      useEmailManagement({
+        user: USER,
+        sendAddEmailVerification,
+        removeAdditionalEmail,
+        changePrimaryEmail,
+      })
+    ),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useEmailManagement", () => {
+  describe("addEmail", () => {
+    it("rejects empty input with an error", async () => {
+      const { hook, sendAddEmailVerification } = setup();
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toBe("Please enter an email address");
+      expect(sendAddEmailVerification).not.toHaveBeenCalled();
+    });
+
+    it("rejects whitespace-only input", async () => {
+      const { hook } = setup();
+      act(() => hook.result.current.setNewEmail("   "));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toBe("Please enter an email address");
+    });
+
+    it("sends verification on success and clears newEmail", async () => {
+      const { hook, sendAddEmailVerification } = setup();
+      act(() => hook.result.current.setNewEmail("new@example.com"));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(sendAddEmailVerification).toHaveBeenCalledWith("new@example.com");
+      expect(hook.result.current.addSuccess).toContain("Verification email sent");
+      expect(hook.result.current.newEmail).toBe("");
+      expect(hook.result.current.addLoading).toBe(false);
+    });
+
+    it("captures Error.message on failure", async () => {
+      const send = jest.fn().mockRejectedValue(new Error("server down"));
+      const { hook } = setup({ sendAddEmailVerification: send });
+      act(() => hook.result.current.setNewEmail("new@example.com"));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toBe("server down");
+      expect(hook.result.current.addLoading).toBe(false);
+    });
+
+    it("falls back to generic message on non-Error throw", async () => {
+      const send = jest.fn().mockRejectedValue("string-thrown");
+      const { hook } = setup({ sendAddEmailVerification: send });
+      act(() => hook.result.current.setNewEmail("new@example.com"));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toContain("Failed to send verification email");
+    });
+  });
+
+  describe("removeEmail", () => {
+    it("removes successfully and clears removeLoading", async () => {
+      const { hook, removeAdditionalEmail } = setup();
+      await act(async () => {
+        await hook.result.current.removeEmail("old@example.com");
+      });
+      expect(removeAdditionalEmail).toHaveBeenCalledWith("old@example.com");
+      expect(hook.result.current.removeLoading).toBeNull();
+    });
+
+    it("logs and recovers on remove failure", async () => {
+      const remove = jest.fn().mockRejectedValue(new Error("not allowed"));
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const { hook } = setup({ removeAdditionalEmail: remove });
+      await act(async () => {
+        await hook.result.current.removeEmail("old@example.com");
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(hook.result.current.removeLoading).toBeNull();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("makePrimary", () => {
+    // The "happy path" for makePrimary calls window.location.reload(),
+    // which jsdom blocks from being spied on or redefined. The reload
+    // call itself can't be asserted here; the failure-path test below
+    // exercises the error branch. Source line 70 stays uncovered.
+
+    it("logs and clears primaryLoading on failure", async () => {
+      const change = jest.fn().mockRejectedValue(new Error("nope"));
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const { hook } = setup({ changePrimaryEmail: change });
+      await act(async () => {
+        await hook.result.current.makePrimary("new@example.com");
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(hook.result.current.primaryLoading).toBeNull();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  it("exposes setVerificationStatus for verification flow callers", () => {
+    const { hook } = setup();
+    act(() => {
+      hook.result.current.setVerificationStatus({
+        type: "success",
+        message: "Email verified",
+      });
+    });
+    expect(hook.result.current.verificationStatus).toEqual({
+      type: "success",
+      message: "Email verified",
+    });
+  });
+});

--- a/__tests__/app/(auth)/profile/_hooks/useGoogleConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useGoogleConnection.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #7 — useGoogleConnection (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { unlink } from "firebase/auth";
+import { useGoogleConnection } from "@/app/(auth)/profile/_hooks/useGoogleConnection";
+
+jest.mock("firebase/auth", () => ({
+  unlink: jest.fn(),
+  User: class {},
+}));
+jest.mock("@/lib/firebase", () => ({
+  auth: { currentUser: null },
+}));
+
+const mockUnlink = unlink as jest.MockedFunction<typeof unlink>;
+
+function makeUser(providers: string[]): User {
+  return {
+    providerData: providers.map((id) => ({ providerId: id })),
+    reload: jest.fn().mockResolvedValue(undefined),
+  } as unknown as User;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useGoogleConnection", () => {
+  it("flags hasGoogleProvider when providerData includes google.com", () => {
+    const user = makeUser(["google.com", "password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(true);
+    expect(result.current.hasPasswordProvider).toBe(true);
+    expect(result.current.canDisconnect).toBe(true);
+  });
+
+  it("flags hasGoogleProvider=false when not in providerData", () => {
+    const user = makeUser(["password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(false);
+    expect(result.current.canDisconnect).toBe(false);
+  });
+
+  it("returns empty providerIds when user is null", () => {
+    const { result } = renderHook(() => useGoogleConnection(null));
+    expect(result.current.hasGoogleProvider).toBe(false);
+    expect(result.current.hasPasswordProvider).toBe(false);
+    expect(result.current.canDisconnect).toBe(false);
+  });
+
+  it("canDisconnect=false when google is the only provider", () => {
+    const user = makeUser(["google.com"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(true);
+    expect(result.current.canDisconnect).toBe(false);
+  });
+
+  it("disconnect is a no-op when user is null", async () => {
+    const { result } = renderHook(() => useGoogleConnection(null));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(mockUnlink).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("disconnect sets error when canDisconnect is false", async () => {
+    const user = makeUser(["google.com"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.error).toContain("at least one other login method");
+    expect(result.current.disconnecting).toBe(false);
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it("disconnect calls unlink and flips wasDisconnected on success", async () => {
+    const user = makeUser(["google.com", "password"]);
+    mockUnlink.mockResolvedValue({} as never);
+    const { result } = renderHook(() => useGoogleConnection(user));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(mockUnlink).toHaveBeenCalledWith(user, "google.com");
+    expect(user.reload).toHaveBeenCalled();
+    expect(result.current.hasGoogleProvider).toBe(false); // wasDisconnected wins
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("disconnect sets error when unlink throws", async () => {
+    const user = makeUser(["google.com", "password"]);
+    mockUnlink.mockRejectedValue(new Error("network"));
+    const { result } = renderHook(() => useGoogleConnection(user));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(result.current.error).toContain("Failed to disconnect Google");
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("resetIfReconnected clears wasDisconnected when google reappears", async () => {
+    const user = makeUser(["google.com", "password"]);
+    mockUnlink.mockResolvedValue({} as never);
+    const { result, rerender } = renderHook(
+      ({ u }: { u: User }) => useGoogleConnection(u),
+      { initialProps: { u: user } },
+    );
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.hasGoogleProvider).toBe(false);
+
+    // Reconnect: provider re-appears (e.g. user re-linked) and we call
+    // resetIfReconnected. wasDisconnected flips back to false.
+    const reconnectedUser = makeUser(["google.com", "password"]);
+    rerender({ u: reconnectedUser });
+
+    act(() => {
+      result.current.resetIfReconnected();
+    });
+
+    expect(result.current.hasGoogleProvider).toBe(true);
+  });
+
+  it("resetIfReconnected is a no-op when google still missing", () => {
+    const user = makeUser(["password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    act(() => {
+      result.current.resetIfReconnected();
+    });
+    expect(result.current.hasGoogleProvider).toBe(false);
+  });
+
+  it("setError exposed for callers to clear external errors", () => {
+    const user = makeUser(["google.com", "password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    act(() => {
+      result.current.setError("forced error");
+    });
+    expect(result.current.error).toBe("forced error");
+    act(() => {
+      result.current.setError(null);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns empty providerIds when user has no providerData", () => {
+    const user = { providerData: undefined } as unknown as User;
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Wave B PR #2 — two previously-untested profile hooks taken from 0% to near-100%.

| File | Statements | Branches | Functions | Lines |
|---|---|---|---|---|
| `useGoogleConnection.ts` | 0 → **100** | 0 → **100** | 0 → **100** | 0 → **100** |
| `useEmailManagement.ts` | 0 → **97.22** | 0 → **100** | 0 → **100** | 0 → **97.22** |

21 tests across both files (21/21 pass). useEmailManagement's lone uncovered line (70) is the `window.location.reload()` call — jsdom doesn't allow spying on or redefining `location.reload`.

## Test plan
- [x] `npx jest --testPathPatterns='__tests__/app/\(auth\)/profile/_hooks/(useGoogleConnection|useEmailManagement)' --coverage` — 21/21 pass, coverage as above
- [ ] CI green (full suite)