### PR TITLE
test(openssf-gold): coverage push #40 — zero-turn toMillis branches

### DIFF
--- a/__tests__/lib/game/zero-turn.test.ts
+++ b/__tests__/lib/game/zero-turn.test.ts
@@ -85,6 +85,15 @@ describe("isHeroMeditating", () => {
   it("returns false when hero is null", () => {
     expect(isHeroMeditating(null, NOW)).toBe(false);
   });
+  it("accepts a Firestore Timestamp-like object via the toMillis branch", () => {
+    const futureMillis = FUTURE.getTime();
+    const timestampLike = { toMillis: () => futureMillis } as unknown as Date;
+    expect(isHeroMeditating(hero({ meditatingUntil: timestampLike }), NOW)).toBe(true);
+  });
+  it("returns false for an unrecognised meditatingUntil shape (no Date, no toMillis)", () => {
+    const garbage = { foo: "bar" } as unknown as Date;
+    expect(isHeroMeditating(hero({ meditatingUntil: garbage }), NOW)).toBe(false);
+  });
 });
 
 describe("countMeditatingHeroes", () => {


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #40.

Backfills the two `toMillis()` helper branches in `lib/game/zero-turn.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 92% | **96%** |
| Branches | 83.78% | **89.18%** |
| Functions | 100% | **100%** |
| Lines | 96.38% | **100%** |

2 small tests cover:
- Firestore Timestamp-like object (with `toMillis()` function) feeds correctly into `isHeroMeditating`
- Unrecognised value shape (no Date, no toMillis) → returns `false`, exercising the `return null` fallback

## Test plan
- [x] `npx jest __tests__/lib/game/zero-turn` — 32/32 pass
- [x] Library at 96% stmt / 89.18% branch / 100% fn / 100% lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)