### PR TITLE
release: 2026-05-21a — newcomer onboarding improvements

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,9 +35,12 @@
 
 Thank you for your interest in contributing to Cursor Boston! This document provides guidelines and instructions for contributing to the project.
 
-> **Never coded before?** Start with [Get Started (No Experience Needed)](../docs/GET_STARTED.md) — a plain-language guide that shows you how to use AI tools to contribute.
+> **In the wrong doc?**
+> - Never coded before → [GET_STARTED.md](../docs/GET_STARTED.md) (uses AI tools, plain language, ~30 min)
+> - Want a guided first-PR walkthrough with each step explained → [FIRST_CONTRIBUTION.md](../docs/FIRST_CONTRIBUTION.md) (~30–45 min)
+> - Full local setup, scripts, troubleshooting → [DEVELOPMENT.md](../docs/DEVELOPMENT.md)
 >
-> **New to open source?** Follow the [First Contribution Guide](../docs/FIRST_CONTRIBUTION.md) for a step-by-step walkthrough, or the [Development Guide](../docs/DEVELOPMENT.md) for full setup, scripts, and troubleshooting.
+> Continue below if you know git and want the contribution policy (5-minute path + full reference).
 
 ## Your first PR in 5 minutes
 
@@ -132,6 +135,7 @@ After the RFC ships, a corresponding ADR is added under [`docs/adr/`](../docs/ad
 - [RFCs — proposing substantial changes](#rfcs--proposing-substantial-changes)
 - [Code of Conduct](#code-of-conduct)
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
+- [License: GPL-3.0](#license-gpl-30)
 - [Getting Started](#getting-started)
 - [Development Workflow](#development-workflow)
 - [Claiming an Issue](#claiming-an-issue)
@@ -155,6 +159,19 @@ git commit -s -m "Your commit message"
 ```
 
 This adds a `Signed-off-by: Your Name <your.email@example.com>` line to the commit. PRs with unsigned commits are blocked by the `dco.yml` workflow. See [DCO.md](DCO.md) for the full text of what you're certifying and how to fix a missing sign-off on past commits.
+
+## License: GPL-3.0
+
+This project is licensed under [GPL-3.0](../LICENSE). By contributing, you agree your contributions are licensed under the same terms — the DCO sign-off on each commit certifies this.
+
+Practical implications you should know up front:
+
+- **If you fork** this codebase for your own community / event platform, your fork must also be GPL-3.0. You cannot relicense it under MIT or Apache.
+- **Derivative works** that incorporate code from this project must also be GPL-3.0 — this is "strong copyleft."
+- **Network use is not distribution.** Running a private hosted instance does not trigger the copyleft. Only redistributing the code (or a binary) does. (This project uses GPL-3.0, not AGPL-3.0.)
+- **If you need a permissive license** (MIT / Apache) for proprietary use, this project is not the right starting point.
+
+Every TypeScript / TSX source file under `app/`, `lib/`, `components/`, `hooks/`, `contexts/`, and `types/` carries an `SPDX-License-Identifier: GPL-3.0-or-later` header. The CI gate refuses to land new files without one — run `node scripts/add-gpl-headers.js` if you add files in those directories. See [LICENSE](../LICENSE) for full terms and [NOTICE](../NOTICE) for third-party attributions.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Want to add a major feature to the platform? We have **6 open feature projects**
 
 Each feature is **fully isolated** — new routes, new Firestore collections, no entanglement with existing code. Pick one, comment to claim it, and ship it. See the [Contributing Guide](.github/CONTRIBUTING.md#claiming-an-issue) for how to get started.
 
+> **Looking for something smaller?** Browse [`good first issue`](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) for beginner-friendly tasks. Issues tagged **`maintainer:audit`** are internal maintainer review work — not for new contributors; you can safely ignore that label.
+
 > **Where does my PR go?** Most contributions target **`develop`** (the default base). A few — PyData notebooks, summer cohort weekly submissions, game content, maintainer applications — target dedicated long-lived branches instead. See [docs/SUBMISSION_BRANCHES.md](docs/SUBMISSION_BRANCHES.md) for the routing table.
 
 ---
@@ -151,6 +153,18 @@ Each feature is **fully isolated** — new routes, new Firestore collections, no
 ---
 
 ## 📚 Community
+
+### Which onboarding doc do I read?
+
+| If you… | Read this | Time |
+|---|---|---|
+| Have never coded before | [GET_STARTED.md](docs/GET_STARTED.md) — uses AI tools, plain language | ~30 min |
+| Know git, want the shortest path to a merged PR | [CONTRIBUTING.md § Your first PR in 5 minutes](.github/CONTRIBUTING.md#your-first-pr-in-5-minutes) | ~5 min |
+| Want a guided first-PR walkthrough with explanations | [FIRST_CONTRIBUTION.md](docs/FIRST_CONTRIBUTION.md) | ~30–45 min |
+| Want the full contribution policy (issue claiming, code style, review process) | [CONTRIBUTING.md](.github/CONTRIBUTING.md) | reference |
+
+### Full documentation index
+
 - [Documentation index](docs/README.md) - Order of docs for newcomers vs maintainers
 - [User Guide](docs/USER_GUIDE.md) - Map of every section on cursorboston.com (visitor sitemap)
 - [Get Started (No Experience Needed)](docs/GET_STARTED.md) - Plain-language guide for complete beginners

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -2,6 +2,13 @@
 
 A step-by-step guide to making your first pull request. Time estimate: 30-45 minutes (including setup).
 
+> **In the wrong doc?**
+> - Never coded before → [GET_STARTED.md](GET_STARTED.md) (uses AI tools, plain language, ~30 min)
+> - Just want the shortest path to a merged PR → [CONTRIBUTING.md § Your first PR in 5 minutes](../.github/CONTRIBUTING.md#your-first-pr-in-5-minutes) (~5 min)
+> - Want the full contribution policy → [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
+>
+> Continue below if you want a guided first-PR walkthrough with each step explained.
+
 > **Prerequisites:** Complete the [Development Guide](DEVELOPMENT.md) setup first and verify the [Onboarding Checklist](DEVELOPMENT.md#onboarding-checklist) passes.
 
 ---

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -1,5 +1,12 @@
 # Getting Started (No Experience Needed)
 
+> **In the wrong doc?**
+> - Know git → [CONTRIBUTING.md § Your first PR in 5 minutes](../.github/CONTRIBUTING.md#your-first-pr-in-5-minutes) (~5 min)
+> - Want a guided first-PR walkthrough with explanations → [FIRST_CONTRIBUTION.md](FIRST_CONTRIBUTION.md) (~30–45 min)
+> - Want the full contribution policy → [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
+>
+> Continue below if you've never coded before.
+
 You don't need to know how to code to contribute to this project. Seriously.
 
 AI tools like **Cursor**, **Claude Code**, and **Codex** can do the heavy lifting for you. This guide walks you through everything in plain language — no jargon, no assumptions.


### PR DESCRIPTION
## Summary

Single-PR docs release. Companion to the 2026-05-21 newcomer's-eye OSS review.

## Included PRs

- **#1314** — `docs(onboarding): add decision-tree headers, GPL-3.0 implications, audit-label clarification` — by [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) (with Claude as Co-Authored-By)

## What changed

- **Onboarding decision tree** — README, GET_STARTED, FIRST_CONTRIBUTION, and CONTRIBUTING all open with a consistent "which doc should I read?" table. Removes silent overlap between the three onboarding paths.
- **`maintainer:audit` label disambiguation** — README clarifies this is internal-only. Points newcomers at `good first issue` + the 6 feature projects.
- **GPL-3.0 implications** — new CONTRIBUTING section right after DCO; covers fork licensing, derivative works, network-use vs distribution, and the SPDX-header CI gate.

## Companion settings changes (already landed, not via this PR)

- Label rename: `audit` → `maintainer:audit` (gray, neutral description). All 38 issues automatically retagged.
- GitHub Discussions enabled at the repo level.

## Contributors

- [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) — author + sign-off (DCO)
- Claude — co-author (review + drafting)

## Test plan

- [x] Local `npm run build` — succeeded
- [x] Local `npm start` against the production build — homepage 200, served correctly
- [x] No code changes — 4 doc files only
- [x] Markdown rendered + cross-doc links verified
- [x] CONTRIBUTING TOC updated with new section anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)