### PR TITLE
test(openssf-gold): coverage push #89 — auth/remove-email db + error paths

### DIFF
--- a/__tests__/app/api/auth/remove-email.test.ts
+++ b/__tests__/app/api/auth/remove-email.test.ts
@@ -83,4 +83,46 @@ describe("POST /api/auth/remove-email", () => {
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockDelete).toHaveBeenCalled();
   });
+
+  it("returns 500 when admin db is null", async () => {
+    const fb = require("@/lib/firebase-admin");
+    fb.getAdminDb.mockReturnValueOnce(null);
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/auth/remove-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("treats user.additionalEmails missing as empty (still 400 with not found)", async () => {
+    mockUserGet.mockResolvedValue({
+      data: () => ({}),
+    });
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("not found");
+  });
+
+  it("returns 500 'Failed to remove email' on unexpected throw", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockUserGet.mockResolvedValue({
+      data: () => ({
+        additionalEmails: [{ email: "test@example.com" }],
+      }),
+    });
+    mockUpdate.mockRejectedValueOnce(new Error("firestore write failed"));
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to remove email");
+    consoleErrorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push #89.

Covers `app/api/auth/remove-email/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 89.18% | **100%** |
| Branches | 75% | **93.75%** |
| Functions | 100% | **100%** |
| Lines | 91.66% | **100%** |

4 new tests cover db-null, invalid JSON, missing-additionalEmails, and the update-throw 500.

**Branch coverage +18.75pp**. Statement coverage 100%.

## Test plan
- [x] `npx jest __tests__/app/api/auth/remove-email` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)