### PR TITLE
fix(docker): skip npm lifecycle scripts in deps stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,12 @@ WORKDIR /app
 # Copy package files
 COPY package.json package-lock.json ./
 
-# Install dependencies
-RUN npm ci --only=production && npm cache clean --force
+# Install dependencies. `--ignore-scripts` skips:
+#   - prepare → `husky install` (no .git in the image)
+#   - postinstall → `node scripts/maybe-install-playwright.js` (script file isn't
+#     copied into this stage and Playwright is for e2e/dev only, not production)
+# Both are dev-environment niceties, not runtime requirements.
+RUN npm ci --only=production --ignore-scripts && npm cache clean --force
 
 # Stage 2: Builder
 FROM node:22.20.0-alpine3.21 AS builder


### PR DESCRIPTION
## Summary

Continuation of the Docker Build green-up. After #1304 bumped the node base image, the build advanced to the npm install step and hit:

```
Error: Cannot find module '/app/scripts/maybe-install-playwright.js'
npm error path /app
npm error command sh -c node scripts/maybe-install-playwright.js
```

The deps stage only copies `package.json` + `package-lock.json` (intentional, for layer caching), so the postinstall script can't find its target file. The script is a dev-only Playwright Chromium pre-fetch, which a production image doesn't need anyway.

Added `--ignore-scripts` to `npm ci --only=production` in the deps stage. This also skips `prepare → husky install` (which would also fail since there's no `.git` in the image).

## Test plan
- [x] `--ignore-scripts` is the documented npm flag for this exact use case
- [ ] Next Docker Build job on main goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)