### PR TITLE
test(openssf-gold): coverage push #36 — middleware CSRF same-origin paths

### DIFF
--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -135,6 +135,43 @@ describe("isOriginAllowed", () => {
       isOriginAllowed(makeRequest({ method: "POST", referer: "not a url" }))
     ).toBe(false);
   });
+
+  it("returns true when origin equals the request URL origin (same-origin POST)", () => {
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          origin: "http://localhost:3000",
+          url: "http://localhost:3000/api/x",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when referer origin equals the request URL origin (same-origin)", () => {
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          referer: "http://localhost:3000/path/to/page",
+          url: "http://localhost:3000/api/x",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when referer origin matches NEXT_PUBLIC_APP_URL", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://staging.example.com";
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          referer: "https://staging.example.com/some/page",
+        }),
+      ),
+    ).toBe(true);
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
 });
 
 describe("withCsrfProtection", () => {


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #36.

Backfills the three same-origin / NEXT_PUBLIC_APP_URL branches in `lib/middleware.ts` `isOriginAllowed`:

| Metric | Before | After |
|---|---|---|
| Statements | 95.34% | **98.83%** |
| Branches | 87.23% | **95.74%** |
| Functions | 100% | **100%** |
| Lines | 95.34% | **98.83%** |

3 new tests cover:
- Origin equals `new URL(request.url).origin` (same-origin POST)
- Referer origin equals request URL origin (same-origin via referer fallback)
- Referer origin matches `NEXT_PUBLIC_APP_URL` env var

## Test plan
- [x] `npx jest __tests__/lib/middleware` — 30/30 pass
- [x] Library at 98.83% stmt / 95.74% branch / 100% fn / 98.83% lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)