### PR TITLE
test(openssf-gold): coverage push #46 — community/repost rate-limit/db/error paths

### DIFF
--- a/__tests__/app/api/community/repost.test.ts
+++ b/__tests__/app/api/community/repost.test.ts
@@ -6,6 +6,8 @@ import { NextRequest } from "next/server";
 import { POST } from "@/app/api/community/repost/route";
 import type { VerifiedUser } from "@/lib/server-auth";
 import { getVerifiedUser } from "@/lib/server-auth";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import { getAdminDb } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/logger", () => ({
   logger: { error: jest.fn(), logError: jest.fn() },
@@ -106,5 +108,72 @@ describe("POST /api/community/repost", () => {
       })
     );
     expect(mockTxUpdate).toHaveBeenCalled();
+  });
+
+  it("returns 429 when rate limit denies, with Retry-After header", async () => {
+    const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+    mockRate.mockResolvedValueOnce({
+      success: false,
+      remaining: 0,
+      retryAfter: 45,
+      resetTime: Date.now() + 60000,
+    } as never);
+    const res = await POST(makeRequest({ originalId: "msg-1", content: validContent }));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("45");
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+  });
+
+  it("returns 429 with default Retry-After=60 when rate limit lacks retryAfter", async () => {
+    const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+    mockRate.mockResolvedValueOnce({
+      success: false,
+      remaining: 0,
+      resetTime: Date.now() + 60000,
+    } as never);
+    const res = await POST(makeRequest({ originalId: "msg-1", content: validContent }));
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 500 when admin db is null", async () => {
+    const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+    mockDb.mockReturnValueOnce(null as never);
+    const res = await POST(makeRequest({ originalId: "msg-1", content: validContent }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Server not configured");
+  });
+
+  it("returns 400 for invalid JSON in body", async () => {
+    const req = new NextRequest("http://localhost/api/community/repost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid JSON");
+  });
+
+  it("returns 400 for content too long (>500 chars)", async () => {
+    const res = await POST(
+      makeRequest({ originalId: "msg-1", content: "A".repeat(501) }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod schema rejects the body shape", async () => {
+    const res = await POST(makeRequest({ originalId: 123, content: 456 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 'Internal server error' when transaction throws", async () => {
+    mockRunTransaction.mockRejectedValueOnce(new Error("tx exploded"));
+    const res = await POST(makeRequest({ originalId: "msg-1", content: validContent }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Internal server error");
   });
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #46.

Backfills rate-limit, db, JSON-parse, and error-catch paths in `app/api/community/repost/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 87.09% | **94.64%** |
| Branches | 66.66% | **78.12%** |
| Functions | 100% | **100%** |
| Lines | 90% | **98.14%** |

7 new tests cover rate-limit 429 (with explicit retryAfter + default), admin db null, invalid JSON body, content too long (>500), schema-rejection on bad shape, and the runTransaction-throw catch.

## Test plan
- [x] `npx jest __tests__/app/api/community/repost` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)