### PR TITLE
release: 2026-05-20c — cache-bust Gold badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.bestpractices.dev/projects/12883/2"><img src="https://www.bestpractices.dev/projects/12883/badge" alt="OpenSSF Best Practices Gold" height="28" /></a>
+  <a href="https://www.bestpractices.dev/projects/12883/2"><img src="https://www.bestpractices.dev/projects/12883/badge?v=gold-2026-05-20" alt="OpenSSF Best Practices Gold" height="28" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Tiny follow-up release: append a cache-bust query string to the OpenSSF badge URL so GitHub's camo image proxy serves the Gold SVG instead of the previously-cached Silver one.

- #1297 — fix(readme): cache-bust OpenSSF badge URL so GitHub shows Gold (Roger Hunt)

## Test plan
- [x] curl confirms `/projects/12883/badge?v=gold-2026-05-20` returns Gold
- [ ] github.com/rogerSuperBuilderAlpha/cursor-boston README renders the Gold badge after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)