### PR TITLE
test(openssf-gold): coverage push #83 — cursor idea-run questions guards

### DIFF
--- a/__tests__/app/api/cursor/idea-runs.route.test.ts
+++ b/__tests__/app/api/cursor/idea-runs.route.test.ts
@@ -423,6 +423,87 @@ describe("Cursor idea runs API", () => {
     });
   });
 
+  it("questions returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/questions/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/questions", "POST", { selectedIdea: "x" }),
+      params("run-1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("questions returns 500 when admin db is null", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/questions/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/questions", "POST", { selectedIdea: "x" }),
+      params("run-1"),
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("questions returns 400 on invalid JSON body", async () => {
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/questions/route");
+    const req = new NextRequest("http://localhost/api/cursor/idea-runs/run-1/questions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req, params("run-1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("questions returns 400 on schema rejection (no selectedIdea)", async () => {
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/questions/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/questions", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("questions returns 404 when run missing or has no cursorAgentId", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "ideas",
+      // No cursorAgentId
+      result: "Idea list",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/questions/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/questions", "POST", { selectedIdea: "x" }),
+      params("run-1"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("questions returns 409 'agent_recovery_required' when sendCursorFollowUp throws", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "ideas",
+      cursorAgentId: "bc-agent-1",
+      result: "Idea list",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockSendCursorFollowUp.mockRejectedValueOnce(new Error("cursor api down"));
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/questions/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/questions", "POST", { selectedIdea: "x" }),
+      params("run-1"),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "agent_recovery_required" });
+  });
+
   it("rejects questions before ideas are ready", async () => {
     docs.set("run-1", {
       userId: "user-1",


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #83.

Covers `app/api/cursor/idea-runs/[runId]/questions/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 75% | **95.34%** |
| Branches | 55.55% | **100%** |
| Functions | 50% | **100%** |
| Lines | 82.5% | **100%** |

6 new tests cover the 401/500/400/404 guards + the 'agent_recovery_required' 409 catch.

**Branch coverage 100%** on this file.

## Test plan
- [x] `npx jest __tests__/app/api/cursor/idea-runs` — 73/73 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)