### PR TITLE
test(lib): full coverage for registrations (Gold push #12)

### DIFF
--- a/__tests__/lib/registrations.test.ts
+++ b/__tests__/lib/registrations.test.ts
@@ -1,5 +1,10 @@
-import { getUserStats } from "@/lib/registrations";
-import { getDocs, getDoc } from "firebase/firestore";
+import {
+  getUserStats,
+  registerForEvent,
+  getUserRegistrations,
+  isUserRegistered,
+} from "@/lib/registrations";
+import { getDocs, getDoc, setDoc } from "firebase/firestore";
 
 jest.mock("@/lib/firebase", () => ({
   db: { mocked: true },
@@ -19,6 +24,7 @@ jest.mock("firebase/firestore", () => ({
 
 const mockGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
 const mockGetDoc = getDoc as jest.MockedFunction<typeof getDoc>;
+const mockSetDoc = setDoc as jest.MockedFunction<typeof setDoc>;
 
 describe("getUserStats", () => {
   beforeEach(() => {
@@ -60,5 +66,134 @@ describe("getUserStats", () => {
     });
     expect(mockGetDocs).toHaveBeenCalledTimes(3);
     expect(mockGetDoc).not.toHaveBeenCalled();
+  });
+
+  // Gold coverage push #12 — broader coverage
+
+  it("returns zeroed stats when db is null", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { getUserStats: getZeroed } = await import("@/lib/registrations");
+    const stats = await getZeroed("u1");
+    expect(stats).toEqual({
+      eventsRegistered: 0,
+      eventsAttended: 0,
+      talksSubmitted: 0,
+      talksGiven: 0,
+      pullRequestsCount: 0,
+    });
+  });
+});
+
+describe("registerForEvent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws when db is not configured", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { registerForEvent: regNull } = await import("@/lib/registrations");
+    await expect(
+      regNull("u1", "u@example.com", "User", "evt-1", "Evt"),
+    ).rejects.toThrow("Firebase is not configured");
+  });
+
+  it("silently returns when already registered", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => true } as never);
+    await registerForEvent("u1", "u@example.com", "User", "evt-1", "Evt");
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it("writes registration doc with source=manual when no lumaGuestId", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false } as never);
+    mockSetDoc.mockResolvedValue(undefined as never);
+    await registerForEvent("u1", "u@example.com", "User", "evt-1", "Evt", "2026-06-01");
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: "u1_evt-1",
+        eventId: "evt-1",
+        eventTitle: "Evt",
+        userId: "u1",
+        userEmail: "u@example.com",
+        userName: "User",
+        eventDate: "2026-06-01",
+        source: "manual",
+        status: "registered",
+      }),
+    );
+  });
+
+  it("writes source=luma when lumaGuestId provided", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false } as never);
+    mockSetDoc.mockResolvedValue(undefined as never);
+    await registerForEvent(
+      "u1",
+      "u@example.com",
+      "User",
+      "evt-1",
+      "Evt",
+      undefined,
+      "luma-guest-1",
+    );
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        source: "luma",
+        lumaGuestId: "luma-guest-1",
+      }),
+    );
+  });
+});
+
+describe("getUserRegistrations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns empty array when db is null", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { getUserRegistrations: getNull } = await import("@/lib/registrations");
+    const regs = await getNull("u1");
+    expect(regs).toEqual([]);
+  });
+
+  it("returns mapped registrations from Firestore docs", async () => {
+    mockGetDocs.mockResolvedValue({
+      docs: [
+        { data: () => ({ id: "u1_e1", eventId: "e1" }) },
+        { data: () => ({ id: "u1_e2", eventId: "e2" }) },
+      ],
+    } as never);
+    const regs = await getUserRegistrations("u1");
+    expect(regs).toEqual([
+      { id: "u1_e1", eventId: "e1" },
+      { id: "u1_e2", eventId: "e2" },
+    ]);
+  });
+});
+
+describe("isUserRegistered", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns false when db is null", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { isUserRegistered: isNull } = await import("@/lib/registrations");
+    expect(await isNull("u1", "e1")).toBe(false);
+  });
+
+  it("returns true when registration document exists", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => true } as never);
+    expect(await isUserRegistered("u1", "e1")).toBe(true);
+  });
+
+  it("returns false when registration document does not exist", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false } as never);
+    expect(await isUserRegistered("u1", "e1")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Wave E PR #2.

| File | Stmt | Branch | Funcs | Lines |
|---|---|---|---|---|
| `lib/registrations.ts` | 47.91 → **100** | 8.33 → **100** | 50 → **100** | 52.27 → **100** |

10 new tests covering db=null guards on every export, registerForEvent's already-registered short-circuit, source=manual vs source=luma branching, and isUserRegistered's exists/!exists paths.

Branch coverage on this file was the lowest in the lib/ tree (8.33%). Now 100%.

## Test plan
- [x] `npx jest --testPathPatterns='__tests__/lib/registrations' --coverage` — 11/11 pass
- [ ] CI green (full suite)