### PR TITLE
feat(summer-cohort): promote c1 week 2 comms submissions to develop

### DIFF
--- a/content/summer-cohort/c1/w2-comms/submissions/HarryJ12.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/HarryJ12.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "HarryJ12",
+  "name": "Harry Joshi",
+  "photoUrl": "https://firebasestorage.googleapis.com/v0/b/cursor-boston.firebasestorage.app/o/profile-photos%2F8NQGf7Bt1IPSqAwC9DjgF9HqU7B2?alt=media&token=9b3b3d02-035d-48db-8aaa-7cd33733eac2",
+  "repoUrl": "https://github.com/HarryJ12/Pulse",
+  "liveUrl": "https://pulse-cohort.vercel.app",
+  "loomUrl": "https://www.loom.com/share/f1136634ff5840f2910df4d5e120ca23",
+  "pitch": "Pulse turns Cursor Summer Cohort 1 conversations into execution with AI-generated Markdown prompts, summaries, and digests built from project context.",
+  "competeForWin": true
+}

--- a/content/summer-cohort/c1/w2-comms/submissions/dengziwu123.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/dengziwu123.json
@@ -1,0 +1,9 @@
+{
+  "githubHandle": "dengziwu123",
+  "name": "Bo Wu",
+  "repoUrl": "https://github.com/dengziwu123/your-week-2-build",
+  "liveUrl": "https://yourthing.example.com",
+  "loomUrl": "https://www.loom.com/share/...",
+  "pitch": "Work in progress — will update before 5pm EST.",
+  "competeForWin": false
+}


### PR DESCRIPTION
## Summary

Bulk-promote the current `c1w2comms-submission` content onto `develop` ahead of Friday May 22 5pm EST submission deadline.

Brings two Week 2 cohort comms submission JSONs onto develop:

- `content/summer-cohort/c1/w2-comms/submissions/HarryJ12.json` — Harry Joshi, **Pulse** (competing for win, real submission) — from #1318
- `content/summer-cohort/c1/w2-comms/submissions/dengziwu123.json` — Bo Wu, placeholder slot (`competeForWin: false`) — from #1103

No code changes; submission JSON files only.

## Test plan

- [x] Both files parse as valid JSON
- [x] Both `githubHandle` values match the filename
- [x] HarryJ12 live app reachable at https://pulse-cohort.vercel.app
- [x] dengziwu123 is a `competeForWin: false` placeholder — won't affect Week 2 voting