### PR TITLE
release: 2026-05-20i — wire SKIP_TYPECHECK=1 build bypass

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,6 +32,20 @@ const nextConfig = {
 
   // Standalone output is only for Docker builds (see docker/Dockerfile). Omit on Vercel.
   ...(process.env.DOCKER_BUILD === '1' ? { output: 'standalone' } : {}),
+
+  // Emergency local-build bypass — SKIP_TYPECHECK=1 disables both the
+  // TypeScript type-check and the ESLint check during `next build`. Use ONLY
+  // for local visual QA when pre-existing in-flight branch state has
+  // unrelated type/lint errors. NEVER set this in CI; CI is the boundary
+  // that catches real type errors. See CLAUDE.md "Local production
+  // verification — emergency typecheck bypass".
+  ...(process.env.SKIP_TYPECHECK === '1'
+    ? {
+        typescript: { ignoreBuildErrors: true },
+        eslint: { ignoreDuringBuilds: true },
+      }
+    : {}),
+
   serverExternalPackages: ['@cursor/sdk'],
 
   webpack: (config) => {


### PR DESCRIPTION
## Summary

- #1310 — fix(build): wire SKIP_TYPECHECK=1 to actually bypass type/eslint checks (Roger Hunt / committed by Ludwitt)

Single-commit release: makes CLAUDE.md's documented `SKIP_TYPECHECK=1 npm run build` emergency local-build bypass actually work — `next.config.js` now honors the env var by conditionally setting `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds`. Mirrors the existing `DOCKER_BUILD === '1'` conditional pattern. No CI-side change; CI remains the boundary that catches real type errors.

Surfaced during today's `2026-05-20h` release prep where the documented bypass turned out to be a stale claim — fix lands so the next agent doesn't hit the same workaround dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)