### PR TITLE
release: 2026-05-20f — bump Docker base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 # ==========================================
 
 # Stage 1: Dependencies
-FROM node:22.11.0-alpine3.21 AS deps
+FROM node:22.20.0-alpine3.21 AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -17,7 +17,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --only=production && npm cache clean --force
 
 # Stage 2: Builder
-FROM node:22.11.0-alpine3.21 AS builder
+FROM node:22.20.0-alpine3.21 AS builder
 WORKDIR /app
 
 # Copy dependencies from deps stage
@@ -52,7 +52,7 @@ ENV DOCKER_BUILD=1
 RUN npm run build
 
 # Stage 3: Runner (Production)
-FROM node:22.11.0-alpine3.21 AS runner
+FROM node:22.20.0-alpine3.21 AS runner
 WORKDIR /app
 
 # Set production environment


### PR DESCRIPTION
## Summary

Tiny follow-up release to keep CI green:

- #1304 — fix(docker): bump node base image 22.11.0 → 22.20.0 (Roger Hunt)

Surfaces the Docker Build green on next main run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)