### PR TITLE
fix(readme): cache-bust OpenSSF badge URL so GitHub shows Gold

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.bestpractices.dev/projects/12883/2"><img src="https://www.bestpractices.dev/projects/12883/badge" alt="OpenSSF Best Practices Gold" height="28" /></a>
+  <a href="https://www.bestpractices.dev/projects/12883/2"><img src="https://www.bestpractices.dev/projects/12883/badge?v=gold-2026-05-20" alt="OpenSSF Best Practices Gold" height="28" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

The README still rendered as Silver in GitHub even after #1295 pointed the click-through to the Gold show page. Root cause: **GitHub's camo image proxy** keyed the cached SVG on the badge URL hash, and that hash hadn't changed. The bestpractices.dev `/projects/12883/badge` endpoint already serves Gold (`curl` confirms it contains `gold` in the SVG), but camo kept serving its cached Silver copy.

Fix: append `?v=gold-2026-05-20` to the badge URL. New hash → camo re-fetches → Gold renders.

## Test plan
- [x] `curl https://www.bestpractices.dev/projects/12883/badge?v=gold-2026-05-20` returns SVG containing `gold`
- [ ] After merge + main release, the README on github.com/rogerSuperBuilderAlpha/cursor-boston shows the Gold badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)