### PR TITLE
feat(sports-hack): expand May 26 cap to 119 + persisted leaderboard snapshot

### DIFF
--- a/__tests__/app/api/hackathons/events/[eventId]/signup/route.test.ts
+++ b/__tests__/app/api/hackathons/events/[eventId]/signup/route.test.ts
@@ -14,15 +14,37 @@ import { getVerifiedUser, getOptionalVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { fetchMergedPrCountsForLogins } from "@/lib/github-merged-pr-count";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
-import { revalidateTag } from "next/cache";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
-jest.mock("next/cache", () => ({
-  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
-  revalidateTag: jest.fn(),
-}));
+// The route reads/writes a persisted snapshot doc in Firestore. These tests
+// exercise route handler logic (auth, validation, status flag transitions),
+// not the snapshot lib internals (covered separately). Stub:
+//   - getSnapshotOrRefresh: GET fall-through. Live-computes via the existing
+//     Firestore mocks so GET tests continue to read entries through them.
+//   - refreshSnapshot: POST/PATCH/DELETE fall-through. Returns a static empty
+//     payload (no Firestore touch) so mutation tests only need their minimal
+//     write-path mocks. Asserted as the post-mutation cache bust.
+jest.mock("@/lib/hackathon-leaderboard-snapshot", () => {
+   
+  const actual = jest.requireActual("@/lib/hackathon-leaderboard-snapshot");
+  return {
+    ...actual,
+    getSnapshotOrRefresh: jest.fn(async (eventId: string) => {
+      const payload = await actual.buildLeaderboardPayload(eventId);
+      return { ...payload, generatedAt: new Date().toISOString() };
+    }),
+    refreshSnapshot: jest.fn(async () => ({
+      entries: [],
+      totalCount: 0,
+      websiteSignupCount: 0,
+      creditTopN: 0,
+      generatedAt: new Date().toISOString(),
+    })),
+  };
+});
 
-const mockRevalidateTag = revalidateTag as jest.MockedFunction<typeof revalidateTag>;
+const mockRefreshSnapshot = refreshSnapshot as jest.MockedFunction<typeof refreshSnapshot>;
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
@@ -651,7 +673,7 @@ describe("POST /api/hackathons/events/[eventId]/signup", () => {
       }),
     );
     expect(mockSet.mock.calls[0]?.[0]).not.toHaveProperty("confirmedAt");
-    expect(mockRevalidateTag).toHaveBeenCalledWith("hackathon-event-signup", { expire: 0 });
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith(EVENT_ID);
   });
 
   it("returns 200 with alreadySignedUp when duplicate signup", async () => {
@@ -986,7 +1008,7 @@ describe("PATCH /api/hackathons/events/[eventId]/signup", () => {
     expect(status).toBe(200);
     expect(body).toMatchObject({ ok: true });
     expect(mockUpdate).toHaveBeenCalled();
-    expect(mockRevalidateTag).toHaveBeenCalledWith("hackathon-event-signup", { expire: 0 });
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith(EVENT_ID);
   });
 
   it("returns 200 when confirmed user gives up spot", async () => {
@@ -1084,6 +1106,6 @@ describe("DELETE /api/hackathons/events/[eventId]/signup", () => {
 
     expect(status).toBe(200);
     expect(body).toMatchObject({ left: true });
-    expect(mockRevalidateTag).toHaveBeenCalledWith("hackathon-event-signup", { expire: 0 });
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith(EVENT_ID);
   });
 });

--- a/__tests__/app/api/hackathons/events/signup.route.test.ts
+++ b/__tests__/app/api/hackathons/events/signup.route.test.ts
@@ -33,6 +33,33 @@ jest.mock("@/lib/github-merged-pr-count", () => ({
   fetchMergedPrCountsForLogins: jest.fn(async () => new Map()),
 }));
 
+// The route reads/writes a persisted snapshot doc in Firestore. These tests
+// exercise the route handler logic (auth, validation, status flag transitions)
+// — not the snapshot lib internals (covered separately). Stub:
+//   - getSnapshotOrRefresh: GET fall-through. Live-computes via the existing
+//     Firestore mocks so GET tests continue to read entries through them.
+//   - refreshSnapshot: POST/PATCH/DELETE fall-through. Returns a static empty
+//     payload (no Firestore touch) so mutation tests only need their
+//     minimal write-path mocks.
+jest.mock("@/lib/hackathon-leaderboard-snapshot", () => {
+   
+  const actual = jest.requireActual("@/lib/hackathon-leaderboard-snapshot");
+  return {
+    ...actual,
+    getSnapshotOrRefresh: jest.fn(async (eventId: string) => {
+      const payload = await actual.buildLeaderboardPayload(eventId);
+      return { ...payload, generatedAt: new Date().toISOString() };
+    }),
+    refreshSnapshot: jest.fn(async () => ({
+      entries: [],
+      totalCount: 0,
+      websiteSignupCount: 0,
+      creditTopN: 0,
+      generatedAt: new Date().toISOString(),
+    })),
+  };
+});
+
 jest.mock("@/lib/github-recent-merged-prs", () => ({
   getGithubRepoPair: jest.fn(() => ({ owner: "test", repo: "repo" })),
 }));

--- a/__tests__/lib/sports-hack-2026.test.ts
+++ b/__tests__/lib/sports-hack-2026.test.ts
@@ -24,8 +24,8 @@ describe("sports-hack-2026 constants", () => {
     expect(SPORTS_HACK_2026_EVENT_ID).toBe("sports-hack-2026");
   });
 
-  it("is capped at 80 confirmed seats (matches plan with user)", () => {
-    expect(SPORTS_HACK_2026_CAPACITY).toBe(80);
+  it("is capped at 119 confirmed seats (bumped 2026-05-22 to match available Cursor credits)", () => {
+    expect(SPORTS_HACK_2026_CAPACITY).toBe(119);
   });
 
   it("points at the correct Luma slug + embed id for Boston Tech Week Sports Hack", () => {
@@ -56,30 +56,30 @@ describe("sports-hack-2026 constants", () => {
   });
 
   describe("getSportsHack2026RankTier", () => {
-    it("tier progression walks from hot → far as rank increases, with the bubble at the 80-seat cap", () => {
+    it("tier progression walks from hot → far as rank increases, with the bubble at the 119-seat cap", () => {
       expect(getSportsHack2026RankTier(1).tone).toBe("hot");
-      expect(getSportsHack2026RankTier(10).tone).toBe("hot");
-      expect(getSportsHack2026RankTier(11).tone).toBe("good");
-      expect(getSportsHack2026RankTier(30).tone).toBe("good");
-      expect(getSportsHack2026RankTier(31).tone).toBe("solid");
-      expect(getSportsHack2026RankTier(60).tone).toBe("solid");
-      expect(getSportsHack2026RankTier(61).tone).toBe("bubble");
-      expect(getSportsHack2026RankTier(80).tone).toBe("bubble"); // exactly at the cap
-      expect(getSportsHack2026RankTier(81).tone).toBe("close");
-      expect(getSportsHack2026RankTier(100).tone).toBe("close");
-      expect(getSportsHack2026RankTier(101).tone).toBe("climb");
-      expect(getSportsHack2026RankTier(130).tone).toBe("climb");
-      expect(getSportsHack2026RankTier(131).tone).toBe("far");
+      expect(getSportsHack2026RankTier(15).tone).toBe("hot");
+      expect(getSportsHack2026RankTier(16).tone).toBe("good");
+      expect(getSportsHack2026RankTier(45).tone).toBe("good");
+      expect(getSportsHack2026RankTier(46).tone).toBe("solid");
+      expect(getSportsHack2026RankTier(90).tone).toBe("solid");
+      expect(getSportsHack2026RankTier(91).tone).toBe("bubble");
+      expect(getSportsHack2026RankTier(119).tone).toBe("bubble"); // exactly at the cap
+      expect(getSportsHack2026RankTier(120).tone).toBe("close");
+      expect(getSportsHack2026RankTier(150).tone).toBe("close");
+      expect(getSportsHack2026RankTier(151).tone).toBe("climb");
+      expect(getSportsHack2026RankTier(190).tone).toBe("climb");
+      expect(getSportsHack2026RankTier(191).tone).toBe("far");
       expect(getSportsHack2026RankTier(1000).tone).toBe("far");
     });
 
     it("bubble/close copy references the capacity so it stays in sync with SPORTS_HACK_2026_CAPACITY", () => {
-      expect(getSportsHack2026RankTier(75).detail).toContain(String(SPORTS_HACK_2026_CAPACITY));
-      expect(getSportsHack2026RankTier(90).detail).toContain(String(SPORTS_HACK_2026_CAPACITY));
+      expect(getSportsHack2026RankTier(110).detail).toContain(String(SPORTS_HACK_2026_CAPACITY));
+      expect(getSportsHack2026RankTier(130).detail).toContain(String(SPORTS_HACK_2026_CAPACITY));
     });
 
     it("every tier has a non-empty label and detail", () => {
-      for (const rank of [1, 15, 45, 70, 90, 120, 200]) {
+      for (const rank of [1, 20, 60, 100, 130, 170, 300]) {
         const t = getSportsHack2026RankTier(rank);
         expect(t.label.length).toBeGreaterThan(0);
         expect(t.detail.length).toBeGreaterThan(0);

--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -6,8 +6,6 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { unstable_cache, revalidateTag } from "next/cache";
-import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import {
@@ -15,496 +13,22 @@ import {
   getOptionalVerifiedUser,
 } from "@/lib/server-auth";
 import {
-  getConfirmedCapacityForEvent,
-  getDeclinedEmailsForEvent,
   getHackathonEventSignupBlockReason,
-  getJudgeEmailsForEvent,
   hackathonEventSignupDocId,
   isHackathonEventSignupId,
 } from "@/lib/hackathon-event-signup";
-import { fetchMergedPrCountsForLogins } from "@/lib/github-merged-pr-count";
-import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
 import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
-import { SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
 import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+import {
+  getSnapshotOrRefresh,
+  refreshSnapshot,
+} from "@/lib/hackathon-leaderboard-snapshot";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const RATE = rateLimitConfigs.hackathonEventSignup;
-
-/**
- * Cache tag for the signup leaderboard payload. Bust it from POST/PATCH/DELETE
- * so mutations are visible on the next GET instead of waiting out the 30s
- * revalidate window. Shared across all events — fine at current scale (2
- * active event ids); split into `:${eventId}` if that ever grows.
- */
-const HACKATHON_SIGNUP_CACHE_TAG = "hackathon-event-signup";
-
-function signedUpAtToMs(value: unknown): number {
-  if (
-    value &&
-    typeof value === "object" &&
-    "toMillis" in value &&
-    typeof (value as { toMillis: () => number }).toMillis === "function"
-  ) {
-    return (value as { toMillis: () => number }).toMillis();
-  }
-  if (value instanceof Date) return value.getTime();
-  return 0;
-}
-
-async function fetchUserDataMap(
-  db: Firestore,
-  userIds: string[]
-): Promise<Map<string, DocumentData>> {
-  const map = new Map<string, DocumentData>();
-  const unique = [...new Set(userIds)];
-  const chunks: string[][] = [];
-  for (let i = 0; i < unique.length; i += 10) {
-    chunks.push(unique.slice(i, i + 10));
-  }
-  const chunkResults = await Promise.all(
-    chunks.map((chunk) => {
-      const refs = chunk.map((id) => db.collection("users").doc(id));
-      return db.getAll(...refs);
-    })
-  );
-  for (const snaps of chunkResults) {
-    snaps.forEach((s) => {
-      if (s.exists) {
-        map.set(s.id, s.data() ?? {});
-      }
-    });
-  }
-  return map;
-}
-
-/** Firestore `in` queries are limited to 10 values. */
-const USER_ID_IN_CHUNK = 10;
-
-/**
- * Merged PR counts from pullRequests (same source as contributor badges), not users.pullRequestsCount.
- */
-async function countMergedCommunityPrsByUserIds(
-  db: Firestore,
-  userIds: string[]
-): Promise<Map<string, number>> {
-  const counts = new Map<string, number>();
-  const unique = [...new Set(userIds.filter(Boolean))];
-  for (const id of unique) counts.set(id, 0);
-  if (unique.length === 0) return counts;
-
-  const { owner, repo } = getGithubRepoPair();
-  const expectedRepo = `${owner}/${repo}`;
-
-  const chunks: string[][] = [];
-  for (let i = 0; i < unique.length; i += USER_ID_IN_CHUNK) {
-    chunks.push(unique.slice(i, i + USER_ID_IN_CHUNK));
-  }
-  const chunkSnaps = await Promise.all(
-    chunks.map((chunk) =>
-      db
-        .collection("pullRequests")
-        .where("userId", "in", chunk)
-        .where("state", "==", "merged")
-        .get()
-    )
-  );
-  for (const snap of chunkSnaps) {
-    for (const doc of snap.docs) {
-      const data = doc.data();
-      const uid = data.userId as string | undefined;
-      if (!uid) continue;
-      const repoField = data.repository;
-      if (
-        typeof repoField === "string" &&
-        repoField.length > 0 &&
-        repoField !== expectedRepo
-      ) {
-        continue;
-      }
-      counts.set(uid, (counts.get(uid) ?? 0) + 1);
-    }
-  }
-
-  return counts;
-}
-
-type EntryStatus = "confirmed" | "waitlisted";
-
-type LeaderboardEntry = {
-  rank: number;
-  userId: string | null;
-  displayName: string | null;
-  githubLogin: string | null;
-  mergedPrCount: number;
-  signedUpAt: string;
-  creditEligible: boolean;
-  status: EntryStatus;
-  checkedIn: boolean;
-  willBeLate: boolean;
-  queuingForSpot: boolean;
-  lumaRegistered: boolean;
-  /** True when the email matches a Cohort-1 application (status pending/admitted). */
-  isCohort1: boolean;
-};
-
-type LeaderboardPayload = {
-  entries: LeaderboardEntry[];
-  totalCount: number;
-  websiteSignupCount: number;
-  creditTopN: number;
-};
-
-/**
- * Uncached body of the leaderboard load. Pulled out of the GET handler so
- * `unstable_cache` can collapse N concurrent page loads (e.g., after an email
- * blast) into one Firestore pass per 30s. `me` is computed on top of this by
- * the handler since it varies per-caller and shouldn't be cached.
- */
-async function buildLeaderboardPayload(eventId: string): Promise<LeaderboardPayload> {
-  const db = getAdminDb();
-  if (!db) throw new Error("Server not configured");
-
-  const judgeEmails = getJudgeEmailsForEvent(eventId);
-  const declinedEmails = getDeclinedEmailsForEvent(eventId);
-
-  // Cohort-1 applicant emails (status pending/admitted only). Used to push
-  // cohort-1 attendees to the top of this event's leaderboard, since the
-  // May 26 immersion is the in-person event for the summer cohort.
-  const cohort1Emails = new Set<string>();
-  const cohortAppsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
-  for (const doc of cohortAppsSnap.docs) {
-    const d = doc.data();
-    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
-    if (!cohorts.includes("cohort-1")) continue;
-    const status = typeof d.status === "string" ? d.status : "pending";
-    if (status !== "pending" && status !== "admitted") continue;
-    const email = typeof d.email === "string" ? d.email.trim().toLowerCase() : "";
-    if (email) cohort1Emails.add(email);
-  }
-
-  const snap = await db
-    .collection("hackathonEventSignups")
-    .where("eventId", "==", eventId)
-    .get();
-
-    const rows: {
-      userId: string;
-      signedUpAtMs: number;
-      mergedPrCount: number;
-      displayName: string | null;
-      githubLogin: string | null;
-      confirmedAt: number | null;
-      frozenRank: number | null;
-      frozenPrCount: number | null;
-      checkedInAt: number | null;
-      willBeLate: boolean;
-      queuingForSpot: boolean;
-      /** True when a matching row was found in hackathonLumaRegistrants (email or githubLogin match). */
-      lumaRegistered: boolean;
-    }[] = [];
-
-    const userIds = snap.docs.map((d) => d.data().userId as string).filter(Boolean);
-    // Phase 1: load user profiles. We need profile.github.login to decide
-    // whether to hit the GitHub API (primary) or the Firestore pullRequests
-    // fallback (for the rare user with no linked GitHub). Signup gate already
-    // blocks users without linked GitHub from posting, so the fallback set is
-    // usually empty in practice.
-    const userMap = await fetchUserDataMap(db, userIds);
-
-    const githubLogins: string[] = [];
-    const userIdsWithoutGithub: string[] = [];
-    for (const uid of userIds) {
-      const profile = userMap.get(uid);
-      const login =
-        profile?.github && typeof profile.github === "object"
-          ? (profile.github as { login?: string }).login
-          : undefined;
-      if (typeof login === "string" && login.trim()) {
-        githubLogins.push(login.trim());
-      } else {
-        userIdsWithoutGithub.push(uid);
-      }
-    }
-
-    // Phase 2: GitHub + Firestore pullRequests fan out in parallel, but the
-    // Firestore scan is now scoped to only users whose profile has no linked
-    // GitHub login (so a hack-a-sprint-scale event skips ~40 users' worth of
-    // pullRequests reads per page load).
-    const [githubMergedByLogin, firestoreMergedCounts] = await Promise.all([
-      fetchMergedPrCountsForLogins(githubLogins),
-      userIdsWithoutGithub.length > 0
-        ? countMergedCommunityPrsByUserIds(db, userIdsWithoutGithub)
-        : Promise.resolve(new Map<string, number>()),
-    ]);
-
-    for (const doc of snap.docs) {
-      const data = doc.data();
-      const userId = data.userId as string;
-      if (!userId) continue;
-      const profile = userMap.get(userId);
-      if (
-        typeof profile?.email === "string" &&
-        declinedEmails.has(profile.email.toLowerCase())
-      ) {
-        continue;
-      }
-      const gh =
-        profile?.github && typeof profile.github === "object"
-          ? (profile.github as { login?: string }).login
-          : undefined;
-      const githubLogin = typeof gh === "string" ? gh : null;
-      let pr = firestoreMergedCounts.get(userId) ?? 0;
-      if (githubLogin) {
-        const fromApi = githubMergedByLogin.get(githubLogin.toLowerCase());
-        if (fromApi !== undefined) pr = fromApi;
-      }
-      rows.push({
-        userId,
-        signedUpAtMs: signedUpAtToMs(data.signedUpAt),
-        mergedPrCount: pr,
-        displayName:
-          typeof profile?.displayName === "string" ? profile.displayName : null,
-        githubLogin,
-        confirmedAt: data.confirmedAt ? signedUpAtToMs(data.confirmedAt) : null,
-        frozenRank: typeof data.frozenRank === "number" ? data.frozenRank : null,
-        frozenPrCount: typeof data.frozenPrCount === "number" ? data.frozenPrCount : null,
-        checkedInAt: data.checkedInAt ? signedUpAtToMs(data.checkedInAt) : null,
-        willBeLate: data.willBeLate === true,
-        queuingForSpot: data.queuingForSpot === true,
-        lumaRegistered: false, // flipped true below when the Luma loop finds a match
-      });
-    }
-
-    // Build a set of emails/logins already on the website list to deduplicate
-    const websiteEmails = new Set<string>();
-    const websiteGithubLogins = new Set<string>();
-    for (const uid of userIds) {
-      const profile = userMap.get(uid);
-      if (typeof profile?.email === "string") websiteEmails.add(profile.email.toLowerCase());
-      const gh = profile?.github && typeof profile.github === "object"
-        ? (profile.github as { login?: string }).login : undefined;
-      if (typeof gh === "string" && gh.trim()) websiteGithubLogins.add(gh.trim().toLowerCase());
-    }
-
-    // Reverse-lookup maps: email/githubLogin → rows index (for merging Luma fields)
-    const emailToRowIdx = new Map<string, number>();
-    const ghLoginToRowIdx = new Map<string, number>();
-    for (let i = 0; i < rows.length; i++) {
-      const profile = userMap.get(rows[i].userId);
-      if (typeof profile?.email === "string") {
-        emailToRowIdx.set(profile.email.toLowerCase(), i);
-      }
-      const gh = profile?.github && typeof profile.github === "object"
-        ? (profile.github as { login?: string }).login : undefined;
-      if (typeof gh === "string" && gh.trim()) {
-        ghLoginToRowIdx.set(gh.trim().toLowerCase(), i);
-      }
-    }
-
-    // Fetch Luma-only registrants
-    const lumaSnap = await db
-      .collection("hackathonLumaRegistrants")
-      .where("eventId", "==", eventId)
-      .get();
-
-    const lumaGithubLogins: string[] = [];
-    type LumaRow = {
-      name: string;
-      email: string | null;
-      githubLogin: string | null;
-      lumaCreatedAt: string;
-      mergedPrCount: number;
-      confirmedAt: number | null;
-      frozenRank: number | null;
-      frozenPrCount: number | null;
-    };
-    const lumaRows: LumaRow[] = [];
-
-    for (const doc of lumaSnap.docs) {
-      const d = doc.data();
-      const email = (d.email as string || "").toLowerCase();
-      const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
-      if (judgeEmails.has(email) || declinedEmails.has(email)) continue;
-
-      // When a Luma registrant also signed up on the website, carry over
-      // confirmed status from the Luma record so it isn't lost.
-      // Also preserve the earlier signup time so waitlist ordering stays stable.
-      const matchIdx = websiteEmails.has(email)
-        ? emailToRowIdx.get(email)
-        : (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase()))
-          ? ghLoginToRowIdx.get(ghLogin.toLowerCase())
-          : undefined;
-      if (matchIdx !== undefined) {
-        rows[matchIdx].lumaRegistered = true;
-        if (rows[matchIdx].confirmedAt == null && d.confirmedAt) {
-          rows[matchIdx].confirmedAt = signedUpAtToMs(d.confirmedAt);
-        }
-        if (rows[matchIdx].frozenRank == null && typeof d.frozenRank === "number") {
-          rows[matchIdx].frozenRank = d.frozenRank;
-        }
-        if (rows[matchIdx].frozenPrCount == null && typeof d.frozenPrCount === "number") {
-          rows[matchIdx].frozenPrCount = d.frozenPrCount;
-        }
-        const lumaMs = d.lumaCreatedAt ? new Date(d.lumaCreatedAt as string).getTime() : 0;
-        if (lumaMs > 0 && lumaMs < rows[matchIdx].signedUpAtMs) {
-          rows[matchIdx].signedUpAtMs = lumaMs;
-        }
-        continue;
-      }
-      if (ghLogin) lumaGithubLogins.push(ghLogin);
-      lumaRows.push({
-        name: typeof d.name === "string" ? d.name : "",
-        email: email || null,
-        githubLogin: ghLogin,
-        lumaCreatedAt: typeof d.lumaCreatedAt === "string" ? d.lumaCreatedAt : "",
-        mergedPrCount: 0,
-        confirmedAt: d.confirmedAt ? signedUpAtToMs(d.confirmedAt) : null,
-        frozenRank: typeof d.frozenRank === "number" ? d.frozenRank : null,
-        frozenPrCount: typeof d.frozenPrCount === "number" ? d.frozenPrCount : null,
-      });
-    }
-
-    // Look up PR counts for Luma-only registrants
-    if (lumaGithubLogins.length > 0) {
-      const lumaPrCounts = await fetchMergedPrCountsForLogins(lumaGithubLogins);
-      for (const lr of lumaRows) {
-        if (lr.githubLogin) {
-          const count = lumaPrCounts.get(lr.githubLogin.toLowerCase());
-          if (count !== undefined) lr.mergedPrCount = count;
-        }
-      }
-    }
-
-    type UnifiedRow = {
-      userId: string | null;
-      displayName: string | null;
-      githubLogin: string | null;
-      mergedPrCount: number;
-      signedUpAtMs: number;
-      signedUpAtIso: string;
-      confirmedAt: number | null;
-      frozenRank: number | null;
-      frozenPrCount: number | null;
-      checkedInAt: number | null;
-      willBeLate: boolean;
-      queuingForSpot: boolean;
-      lumaRegistered: boolean;
-      isCohort1: boolean;
-    };
-    const unified: UnifiedRow[] = [];
-
-    for (const r of rows) {
-      const profile = userMap.get(r.userId);
-      const email =
-        typeof profile?.email === "string" ? profile.email.trim().toLowerCase() : "";
-      unified.push({
-        userId: r.userId,
-        displayName: r.displayName,
-        githubLogin: r.githubLogin,
-        mergedPrCount: r.mergedPrCount,
-        signedUpAtMs: r.signedUpAtMs,
-        signedUpAtIso: new Date(r.signedUpAtMs).toISOString(),
-        confirmedAt: r.confirmedAt,
-        frozenRank: r.frozenRank,
-        frozenPrCount: r.frozenPrCount,
-        checkedInAt: r.checkedInAt,
-        willBeLate: r.willBeLate,
-        queuingForSpot: r.queuingForSpot,
-        lumaRegistered: r.lumaRegistered,
-        isCohort1: email ? cohort1Emails.has(email) : false,
-      });
-    }
-    for (const lr of lumaRows) {
-      const email = lr.email?.trim().toLowerCase() ?? "";
-      unified.push({
-        userId: null,
-        displayName: lr.name || null,
-        githubLogin: lr.githubLogin,
-        mergedPrCount: lr.mergedPrCount,
-        signedUpAtMs: lr.lumaCreatedAt ? new Date(lr.lumaCreatedAt).getTime() : 0,
-        signedUpAtIso: lr.lumaCreatedAt,
-        confirmedAt: lr.confirmedAt,
-        frozenRank: typeof lr.frozenRank === "number" ? lr.frozenRank : null,
-        frozenPrCount: typeof lr.frozenPrCount === "number" ? lr.frozenPrCount : null,
-        checkedInAt: null,
-        willBeLate: false,
-        queuingForSpot: false,
-        // Rows with no matching website signup came from the Luma collection directly —
-        // they're on Luma by definition.
-        lumaRegistered: true,
-        isCohort1: email ? cohort1Emails.has(email) : false,
-      });
-    }
-
-    // Split into confirmed (frozen rank) and waitlisted (live PRs)
-    const confirmed = unified.filter((u) => u.confirmedAt != null);
-    const waitlisted = unified.filter((u) => u.confirmedAt == null);
-
-    // Confirmed: cohort-1 first, then frozen rank, then PRs desc → time asc.
-    // Once frozen, cohort-1 still trumps the snapshot order so the leaderboard
-    // visibly prioritizes cohort builders for the May 26 immersion.
-    confirmed.sort((a, b) => {
-      if (a.isCohort1 !== b.isCohort1) return a.isCohort1 ? -1 : 1;
-      if (a.frozenRank != null && b.frozenRank != null) return a.frozenRank - b.frozenRank;
-      if (a.frozenRank != null) return -1;
-      if (b.frozenRank != null) return 1;
-      if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
-      return a.signedUpAtMs - b.signedUpAtMs;
-    });
-
-    // Waitlisted: cohort-1 first, then PRs desc, then signup time asc.
-    waitlisted.sort((a, b) => {
-      if (a.isCohort1 !== b.isCohort1) return a.isCohort1 ? -1 : 1;
-      if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
-      return a.signedUpAtMs - b.signedUpAtMs;
-    });
-
-    const sorted = [...confirmed, ...waitlisted];
-
-    const websiteCount = rows.length;
-    const entries: LeaderboardEntry[] = sorted.map((u, i) => {
-      const rank = i + 1;
-      const isConfirmed = u.confirmedAt != null;
-      const displayPrs = isConfirmed && u.frozenPrCount != null ? u.frozenPrCount : u.mergedPrCount;
-      return {
-        rank,
-        userId: u.userId,
-        displayName: u.displayName,
-        githubLogin: u.githubLogin,
-        mergedPrCount: displayPrs,
-        signedUpAt: u.signedUpAtIso,
-        creditEligible: isConfirmed,
-        status: isConfirmed ? "confirmed" : "waitlisted",
-        checkedIn: u.checkedInAt != null,
-        willBeLate: u.willBeLate,
-        queuingForSpot: u.queuingForSpot,
-        lumaRegistered: u.lumaRegistered,
-        isCohort1: u.isCohort1,
-      };
-    });
-
-    return {
-      entries,
-      totalCount: entries.length,
-      websiteSignupCount: websiteCount,
-      creditTopN: getConfirmedCapacityForEvent(eventId),
-    };
-}
-
-/**
- * 30s cache around the Firestore + GitHub work. Bust with
- * `revalidateTag(HACKATHON_SIGNUP_CACHE_TAG)` from mutations so the next GET
- * sees fresh data without waiting out the window.
- */
-const loadLeaderboardPayload = unstable_cache(
-  buildLeaderboardPayload,
-  ["hackathon-event-signup:leaderboard"],
-  { revalidate: 30, tags: [HACKATHON_SIGNUP_CACHE_TAG] }
-);
 
 type RouteContext = { params: Promise<{ eventId: string }> };
 
@@ -526,7 +50,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
     }
 
     const meUser = await getOptionalVerifiedUser(request);
-    const payload = await loadLeaderboardPayload(eventId);
+    // Read the persisted snapshot. Mutations (POST/PATCH/DELETE below) refresh
+    // it inline, so this returns the post-mutation state on the next GET without
+    // re-running the Firestore + GitHub fan-out per page load.
+    const payload = await getSnapshotOrRefresh(eventId);
 
     let me: {
       signedUp: boolean;
@@ -633,7 +160,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
       userId: user.uid,
       signedUpAt: FieldValue.serverTimestamp(),
     });
-    revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+    // Block on snapshot refresh so the next GET reflects this claim.
+    await refreshSnapshot(eventId);
 
     return NextResponse.json({ signedUp: true }, { status: 200 });
   } catch (e) {
@@ -713,7 +241,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         gaveUpSpotAt: FieldValue.serverTimestamp(),
         willBeLate: FieldValue.delete(),
       });
-      revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+      await refreshSnapshot(eventId);
       return NextResponse.json({ ok: true, gaveUpSpot: true }, { status: 200 });
     }
 
@@ -751,7 +279,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     }
 
     await ref.update(patch);
-    revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+    await refreshSnapshot(eventId);
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (e) {
@@ -789,7 +317,7 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
 
     const docId = hackathonEventSignupDocId(eventId, user.uid);
     await db.collection("hackathonEventSignups").doc(docId).delete().catch(() => undefined);
-    revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+    await refreshSnapshot(eventId);
 
     return NextResponse.json({ left: true }, { status: 200 });
   } catch (e) {

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -35,6 +35,7 @@ import {
   isValidCohortId,
   type SummerCohortId,
 } from "@/lib/summer-cohort";
+import { SPORTS_HACK_2026_CAPACITY } from "@/lib/sports-hack-2026";
 import { ClaimSpotByPRCard } from "./_components/ClaimSpotByPRCard";
 import { CohortProgramBreakdown } from "./_components/CohortProgramBreakdown";
 import { CohortSwitcher } from "./_components/CohortSwitcher";
@@ -269,7 +270,7 @@ function NextStepsCard({
         title: `RSVP for ${SUMMER_COHORT_IMMERSION.label} on Luma`,
         body: (
           <>
-            Cohort 1 gets priority on the 80-person cap, but you still need to
+            Cohort 1 gets priority on the {SPORTS_HACK_2026_CAPACITY}-person cap, but you still need to
             grab the seat.{" "}
             <a
               href={SUMMER_COHORT_IMMERSION.lumaUrl}

--- a/lib/game/content/hero-backstories/_index.ts
+++ b/lib/game/content/hero-backstories/_index.ts
@@ -1,5 +1,4 @@
 /**
- * SPDX-License-Identifier: GPL-3.0-only
  * Copyright (C) 2026 Cursor Boston
  * This file is part of Cursor Boston, licensed under GPL-3.0.
  * See LICENSE file for details.

--- a/lib/github-merged-pr-count.ts
+++ b/lib/github-merged-pr-count.ts
@@ -34,7 +34,16 @@ function searchHeaders(): Record<string, string> {
   return headers;
 }
 
-async function fetchMergedPrCountByAuthorForRepoUncached(): Promise<
+/**
+ * Uncached bulk merged-PR search. Exported so node scripts (which don't run
+ * inside the Next.js request lifecycle and therefore can't use `unstable_cache`)
+ * can pre-fetch the bulk map and pass it as `preloadedBulk` to
+ * {@link fetchMergedPrCountsForLogins}.
+ *
+ * Inside the Next runtime, prefer {@link fetchMergedPrCountByAuthorForRepo}
+ * (the cached variant) — it shares the result across concurrent requests.
+ */
+export async function fetchMergedPrCountByAuthorForRepoUncached(): Promise<
   Array<[string, number]> | null
 > {
   const { owner, repo } = getGithubRepoPair();

--- a/lib/hackathon-leaderboard-snapshot.ts
+++ b/lib/hackathon-leaderboard-snapshot.ts
@@ -1,0 +1,578 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Persisted leaderboard snapshot for hackathon event signup pages.
+ *
+ * The signup leaderboard used to recompute on every GET (Firestore +
+ * GitHub fan-out), wrapped in a 30s in-process `unstable_cache`. That cache is
+ * per-instance and doesn't survive cold starts, so a quiet site still pays the
+ * full fan-out cost on the first hit in each region.
+ *
+ * Instead we keep a single Firestore doc per event holding the rendered
+ * leaderboard payload. GET reads the doc. Mutations (POST/PATCH/DELETE on the
+ * signup route, plus offline scripts like seed-luma-registrants and the
+ * ranking-freeze snapshot) call `refreshSnapshot` to recompute and overwrite
+ * the doc. New events with no snapshot fall through to a fresh compute that
+ * also writes the doc on first read.
+ *
+ * Why a separate collection (not embedded on `hackathonEvents/{eventId}`):
+ *   - Snapshot writes are frequent (every claim). Keeping them off the main
+ *     event doc avoids fan-out to anything subscribed to event metadata.
+ *   - Easier to wipe + rebuild a single event's snapshot from scripts.
+ */
+import type { DocumentData, Firestore } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  getConfirmedCapacityForEvent,
+  getDeclinedEmailsForEvent,
+  getJudgeEmailsForEvent,
+} from "@/lib/hackathon-event-signup";
+import { fetchMergedPrCountsForLogins } from "@/lib/github-merged-pr-count";
+import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
+
+export const HACKATHON_LEADERBOARD_SNAPSHOTS_COLLECTION =
+  "hackathonLeaderboardSnapshots";
+
+export type LeaderboardEntryStatus = "confirmed" | "waitlisted";
+
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string | null;
+  displayName: string | null;
+  githubLogin: string | null;
+  mergedPrCount: number;
+  signedUpAt: string;
+  creditEligible: boolean;
+  status: LeaderboardEntryStatus;
+  checkedIn: boolean;
+  willBeLate: boolean;
+  queuingForSpot: boolean;
+  lumaRegistered: boolean;
+  /** True when the email matches a Cohort-1 application (status pending/admitted). */
+  isCohort1: boolean;
+}
+
+export interface LeaderboardPayload {
+  entries: LeaderboardEntry[];
+  totalCount: number;
+  websiteSignupCount: number;
+  creditTopN: number;
+}
+
+export interface LeaderboardSnapshot extends LeaderboardPayload {
+  /** ISO-8601 timestamp of when the snapshot was generated. */
+  generatedAt: string;
+}
+
+function signedUpAtToMs(value: unknown): number {
+  if (
+    value &&
+    typeof value === "object" &&
+    "toMillis" in value &&
+    typeof (value as { toMillis: () => number }).toMillis === "function"
+  ) {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  if (value instanceof Date) return value.getTime();
+  return 0;
+}
+
+async function fetchUserDataMap(
+  db: Firestore,
+  userIds: string[]
+): Promise<Map<string, DocumentData>> {
+  const map = new Map<string, DocumentData>();
+  const unique = [...new Set(userIds)];
+  const chunks: string[][] = [];
+  for (let i = 0; i < unique.length; i += 10) {
+    chunks.push(unique.slice(i, i + 10));
+  }
+  const chunkResults = await Promise.all(
+    chunks.map((chunk) => {
+      const refs = chunk.map((id) => db.collection("users").doc(id));
+      return db.getAll(...refs);
+    })
+  );
+  for (const snaps of chunkResults) {
+    snaps.forEach((s) => {
+      if (s.exists) {
+        map.set(s.id, s.data() ?? {});
+      }
+    });
+  }
+  return map;
+}
+
+/** Firestore `in` queries are limited to 10 values. */
+const USER_ID_IN_CHUNK = 10;
+
+/**
+ * Merged PR counts from pullRequests (same source as contributor badges), not users.pullRequestsCount.
+ */
+async function countMergedCommunityPrsByUserIds(
+  db: Firestore,
+  userIds: string[]
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  const unique = [...new Set(userIds.filter(Boolean))];
+  for (const id of unique) counts.set(id, 0);
+  if (unique.length === 0) return counts;
+
+  const { owner, repo } = getGithubRepoPair();
+  const expectedRepo = `${owner}/${repo}`;
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < unique.length; i += USER_ID_IN_CHUNK) {
+    chunks.push(unique.slice(i, i + USER_ID_IN_CHUNK));
+  }
+  const chunkSnaps = await Promise.all(
+    chunks.map((chunk) =>
+      db
+        .collection("pullRequests")
+        .where("userId", "in", chunk)
+        .where("state", "==", "merged")
+        .get()
+    )
+  );
+  for (const snap of chunkSnaps) {
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      const uid = data.userId as string | undefined;
+      if (!uid) continue;
+      const repoField = data.repository;
+      if (
+        typeof repoField === "string" &&
+        repoField.length > 0 &&
+        repoField !== expectedRepo
+      ) {
+        continue;
+      }
+      counts.set(uid, (counts.get(uid) ?? 0) + 1);
+    }
+  }
+
+  return counts;
+}
+
+export interface BuildLeaderboardPayloadOptions {
+  /**
+   * Bulk merged-PR counts (lowercased login → count) to pass to
+   * {@link fetchMergedPrCountsForLogins}. Node scripts pre-fetch via
+   * {@link fetchMergedPrCountByAuthorForRepoUncached} and pass them here to
+   * bypass the next/cache wrapper that throws outside the Next runtime.
+   */
+  preloadedBulkPrCounts?: Map<string, number> | null;
+}
+
+/**
+ * Live compute of the leaderboard payload. Hits Firestore + GitHub.
+ *
+ * Avoid calling this on every page GET — use {@link readSnapshot} for that.
+ * This is the function the snapshot is built from; it's exported so callers
+ * outside the API route (admin pages, scripts) can render the live state
+ * without going through the snapshot.
+ */
+export async function buildLeaderboardPayload(
+  eventId: string,
+  options: BuildLeaderboardPayloadOptions = {}
+): Promise<LeaderboardPayload> {
+  const { preloadedBulkPrCounts } = options;
+  const db = getAdminDb();
+  if (!db) throw new Error("Server not configured");
+
+  const judgeEmails = getJudgeEmailsForEvent(eventId);
+  const declinedEmails = getDeclinedEmailsForEvent(eventId);
+
+  // Cohort-1 applicant emails (status pending/admitted only). Used to push
+  // cohort-1 attendees to the top of this event's leaderboard, since the
+  // May 26 immersion is the in-person event for the summer cohort.
+  const cohort1Emails = new Set<string>();
+  const cohortAppsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  for (const doc of cohortAppsSnap.docs) {
+    const d = doc.data();
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) continue;
+    const status = typeof d.status === "string" ? d.status : "pending";
+    if (status !== "pending" && status !== "admitted") continue;
+    const email = typeof d.email === "string" ? d.email.trim().toLowerCase() : "";
+    if (email) cohort1Emails.add(email);
+  }
+
+  const snap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", eventId)
+    .get();
+
+  const rows: {
+    userId: string;
+    signedUpAtMs: number;
+    mergedPrCount: number;
+    displayName: string | null;
+    githubLogin: string | null;
+    confirmedAt: number | null;
+    frozenRank: number | null;
+    frozenPrCount: number | null;
+    checkedInAt: number | null;
+    willBeLate: boolean;
+    queuingForSpot: boolean;
+    lumaRegistered: boolean;
+  }[] = [];
+
+  const userIds = snap.docs.map((d) => d.data().userId as string).filter(Boolean);
+  const userMap = await fetchUserDataMap(db, userIds);
+
+  const githubLogins: string[] = [];
+  const userIdsWithoutGithub: string[] = [];
+  for (const uid of userIds) {
+    const profile = userMap.get(uid);
+    const login =
+      profile?.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login
+        : undefined;
+    if (typeof login === "string" && login.trim()) {
+      githubLogins.push(login.trim());
+    } else {
+      userIdsWithoutGithub.push(uid);
+    }
+  }
+
+  const [githubMergedByLogin, firestoreMergedCounts] = await Promise.all([
+    fetchMergedPrCountsForLogins(githubLogins, preloadedBulkPrCounts),
+    userIdsWithoutGithub.length > 0
+      ? countMergedCommunityPrsByUserIds(db, userIdsWithoutGithub)
+      : Promise.resolve(new Map<string, number>()),
+  ]);
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const userId = data.userId as string;
+    if (!userId) continue;
+    const profile = userMap.get(userId);
+    if (
+      typeof profile?.email === "string" &&
+      declinedEmails.has(profile.email.toLowerCase())
+    ) {
+      continue;
+    }
+    const gh =
+      profile?.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login
+        : undefined;
+    const githubLogin = typeof gh === "string" ? gh : null;
+    let pr = firestoreMergedCounts.get(userId) ?? 0;
+    if (githubLogin) {
+      const fromApi = githubMergedByLogin.get(githubLogin.toLowerCase());
+      if (fromApi !== undefined) pr = fromApi;
+    }
+    rows.push({
+      userId,
+      signedUpAtMs: signedUpAtToMs(data.signedUpAt),
+      mergedPrCount: pr,
+      displayName:
+        typeof profile?.displayName === "string" ? profile.displayName : null,
+      githubLogin,
+      confirmedAt: data.confirmedAt ? signedUpAtToMs(data.confirmedAt) : null,
+      frozenRank: typeof data.frozenRank === "number" ? data.frozenRank : null,
+      frozenPrCount: typeof data.frozenPrCount === "number" ? data.frozenPrCount : null,
+      checkedInAt: data.checkedInAt ? signedUpAtToMs(data.checkedInAt) : null,
+      willBeLate: data.willBeLate === true,
+      queuingForSpot: data.queuingForSpot === true,
+      lumaRegistered: false, // flipped true below when the Luma loop finds a match
+    });
+  }
+
+  // Build a set of emails/logins already on the website list to deduplicate
+  const websiteEmails = new Set<string>();
+  const websiteGithubLogins = new Set<string>();
+  for (const uid of userIds) {
+    const profile = userMap.get(uid);
+    if (typeof profile?.email === "string") websiteEmails.add(profile.email.toLowerCase());
+    const gh =
+      profile?.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login
+        : undefined;
+    if (typeof gh === "string" && gh.trim()) websiteGithubLogins.add(gh.trim().toLowerCase());
+  }
+
+  // Reverse-lookup maps: email/githubLogin → rows index (for merging Luma fields)
+  const emailToRowIdx = new Map<string, number>();
+  const ghLoginToRowIdx = new Map<string, number>();
+  for (let i = 0; i < rows.length; i++) {
+    const profile = userMap.get(rows[i].userId);
+    if (typeof profile?.email === "string") {
+      emailToRowIdx.set(profile.email.toLowerCase(), i);
+    }
+    const gh =
+      profile?.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login
+        : undefined;
+    if (typeof gh === "string" && gh.trim()) {
+      ghLoginToRowIdx.set(gh.trim().toLowerCase(), i);
+    }
+  }
+
+  // Fetch Luma-only registrants
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", eventId)
+    .get();
+
+  const lumaGithubLogins: string[] = [];
+  type LumaRow = {
+    name: string;
+    email: string | null;
+    githubLogin: string | null;
+    lumaCreatedAt: string;
+    mergedPrCount: number;
+    confirmedAt: number | null;
+    frozenRank: number | null;
+    frozenPrCount: number | null;
+  };
+  const lumaRows: LumaRow[] = [];
+
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (d.email as string || "").toLowerCase();
+    const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+    if (judgeEmails.has(email) || declinedEmails.has(email)) continue;
+
+    const matchIdx = websiteEmails.has(email)
+      ? emailToRowIdx.get(email)
+      : (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase()))
+        ? ghLoginToRowIdx.get(ghLogin.toLowerCase())
+        : undefined;
+    if (matchIdx !== undefined) {
+      rows[matchIdx].lumaRegistered = true;
+      if (rows[matchIdx].confirmedAt == null && d.confirmedAt) {
+        rows[matchIdx].confirmedAt = signedUpAtToMs(d.confirmedAt);
+      }
+      if (rows[matchIdx].frozenRank == null && typeof d.frozenRank === "number") {
+        rows[matchIdx].frozenRank = d.frozenRank;
+      }
+      if (rows[matchIdx].frozenPrCount == null && typeof d.frozenPrCount === "number") {
+        rows[matchIdx].frozenPrCount = d.frozenPrCount;
+      }
+      const lumaMs = d.lumaCreatedAt ? new Date(d.lumaCreatedAt as string).getTime() : 0;
+      if (lumaMs > 0 && lumaMs < rows[matchIdx].signedUpAtMs) {
+        rows[matchIdx].signedUpAtMs = lumaMs;
+      }
+      continue;
+    }
+    if (ghLogin) lumaGithubLogins.push(ghLogin);
+    lumaRows.push({
+      name: typeof d.name === "string" ? d.name : "",
+      email: email || null,
+      githubLogin: ghLogin,
+      lumaCreatedAt: typeof d.lumaCreatedAt === "string" ? d.lumaCreatedAt : "",
+      mergedPrCount: 0,
+      confirmedAt: d.confirmedAt ? signedUpAtToMs(d.confirmedAt) : null,
+      frozenRank: typeof d.frozenRank === "number" ? d.frozenRank : null,
+      frozenPrCount: typeof d.frozenPrCount === "number" ? d.frozenPrCount : null,
+    });
+  }
+
+  if (lumaGithubLogins.length > 0) {
+    const lumaPrCounts = await fetchMergedPrCountsForLogins(
+      lumaGithubLogins,
+      preloadedBulkPrCounts
+    );
+    for (const lr of lumaRows) {
+      if (lr.githubLogin) {
+        const count = lumaPrCounts.get(lr.githubLogin.toLowerCase());
+        if (count !== undefined) lr.mergedPrCount = count;
+      }
+    }
+  }
+
+  type UnifiedRow = {
+    userId: string | null;
+    displayName: string | null;
+    githubLogin: string | null;
+    mergedPrCount: number;
+    signedUpAtMs: number;
+    signedUpAtIso: string;
+    confirmedAt: number | null;
+    frozenRank: number | null;
+    frozenPrCount: number | null;
+    checkedInAt: number | null;
+    willBeLate: boolean;
+    queuingForSpot: boolean;
+    lumaRegistered: boolean;
+    isCohort1: boolean;
+  };
+  const unified: UnifiedRow[] = [];
+
+  for (const r of rows) {
+    const profile = userMap.get(r.userId);
+    const email =
+      typeof profile?.email === "string" ? profile.email.trim().toLowerCase() : "";
+    unified.push({
+      userId: r.userId,
+      displayName: r.displayName,
+      githubLogin: r.githubLogin,
+      mergedPrCount: r.mergedPrCount,
+      signedUpAtMs: r.signedUpAtMs,
+      signedUpAtIso: new Date(r.signedUpAtMs).toISOString(),
+      confirmedAt: r.confirmedAt,
+      frozenRank: r.frozenRank,
+      frozenPrCount: r.frozenPrCount,
+      checkedInAt: r.checkedInAt,
+      willBeLate: r.willBeLate,
+      queuingForSpot: r.queuingForSpot,
+      lumaRegistered: r.lumaRegistered,
+      isCohort1: email ? cohort1Emails.has(email) : false,
+    });
+  }
+  for (const lr of lumaRows) {
+    const email = lr.email?.trim().toLowerCase() ?? "";
+    unified.push({
+      userId: null,
+      displayName: lr.name || null,
+      githubLogin: lr.githubLogin,
+      mergedPrCount: lr.mergedPrCount,
+      signedUpAtMs: lr.lumaCreatedAt ? new Date(lr.lumaCreatedAt).getTime() : 0,
+      signedUpAtIso: lr.lumaCreatedAt,
+      confirmedAt: lr.confirmedAt,
+      frozenRank: typeof lr.frozenRank === "number" ? lr.frozenRank : null,
+      frozenPrCount: typeof lr.frozenPrCount === "number" ? lr.frozenPrCount : null,
+      checkedInAt: null,
+      willBeLate: false,
+      queuingForSpot: false,
+      lumaRegistered: true,
+      isCohort1: email ? cohort1Emails.has(email) : false,
+    });
+  }
+
+  const confirmed = unified.filter((u) => u.confirmedAt != null);
+  const waitlisted = unified.filter((u) => u.confirmedAt == null);
+
+  confirmed.sort((a, b) => {
+    if (a.isCohort1 !== b.isCohort1) return a.isCohort1 ? -1 : 1;
+    if (a.frozenRank != null && b.frozenRank != null) return a.frozenRank - b.frozenRank;
+    if (a.frozenRank != null) return -1;
+    if (b.frozenRank != null) return 1;
+    if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
+    return a.signedUpAtMs - b.signedUpAtMs;
+  });
+
+  waitlisted.sort((a, b) => {
+    if (a.isCohort1 !== b.isCohort1) return a.isCohort1 ? -1 : 1;
+    if (b.mergedPrCount !== a.mergedPrCount) return b.mergedPrCount - a.mergedPrCount;
+    return a.signedUpAtMs - b.signedUpAtMs;
+  });
+
+  const sorted = [...confirmed, ...waitlisted];
+
+  const websiteCount = rows.length;
+  const entries: LeaderboardEntry[] = sorted.map((u, i) => {
+    const rank = i + 1;
+    const isConfirmed = u.confirmedAt != null;
+    const displayPrs =
+      isConfirmed && u.frozenPrCount != null ? u.frozenPrCount : u.mergedPrCount;
+    return {
+      rank,
+      userId: u.userId,
+      displayName: u.displayName,
+      githubLogin: u.githubLogin,
+      mergedPrCount: displayPrs,
+      signedUpAt: u.signedUpAtIso,
+      creditEligible: isConfirmed,
+      status: isConfirmed ? "confirmed" : "waitlisted",
+      checkedIn: u.checkedInAt != null,
+      willBeLate: u.willBeLate,
+      queuingForSpot: u.queuingForSpot,
+      lumaRegistered: u.lumaRegistered,
+      isCohort1: u.isCohort1,
+    };
+  });
+
+  return {
+    entries,
+    totalCount: entries.length,
+    websiteSignupCount: websiteCount,
+    creditTopN: getConfirmedCapacityForEvent(eventId),
+  };
+}
+
+/**
+ * Read the persisted snapshot for an event. Returns null if no snapshot has
+ * been written yet (callers should fall through to {@link refreshSnapshot}).
+ */
+export async function readSnapshot(
+  eventId: string
+): Promise<LeaderboardSnapshot | null> {
+  const db = getAdminDb();
+  if (!db) return null;
+  const doc = await db
+    .collection(HACKATHON_LEADERBOARD_SNAPSHOTS_COLLECTION)
+    .doc(eventId)
+    .get();
+  if (!doc.exists) return null;
+  const data = doc.data();
+  if (!data || !Array.isArray(data.entries)) return null;
+  const generatedAt =
+    typeof data.generatedAt === "string"
+      ? data.generatedAt
+      : data.generatedAt &&
+          typeof (data.generatedAt as { toDate?: () => Date }).toDate === "function"
+        ? (data.generatedAt as { toDate: () => Date }).toDate().toISOString()
+        : new Date(0).toISOString();
+  return {
+    entries: data.entries as LeaderboardEntry[],
+    totalCount:
+      typeof data.totalCount === "number"
+        ? data.totalCount
+        : (data.entries as unknown[]).length,
+    websiteSignupCount:
+      typeof data.websiteSignupCount === "number" ? data.websiteSignupCount : 0,
+    creditTopN:
+      typeof data.creditTopN === "number"
+        ? data.creditTopN
+        : getConfirmedCapacityForEvent(eventId),
+    generatedAt,
+  };
+}
+
+/**
+ * Recompute the leaderboard from Firestore + GitHub and persist as the new
+ * snapshot. Called from POST/PATCH/DELETE on the signup route after the
+ * underlying mutation lands, and from scripts/snapshot-hackathon-leaderboard.ts
+ * for the initial seed (or manual refresh).
+ */
+export async function refreshSnapshot(
+  eventId: string,
+  options: BuildLeaderboardPayloadOptions = {}
+): Promise<LeaderboardSnapshot> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Server not configured");
+  const payload = await buildLeaderboardPayload(eventId, options);
+  const generatedAtIso = new Date().toISOString();
+  await db
+    .collection(HACKATHON_LEADERBOARD_SNAPSHOTS_COLLECTION)
+    .doc(eventId)
+    .set({
+      ...payload,
+      generatedAt: FieldValue.serverTimestamp(),
+    });
+  return { ...payload, generatedAt: generatedAtIso };
+}
+
+/**
+ * Return the cached snapshot if present, otherwise compute + persist + return
+ * a fresh one. Use this from API GETs so the first hit after a deploy/wipe
+ * doesn't 500.
+ */
+export async function getSnapshotOrRefresh(
+  eventId: string
+): Promise<LeaderboardSnapshot> {
+  const existing = await readSnapshot(eventId);
+  if (existing) return existing;
+  return refreshSnapshot(eventId);
+}

--- a/lib/sports-hack-2026.ts
+++ b/lib/sports-hack-2026.ts
@@ -14,7 +14,11 @@ export const SPORTS_HACK_2026_LUMA_SLUG = "t5vseeed";
 export const SPORTS_HACK_2026_LUMA_EMBED_ID = "evt-tTiu9jkwv4jVVxx";
 export const SPORTS_HACK_2026_LUMA_URL = `https://luma.com/${SPORTS_HACK_2026_LUMA_SLUG}`;
 
-export const SPORTS_HACK_2026_CAPACITY = 80;
+/**
+ * Confirmed-seat cap for the May 26 event. Bumped from 80 → 119 on 2026-05-22
+ * when an additional batch of Cursor credit codes brought the total to 119.
+ */
+export const SPORTS_HACK_2026_CAPACITY = 119;
 export const SPORTS_HACK_2026_TIMEZONE = "America/New_York";
 export const SPORTS_HACK_2026_EVENT_DATE = "2026-05-26";
 export const SPORTS_HACK_2026_START_HOUR_ET = 10;
@@ -66,21 +70,21 @@ export interface SportsHack2026RankTier {
 }
 
 export function getSportsHack2026RankTier(rank: number): SportsHack2026RankTier {
-  if (rank <= 10) {
+  if (rank <= 15) {
     return {
       label: "🔥 On fire",
       detail: "You're at the top of the leaderboard — stay active and you're in.",
       tone: "hot",
     };
   }
-  if (rank <= 30) {
+  if (rank <= 45) {
     return {
       label: "💪 Looking great",
       detail: "Great position — a couple more PRs and you're locked in.",
       tone: "good",
     };
   }
-  if (rank <= 60) {
+  if (rank <= 90) {
     return {
       label: "👍 Solid — in the band",
       detail: "You're comfortably in the confirmed band. Keep the momentum.",
@@ -94,14 +98,14 @@ export function getSportsHack2026RankTier(rank: number): SportsHack2026RankTier 
       tone: "bubble",
     };
   }
-  if (rank <= 100) {
+  if (rank <= 150) {
     return {
       label: "🎯 One good week away",
       detail: `Just outside the top ${SPORTS_HACK_2026_CAPACITY}. One productive week of PRs and you're in.`,
       tone: "close",
     };
   }
-  if (rank <= 130) {
+  if (rank <= 190) {
     return {
       label: "🚀 Climb mode",
       detail: `Needs a meaningful PR push to break into the top ${SPORTS_HACK_2026_CAPACITY}.`,

--- a/scripts/send-cohort1-may26-jackie-deadline.ts
+++ b/scripts/send-cohort1-may26-jackie-deadline.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Fri May 22 send to every admitted Cohort 1 applicant — three things:
+ *   1. May 26 immersion at Hult is Tuesday — looking forward to seeing
+ *      everyone there.
+ *   2. TODAY (Fri May 22) at 5pm EST is the Week 2 comms-platform submission
+ *      deadline. Voting call right after at 6pm.
+ *   3. Jackie — Ying's Week 1 PM tool, the Cohort 1 winner — is live at
+ *      jackie.cursorboston.com. Everyone should log in with their GitHub
+ *      handle and use it as the cohort's project-management surface.
+ *
+ * Idempotent via `cohort1May26JackieEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-may26-jackie-deadline.ts --dry-run
+ *   npx tsx scripts/send-cohort1-may26-jackie-deadline.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-may26-jackie-deadline.ts --send
+ *   npx tsx scripts/send-cohort1-may26-jackie-deadline.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1May26JackieEmailedAt";
+
+const JACKIE_URL = "https://jackie.cursorboston.com";
+const JACKIE_LOOM_URL =
+  "https://www.loom.com/share/7424fcbc4e294a0fa39e38d1242736d4";
+const SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/c1w2comms-submission";
+const SUBMISSION_PATH =
+  "content/summer-cohort/c1/w2-comms/submissions/<github-handle>.json";
+const MAY26_DETAIL_URL =
+  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
+
+const MAY26_LABEL = "Tue, May 26 · Hult International (Cambridge)";
+const DEADLINE_LABEL = "TODAY · Fri, May 22 · 5pm EST";
+const VOTING_CALL_LABEL = "Fri, May 22 · 6pm EST";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject =
+    "May 26 immersion · Week 2 deadline TODAY 5pm · Jackie is live";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Three things heading into the weekend.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">1. May 26 immersion — see you Tuesday</h3>
+<p>Our <strong>${escapeHtml(MAY26_LABEL)}</strong> immersion day is right around the corner. Cohort 1 has priority on the 80-person cap, and it&apos;s a chance to put faces to handles, demo what you&apos;re building, and spend a real day in the room with the rest of the cohort. Genuinely excited to see everyone there. <a href="${escapeHtml(MAY26_DETAIL_URL)}">Event details</a>.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">2. Week 2 comms-platform deadline — TODAY at 5pm EST</h3>
+<p>The Week 2 comms-platform submission PR is due <strong>${escapeHtml(DEADLINE_LABEL)}</strong>. Voting call is right after at <strong>${escapeHtml(VOTING_CALL_LABEL)}</strong>. If you&apos;ve got something close, open the PR now — even a draft locks in your slot on the branch and you can push polish up to 5.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:16px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>How to submit</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Open a PR into <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> with your submission JSON at:
+  </p>
+  <p style="margin:0 0 10px 0;">
+    <code>${escapeHtml(SUBMISSION_PATH)}</code>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Deadline: <strong>${escapeHtml(DEADLINE_LABEL)}</strong>
+  </p>
+  <p style="margin:0;">
+    Voting call: <strong>${escapeHtml(VOTING_CALL_LABEL)}</strong>
+  </p>
+</div>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">3. Jackie is live — the Cohort 1 tracker, built by Ying (Week 1 winner)</h3>
+<p>Big one. <strong>Jackie</strong>, the Cohort 1 tracker Ying built as our Week 1 PM-tool winner, is shipped and ready to help you manage your work. It&apos;s officially the cohort&apos;s lightweight project-management surface — please register and start using it through the rest of the cohort.</p>
+
+<p style="margin:8px 0 12px 0;">
+  <a href="${escapeHtml(JACKIE_URL)}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open Jackie →
+  </a>
+  &nbsp;·&nbsp;
+  <a href="${escapeHtml(JACKIE_LOOM_URL)}">Watch Ying&apos;s walkthrough (Loom)</a>
+</p>
+
+<p><strong>Quick start (from Ying):</strong> Jackie isn&apos;t a PM tool that makes you do work — it&apos;s a lightweight assistant that keeps track of what&apos;s due, where you are, and what the cohort is building, without asking you to do anything. GitHub is the source of truth for submissions, so Jackie reads directly from there. Submit your work once, Jackie picks it up automatically.</p>
+
+<p><strong>Login.</strong> Go to <a href="${escapeHtml(JACKIE_URL)}">${escapeHtml(JACKIE_URL)}</a>, enter your GitHub handle, and Jackie checks you&apos;re in the cohort and lets you in. You need at least one PR submitted to the Cursor Boston repo to get access. Jackie uses your GitHub handle to personalize your view — it&apos;s not authenticated, so whatever you add in Jackie stays in your browser and is only visible to you.</p>
+
+<p><strong>Progress Tracker (My Stuff).</strong> Your weekly dashboard. Each week shows what you&apos;re building, your submission status pulled live from GitHub, and any tasks you&apos;ve added. Click &quot;Add task&quot;, type what it is, set a due date, save. Trash icon to delete.</p>
+
+<p><strong>Cohort.</strong> See what everyone is building. Browse by week, search by GitHub handle, sort by newest or oldest. Each card shows the builder&apos;s repo, live link, Loom, and pitch. Week 5 cards show a green demo icon for anyone demoing on Friday.</p>
+
+<p>If something feels off, ping Ying in Discord or open an issue on the Jackie repo. The cohort gets stronger when folks pitch in on each other&apos;s work.</p>
+
+<p>See you Tuesday on the 26th —</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Three things heading into the weekend.
+
+1) MAY 26 IMMERSION — SEE YOU TUESDAY
+Our ${MAY26_LABEL} immersion day is right around the corner. Cohort 1 has priority on the 80-person cap, and it's a chance to put faces to handles, demo what you're building, and spend a real day in the room with the rest of the cohort. Genuinely excited to see everyone there.
+Event details: ${MAY26_DETAIL_URL}
+
+2) WEEK 2 COMMS-PLATFORM DEADLINE — TODAY AT 5PM EST
+The Week 2 comms-platform submission PR is due ${DEADLINE_LABEL}. Voting call is right after at ${VOTING_CALL_LABEL}. If you've got something close, open the PR now — even a draft locks in your slot on the branch and you can push polish up to 5.
+
+HOW TO SUBMIT
+  Open a PR into the c1w2comms-submission branch
+  (${SUBMISSION_BRANCH_URL})
+  with your submission JSON at:
+    ${SUBMISSION_PATH}
+  Deadline:     ${DEADLINE_LABEL}
+  Voting call:  ${VOTING_CALL_LABEL}
+
+3) JACKIE IS LIVE — THE COHORT 1 TRACKER, BUILT BY YING (WEEK 1 WINNER)
+Jackie, the Cohort 1 tracker Ying built as our Week 1 PM-tool winner, is shipped and ready to help you manage your work. It's officially the cohort's lightweight project-management surface — please register and start using it through the rest of the cohort.
+
+  Open Jackie:       ${JACKIE_URL}
+  Ying's walkthrough: ${JACKIE_LOOM_URL}
+
+QUICK START (FROM YING)
+Jackie isn't a PM tool that makes you do work — it's a lightweight assistant that keeps track of what's due, where you are, and what the cohort is building, without asking you to do anything. GitHub is the source of truth for submissions, so Jackie reads directly from there. Submit your work once, Jackie picks it up automatically.
+
+LOGIN
+Go to ${JACKIE_URL}, enter your GitHub handle, and Jackie checks you're in the cohort and lets you in. You need at least one PR submitted to the Cursor Boston repo to get access. Jackie uses your GitHub handle to personalize your view — it's not authenticated, so whatever you add in Jackie stays in your browser and is only visible to you.
+
+PROGRESS TRACKER (MY STUFF)
+Your weekly dashboard. Each week shows what you're building, your submission status pulled live from GitHub, and any tasks you've added. Click "Add task", type what it is, set a due date, save. Trash icon to delete.
+
+COHORT
+See what everyone is building. Browse by week, search by GitHub handle, sort by newest or oldest. Each card shows the builder's repo, live link, Loom, and pitch. Week 5 cards show a green demo icon for anyone demoing on Friday.
+
+If something feels off, ping Ying in Discord or open an issue on the Jackie repo. The cohort gets stronger when folks pitch in on each other's work.
+
+See you Tuesday on the 26th —
+
+— Roger
+roger@cursorboston.com
+
+Open the cohort page: ${COHORT_URL}
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/snapshot-hackathon-leaderboard.ts
+++ b/scripts/snapshot-hackathon-leaderboard.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-shot: recompute the leaderboard snapshot for an event and persist it to
+ * `hackathonLeaderboardSnapshots/{eventId}`. The signup API GET reads this doc
+ * directly; mutations (POST/PATCH/DELETE) refresh it inline. Use this script
+ * to seed the doc for a new event or to force a refresh after manual Firestore
+ * edits (e.g., after seed-luma-registrants or freeze-confirmed-top50 ran but
+ * the snapshot is stale).
+ *
+ * Usage:
+ *   npx tsx scripts/snapshot-hackathon-leaderboard.ts --event-id=sports-hack-2026
+ *   npx tsx scripts/snapshot-hackathon-leaderboard.ts --event-id=sports-hack-2026 --dry-run
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON, GITHUB_TOKEN (for PR-count fan-out).
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import {
+  buildLeaderboardPayload,
+  refreshSnapshot,
+} from "../lib/hackathon-leaderboard-snapshot";
+import { isHackathonEventSignupId } from "../lib/hackathon-event-signup";
+import { fetchMergedPrCountByAuthorForRepoUncached } from "../lib/github-merged-pr-count";
+
+function getFlag(name: string): string | null {
+  const arg = process.argv.find((a) => a.startsWith(`--${name}=`));
+  if (!arg) return null;
+  return arg.slice(`--${name}=`.length).trim();
+}
+
+async function main(): Promise<void> {
+  const eventId = getFlag("event-id");
+  const dryRun = process.argv.includes("--dry-run");
+  if (!eventId) {
+    console.error("Pass --event-id=<id>. Example: --event-id=sports-hack-2026");
+    process.exit(1);
+  }
+  if (!isHackathonEventSignupId(eventId)) {
+    console.error(`Unknown event id: ${eventId}`);
+    process.exit(1);
+  }
+
+  // Pre-fetch the bulk merged-PR map directly (the cached lib variant uses
+  // next/cache `unstable_cache`, which throws when called outside the Next.js
+  // request lifecycle). Pass it down so the snapshot computation reuses it
+  // instead of hitting the cached path.
+  const bulkEntries = await fetchMergedPrCountByAuthorForRepoUncached();
+  const preloadedBulkPrCounts = bulkEntries ? new Map(bulkEntries) : null;
+
+  if (dryRun) {
+    const payload = await buildLeaderboardPayload(eventId, { preloadedBulkPrCounts });
+    console.log(
+      `[dry-run] would persist snapshot for ${eventId}: ${payload.entries.length} entries, ` +
+        `websiteSignupCount=${payload.websiteSignupCount}, creditTopN=${payload.creditTopN}`
+    );
+    return;
+  }
+
+  const snapshot = await refreshSnapshot(eventId, { preloadedBulkPrCounts });
+  console.log(
+    `Persisted snapshot for ${eventId}: ${snapshot.entries.length} entries, ` +
+      `websiteSignupCount=${snapshot.websiteSignupCount}, creditTopN=${snapshot.creditTopN}`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Bumps `SPORTS_HACK_2026_CAPACITY` from 80 → 119 (additional Cursor credit codes available). Scales rank-tier bands proportionally so `bubble ≤ 119` doesn't collide with `close`. Replaces hardcoded "80-person cap" copy on `/summer-cohort` with the constant.
- Replaces the per-instance `unstable_cache` on the signup leaderboard with a Firestore-persisted snapshot. GET reads the snapshot doc directly — no GitHub fan-out per page load. POST/PATCH/DELETE block on `refreshSnapshot(eventId)` so the next GET reflects the mutation immediately. Cold start fall-through writes the doc on first read.
- Adds `scripts/snapshot-hackathon-leaderboard.ts` to seed/refresh the snapshot from CLI (also useful after `seed-luma-registrants` or `freeze-confirmed-top50` runs).
- Bundles `scripts/send-cohort1-may26-jackie-deadline.ts` — the Fri May 22 5pm-deadline send that already went out to 94 admitted Cohort 1 applicants.

## Test plan

- [x] `npm test` — 490 tests passing across 38 hackathon-related suites
- [x] `npx tsc --noEmit` clean (excluding pre-existing unrelated in-flight script)
- [x] `SKIP_TYPECHECK=1 npm run build` succeeds
- [x] `snapshot-hackathon-leaderboard.ts --event-id=sports-hack-2026` ran successfully (228 entries, 28 website signups, creditTopN=119)
- [ ] Local `npm start` verification of /hackathons/sports-hack-2026/signup → confirm leaderboard renders from snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)