### PR TITLE
release: OpenSSF Gold coverage pushes #11-#12 (lib/ tier)

### DIFF
--- a/__tests__/lib/registrations.test.ts
+++ b/__tests__/lib/registrations.test.ts
@@ -1,5 +1,10 @@
-import { getUserStats } from "@/lib/registrations";
-import { getDocs, getDoc } from "firebase/firestore";
+import {
+  getUserStats,
+  registerForEvent,
+  getUserRegistrations,
+  isUserRegistered,
+} from "@/lib/registrations";
+import { getDocs, getDoc, setDoc } from "firebase/firestore";
 
 jest.mock("@/lib/firebase", () => ({
   db: { mocked: true },
@@ -19,6 +24,7 @@ jest.mock("firebase/firestore", () => ({
 
 const mockGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
 const mockGetDoc = getDoc as jest.MockedFunction<typeof getDoc>;
+const mockSetDoc = setDoc as jest.MockedFunction<typeof setDoc>;
 
 describe("getUserStats", () => {
   beforeEach(() => {
@@ -60,5 +66,134 @@ describe("getUserStats", () => {
     });
     expect(mockGetDocs).toHaveBeenCalledTimes(3);
     expect(mockGetDoc).not.toHaveBeenCalled();
+  });
+
+  // Gold coverage push #12 — broader coverage
+
+  it("returns zeroed stats when db is null", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { getUserStats: getZeroed } = await import("@/lib/registrations");
+    const stats = await getZeroed("u1");
+    expect(stats).toEqual({
+      eventsRegistered: 0,
+      eventsAttended: 0,
+      talksSubmitted: 0,
+      talksGiven: 0,
+      pullRequestsCount: 0,
+    });
+  });
+});
+
+describe("registerForEvent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws when db is not configured", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { registerForEvent: regNull } = await import("@/lib/registrations");
+    await expect(
+      regNull("u1", "u@example.com", "User", "evt-1", "Evt"),
+    ).rejects.toThrow("Firebase is not configured");
+  });
+
+  it("silently returns when already registered", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => true } as never);
+    await registerForEvent("u1", "u@example.com", "User", "evt-1", "Evt");
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it("writes registration doc with source=manual when no lumaGuestId", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false } as never);
+    mockSetDoc.mockResolvedValue(undefined as never);
+    await registerForEvent("u1", "u@example.com", "User", "evt-1", "Evt", "2026-06-01");
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: "u1_evt-1",
+        eventId: "evt-1",
+        eventTitle: "Evt",
+        userId: "u1",
+        userEmail: "u@example.com",
+        userName: "User",
+        eventDate: "2026-06-01",
+        source: "manual",
+        status: "registered",
+      }),
+    );
+  });
+
+  it("writes source=luma when lumaGuestId provided", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false } as never);
+    mockSetDoc.mockResolvedValue(undefined as never);
+    await registerForEvent(
+      "u1",
+      "u@example.com",
+      "User",
+      "evt-1",
+      "Evt",
+      undefined,
+      "luma-guest-1",
+    );
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        source: "luma",
+        lumaGuestId: "luma-guest-1",
+      }),
+    );
+  });
+});
+
+describe("getUserRegistrations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns empty array when db is null", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { getUserRegistrations: getNull } = await import("@/lib/registrations");
+    const regs = await getNull("u1");
+    expect(regs).toEqual([]);
+  });
+
+  it("returns mapped registrations from Firestore docs", async () => {
+    mockGetDocs.mockResolvedValue({
+      docs: [
+        { data: () => ({ id: "u1_e1", eventId: "e1" }) },
+        { data: () => ({ id: "u1_e2", eventId: "e2" }) },
+      ],
+    } as never);
+    const regs = await getUserRegistrations("u1");
+    expect(regs).toEqual([
+      { id: "u1_e1", eventId: "e1" },
+      { id: "u1_e2", eventId: "e2" },
+    ]);
+  });
+});
+
+describe("isUserRegistered", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns false when db is null", async () => {
+    jest.resetModules();
+    jest.doMock("@/lib/firebase", () => ({ db: null }));
+    const { isUserRegistered: isNull } = await import("@/lib/registrations");
+    expect(await isNull("u1", "e1")).toBe(false);
+  });
+
+  it("returns true when registration document exists", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => true } as never);
+    expect(await isUserRegistered("u1", "e1")).toBe(true);
+  });
+
+  it("returns false when registration document does not exist", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false } as never);
+    expect(await isUserRegistered("u1", "e1")).toBe(false);
   });
 });

--- a/__tests__/lib/server-auth.test.ts
+++ b/__tests__/lib/server-auth.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { NextRequest } from "next/server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, getOptionalVerifiedUser } from "@/lib/server-auth";
 import { getAdminAuth } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -12,10 +12,14 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 const mockGetAdminAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
 
-function makeRequest() {
-  return new NextRequest("http://localhost/api/test", {
-    headers: { Authorization: "Bearer test-token" },
-  });
+function makeRequest(headers: Record<string, string> = { Authorization: "Bearer test-token" }) {
+  return new NextRequest("http://localhost/api/test", { headers });
+}
+
+function mockVerify(returnValue: Record<string, unknown>) {
+  mockGetAdminAuth.mockReturnValue({
+    verifyIdToken: jest.fn(async () => returnValue),
+  } as never);
 }
 
 describe("getVerifiedUser admin authorization bridge", () => {
@@ -26,57 +30,202 @@ describe("getVerifiedUser admin authorization bridge", () => {
   });
 
   it("allows admin via explicit claim", async () => {
-    mockGetAdminAuth.mockReturnValue({
-      verifyIdToken: jest.fn(async () => ({
-        uid: "u1",
-        email: "member@example.com",
-        admin: true,
-      })),
-    } as never);
-
+    mockVerify({ uid: "u1", email: "member@example.com", admin: true });
     const user = await getVerifiedUser(makeRequest());
-
     expect(user?.isAdmin).toBe(true);
   });
 
   it("allows fallback email admin when no explicit admin claim fields exist", async () => {
-    mockGetAdminAuth.mockReturnValue({
-      verifyIdToken: jest.fn(async () => ({
-        uid: "u2",
-        email: "legacy-admin@example.com",
-      })),
-    } as never);
-
+    mockVerify({ uid: "u2", email: "legacy-admin@example.com" });
     const user = await getVerifiedUser(makeRequest());
-
     expect(user?.isAdmin).toBe(true);
   });
 
   it("does not override explicit non-admin claim with fallback email", async () => {
-    mockGetAdminAuth.mockReturnValue({
-      verifyIdToken: jest.fn(async () => ({
-        uid: "u3",
-        email: "legacy-admin@example.com",
-        role: "member",
-      })),
-    } as never);
-
+    mockVerify({ uid: "u3", email: "legacy-admin@example.com", role: "member" });
     const user = await getVerifiedUser(makeRequest());
-
     expect(user?.isAdmin).toBe(false);
   });
 
   it("denies admin when no explicit claim and no fallback email match", async () => {
-    mockGetAdminAuth.mockReturnValue({
-      verifyIdToken: jest.fn(async () => ({
-        uid: "u4",
-        email: "member@example.com",
-      })),
-    } as never);
-
+    mockVerify({ uid: "u4", email: "member@example.com" });
     const user = await getVerifiedUser(makeRequest());
-
     expect(user?.isAdmin).toBe(false);
+  });
+
+  // OpenSSF Gold coverage push #11 — broader branch coverage
+
+  it("returns null when no Authorization or x-firebase-id-token header is present", async () => {
+    const req = new NextRequest("http://localhost/api/test");
+    const user = await getVerifiedUser(req);
+    expect(user).toBeNull();
+    expect(mockGetAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("accepts token from x-firebase-id-token header when no Bearer", async () => {
+    mockVerify({ uid: "u5", email: "member@example.com" });
+    const user = await getVerifiedUser(
+      makeRequest({ "x-firebase-id-token": "alt-token" }),
+    );
+    expect(user?.uid).toBe("u5");
+  });
+
+  it("Bearer header takes precedence over x-firebase-id-token", async () => {
+    const verifyFn = jest.fn(async () => ({ uid: "primary", email: "x@y" }));
+    mockGetAdminAuth.mockReturnValue({ verifyIdToken: verifyFn } as never);
+    await getVerifiedUser(
+      makeRequest({
+        Authorization: "Bearer primary-token",
+        "x-firebase-id-token": "alt-token",
+      }),
+    );
+    expect(verifyFn).toHaveBeenCalledWith("primary-token", false);
+  });
+
+  it("throws when Firebase Admin Auth is not configured", async () => {
+    mockGetAdminAuth.mockReturnValue(null as never);
+    await expect(getVerifiedUser(makeRequest())).rejects.toThrow(
+      "Firebase Admin Auth is not configured",
+    );
+  });
+
+  it("hasAdminClaim: isAdmin=true grants admin", async () => {
+    mockVerify({ uid: "u6", email: "x", isAdmin: true });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("hasAdminClaim: role='admin' grants admin", async () => {
+    mockVerify({ uid: "u7", email: "x", role: "admin" });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+    expect(user?.role).toBe("admin");
+  });
+
+  it("hasAdminClaim: roles array containing 'admin' grants admin", async () => {
+    mockVerify({ uid: "u8", email: "x", roles: ["editor", "admin"] });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+    expect(user?.roles).toEqual(["editor", "admin"]);
+  });
+
+  it("hasAdminClaim: roles array without 'admin' does not grant admin", async () => {
+    mockVerify({ uid: "u9", email: "x", roles: ["editor"] });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(false);
+  });
+
+  it("toStringArray filters non-string entries from roles", async () => {
+    mockVerify({ uid: "u10", email: "x", roles: ["editor", 123, null, "admin"] });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.roles).toEqual(["editor", "admin"]);
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("toStringArray returns empty array when roles is not an array", async () => {
+    mockVerify({ uid: "u11", email: "x", roles: "admin" });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.roles).toEqual([]);
+    expect(user?.isAdmin).toBe(false);
+  });
+
+  it("falls back to ADMIN_EMAIL env when ADMIN_EMAILS is empty", async () => {
+    process.env.ADMIN_EMAILS = "";
+    process.env.ADMIN_EMAIL = "single-admin@example.com";
+    mockVerify({ uid: "u12", email: "single-admin@example.com" });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("legacy admin email match is case-insensitive and trims whitespace", async () => {
+    process.env.ADMIN_EMAILS = " UPPER@Example.com , other@example.com ";
+    mockVerify({ uid: "u13", email: "upper@example.com" });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("returns full user shape including name/picture passthrough", async () => {
+    mockVerify({
+      uid: "u14",
+      email: "x@y",
+      name: "Test User",
+      picture: "https://example.com/avatar.png",
+    });
+    const user = await getVerifiedUser(makeRequest());
+    expect(user).toMatchObject({
+      uid: "u14",
+      name: "Test User",
+      picture: "https://example.com/avatar.png",
+    });
+  });
+
+  it("ignores empty Bearer token (whitespace only)", async () => {
+    const user = await getVerifiedUser(makeRequest({ Authorization: "Bearer    " }));
+    // The regex `^Bearer\s+(.+)$` requires at least one non-whitespace char,
+    // so a Bearer with only whitespace doesn't match — falls through to
+    // null. (The fallthrough is the documented behavior.)
+    expect(user).toBeNull();
+  });
+});
+
+describe("getOptionalVerifiedUser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_EMAILS = "legacy-admin@example.com";
+    process.env.ADMIN_EMAIL = "";
+  });
+
+  it("returns null when no token is present", async () => {
+    const req = new NextRequest("http://localhost/api/test");
+    const user = await getOptionalVerifiedUser(req);
+    expect(user).toBeNull();
+  });
+
+  it("returns null (NOT throws) when admin auth is not configured", async () => {
+    mockGetAdminAuth.mockReturnValue(null as never);
+    const user = await getOptionalVerifiedUser(makeRequest());
+    expect(user).toBeNull();
+  });
+
+  it("returns null when verifyIdToken throws (invalid/expired token)", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => {
+        throw new Error("token expired");
+      }),
+    } as never);
+    const user = await getOptionalVerifiedUser(makeRequest());
+    expect(user).toBeNull();
+  });
+
+  it("returns the verified user on success", async () => {
+    mockVerify({ uid: "opt-1", email: "x@y", admin: true });
+    const user = await getOptionalVerifiedUser(makeRequest());
+    expect(user?.uid).toBe("opt-1");
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("derives admin via legacy email fallback for optional path too", async () => {
+    mockVerify({ uid: "opt-2", email: "legacy-admin@example.com" });
+    const user = await getOptionalVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+  });
+
+  it("denies admin when explicit non-admin claim exists for optional path", async () => {
+    mockVerify({
+      uid: "opt-3",
+      email: "legacy-admin@example.com",
+      role: "member",
+    });
+    const user = await getOptionalVerifiedUser(makeRequest());
+    expect(user?.isAdmin).toBe(false);
+  });
+
+  it("accepts x-firebase-id-token in the optional path", async () => {
+    mockVerify({ uid: "opt-4", email: "x@y" });
+    const user = await getOptionalVerifiedUser(
+      makeRequest({ "x-firebase-id-token": "alt" }),
+    );
+    expect(user?.uid).toBe("opt-4");
   });
 });
 


### PR DESCRIPTION
## Summary
Two coverage push PRs in Wave E (lib long tail):

- **#1130** `lib/server-auth.ts` — 54.38/49.05 → 98.24/96.22. Adds full `getOptionalVerifiedUser` coverage (was 0%). _@Ludwitt (with Claude)._
- **#1131** `lib/registrations.ts` — 47.91/8.33 → 100/100. Branch coverage was lowest in lib/. _@Ludwitt (with Claude)._

**Global coverage**: 81.14 → 81.28 stmt; 66.75 → 66.91 branch.

**Gold tier:** stays at 91% — coverage criteria still need ~8.7pp stmt / 13.1pp branch.

## Test plan
- [ ] CI green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)