### PR TITLE
test(openssf-gold): coverage push #77 — auth/resolve-email guards

### DIFF
--- a/__tests__/app/api/auth/resolve-email.test.ts
+++ b/__tests__/app/api/auth/resolve-email.test.ts
@@ -91,4 +91,49 @@ describe("POST /api/auth/resolve-email", () => {
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
+
+  it("returns 500 when admin db is null", async () => {
+    const fb = require("@/lib/firebase-admin");
+    fb.getAdminDb.mockReturnValueOnce(null);
+    const res = await POST(makeRequest({ email: "alice@example.com" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when admin auth is null", async () => {
+    const fb = require("@/lib/firebase-admin");
+    fb.getAdminAuth.mockReturnValueOnce(null);
+    const res = await POST(makeRequest({ email: "alice@example.com" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns null when emailLookup doc has no data", async () => {
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => undefined,
+    });
+    const res = await POST(makeRequest({ email: "alias@example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBeNull();
+    expect(body.message).toBe("Email not found");
+  });
+
+  it("returns null when user record has no primary email", async () => {
+    mockGetUserByEmail.mockRejectedValue(new Error("not found"));
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ uid: "u1" }),
+    });
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({}),
+    });
+    const res = await POST(makeRequest({ email: "orphan@example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryEmail).toBeNull();
+    expect(body.message).toContain("no primary email");
+  });
+
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #77.

Covers `app/api/auth/resolve-email/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 86.84% | **94.73%** |
| Branches | 75% | **93.75%** |
| Functions | 100% | **100%** |
| Lines | 86.11% | **94.44%** |

4 new tests cover db-null, auth-null, the emailLookup-doc-no-data fallback, and the user-record-without-primary-email fallback.

**Branch coverage +18.75pp**.

## Test plan
- [x] `npx jest __tests__/app/api/auth/resolve-email` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)