### PR TITLE
test(openssf-gold): coverage push #85 — cursor idea-run approve-plan guards

### DIFF
--- a/__tests__/app/api/cursor/idea-runs.route.test.ts
+++ b/__tests__/app/api/cursor/idea-runs.route.test.ts
@@ -711,6 +711,94 @@ describe("Cursor idea runs API", () => {
     });
   });
 
+  it("approve-plan returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/approve-plan/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/approve-plan", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("approve-plan returns 500 when admin db is null", async () => {
+    const fbAdmin = require("@/lib/firebase-admin");
+    fbAdmin.getAdminDb.mockReturnValueOnce(null);
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/approve-plan/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/approve-plan", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("approve-plan returns 404 when run missing or buildPlan absent", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "plan_approval",
+      cursorAgentId: "bc-agent-1",
+      // No buildPlan
+      prompt: "Prompt",
+      inputs: {},
+    });
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/approve-plan/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/approve-plan", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("approve-plan falls back to launchCursorAgentRun when sendCursorFollowUp throws", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "plan_approval",
+      cursorAgentId: "bc-agent-1",
+      buildPlan: "## Plan",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockSendCursorFollowUp.mockRejectedValueOnce(new Error("follow-up failed"));
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/approve-plan/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/approve-plan", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(202);
+    expect(mockLaunchCursorAgentRun).toHaveBeenCalled();
+    expect(docs.get("run-1")).toMatchObject({
+      cursorAgentId: "bc-agent-fresh",
+      buildRunId: "fresh-run-1",
+      workflowStage: "building",
+    });
+  });
+
+  it("approve-plan returns 500 'approval_failed' when both follow-up and fresh agent fail", async () => {
+    docs.set("run-1", {
+      userId: "user-1",
+      type: "pr_ideas",
+      status: "finished",
+      workflowStage: "plan_approval",
+      cursorAgentId: "bc-agent-1",
+      buildPlan: "## Plan",
+      prompt: "Prompt",
+      inputs: {},
+    });
+    mockSendCursorFollowUp.mockRejectedValueOnce(new Error("follow-up failed"));
+    mockLaunchCursorAgentRun.mockRejectedValueOnce(new Error("fresh agent failed"));
+    const { POST } = await import("@/app/api/cursor/idea-runs/[runId]/approve-plan/route");
+    const res = await POST(
+      request("/api/cursor/idea-runs/run-1/approve-plan", "POST", {}),
+      params("run-1"),
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "approval_failed" });
+  });
+
   it("opens a PR after build readiness", async () => {
     docs.set("run-1", {
       userId: "user-1",


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #85.

Covers `app/api/cursor/idea-runs/[runId]/approve-plan/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 79.54% | **90.9%** |
| Branches | 58.82% | **88.88%** |
| Functions | 66.66% | **100%** |
| Lines | 91.89% | **95%** |

5 new tests cover 401/500/404 guards, the launchCursorAgentRun fresh-agent fallback path when sendCursorFollowUp fails, and the 'approval_failed' 500 catch when both paths fail.

**Branch coverage +30pp**.

## Test plan
- [x] `npx jest __tests__/app/api/cursor/idea-runs` — 83/83 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)