### PR TITLE
test(openssf-gold): coverage push #47 — community/reply rate-limit/db/error paths

### DIFF
--- a/__tests__/app/api/community/reply.test.ts
+++ b/__tests__/app/api/community/reply.test.ts
@@ -6,6 +6,8 @@ import { NextRequest } from "next/server";
 import { POST } from "@/app/api/community/reply/route";
 import type { VerifiedUser } from "@/lib/server-auth";
 import { getVerifiedUser } from "@/lib/server-auth";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import { getAdminDb } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/logger", () => ({
   logger: { error: jest.fn(), logError: jest.fn() },
@@ -93,5 +95,70 @@ describe("POST /api/community/reply", () => {
     expect(body.replyId).toBe("reply-123");
     expect(mockTxSet).toHaveBeenCalled();
     expect(mockTxUpdate).toHaveBeenCalled();
+  });
+
+  it("returns 429 when rate limit denies, with Retry-After", async () => {
+    const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+    mockRate.mockResolvedValueOnce({
+      success: false,
+      remaining: 0,
+      retryAfter: 20,
+      resetTime: Date.now() + 60000,
+    } as never);
+    const res = await POST(makeRequest({ parentId: "msg-1", content: validContent }));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("20");
+  });
+
+  it("returns 429 with default Retry-After=60 when retryAfter absent", async () => {
+    const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
+    mockRate.mockResolvedValueOnce({
+      success: false,
+      remaining: 0,
+      resetTime: Date.now() + 60000,
+    } as never);
+    const res = await POST(makeRequest({ parentId: "msg-1", content: validContent }));
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 500 when admin db is null", async () => {
+    const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+    mockDb.mockReturnValueOnce(null as never);
+    const res = await POST(makeRequest({ parentId: "msg-1", content: validContent }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Server not configured");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/community/reply", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid JSON");
+  });
+
+  it("returns 400 for content too long (>500 chars)", async () => {
+    const res = await POST(
+      makeRequest({ parentId: "msg-1", content: "A".repeat(501) }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod schema rejects the body shape", async () => {
+    const res = await POST(makeRequest({ parentId: 123, content: 456 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 'Internal server error' when transaction throws", async () => {
+    mockRunTransaction.mockRejectedValueOnce(new Error("tx died"));
+    const res = await POST(makeRequest({ parentId: "msg-1", content: validContent }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Internal server error");
   });
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #47.

Mirrors push #46's pattern on `app/api/community/reply/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 83.92% | **94.64%** |
| Branches | 69.23% | **84.61%** |
| Functions | 100% | **100%** |
| Lines | 87.03% | **98.14%** |

7 new tests cover rate-limit 429 (explicit + default Retry-After), admin db null, invalid JSON body, content >500, schema-rejection, and runTransaction-throw 500.

Branch coverage +15.38pp.

## Test plan
- [x] `npx jest __tests__/app/api/community/reply` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)