### PR TITLE
fix(build): wire SKIP_TYPECHECK=1 to actually bypass type/eslint checks

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,6 +32,20 @@ const nextConfig = {
 
   // Standalone output is only for Docker builds (see docker/Dockerfile). Omit on Vercel.
   ...(process.env.DOCKER_BUILD === '1' ? { output: 'standalone' } : {}),
+
+  // Emergency local-build bypass — SKIP_TYPECHECK=1 disables both the
+  // TypeScript type-check and the ESLint check during `next build`. Use ONLY
+  // for local visual QA when pre-existing in-flight branch state has
+  // unrelated type/lint errors. NEVER set this in CI; CI is the boundary
+  // that catches real type errors. See CLAUDE.md "Local production
+  // verification — emergency typecheck bypass".
+  ...(process.env.SKIP_TYPECHECK === '1'
+    ? {
+        typescript: { ignoreBuildErrors: true },
+        eslint: { ignoreDuringBuilds: true },
+      }
+    : {}),
+
   serverExternalPackages: ['@cursor/sdk'],
 
   webpack: (config) => {


### PR DESCRIPTION
## Summary

CLAUDE.md documents \`SKIP_TYPECHECK=1 npm run build\` as the emergency local-build bypass for "pre-existing in-flight branch state has typecheck/lint errors in unrelated files" — but \`next.config.js\` never honored the env var, so the documented behavior didn't actually exist.

This makes the doc claim true by conditionally enabling:
- \`typescript.ignoreBuildErrors: true\`
- \`eslint.ignoreDuringBuilds: true\`

… only when \`SKIP_TYPECHECK=1\` is set. The pattern mirrors the existing \`DOCKER_BUILD === '1'\` conditional a few lines above.

## Why now

Surfaced during the 2026-05-20h release local prod verify (#1309): the build tripped on two unrelated untracked WIP scripts in \`scripts/\`, \`SKIP_TYPECHECK=1\` per CLAUDE.md was tried, did not take effect, and we had to manually move the files aside as a workaround.

## Safety

CLAUDE.md's "Never set it in CI" warning stays. CI is still the boundary that catches real type errors — this is purely a local visual-QA escape hatch.

## Test plan

- [ ] CI: lint / type-check / build / scorecard all green
- [ ] Manual: \`SKIP_TYPECHECK=1 npm run build\` succeeds on a worktree with intentional unrelated \`.ts\` type errors
- [ ] Manual: \`npm run build\` (no env var) still fails on those same errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)