### PR TITLE
release: OpenSSF Gold coverage pushes #9-#10

### DIFF
--- a/__tests__/app/(auth)/profile/_hooks/useGithubConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useGithubConnection.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #10 — useGithubConnection (was 0%).
+ */
+import { renderHook, act } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
+
+const mockReplace = jest.fn();
+const mockUpdateDoc = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn((db, col, id) => ({ db, col, id })),
+  updateDoc: (...args: unknown[]) => mockUpdateDoc(...args),
+  serverTimestamp: jest.fn(() => "TS"),
+  deleteField: jest.fn(() => "DEL"),
+}));
+
+jest.mock("@/lib/firebase", () => ({ db: { fake: true } }));
+
+const USER = { uid: "u1" } as unknown as User;
+const PROFILE_INFO = {
+  id: "gh-1",
+  login: "user",
+  html_url: "https://github.com/user",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID = "fake-client";
+});
+
+describe("useGithubConnection", () => {
+  describe("githubInfo / hasGithubConnection resolution", () => {
+    it("falls back to userProfileGithub when local state empty", () => {
+      const { result } = renderHook(() =>
+        useGithubConnection(USER, PROFILE_INFO),
+      );
+      expect(result.current.githubInfo).toEqual(PROFILE_INFO);
+      expect(result.current.hasGithubConnection).toBe(true);
+    });
+
+    it("returns null githubInfo when nothing provided", () => {
+      const { result } = renderHook(() => useGithubConnection(USER));
+      expect(result.current.githubInfo).toBeNull();
+      expect(result.current.hasGithubConnection).toBe(false);
+    });
+
+    it("hasGithubConnection=true when userProvider=github", () => {
+      const { result } = renderHook(() =>
+        useGithubConnection(USER, null, "github"),
+      );
+      expect(result.current.hasGithubConnection).toBe(true);
+    });
+  });
+
+  describe("connect", () => {
+    it("sets error when user is null", () => {
+      const { result } = renderHook(() => useGithubConnection(null));
+      act(() => result.current.connect());
+      expect(result.current.error).toContain("not configured");
+    });
+  });
+
+  describe("disconnect", () => {
+    it("is a no-op when user is null", async () => {
+      const { result } = renderHook(() => useGithubConnection(null));
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(mockUpdateDoc).not.toHaveBeenCalled();
+    });
+
+    it("calls updateDoc with deleteField and flips state on success", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() =>
+        useGithubConnection(USER, PROFILE_INFO),
+      );
+      expect(result.current.githubInfo).toBeTruthy();
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        { github: "DEL" },
+      );
+      expect(result.current.githubInfo).toBeNull();
+      expect(result.current.disconnecting).toBe(false);
+    });
+
+    it("sets error on updateDoc failure", async () => {
+      mockUpdateDoc.mockRejectedValue(new Error("permission"));
+      const { result } = renderHook(() => useGithubConnection(USER));
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(result.current.error).toContain("Failed to disconnect GitHub");
+    });
+  });
+
+  describe("handleOAuthSuccess", () => {
+    it("redirects to login when user is null", async () => {
+      const { result } = renderHook(() => useGithubConnection(null));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "gh-1",
+          login: "user",
+          html_url: "x",
+        });
+      });
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining("/login?redirect="),
+      );
+    });
+
+    it("writes github info on success", async () => {
+      mockUpdateDoc.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useGithubConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "gh-1",
+          login: "user",
+          name: "User Name",
+          avatar_url: "https://avatar",
+          html_url: "https://github.com/user",
+        });
+      });
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          github: expect.objectContaining({
+            id: "gh-1",
+            login: "user",
+            name: "User Name",
+          }),
+        }),
+      );
+      expect(result.current.githubInfo).toMatchObject({ login: "user" });
+    });
+
+    it("sets error when updateDoc fails", async () => {
+      mockUpdateDoc.mockRejectedValue(new Error("Firestore down"));
+      const { result } = renderHook(() => useGithubConnection(USER));
+      await act(async () => {
+        await result.current.handleOAuthSuccess({
+          id: "g",
+          login: "u",
+          html_url: "x",
+        });
+      });
+      expect(result.current.error).toContain("Failed to save GitHub");
+    });
+  });
+
+  describe("handleOAuthError", () => {
+    it("falls back to generic message", () => {
+      const { result } = renderHook(() => useGithubConnection(USER));
+      act(() => result.current.handleOAuthError("anything"));
+      expect(result.current.error).toContain("Failed to connect GitHub");
+    });
+  });
+
+  it("exposes setError to clear external errors", () => {
+    const { result } = renderHook(() => useGithubConnection(USER));
+    act(() => result.current.setError("forced"));
+    expect(result.current.error).toBe("forced");
+  });
+});

--- a/__tests__/app/pr-ideas/_hooks/useIdeaRuns.test.tsx
+++ b/__tests__/app/pr-ideas/_hooks/useIdeaRuns.test.tsx
@@ -1,0 +1,502 @@
+/**
+ * @jest-environment jsdom
+ *
+ * OpenSSF Gold coverage push #9 — useIdeaRuns (447 LOC, was 0% coverage).
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { User } from "firebase/auth";
+import { useIdeaRuns } from "@/app/pr-ideas/_hooks/useIdeaRuns";
+
+const mockReplace = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+const USER = {
+  uid: "u1",
+  getIdToken: jest.fn().mockResolvedValue("test-token"),
+} as unknown as User;
+
+function fakeResponse(opts: {
+  ok: boolean;
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}) {
+  const headers = new Headers(opts.headers ?? {});
+  return {
+    ok: opts.ok,
+    status: opts.status ?? (opts.ok ? 200 : 500),
+    headers,
+    json: () => Promise.resolve(opts.body ?? {}),
+  } as never;
+}
+
+const FAKE_RUN = {
+  id: "run-1",
+  status: "pending",
+  title: "Test idea",
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+});
+
+describe("useIdeaRuns", () => {
+  describe("initial state + auto-load", () => {
+    it("returns empty state when cursorConnected=false", () => {
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: false }),
+      );
+      expect(result.current.runs).toEqual([]);
+      expect(result.current.hasRuns).toBe(false);
+      expect(result.current.hasActiveRun).toBe(false);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns empty state when user is null", () => {
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: null, cursorConnected: true }),
+      );
+      expect(result.current.runs).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("auto-loads runs on mount when user + cursorConnected", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }),
+      );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      expect(result.current.selectedRun?.id).toBe("run-1");
+    });
+  });
+
+  describe("loadRuns", () => {
+    it("sets pollPausedUntil on 429 with Retry-After", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        fakeResponse({
+          ok: false,
+          status: 429,
+          body: { error: "rate_limited" },
+          headers: { "Retry-After": "30" },
+        }),
+      );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.error).toContain("Pausing refresh"));
+    });
+
+    it("sets generic error on 4xx", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        fakeResponse({ ok: false, status: 400, body: { error: "bad_request", errorId: "x1" } }),
+      );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+    });
+
+    it("bumps poll failures on 5xx", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        fakeResponse({ ok: false, status: 500, body: {} }),
+      );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+    });
+
+    it("sets network-error message on fetch throw", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("offline"));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.error).toContain("Network error"));
+    });
+  });
+
+  describe("launchIdeaRun", () => {
+    const FORM = {
+      mode: "freeform" as const,
+      interests: ["ai"],
+      skills: ["ts"],
+      preferredArea: [],
+      constraints: [],
+      freeform: "Build a thing",
+      issue: null,
+    };
+
+    it("returns null when user is missing", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        fakeResponse({ ok: true, body: { runs: [] } }),
+      );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: null, cursorConnected: true }),
+      );
+      const run = await result.current.launchIdeaRun(FORM);
+      expect(run).toBeNull();
+    });
+
+    it("redirects to /profile/cursor when error is cursor_not_connected", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [] } })) // mount load
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 412, body: { error: "cursor_not_connected" } }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.loadingState).toBe("idle"));
+      await act(async () => {
+        await result.current.launchIdeaRun(FORM);
+      });
+      expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining("/profile/cursor"));
+    });
+
+    it("prepends new run + selects it on success", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [] } }))
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { run: FAKE_RUN } }));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.loadingState).toBe("idle"));
+      await act(async () => {
+        const run = await result.current.launchIdeaRun(FORM);
+        expect(run?.id).toBe("run-1");
+      });
+      expect(result.current.runs).toHaveLength(1);
+      expect(result.current.selectedRun?.id).toBe("run-1");
+    });
+
+    it("sets network-error when fetch throws", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [] } }))
+        .mockRejectedValueOnce(new Error("offline"));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.loadingState).toBe("idle"));
+      await act(async () => {
+        const run = await result.current.launchIdeaRun(FORM);
+        expect(run).toBeNull();
+      });
+      expect(result.current.error).toContain("Network error while launching");
+    });
+
+    it("sets error from API errorId/error on !ok", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [] } }))
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 400, body: { error: "validation_failed", errorId: "abc" } }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.loadingState).toBe("idle"));
+      await act(async () => {
+        await result.current.launchIdeaRun(FORM);
+      });
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+
+  describe("loadGithubIssues", () => {
+    it("populates issues on success", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [] } }))
+        .mockResolvedValueOnce(
+          fakeResponse({
+            ok: true,
+            body: {
+              issues: [
+                {
+                  number: 7,
+                  title: "Bug",
+                  url: "https://example.com/7",
+                  body: null,
+                  labels: [],
+                },
+              ],
+            },
+          }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.loadingState).toBe("idle"));
+      await act(async () => {
+        await result.current.loadGithubIssues();
+      });
+      expect(result.current.githubIssues).toHaveLength(1);
+    });
+
+    it("sets error when API returns !ok", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [] } }))
+        .mockResolvedValueOnce(fakeResponse({ ok: false, status: 500, body: {} }));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.loadingState).toBe("idle"));
+      await act(async () => {
+        await result.current.loadGithubIssues();
+      });
+      expect(result.current.githubIssuesError).toContain("Could not load");
+    });
+
+    it("sets network error on fetch throw", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [] } }))
+        .mockRejectedValueOnce(new Error("net"));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.loadingState).toBe("idle"));
+      await act(async () => {
+        await result.current.loadGithubIssues();
+      });
+      expect(result.current.githubIssuesError).toContain("Network error");
+    });
+
+    it("is a no-op when user is null", async () => {
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: null, cursorConnected: true }),
+      );
+      await act(async () => {
+        await result.current.loadGithubIssues();
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("refreshRun", () => {
+    it("redirects when refreshSkipped=cursor_not_connected", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: true, body: { refreshSkipped: "cursor_not_connected" } }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.refreshRun("run-1");
+      });
+      expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining("/profile/cursor"));
+    });
+
+    it("updates the run on success", async () => {
+      const UPDATED = { ...FAKE_RUN, status: "complete" };
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { run: UPDATED } }));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.refreshRun("run-1");
+      });
+      expect(result.current.runs[0]?.status).toBe("complete");
+    });
+
+    it("sets error when !ok", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 500, body: { error: "boom" } }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.refreshRun("run-1");
+      });
+      expect(result.current.error).toBeTruthy();
+    });
+
+    it("sets network error on throw", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockRejectedValueOnce(new Error("nope"));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.refreshRun("run-1");
+      });
+      expect(result.current.error).toContain("Network error");
+    });
+  });
+
+  describe("clearError", () => {
+    it("clears the error state", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        fakeResponse({ ok: false, status: 500, body: { error: "boom" } }),
+      );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+      act(() => result.current.clearError());
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("mutateRun", () => {
+    beforeEach(() => {
+      jest.spyOn(window, "confirm").mockReturnValue(true);
+    });
+    afterEach(() => {
+      jest.spyOn(window, "confirm").mockRestore();
+    });
+
+    it("delete: removes run from list and re-selects", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: {} }));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.mutateRun("run-1", "delete");
+      });
+      expect(result.current.runs).toHaveLength(0);
+    });
+
+    it("delete: returns early if user cancels window.confirm", async () => {
+      (window.confirm as jest.Mock).mockReturnValue(false);
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }),
+      );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      const fetchCallsBefore = (global.fetch as jest.Mock).mock.calls.length;
+      await act(async () => {
+        await result.current.mutateRun("run-1", "delete");
+      });
+      expect((global.fetch as jest.Mock).mock.calls.length).toBe(fetchCallsBefore);
+    });
+
+    it("cancel: replaces run with updated payload", async () => {
+      const UPDATED = { ...FAKE_RUN, status: "cancelled" };
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { run: UPDATED } }));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.mutateRun("run-1", "cancel");
+      });
+      expect(result.current.runs[0]?.status).toBe("cancelled");
+    });
+
+    it("sets error when API !ok", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 500, body: { error: "boom" } }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.mutateRun("run-1", "archive");
+      });
+      expect(result.current.error).toBeTruthy();
+    });
+
+    it("sets network error on throw", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockRejectedValueOnce(new Error("net"));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.mutateRun("run-1", "archive");
+      });
+      expect(result.current.error).toContain("Network error");
+    });
+  });
+
+  describe("advanceWorkflow", () => {
+    it("updates the run on success", async () => {
+      const UPDATED = { ...FAKE_RUN, status: "questions-answered" };
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { run: UPDATED } }));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        const run = await result.current.advanceWorkflow("run-1", "answers", { foo: "bar" });
+        expect(run?.id).toBe("run-1");
+      });
+      expect(result.current.runs[0]?.status).toBe("questions-answered");
+    });
+
+    it("sets run-scoped error for agent_recovery_required", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 409, body: { error: "agent_recovery_required" } }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.advanceWorkflow("run-1", "approve-plan");
+      });
+      expect(result.current.runErrors["run-1"]).toContain("Cloud Agent");
+    });
+
+    it("sets generic run-scoped error on !ok", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockResolvedValueOnce(
+          fakeResponse({ ok: false, status: 400, body: { error: "boom", errorId: "x" } }),
+        );
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.advanceWorkflow("run-1", "approve-plan");
+      });
+      expect(result.current.runErrors["run-1"]).toBeTruthy();
+    });
+
+    it("sets network error on throw", async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(fakeResponse({ ok: true, body: { runs: [FAKE_RUN] } }))
+        .mockRejectedValueOnce(new Error("net"));
+      const { result } = renderHook(() =>
+        useIdeaRuns({ user: USER, cursorConnected: true }),
+      );
+      await waitFor(() => expect(result.current.runs).toHaveLength(1));
+      await act(async () => {
+        await result.current.advanceWorkflow("run-1", "open-pr");
+      });
+      expect(result.current.runErrors["run-1"]).toContain("Network error");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Two coverage push PRs:

- **#1127** `useIdeaRuns` (447 LOC) — 0 → 79.28/65.18 stmt/branch. Biggest single previously-untested file in the codebase. _@Ludwitt (with Claude)._
- **#1128** `useGithubConnection` (133 LOC) — 0 → 89.65/76 stmt/branch. Closes the profile-hooks workstream — every hook in `app/(auth)/profile/_hooks/` now has tests. _@Ludwitt (with Claude)._

**Global coverage**: 80.97 → 81.14 stmt (+0.17pp); 66.62 → 66.75 branch (+0.13pp).

**Gold tier:** stays at 91% — coverage criteria still need ~8.9pp stmt / 13.3pp branch.

## Test plan
- [ ] CI green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)