### PR TITLE
test(openssf-gold): coverage push #38 — pydata score.json error paths

### DIFF
--- a/__tests__/lib/pydata-submissions.test.ts
+++ b/__tests__/lib/pydata-submissions.test.ts
@@ -270,6 +270,88 @@ describe("getPyDataSubmissions", () => {
       { displayName: "Co B", githubHandle: null },
     ]);
   });
+
+  it("silently ignores a malformed score.json (still returns the submission, no score)", () => {
+    const result = withTempCwd((root) => {
+      const folder = path.join(root, PYDATA_SUBMISSIONS_DIR, "scored-bad");
+      fs.mkdirSync(folder, { recursive: true });
+      fs.writeFileSync(path.join(folder, "submission.py"), "# marimo notebook\n");
+      fs.writeFileSync(
+        path.join(folder, "meta.json"),
+        JSON.stringify({ title: "T", description: "D", displayName: "T" }),
+      );
+      fs.writeFileSync(path.join(folder, "score.json"), "{ not valid json");
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].score).toBeNull();
+  });
+
+  it("ignores a score.json with out-of-range score", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-oor",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: 11, rationale: "too high", model: "claude" } },
+      );
+    });
+    expect(result[0].score).toBeNull();
+  });
+
+  it("ignores a score.json with non-numeric score", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-non-num",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: "not a number", rationale: "x", model: "claude" } },
+      );
+    });
+    expect(result[0].score).toBeNull();
+  });
+
+  it("ignores a score.json with empty rationale", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-no-rationale",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: 7, rationale: "", model: "claude" } },
+      );
+    });
+    expect(result[0].score).toBeNull();
+  });
+
+  it("defaults missing model to 'unknown' in a valid score.json", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-no-model",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: 8, rationale: "good work" } },
+      );
+    });
+    expect(result[0].score?.model).toBe("unknown");
+  });
+
+  it("returns [] when the on-disk readdir throws (e.g. permission denied)", () => {
+    const original = process.cwd();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pydata-readdir-throw-"));
+    try {
+      process.chdir(tmp);
+      const base = path.join(tmp, PYDATA_SUBMISSIONS_DIR);
+      fs.mkdirSync(base, { recursive: true });
+      const readdirSpy = jest.spyOn(fs, "readdirSync").mockImplementation(() => {
+        throw new Error("EACCES");
+      });
+      const result = getPyDataSubmissions();
+      expect(result).toEqual([]);
+      readdirSpy.mockRestore();
+    } finally {
+      process.chdir(original);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("submissions constants", () => {


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #38.

Backfills score-loading and filesystem-error paths in `lib/pydata-submissions.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 93.44% | **96.72%** |
| Branches | 87.67% | **93.15%** |
| Functions | 100% | **100%** |
| Lines | 98% | **100%** |

6 new tests cover malformed score.json JSON parse, out-of-range score, non-numeric score, empty rationale, missing-model defaulting to "unknown", and the readdirSync-throw → [] graceful filesystem failure.

## Test plan
- [x] `npx jest __tests__/lib/pydata-submissions` — 19/19 pass
- [x] Library at 96.72% stmt / 93.15% branch / 100% fn / 100% lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)