### PR TITLE
test(openssf-gold): coverage push #90 — hackathon event checkin edge cases

### DIFF
--- a/__tests__/app/api/hackathons/events/checkin.route.test.ts
+++ b/__tests__/app/api/hackathons/events/checkin.route.test.ts
@@ -6,6 +6,7 @@ import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/events/[eventId]/checkin/route";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 jest.mock("@/lib/rate-limit", () => {
   const actual = jest.requireActual("@/lib/rate-limit");
@@ -226,5 +227,42 @@ describe("POST /api/hackathons/events/[eventId]/checkin", () => {
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toContain("cursorboston.com account");
+  });
+
+  it("returns 429 when rate-limited with defaulted Retry-After=60", async () => {
+    (checkRateLimit as jest.Mock).mockReturnValueOnce({ success: false });
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", isAdmin: true });
+    const req = makeRequest({ userId: "u1", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("returns 400 when userId is whitespace-only", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", isAdmin: true });
+    const req = makeRequest({ userId: "   ", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("userId required");
+  });
+
+  it("returns 500 'Failed to update check-in' when firestore update throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockGetVerifiedUser.mockResolvedValue({ uid: "admin", isAdmin: true });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => makeMockDoc({ /* signup exists */ })),
+          update: jest.fn().mockRejectedValue(new Error("write conflict")),
+        })),
+      })),
+    } as never);
+    const req = makeRequest({ userId: "u1", checkedIn: true });
+    const res = await POST(req, makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Failed to update check-in");
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Gold** coverage push **#90** — milestone push.

Covers `app/api/hackathons/events/[eventId]/checkin/route.ts`:

| Metric | Before | After |
|---|---|---|
| Statements | 89.65% | **96.55%** |
| Branches | 78.57% | **92.85%** |
| Functions | 100% | **100%** |
| Lines | 92.85% | **100%** |

3 new tests cover the default Retry-After=60, whitespace userId 400, and the update-throw 500.

## Test plan
- [x] `npx jest __tests__/app/api/hackathons/events/checkin` — 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)