### PR TITLE
fix(ci): clean up lint, scorecard trigger, contributors SIGPIPE

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,5 +1,10 @@
-# OpenSSF Scorecard — supply-chain posture signal (weekly + on push to main/develop).
+# OpenSSF Scorecard — supply-chain posture signal (weekly + on push to default branch).
 # https://github.com/ossf/scorecard-action
+#
+# The scorecard action only analyzes the repository's default branch, which is
+# `develop` for this project. Triggering on push to `main` (or any non-default
+# branch) makes the action error with "Only the default branch develop is
+# supported." Keep this in sync with the GitHub default-branch setting.
 
 name: Scorecard
 
@@ -7,7 +12,7 @@ on:
   schedule:
     - cron: '25 4 * * 1'
   push:
-    branches: [main]
+    branches: [develop]
   workflow_dispatch:
 
 permissions: read-all

--- a/__tests__/app/game/zero-turn-page.test.tsx
+++ b/__tests__/app/game/zero-turn-page.test.tsx
@@ -466,7 +466,6 @@ describe("ZeroTurnHubPage — action handlers", () => {
   it("Throw with non-Error value surfaces 'Failed' fallback", async () => {
     global.fetch = jest.fn(async (url: string, init?: RequestInit) => {
       if (url.includes("/api/game/heroes/meditate") && init?.method === "POST") {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw "string-thrown";
       }
       if (url.includes("/api/game/player")) {

--- a/__tests__/app/hackathons/hack-a-sprint-admin-page.test.tsx
+++ b/__tests__/app/hackathons/hack-a-sprint-admin-page.test.tsx
@@ -221,7 +221,6 @@ describe("AdminDashboardPage (hack-a-sprint-2026)", () => {
     setAuth({ user: makeUser() });
     global.fetch = jest.fn(async () => {
       // Throw a non-Error (string) — exercises the `e instanceof Error ? ... : "Couldn't..."` branch.
-      // eslint-disable-next-line @typescript-eslint/no-throw-literal -- intentional non-Error throw to test fallback branch
       throw "boom-non-error";
     }) as never;
     render(<AdminDashboardPage />);

--- a/__tests__/app/hackathons/sports-hack-admin-page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-admin-page.test.tsx
@@ -16,8 +16,8 @@
  * 60s polling skipped when error is set, and StatCard highlight/warn
  * variants.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
+ 
+ 
 
 import React from "react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
@@ -352,7 +352,6 @@ describe("SportsHack2026AdminPage", () => {
     setAuth({ user: makeUser() });
     (global.fetch as unknown as jest.Mock).mockImplementationOnce(() => {
       // Throw a non-Error → falls back to the default error string.
-      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw "boom";
     });
     render(<SportsHack2026AdminPage />);

--- a/__tests__/components/cookbook/prompt-markdown.test.tsx
+++ b/__tests__/components/cookbook/prompt-markdown.test.tsx
@@ -105,16 +105,16 @@ describe("PromptMarkdown", () => {
     // Render each non-code override to make sure they produce DOM.
     const { container } = render(
       <>
-        {React.createElement(C.p as React.ComponentType<{ children: React.ReactNode }>, { children: "para" })}
-        {React.createElement(C.ul as React.ComponentType<{ children: React.ReactNode }>, { children: <li>one</li> })}
-        {React.createElement(C.ol as React.ComponentType<{ children: React.ReactNode }>, { children: <li>two</li> })}
-        {React.createElement(C.li as React.ComponentType<{ children: React.ReactNode }>, { children: "item" })}
-        {React.createElement(C.h1 as React.ComponentType<{ children: React.ReactNode }>, { children: "h1" })}
-        {React.createElement(C.h2 as React.ComponentType<{ children: React.ReactNode }>, { children: "h2" })}
-        {React.createElement(C.h3 as React.ComponentType<{ children: React.ReactNode }>, { children: "h3" })}
-        {React.createElement(C.strong as React.ComponentType<{ children: React.ReactNode }>, { children: "b" })}
-        {React.createElement(C.blockquote as React.ComponentType<{ children: React.ReactNode }>, { children: "quote" })}
-        {React.createElement(C.pre as React.ComponentType<{ children: React.ReactNode }>, { children: "raw" })}
+        {React.createElement(C.p as React.ComponentType<{ children: React.ReactNode }>, null, "para")}
+        {React.createElement(C.ul as React.ComponentType<{ children: React.ReactNode }>, null, <li>one</li>)}
+        {React.createElement(C.ol as React.ComponentType<{ children: React.ReactNode }>, null, <li>two</li>)}
+        {React.createElement(C.li as React.ComponentType<{ children: React.ReactNode }>, null, "item")}
+        {React.createElement(C.h1 as React.ComponentType<{ children: React.ReactNode }>, null, "h1")}
+        {React.createElement(C.h2 as React.ComponentType<{ children: React.ReactNode }>, null, "h2")}
+        {React.createElement(C.h3 as React.ComponentType<{ children: React.ReactNode }>, null, "h3")}
+        {React.createElement(C.strong as React.ComponentType<{ children: React.ReactNode }>, null, "b")}
+        {React.createElement(C.blockquote as React.ComponentType<{ children: React.ReactNode }>, null, "quote")}
+        {React.createElement(C.pre as React.ComponentType<{ children: React.ReactNode }>, null, "raw")}
       </>
     );
     expect(container.textContent).toContain("para");

--- a/scripts/generate-contributors.sh
+++ b/scripts/generate-contributors.sh
@@ -79,8 +79,11 @@ while read -r line; do
   name=$(echo "$rest" | cut -d'|' -f1)
   email=$(echo "$rest" | cut -d'|' -f2)
 
-  first_date=$(git log --no-merges --use-mailmap --author="$email" \
-    --format='%ai' --reverse 2>/dev/null | head -1 | cut -d' ' -f1)
+  # `git log ... | head -1` would SIGPIPE under `set -o pipefail` once head
+  # closes the pipe — kills the script in CI with exit 141. Wrap the log in
+  # `|| true` so its SIGPIPE death is swallowed before head sees the close.
+  first_date=$( { git log --no-merges --use-mailmap --author="$email" \
+    --format='%ai' --reverse 2>/dev/null || true; } | head -1 | cut -d' ' -f1)
 
   ghuser=$(github_user "$email")
   prs=$(pr_count_for "$ghuser")


### PR DESCRIPTION
## Summary

Bundles three independent CI failures that were keeping develop + main red even after the Gold release. Each is small and scoped.

### 1. Lint — stale `no-throw-literal` disable comments (3 files)

`eslint.config.mjs` doesn't load `@typescript-eslint/no-throw-literal` (the `@typescript-eslint` plugin is registered but no rules from it are enabled). The `eslint-disable-next-line @typescript-eslint/no-throw-literal` comments referenced a rule the linter doesn't know about, which ESLint treats as an error:

```
Definition for rule '@typescript-eslint/no-throw-literal' was not found
```

Removed the stale disable comments from:
- `__tests__/app/game/zero-turn-page.test.tsx:469`
- `__tests__/app/hackathons/hack-a-sprint-admin-page.test.tsx:224`
- `__tests__/app/hackathons/sports-hack-admin-page.test.tsx:355`

The `throw "string"` statements aren't flagged by any other rule, so no replacement disable is needed.

### 2. Lint — `react/no-children-prop` in prompt-markdown.test.tsx (10 violations)

`React.createElement(C.p, { children: "para" })` triggers `react/no-children-prop`. Switched all 10 sites to the idiomatic third-arg form: `React.createElement(C.p, null, "para")`. Behavior is identical; the rule is satisfied.

### 3. Scorecard workflow — wrong default-branch trigger

`.github/workflows/scorecards.yml` triggered on push to `main`, but `ossf/scorecard-action` only analyzes the repository's default branch (which is `develop` here). Every push-to-main fired the workflow and the action errored with:

```
Only the default branch develop is supported.
```

Switched trigger to `[develop]` and added a comment explaining why so future readers don't try to bring `main` back without changing the GitHub default-branch setting first.

### 4. Update Contributors workflow — `head -1` SIGPIPE under pipefail

`scripts/generate-contributors.sh` ran `git log ... | head -1 | cut ...` inside a loop. Under `set -o pipefail`, once `head -1` closed the pipe, `git log` received SIGPIPE and the script exited 141. Wrapped the `git log` in `|| true` inside a subshell so its SIGPIPE death is swallowed before `head` sees the close. Local reruns now exit 0 and write the 92-contributor file successfully.

## Test plan

- [x] Lint: `npx eslint <the 4 files>` → 0 errors (was 13 errors)
- [x] Jest: 1218/1218 tests still pass across the 4 touched test files
- [x] Contributors script: `bash scripts/generate-contributors.sh` exits 0 locally
- [ ] Verify CI Lint job goes green on develop after merge
- [ ] Verify next Scorecard run (triggered on push to develop) doesn't error
- [ ] Verify next Update Contributors run (triggered on push to main) doesn't exit 141

🤖 Generated with [Claude Code](https://claude.com/claude-code)