### PR TITLE
release: 2026-05-21b — good-first-issue relabel pass + expectations doc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -203,9 +203,10 @@ Open [http://localhost:3000](http://localhost:3000) to see the app.
 ### Finding Issues to Work On
 
 - Browse [GitHub Issues](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues) for open tasks
-- Look for issues labeled `good first issue` if you're new to the project
-- Issues labeled `help wanted` are actively seeking contributors
-- **Feature projects** (issues [#78](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/78)–[#83](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/83)) are fully scoped, isolated features ready to build — see the [Claiming an Issue](#claiming-an-issue) section below
+- Look for issues labeled [`good first issue`](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if you're new to the project. These are small (S/M-sized) self-contained tasks with explicit file paths and acceptance criteria — typically JSDoc / README additions, light refactors (extracting magic numbers or duplicate error strings, adding return-type annotations), accessibility labels, or scoped UI additions like empty/loading states. They're chosen to be doable without needing deep knowledge of the wider system.
+- Issues labeled `help wanted` are actively seeking contributors.
+- Issues labeled `maintainer:audit` are internal maintainer review work and are **not** contributor surface — you can safely ignore that label.
+- **Feature projects** (issues [#78](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/78)–[#83](https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/83)) are fully scoped, isolated features ready to build end-to-end — see the [Claiming an Issue](#claiming-an-issue) section below.
 
 ### Branch Naming
 


### PR DESCRIPTION
## Summary

Second docs release of the day, following from the newcomer's-eye OSS review (in chat).

## Included PRs

- **#1316** — `docs(contributing): set expectations for what good first issue means` — by [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) (with Claude as Co-Authored-By)

## What changed

- **CONTRIBUTING.md** — expanded the `good first issue` bullet under "Finding Issues to Work On" so contributors landing on the label know what to expect: S/M-sized, self-contained, explicit file paths + acceptance criteria. Surfaces `maintainer:audit` inline as a label to ignore.

## Companion operational changes (already landed, not via this PR)

- **GFI relabel pass**: 14 issues moved from `maintainer:audit` → `good first issue` (count 2 → 16):
  - **Docs**: #594 #585 (skipped — broader caching) #562 #565
  - **Code quality**: #591 #590 #583 #573 #563 #560 #558
  - **Enhancement / UI**: #579 #568 #557
  - **Accessibility**: #553
  
  All originally filed for the Sports Hack 2026 contributor audit with S/M sizing and explicit file paths + acceptance criteria — they were correctly designed for contributor pickup, just mis-labeled.

## Contributors

- [@rogerSuperBuilderAlpha](https://github.com/rogerSuperBuilderAlpha) — author + DCO sign-off
- Claude — co-author (review + judgment on which audit issues qualify as GFI)

## Test plan

- [x] Local `npm run build` — succeeded
- [x] Local `npm start` against the production build — homepage 200, same byte count as previous release (doc-only diff)
- [x] No code changes — single doc-file edit
- [x] Label distribution verified post-relabel

🤖 Generated with [Claude Code](https://claude.com/claude-code)