### PR TITLE
release: OpenSSF Gold coverage pushes #13-#15 (OAuth + small routes)

### DIFF
--- a/__tests__/app/api/cursor/disconnect.route.test.ts
+++ b/__tests__/app/api/cursor/disconnect.route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #13 — cursor disconnect route.
+ */
+import { POST } from "@/app/api/cursor/disconnect/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/middleware", () => ({
+  withMiddleware: (_config: unknown, handler: (req: unknown) => unknown) => handler,
+  rateLimitConfigs: { oauthCallback: {} },
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { delete: jest.fn(() => "DELETE_FIELD") },
+}));
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+function fakeDb(behavior: { setOk?: boolean; deleteOk?: boolean } = {}) {
+  const setSpy = jest.fn().mockImplementation(() =>
+    behavior.setOk === false ? Promise.reject(new Error("set fail")) : Promise.resolve(),
+  );
+  const deleteSpy = jest.fn().mockImplementation(() =>
+    behavior.deleteOk === false ? Promise.reject(new Error("delete fail")) : Promise.resolve(),
+  );
+  const userDocChain = {
+    set: setSpy,
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({ delete: deleteSpy })),
+    })),
+  };
+  return {
+    spies: { setSpy, deleteSpy },
+    db: {
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => userDocChain),
+      })),
+    } as never,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("POST /api/cursor/disconnect", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const { status, body } = await readJson(
+      await POST(makeRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(401);
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  it("returns 500 when admin db is not configured", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    mockDb.mockReturnValue(null as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("not_configured");
+  });
+
+  it("deletes cursor field + secrets doc on success", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const { db, spies } = fakeDb();
+    mockDb.mockReturnValue(db);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(200);
+    expect(body.disconnected).toBe(true);
+    expect(spies.setSpy).toHaveBeenCalledWith(
+      { cursor: "DELETE_FIELD" },
+      { merge: true },
+    );
+    expect(spies.deleteSpy).toHaveBeenCalled();
+  });
+
+  it("returns 500 disconnect_failed when set throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const { db } = fakeDb({ setOk: false });
+    mockDb.mockReturnValue(db);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+
+  it("returns 500 disconnect_failed when delete throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const { db } = fakeDb({ deleteOk: false });
+    mockDb.mockReturnValue(db);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/cursor/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+});

--- a/__tests__/app/api/github/authorize.route.test.ts
+++ b/__tests__/app/api/github/authorize.route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #14 — github authorize route.
+ */
+import { GET } from "@/app/api/github/authorize/route";
+import { NextRequest } from "next/server";
+
+function makeReq(url: string) {
+  return new NextRequest(url, { method: "GET" });
+}
+
+describe("GET /api/github/authorize", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("redirects to error page when GITHUB_CLIENT_ID is missing", async () => {
+    delete process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID;
+    jest.resetModules();
+    const { GET: getFresh } = await import("@/app/api/github/authorize/route");
+    const res = await getFresh(makeReq("https://example.com/api/github/authorize"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/profile?github=error&message=not_configured");
+  });
+
+  it("redirects to GitHub OAuth + sets state cookie on happy path", async () => {
+    process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID = "fake-client";
+    delete process.env.NEXT_PUBLIC_GITHUB_REDIRECT_URI;
+    jest.resetModules();
+    const { GET: getFresh } = await import("@/app/api/github/authorize/route");
+    const res = await getFresh(makeReq("https://example.com/api/github/authorize"));
+    expect(res.status).toBe(307);
+    const loc = res.headers.get("location") || "";
+    expect(loc).toContain("https://github.com/login/oauth/authorize?");
+    expect(loc).toContain("client_id=fake-client");
+    expect(loc).toContain("scope=read%3Auser");
+    expect(loc).toContain("redirect_uri=");
+    expect(loc).toMatch(/state=[A-Za-z0-9_-]{40,}/);
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain("github_oauth_state=");
+  });
+
+  it("respects NEXT_PUBLIC_GITHUB_REDIRECT_URI when set", async () => {
+    process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID = "fake-client";
+    process.env.NEXT_PUBLIC_GITHUB_REDIRECT_URI = "https://override.example.com/cb";
+    jest.resetModules();
+    const { GET: getFresh } = await import("@/app/api/github/authorize/route");
+    const res = await getFresh(makeReq("https://example.com/api/github/authorize"));
+    const loc = res.headers.get("location") || "";
+    expect(loc).toContain("redirect_uri=" + encodeURIComponent("https://override.example.com/cb"));
+  });
+
+  it("sets return_to cookie for safe relative returnTo", async () => {
+    process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID = "fake-client";
+    jest.resetModules();
+    const { GET: getFresh } = await import("@/app/api/github/authorize/route");
+    const res = await getFresh(
+      makeReq("https://example.com/api/github/authorize?returnTo=/profile%3Ftab%3Dconnections"),
+    );
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain("github_oauth_return_to=");
+  });
+
+  it("rejects open-redirect returnTo (starts with //)", async () => {
+    process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID = "fake-client";
+    jest.resetModules();
+    const { GET: getFresh } = await import("@/app/api/github/authorize/route");
+    const res = await getFresh(
+      makeReq("https://example.com/api/github/authorize?returnTo=//evil.com/x"),
+    );
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).not.toContain("github_oauth_return_to=");
+  });
+
+  it("rejects returnTo not starting with /", async () => {
+    process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID = "fake-client";
+    jest.resetModules();
+    const { GET: getFresh } = await import("@/app/api/github/authorize/route");
+    const res = await getFresh(
+      makeReq("https://example.com/api/github/authorize?returnTo=https://evil.com"),
+    );
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).not.toContain("github_oauth_return_to=");
+  });
+
+  it("does not set return_to cookie when returnTo is absent", async () => {
+    process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID = "fake-client";
+    jest.resetModules();
+    const { GET: getFresh } = await import("@/app/api/github/authorize/route");
+    const res = await getFresh(
+      makeReq("https://example.com/api/github/authorize"),
+    );
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).not.toContain("github_oauth_return_to=");
+  });
+});

--- a/__tests__/app/api/ludwitt/authorize.route.test.ts
+++ b/__tests__/app/api/ludwitt/authorize.route.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #15 — ludwitt authorize (OAuth init).
+ */
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/ludwitt/authorize/route";
+import {
+  getLudwittClientId,
+  getLudwittRedirectUri,
+  LUDWITT_AUTHORIZE_URL,
+  LUDWITT_STATE_COOKIE,
+  LUDWITT_PKCE_COOKIE,
+  LUDWITT_RETURN_TO_COOKIE,
+} from "@/lib/ludwitt-config";
+
+jest.mock("@/lib/ludwitt-config", () => {
+  const actual = jest.requireActual("@/lib/ludwitt-config");
+  return {
+    ...actual,
+    getLudwittClientId: jest.fn(),
+    getLudwittRedirectUri: jest.fn(),
+  };
+});
+
+const mockClientId = getLudwittClientId as jest.MockedFunction<typeof getLudwittClientId>;
+const mockRedirectUri = getLudwittRedirectUri as jest.MockedFunction<typeof getLudwittRedirectUri>;
+
+function makeReq(url: string) {
+  return new NextRequest(url, { method: "GET" });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockClientId.mockReturnValue("lc-1");
+  mockRedirectUri.mockReturnValue("https://example.com/api/ludwitt/callback");
+});
+
+describe("GET /api/ludwitt/authorize", () => {
+  it("redirects to login error page when client_id missing", async () => {
+    mockClientId.mockReturnValue(null);
+    const res = await GET(makeReq("https://example.com/api/ludwitt/authorize"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("ludwitt=error&message=not_configured");
+  });
+
+  it("redirects to Ludwitt authorize URL with all OAuth params + PKCE", async () => {
+    const res = await GET(makeReq("https://example.com/api/ludwitt/authorize"));
+    expect(res.status).toBe(307);
+    const loc = res.headers.get("location") || "";
+    expect(loc.startsWith(LUDWITT_AUTHORIZE_URL)).toBe(true);
+    expect(loc).toContain("client_id=lc-1");
+    expect(loc).toContain("response_type=code");
+    expect(loc).toContain("code_challenge_method=S256");
+    expect(loc).toMatch(/code_challenge=[A-Za-z0-9_-]{20,}/);
+    expect(loc).toMatch(/state=[A-Za-z0-9_-]{40,}/);
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain(LUDWITT_STATE_COOKIE);
+    expect(setCookie).toContain(LUDWITT_PKCE_COOKIE);
+  });
+
+  it("sets return_to cookie for safe relative returnTo", async () => {
+    const res = await GET(
+      makeReq("https://example.com/api/ludwitt/authorize?returnTo=/profile"),
+    );
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain(LUDWITT_RETURN_TO_COOKIE);
+  });
+
+  it("rejects open-redirect returnTo (starts with //)", async () => {
+    const res = await GET(
+      makeReq("https://example.com/api/ludwitt/authorize?returnTo=//evil.com"),
+    );
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).not.toContain(LUDWITT_RETURN_TO_COOKIE);
+  });
+
+  it("rejects absolute-URL returnTo", async () => {
+    const res = await GET(
+      makeReq("https://example.com/api/ludwitt/authorize?returnTo=https://evil"),
+    );
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).not.toContain(LUDWITT_RETURN_TO_COOKIE);
+  });
+
+  it("does not set return_to cookie when returnTo is absent", async () => {
+    const res = await GET(makeReq("https://example.com/api/ludwitt/authorize"));
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).not.toContain(LUDWITT_RETURN_TO_COOKIE);
+  });
+});

--- a/__tests__/app/api/ludwitt/disconnect.route.test.ts
+++ b/__tests__/app/api/ludwitt/disconnect.route.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #13 — ludwitt disconnect route.
+ */
+import { POST } from "@/app/api/ludwitt/disconnect/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { deleteLudwittTokens } from "@/lib/ludwitt-tokens";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/middleware", () => ({
+  withMiddleware: (_config: unknown, handler: (req: unknown) => unknown) => handler,
+  rateLimitConfigs: { standard: {} },
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/ludwitt-tokens", () => ({ deleteLudwittTokens: jest.fn() }));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { delete: jest.fn(() => "DELETE_FIELD") },
+}));
+
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockDeleteTokens = deleteLudwittTokens as jest.MockedFunction<typeof deleteLudwittTokens>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDeleteTokens.mockResolvedValue(undefined);
+});
+
+describe("POST /api/ludwitt/disconnect", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+    const { status, body } = await readJson(
+      await POST(makeRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(401);
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  it("returns 500 when admin db is not configured", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    mockDb.mockReturnValue(null as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("not_configured");
+  });
+
+  it("deletes tokens + ludwitt field on success", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const setSpy = jest.fn().mockResolvedValue(undefined);
+    mockDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({ set: setSpy })),
+      })),
+    } as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(200);
+    expect(body.disconnected).toBe(true);
+    expect(mockDeleteTokens).toHaveBeenCalledWith("u1");
+    expect(setSpy).toHaveBeenCalledWith(
+      { ludwitt: "DELETE_FIELD" },
+      { merge: true },
+    );
+  });
+
+  it("returns 500 disconnect_failed when deleteLudwittTokens throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    mockDb.mockReturnValue({ collection: jest.fn() } as never);
+    mockDeleteTokens.mockRejectedValue(new Error("ouch"));
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+
+  it("returns 500 disconnect_failed when set throws", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    const setSpy = jest.fn().mockRejectedValue(new Error("set fail"));
+    mockDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({ set: setSpy })),
+      })),
+    } as never);
+    const { status, body } = await readJson(
+      await POST(makeAuthedRequest({ method: "POST", path: "/api/ludwitt/disconnect" })),
+    );
+    expect(status).toBe(500);
+    expect(body.error).toBe("disconnect_failed");
+  });
+});

--- a/__tests__/app/api/ludwitt/finalize-token.route.test.ts
+++ b/__tests__/app/api/ludwitt/finalize-token.route.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #13 — ludwitt finalize-token route.
+ */
+import { POST } from "@/app/api/ludwitt/finalize-token/route";
+import { LUDWITT_FINALIZE_COOKIE } from "@/lib/ludwitt-config";
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/middleware", () => ({
+  withMiddleware: (_config: unknown, handler: (req: unknown) => unknown) => handler,
+  rateLimitConfigs: { standard: {} },
+}));
+
+function makeReq(cookieValue: string | null) {
+  const headers = new Headers();
+  if (cookieValue !== null) {
+    headers.set("cookie", `${LUDWITT_FINALIZE_COOKIE}=${cookieValue}`);
+  }
+  return new NextRequest("https://example.com/api/ludwitt/finalize-token", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/ludwitt/finalize-token", () => {
+  it("returns 410 when finalize cookie is missing", async () => {
+    const res = await POST(makeReq(null));
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toBe("expired");
+  });
+
+  it("returns the token from the cookie and clears it on success", async () => {
+    const res = await POST(makeReq("the-token"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("the-token");
+    // Cookie cleared via maxAge=0
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain(LUDWITT_FINALIZE_COOKIE);
+    expect(setCookie.toLowerCase()).toContain("max-age=0");
+  });
+});


### PR DESCRIPTION
## Summary
Three coverage push PRs targeting small OAuth + disconnect routes:

- **#1133** cursor/disconnect + ludwitt/disconnect + ludwitt/finalize-token bundle — 44-48 → 86-92 stmt; 0 → 100 branch. _@Ludwitt (with Claude)._
- **#1134** github/authorize — 31 → 93.1 stmt; 8 → 100 branch. Open-redirect sanitization tested. _@Ludwitt (with Claude)._
- **#1135** ludwitt/authorize — 30 → 93.33 stmt; 10 → 100 branch. PKCE flow with state + code_challenge tested. _@Ludwitt (with Claude)._

## Test plan
- [ ] CI green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)