### PR TITLE
fix(test): add scrollIntoView jsdom polyfill

### DIFF
--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -9,6 +9,12 @@ if (typeof globalThis.TextEncoder === 'undefined') {
   globalThis.TextDecoder = util.TextDecoder
 }
 
+// jsdom does not implement Element.prototype.scrollIntoView; pages that call it
+// inside a requestAnimationFrame throw under test (e.g. summer-cohort edit flow).
+if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = function scrollIntoViewStub() {}
+}
+
 // Stub next/cache for unit tests. `unstable_cache` and `revalidateTag` need
 // Next's request-scoped incremental cache store, which Jest route-handler
 // tests don't set up. Pass-through unstable_cache (no caching — every call


### PR DESCRIPTION
## Summary

- Adds `Element.prototype.scrollIntoView` no-op polyfill to `config/jest.setup.js`.
- Fixes the single failing test on develop CI introduced by #1287 (`__tests__/app/summer-cohort/page-coverage.test.tsx > clicking openEditDetails from a NextSteps todo opens the edit form`).
- jsdom doesn't implement `scrollIntoView`; the page calls it inside a `requestAnimationFrame` in the edit-details handler, which throws under the jsdom env even though the suite passes on agents' worktrees (jest cache).

## Test plan
- [x] Run failing suite locally: `npm test -- __tests__/app/summer-cohort/page-coverage.test.tsx` — 66/66 pass
- [ ] Verify CI Test job goes green on the post-merge develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)