### PR TITLE
fix(docker): bump node base image 22.11.0 → 22.20.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 # ==========================================
 
 # Stage 1: Dependencies
-FROM node:22.11.0-alpine3.21 AS deps
+FROM node:22.20.0-alpine3.21 AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -17,7 +17,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --only=production && npm cache clean --force
 
 # Stage 2: Builder
-FROM node:22.11.0-alpine3.21 AS builder
+FROM node:22.20.0-alpine3.21 AS builder
 WORKDIR /app
 
 # Copy dependencies from deps stage
@@ -52,7 +52,7 @@ ENV DOCKER_BUILD=1
 RUN npm run build
 
 # Stage 3: Runner (Production)
-FROM node:22.11.0-alpine3.21 AS runner
+FROM node:22.20.0-alpine3.21 AS runner
 WORKDIR /app
 
 # Set production environment


### PR DESCRIPTION
## Summary

`node:22.11.0-alpine3.21` was unpublished from Docker Hub. The Docker Build CI job (in the main CI workflow) failed with:

```
ERROR: failed to build: failed to solve: docker.io/library/node:22.11.0-alpine3.21: not found
```

Bumped all three FROM lines in `docker/Dockerfile` to `22.20.0-alpine3.21`. Verified the new tag exists via the Docker Hub registry API. Still on the same alpine3.21 base.

## Test plan
- [x] `curl https://registry.hub.docker.com/v2/repositories/library/node/tags/22.20.0-alpine3.21/` returns 200
- [ ] After merge, the Docker Build job in the next CI run goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)