### PR TITLE
test(openssf-gold): coverage push #42 — validateGeneralName error branches

### DIFF
--- a/__tests__/lib/game/turns-pure.test.ts
+++ b/__tests__/lib/game/turns-pure.test.ts
@@ -63,6 +63,24 @@ describe("lib/game/turns (pure)", () => {
         `at most ${GENERAL_NAME_MAX}`,
       );
     });
+
+    it("rejects non-string input", () => {
+      expect(() => validateGeneralName(42 as unknown as string)).toThrow(
+        "Name must be a string",
+      );
+    });
+
+    it("rejects names with disallowed characters (e.g. emoji)", () => {
+      expect(() => validateGeneralName("Ada 🚀")).toThrow(
+        /only letters, digits, spaces/,
+      );
+    });
+
+    it("rejects names with leading or trailing apostrophes/hyphens", () => {
+      expect(() => validateGeneralName("-Ada")).toThrow();
+      expect(() => validateGeneralName("Ada-")).toThrow();
+      expect(() => validateGeneralName("'Ada")).toThrow();
+    });
   });
 
   it("newPlayer seeds starting turns and explore phase", () => {


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #42.

Backfills name-validation error branches in `lib/game/turns.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 93.44% | **95.08%** |
| Branches | 84.5% | **87.32%** |
| Functions | 100% | **100%** |
| Lines | 95.14% | **97.08%** |

3 new tests cover non-string input rejection, disallowed-character (emoji) rejection, and leading/trailing punctuation rejection.

## Test plan
- [x] `npx jest __tests__/lib/game/turns` — 58/58 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)