### PR TITLE
release: 2026-05-20d — CI green (lint + scorecard + contributors fixes)

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,5 +1,10 @@
-# OpenSSF Scorecard — supply-chain posture signal (weekly + on push to main/develop).
+# OpenSSF Scorecard — supply-chain posture signal (weekly + on push to default branch).
 # https://github.com/ossf/scorecard-action
+#
+# The scorecard action only analyzes the repository's default branch, which is
+# `develop` for this project. Triggering on push to `main` (or any non-default
+# branch) makes the action error with "Only the default branch develop is
+# supported." Keep this in sync with the GitHub default-branch setting.
 
 name: Scorecard
 
@@ -7,7 +12,7 @@ on:
   schedule:
     - cron: '25 4 * * 1'
   push:
-    branches: [main]
+    branches: [develop]
   workflow_dispatch:
 
 permissions: read-all

--- a/__tests__/app/game/zero-turn-page.test.tsx
+++ b/__tests__/app/game/zero-turn-page.test.tsx
@@ -466,7 +466,6 @@ describe("ZeroTurnHubPage — action handlers", () => {
   it("Throw with non-Error value surfaces 'Failed' fallback", async () => {
     global.fetch = jest.fn(async (url: string, init?: RequestInit) => {
       if (url.includes("/api/game/heroes/meditate") && init?.method === "POST") {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw "string-thrown";
       }
       if (url.includes("/api/game/player")) {

--- a/__tests__/app/hackathons/hack-a-sprint-admin-page.test.tsx
+++ b/__tests__/app/hackathons/hack-a-sprint-admin-page.test.tsx
@@ -221,7 +221,6 @@ describe("AdminDashboardPage (hack-a-sprint-2026)", () => {
     setAuth({ user: makeUser() });
     global.fetch = jest.fn(async () => {
       // Throw a non-Error (string) — exercises the `e instanceof Error ? ... : "Couldn't..."` branch.
-      // eslint-disable-next-line @typescript-eslint/no-throw-literal -- intentional non-Error throw to test fallback branch
       throw "boom-non-error";
     }) as never;
     render(<AdminDashboardPage />);

--- a/__tests__/app/hackathons/sports-hack-admin-page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-admin-page.test.tsx
@@ -16,8 +16,8 @@
  * 60s polling skipped when error is set, and StatCard highlight/warn
  * variants.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
+ 
+ 
 
 import React from "react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
@@ -352,7 +352,6 @@ describe("SportsHack2026AdminPage", () => {
     setAuth({ user: makeUser() });
     (global.fetch as unknown as jest.Mock).mockImplementationOnce(() => {
       // Throw a non-Error → falls back to the default error string.
-      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw "boom";
     });
     render(<SportsHack2026AdminPage />);

--- a/__tests__/components/cookbook/prompt-markdown.test.tsx
+++ b/__tests__/components/cookbook/prompt-markdown.test.tsx
@@ -105,16 +105,16 @@ describe("PromptMarkdown", () => {
     // Render each non-code override to make sure they produce DOM.
     const { container } = render(
       <>
-        {React.createElement(C.p as React.ComponentType<{ children: React.ReactNode }>, { children: "para" })}
-        {React.createElement(C.ul as React.ComponentType<{ children: React.ReactNode }>, { children: <li>one</li> })}
-        {React.createElement(C.ol as React.ComponentType<{ children: React.ReactNode }>, { children: <li>two</li> })}
-        {React.createElement(C.li as React.ComponentType<{ children: React.ReactNode }>, { children: "item" })}
-        {React.createElement(C.h1 as React.ComponentType<{ children: React.ReactNode }>, { children: "h1" })}
-        {React.createElement(C.h2 as React.ComponentType<{ children: React.ReactNode }>, { children: "h2" })}
-        {React.createElement(C.h3 as React.ComponentType<{ children: React.ReactNode }>, { children: "h3" })}
-        {React.createElement(C.strong as React.ComponentType<{ children: React.ReactNode }>, { children: "b" })}
-        {React.createElement(C.blockquote as React.ComponentType<{ children: React.ReactNode }>, { children: "quote" })}
-        {React.createElement(C.pre as React.ComponentType<{ children: React.ReactNode }>, { children: "raw" })}
+        {React.createElement(C.p as React.ComponentType<{ children: React.ReactNode }>, null, "para")}
+        {React.createElement(C.ul as React.ComponentType<{ children: React.ReactNode }>, null, <li>one</li>)}
+        {React.createElement(C.ol as React.ComponentType<{ children: React.ReactNode }>, null, <li>two</li>)}
+        {React.createElement(C.li as React.ComponentType<{ children: React.ReactNode }>, null, "item")}
+        {React.createElement(C.h1 as React.ComponentType<{ children: React.ReactNode }>, null, "h1")}
+        {React.createElement(C.h2 as React.ComponentType<{ children: React.ReactNode }>, null, "h2")}
+        {React.createElement(C.h3 as React.ComponentType<{ children: React.ReactNode }>, null, "h3")}
+        {React.createElement(C.strong as React.ComponentType<{ children: React.ReactNode }>, null, "b")}
+        {React.createElement(C.blockquote as React.ComponentType<{ children: React.ReactNode }>, null, "quote")}
+        {React.createElement(C.pre as React.ComponentType<{ children: React.ReactNode }>, null, "raw")}
       </>
     );
     expect(container.textContent).toContain("para");

--- a/scripts/generate-contributors.sh
+++ b/scripts/generate-contributors.sh
@@ -79,8 +79,11 @@ while read -r line; do
   name=$(echo "$rest" | cut -d'|' -f1)
   email=$(echo "$rest" | cut -d'|' -f2)
 
-  first_date=$(git log --no-merges --use-mailmap --author="$email" \
-    --format='%ai' --reverse 2>/dev/null | head -1 | cut -d' ' -f1)
+  # `git log ... | head -1` would SIGPIPE under `set -o pipefail` once head
+  # closes the pipe — kills the script in CI with exit 141. Wrap the log in
+  # `|| true` so its SIGPIPE death is swallowed before head sees the close.
+  first_date=$( { git log --no-merges --use-mailmap --author="$email" \
+    --format='%ai' --reverse 2>/dev/null || true; } | head -1 | cut -d' ' -f1)
 
   ghuser=$(github_user "$email")
   prs=$(pr_count_for "$ghuser")


### PR DESCRIPTION
## Summary

Ships the CI-cleanup PRs that should bring both develop and main back to green:

- #1297 — fix(readme): cache-bust OpenSSF badge URL so GitHub shows Gold (already on main via #1298)
- #1299 — fix(ci): clean up lint, scorecard trigger, contributors SIGPIPE

After this lands:
- **Lint and Type Check** job — passes (removed stale `@typescript-eslint/no-throw-literal` disables, fixed `react/no-children-prop` in cookbook test)
- **Scorecard** workflow — no longer triggers on `main` (would error "Only the default branch develop is supported"); runs only on push to `develop` + the existing weekly cron
- **Update Contributors** workflow — `head -1` SIGPIPE under pipefail fixed; the post-merge run on main will exit 0 and regenerate CONTRIBUTORS.md

### Contributor

- **Roger Hunt** — both PRs (pair-programmed with Claude per Co-Authored-By trailers)

## Test plan

- [x] Verified locally: lint 0 errors, jest 1218/1218 pass on touched test files, contributors script exits 0
- [ ] After merge, watch the Lint + Test + Update Contributors jobs on the post-merge main run — should all be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)