### PR TITLE
test(openssf-gold): coverage push #41 — world-gen spawn-validation throws

### DIFF
--- a/__tests__/lib/game/world-gen.test.ts
+++ b/__tests__/lib/game/world-gen.test.ts
@@ -206,4 +206,42 @@ describe("spawnPlayerLands", () => {
     expect(r.contiguousTileIds).toHaveLength(40);
     expect(r.exclaveTileIds).toHaveLength(10);
   });
+
+  it("throws when contiguousTarget + exclavesMin exceeds totalTiles", () => {
+    expect(() =>
+      spawnPlayerLands({
+        center: { q: 0, r: 0 },
+        claimedTileIds: new Set(),
+        rng: makeSeededRng("invalid"),
+        totalTiles: 30,
+        contiguousTarget: 25,
+        exclavesMin: 10,
+        exclavesMax: 10, // sum 35 > 30
+      }),
+    ).toThrow(/exceeds totalTiles/);
+  });
+
+  it("throws when every tile near the spawn center is already claimed", () => {
+    // Fully claim a wide hex radius around the requested center so
+    // findUnclaimedNear can't find an unclaimed seed → throw branch.
+    const center = { q: 500, r: 500 };
+    const claimed = new Set<string>();
+    for (let dq = -10; dq <= 10; dq++) {
+      for (let dr = -10; dr <= 10; dr++) {
+        claimed.add(tileIdFromAxial(center.q + dq, center.r + dr));
+      }
+    }
+    expect(() =>
+      spawnPlayerLands({
+        center,
+        claimedTileIds: claimed,
+        rng: makeSeededRng("blocked"),
+        totalTiles: 10,
+        contiguousTarget: 5,
+        exclavesMin: 1,
+        exclavesMax: 1,
+        scatterRadius: 3, // small radius → all blocked
+      }),
+    ).toThrow(/Could not find an unclaimed tile/);
+  });
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #41.

Backfills the two spawn-validation throw paths in `lib/game/world-gen.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 92.36% | **95.41%** |
| Branches | 83.87% | **90.32%** |
| Functions | 100% | **100%** |
| Lines | 92.92% | **96.46%** |

2 new tests:
- Throws `exceeds totalTiles` when `contiguousTarget + exclavesMin > totalTiles`
- Throws `Could not find an unclaimed tile` when every tile in `scatterRadius` of the spawn center is already claimed

Branch coverage +6.45pp.

## Test plan
- [x] `npx jest __tests__/lib/game/world-gen` — 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)