### PR TITLE
release: OpenSSF Gold Wave B coverage push (3 PRs)

### DIFF
--- a/__tests__/app/(auth)/profile/_hooks/useCursorConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useCursorConnection.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #8 — useCursorConnection (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useCursorConnection, type CursorInfo } from "@/app/(auth)/profile/_hooks/useCursorConnection";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+}));
+
+const USER = {
+  uid: "u1",
+  getIdToken: jest.fn().mockResolvedValue("token-1"),
+} as unknown as User;
+
+const PROFILE_INFO: CursorInfo = {
+  apiKeyFingerprint: "fp",
+  monthlyCapUsd: 10,
+  scopesConsented: ["read"],
+  connectedAt: new Date("2026-05-19"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
+
+describe("useCursorConnection", () => {
+  it("falls back to userProfileCursor when local state is empty", () => {
+    const { result } = renderHook(() =>
+      useCursorConnection(USER, PROFILE_INFO, undefined, "/profile?tab=connections"),
+    );
+    expect(result.current.cursorInfo).toEqual(PROFILE_INFO);
+  });
+
+  it("returns null cursorInfo when nothing is provided", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    expect(result.current.cursorInfo).toBeNull();
+  });
+
+  it("connect sets error when user is null", () => {
+    const { result } = renderHook(() => useCursorConnection(null));
+    act(() => {
+      result.current.connect();
+    });
+    expect(result.current.error).toContain("Please sign in");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("connect navigates to /profile/cursor when user is present", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    act(() => {
+      result.current.connect();
+    });
+    expect(result.current.connecting).toBe(true);
+    expect(mockPush).toHaveBeenCalledWith("/profile/cursor");
+  });
+
+  it("disconnect is a no-op when user is null", async () => {
+    const { result } = renderHook(() => useCursorConnection(null));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("disconnect calls /api/cursor/disconnect with bearer token and flips state", async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(() => useCursorConnection(USER, PROFILE_INFO, refresh));
+    expect(result.current.cursorInfo).toEqual(PROFILE_INFO);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/cursor/disconnect",
+      expect.objectContaining({
+        method: "POST",
+        headers: { Authorization: "Bearer token-1" },
+      }),
+    );
+    expect(refresh).toHaveBeenCalled();
+    expect(result.current.cursorInfo).toBeNull(); // wasDisconnected wins
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("disconnect sets error when API returns !ok", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    const { result } = renderHook(() => useCursorConnection(USER));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.error).toContain("Failed to disconnect");
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("disconnect sets error on network throw", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useCursorConnection(USER));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.error).toContain("Network error");
+  });
+
+  it("handleOAuthSuccess clears wasDisconnected and routes to fallback", async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useCursorConnection(USER, PROFILE_INFO, refresh, "/profile?tab=connections"),
+    );
+    await act(async () => {
+      await result.current.handleOAuthSuccess();
+    });
+    expect(refresh).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith("/profile?tab=connections", { scroll: false });
+  });
+
+  it("handleOAuthSuccess works without refresh callback", async () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    await act(async () => {
+      await result.current.handleOAuthSuccess();
+    });
+    expect(mockReplace).toHaveBeenCalledWith("/profile", { scroll: false });
+  });
+
+  it("handleOAuthError sets specific message for invalid_key", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    act(() => {
+      result.current.handleOAuthError("invalid_key");
+    });
+    expect(result.current.error).toContain("could not be validated");
+    expect(mockReplace).toHaveBeenCalled();
+  });
+
+  it("handleOAuthError falls back to generic message", () => {
+    const { result } = renderHook(() => useCursorConnection(USER));
+    act(() => {
+      result.current.handleOAuthError("something_else");
+    });
+    expect(result.current.error).toContain("Failed to connect Cursor");
+  });
+});

--- a/__tests__/app/(auth)/profile/_hooks/useDiscordConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useDiscordConnection.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #8 — useDiscordConnection (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useDiscordConnection } from "@/app/(auth)/profile/_hooks/useDiscordConnection";
+
+const mockReplace = jest.fn();
+const mockUpdateDoc = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn((db, col, id) => ({ db, col, id })),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  serverTimestamp: jest.fn(() => "TS"),
+  deleteField: jest.fn(() => "DEL"),
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: { fake: true } }));
+
+const USER = { uid: "u1" } as unknown as User;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID = "fake-client-id";
+});
+
+describe("useDiscordConnection", () => {
+  describe("discordInfo resolution", () => {
+    it("falls back to userProfileDiscord", () => {
+      const profileDiscord = { id: "d1", username: "user1" };
+      const { result } = renderHook(() =>
+        useDiscordConnection(USER, profileDiscord),
+      );
+      expect(result.current.discordInfo).toEqual(profileDiscord);
+    });
+
+    it("returns null when nothing provided", () => {
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      expect(result.current.discordInfo).toBeNull();
+    });
+  });
+
+  describe("connect", () => {
+    it("sets error when user is null", () => {
+      const { result } = renderHook(() => useDiscordConnection(null));
+      act(() => result.current.connect());
+      expect(result.current.error).toContain("not configured");
+    });
+    // The remaining connect paths (DISCORD_CLIENT_ID unset, happy-path
+    // window.location.href assignment) can't be reliably exercised in
+    // jsdom: jest.isolateModules + renderHook collides with React's
+    // module identity, and window.location is read-only and resists
+    // delete/redefine. Lines 44-48 of the source stay uncovered.
+  });
+
+  describe("disconnect", () => {
+    it("is a no-op when user is null", async () => {
+      const { result } = renderHook(() => useDiscordConnection(null));
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(mockUpdateDoc).not.toHaveBeenCalled();
+    });
+
+    it("calls updateDoc with deleteField and flips state on success", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() =>
+        useDiscordConnection(USER, { id: "d1", username: "user1" }),
+      );
+      expect(result.current.discordInfo).toBeTruthy();
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        { discord: "DEL" },
+      );
+      expect(result.current.discordInfo).toBeNull();
+      expect(result.current.disconnecting).toBe(false);
+    });
+
+    it("sets error on updateDoc failure", async () => {
+      mockUpdateDoc.mockRejectedValue(new Error("permission"));
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(result.current.error).toContain("Failed to disconnect Discord");
+    });
+  });
+
+  describe("handleOAuthSuccess", () => {
+    it("redirects to login if user is null", async () => {
+      const { result } = renderHook(() => useDiscordConnection(null));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "d1",
+          username: "user1",
+        });
+      });
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining("/login?redirect="),
+      );
+    });
+
+    it("writes discord info to Firestore on success", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "d1",
+          username: "userX",
+          globalName: "Global Name",
+          avatar: "abc123",
+        });
+      });
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          discord: expect.objectContaining({
+            id: "d1",
+            username: "Global Name", // globalName takes precedence
+            avatar: "abc123",
+          }),
+        }),
+      );
+      expect(result.current.discordInfo).toMatchObject({ id: "d1", username: "Global Name" });
+      expect(mockReplace).toHaveBeenCalled();
+    });
+
+    it("falls back to username when globalName is not provided", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "d1",
+          username: "plain-username",
+        });
+      });
+      expect(result.current.discordInfo?.username).toBe("plain-username");
+    });
+
+    it("sets error when updateDoc fails", async () => {
+      mockUpdateDoc.mockRejectedValue(new Error("Firestore down"));
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({ id: "d1", username: "u" });
+      });
+      expect(result.current.error).toContain("Failed to save Discord");
+    });
+  });
+
+  describe("handleOAuthError", () => {
+    it("sets specific message for not_member", () => {
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      act(() => result.current.handleOAuthError("not_member"));
+      expect(result.current.error).toContain("Cursor Boston Discord");
+    });
+
+    it("falls back to generic message", () => {
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      act(() => result.current.handleOAuthError("anything_else"));
+      expect(result.current.error).toContain("Failed to connect Discord");
+    });
+  });
+});

--- a/__tests__/app/(auth)/profile/_hooks/useEmailManagement.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useEmailManagement.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #7 — useEmailManagement (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useEmailManagement } from "@/app/(auth)/profile/_hooks/useEmailManagement";
+
+const USER = { uid: "u1" } as unknown as User;
+
+function setup(overrides: Partial<{
+  sendAddEmailVerification: jest.Mock;
+  removeAdditionalEmail: jest.Mock;
+  changePrimaryEmail: jest.Mock;
+}> = {}) {
+  const sendAddEmailVerification = overrides.sendAddEmailVerification ?? jest.fn().mockResolvedValue(undefined);
+  const removeAdditionalEmail = overrides.removeAdditionalEmail ?? jest.fn().mockResolvedValue(undefined);
+  const changePrimaryEmail = overrides.changePrimaryEmail ?? jest.fn().mockResolvedValue(undefined);
+  return {
+    sendAddEmailVerification,
+    removeAdditionalEmail,
+    changePrimaryEmail,
+    hook: renderHook(() =>
+      useEmailManagement({
+        user: USER,
+        sendAddEmailVerification,
+        removeAdditionalEmail,
+        changePrimaryEmail,
+      })
+    ),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useEmailManagement", () => {
+  describe("addEmail", () => {
+    it("rejects empty input with an error", async () => {
+      const { hook, sendAddEmailVerification } = setup();
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toBe("Please enter an email address");
+      expect(sendAddEmailVerification).not.toHaveBeenCalled();
+    });
+
+    it("rejects whitespace-only input", async () => {
+      const { hook } = setup();
+      act(() => hook.result.current.setNewEmail("   "));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toBe("Please enter an email address");
+    });
+
+    it("sends verification on success and clears newEmail", async () => {
+      const { hook, sendAddEmailVerification } = setup();
+      act(() => hook.result.current.setNewEmail("new@example.com"));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(sendAddEmailVerification).toHaveBeenCalledWith("new@example.com");
+      expect(hook.result.current.addSuccess).toContain("Verification email sent");
+      expect(hook.result.current.newEmail).toBe("");
+      expect(hook.result.current.addLoading).toBe(false);
+    });
+
+    it("captures Error.message on failure", async () => {
+      const send = jest.fn().mockRejectedValue(new Error("server down"));
+      const { hook } = setup({ sendAddEmailVerification: send });
+      act(() => hook.result.current.setNewEmail("new@example.com"));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toBe("server down");
+      expect(hook.result.current.addLoading).toBe(false);
+    });
+
+    it("falls back to generic message on non-Error throw", async () => {
+      const send = jest.fn().mockRejectedValue("string-thrown");
+      const { hook } = setup({ sendAddEmailVerification: send });
+      act(() => hook.result.current.setNewEmail("new@example.com"));
+      await act(async () => {
+        await hook.result.current.addEmail();
+      });
+      expect(hook.result.current.addError).toContain("Failed to send verification email");
+    });
+  });
+
+  describe("removeEmail", () => {
+    it("removes successfully and clears removeLoading", async () => {
+      const { hook, removeAdditionalEmail } = setup();
+      await act(async () => {
+        await hook.result.current.removeEmail("old@example.com");
+      });
+      expect(removeAdditionalEmail).toHaveBeenCalledWith("old@example.com");
+      expect(hook.result.current.removeLoading).toBeNull();
+    });
+
+    it("logs and recovers on remove failure", async () => {
+      const remove = jest.fn().mockRejectedValue(new Error("not allowed"));
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const { hook } = setup({ removeAdditionalEmail: remove });
+      await act(async () => {
+        await hook.result.current.removeEmail("old@example.com");
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(hook.result.current.removeLoading).toBeNull();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("makePrimary", () => {
+    // The "happy path" for makePrimary calls window.location.reload(),
+    // which jsdom blocks from being spied on or redefined. The reload
+    // call itself can't be asserted here; the failure-path test below
+    // exercises the error branch. Source line 70 stays uncovered.
+
+    it("logs and clears primaryLoading on failure", async () => {
+      const change = jest.fn().mockRejectedValue(new Error("nope"));
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const { hook } = setup({ changePrimaryEmail: change });
+      await act(async () => {
+        await hook.result.current.makePrimary("new@example.com");
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(hook.result.current.primaryLoading).toBeNull();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  it("exposes setVerificationStatus for verification flow callers", () => {
+    const { hook } = setup();
+    act(() => {
+      hook.result.current.setVerificationStatus({
+        type: "success",
+        message: "Email verified",
+      });
+    });
+    expect(hook.result.current.verificationStatus).toEqual({
+      type: "success",
+      message: "Email verified",
+    });
+  });
+});

--- a/__tests__/app/(auth)/profile/_hooks/useGoogleConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useGoogleConnection.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #7 — useGoogleConnection (was 0% coverage).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { unlink } from "firebase/auth";
+import { useGoogleConnection } from "@/app/(auth)/profile/_hooks/useGoogleConnection";
+
+jest.mock("firebase/auth", () => ({
+  unlink: jest.fn(),
+  User: class {},
+}));
+jest.mock("@/lib/firebase", () => ({
+  auth: { currentUser: null },
+}));
+
+const mockUnlink = unlink as jest.MockedFunction<typeof unlink>;
+
+function makeUser(providers: string[]): User {
+  return {
+    providerData: providers.map((id) => ({ providerId: id })),
+    reload: jest.fn().mockResolvedValue(undefined),
+  } as unknown as User;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useGoogleConnection", () => {
+  it("flags hasGoogleProvider when providerData includes google.com", () => {
+    const user = makeUser(["google.com", "password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(true);
+    expect(result.current.hasPasswordProvider).toBe(true);
+    expect(result.current.canDisconnect).toBe(true);
+  });
+
+  it("flags hasGoogleProvider=false when not in providerData", () => {
+    const user = makeUser(["password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(false);
+    expect(result.current.canDisconnect).toBe(false);
+  });
+
+  it("returns empty providerIds when user is null", () => {
+    const { result } = renderHook(() => useGoogleConnection(null));
+    expect(result.current.hasGoogleProvider).toBe(false);
+    expect(result.current.hasPasswordProvider).toBe(false);
+    expect(result.current.canDisconnect).toBe(false);
+  });
+
+  it("canDisconnect=false when google is the only provider", () => {
+    const user = makeUser(["google.com"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(true);
+    expect(result.current.canDisconnect).toBe(false);
+  });
+
+  it("disconnect is a no-op when user is null", async () => {
+    const { result } = renderHook(() => useGoogleConnection(null));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(mockUnlink).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("disconnect sets error when canDisconnect is false", async () => {
+    const user = makeUser(["google.com"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.error).toContain("at least one other login method");
+    expect(result.current.disconnecting).toBe(false);
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it("disconnect calls unlink and flips wasDisconnected on success", async () => {
+    const user = makeUser(["google.com", "password"]);
+    mockUnlink.mockResolvedValue({} as never);
+    const { result } = renderHook(() => useGoogleConnection(user));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(mockUnlink).toHaveBeenCalledWith(user, "google.com");
+    expect(user.reload).toHaveBeenCalled();
+    expect(result.current.hasGoogleProvider).toBe(false); // wasDisconnected wins
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("disconnect sets error when unlink throws", async () => {
+    const user = makeUser(["google.com", "password"]);
+    mockUnlink.mockRejectedValue(new Error("network"));
+    const { result } = renderHook(() => useGoogleConnection(user));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(result.current.error).toContain("Failed to disconnect Google");
+    expect(result.current.disconnecting).toBe(false);
+  });
+
+  it("resetIfReconnected clears wasDisconnected when google reappears", async () => {
+    const user = makeUser(["google.com", "password"]);
+    mockUnlink.mockResolvedValue({} as never);
+    const { result, rerender } = renderHook(
+      ({ u }: { u: User }) => useGoogleConnection(u),
+      { initialProps: { u: user } },
+    );
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.hasGoogleProvider).toBe(false);
+
+    // Reconnect: provider re-appears (e.g. user re-linked) and we call
+    // resetIfReconnected. wasDisconnected flips back to false.
+    const reconnectedUser = makeUser(["google.com", "password"]);
+    rerender({ u: reconnectedUser });
+
+    act(() => {
+      result.current.resetIfReconnected();
+    });
+
+    expect(result.current.hasGoogleProvider).toBe(true);
+  });
+
+  it("resetIfReconnected is a no-op when google still missing", () => {
+    const user = makeUser(["password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    act(() => {
+      result.current.resetIfReconnected();
+    });
+    expect(result.current.hasGoogleProvider).toBe(false);
+  });
+
+  it("setError exposed for callers to clear external errors", () => {
+    const user = makeUser(["google.com", "password"]);
+    const { result } = renderHook(() => useGoogleConnection(user));
+    act(() => {
+      result.current.setError("forced error");
+    });
+    expect(result.current.error).toBe("forced error");
+    act(() => {
+      result.current.setError(null);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns empty providerIds when user has no providerData", () => {
+    const user = { providerData: undefined } as unknown as User;
+    const { result } = renderHook(() => useGoogleConnection(user));
+    expect(result.current.hasGoogleProvider).toBe(false);
+  });
+});

--- a/__tests__/app/game/use-dashboard-data.test.tsx
+++ b/__tests__/app/game/use-dashboard-data.test.tsx
@@ -315,4 +315,172 @@ describe("useDashboardData", () => {
     expect(castSpell).toHaveBeenCalled();
     expect(castArmageddon).toHaveBeenCalled();
   });
+
+  // OpenSSF Gold coverage push #6 — exercises the merge-callback bodies
+  // (mergeOwnedTiles / mergeBorderTiles / mergeArtifacts) and the
+  // shouldTriggerResolve setTimeout branch on castArmageddon.
+
+  it("mergeOwnedTiles patches tiles state when action returns updates (Gold push)", async () => {
+    const user = makeUser();
+    mockUseAuth.mockReturnValue({ user, userProfile: null, loading: false });
+
+    // Seed initial tiles via fetchInitialData
+    (fetchInitialData as jest.Mock).mockImplementation(async (_user, set) => {
+      set.setTiles([FAKE_TILE]);
+      set.setLoading(false);
+    });
+    // frontierExplore mock invokes mergeOwnedTiles with a NEW tile to
+    // exercise lines 119-124 of use-dashboard-data.ts.
+    const NEW_TILE: MapTile = {
+      ...FAKE_TILE,
+      tileId: "2_0",
+      q: 2,
+    };
+    (frontierExplore as jest.Mock).mockImplementation(async (_u, _c, mut) => {
+      mut.mergeOwnedTiles([NEW_TILE]);
+    });
+
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(result.current.tiles).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.handleFrontierExplore(1);
+    });
+
+    await waitFor(() => expect(result.current.tiles).toHaveLength(2));
+    expect(result.current.tiles.map((t) => t.tileId).sort()).toEqual(["1_0", "2_0"]);
+  });
+
+  it("mergeOwnedTiles no-ops on empty updates (early-return branch)", async () => {
+    const user = makeUser();
+    mockUseAuth.mockReturnValue({ user, userProfile: null, loading: false });
+    (fetchInitialData as jest.Mock).mockImplementation(async (_u, set) => {
+      set.setTiles([FAKE_TILE]);
+      set.setLoading(false);
+    });
+    (frontierExplore as jest.Mock).mockImplementation(async (_u, _c, mut) => {
+      mut.mergeOwnedTiles([]);
+    });
+
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(result.current.tiles).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.handleFrontierExplore(1);
+    });
+    expect(result.current.tiles).toHaveLength(1);
+  });
+
+  it("mergeBorderTiles patches worldTiles for other-owner updates", async () => {
+    const user = makeUser();
+    mockUseAuth.mockReturnValue({ user, userProfile: null, loading: false });
+    (fetchInitialData as jest.Mock).mockImplementation(async (_u, set) => {
+      set.setLoading(false);
+    });
+    // attack mock invokes mergeBorderTiles with another-owner tile to
+    // exercise lines 137-144.
+    const OTHER_TILE: MapTile = {
+      ...FAKE_TILE,
+      tileId: "5_5",
+      ownerId: "other-user",
+    };
+    (attack as jest.Mock).mockImplementation(async (_u, _p, mut) => {
+      mut.mergeBorderTiles([OTHER_TILE]);
+    });
+
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(fetchInitialData).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.handleAttack({
+        sourceTileId: "1_0",
+        targetTileId: "5_5",
+        units: { ground: 1, air: 0, siege: 0 },
+        offenseSpellId: null,
+      });
+    });
+
+    expect(attack).toHaveBeenCalled();
+  });
+
+  it("mergeBorderTiles is a no-op when all updates are own-owner tiles", async () => {
+    const user = makeUser();
+    mockUseAuth.mockReturnValue({ user, userProfile: null, loading: false });
+    (fetchInitialData as jest.Mock).mockImplementation(async (_u, set) => {
+      set.setLoading(false);
+    });
+    // Own-owner tile: filter strips it; setWorldTiles is not called.
+    const OWN_TILE: MapTile = { ...FAKE_TILE, ownerId: user.uid };
+    (attack as jest.Mock).mockImplementation(async (_u, _p, mut) => {
+      mut.mergeBorderTiles([OWN_TILE]);
+    });
+
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(fetchInitialData).toHaveBeenCalled());
+    await act(async () => {
+      await result.current.handleAttack({
+        sourceTileId: "1_0",
+        targetTileId: "1_0",
+        units: { ground: 1, air: 0, siege: 0 },
+        offenseSpellId: null,
+      });
+    });
+    expect(attack).toHaveBeenCalled();
+  });
+
+  it("mergeArtifacts patches inventory and filters out used artifacts", async () => {
+    const user = makeUser();
+    mockUseAuth.mockReturnValue({ user, userProfile: null, loading: false });
+    (fetchInitialData as jest.Mock).mockImplementation(async (_u, set) => {
+      set.setArtifacts([
+        { id: "art-1", used: false, type: "crown" },
+        { id: "art-2", used: false, type: "scroll" },
+      ] as never);
+      set.setLoading(false);
+    });
+    // spendArtifact returns an update marking art-1 used; the merge body
+    // filters it out so only art-2 remains.
+    (spendArtifact as jest.Mock).mockImplementation(async (_u, _id, _tile, mut) => {
+      mut.mergeArtifacts([
+        { id: "art-1", used: true, type: "crown" },
+        { id: "art-3", used: false, type: "ring" },
+      ]);
+    });
+
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(result.current.artifacts).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.handleUseArtifact("art-1", "1_0");
+    });
+
+    await waitFor(() => {
+      const ids = result.current.artifacts.map((a) => a.id).sort();
+      expect(ids).toEqual(["art-2", "art-3"]);
+    });
+  });
+
+  it("castArmageddon shouldTriggerResolve schedules a delayed fetchPlayer", async () => {
+    jest.useFakeTimers();
+    const user = makeUser();
+    mockUseAuth.mockReturnValue({ user, userProfile: null, loading: false });
+    (fetchInitialData as jest.Mock).mockImplementation(async (_u, set) => {
+      set.setLoading(false);
+    });
+    (castArmageddon as jest.Mock).mockResolvedValue({ shouldTriggerResolve: true });
+
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(fetchInitialData).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.handleCastArmageddon();
+    });
+
+    // Advance past the 12s setTimeout and verify the second fetch landed.
+    await act(async () => {
+      jest.advanceTimersByTime(12_500);
+    });
+    await waitFor(() => expect(fetchInitialData).toHaveBeenCalledTimes(2));
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
Phase 6 Wave B of the OpenSSF Gold coverage grind — pivot from per-route game tests to denser page-hook surfaces.

- **#1123** `use-dashboard-data` (436 LOC hook) — 67/41 → 87/63 stmt/branch. _@Ludwitt (with Claude)._
- **#1124** `useGoogleConnection` + `useEmailManagement` — 0/0 → 100/100 and 0/0 → 97/100. _@Ludwitt (with Claude)._
- **#1125** `useCursorConnection` + `useDiscordConnection` — 0/0 → 100/95 and 0/0 → 94/84. _@Ludwitt (with Claude)._

**Global coverage**: 80.44 → 80.97 stmt (+0.53pp); 66.28 → 66.62 branch (+0.34pp). Five previously-untested hook files now have substantial coverage. Per-PR global lift remains modest (the codebase is large) but file-level lifts are major.

**Gold tier:** stays at 91% on bestpractices.dev — coverage criteria still need ~9pp / 13pp more.

## Test plan
- [ ] CI green on main after merge
- [ ] No regressions in the rest of the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)