### PR TITLE
test(openssf-gold): coverage push #43 — hackathon signup remaining branches

### DIFF
--- a/__tests__/lib/hackathon-event-signup.test.ts
+++ b/__tests__/lib/hackathon-event-signup.test.ts
@@ -76,4 +76,48 @@ describe("hackathon-event-signup", () => {
       profileMatchesHackathonJudgeCheckinException(null, { email: "participant@example.com" })
     ).toBe(false);
   });
+
+  it("blocks when public but no GitHub linked", () => {
+    expect(
+      getHackathonEventSignupBlockReason({
+        visibility: { isPublic: true },
+        // No github
+        discord: { id: "1" },
+      }),
+    ).toBe("Connect GitHub in your profile to sign up.");
+  });
+
+  it("blocks when public + github but no Discord", () => {
+    expect(
+      getHackathonEventSignupBlockReason({
+        visibility: { isPublic: true },
+        github: { login: "u" },
+        // No discord
+      }),
+    ).toBe("Connect Discord in your profile to sign up.");
+  });
+
+  it("judge exception: token mismatch + undefined profile returns false (no further checks)", () => {
+    expect(
+      profileMatchesHackathonJudgeCheckinException("not-a-judge@example.com", undefined),
+    ).toBe(false);
+  });
+
+  it("judge exception: additionalEmails with verified=false is ignored", () => {
+    expect(
+      profileMatchesHackathonJudgeCheckinException(null, {
+        email: "non-judge@example.com",
+        additionalEmails: [{ verified: false, email: "MikeBoensel@gmail.com" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("judge exception: additionalEmails entry without email field is skipped", () => {
+    expect(
+      profileMatchesHackathonJudgeCheckinException(null, {
+        email: "non-judge@example.com",
+        additionalEmails: [{ verified: true }],
+      }),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #43.

Backfills remaining branches in `lib/hackathon-event-signup.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 93.1% | **94.82%** |
| Branches | 93.02% | **97.67%** |
| Functions | 100% | **100%** |
| Lines | 100% | **100%** |

5 new tests cover the public-without-GitHub block, public-with-github-no-discord block, and three judge-exception edge cases (token mismatch + no profile, additionalEmails with verified=false, additionalEmails without email field).

## Test plan
- [x] `npx jest __tests__/lib/hackathon-event-signup` — 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)