### PR TITLE
test(profile): useCursorConnection + useDiscordConnection (Gold push #8)

### DIFF
--- a/__tests__/app/(auth)/profile/_hooks/useCursorConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useCursorConnection.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #8 — useCursorConnection (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useCursorConnection, type CursorInfo } from "@/app/(auth)/profile/_hooks/useCursorConnection";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+}));
+
+const USER = {
+  uid: "u1",
+  getIdToken: jest.fn().mockResolvedValue("token-1"),
+} as unknown as User;
+
+const PROFILE_INFO: CursorInfo = {
+  apiKeyFingerprint: "fp",
+  monthlyCapUsd: 10,
+  scopesConsented: ["read"],
+  connectedAt: new Date("2026-05-19"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
+
+describe("useCursorConnection", () => {
+  it("falls back to userProfileCursor when local state is empty", () => {
+    const { result } = renderHook(() =>
+      useCursorConnection(USER, PROFILE_INFO, undefined, "/profile?tab=connections"),
+    );
+    expect(result.current.cursorInfo).toEqual(PROFILE_INFO);
+  });
+
+  it("returns null cursorInfo when nothing is provided", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    expect(result.current.cursorInfo).toBeNull();
+  });
+
+  it("connect sets error when user is null", () => {
+    const { result } = renderHook(() => useCursorConnection(null));
+    act(() => {
+      result.current.connect();
+    });
+    expect(result.current.error).toContain("Please sign in");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("connect navigates to /profile/cursor when user is present", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    act(() => {
+      result.current.connect();
+    });
+    expect(result.current.connecting).toBe(true);
+    expect(mockPush).toHaveBeenCalledWith("/profile/cursor");
+  });
+
+  it("disconnect is a no-op when user is null", async () => {
+    const { result } = renderHook(() => useCursorConnection(null));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("disconnect calls /api/cursor/disconnect with bearer token and flips state", async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(() => useCursorConnection(USER, PROFILE_INFO, refresh));
+    expect(result.current.cursorInfo).toEqual(PROFILE_INFO);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/cursor/disconnect",
+      expect.objectContaining({
+        method: "POST",
+        headers: { Authorization: "Bearer token-1" },
+      }),
+    );
+    expect(refresh).toHaveBeenCalled();
+    expect(result.current.cursorInfo).toBeNull(); // wasDisconnected wins
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("disconnect sets error when API returns !ok", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    const { result } = renderHook(() => useCursorConnection(USER));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.error).toContain("Failed to disconnect");
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("disconnect sets error on network throw", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useCursorConnection(USER));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.error).toContain("Network error");
+  });
+
+  it("handleOAuthSuccess clears wasDisconnected and routes to fallback", async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useCursorConnection(USER, PROFILE_INFO, refresh, "/profile?tab=connections"),
+    );
+    await act(async () => {
+      await result.current.handleOAuthSuccess();
+    });
+    expect(refresh).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith("/profile?tab=connections", { scroll: false });
+  });
+
+  it("handleOAuthSuccess works without refresh callback", async () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    await act(async () => {
+      await result.current.handleOAuthSuccess();
+    });
+    expect(mockReplace).toHaveBeenCalledWith("/profile", { scroll: false });
+  });
+
+  it("handleOAuthError sets specific message for invalid_key", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    act(() => {
+      result.current.handleOAuthError("invalid_key");
+    });
+    expect(result.current.error).toContain("could not be validated");
+    expect(mockReplace).toHaveBeenCalled();
+  });
+
+  it("handleOAuthError falls back to generic message", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    act(() => {
+      result.current.handleOAuthError("something_else");
+    });
+    expect(result.current.error).toContain("Failed to connect Cursor");
+  });
+});

--- a/__tests__/app/(auth)/profile/_hooks/useDiscordConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useDiscordConnection.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #8 — useDiscordConnection (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useDiscordConnection } from "@/app/(auth)/profile/_hooks/useDiscordConnection";
+
+const mockReplace = jest.fn();
+const mockUpdateDoc = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn((db, col, id) => ({ db, col, id })),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  serverTimestamp: jest.fn(() => "TS"),
+  deleteField: jest.fn(() => "DEL"),
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: { fake: true } }));
+
+const USER = { uid: "u1" } as unknown as User;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID = "fake-client-id";
+});
+
+describe("useDiscordConnection", () => {
+  describe("discordInfo resolution", () => {
+    it("falls back to userProfileDiscord", () => {
+      const profileDiscord = { id: "d1", username: "user1" };
+      const { result } = renderHook(() =>
+        useDiscordConnection(USER, profileDiscord),
+      );
+      expect(result.current.discordInfo).toEqual(profileDiscord);
+    });
+
+    it("returns null when nothing provided", () => {
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      expect(result.current.discordInfo).toBeNull();
+    });
+  });
+
+  describe("connect", () => {
+    it("sets error when user is null", () => {
+      const { result } = renderHook(() => useDiscordConnection(null));
+      act(() => result.current.connect());
+      expect(result.current.error).toContain("not configured");
+    });
+    // The remaining connect paths (DISCORD_CLIENT_ID unset, happy-path
+    // window.location.href assignment) can't be reliably exercised in
+    // jsdom: jest.isolateModules + renderHook collides with React's
+    // module identity, and window.location is read-only and resists
+    // delete/redefine. Lines 44-48 of the source stay uncovered.
+  });
+
+  describe("disconnect", () => {
+    it("is a no-op when user is null", async () => {
+      const { result } = renderHook(() => useDiscordConnection(null));
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(mockUpdateDoc).not.toHaveBeenCalled();
+    });
+
+    it("calls updateDoc with deleteField and flips state on success", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() =>
+        useDiscordConnection(USER, { id: "d1", username: "user1" }),
+      );
+      expect(result.current.discordInfo).toBeTruthy();
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        { discord: "DEL" },
+      );
+      expect(result.current.discordInfo).toBeNull();
+      expect(result.current.disconnecting).toBe(false);
+    });
+
+    it("sets error on updateDoc failure", async () => {
+      mockUpdateDoc.mockRejectedValue(new Error("permission"));
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(result.current.error).toContain("Failed to disconnect Discord");
+    });
+  });
+
+  describe("handleOAuthSuccess", () => {
+    it("redirects to login if user is null", async () => {
+      const { result } = renderHook(() => useDiscordConnection(null));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "d1",
+          username: "user1",
+        });
+      });
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining("/login?redirect="),
+      );
+    });
+
+    it("writes discord info to Firestore on success", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "d1",
+          username: "userX",
+          globalName: "Global Name",
+          avatar: "abc123",
+        });
+      });
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          discord: expect.objectContaining({
+            id: "d1",
+            username: "Global Name", // globalName takes precedence
+            avatar: "abc123",
+          }),
+        }),
+      );
+      expect(result.current.discordInfo).toMatchObject({ id: "d1", username: "Global Name" });
+      expect(mockReplace).toHaveBeenCalled();
+    });
+
+    it("falls back to username when globalName is not provided", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "d1",
+          username: "plain-username",
+        });
+      });
+      expect(result.current.discordInfo?.username).toBe("plain-username");
+    });
+
+    it("sets error when updateDoc fails", async () => {
+      mockUpdateDoc.mockRejectedValue(new Error("Firestore down"));
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({ id: "d1", username: "u" });
+      });
+      expect(result.current.error).toContain("Failed to save Discord");
+    });
+  });
+
+  describe("handleOAuthError", () => {
+    it("sets specific message for not_member", () => {
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      act(() => result.current.handleOAuthError("not_member"));
+      expect(result.current.error).toContain("Cursor Boston Discord");
+    });
+
+    it("falls back to generic message", () => {
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      act(() => result.current.handleOAuthError("anything_else"));
+      expect(result.current.error).toContain("Failed to connect Discord");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Wave B PR #3 — two more profile hooks (Cursor + Discord) lifted from 0% to near-100%.

| File | Stmt | Branch | Funcs | Lines |
|---|---|---|---|---|
| `useCursorConnection.ts` | 0 → **100** | 0 → **94.73** | 0 → **100** | 0 → **100** |
| `useDiscordConnection.ts` | 0 → **94.23** | 0 → **84** | 0 → **100** | 0 → **94.11** |

24 tests across both files (24/24 pass).

useDiscordConnection has 5 intentionally-uncovered lines (env-var unset + window.location.href assignment) — jsdom limitations documented inline.

## Test plan
- [x] `npx jest --testPathPatterns='__tests__/app/\(auth\)/profile/_hooks/(useCursorConnection|useDiscordConnection)' --coverage` — 24/24 pass
- [ ] CI green (full suite)