### PR TITLE
docs(contributing): set expectations for 'good first issue'

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -203,9 +203,10 @@ Open [http://localhost:3000](http://localhost:3000) to see the app.
 ### Finding Issues to Work On
 
 - Browse [GitHub Issues](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues) for open tasks
-- Look for issues labeled `good first issue` if you're new to the project
-- Issues labeled `help wanted` are actively seeking contributors
-- **Feature projects** (issues [#78](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/78)–[#83](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/83)) are fully scoped, isolated features ready to build — see the [Claiming an Issue](#claiming-an-issue) section below
+- Look for issues labeled [`good first issue`](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if you're new to the project. These are small (S/M-sized) self-contained tasks with explicit file paths and acceptance criteria — typically JSDoc / README additions, light refactors (extracting magic numbers or duplicate error strings, adding return-type annotations), accessibility labels, or scoped UI additions like empty/loading states. They're chosen to be doable without needing deep knowledge of the wider system.
+- Issues labeled `help wanted` are actively seeking contributors.
+- Issues labeled `maintainer:audit` are internal maintainer review work and are **not** contributor surface — you can safely ignore that label.
+- **Feature projects** (issues [#78](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/78)–[#83](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/83)) are fully scoped, isolated features ready to build end-to-end — see the [Claiming an Issue](#claiming-an-issue) section below.
 
 ### Branch Naming
 


### PR DESCRIPTION
## Summary

Companion to today's relabel pass: 14 issues moved from `maintainer:audit` → `good first issue` (GFI count 2 → 16).

This PR adds a paragraph in CONTRIBUTING.md so contributors landing on the GFI label know what size / shape of work to expect.

## Relabeled issues (already on GitHub)

#594 #591 #590 #583 #579 #573 #568 #565 #563 #562 #560 #558 #557 #553

All were originally filed for the Sports Hack 2026 contributor audit with S/M sizing and explicit file paths + acceptance criteria — they were correctly designed for contributor pickup, just mis-labeled. Cluster: JSDoc / README docs, light refactors (magic numbers, duplicate error strings, return types), a11y labels, scoped UI (empty/loading states).

## Why this matters

Before: `good first issue` had only 2 tickets — a newcomer scanning for entry points would bounce. After: 16, with explicit expectations documented so the label has a stable meaning.

## Test plan

- [x] No code changes — single doc file edit
- [x] Label distribution verified: `good first issue` 2 → 16; `maintainer:audit` 38 → 24
- [ ] Local build verification runs as part of the develop→main release flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)