### PR TITLE
release: develop → main (chore(game): +100 bonus grant + email scripts)

### DIFF
--- a/scripts/admin-grant-100-bonus.ts
+++ b/scripts/admin-grant-100-bonus.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-shot bonus grant: +100 turns to every real (non-NPC) player, layered on
+ * top of whatever they already had. Unlike admin-grant-100-this-week.ts, this
+ * does NOT touch lastWeeklyGrantWeekStart — Sunday's regular weekly grant
+ * still fires normally for anyone who merged a PR this week.
+ *
+ * Idempotent via `bonusGrantsApplied` map on the player doc, keyed by
+ * BONUS_KEY. Re-running with the same key is a no-op for already-granted
+ * players. Pair with scripts/send-game-bonus-100.ts to email recipients.
+ *
+ * Usage:
+ *   npx tsx scripts/admin-grant-100-bonus.ts --dry-run
+ *   npx tsx scripts/admin-grant-100-bonus.ts --apply
+ *   npx tsx scripts/admin-grant-100-bonus.ts --apply --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+
+const BONUS_KEY = "2026-05-20-bonus-100";
+const BONUS_AMOUNT = 100;
+
+interface PlayerDoc {
+  isNpc?: boolean;
+  displayName?: string;
+  turnsRemaining?: number;
+  bonusGrantsApplied?: Record<string, unknown>;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const apply = process.argv.includes("--apply");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !apply) {
+    console.error("Pass --dry-run or --apply.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log(`Bonus key: ${BONUS_KEY}  amount: +${BONUS_AMOUNT}`);
+  const snap = await db.collection("game_players").get();
+
+  const eligible: Array<{ userId: string; name: string; before: number; after: number }> = [];
+  let skippedNpc = 0;
+  let skippedAlreadyGranted = 0;
+
+  for (const doc of snap.docs) {
+    const d = doc.data() as PlayerDoc;
+    if (d.isNpc === true) {
+      skippedNpc++;
+      continue;
+    }
+    const already = !!d.bonusGrantsApplied?.[BONUS_KEY];
+    if (already && !force) {
+      skippedAlreadyGranted++;
+      continue;
+    }
+    const before = d.turnsRemaining ?? 0;
+    eligible.push({
+      userId: doc.id,
+      name: d.displayName?.trim() || "(unnamed)",
+      before,
+      after: before + BONUS_AMOUNT,
+    });
+  }
+
+  console.log(`Eligible real players: ${eligible.length}`);
+  console.log(`Skipped — NPC: ${skippedNpc}`);
+  console.log(`Skipped — already granted (${BONUS_KEY}): ${skippedAlreadyGranted}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no writes.");
+    const preview = eligible.slice(0, 10);
+    for (const e of preview) {
+      console.log(`  ${e.name}: ${e.before} -> ${e.after}`);
+    }
+    if (eligible.length > preview.length) {
+      console.log(`  ...and ${eligible.length - preview.length} more`);
+    }
+    return;
+  }
+
+  let applied = 0;
+  let failed = 0;
+  for (const e of eligible) {
+    try {
+      await db.collection("game_players").doc(e.userId).update({
+        turnsRemaining: FieldValue.increment(BONUS_AMOUNT),
+        [`bonusGrantsApplied.${BONUS_KEY}`]: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      applied++;
+    } catch (err) {
+      failed++;
+      console.error(`Failed: ${e.userId} (${e.name})`, err);
+    }
+  }
+
+  console.log(JSON.stringify({ bonusKey: BONUS_KEY, applied, failed, skippedNpc, skippedAlreadyGranted }, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-game-bonus-100.ts
+++ b/scripts/send-game-bonus-100.ts
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-shot bonus-grant notification — emails every real (non-NPC) player who
+ * received the +100 bonus grant keyed by BONUS_KEY. Personalizes with caste +
+ * current balance. Pair with scripts/admin-grant-100-bonus.ts (run grant
+ * first so the balance shown is accurate).
+ *
+ * Idempotent via `bonusEmailsSent` map on the player doc, keyed by BONUS_KEY.
+ *
+ * Usage:
+ *   npx tsx scripts/send-game-bonus-100.ts --dry-run
+ *   npx tsx scripts/send-game-bonus-100.ts --send
+ *   npx tsx scripts/send-game-bonus-100.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const BONUS_KEY = "2026-05-20-bonus-100";
+const GAME_URL = "https://cursorboston.com/game";
+
+interface Recipient {
+  userId: string;
+  email: string;
+  firstName: string;
+  displayName: string;
+  caste: string | null;
+  turnsRemaining: number;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmailContent(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "general");
+  const general = escapeHtml(r.displayName?.trim() || "your general");
+  const balance = r.turnsRemaining;
+  const casteLine = r.caste
+    ? `Your ${escapeHtml(r.caste)} caste has the run of the field.`
+    : "";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = `Surprise: +100 bonus turns for everyone — yours just landed`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Today every active general got a <strong>+100 turn bonus</strong> on the house. <strong>${general}</strong> is one of them. ${casteLine}</p>
+
+<p>Your current bucket: <strong>${balance} turns</strong>.</p>
+
+<p>This is a one-time gift on top of the normal Sunday grant — no PR required, no strings. Burn them on recruiting, attacks, spells, exploration — whatever moves you up the leaderboard.</p>
+
+<p>
+  <a href="${GAME_URL}" style="display:inline-block;background:#7c3aed;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open /game →
+  </a>
+</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you have an active general at cursorboston.com/game.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.firstName?.trim() || "general"},
+
+Today every active general got a +100 turn bonus on the house. ${r.displayName?.trim() || "Your general"} is one of them.${r.caste ? ` Your ${r.caste} caste has the run of the field.` : ""}
+
+Your current bucket: ${balance} turns.
+
+This is a one-time gift on top of the normal Sunday grant — no PR required, no strings. Burn them on recruiting, attacks, spells, exploration — whatever moves you up the leaderboard.
+
+Open /game: ${GAME_URL}
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you have an active general at cursorboston.com/game.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log(`Bonus key: ${BONUS_KEY}`);
+  console.log("Loading real players...");
+  const playersSnap = await db.collection("game_players").get();
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const emailByUserId = new Map<string, string>();
+  for (const doc of appsSnap.docs) {
+    const d = doc.data() as { userId?: string; email?: string };
+    if (d.userId && d.email) emailByUserId.set(d.userId, d.email.trim());
+  }
+
+  const recipients: Recipient[] = [];
+  let skippedNpc = 0;
+  let skippedNoBonus = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of playersSnap.docs) {
+    const d = doc.data() as {
+      isNpc?: boolean;
+      displayName?: string;
+      caste?: string | null;
+      turnsRemaining?: number;
+      bonusGrantsApplied?: Record<string, unknown>;
+      bonusEmailsSent?: Record<string, unknown>;
+    };
+    if (d.isNpc === true) {
+      skippedNpc++;
+      continue;
+    }
+    if (!d.bonusGrantsApplied?.[BONUS_KEY]) {
+      skippedNoBonus++;
+      continue;
+    }
+    if (!force && d.bonusEmailsSent?.[BONUS_KEY]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const email = emailByUserId.get(doc.id);
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    const displayName = (d.displayName || "").trim() || "your general";
+    const firstName = displayName.split(" ")[0] || "general";
+    recipients.push({
+      userId: doc.id,
+      email,
+      firstName,
+      displayName,
+      caste: d.caste ?? null,
+      turnsRemaining: d.turnsRemaining ?? 0,
+    });
+  }
+
+  console.log(`Eligible (got bonus, not yet emailed, has email): ${recipients.length}`);
+  console.log(`Skipped — NPC: ${skippedNpc}`);
+  console.log(`Skipped — bonus not applied: ${skippedNoBonus}`);
+  console.log(`Skipped — already emailed (${BONUS_KEY}): ${skippedAlreadyEmailed}`);
+  console.log(`Skipped — no email on cohort application: ${skippedNoEmail}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmailContent(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview (first 1500 chars) ---");
+      console.log(html.slice(0, 1500));
+      console.log("\n--- Text preview (first 1500 chars) ---");
+      console.log(text.slice(0, 1500));
+    }
+    console.log(`\nWould send to ${recipients.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmailContent(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection("game_players")
+        .doc(r.userId)
+        .update({
+          [`bonusEmailsSent.${BONUS_KEY}`]: FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+      sent++;
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Release sync. One PR included since the last develop→main:

- **#1312** chore(game): add one-shot +100 bonus grant + email scripts — @Ludwitt + Claude (Co-Authored-By)

Already executed against production data with the `2026-05-20-bonus-100` key: 21 grants applied, 20 emails sent, 0 failures. This PR commits the scripts so the action is auditable and the helpers are reusable.

## Test plan
- [x] Local `SKIP_TYPECHECK=1 npm run build` succeeds (unrelated pre-existing tsx in working tree caused typecheck noise, no impact on bundle)
- [x] `npm start` boots cleanly; `/` and `/game` return 200
- [x] Scripts are admin tsx, not imported by the Next.js bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)