### PR TITLE
release: develop → main (OpenSSF Gold coverage pushes #18-#38, 21 PRs)

### DIFF
--- a/__tests__/app/api/cursor/idea-runs.route.test.ts
+++ b/__tests__/app/api/cursor/idea-runs.route.test.ts
@@ -501,4 +501,188 @@ describe("Cursor idea runs API", () => {
       status: "running",
     });
   });
+
+  it("recover-agent returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "unauthenticated" });
+  });
+
+  it("recover-agent returns 500 when admin db missing", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "not_configured" });
+  });
+
+  it("recover-agent returns 404 when run does not exist for user", async () => {
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/missing-run/recover-agent", "POST", {}),
+      params("missing-run"),
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "not_found" });
+  });
+
+  it("recover-agent returns 409 when ideas stage has no result or selectedIdea", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "ideas",
+      cursorAgentId: "bc-agent-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "recovery_not_available" });
+  });
+
+  it("recover-agent advances from ideas → questions when selectedIdea exists", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "ideas",
+      cursorAgentId: "bc-agent-1",
+      selectedIdea: "Add a cache layer",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(202);
+    expect(mockLaunchCursorAgentRun).toHaveBeenCalledWith(
+      "cursor-key",
+      expect.any(String),
+      expect.stringContaining("run-1:questions:fresh"),
+      { name: "Cursor Boston PR questions", autoCreatePR: false },
+    );
+    expect(docs.get("run-1")).toMatchObject({
+      workflowStage: "questions",
+      questionRunId: "fresh-run-1",
+      status: "running",
+    });
+  });
+
+  it("recover-agent advances from questions → plan when selectedIdea + questions present", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "questions",
+      cursorAgentId: "bc-agent-1",
+      selectedIdea: "Refactor X",
+      questions: [{ id: "q1", text: "Scope?" }],
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(202);
+    expect(mockLaunchCursorAgentRun).toHaveBeenCalledWith(
+      "cursor-key",
+      expect.any(String),
+      expect.stringContaining("run-1:plan:fresh"),
+      { name: "Cursor Boston PR plan", autoCreatePR: false },
+    );
+    expect(docs.get("run-1")).toMatchObject({
+      workflowStage: "planning",
+      planRunId: "fresh-run-1",
+    });
+  });
+
+  it("recover-agent advances from ready_for_pr → pr stage with autoCreatePR=true and pr opening object", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "ready_for_pr",
+      cursorAgentId: "bc-agent-1",
+      buildResult: "Built it",
+      pr: { previous: "value" },
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(202);
+    expect(mockLaunchCursorAgentRun).toHaveBeenCalledWith(
+      "cursor-key",
+      expect.stringContaining("Open a pull request"),
+      expect.stringContaining("run-1:pr:fresh"),
+      { name: "Cursor Boston PR open", autoCreatePR: true },
+    );
+    expect(docs.get("run-1")).toMatchObject({
+      workflowStage: "pr_open",
+      prRunId: "fresh-run-1",
+    });
+    const stored = docs.get("run-1") as Record<string, unknown>;
+    expect(stored.pr).toMatchObject({ previous: "value", status: "opening" });
+  });
+
+  it("recover-agent returns 409 when workflowStage is not recoverable (e.g. running ideas with no buildPlan)", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      workflowStage: "plan_approval",
+      // No buildPlan → no recovery prompt
+      cursorAgentId: "bc-agent-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("recover-agent returns 500 when launchCursorAgentRun throws", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "plan_approval",
+      buildPlan: "## Plan",
+      cursorAgentId: "bc-agent-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockLaunchCursorAgentRun.mockRejectedValueOnce(new Error("cursor api 503"));
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/recover-agent/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/recover-agent", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "recovery_failed" });
+  });
 });

--- a/__tests__/app/api/cursor/idea-runs.route.test.ts
+++ b/__tests__/app/api/cursor/idea-runs.route.test.ts
@@ -863,6 +863,216 @@ describe("Cursor idea runs API", () => {
     expect(docs.has("run-1")).toBe(false);
   });
 
+  // -----------------------------
+  // POST / GET /api/cursor/idea-runs (root) — coverage push #26 (continued)
+  // -----------------------------
+
+  it("POST root returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await POST(request("/api/cursor/idea-runs", "POST", { interests: "x" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("POST root returns 500 when admin db missing", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await POST(request("/api/cursor/idea-runs", "POST", { interests: "x" }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "not_configured" });
+  });
+
+  it("POST root returns 400 when body is not valid JSON", async () => {
+    const { POST } = await import("@/app/api/cursor/idea-runs/route");
+    const req = new NextRequest("http://localhost/api/cursor/idea-runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_body" });
+  });
+
+  it("POST root returns 400 when body fails schema validation", async () => {
+    const { POST } = await import("@/app/api/cursor/idea-runs/route");
+    // interests must be a string; pass a number to trip the schema
+    const res = await POST(request("/api/cursor/idea-runs", "POST", { interests: 42 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST root returns 500 launch_failed when launchPrIdeaRun throws (non-connection)", async () => {
+    mockLaunchPrIdeaRun.mockRejectedValueOnce(new Error("cursor sdk 500"));
+    const { POST } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await POST(request("/api/cursor/idea-runs", "POST", { interests: "x" }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "launch_failed" });
+    // The error doc was persisted on the run row
+    expect(docs.get("run-1")).toMatchObject({ status: "error" });
+  });
+
+  it("GET root returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await GET(request("/api/cursor/idea-runs"));
+    expect(res.status).toBe(401);
+  });
+
+  it("GET root returns 500 when admin db missing", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await GET(request("/api/cursor/idea-runs"));
+    expect(res.status).toBe(500);
+  });
+
+  it("GET root returns 500 list_failed when firestore query throws", async () => {
+    const originalGet = collectionRef.get;
+    collectionRef.get = jest.fn().mockRejectedValueOnce(new Error("query failed"));
+    try {
+      const { GET } = await import("@/app/api/cursor/idea-runs/route");
+      const res = await GET(request("/api/cursor/idea-runs"));
+      expect(res.status).toBe(500);
+      expect(await res.json()).toMatchObject({ error: "list_failed" });
+    } finally {
+      collectionRef.get = originalGet;
+    }
+  });
+
+  it("GET root with refresh=false skips refreshNonTerminalRuns", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      workflowStage: "ideas",
+      cursorAgentId: "bc-agent-1",
+      cursorRunId: "run-sdk-1",
+      prompt: "Prompt",
+      inputs: {},
+      createdAt: "2026-05-19T12:00:00Z",
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await GET(request("/api/cursor/idea-runs?refresh=false"));
+    expect(res.status).toBe(200);
+    expect(mockGetCursorRunSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("GET root swallows MissingCursorConnectionError from getCursorApiKeyForUser during refresh", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      workflowStage: "ideas",
+      cursorAgentId: "bc-agent-1",
+      cursorRunId: "run-sdk-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockGetCursorApiKeyForUser.mockRejectedValueOnce(new MissingCursorConnectionError());
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await GET(request("/api/cursor/idea-runs"));
+    expect(res.status).toBe(200);
+    // No snapshot call because api key fetch failed
+    expect(mockGetCursorRunSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("GET root logs per-run errors from getCursorRunSnapshot but still returns 200", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      workflowStage: "ideas",
+      cursorAgentId: "bc-agent-1",
+      cursorRunId: "run-sdk-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockGetCursorRunSnapshot.mockRejectedValueOnce(new Error("snapshot failed"));
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await GET(request("/api/cursor/idea-runs"));
+    expect(res.status).toBe(200);
+  });
+
+  it("GET root sorts runs by createdAt millis using string and toMillis variants", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      prompt: "Prompt",
+      inputs: {},
+      createdAt: "2026-05-19T10:00:00Z", // String date branch
+    });
+    docs.set("run-2", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      prompt: "Prompt",
+      inputs: {},
+      createdAt: { toMillis: () => new Date("2026-05-19T12:00:00Z").getTime() }, // toMillis branch
+    });
+    docs.set("run-3", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      prompt: "Prompt",
+      inputs: {},
+      createdAt: null, // null branch → 0
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await GET(request("/api/cursor/idea-runs?refresh=false"));
+    const body = await res.json();
+    // toMillis (later time) first, then string, then null
+    expect(body.runs[0].id).toBe("run-2");
+    expect(body.runs[1].id).toBe("run-1");
+    expect(body.runs[2].id).toBe("run-3");
+  });
+
+  it("GET root refreshes a workflow run needing planning refresh (no buildPlan yet)", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished", // terminal status, but workflow needs refresh
+      workflowStage: "planning",
+      cursorAgentId: "bc-agent-1",
+      planRunId: "plan-run-1",
+      // buildPlan absent → needsWorkflowRefresh true
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    await GET(request("/api/cursor/idea-runs"));
+    expect(mockGetCursorRunSnapshot).toHaveBeenCalledWith(
+      "cursor-key",
+      "bc-agent-1",
+      "plan-run-1",
+    );
+  });
+
+  it("GET root sorts runs by createdAt millis desc using Date instances", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      prompt: "Prompt",
+      inputs: {},
+      createdAt: new Date(1000),
+    });
+    docs.set("run-2", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      prompt: "Prompt",
+      inputs: {},
+      createdAt: new Date(2000),
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/route");
+    const res = await GET(request("/api/cursor/idea-runs"));
+    const body = await res.json();
+    expect(body.runs[0].id).toBe("run-2");
+    expect(body.runs[1].id).toBe("run-1");
+  });
+
   it("DELETE [runId] returns 500 when the firestore delete itself throws", async () => {
     docs.set("run-1", {
       userId: "user-1",

--- a/__tests__/app/api/cursor/idea-runs.route.test.ts
+++ b/__tests__/app/api/cursor/idea-runs.route.test.ts
@@ -685,4 +685,214 @@ describe("Cursor idea runs API", () => {
     expect(res.status).toBe(500);
     expect(await res.json()).toMatchObject({ error: "recovery_failed" });
   });
+
+  // -----------------------------
+  // GET / DELETE /[runId] route — coverage push #26
+  // -----------------------------
+
+  it("GET [runId] returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("GET [runId] returns 500 when admin db missing", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(res.status).toBe(500);
+  });
+
+  it("GET [runId] returns the run without refresh when status terminal and no workflow", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      cursorAgentId: "bc-agent-1",
+      cursorRunId: "run-sdk-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(res.status).toBe(200);
+    // No refresh — snapshot was not called for this terminal run
+    expect(mockGetCursorRunSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("GET [runId] returns refreshSkipped=cursor_not_connected when api key missing", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      cursorAgentId: "bc-agent-1",
+      cursorRunId: "run-sdk-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockGetCursorApiKeyForUser.mockRejectedValueOnce(new MissingCursorConnectionError());
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.refreshSkipped).toBe("cursor_not_connected");
+  });
+
+  it("GET [runId] returns 500 when api key fetch fails with non-connection error", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      cursorAgentId: "bc-agent-1",
+      cursorRunId: "run-sdk-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockGetCursorApiKeyForUser.mockRejectedValueOnce(new Error("vault down"));
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "refresh_failed" });
+  });
+
+  it("GET [runId] swallows getCursorRunSnapshot error and writes cursorStatusDetail", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      cursorAgentId: "bc-agent-1",
+      cursorRunId: "run-sdk-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockGetCursorRunSnapshot.mockRejectedValueOnce(new Error("cursor 500"));
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(res.status).toBe(200);
+    // Did the route persist the status detail?
+    const stored = docs.get("run-1") as Record<string, unknown>;
+    expect(String(stored.cursorStatusDetail)).toContain("Could not sync");
+  });
+
+  it("GET [runId] picks planRunId when workflowStage='planning'", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      workflowStage: "planning",
+      cursorAgentId: "bc-agent-1",
+      planRunId: "plan-run-1",
+      // No buildPlan — refresh required
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(mockGetCursorRunSnapshot).toHaveBeenCalledWith("cursor-key", "bc-agent-1", "plan-run-1");
+  });
+
+  it("GET [runId] picks buildRunId when workflowStage='building'", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "running",
+      workflowStage: "building",
+      cursorAgentId: "bc-agent-1",
+      buildRunId: "build-run-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(mockGetCursorRunSnapshot).toHaveBeenCalledWith("cursor-key", "bc-agent-1", "build-run-1");
+  });
+
+  it("GET [runId] picks prRunId when workflowStage='pr_open' and pr is opening", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "pr_open",
+      cursorAgentId: "bc-agent-1",
+      prRunId: "pr-run-1",
+      pr: { status: "opening" },
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { GET } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    await GET(request("/api/cursor/idea-runs/run-1"), params("run-1"));
+    expect(mockGetCursorRunSnapshot).toHaveBeenCalledWith("cursor-key", "bc-agent-1", "pr-run-1");
+  });
+
+  it("DELETE [runId] returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { DELETE } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await DELETE(request("/api/cursor/idea-runs/run-1", "DELETE"), params("run-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE [runId] returns 500 when admin db missing", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { DELETE } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await DELETE(request("/api/cursor/idea-runs/run-1", "DELETE"), params("run-1"));
+    expect(res.status).toBe(500);
+  });
+
+  it("DELETE [runId] returns 404 when run does not exist", async () => {
+    const { DELETE } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await DELETE(request("/api/cursor/idea-runs/missing", "DELETE"), params("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE [runId] swallows deleteCursorAgent errors and still deletes the local doc", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      cursorAgentId: "bc-agent-1",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockDeleteCursorAgent.mockRejectedValueOnce(new Error("cursor api down"));
+    const { DELETE } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+    const res = await DELETE(request("/api/cursor/idea-runs/run-1", "DELETE"), params("run-1"));
+    expect(res.status).toBe(200);
+    expect(docs.has("run-1")).toBe(false);
+  });
+
+  it("DELETE [runId] returns 500 when the firestore delete itself throws", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      // Force the delete() to throw — override the doc's collection().doc() ref
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockImplementationOnce(() => {
+      // First call: getUserOwnedIdeaRun. Use the existing mockDb.
+      // Subsequent: throwing delete via a custom doc ref.
+      return mockDb;
+    });
+    // Hack: override the next collection().doc() to throw on delete by
+    // intercepting via collectionRef.doc temporarily
+    const originalDoc = collectionRef.doc;
+    collectionRef.doc = jest.fn((id?: string) => {
+      const ref = originalDoc(id);
+      ref.delete = jest.fn().mockRejectedValue(new Error("write conflict"));
+      return ref;
+    });
+    try {
+      const { DELETE } = await import("@/app/api/cursor/idea-runs/[runId]/route");
+      const res = await DELETE(request("/api/cursor/idea-runs/run-1", "DELETE"), params("run-1"));
+      expect(res.status).toBe(500);
+      expect(await res.json()).toMatchObject({ error: "delete_failed" });
+    } finally {
+      collectionRef.doc = originalDoc;
+    }
+  });
 });

--- a/__tests__/app/api/events/pydata-2026-withdraw.route.test.ts
+++ b/__tests__/app/api/events/pydata-2026-withdraw.route.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #23 — PyData 2026 withdraw POST route.
+ *
+ * Form-encoded POST that validates an HMAC token, marks the PyData
+ * registration as cancelled, and 303-redirects back to the confirmation
+ * page with a status query string. All response shapes here are
+ * redirects — the assertions read `response.headers.get('location')`.
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/events/pydata-2026/withdraw/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { verifyPydataWithdrawToken } from "@/lib/unsubscribe-token";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/unsubscribe-token", () => ({
+  verifyPydataWithdrawToken: jest.fn(),
+}));
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(),
+  getClientIdentifier: jest.fn(() => "client-1"),
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "TS") },
+}));
+
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockVerifyToken = verifyPydataWithdrawToken as jest.MockedFunction<
+  typeof verifyPydataWithdrawToken
+>;
+const mockRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+const VALID_TOKEN = "a".repeat(64); // 64 hex chars passes the regex
+const VALID_EMAIL = "user@example.com";
+
+function makeFormReq(body: Record<string, string> | null) {
+  const form = new URLSearchParams();
+  if (body) {
+    for (const [k, v] of Object.entries(body)) form.append(k, v);
+  }
+  return new NextRequest("https://example.com/api/events/pydata-2026/withdraw", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: form.toString(),
+  });
+}
+
+function setupDb(opts: { empty?: boolean; updateOk?: boolean } = {}) {
+  const update = jest.fn().mockResolvedValue(undefined);
+  if (opts.updateOk === false) update.mockRejectedValue(new Error("update failed"));
+  const docRef = { update };
+  const docs = opts.empty ? [] : [{ ref: docRef }];
+  const query = {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: jest.fn().mockResolvedValue({
+      empty: !!opts.empty,
+      docs,
+    }),
+  };
+  const db = { collection: jest.fn(() => query) };
+  mockDb.mockReturnValue(db as never);
+  return { db, query, update };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRateLimit.mockReturnValue({ success: true, remaining: 19, resetTime: Date.now() + 60000 } as never);
+  mockVerifyToken.mockReturnValue(true);
+});
+
+describe("POST /api/events/pydata-2026/withdraw", () => {
+  it("303 redirects to ?status=rate-limited when rate limit denied", async () => {
+    mockRateLimit.mockReturnValueOnce({
+      success: false,
+      remaining: 0,
+      resetTime: Date.now() + 60000,
+    } as never);
+    const res = await POST(makeFormReq({ email: VALID_EMAIL, token: VALID_TOKEN }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("status=rate-limited");
+  });
+
+  it("303 redirects to ?status=invalid when zod parse fails (missing fields)", async () => {
+    const res = await POST(makeFormReq({ email: "", token: "" }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("status=invalid");
+  });
+
+  it("303 redirects to ?status=invalid when formData throws", async () => {
+    // formData() throws when body is JSON instead of urlencoded
+    const req = new NextRequest("https://example.com/api/events/pydata-2026/withdraw", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-form-data",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("status=invalid");
+  });
+
+  it("303 redirects to ?status=invalid when token is not 64-hex", async () => {
+    const res = await POST(makeFormReq({ email: VALID_EMAIL, token: "short-token" }));
+    expect(res.headers.get("location")).toContain("status=invalid");
+  });
+
+  it("303 redirects to ?status=invalid when token has non-hex chars", async () => {
+    const res = await POST(
+      makeFormReq({ email: VALID_EMAIL, token: "Z".repeat(64) }),
+    );
+    expect(res.headers.get("location")).toContain("status=invalid");
+  });
+
+  it("303 redirects to ?status=invalid when HMAC verification fails", async () => {
+    mockVerifyToken.mockReturnValueOnce(false);
+    const res = await POST(makeFormReq({ email: VALID_EMAIL, token: VALID_TOKEN }));
+    expect(res.headers.get("location")).toContain("status=invalid");
+  });
+
+  it("303 redirects to ?status=error when admin db is null", async () => {
+    mockDb.mockReturnValue(null as never);
+    const res = await POST(makeFormReq({ email: VALID_EMAIL, token: VALID_TOKEN }));
+    expect(res.headers.get("location")).toContain("status=error");
+  });
+
+  it("303 redirects to ?status=success when no matching registration (does not leak existence)", async () => {
+    setupDb({ empty: true });
+    const res = await POST(makeFormReq({ email: VALID_EMAIL, token: VALID_TOKEN }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("status=success");
+  });
+
+  it("303 redirects to ?status=success and writes cancelled status on happy path", async () => {
+    const { update, query } = setupDb({});
+    const res = await POST(makeFormReq({ email: VALID_EMAIL, token: VALID_TOKEN }));
+    expect(res.headers.get("location")).toContain("status=success");
+    expect(update).toHaveBeenCalledWith({ status: "cancelled", updatedAt: "TS" });
+    expect(query.where).toHaveBeenCalledWith("email", "==", VALID_EMAIL);
+  });
+
+  it("normalises the email to lowercase + trimmed before the query", async () => {
+    const { query } = setupDb({});
+    await POST(
+      makeFormReq({ email: "   USER@EXAMPLE.COM   ", token: VALID_TOKEN }),
+    );
+    expect(query.where).toHaveBeenCalledWith("email", "==", VALID_EMAIL);
+  });
+
+  it("303 redirects to ?status=error when the update transaction throws", async () => {
+    setupDb({ updateOk: false });
+    const res = await POST(makeFormReq({ email: VALID_EMAIL, token: VALID_TOKEN }));
+    expect(res.headers.get("location")).toContain("status=error");
+  });
+});

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
@@ -1,0 +1,227 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #30 — Hack-a-Sprint 2026 credit-email POST.
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route";
+import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
+import { sendEmail } from "@/lib/mailgun";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+  getAdminAuth: jest.fn(),
+}));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
+  resolveHackASprint2026CreditForUser: jest.fn(),
+}));
+jest.mock("@/lib/mailgun", () => ({
+  sendEmail: jest.fn(),
+}));
+jest.mock("@/lib/rate-limit", () => ({
+  ...jest.requireActual("@/lib/rate-limit"),
+  getClientIdentifier: jest.fn(() => "client-1"),
+}));
+jest.mock("@/lib/upstash-rate-limit", () => ({
+  checkUpstashRateLimit: jest.fn(),
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "TS") },
+}));
+
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockResolve = resolveHackASprint2026CreditForUser as jest.MockedFunction<
+  typeof resolveHackASprint2026CreditForUser
+>;
+const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+
+function makeReq() {
+  return new NextRequest(
+    "https://example.com/api/hackathons/showcase/hack-a-sprint-2026/credit-email",
+    { method: "POST" },
+  );
+}
+
+interface DbOpts {
+  userDoc?: { exists: boolean; data?: Record<string, unknown> };
+  userSetThrows?: boolean;
+  authEmail?: string | null;
+}
+
+function setupAdmins(opts: DbOpts = {}) {
+  const userGet = jest.fn().mockResolvedValue({
+    exists: opts.userDoc?.exists ?? true,
+    data: () => opts.userDoc?.data ?? { displayName: "Alice" },
+  });
+  const userSet = jest.fn();
+  if (opts.userSetThrows) {
+    userSet.mockRejectedValue(new Error("write conflict"));
+  } else {
+    userSet.mockResolvedValue(undefined);
+  }
+  const userRef = { get: userGet, set: userSet };
+  mockDb.mockReturnValue({
+    collection: jest.fn(() => ({ doc: jest.fn(() => userRef) })),
+  } as never);
+  const authEmail = "authEmail" in opts ? opts.authEmail : "user@example.com";
+  mockAuth.mockReturnValue({
+    getUser: jest.fn().mockResolvedValue({ email: authEmail }),
+  } as never);
+  return { userGet, userSet };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRate.mockResolvedValue({ success: true } as never);
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+  mockResolve.mockResolvedValue({
+    ok: true,
+    creditUrl: "https://cursor.com/credit/xyz",
+  } as never);
+  mockSendEmail.mockResolvedValue(undefined as never);
+});
+
+describe("POST /api/hackathons/showcase/hack-a-sprint-2026/credit-email", () => {
+  it("returns 429 when client rate limit denied", async () => {
+    mockRate.mockResolvedValueOnce({ success: false, retryAfter: 30 } as never);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.retryAfterSeconds).toBe(30);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValueOnce(null);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when admin db is null", async () => {
+    mockDb.mockReturnValue(null as never);
+    mockAuth.mockReturnValue({ getUser: jest.fn() } as never);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when admin auth is null", async () => {
+    mockDb.mockReturnValue({ collection: jest.fn() } as never);
+    mockAuth.mockReturnValue(null as never);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 429 when per-uid rate limit denies", async () => {
+    setupAdmins();
+    mockRate
+      .mockResolvedValueOnce({ success: true } as never)
+      .mockResolvedValueOnce({ success: false, retryAfter: 10 } as never);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 with reason when resolveCredit returns ok=false", async () => {
+    setupAdmins();
+    mockResolve.mockResolvedValueOnce({ ok: false, reason: "no-team" } as never);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, reason: "no-team" });
+  });
+
+  it("returns ok=true alreadySent when email previously sent", async () => {
+    const { userSet } = setupAdmins({
+      userDoc: {
+        exists: true,
+        data: { displayName: "Alice", hackASprint2026CreditEmailSentAt: { __ts: "earlier" } },
+      },
+    });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: true,
+      alreadySent: true,
+      message: "Credit link was already emailed to you.",
+    });
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(userSet).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when auth has no email on the account", async () => {
+    setupAdmins({ authEmail: null });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("No email");
+  });
+
+  it("returns 400 when auth email is whitespace-only", async () => {
+    setupAdmins({ authEmail: "   " });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("falls back to 'there' when displayName is missing", async () => {
+    setupAdmins({ userDoc: { exists: true, data: {} } });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user@example.com",
+        text: expect.stringContaining("Hi there"),
+      }),
+    );
+  });
+
+  it("falls back to 'there' when displayName is non-string", async () => {
+    setupAdmins({ userDoc: { exists: true, data: { displayName: 42 } } });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("Hi there") }),
+    );
+  });
+
+  it("happy path: sends email and writes sentAt timestamp", async () => {
+    const { userSet } = setupAdmins({
+      userDoc: { exists: true, data: { displayName: "Alice" } },
+    });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, emailedTo: "user@example.com" });
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user@example.com",
+        subject: expect.stringContaining("Cursor credit link"),
+        text: expect.stringContaining("Hi Alice"),
+        html: expect.stringContaining("https://cursor.com/credit/xyz"),
+      }),
+    );
+    expect(userSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hackASprint2026CreditEmailSentAt: "TS",
+        updatedAt: "TS",
+      }),
+      { merge: true },
+    );
+  });
+
+  it("returns 500 when sendEmail throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    setupAdmins();
+    mockSendEmail.mockRejectedValueOnce(new Error("mailgun 5xx"));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to send email");
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #28 — Hack-a-Sprint 2026 judge-score POST.
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
+import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
+import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/hackathon-showcase", () => ({
+  ...jest.requireActual("@/lib/hackathon-showcase"),
+  fetchShowcaseSubmissionsFromGitHub: jest.fn(),
+}));
+jest.mock("@/lib/hackathon-showcase-admin", () => ({
+  userIsHackASprint2026Judge: jest.fn(),
+}));
+jest.mock("@/lib/hackathon-asprint-2026-schedule", () => ({
+  ...jest.requireActual("@/lib/hackathon-asprint-2026-schedule"),
+  getHackASprint2026Phase: jest.fn(),
+}));
+jest.mock("@/lib/rate-limit", () => ({
+  ...jest.requireActual("@/lib/rate-limit"),
+  getClientIdentifier: jest.fn(() => "client-1"),
+}));
+jest.mock("@/lib/upstash-rate-limit", () => ({
+  checkUpstashRateLimit: jest.fn(),
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "TS") },
+}));
+
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
+  typeof fetchShowcaseSubmissionsFromGitHub
+>;
+const mockIsJudge = userIsHackASprint2026Judge as jest.MockedFunction<
+  typeof userIsHackASprint2026Judge
+>;
+const mockPhase = getHackASprint2026Phase as jest.MockedFunction<typeof getHackASprint2026Phase>;
+const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+
+function makeReq(body: unknown) {
+  return new NextRequest(
+    "https://example.com/api/hackathons/showcase/hack-a-sprint-2026/judge-score",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+  );
+}
+
+function setupDb() {
+  const set = jest.fn().mockResolvedValue(undefined);
+  const doc = jest.fn(() => ({ set }));
+  const collection = jest.fn(() => ({ doc }));
+  mockDb.mockReturnValue({ collection } as never);
+  return { set, doc, collection };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRate.mockResolvedValue({ success: true, remaining: 9 } as never);
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+  mockPhase.mockReturnValue("peerVotingOpen");
+  mockIsJudge.mockResolvedValue(true);
+  mockSubs.mockResolvedValue([
+    { submissionId: "team-alpha", repoUrl: "https://github.com/x/a" } as never,
+    { submissionId: "team-beta", repoUrl: "https://github.com/x/b" } as never,
+  ]);
+});
+
+describe("POST /api/hackathons/showcase/hack-a-sprint-2026/judge-score", () => {
+  it("returns 429 when rate limit denied", async () => {
+    mockRate.mockResolvedValueOnce({
+      success: false,
+      remaining: 0,
+      retryAfter: 30,
+    } as never);
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(body.retryAfterSeconds).toBe(30);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when phase is not peerVotingOpen", async () => {
+    mockPhase.mockReturnValueOnce("submissionsOpen" as never);
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("judging window");
+  });
+
+  it("returns 500 when admin db is null", async () => {
+    mockDb.mockReturnValue(null as never);
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 403 when user is not a judge", async () => {
+    mockIsJudge.mockResolvedValueOnce(false);
+    setupDb();
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Not a judge");
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    setupDb();
+    const res = await POST(makeReq("not-json"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when schema validation fails (missing submissionId)", async () => {
+    setupDb();
+    const res = await POST(makeReq({ score: 8 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when score is out of range (>10)", async () => {
+    setupDb();
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 11 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when score is non-integer", async () => {
+    setupDb();
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 5.5 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("integer score 1-10");
+  });
+
+  it("returns 400 when submissionId is unknown to GitHub", async () => {
+    setupDb();
+    const res = await POST(makeReq({ submissionId: "team-ghost", score: 7 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Unknown submission");
+  });
+
+  it("normalises submissionId to lowercase + trimmed before lookup", async () => {
+    const { set, doc } = setupDb();
+    const res = await POST(makeReq({ submissionId: "  TEAM-ALPHA  ", score: 8 }));
+    expect(res.status).toBe(200);
+    expect(doc).toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        submissionId: "team-alpha",
+        judgeScores: { u1: 8 },
+      }),
+      { merge: true },
+    );
+  });
+
+  it("writes the score doc on happy path", async () => {
+    const { set } = setupDb();
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 9 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        submissionId: "team-alpha",
+        judgeScores: { u1: 9 },
+        updatedAt: "TS",
+      }),
+      { merge: true },
+    );
+  });
+
+  it("returns 500 when the firestore set call throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const set = jest.fn().mockRejectedValue(new Error("write conflict"));
+    mockDb.mockReturnValue({
+      collection: jest.fn(() => ({ doc: jest.fn(() => ({ set })) })),
+    } as never);
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("Failed to save");
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/me.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/me.route.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #31 — Hack-a-Sprint 2026 "me" GET route.
+ */
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/me/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  fetchShowcaseSubmissionsFromGitHub,
+  getJudgeUidSet,
+  githubUserHasMergedLabeledShowcasePr,
+} from "@/lib/hackathon-showcase";
+import { userIsHackASprint2026JudgeFromUserData } from "@/lib/hackathon-showcase-admin";
+import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
+import {
+  participantBallotComplete,
+  participantPrizeEligibility,
+} from "@/lib/hackathon-asprint-2026-participant-scoring";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/hackathon-showcase", () => ({
+  ...jest.requireActual("@/lib/hackathon-showcase"),
+  fetchShowcaseSubmissionsFromGitHub: jest.fn(),
+  getJudgeUidSet: jest.fn(),
+  githubUserHasMergedLabeledShowcasePr: jest.fn(),
+}));
+jest.mock("@/lib/hackathon-showcase-admin", () => ({
+  ...jest.requireActual("@/lib/hackathon-showcase-admin"),
+  userIsHackASprint2026JudgeFromUserData: jest.fn(),
+}));
+jest.mock("@/lib/hackathon-asprint-2026-schedule", () => ({
+  ...jest.requireActual("@/lib/hackathon-asprint-2026-schedule"),
+  getHackASprint2026Phase: jest.fn(),
+}));
+jest.mock("@/lib/hackathon-asprint-2026-participant-scoring", () => ({
+  ...jest.requireActual("@/lib/hackathon-asprint-2026-participant-scoring"),
+  participantBallotComplete: jest.fn(),
+  participantPrizeEligibility: jest.fn(),
+}));
+
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
+  typeof fetchShowcaseSubmissionsFromGitHub
+>;
+const mockJudgeUidSet = getJudgeUidSet as jest.MockedFunction<typeof getJudgeUidSet>;
+const mockHasMergedPr = githubUserHasMergedLabeledShowcasePr as jest.MockedFunction<
+  typeof githubUserHasMergedLabeledShowcasePr
+>;
+const mockIsJudgeFromUser = userIsHackASprint2026JudgeFromUserData as jest.MockedFunction<
+  typeof userIsHackASprint2026JudgeFromUserData
+>;
+const mockPhase = getHackASprint2026Phase as jest.MockedFunction<typeof getHackASprint2026Phase>;
+const mockBallot = participantBallotComplete as jest.MockedFunction<typeof participantBallotComplete>;
+const mockPrize = participantPrizeEligibility as jest.MockedFunction<
+  typeof participantPrizeEligibility
+>;
+
+function makeReq() {
+  return new NextRequest("https://example.com/api/hackathons/showcase/hack-a-sprint-2026/me");
+}
+
+interface DbOpts {
+  userDoc?: { exists: boolean; data?: Record<string, unknown> };
+  signupDoc?: { exists: boolean; data?: Record<string, unknown> };
+  psDoc?: { exists: boolean; data?: Record<string, unknown> };
+}
+
+function setupDb(opts: DbOpts = {}) {
+  const userSnap = {
+    exists: opts.userDoc?.exists ?? true,
+    data: () =>
+      opts.userDoc?.data ?? { github: { login: "alice-handle" } },
+  };
+  const signupSnap = {
+    exists: opts.signupDoc?.exists ?? true,
+    data: () => opts.signupDoc?.data ?? { checkedInAt: new Date() },
+  };
+  const psGet = jest.fn().mockResolvedValue({
+    exists: opts.psDoc?.exists ?? false,
+    data: () => opts.psDoc?.data ?? undefined,
+  });
+
+  const collection = jest.fn((name: string) => {
+    if (name === "hackathonASprint2026ParticipantScores") {
+      return { doc: jest.fn(() => ({ get: psGet })) };
+    }
+    return { doc: jest.fn(() => ({ id: "ref" })) };
+  });
+  const getAll = jest.fn().mockResolvedValue([signupSnap, userSnap]);
+  mockDb.mockReturnValue({ collection, getAll } as never);
+  return { psGet, getAll };
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+  mockJudgeUidSet.mockReturnValue(new Set());
+  mockIsJudgeFromUser.mockReturnValue(false);
+  mockPhase.mockReturnValue("checkin");
+  mockSubs.mockResolvedValue([
+    { submissionId: "team-alpha", githubLogin: "alice-handle" } as never,
+    { submissionId: "team-beta", githubLogin: "bob-handle" } as never,
+  ]);
+  mockHasMergedPr.mockResolvedValue(false);
+  mockBallot.mockReturnValue(false);
+  mockPrize.mockReturnValue({
+    eligible: false,
+    highScoreCount: 0,
+    requiredHighScores: 3,
+  } as never);
+  delete process.env.HACK_A_SPRINT_2026_ALLOWED_SUBMISSIONS;
+});
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("GET /api/hackathons/showcase/hack-a-sprint-2026/me", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValueOnce(null);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns default eligibility shape when admin db is null", async () => {
+    mockDb.mockReturnValue(null as never);
+    mockHasMergedPr.mockResolvedValueOnce(false);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      signedUp: false,
+      checkedIn: false,
+      githubLogin: null,
+      participantEligible: false,
+    });
+  });
+
+  it("marks user as judgeEligible from getJudgeUidSet", async () => {
+    mockJudgeUidSet.mockReturnValue(new Set(["u1"]));
+    mockDb.mockReturnValue(null as never);
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.judgeEligible).toBe(true);
+  });
+
+  it("re-derives judgeEligible from user profile when db is available", async () => {
+    mockIsJudgeFromUser.mockReturnValue(true);
+    setupDb();
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.judgeEligible).toBe(true);
+  });
+
+  it("returns signedUp=true and checkedIn=true when signup doc has checkedInAt", async () => {
+    setupDb();
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.signedUp).toBe(true);
+    expect(body.checkedIn).toBe(true);
+    expect(body.githubLogin).toBe("alice-handle");
+  });
+
+  it("uses profileMatchesHackathonJudgeCheckinException to allow judge checkin without signup", async () => {
+    setupDb({
+      signupDoc: { exists: false },
+      userDoc: {
+        exists: true,
+        data: {
+          github: { login: "judge-x" },
+          // Mark profile as judge exception via the judge claim (function uses email lookup mostly)
+          isHackASprint2026Judge: true,
+        },
+      },
+    });
+    const res = await GET(makeReq());
+    const body = await res.json();
+    // signedUp is exists, not the exception
+    expect(body.signedUp).toBe(false);
+    // checkedIn may be true if judge exception applies for this email — depends on the helper.
+    // We mainly want to ensure no throw.
+    expect(typeof body.checkedIn).toBe("boolean");
+  });
+
+  it("returns githubLogin lowercased and trimmed", async () => {
+    setupDb({
+      userDoc: { exists: true, data: { github: { login: "   AliceHandle   " } } },
+    });
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.githubLogin).toBe("alicehandle");
+  });
+
+  it("skips peer-voting fetch when no githubLogin on profile", async () => {
+    setupDb({ userDoc: { exists: true, data: { github: {} } } });
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.githubLogin).toBeNull();
+    expect(mockSubs).not.toHaveBeenCalled();
+  });
+
+  it("skips peer-voting when signedUp=false", async () => {
+    setupDb({ signupDoc: { exists: false } });
+    const res = await GET(makeReq());
+    expect(mockSubs).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.signedUp).toBe(false);
+  });
+
+  it("skips peer-voting when checkedIn=false", async () => {
+    setupDb({ signupDoc: { exists: true, data: { checkedInAt: null } } });
+    const res = await GET(makeReq());
+    expect(mockSubs).not.toHaveBeenCalled();
+  });
+
+  it("loads existing participant scores and computes ballot completeness + prize eligibility", async () => {
+    mockBallot.mockReturnValue(true);
+    mockPrize.mockReturnValue({
+      eligible: true,
+      highScoreCount: 5,
+      requiredHighScores: 3,
+    } as never);
+    setupDb({
+      psDoc: {
+        exists: true,
+        data: { scores: { "team-beta": 9 } },
+      },
+    });
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.hasCompletedPeerVoting).toBe(true);
+    expect(body.prizeEligible).toBe(true);
+    expect(body.highScoreCount).toBe(5);
+    expect(body.requiredHighScores).toBe(3);
+  });
+
+  it("uses empty scores map when participant scores doc does not exist", async () => {
+    setupDb({ psDoc: { exists: false } });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(mockBallot).toHaveBeenCalledWith({}, "alice-handle", expect.any(Array));
+  });
+
+  it("filters submissions via HACK_A_SPRINT_2026_ALLOWED_SUBMISSIONS env var", async () => {
+    process.env.HACK_A_SPRINT_2026_ALLOWED_SUBMISSIONS = "team-beta";
+    setupDb();
+    await GET(makeReq());
+    // Identities passed to participantBallotComplete should only contain team-beta
+    const identities = mockBallot.mock.calls[0]?.[2] as Array<{ submissionId: string }>;
+    expect(identities).toEqual([{ submissionId: "team-beta", githubLogin: "bob-handle" }]);
+  });
+
+  it("ignores empty-string allowed env var (filter pass-through)", async () => {
+    process.env.HACK_A_SPRINT_2026_ALLOWED_SUBMISSIONS = "   ";
+    setupDb();
+    await GET(makeReq());
+    const identities = mockBallot.mock.calls[0]?.[2] as Array<{ submissionId: string }>;
+    expect(identities.length).toBe(2);
+  });
+
+  it("sets participantEligible from githubUserHasMergedLabeledShowcasePr", async () => {
+    mockHasMergedPr.mockResolvedValueOnce(true);
+    setupDb();
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.participantEligible).toBe(true);
+  });
+
+  it("returns 500 on unexpected throw from db.getAll", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockDb.mockReturnValue({
+      collection: jest.fn(() => ({ doc: jest.fn(() => ({})) })),
+      getAll: jest.fn().mockRejectedValue(new Error("boom")),
+    } as never);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("Failed to load");
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/participant-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/participant-score.route.test.ts
@@ -1,0 +1,256 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #29 — Hack-a-Sprint 2026 participant-score POST.
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/participant-score/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
+import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/hackathon-showcase", () => ({
+  ...jest.requireActual("@/lib/hackathon-showcase"),
+  fetchShowcaseSubmissionsFromGitHub: jest.fn(),
+}));
+jest.mock("@/lib/hackathon-asprint-2026-schedule", () => ({
+  ...jest.requireActual("@/lib/hackathon-asprint-2026-schedule"),
+  getHackASprint2026Phase: jest.fn(),
+}));
+jest.mock("@/lib/rate-limit", () => ({
+  ...jest.requireActual("@/lib/rate-limit"),
+  getClientIdentifier: jest.fn(() => "client-1"),
+}));
+jest.mock("@/lib/upstash-rate-limit", () => ({
+  checkUpstashRateLimit: jest.fn(),
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "TS") },
+}));
+
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
+  typeof fetchShowcaseSubmissionsFromGitHub
+>;
+const mockPhase = getHackASprint2026Phase as jest.MockedFunction<typeof getHackASprint2026Phase>;
+const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+
+function makeReq(body: unknown) {
+  return new NextRequest(
+    "https://example.com/api/hackathons/showcase/hack-a-sprint-2026/participant-score",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+  );
+}
+
+interface DbOpts {
+  userDoc?: { exists: boolean; data?: Record<string, unknown> };
+  signupDoc?: { exists: boolean; data?: Record<string, unknown> };
+  scoresDoc?: { exists: boolean; data?: Record<string, unknown> };
+  scoresSetThrows?: boolean;
+}
+
+function setupDb(opts: DbOpts = {}) {
+  const userGet = jest.fn().mockResolvedValue({
+    exists: opts.userDoc?.exists ?? true,
+    data: () => opts.userDoc?.data ?? { github: { login: "judge-alpha" } },
+  });
+  const signupGet = jest.fn().mockResolvedValue({
+    exists: opts.signupDoc?.exists ?? true,
+    data: () => opts.signupDoc?.data ?? { checkedInAt: new Date() },
+  });
+  const scoresGet = jest.fn().mockResolvedValue({
+    exists: opts.scoresDoc?.exists ?? false,
+    data: () => opts.scoresDoc?.data ?? undefined,
+  });
+  const scoresSet = jest.fn();
+  if (opts.scoresSetThrows) {
+    scoresSet.mockRejectedValue(new Error("write conflict"));
+  } else {
+    scoresSet.mockResolvedValue(undefined);
+  }
+  const collection = jest.fn((name: string) => {
+    if (name === "users") return { doc: jest.fn(() => ({ get: userGet })) };
+    if (name === "hackathonEventSignups") return { doc: jest.fn(() => ({ get: signupGet })) };
+    return {
+      // participant scores
+      doc: jest.fn(() => ({ get: scoresGet, set: scoresSet })),
+    };
+  });
+  mockDb.mockReturnValue({ collection } as never);
+  return { userGet, signupGet, scoresGet, scoresSet };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRate.mockResolvedValue({ success: true, remaining: 9 } as never);
+  mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+  mockPhase.mockReturnValue("checkin");
+  mockSubs.mockResolvedValue([
+    { submissionId: "team-alpha", githubLogin: "judge-alpha" } as never,
+    { submissionId: "team-beta", githubLogin: "judge-beta" } as never,
+  ]);
+});
+
+describe("POST /api/hackathons/showcase/hack-a-sprint-2026/participant-score", () => {
+  it("returns 429 when client rate limit denied", async () => {
+    mockRate.mockResolvedValueOnce({ success: false, retryAfter: 60 } as never);
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 9 }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 9 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when admin db is null", async () => {
+    mockDb.mockReturnValue(null as never);
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 9 }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    setupDb();
+    const res = await POST(makeReq("not-json"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid JSON");
+  });
+
+  it("returns 400 when schema validation fails", async () => {
+    setupDb();
+    const res = await POST(makeReq({ score: 5 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when score is not an integer 1-10", async () => {
+    setupDb();
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 7.5 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("integer score 1-10");
+  });
+
+  it("returns 400 when submission is unknown", async () => {
+    setupDb();
+    const res = await POST(makeReq({ submissionId: "ghost", score: 5 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Unknown submission");
+  });
+
+  it("returns 403 when user has no github.login on profile", async () => {
+    setupDb({ userDoc: { exists: true, data: { github: {} } } });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 6 }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Connect GitHub");
+  });
+
+  it("returns 403 when user is not a merged-submission submitter", async () => {
+    setupDb({ userDoc: { exists: true, data: { github: { login: "outsider" } } } });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 6 }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("merged showcase submission");
+  });
+
+  it("returns 400 when user tries to score their own submission", async () => {
+    setupDb({ userDoc: { exists: true, data: { github: { login: "judge-alpha" } } } });
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 9 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("cannot score your own");
+  });
+
+  it("returns 403 when not checked in (signup doc missing during checkin phase)", async () => {
+    setupDb({ signupDoc: { exists: false } });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 7 }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("checked in");
+  });
+
+  it("returns 403 when signup exists but checkedInAt is null", async () => {
+    setupDb({
+      signupDoc: { exists: true, data: { checkedInAt: null } },
+    });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 7 }));
+    expect(res.status).toBe(403);
+  });
+
+  it("skips checkin requirement during peerVotingOpen phase", async () => {
+    mockPhase.mockReturnValue("peerVotingOpen");
+    const { scoresSet } = setupDb({ signupDoc: { exists: false } });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 8 }));
+    expect(res.status).toBe(200);
+    expect(scoresSet).toHaveBeenCalled();
+  });
+
+  it("skips checkin requirement during resultsOpen phase", async () => {
+    mockPhase.mockReturnValue("resultsOpen");
+    setupDb({ signupDoc: { exists: false } });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 8 }));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 429 when per-uid rate limit denies", async () => {
+    setupDb();
+    mockRate
+      .mockResolvedValueOnce({ success: true } as never)
+      .mockResolvedValueOnce({ success: false, retryAfter: 5 } as never);
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 5 }));
+    expect(res.status).toBe(429);
+  });
+
+  it("writes a new scores doc with the submitter's previous scores merged", async () => {
+    const { scoresSet } = setupDb({
+      scoresDoc: { exists: true, data: { scores: { "team-other": 3 } } },
+    });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 9 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, submissionId: "team-beta", score: 9 });
+    expect(scoresSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "u1",
+        githubLogin: "judge-alpha",
+        scores: { "team-other": 3, "team-beta": 9 },
+        updatedAt: "TS",
+      }),
+      { merge: true },
+    );
+  });
+
+  it("creates a fresh scores doc on first submission (snap.exists=false)", async () => {
+    const { scoresSet } = setupDb({ scoresDoc: { exists: false } });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 9 }));
+    expect(res.status).toBe(200);
+    expect(scoresSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scores: { "team-beta": 9 },
+      }),
+      { merge: true },
+    );
+  });
+
+  it("returns 500 with 'Save failed' when the firestore set throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    setupDb({ scoresSetThrows: true });
+    const res = await POST(makeReq({ submissionId: "team-beta", score: 9 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Save failed");
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/__tests__/app/api/internal/digest/weekly-hiring-partners.test.ts
+++ b/__tests__/app/api/internal/digest/weekly-hiring-partners.test.ts
@@ -3,8 +3,9 @@
  */
 
 import { NextRequest } from "next/server";
-import { GET } from "@/app/api/internal/digest/weekly-hiring-partners/route";
+import { GET, POST } from "@/app/api/internal/digest/weekly-hiring-partners/route";
 import { sendEmail } from "@/lib/mailgun";
+import { getAdminDb } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/mailgun", () => ({
   sendEmail: jest.fn().mockResolvedValue(undefined),
@@ -20,7 +21,12 @@ jest.mock("@/lib/firebase-admin", () => ({
   })),
 }));
 
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), logError: jest.fn() },
+}));
+
 const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
 const ORIGINAL_CRON_SECRET = process.env.CRON_SECRET;
 
@@ -120,5 +126,105 @@ describe("GET /api/internal/digest/weekly-hiring-partners", () => {
     expect(args.subject).toContain("2 pending");
     expect(args.text).toContain("Alice");
     expect(args.text).toContain("Bob");
+  });
+
+  it("returns 500 when CRON_SECRET env is missing", async () => {
+    const saved = process.env.CRON_SECRET;
+    delete process.env.CRON_SECRET;
+    try {
+      const res = await GET(makeReq({ "x-cron-secret": "anything" }));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toContain("CRON_SECRET not set");
+    } finally {
+      if (saved !== undefined) process.env.CRON_SECRET = saved;
+    }
+  });
+
+  it("returns 500 when admin db is unavailable", async () => {
+    mockGetAdminDb.mockReturnValueOnce(null as never);
+    const res = await GET(makeReq({ "x-cron-secret": "test-secret" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Server not configured");
+  });
+
+  it("formats null appliedAtMs as '(unknown date)' in the rendered text", async () => {
+    mockWhereGet.mockResolvedValue({
+      docs: [
+        {
+          id: "user-no-date",
+          data: () => ({
+            contactName: "Carol",
+            email: "carol@example.com",
+            // No createdAt → toMillis undefined → appliedAtMs is null
+          }),
+        },
+      ],
+    });
+    const res = await GET(makeReq({ "x-cron-secret": "test-secret" }));
+    expect(res.status).toBe(200);
+    const args = mockSendEmail.mock.calls[0][0];
+    expect(args.text).toContain("(unknown date)");
+  });
+
+  it("returns 500 with the error message when the firestore query throws", async () => {
+    mockWhereGet.mockRejectedValueOnce(new Error("firestore down"));
+    const res = await GET(makeReq({ "x-cron-secret": "test-secret" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("firestore down");
+  });
+
+  it("returns 500 with stringified non-Error throw", async () => {
+    mockWhereGet.mockRejectedValueOnce("hard-failure-string");
+    const res = await GET(makeReq({ "x-cron-secret": "test-secret" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("hard-failure-string");
+  });
+
+  it("escapes HTML special chars in row fields", async () => {
+    mockWhereGet.mockResolvedValue({
+      docs: [
+        {
+          id: "user-evil",
+          data: () => ({
+            contactName: "<script>alert(1)</script>",
+            email: "evil@example.com",
+            companyWebsite: "https://x.example.com?a=1&b=2",
+            rolesHiring: "ops & \"engineering\"",
+            notes: "needs 'help'",
+            createdAt: { toMillis: () => 1_700_000_000_000 },
+          }),
+        },
+      ],
+    });
+    const res = await GET(makeReq({ "x-cron-secret": "test-secret" }));
+    expect(res.status).toBe(200);
+    const args = mockSendEmail.mock.calls[0][0];
+    const html = args.html ?? "";
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("&amp;b=2");
+    expect(html).toContain("&quot;engineering&quot;");
+    expect(html).toContain("&#39;help&#39;");
+  });
+});
+
+describe("POST /api/internal/digest/weekly-hiring-partners", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shares the same handler — accepts cron secret and returns 200", async () => {
+    mockWhereGet.mockResolvedValue({ docs: [] });
+    const res = await POST(makeReq({ "x-cron-secret": "test-secret" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 unauthorized without secret", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
   });
 });

--- a/__tests__/app/api/internal/hunt-email-retry.route.test.ts
+++ b/__tests__/app/api/internal/hunt-email-retry.route.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #19 — internal hunt email-retry cron route.
+ *
+ * The route reads CRON_SECRET at module load and re-uses a single `handle`
+ * implementation for both GET and POST, so each test re-imports the module
+ * via importRoute() after configuring env + mocks.
+ */
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/mailgun", () => ({ sendEmail: jest.fn() }));
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), logError: jest.fn() },
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "TS") },
+}));
+
+function makeReq(opts: {
+  method?: "GET" | "POST";
+  cronSecretHeader?: string;
+  bearerToken?: string;
+} = {}) {
+  const url = new URL("https://example.com/api/internal/hunt/email-retry");
+  const headers: Record<string, string> = {};
+  if (opts.cronSecretHeader) headers["x-cron-secret"] = opts.cronSecretHeader;
+  if (opts.bearerToken) headers["authorization"] = `Bearer ${opts.bearerToken}`;
+  return new NextRequest(url, { method: opts.method ?? "POST", headers });
+}
+
+type DocRef = { set: jest.Mock };
+type Doc = { id: string; data: () => Record<string, unknown>; ref: DocRef };
+
+function fakeMarker(opts: { exists?: boolean; queueEmpty?: boolean } = {}) {
+  return {
+    set: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn().mockResolvedValue({
+      exists: opts.exists ?? false,
+      data: () => ({ queueEmpty: opts.queueEmpty ?? false }),
+    }),
+  };
+}
+
+function fakeStuckQuery(docs: Doc[]) {
+  return {
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    get: jest.fn().mockResolvedValue({ docs, size: docs.length }),
+  };
+}
+
+function setupDb(opts: {
+  marker?: ReturnType<typeof fakeMarker>;
+  stuckDocs?: Doc[];
+}) {
+  const marker = opts.marker ?? fakeMarker();
+  const stuck = fakeStuckQuery(opts.stuckDocs ?? []);
+  const db = {
+    collection: jest.fn((name: string) => {
+      if (name === "treasureHuntRuntime") {
+        return { doc: jest.fn(() => marker) };
+      }
+      // treasureHuntProgress
+      return stuck;
+    }),
+  };
+  return { db, marker, stuck };
+}
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.CRON_SECRET = "test-secret";
+});
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+async function importRoute() {
+  jest.resetModules();
+  const route = await import("@/app/api/internal/hunt/email-retry/route");
+  const adminMod = await import("@/lib/firebase-admin");
+  const mailgunMod = await import("@/lib/mailgun");
+  const mockDb = adminMod.getAdminDb as jest.MockedFunction<typeof adminMod.getAdminDb>;
+  const mockSendEmail = mailgunMod.sendEmail as jest.MockedFunction<typeof mailgunMod.sendEmail>;
+  return { ...route, mockDb, mockSendEmail };
+}
+
+describe("POST /api/internal/hunt/email-retry", () => {
+  it("returns 500 when CRON_SECRET env is missing", async () => {
+    delete process.env.CRON_SECRET;
+    const { POST } = await importRoute();
+    const res = await POST(makeReq({ cronSecretHeader: "anything" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("CRON_SECRET missing");
+  });
+
+  it("returns 401 when no cron secret is provided", async () => {
+    const { POST } = await importRoute();
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when cron secret mismatches", async () => {
+    const { POST } = await importRoute();
+    const res = await POST(makeReq({ cronSecretHeader: "wrong" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts CRON_SECRET via x-cron-secret header", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db } = setupDb({});
+    mockDb.mockReturnValue(db as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts CRON_SECRET via Authorization: Bearer header (case-insensitive)", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db } = setupDb({});
+    mockDb.mockReturnValue(db as never);
+    const res = await POST(makeReq({ bearerToken: "test-secret" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when admin db unavailable", async () => {
+    const { POST, mockDb } = await importRoute();
+    mockDb.mockReturnValue(null as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("No DB");
+  });
+
+  it("short-circuits when known_empty marker is set", async () => {
+    const { POST, mockDb } = await importRoute();
+    const marker = fakeMarker({ exists: true, queueEmpty: true });
+    const { db, stuck } = setupDb({ marker });
+    mockDb.mockReturnValue(db as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body).toEqual({ scanned: 0, sent: 0, failed: 0, skipped: "known_empty" });
+    // Never queried treasureHuntProgress
+    expect(stuck.get).not.toHaveBeenCalled();
+  });
+
+  it("sets queueEmpty=true when no stuck docs found", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db, marker } = setupDb({ stuckDocs: [] });
+    mockDb.mockReturnValue(db as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body).toEqual({ scanned: 0, sent: 0, failed: 0 });
+    expect(marker.set).toHaveBeenCalledWith(
+      { queueEmpty: true, updatedAt: "TS" },
+      { merge: true },
+    );
+  });
+
+  it("sends emails for stuck docs and marks them delivered", async () => {
+    const { POST, mockDb, mockSendEmail } = await importRoute();
+    const doc1Ref = { set: jest.fn().mockResolvedValue(undefined) };
+    const doc2Ref = { set: jest.fn().mockResolvedValue(undefined) };
+    const stuckDocs: Doc[] = [
+      {
+        id: "u1",
+        data: () => ({ winnerEmail: "a@x", prizeCreditUrl: "https://credit/a" }),
+        ref: doc1Ref,
+      },
+      {
+        id: "u2",
+        data: () => ({ winnerEmail: "b@x", prizeCreditUrl: "https://credit/b" }),
+        ref: doc2Ref,
+      },
+    ];
+    const { db, marker } = setupDb({ stuckDocs });
+    mockDb.mockReturnValue(db as never);
+    mockSendEmail.mockResolvedValue(undefined as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body).toEqual({ scanned: 2, sent: 2, failed: 0 });
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(doc1Ref.set).toHaveBeenCalledWith(
+      { prizeEmailSentAt: "TS" },
+      { merge: true },
+    );
+    // queueEmpty=false marker written because we found work
+    expect(marker.set).toHaveBeenCalledWith(
+      { queueEmpty: false, updatedAt: "TS" },
+      { merge: true },
+    );
+  });
+
+  it("skips docs missing winnerEmail or prizeCreditUrl", async () => {
+    const { POST, mockDb, mockSendEmail } = await importRoute();
+    const docRef = { set: jest.fn() };
+    const stuckDocs: Doc[] = [
+      {
+        id: "u1",
+        data: () => ({ winnerEmail: "", prizeCreditUrl: "https://credit/a" }),
+        ref: docRef,
+      },
+      {
+        id: "u2",
+        data: () => ({ winnerEmail: "b@x", prizeCreditUrl: 123 /* not string */ }),
+        ref: docRef,
+      },
+    ];
+    const { db } = setupDb({ stuckDocs });
+    mockDb.mockReturnValue(db as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body).toEqual({ scanned: 2, sent: 0, failed: 0 });
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(docRef.set).not.toHaveBeenCalled();
+  });
+
+  it("counts a failed sendEmail as failed and continues the loop", async () => {
+    const { POST, mockDb, mockSendEmail } = await importRoute();
+    const docRef1 = { set: jest.fn().mockResolvedValue(undefined) };
+    const docRef2 = { set: jest.fn().mockResolvedValue(undefined) };
+    const stuckDocs: Doc[] = [
+      {
+        id: "u1",
+        data: () => ({ winnerEmail: "a@x", prizeCreditUrl: "https://credit/a" }),
+        ref: docRef1,
+      },
+      {
+        id: "u2",
+        data: () => ({ winnerEmail: "b@x", prizeCreditUrl: "https://credit/b" }),
+        ref: docRef2,
+      },
+    ];
+    const { db } = setupDb({ stuckDocs });
+    mockDb.mockReturnValue(db as never);
+    mockSendEmail
+      .mockRejectedValueOnce(new Error("mailgun 5xx"))
+      .mockResolvedValueOnce(undefined as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body).toEqual({ scanned: 2, sent: 1, failed: 1 });
+    // Only the successful send wrote the marker
+    expect(docRef1.set).not.toHaveBeenCalled();
+    expect(docRef2.set).toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/internal/hunt/email-retry", () => {
+  it("shares the same handle — accepts cron secret and returns scan summary", async () => {
+    const { GET, mockDb } = await importRoute();
+    const { db } = setupDb({});
+    mockDb.mockReturnValue(db as never);
+    const res = await GET(makeReq({ method: "GET", cronSecretHeader: "test-secret" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ scanned: 0, sent: 0, failed: 0 });
+  });
+
+  it("returns 401 when GET is unauthorized", async () => {
+    const { GET } = await importRoute();
+    const res = await GET(makeReq({ method: "GET" }));
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/app/api/internal/rate-limits-cleanup.route.test.ts
+++ b/__tests__/app/api/internal/rate-limits-cleanup.route.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #18 — internal rate-limits cleanup cron route.
+ */
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  Timestamp: { now: jest.fn(() => ({ _ts: "now" })) },
+}));
+
+function makeReq(opts: {
+  searchParams?: Record<string, string>;
+  cronSecretHeader?: string;
+  bearerToken?: string;
+} = {}) {
+  const url = new URL("https://example.com/api/internal/rate-limits/cleanup");
+  for (const [k, v] of Object.entries(opts.searchParams ?? {})) {
+    url.searchParams.set(k, v);
+  }
+  const headers: Record<string, string> = {};
+  if (opts.cronSecretHeader) headers["x-cron-secret"] = opts.cronSecretHeader;
+  if (opts.bearerToken) headers["authorization"] = `Bearer ${opts.bearerToken}`;
+  return new NextRequest(url, { method: "POST", headers });
+}
+
+function fakeDb(batches: Array<{ size: number; docs: Array<{ ref: unknown }> }>) {
+  let callCount = 0;
+  const queryChain: {
+    where: jest.Mock;
+    orderBy: jest.Mock;
+    limit: jest.Mock;
+    get: jest.Mock;
+  } = {
+    where: jest.fn(),
+    orderBy: jest.fn(),
+    limit: jest.fn(),
+    get: jest.fn().mockImplementation(() => {
+      const batch = batches[callCount++] ?? { size: 0, docs: [] };
+      return Promise.resolve({
+        empty: batch.size === 0,
+        size: batch.size,
+        docs: batch.docs,
+      });
+    }),
+  };
+  queryChain.where.mockReturnValue(queryChain);
+  queryChain.orderBy.mockReturnValue(queryChain);
+  queryChain.limit.mockReturnValue(queryChain);
+
+  const batchCommit = jest.fn().mockResolvedValue(undefined);
+  const batchDelete = jest.fn();
+
+  return {
+    spies: { batchCommit, batchDelete, get: queryChain.get },
+    db: {
+      collection: jest.fn(() => queryChain),
+      batch: jest.fn(() => ({ delete: batchDelete, commit: batchCommit })),
+    } as never,
+  };
+}
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.CRON_SECRET = "test-secret";
+});
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+async function importRoute() {
+  jest.resetModules();
+  const route = await import("@/app/api/internal/rate-limits/cleanup/route");
+  const adminMod = await import("@/lib/firebase-admin");
+  const mockDb = adminMod.getAdminDb as jest.MockedFunction<typeof adminMod.getAdminDb>;
+  return { ...route, mockDb };
+}
+
+describe("POST /api/internal/rate-limits/cleanup", () => {
+  it("returns 500 when CRON_SECRET env is missing", async () => {
+    delete process.env.CRON_SECRET;
+    const { POST, mockDb } = await importRoute();
+    const res = await POST(makeReq({ cronSecretHeader: "anything" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("CRON_SECRET not set");
+  });
+
+  it("returns 401 when no cron secret is provided", async () => {
+    const { POST, mockDb } = await importRoute();
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when cron secret mismatches", async () => {
+    const { POST, mockDb } = await importRoute();
+    const res = await POST(makeReq({ cronSecretHeader: "wrong" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts CRON_SECRET via x-cron-secret header", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db } = fakeDb([{ size: 0, docs: [] }]);
+    mockDb.mockReturnValue(db);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts CRON_SECRET via Authorization: Bearer header", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db } = fakeDb([{ size: 0, docs: [] }]);
+    mockDb.mockReturnValue(db);
+    const res = await POST(makeReq({ bearerToken: "test-secret" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when admin db unavailable", async () => {
+    const { POST, mockDb } = await importRoute();
+    mockDb.mockReturnValue(null as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("breaks out of the loop when first batch is empty", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db, spies } = fakeDb([{ size: 0, docs: [] }]);
+    mockDb.mockReturnValue(db);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.totalMatched).toBe(0);
+    expect(body.totalDeleted).toBe(0);
+    expect(body.batchesProcessed).toBe(0);
+    expect(spies.batchCommit).not.toHaveBeenCalled();
+  });
+
+  it("processes one full batch and continues if exactly batchSize results", async () => {
+    const { POST, mockDb } = await importRoute();
+    // First call returns full batch of size 500, second returns 0 → stop.
+    const fullBatch = {
+      size: 500,
+      docs: Array.from({ length: 500 }, (_, i) => ({ ref: { id: `r${i}` } })),
+    };
+    const { db, spies } = fakeDb([fullBatch, { size: 0, docs: [] }]);
+    mockDb.mockReturnValue(db);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.totalDeleted).toBe(500);
+    expect(body.batchesProcessed).toBe(1);
+    expect(spies.batchCommit).toHaveBeenCalled();
+  });
+
+  it("dryRun=true matches but does not delete", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db, spies } = fakeDb([
+      { size: 3, docs: [{ ref: 1 }, { ref: 2 }, { ref: 3 }] },
+    ]);
+    mockDb.mockReturnValue(db);
+    const res = await POST(
+      makeReq({
+        cronSecretHeader: "test-secret",
+        searchParams: { dryRun: "true" },
+      }),
+    );
+    const body = await res.json();
+    expect(body.dryRun).toBe(true);
+    expect(body.totalMatched).toBe(3);
+    expect(body.totalDeleted).toBe(0);
+    expect(spies.batchCommit).not.toHaveBeenCalled();
+  });
+
+  it("clamps batchSize / maxBatches to documented bounds", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db } = fakeDb([{ size: 0, docs: [] }]);
+    mockDb.mockReturnValue(db);
+    const res = await POST(
+      makeReq({
+        cronSecretHeader: "test-secret",
+        searchParams: { batchSize: "10000", maxBatches: "9999" },
+      }),
+    );
+    const body = await res.json();
+    expect(body.batchSize).toBe(500); // MAX_BATCH_SIZE
+    expect(body.maxBatches).toBe(20); // MAX_MAX_BATCHES
+  });
+
+  it("breaks early when batch returns less than batchSize", async () => {
+    const { POST, mockDb } = await importRoute();
+    const { db } = fakeDb([
+      { size: 2, docs: [{ ref: 1 }, { ref: 2 }] }, // < default 500
+    ]);
+    mockDb.mockReturnValue(db);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    const body = await res.json();
+    expect(body.batchesProcessed).toBe(1);
+    expect(body.totalDeleted).toBe(2);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("catch-block returns 500 when get() throws", async () => {
+    const { POST, mockDb } = await importRoute();
+    mockDb.mockReturnValue({
+      collection: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => ({
+              get: jest.fn().mockRejectedValue(new Error("query failed")),
+            }),
+          }),
+        }),
+      }),
+    } as never);
+    const res = await POST(makeReq({ cronSecretHeader: "test-secret" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("Failed to clean");
+  });
+});
+
+describe("GET /api/internal/rate-limits/cleanup", () => {
+  it("returns 405 method not allowed", async () => {
+    const { GET } = await importRoute();
+    const res = await GET();
+    expect(res.status).toBe(405);
+  });
+});

--- a/__tests__/app/api/live/queue/route.test.ts
+++ b/__tests__/app/api/live/queue/route.test.ts
@@ -131,4 +131,130 @@ describe("POST /api/live/[sessionId]/queue", () => {
     });
     expect(duplicateRes.status).toBe(409);
   });
+
+  it("returns 400 when sessionId is whitespace-only", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@x" });
+    const res = await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "   " }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Session ID");
+  });
+
+  it("returns 400 when request body is not valid JSON", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@x" });
+    const req = new NextRequest("http://localhost/api/live/session-1/queue", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req, { params: Promise.resolve({ sessionId: "session-1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid JSON");
+  });
+
+  it("returns 400 when talkTitle is a non-string type (normalizeTalkTitle)", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@x" });
+    const res = await POST(
+      makeRequest({ talkTitle: 12345, durationMinutes: 3 }),
+      { params: Promise.resolve({ sessionId: "session-1" }) },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Talk title");
+  });
+
+  it("returns 400 when talkTitle exceeds 140 char max", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@x" });
+    const longTitle = "x".repeat(141);
+    const res = await POST(
+      makeRequest({ talkTitle: longTitle, durationMinutes: 3 }),
+      { params: Promise.resolve({ sessionId: "session-1" }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 with duration error when durationMinutes is a non-number type", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@x" });
+    const res = await POST(
+      makeRequest({ talkTitle: "Demo", durationMinutes: "not-a-number" }),
+      { params: Promise.resolve({ sessionId: "session-1" }) },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Duration");
+  });
+
+  it("returns 400 with duration error when durationMinutes is not in LIVE_TALK_DURATIONS", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@x" });
+    const res = await POST(
+      makeRequest({ talkTitle: "Demo", durationMinutes: 7 }),
+      { params: Promise.resolve({ sessionId: "session-1" }) },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Duration");
+  });
+
+  it("falls back to email then 'Speaker' when user.name is missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({
+      uid: "u1",
+      email: "fallback@example.com",
+    });
+    mockEnqueueSpeakerServer.mockResolvedValue({
+      id: "entry-2",
+      sessionId: "session-1",
+      userId: "u1",
+      speakerName: "fallback@example.com",
+      speakerPhotoUrl: null,
+      talkTitle: "Demo",
+      durationMinutes: 3,
+      status: "queued",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    });
+    await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(mockEnqueueSpeakerServer).toHaveBeenCalledWith(
+      expect.objectContaining({ speakerName: "fallback@example.com", speakerPhotoUrl: null }),
+    );
+  });
+
+  it("uses 'Speaker' default when both name and email are missing", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1" } as never);
+    mockEnqueueSpeakerServer.mockResolvedValue({
+      id: "entry-3",
+      sessionId: "session-1",
+      userId: "u1",
+      speakerName: "Speaker",
+      speakerPhotoUrl: null,
+      talkTitle: "Demo",
+      durationMinutes: 3,
+      status: "queued",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    });
+    await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(mockEnqueueSpeakerServer).toHaveBeenCalledWith(
+      expect.objectContaining({ speakerName: "Speaker" }),
+    );
+  });
+
+  it("returns 500 on unknown error from enqueueSpeakerServer", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1", email: "u@x" });
+    mockEnqueueSpeakerServer.mockRejectedValueOnce(new Error("unexpected"));
+    const res = await POST(makeRequest({ talkTitle: "Demo", durationMinutes: 3 }), {
+      params: Promise.resolve({ sessionId: "session-1" }),
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Internal server error");
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/__tests__/app/api/showcase/vote/route.test.ts
+++ b/__tests__/app/api/showcase/vote/route.test.ts
@@ -3,9 +3,10 @@
  */
 
 import { NextRequest } from "next/server";
-import { GET } from "@/app/api/showcase/vote/route";
+import { GET, POST } from "@/app/api/showcase/vote/route";
 import type { VerifiedUser } from "@/lib/server-auth";
 import { getVerifiedUser } from "@/lib/server-auth";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/logger", () => ({
   logger: { logError: jest.fn() },
@@ -26,6 +27,15 @@ jest.mock("@/lib/server-auth", () => ({
 
 jest.mock("@/lib/sanitize", () => ({
   sanitizeDocId: (id: string) => (id && /^[a-zA-Z0-9_-]+$/.test(id) ? id : ""),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: jest.fn(() => "TS") },
+}));
+
+jest.mock("@/lib/api-response", () => ({
+  ...jest.requireActual("@/lib/api-response"),
+  parseRequestBody: jest.fn(),
 }));
 
 const mockForEach = jest.fn();
@@ -192,5 +202,265 @@ describe("GET /api/showcase/vote", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ votes: {}, userVotes: {} });
+  });
+});
+
+/* ---------------------------------------------------------- *
+ *  POST /api/showcase/vote — coverage push #22                *
+ * ---------------------------------------------------------- */
+
+type TxFns = {
+  get: jest.Mock;
+  set: jest.Mock;
+  update: jest.Mock;
+  delete: jest.Mock;
+};
+
+interface TxScenario {
+  project: { exists: boolean; data?: Record<string, unknown> };
+  vote: { exists: boolean; data?: Record<string, unknown> };
+}
+
+function fakeTxDb(scenario: TxScenario) {
+  const tx: TxFns = {
+    get: jest.fn().mockImplementation(async (ref: { __which: string }) => {
+      if (ref.__which === "project") {
+        return { exists: scenario.project.exists, data: () => scenario.project.data };
+      }
+      return { exists: scenario.vote.exists, data: () => scenario.vote.data };
+    }),
+    set: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+  const runTransaction = jest.fn(async (cb: (t: TxFns) => Promise<unknown>) => cb(tx));
+  const projectRef = { __which: "project" };
+  const voteRef = { __which: "vote" };
+  const db = {
+    collection: jest.fn((name: string) => ({
+      doc: jest.fn(() =>
+        name === "showcaseProjects" ? projectRef : voteRef,
+      ),
+    })),
+    runTransaction,
+  };
+  return { db, tx, runTransaction };
+}
+
+function makePostRequest() {
+  const url = new URL("http://localhost/api/showcase/vote");
+  return new NextRequest(url, { method: "POST" });
+}
+
+const mockRateLimit = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+const { parseRequestBody } = require("@/lib/api-response");
+const mockParseBody = parseRequestBody as jest.Mock;
+
+describe("POST /api/showcase/vote", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRateLimit.mockResolvedValue({
+      success: true,
+      remaining: 9,
+      limit: 60,
+      resetTime: Date.now() + 60000,
+    } as never);
+    mockParseBody.mockResolvedValue({ projectId: "proj1", type: "up" });
+  });
+
+  it("returns 429 when rate limit exceeded", async () => {
+    mockRateLimit.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      limit: 60,
+      resetTime: Date.now() + 30000,
+      retryAfter: 30,
+    } as never);
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(body.retryAfterSeconds).toBe(30);
+  });
+
+  it("defaults Retry-After to 60 when rate limit has no retryAfter", async () => {
+    mockRateLimit.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      limit: 60,
+      resetTime: Date.now() + 60000,
+    } as never);
+    const res = await POST(makePostRequest());
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when admin db is null", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(null);
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns parse error response from parseRequestBody (passthrough)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db } = fakeTxDb({ project: { exists: false }, vote: { exists: false } });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    const errResp = new (require("next/server").NextResponse)("nope", { status: 400 });
+    mockParseBody.mockResolvedValueOnce(errResp);
+    const res = await POST(makePostRequest());
+    expect(res).toBe(errResp);
+  });
+
+  it("returns 400 for invalid payload (schema fails)", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db } = fakeTxDb({ project: { exists: false }, vote: { exists: false } });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: 1, type: "x" });
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when sanitizeDocId rejects projectId", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db } = fakeTxDb({ project: { exists: false }, vote: { exists: false } });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: "../../bad", type: "up" });
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it("adds first vote (action=added) and SETs project doc when project absent", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db, tx } = fakeTxDb({ project: { exists: false }, vote: { exists: false } });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ action: "added", type: "up", upCount: 1, downCount: 0 });
+    expect(tx.set).toHaveBeenCalledTimes(2); // vote doc + project doc
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it("adds first vote (action=added) and UPDATEs project doc when project exists", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db, tx } = fakeTxDb({
+      project: { exists: true, data: { upCount: 5, downCount: 2 } },
+      vote: { exists: false },
+    });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: "proj1", type: "down" });
+    const res = await POST(makePostRequest());
+    const body = await res.json();
+    expect(body).toMatchObject({ action: "added", type: "down", upCount: 5, downCount: 3 });
+    expect(tx.update).toHaveBeenCalled();
+  });
+
+  it("toggle off (action=removed): existing same-type vote deletes, decrements upCount", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db, tx } = fakeTxDb({
+      project: { exists: true, data: { upCount: 4, downCount: 1 } },
+      vote: { exists: true, data: { type: "up" } },
+    });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: "proj1", type: "up" });
+    const res = await POST(makePostRequest());
+    const body = await res.json();
+    expect(body).toMatchObject({ action: "removed", type: "up", upCount: 3, downCount: 1 });
+    expect(tx.delete).toHaveBeenCalled();
+    expect(tx.update).toHaveBeenCalled();
+  });
+
+  it("toggle off down: decrements downCount and clamps at 0", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db, tx } = fakeTxDb({
+      project: { exists: true, data: { upCount: 2, downCount: 0 } },
+      vote: { exists: true, data: { type: "down" } },
+    });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: "proj1", type: "down" });
+    const res = await POST(makePostRequest());
+    const body = await res.json();
+    expect(body).toMatchObject({ action: "removed", type: "down", upCount: 2, downCount: 0 });
+    expect(tx.delete).toHaveBeenCalled();
+  });
+
+  it("toggle off when project doc absent uses tx.set for the project update", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db, tx } = fakeTxDb({
+      project: { exists: false },
+      vote: { exists: true, data: { type: "up" } },
+    });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: "proj1", type: "up" });
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(200);
+    expect(tx.delete).toHaveBeenCalled();
+    // No project update call, only set — since exists=false branch
+    expect(tx.set).toHaveBeenCalled();
+  });
+
+  it("switch vote (action=switched) up→down updates counts", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db, tx } = fakeTxDb({
+      project: { exists: true, data: { upCount: 3, downCount: 1 } },
+      vote: { exists: true, data: { type: "up" } },
+    });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: "proj1", type: "down" });
+    const res = await POST(makePostRequest());
+    const body = await res.json();
+    expect(body).toMatchObject({
+      action: "switched",
+      type: "down",
+      previousType: "up",
+      upCount: 2,
+      downCount: 2,
+    });
+    expect(tx.update).toHaveBeenCalled();
+  });
+
+  it("switch vote when project doc absent uses tx.set for project doc", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const { db, tx } = fakeTxDb({
+      project: { exists: false },
+      vote: { exists: true, data: { type: "down" } },
+    });
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce(db);
+    mockParseBody.mockResolvedValueOnce({ projectId: "proj1", type: "up" });
+    const res = await POST(makePostRequest());
+    const body = await res.json();
+    expect(body.action).toBe("switched");
+    expect(tx.set).toHaveBeenCalled();
+  });
+
+  it("returns 500 when transaction throws", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    const firebaseAdmin = require("@/lib/firebase-admin");
+    firebaseAdmin.getAdminDb.mockReturnValueOnce({
+      collection: () => ({ doc: () => ({}) }),
+      runTransaction: jest.fn().mockRejectedValue(new Error("tx died")),
+    });
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Internal server error");
   });
 });

--- a/__tests__/app/api/summer-cohort/my-score-by-week.route.test.ts
+++ b/__tests__/app/api/summer-cohort/my-score-by-week.route.test.ts
@@ -1,0 +1,336 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #21 — summer-cohort per-user score endpoint.
+ *
+ * The route resolves the calling user's github handle server-side and fetches
+ * their AI-judge score file from the submission branch on github raw. Never
+ * accepts a handle query parameter, so the test covers each guard around
+ * verification, db, handle resolution, fetch, and parse.
+ */
+import { GET } from "@/app/api/summer-cohort/my-score/[weekId]/route";
+import { getOptionalVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVoteWeekById } from "@/lib/summer-cohort-submissions";
+import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { makeRequest } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/server-auth", () => ({ getOptionalVerifiedUser: jest.fn() }));
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/summer-cohort-submissions", () => ({
+  getVoteWeekById: jest.fn(),
+}));
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: jest.fn(() => ({ owner: "rogerSuperBuilderAlpha", repo: "cursor-boston" })),
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), logError: jest.fn() },
+}));
+
+const mockUser = getOptionalVerifiedUser as jest.MockedFunction<typeof getOptionalVerifiedUser>;
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockVoteWeek = getVoteWeekById as jest.MockedFunction<typeof getVoteWeekById>;
+const mockRepoPair = getGithubRepoPair as jest.MockedFunction<typeof getGithubRepoPair>;
+
+function withParams(weekId: string) {
+  return { params: Promise.resolve({ weekId }) };
+}
+
+function setupUserDoc(login: string | undefined | null) {
+  mockDb.mockReturnValue({
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({
+          exists: login !== null,
+          data: () => (login === undefined ? {} : { github: { login } }),
+        }),
+      })),
+    })),
+  } as never);
+}
+
+function setupMissingUserDoc() {
+  mockDb.mockReturnValue({
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({ exists: false, data: () => undefined }),
+      })),
+    })),
+  } as never);
+}
+
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+  mockRepoPair.mockReturnValue({ owner: "rogerSuperBuilderAlpha", repo: "cursor-boston" });
+  delete process.env.GITHUB_TOKEN;
+});
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_GITHUB_TOKEN !== undefined) process.env.GITHUB_TOKEN = ORIGINAL_GITHUB_TOKEN;
+});
+
+describe("GET /api/summer-cohort/my-score/[weekId]", () => {
+  it("returns 404 when weekId fails zod validation (empty string)", async () => {
+    const res = await GET(makeRequest({ method: "GET" }), withParams(""));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("Unknown weekId");
+  });
+
+  it("returns 404 when getVoteWeekById returns null", async () => {
+    mockVoteWeek.mockReturnValue(null as never);
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-99"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("Unknown weekId");
+  });
+
+  it("falls back to cohort-1 when cohortId param is invalid", async () => {
+    mockVoteWeek.mockReturnValue(null as never);
+    await GET(
+      makeRequest({ method: "GET", searchParams: { cohortId: "not-a-valid-cohort" } }),
+      withParams("week-1"),
+    );
+    expect(mockVoteWeek).toHaveBeenCalledWith("week-1", "cohort-1");
+  });
+
+  it("uses query cohortId when valid", async () => {
+    mockVoteWeek.mockReturnValue(null as never);
+    await GET(
+      makeRequest({ method: "GET", searchParams: { cohortId: "cohort-2" } }),
+      withParams("week-1"),
+    );
+    expect(mockVoteWeek).toHaveBeenCalledWith("week-1", "cohort-2");
+  });
+
+  it("returns 401 when verifier throws", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/x.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockRejectedValue(new Error("token bad"));
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when not signed in", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/x.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue(null);
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when admin db missing", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/x.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    mockDb.mockReturnValue(null as never);
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("Server misconfigured");
+  });
+
+  it("returns 404 when the user doc has no github login", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/x.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc(undefined);
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("Link your GitHub");
+  });
+
+  it("returns 404 when user doc does not exist", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/x.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupMissingUserDoc();
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when github login is empty/whitespace", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/x.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("   ");
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when submissionPath has no /submissions/ segment", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/bogus/path/no-submissions-segment.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("Misconfigured week");
+  });
+
+  it("returns 500 when fetch throws", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network down"));
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("Couldn't load");
+  });
+
+  it("returns 500 for non-Error throw from fetch", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockRejectedValueOnce("string-failure");
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 404 when raw fetch status is 404 (no score yet)", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      status: 404,
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("No judge feedback");
+  });
+
+  it("returns 500 when raw fetch non-OK with status != 404", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      status: 500,
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when score JSON parse throws", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: () => Promise.reject(new Error("not json")),
+    });
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("malformed");
+  });
+
+  it("returns 200 with score payload and private no-store cache header on happy path", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          score: 9,
+          rationale: "great PR",
+          model: "claude-3",
+          scoredAt: "2026-05-10T12:00:00Z",
+        }),
+    });
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    const body = await res.json();
+    expect(body).toEqual({
+      weekId: "week-1",
+      githubHandle: "octocat",
+      score: 9,
+      rationale: "great PR",
+      model: "claude-3",
+      scoredAt: "2026-05-10T12:00:00Z",
+    });
+  });
+
+  it("nulls out missing model/scoredAt fields in the response", async () => {
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: () => Promise.resolve({ score: 7, rationale: "ok" }),
+    });
+    const res = await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    const body = await res.json();
+    expect(body.model).toBeNull();
+    expect(body.scoredAt).toBeNull();
+  });
+
+  it("sends Authorization header when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_secret";
+    mockVoteWeek.mockReturnValue({
+      submissionPath: "content/summer-cohort/c1/w1-pm/submissions/octocat.json",
+      submissionBranch: "c1w1pm-submission",
+    } as never);
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
+    setupUserDoc("octocat");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: () => Promise.resolve({ score: 5, rationale: "fine" }),
+    });
+    await GET(makeRequest({ method: "GET" }), withParams("week-1"));
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer ghp_secret");
+  });
+});

--- a/__tests__/lib/api-response.test.ts
+++ b/__tests__/lib/api-response.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ *
+ * OpenSSF Gold coverage push #37 — lib/api-response standardised
+ * response helpers.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import {
+  apiError,
+  apiSuccess,
+  parseRequestBody,
+  ErrorCode,
+} from "@/lib/api-response";
+
+describe("ErrorCode constants", () => {
+  it("exposes the 8 documented codes", () => {
+    expect(Object.keys(ErrorCode).sort()).toEqual([
+      "CONFLICT",
+      "FORBIDDEN",
+      "NOT_CONFIGURED",
+      "NOT_FOUND",
+      "RATE_LIMITED",
+      "SERVER_ERROR",
+      "UNAUTHORIZED",
+      "VALIDATION_ERROR",
+    ]);
+  });
+});
+
+describe("apiError", () => {
+  async function bodyOf(res: NextResponse) {
+    return res.json();
+  }
+
+  it("returns status 401 + UNAUTHORIZED inferred from 401", async () => {
+    const res = apiError("not signed in", 401);
+    expect(res.status).toBe(401);
+    const body = await bodyOf(res);
+    expect(body).toEqual({
+      success: false,
+      error: { message: "not signed in", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns status 403 + FORBIDDEN inferred", async () => {
+    const res = apiError("no", 403);
+    expect((await bodyOf(res)).error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns status 404 + NOT_FOUND inferred", async () => {
+    const res = apiError("missing", 404);
+    expect((await bodyOf(res)).error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns status 409 + CONFLICT inferred", async () => {
+    const res = apiError("conflict", 409);
+    expect((await bodyOf(res)).error.code).toBe("CONFLICT");
+  });
+
+  it("returns status 429 + RATE_LIMITED inferred", async () => {
+    const res = apiError("slow down", 429);
+    expect((await bodyOf(res)).error.code).toBe("RATE_LIMITED");
+  });
+
+  it("returns VALIDATION_ERROR for generic 4xx (e.g. 400)", async () => {
+    const res = apiError("bad body", 400);
+    expect((await bodyOf(res)).error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns SERVER_ERROR for 5xx", async () => {
+    const res = apiError("boom", 500);
+    expect((await bodyOf(res)).error.code).toBe("SERVER_ERROR");
+  });
+
+  it("honours an explicit code override", async () => {
+    const res = apiError("not configured", 500, ErrorCode.NOT_CONFIGURED);
+    expect((await bodyOf(res)).error.code).toBe("NOT_CONFIGURED");
+  });
+});
+
+describe("apiSuccess", () => {
+  it("returns status 200 with success=true and spread data by default", async () => {
+    const res = apiSuccess({ foo: "bar", count: 3 });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, foo: "bar", count: 3 });
+  });
+
+  it("honours a custom status (e.g. 201)", async () => {
+    const res = apiSuccess({ id: "new" }, 201);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, id: "new" });
+  });
+});
+
+describe("parseRequestBody", () => {
+  function makeReq(body: string | null, contentType = "application/json") {
+    return new NextRequest("https://example.com/x", {
+      method: "POST",
+      headers: { "content-type": contentType },
+      body: body ?? undefined,
+    });
+  }
+
+  it("returns the parsed object on valid JSON", async () => {
+    const req = makeReq(JSON.stringify({ a: 1, b: "two" }));
+    const parsed = await parseRequestBody(req);
+    expect(parsed).toEqual({ a: 1, b: "two" });
+  });
+
+  it("returns a 400 NextResponse when body is not valid JSON", async () => {
+    const req = makeReq("not json");
+    const parsed = await parseRequestBody(req);
+    expect(parsed).toBeInstanceOf(NextResponse);
+    if (parsed instanceof NextResponse) {
+      expect(parsed.status).toBe(400);
+      const body = await parsed.json();
+      expect(body.error).toContain("Invalid JSON");
+    }
+  });
+
+  it("works with a plain Request (not just NextRequest)", async () => {
+    const req = new Request("https://example.com/x", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true }),
+    });
+    const parsed = await parseRequestBody(req);
+    expect(parsed).toEqual({ ok: true });
+  });
+
+  it("returns 400 when body is empty (no JSON)", async () => {
+    const req = makeReq("");
+    const parsed = await parseRequestBody(req);
+    expect(parsed).toBeInstanceOf(NextResponse);
+    if (parsed instanceof NextResponse) {
+      expect(parsed.status).toBe(400);
+    }
+  });
+});

--- a/__tests__/lib/github-merged-pr-reconcile.test.ts
+++ b/__tests__/lib/github-merged-pr-reconcile.test.ts
@@ -2,7 +2,10 @@
  * @jest-environment node
  */
 
-import { reconcileMergedPrCreditForUser } from "@/lib/github-merged-pr-reconcile";
+import {
+  fetchMergedPullRequestsForAuthor,
+  reconcileMergedPrCreditForUser,
+} from "@/lib/github-merged-pr-reconcile";
 import { getAdminDb } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/logger", () => ({
@@ -128,5 +131,107 @@ describe("reconcileMergedPrCreditForUser", () => {
       }),
       { merge: true }
     );
+  });
+
+  it("throws when admin db is null", async () => {
+    mockGetAdminDb.mockReturnValueOnce(null as never);
+    await expect(reconcileMergedPrCreditForUser("u1", "alice")).rejects.toThrow(
+      "Firebase Admin",
+    );
+  });
+
+  it("throws when github login is empty / whitespace", async () => {
+    mockGetAdminDb.mockReturnValueOnce({} as never);
+    await expect(reconcileMergedPrCreditForUser("u1", "   ")).rejects.toThrow(
+      "GitHub login is required",
+    );
+  });
+
+});
+
+describe("fetchMergedPullRequestsForAuthor", () => {
+  const originalFetch = global.fetch;
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = { ...originalEnv };
+  });
+
+  it("returns [] for empty / whitespace login without calling fetch", async () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as never;
+    expect(await fetchMergedPullRequestsForAuthor("")).toEqual([]);
+    expect(await fetchMergedPullRequestsForAuthor("   ")).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when github search returns non-OK", async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 503,
+      text: async () => "service unavailable",
+    })) as typeof fetch;
+    await expect(fetchMergedPullRequestsForAuthor("alice")).rejects.toThrow(
+      "GitHub merged PR search failed",
+    );
+  });
+
+  it("includes Authorization Bearer header when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_secret";
+    const fetchSpy = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ items: [] }),
+    }));
+    global.fetch = fetchSpy as never;
+    await fetchMergedPullRequestsForAuthor("alice");
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init as { headers: Record<string, string> }).headers.Authorization).toBe(
+      "Bearer ghp_secret",
+    );
+  });
+
+  it("breaks pagination when a page returns empty items array", async () => {
+    const fetchSpy = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ items: [] }),
+    }));
+    global.fetch = fetchSpy as never;
+    const items = await fetchMergedPullRequestsForAuthor("alice");
+    expect(items).toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("breaks pagination when a page has fewer than SEARCH_PER_PAGE items", async () => {
+    let calls = 0;
+    const fetchSpy = jest.fn(async () => {
+      calls += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          items: Array.from({ length: 3 }, (_, i) => ({
+            number: i + 1,
+            title: `PR ${i + 1}`,
+            html_url: `https://example.com/${i + 1}`,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            closed_at: "2026-01-01T00:01:00Z",
+            user: { login: "alice" },
+          })),
+        }),
+      };
+    });
+    global.fetch = fetchSpy as never;
+    const items = await fetchMergedPullRequestsForAuthor("alice");
+    expect(items).toHaveLength(3);
+    expect(calls).toBe(1); // Did not fetch page 2 because page 1 had < 100
+  });
+
+  it("handles items=undefined in response (defaults to [])", async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    })) as typeof fetch;
+    expect(await fetchMergedPullRequestsForAuthor("alice")).toEqual([]);
   });
 });

--- a/__tests__/lib/github.test.ts
+++ b/__tests__/lib/github.test.ts
@@ -337,3 +337,88 @@ describe("processPullRequest", () => {
     ).rejects.toThrow("Firebase Admin is not configured");
   });
 });
+
+/* ------------------------------------------------------------------ */
+/*  Additional edge cases — coverage push #35                         */
+/* ------------------------------------------------------------------ */
+
+describe("verifyWebhookSignature — secret-set path", () => {
+  it("returns true for a correctly-signed payload", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret-1";
+    jest.resetModules();
+    const { verifyWebhookSignature: verify } = await import("@/lib/github");
+    const crypto = await import("crypto");
+    const payload = '{"foo":"bar"}';
+    const sig =
+      "sha256=" +
+      crypto.createHmac("sha256", "test-secret-1").update(payload).digest("hex");
+    expect(verify(payload, sig)).toBe(true);
+  });
+
+  it("returns false for a tampered signature with the same length", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret-2";
+    jest.resetModules();
+    const { verifyWebhookSignature: verify } = await import("@/lib/github");
+    const crypto = await import("crypto");
+    const payload = '{"foo":"bar"}';
+    const correctSig =
+      "sha256=" +
+      crypto.createHmac("sha256", "test-secret-2").update(payload).digest("hex");
+    // Flip one char while preserving length
+    const tampered = correctSig.slice(0, -1) + (correctSig.slice(-1) === "0" ? "1" : "0");
+    expect(verify(payload, tampered)).toBe(false);
+  });
+});
+
+describe("findUserByGitHubLogin — extra branches", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockReset();
+  });
+
+  it("returns null when admin db is unavailable", async () => {
+    const { getAdminDb } = require("@/lib/firebase-admin");
+    (getAdminDb as jest.Mock).mockReturnValueOnce(null);
+    expect(await findUserByGitHubLogin("alice")).toBeNull();
+  });
+
+  it("falls back to exact-case query when lowercase query is empty AND case differs", async () => {
+    // First query (lowercase) → empty
+    mockGet.mockResolvedValueOnce({ empty: true, docs: [] });
+    // Second query (exact case) → finds user
+    mockGet.mockResolvedValueOnce({ empty: false, docs: [{ id: "u-mixed" }] });
+    const result = await findUserByGitHubLogin("MixedCase");
+    expect(result).toBe("u-mixed");
+    // Should have queried lowercase then exact
+    expect(mockWhere).toHaveBeenNthCalledWith(1, "github.login", "==", "mixedcase");
+    expect(mockWhere).toHaveBeenNthCalledWith(2, "github.login", "==", "MixedCase");
+  });
+
+  it("returns null when both lowercase and exact-case queries are empty", async () => {
+    mockGet
+      .mockResolvedValueOnce({ empty: true, docs: [] })
+      .mockResolvedValueOnce({ empty: true, docs: [] });
+    expect(await findUserByGitHubLogin("MixedCase")).toBeNull();
+  });
+});
+
+describe("fetchPullRequestChangedFilenames — env-token branch", () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+  afterEach(() => {
+    if (originalToken !== undefined) process.env.GITHUB_TOKEN = originalToken;
+    else delete process.env.GITHUB_TOKEN;
+  });
+
+  it("sends Authorization: Bearer when GITHUB_TOKEN is set", async () => {
+    process.env.GITHUB_TOKEN = "ghp_secret-token";
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ filename: "a.ts" }],
+    });
+    await fetchPullRequestChangedFilenames("o", "r", 1);
+    const [, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+    expect((init as { headers: Record<string, string> }).headers.Authorization).toBe(
+      "Bearer ghp_secret-token",
+    );
+  });
+});

--- a/__tests__/lib/hackathon-asprint-2026-awards.test.ts
+++ b/__tests__/lib/hackathon-asprint-2026-awards.test.ts
@@ -6,7 +6,10 @@ import {
   computeShowcaseAwards,
   hackASprint2026ZonedWallTimeToUtcMs,
   isHackASprint2026PeerAwardsRevealed,
+  showcaseAwardLabelsForRow,
+  SHOWCASE_AWARD_LABEL,
   type ShowcaseAwardInput,
+  type ShowcaseAwardKind,
 } from "@/lib/hackathon-asprint-2026-awards";
 import { HACK_A_SPRINT_2026_TIMEZONE } from "@/lib/hackathon-asprint-2026-schedule";
 
@@ -114,5 +117,185 @@ describe("computeShowcaseAwards", () => {
     expect(isHackASprint2026PeerAwardsRevealed(new Date("2026-04-17T12:01:00-04:00"))).toBe(
       true
     );
+  });
+
+  it("breaks AI ties by score then by submissionId", () => {
+    // Two rows share aiRank=1 — score then submissionId should resolve ordering
+    const rows: ShowcaseAwardInput[] = [
+      {
+        submissionId: "z-row",
+        githubLogin: "z-user",
+        aiRank: 1,
+        aiScore: 5,
+        peerAverage: null,
+      },
+      {
+        submissionId: "a-row",
+        githubLogin: "a-user",
+        aiRank: 1,
+        aiScore: 5,
+        peerAverage: null,
+      },
+      {
+        submissionId: "b-row",
+        githubLogin: "b-user",
+        aiRank: 1,
+        aiScore: 9, // higher score, wins first AI slot
+        peerAverage: null,
+      },
+    ];
+    const m = computeShowcaseAwards(rows, new Date("2026-04-17T11:00:00-04:00"));
+    // Top AI score takes the first AI slot
+    expect(m.get("b-row")).toEqual(["aiJudgedWinner"]);
+    // Then ties resolved by submissionId localeCompare: a-row before z-row
+    expect(m.get("a-row")).toEqual(["aiJudgedWinner"]);
+    expect(m.get("z-row")).toBeUndefined();
+  });
+
+  it("excludes rows with null AI rank AND null AI score from AI awards", () => {
+    const rows: ShowcaseAwardInput[] = [
+      {
+        submissionId: "missing-ai",
+        githubLogin: "missing-ai",
+        aiRank: null,
+        aiScore: null,
+        peerAverage: null,
+      },
+      {
+        submissionId: "has-ai",
+        githubLogin: "has-ai",
+        aiRank: 1,
+        aiScore: 9,
+        peerAverage: null,
+      },
+    ];
+    const m = computeShowcaseAwards(rows, new Date("2026-04-17T11:00:00-04:00"));
+    expect(m.get("has-ai")).toEqual(["aiJudgedWinner"]);
+    expect(m.get("missing-ai")).toBeUndefined();
+  });
+
+  it("breaks peer ties by submissionId localeCompare", () => {
+    const afterPeer = new Date("2026-04-17T13:00:00-04:00");
+    const rows: ShowcaseAwardInput[] = [
+      {
+        submissionId: "z-peer",
+        githubLogin: "z-peer",
+        aiRank: null,
+        aiScore: null,
+        peerAverage: 8.0,
+      },
+      {
+        submissionId: "a-peer",
+        githubLogin: "a-peer",
+        aiRank: null,
+        aiScore: null,
+        peerAverage: 8.0,
+      },
+    ];
+    const m = computeShowcaseAwards(rows, afterPeer);
+    // Ties resolved alphabetically; a-peer wins first slot
+    expect(m.get("a-peer")).toEqual(["peerReviewWinner"]);
+    expect(m.get("z-peer")).toEqual(["peerReviewWinner"]);
+  });
+
+  it("pushes rows with null peerAverage to end of peer ranking", () => {
+    const afterPeer = new Date("2026-04-17T13:00:00-04:00");
+    const rows: ShowcaseAwardInput[] = [
+      {
+        submissionId: "no-peer",
+        githubLogin: "no-peer",
+        aiRank: null,
+        aiScore: null,
+        peerAverage: null,
+      },
+      {
+        submissionId: "low-peer",
+        githubLogin: "low-peer",
+        aiRank: null,
+        aiScore: null,
+        peerAverage: 1.0,
+      },
+    ];
+    const m = computeShowcaseAwards(rows, afterPeer);
+    // low-peer wins despite low score; no-peer is excluded by `peerAverage == null` skip
+    expect(m.get("low-peer")).toEqual(["peerReviewWinner"]);
+    expect(m.get("no-peer")).toBeUndefined();
+  });
+
+  it("handles all-null peer averages by alphabetic ordering (still excluded)", () => {
+    const afterPeer = new Date("2026-04-17T13:00:00-04:00");
+    const rows: ShowcaseAwardInput[] = [
+      {
+        submissionId: "alpha",
+        githubLogin: "alpha",
+        aiRank: null,
+        aiScore: null,
+        peerAverage: null,
+      },
+      {
+        submissionId: "beta",
+        githubLogin: "beta",
+        aiRank: null,
+        aiScore: null,
+        peerAverage: null,
+      },
+    ];
+    // No peer winners since peerAverage is null for everyone (continue branch)
+    const m = computeShowcaseAwards(rows, afterPeer);
+    expect(m.size).toBe(0);
+  });
+});
+
+describe("env-var override for peer reveal", () => {
+  const originalEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("honours NEXT_PUBLIC_HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT when set", () => {
+    process.env.NEXT_PUBLIC_HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT =
+      "2026-04-01T00:00:00Z";
+    expect(isHackASprint2026PeerAwardsRevealed(new Date("2026-04-02T00:00:00Z"))).toBe(true);
+    expect(isHackASprint2026PeerAwardsRevealed(new Date("2026-03-31T23:00:00Z"))).toBe(false);
+  });
+
+  it("ignores invalid env-var values and falls back to compiled reveal time", () => {
+    process.env.NEXT_PUBLIC_HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT = "not-a-date";
+    // Falls back to compiled 2026-04-17 12:00 NY time
+    expect(isHackASprint2026PeerAwardsRevealed(new Date("2026-04-17T11:00:00-04:00"))).toBe(
+      false,
+    );
+  });
+
+  it("uses HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT when NEXT_PUBLIC variant absent", () => {
+    delete process.env.NEXT_PUBLIC_HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT;
+    process.env.HACK_A_SPRINT_2026_PEER_AWARDS_REVEAL_AT = "2026-04-01T00:00:00Z";
+    expect(isHackASprint2026PeerAwardsRevealed(new Date("2026-04-02T00:00:00Z"))).toBe(true);
+  });
+});
+
+describe("showcaseAwardLabelsForRow", () => {
+  it("returns empty array when no award for the submission", () => {
+    const awards = new Map<string, ShowcaseAwardKind[]>();
+    expect(showcaseAwardLabelsForRow(awards, "no-such-id")).toEqual([]);
+  });
+
+  it("translates award kinds to display labels", () => {
+    const awards = new Map<string, ShowcaseAwardKind[]>([
+      ["alice", ["judgesWinner", "peerReviewWinner"]],
+    ]);
+    expect(showcaseAwardLabelsForRow(awards, "alice")).toEqual([
+      SHOWCASE_AWARD_LABEL.judgesWinner,
+      SHOWCASE_AWARD_LABEL.peerReviewWinner,
+    ]);
+  });
+
+  it("normalises submissionId (trim + lowercase) before lookup", () => {
+    const awards = new Map<string, ShowcaseAwardKind[]>([
+      ["alice", ["aiJudgedWinner"]],
+    ]);
+    expect(showcaseAwardLabelsForRow(awards, "  ALICE  ")).toEqual([
+      SHOWCASE_AWARD_LABEL.aiJudgedWinner,
+    ]);
   });
 });

--- a/__tests__/lib/ludwitt-tokens.test.ts
+++ b/__tests__/lib/ludwitt-tokens.test.ts
@@ -397,4 +397,111 @@ describe("lib/ludwitt-tokens", () => {
       expect(call.mock.calls).toEqual([["AT0"], ["AT1"]]);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Lock-wait path — coverage push #32
+  // ---------------------------------------------------------------------------
+
+  describe("refreshLudwittTokens — lock-wait path", () => {
+    function lockedTokenDb(initialSnap: ReturnType<typeof tokenSnap>, refreshedSnap?: ReturnType<typeof tokenSnap>) {
+      const update = jest.fn().mockResolvedValue(undefined);
+      // The post-claim re-read of the doc returns refreshedSnap if provided
+      const get = jest
+        .fn()
+        .mockResolvedValueOnce(initialSnap)
+        .mockResolvedValue(refreshedSnap ?? initialSnap);
+      const docRef = { get, update };
+      const collection = jest.fn().mockReturnValue({
+        doc: jest.fn().mockReturnValue(docRef),
+      });
+      // Transaction sees a fresh lock that hasn't expired → returns false (lock-wait branch)
+      const runTransaction = jest.fn(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          get: jest.fn().mockResolvedValue(initialSnap),
+          update: jest.fn(),
+        };
+        return fn(tx);
+      });
+      const db = { collection, runTransaction };
+      return { db, docRef, get, update };
+    }
+
+    it("waits and returns fresh tokens when another caller releases the lock", async () => {
+      // Initial snapshot: lock held (expires in 5s)
+      const locked = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+        refreshLockId: "other-lock",
+        refreshLockExpiresAt: tsLikeMs(Date.now() + 5000),
+      });
+      // After the wait, the lock is gone and the tokens are fresh
+      const released = tokenSnap({
+        accessToken: "AT1",
+        refreshToken: "RT1",
+        scope: "read",
+        accessExpiresAt: tsLikeMs(Date.now() + 3600 * 1000),
+        // refreshLockId absent → unlocked
+      });
+      const { db } = lockedTokenDb(locked, released);
+      adminDbMock.mockReturnValueOnce(db);
+
+      const out = await refreshLudwittTokens("u1");
+      expect(out.accessToken).toBe("AT1");
+      expect(out.refreshToken).toBe("RT1");
+    });
+
+    it("times out after LOCK_WAIT_MAX_ATTEMPTS polls when lock is never released", async () => {
+      const locked = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+        refreshLockId: "other-lock",
+        refreshLockExpiresAt: tsLikeMs(Date.now() + 60_000),
+      });
+      const { db } = lockedTokenDb(locked, locked);
+      adminDbMock.mockReturnValueOnce(db);
+
+      await expect(refreshLudwittTokens("u1")).rejects.toThrow("ludwitt_refresh_lock_timeout");
+    }, 10_000);
+
+    it("throws ludwitt_tokens_missing if doc disappears during wait", async () => {
+      const locked = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+        refreshLockId: "other-lock",
+        refreshLockExpiresAt: tsLikeMs(Date.now() + 60_000),
+      });
+      const gone = tokenSnap(null);
+      const { db } = lockedTokenDb(locked, gone);
+      adminDbMock.mockReturnValueOnce(db);
+
+      await expect(refreshLudwittTokens("u1")).rejects.toThrow("ludwitt_tokens_missing");
+    }, 10_000);
+
+    it("ignores expired locks and continues the wait loop", async () => {
+      const lockedExpired = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+        refreshLockId: "stale-lock",
+        // Expired lock — wait loop should accept tokens
+        refreshLockExpiresAt: tsLikeMs(Date.now() - 1000),
+      });
+      // The transaction sees an active lock first (so we enter the wait loop)
+      const lockedActive = tokenSnap({
+        accessToken: "AT0",
+        refreshToken: "RT0",
+        accessExpiresAt: tsLikeMs(0),
+        refreshLockId: "active-lock",
+        refreshLockExpiresAt: tsLikeMs(Date.now() + 60_000),
+      });
+      const { db } = lockedTokenDb(lockedActive, lockedExpired);
+      adminDbMock.mockReturnValueOnce(db);
+
+      const out = await refreshLudwittTokens("u1");
+      expect(out.accessToken).toBe("AT0");
+    });
+  });
 });

--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -135,6 +135,43 @@ describe("isOriginAllowed", () => {
       isOriginAllowed(makeRequest({ method: "POST", referer: "not a url" }))
     ).toBe(false);
   });
+
+  it("returns true when origin equals the request URL origin (same-origin POST)", () => {
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          origin: "http://localhost:3000",
+          url: "http://localhost:3000/api/x",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when referer origin equals the request URL origin (same-origin)", () => {
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          referer: "http://localhost:3000/path/to/page",
+          url: "http://localhost:3000/api/x",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when referer origin matches NEXT_PUBLIC_APP_URL", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://staging.example.com";
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          referer: "https://staging.example.com/some/page",
+        }),
+      ),
+    ).toBe(true);
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
 });
 
 describe("withCsrfProtection", () => {

--- a/__tests__/lib/pydata-submissions.test.ts
+++ b/__tests__/lib/pydata-submissions.test.ts
@@ -270,6 +270,88 @@ describe("getPyDataSubmissions", () => {
       { displayName: "Co B", githubHandle: null },
     ]);
   });
+
+  it("silently ignores a malformed score.json (still returns the submission, no score)", () => {
+    const result = withTempCwd((root) => {
+      const folder = path.join(root, PYDATA_SUBMISSIONS_DIR, "scored-bad");
+      fs.mkdirSync(folder, { recursive: true });
+      fs.writeFileSync(path.join(folder, "submission.py"), "# marimo notebook\n");
+      fs.writeFileSync(
+        path.join(folder, "meta.json"),
+        JSON.stringify({ title: "T", description: "D", displayName: "T" }),
+      );
+      fs.writeFileSync(path.join(folder, "score.json"), "{ not valid json");
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].score).toBeNull();
+  });
+
+  it("ignores a score.json with out-of-range score", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-oor",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: 11, rationale: "too high", model: "claude" } },
+      );
+    });
+    expect(result[0].score).toBeNull();
+  });
+
+  it("ignores a score.json with non-numeric score", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-non-num",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: "not a number", rationale: "x", model: "claude" } },
+      );
+    });
+    expect(result[0].score).toBeNull();
+  });
+
+  it("ignores a score.json with empty rationale", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-no-rationale",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: 7, rationale: "", model: "claude" } },
+      );
+    });
+    expect(result[0].score).toBeNull();
+  });
+
+  it("defaults missing model to 'unknown' in a valid score.json", () => {
+    const result = withTempCwd((root) => {
+      writeSubmission(
+        root,
+        "scored-no-model",
+        { title: "T", description: "D", displayName: "T" },
+        { score: { score: 8, rationale: "good work" } },
+      );
+    });
+    expect(result[0].score?.model).toBe("unknown");
+  });
+
+  it("returns [] when the on-disk readdir throws (e.g. permission denied)", () => {
+    const original = process.cwd();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pydata-readdir-throw-"));
+    try {
+      process.chdir(tmp);
+      const base = path.join(tmp, PYDATA_SUBMISSIONS_DIR);
+      fs.mkdirSync(base, { recursive: true });
+      const readdirSpy = jest.spyOn(fs, "readdirSync").mockImplementation(() => {
+        throw new Error("EACCES");
+      });
+      const result = getPyDataSubmissions();
+      expect(result).toEqual([]);
+      readdirSpy.mockRestore();
+    } finally {
+      process.chdir(original);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("submissions constants", () => {


### PR DESCRIPTION
## Summary

Develop → main release shipping **21 OpenSSF Gold coverage push PRs** (#1140-#1161) accumulated this session.

### Global coverage progress
| Metric | Pre-session | Now | Gold target |
|---|---|---|---|
| Statements | 81.51% | **82.89%** (+1.38pp) | 90% |
| Branches | 67.04% | **68.81%** (+1.77pp) | 80% |
| Lines | n/a | 85.81% | — |
| Functions | n/a | 74.47% | — |

### PRs included (in merge order, oldest first)
| Push | PR | Target | Lift (stmt / branch) |
|---|---|---|---|
| #18 | #1140 | internal rate-limits cleanup | 31→100 / 4→100 |
| #19 | #1141 | internal hunt/email-retry | 0→100 / 0→95.65 |
| #20 | #1142 | weekly-hiring-partners | 84→95 / 76→89 |
| #21 | #1143 | summer-cohort my-score | 0→100 / 0→97 |
| #22 | #1144 | showcase/vote POST | 41→97 / 26→95 |
| #23 | #1145 | pydata withdraw | 0→92 / 0→93 |
| #24 | #1146 | live/queue | 80→96 / 81→100 |
| #25 | #1147 | cursor recover-agent | 66→94 / 34→90 |
| #26 | #1148 | cursor idea-runs [runId] | 64→97 / 31→80 |
| #27 | #1149 | cursor idea-runs root | 69→92 / 31→71 |
| #28 | #1150 | hack-a-sprint judge-score | 0→96 / 0→95 |
| #29 | #1151 | hack-a-sprint participant-score | 0→96 / 0→93 |
| #30 | #1152 | hack-a-sprint credit-email | 0→95 / 0→100 |
| #31 | #1153 | hack-a-sprint me | 0→97 / 0→100 |
| #32 | #1154 | ludwitt-tokens lock-wait | 81→98 / 69→95 |
| #33 | #1156 | hack-a-sprint awards | 77→94 / 58→93 |
| #34 | #1157 | github merged-PR reconcile | 85→95 / 58→80 |
| #35 | #1158 | github helpers | 88→97 / 81→93 |
| #36 | #1159 | middleware CSRF | 95→98 / 87→95 |
| #37 | #1160 | api-response | 0→100 / 0→100 |
| #38 | #1161 | pydata score.json paths | 93→96 / 87→93 |

### Contributors
- @Ludwitt (Project Lead) — all 21 push PRs

### Notes
- All 21 PRs are test-file additions only — no production code touched.
- Released via `gh pr merge --admin` per the documented DCO/BEHIND bypass for the Project Lead.
- Remaining work toward Gold: ~7pp statement coverage + ~11pp branch coverage. Estimated 60-80 more coverage PRs at current cadence.

## Test plan
- [x] All 21 PRs passed local unit + coverage runs before merge
- [x] Global statement coverage now 82.89% (above the 79.5% jest.config.js floor)
- [x] Global branch coverage now 68.81% (above the 65% jest.config.js floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)