### PR TITLE
test(openssf-gold): coverage push #82 — cursor idea-run open-pr guards

### DIFF
--- a/__tests__/app/api/cursor/idea-runs.route.test.ts
+++ b/__tests__/app/api/cursor/idea-runs.route.test.ts
@@ -590,6 +590,69 @@ describe("Cursor idea runs API", () => {
     });
   });
 
+  it("open-pr returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/open-pr/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/open-pr", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("open-pr returns 500 when admin db is null", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/open-pr/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/open-pr", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("open-pr returns 404 when run is missing or has no cursorAgentId", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "ready_for_pr",
+      // No cursorAgentId
+      buildResult: "Built",
+      pr: { status: "not_started" },
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/open-pr/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/open-pr", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("open-pr returns 500 'open_pr_failed' when sendCursorFollowUp throws", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "ready_for_pr",
+      cursorAgentId: "bc-agent-1",
+      buildResult: "Built",
+      pr: { status: "not_started" },
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockSendCursorFollowUp.mockRejectedValueOnce(new Error("cursor api down"));
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/open-pr/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/open-pr", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "open_pr_failed" });
+  });
+
   it("rejects opening a PR before the build is ready", async () => {
     docs.set("run-1", {
       userId: "user-1",


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #82.

Covers `app/api/cursor/idea-runs/[runId]/open-pr/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 81.08% | **94.59%** |
| Branches | 60% | **90%** |
| Functions | 100% | **100%** |
| Lines | 93.75% | **100%** |

4 new tests cover 401/500/404 guards and the 'open_pr_failed' 500 catch.

**Branch coverage +30pp**.

## Test plan
- [x] `npx jest __tests__/app/api/cursor/idea-runs` — 67/67 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)