### PR TITLE
test(openssf-gold): coverage push #34 — github merged-PR reconcile guards

### DIFF
--- a/__tests__/lib/github-merged-pr-reconcile.test.ts
+++ b/__tests__/lib/github-merged-pr-reconcile.test.ts
@@ -2,7 +2,10 @@
  * @jest-environment node
  */
 
-import { reconcileMergedPrCreditForUser } from "@/lib/github-merged-pr-reconcile";
+import {
+  fetchMergedPullRequestsForAuthor,
+  reconcileMergedPrCreditForUser,
+} from "@/lib/github-merged-pr-reconcile";
 import { getAdminDb } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/logger", () => ({
@@ -128,5 +131,107 @@ describe("reconcileMergedPrCreditForUser", () => {
       }),
       { merge: true }
     );
+  });
+
+  it("throws when admin db is null", async () => {
+    mockGetAdminDb.mockReturnValueOnce(null as never);
+    await expect(reconcileMergedPrCreditForUser("u1", "alice")).rejects.toThrow(
+      "Firebase Admin",
+    );
+  });
+
+  it("throws when github login is empty / whitespace", async () => {
+    mockGetAdminDb.mockReturnValueOnce({} as never);
+    await expect(reconcileMergedPrCreditForUser("u1", "   ")).rejects.toThrow(
+      "GitHub login is required",
+    );
+  });
+
+});
+
+describe("fetchMergedPullRequestsForAuthor", () => {
+  const originalFetch = global.fetch;
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = { ...originalEnv };
+  });
+
+  it("returns [] for empty / whitespace login without calling fetch", async () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as never;
+    expect(await fetchMergedPullRequestsForAuthor("")).toEqual([]);
+    expect(await fetchMergedPullRequestsForAuthor("   ")).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when github search returns non-OK", async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 503,
+      text: async () => "service unavailable",
+    })) as typeof fetch;
+    await expect(fetchMergedPullRequestsForAuthor("alice")).rejects.toThrow(
+      "GitHub merged PR search failed",
+    );
+  });
+
+  it("includes Authorization Bearer header when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_secret";
+    const fetchSpy = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ items: [] }),
+    }));
+    global.fetch = fetchSpy as never;
+    await fetchMergedPullRequestsForAuthor("alice");
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init as { headers: Record<string, string> }).headers.Authorization).toBe(
+      "Bearer ghp_secret",
+    );
+  });
+
+  it("breaks pagination when a page returns empty items array", async () => {
+    const fetchSpy = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ items: [] }),
+    }));
+    global.fetch = fetchSpy as never;
+    const items = await fetchMergedPullRequestsForAuthor("alice");
+    expect(items).toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("breaks pagination when a page has fewer than SEARCH_PER_PAGE items", async () => {
+    let calls = 0;
+    const fetchSpy = jest.fn(async () => {
+      calls += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          items: Array.from({ length: 3 }, (_, i) => ({
+            number: i + 1,
+            title: `PR ${i + 1}`,
+            html_url: `https://example.com/${i + 1}`,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            closed_at: "2026-01-01T00:01:00Z",
+            user: { login: "alice" },
+          })),
+        }),
+      };
+    });
+    global.fetch = fetchSpy as never;
+    const items = await fetchMergedPullRequestsForAuthor("alice");
+    expect(items).toHaveLength(3);
+    expect(calls).toBe(1); // Did not fetch page 2 because page 1 had < 100
+  });
+
+  it("handles items=undefined in response (defaults to [])", async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    })) as typeof fetch;
+    expect(await fetchMergedPullRequestsForAuthor("alice")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #34.

Backfills guard paths and pagination break conditions in `lib/github-merged-pr-reconcile.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 85.18% | **95.06%** |
| Branches | 58.06% | **80.64%** |
| Functions | 83.33% | **83.33%** |
| Lines | 89.33% | **97.33%** |

7 new tests cover: admin db null in reconcile guard, empty/whitespace github login, the empty-login no-fetch early-return, GitHub search non-OK error, `Authorization: Bearer` header when `GITHUB_TOKEN` set, and both pagination break conditions (empty items array + page < SEARCH_PER_PAGE).

Branch coverage +22.58pp.

## Test plan
- [x] `npx jest __tests__/lib/github-merged-pr-reconcile` — 9/9 pass
- [x] Library at 95.06% stmt / 80.64% branch / 83.33% fn / 97.33% lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)