### PR TITLE
test(api): cover 3 OAuth disconnect routes (Gold push #13)

### DIFF
--- a/__tests__/app/api/cursor/disconnect.route.test.ts
+++ b/__tests__/app/api/cursor/disconnect.route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #13 — cursor disconnect route.
+ */
+import { POST } from "@/app/api/cursor/disconnect/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/middleware", () => ({
+  withMiddleware: (_config: unknown, handler: (req: unknown) => unknown) => handler,
+  rateLimitConfigs: { oauthCallback: {} },
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { delete: jest.fn(() => "DELETE_FIELD") },
+}));
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+function fakeDb(behavior: { setOk?: boolean; deleteOk?: boolean } = {}) {
+  const setSpy = jest.fn().mockImplementation(() =>
+    behavior.setOk === false ? Promise.reject(new Error("set fail")) : Promise.resolve(),
+  );
+  const deleteSpy = jest.fn().mockImplementation(() =>
+    behavior.deleteOk === false ? Promise.reject(new Error("delete fail")) : Promise.resolve(),
+  );
+  const userDocChain = {
+    set: setSpy,
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({ delete: deleteSpy })),
+    })),
+  };
+  return {
+    spies: { setSpy, deleteSpy },
+    db: {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => userDocChain),
+      })),
+    } as never,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("POST /api/cursor/disconnect", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const { status, body } = await readJson(
+      await POST(makeRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(401);
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  it("returns 500 when admin db is not configured", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    mockDb.mockReturnValue(null as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("not_configured");
+  });
+
+  it("deletes cursor field + secrets doc on success", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const { db, spies } = fakeDb();
+    mockDb.mockReturnValue(db);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(200);
+    expect(body.disconnected).toBe(true);
+    expect(spies.setSpy).toHaveBeenCalledWith(
+      { cursor: "DELETE_FIELD" },
+      { merge: true },
+    );
+    expect(spies.deleteSpy).toHaveBeenCalled();
+  });
+
+  it("returns 500 disconnect_failed when set throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const { db } = fakeDb({ setOk: false });
+    mockDb.mockReturnValue(db);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+
+  it("returns 500 disconnect_failed when delete throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const { db } = fakeDb({ deleteOk: false });
+    mockDb.mockReturnValue(db);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+});

--- a/__tests__/app/api/ludwitt/disconnect.route.test.ts
+++ b/__tests__/app/api/ludwitt/disconnect.route.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #13 — ludwitt disconnect route.
+ */
+import { POST } from "@/app/api/ludwitt/disconnect/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { deleteLudwittTokens } from "@/lib/ludwitt-tokens";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/middleware", () => ({
+  withMiddleware: (_config: unknown, handler: (req: unknown) => unknown) => handler,
+  rateLimitConfigs: { standard: {} },
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/ludwitt-tokens", () => ({ deleteLudwittTokens: jest.fn() }));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { delete: jest.fn(() => "DELETE_FIELD") },
+}));
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockDeleteTokens = deleteLudwittTokens as jest.MockedFunction<typeof deleteLudwittTokens>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDeleteTokens.mockResolvedValue(undefined);
+});
+
+describe("POST /api/ludwitt/disconnect", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const { status, body } = await readJson(
+      await POST(makeRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(401);
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  it("returns 500 when admin db is not configured", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    mockDb.mockReturnValue(null as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("not_configured");
+  });
+
+  it("deletes tokens + ludwitt field on success", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const setSpy = jest.fn().mockResolvedValue(undefined);
+    mockDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({ set: setSpy })),
+      })),
+    } as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(200);
+    expect(body.disconnected).toBe(true);
+    expect(mockDeleteTokens).toHaveBeenCalledWith("u1");
+    expect(setSpy).toHaveBeenCalledWith(
+      { ludwitt: "DELETE_FIELD" },
+      { merge: true },
+    );
+  });
+
+  it("returns 500 disconnect_failed when deleteLudwittTokens throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    mockDb.mockReturnValue({ collection: jest.fn() } as never);
+    mockDeleteTokens.mockRejectedValue(new Error("ouch"));
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+
+  it("returns 500 disconnect_failed when set throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const setSpy = jest.fn().mockRejectedValue(new Error("set fail"));
+    mockDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({ set: setSpy })),
+      })),
+    } as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+});

--- a/__tests__/app/api/ludwitt/finalize-token.route.test.ts
+++ b/__tests__/app/api/ludwitt/finalize-token.route.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #13 — ludwitt finalize-token route.
+ */
+import { POST } from "@/app/api/ludwitt/finalize-token/route";
+import { LUDWITT_FINALIZE_COOKIE } from "@/lib/ludwitt-config";
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/middleware", () => ({
+  withMiddleware: (_config: unknown, handler: (req: unknown) => unknown) => handler,
+  rateLimitConfigs: { standard: {} },
+}));
+
+function makeReq(cookieValue: string | null) {
+  const headers = new Headers();
+  if (cookieValue !== null) {
+    headers.set("cookie", `${LUDWITT_FINALIZE_COOKIE}=${cookieValue}`);
+  }
+  return new NextRequest("https://example.com/api/ludwitt/finalize-token", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/ludwitt/finalize-token", () => {
+  it("returns 410 when finalize cookie is missing", async () => {
+    const res = await POST(makeReq(null));
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toBe("expired");
+  });
+
+  it("returns the token from the cookie and clears it on success", async () => {
+    const res = await POST(makeReq("the-token"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("the-token");
+    // Cookie cleared via maxAge=0
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain(LUDWITT_FINALIZE_COOKIE);
+    expect(setCookie.toLowerCase()).toContain("max-age=0");
+  });
+});


### PR DESCRIPTION
## Summary
Bundle of small OAuth disconnect/finalize routes that had 0% branch coverage.

| Route | Stmt | Branch |
|---|---|---|
| `cursor/disconnect` | 48 → **92** | 0 → **100** |
| `ludwitt/disconnect` | 44 → **92** | 0 → **100** |
| `ludwitt/finalize-token` | 47 → **86.66** | 0 → **100** |

12 tests total. withMiddleware passthrough mock used so handler logic runs directly.

## Test plan
- [x] `npx jest --testPathPatterns='__tests__/app/api/(cursor/disconnect|ludwitt/(disconnect|finalize-token))' --coverage` — 12/12 pass
- [ ] CI green (full suite)