### PR TITLE
release: develop → main (May 22 evening)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Current core branches:
 - `c1w1pm-submission`, `c1w2comms-submission`, `c1w3mkt-submission`, `c1w4edu-submission`, `c1w5startup-submission`, `c1w6oss-submission` — summer cohort 1 weekly submissions
 - `c2w1pm-submission`, `c2w2comms-submission`, `c2w3mkt-submission` — summer cohort 2 vote-format weekly submissions (create from `origin/develop` before c2 Week 1 kickoff on Mon Jun 29; the dashboard already references these branches via `SUMMER_COHORT_C2_VOTE_WEEKS` in `lib/summer-cohort.ts`)
 - `pydata-2026-submissions` — PyData attendee notebooks. **Mirrored at root** as `pydata-2026-submissions/` directory; submissions PR into both the branch and the root directory (the scorer + the event page read from the directory; the branch is the staging surface).
+- `sports-hack-2026-submissions` — Boston Tech Week Sports Hack project submissions (`meta.json` per attendee + `score.json` from the AI judge). **Mirrored at root** as `sports-hack-2026-submissions/`; same dual-target model as pydata. Hard PR cutoff for AI-track eligibility: 2026-05-26T20:00:00Z (4 PM ET on event day).
 - `hack-a-sprint-2026-submissions` — Hack-a-Sprint showcase JSON submissions
 - `game-contributions`
 
@@ -47,7 +48,7 @@ After every `develop → main` release PR merges, fast-forward each one to `orig
 ```bash
 git fetch origin --prune --quiet
 DEV=$(git rev-parse origin/develop)
-for b in c1w1pm-submission c1w2comms-submission c1w3mkt-submission c1w4edu-submission c1w5startup-submission c1w6oss-submission c2w1pm-submission c2w2comms-submission c2w3mkt-submission game-contributions pydata-2026-submissions hack-a-sprint-2026-submissions; do
+for b in c1w1pm-submission c1w2comms-submission c1w3mkt-submission c1w4edu-submission c1w5startup-submission c1w6oss-submission c2w1pm-submission c2w2comms-submission c2w3mkt-submission game-contributions pydata-2026-submissions sports-hack-2026-submissions hack-a-sprint-2026-submissions; do
  git push origin "${DEV}:refs/heads/${b}"
 done
 ```

--- a/app/events/cursor-boston-sports-hack-2026/page.tsx
+++ b/app/events/cursor-boston-sports-hack-2026/page.tsx
@@ -1,0 +1,762 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import eventsData from "@/content/events.json";
+import type { EventsData } from "@/types/events";
+import {
+  SPORTS_HACK_2026_CAPACITY,
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_LUMA_URL,
+} from "@/lib/sports-hack-2026";
+import {
+  getSportsHack2026Submissions,
+  SPORTS_HACK_2026_SUBMISSIONS_BRANCH,
+  SPORTS_HACK_2026_SUBMISSIONS_DIR,
+  SPORTS_HACK_2026_SUBMISSIONS_REPO_URL,
+  SPORTS_HACK_2026_WINNER_ELIGIBLE_CUTOFF_ISO,
+  type SportsHack2026Submission,
+} from "@/lib/sports-hack-2026-submissions";
+
+// Static path: this file shadows app/events/[slug]/page.tsx for the exact
+// sports-hack slug. Other slugs continue to hit the dynamic [slug] route.
+
+const typedEvents = eventsData as unknown as EventsData;
+const EVENT_SLUG = "cursor-boston-sports-hack-2026";
+
+interface EventRecord {
+  slug: string;
+  title: string;
+  subtitle?: string;
+  date: string;
+  time: string;
+  location: string;
+  venue?: { name: string; address: string };
+  image: string;
+  description: string;
+}
+
+function findEvent(): EventRecord | null {
+  const all = [
+    ...(typedEvents.upcoming as unknown as EventRecord[]),
+    ...(typedEvents.past as unknown as EventRecord[]),
+    ...((typedEvents.oldEvents ?? []) as unknown as EventRecord[]),
+  ];
+  return all.find((e) => e.slug === EVENT_SLUG) ?? null;
+}
+
+export const metadata: Metadata = {
+  title: "Boston Tech Week Sports Hack — Submissions",
+  description:
+    "Browse merged project submissions from the May 26 Cursor Boston × Hult Sports Hack — and submit your own by opening a PR before 4 PM ET on event day.",
+};
+
+const SIGNUP_URL = `/hackathons/${SPORTS_HACK_2026_EVENT_ID}/signup`;
+const BRANCH_URL = `${SPORTS_HACK_2026_SUBMISSIONS_REPO_URL}/tree/${SPORTS_HACK_2026_SUBMISSIONS_BRANCH}`;
+const FORK_URL = `${SPORTS_HACK_2026_SUBMISSIONS_REPO_URL}/fork`;
+const README_URL = `${SPORTS_HACK_2026_SUBMISSIONS_REPO_URL}/blob/main/${SPORTS_HACK_2026_SUBMISSIONS_DIR}/README.md`;
+
+export default function SportsHack2026HubPage() {
+  const event = findEvent();
+  const submissions = getSportsHack2026Submissions();
+
+  return (
+    <main className="flex flex-col bg-neutral-50 dark:bg-neutral-950">
+      <nav
+        className="px-6 py-4 border-b border-neutral-200 dark:border-neutral-800"
+        aria-label="Breadcrumb"
+      >
+        <div className="max-w-6xl mx-auto">
+          <ol className="flex items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+            <li>
+              <Link
+                href="/events"
+                className="hover:text-foreground transition-colors"
+              >
+                Events
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li className="text-foreground truncate">
+              {event?.title ?? "Boston Tech Week Sports Hack"}
+            </li>
+          </ol>
+        </div>
+      </nav>
+
+      <Hero event={event} />
+      <HowToWinCredits />
+      <HowToSubmit />
+      <Prizes />
+      <SubmissionsGrid submissions={submissions} />
+    </main>
+  );
+}
+
+function Hero({ event }: { event: EventRecord | null }) {
+  return (
+    <section className="px-6 py-10 border-b border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+      <div className="max-w-6xl mx-auto">
+        <span className="inline-block px-3 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold rounded-full mb-3 uppercase tracking-wide">
+          Public showcase
+        </span>
+        <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-2">
+          {event?.title ?? "Boston Tech Week Sports Hack"}
+        </h1>
+        {event?.subtitle ? (
+          <p className="text-lg text-neutral-600 dark:text-neutral-400 mb-4">
+            {event.subtitle}
+          </p>
+        ) : null}
+        <dl className="mt-4 grid gap-3 text-sm text-neutral-700 dark:text-neutral-300 sm:grid-cols-3">
+          {event?.date ? (
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                Date
+              </dt>
+              <dd className="mt-1">
+                {event.date}
+                {event.time && event.time !== "TBD" ? ` · ${event.time}` : ""}
+              </dd>
+            </div>
+          ) : null}
+          {event?.venue ? (
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                Venue
+              </dt>
+              <dd className="mt-1">
+                {event.venue.name}
+                <span className="block text-xs text-neutral-500">
+                  {event.venue.address}
+                </span>
+              </dd>
+            </div>
+          ) : null}
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              Submission branch
+            </dt>
+            <dd className="mt-1 font-mono text-xs">
+              <a
+                href={BRANCH_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+              >
+                {SPORTS_HACK_2026_SUBMISSIONS_BRANCH}
+              </a>
+            </dd>
+          </div>
+        </dl>
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <Link
+            href={SIGNUP_URL}
+            className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+          >
+            Claim your participation spot →
+          </Link>
+          <a
+            href={SPORTS_HACK_2026_LUMA_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+          >
+            RSVP on Luma →
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HowToWinCredits() {
+  return (
+    <section className="px-6 py-12 border-b border-neutral-200 dark:border-neutral-800">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-3">
+          How to win a Cursor credit
+        </h2>
+        <p className="text-lg text-neutral-700 dark:text-neutral-300 max-w-3xl mb-6">
+          We have <strong>{SPORTS_HACK_2026_CAPACITY} Cursor credit codes</strong>{" "}
+          for participants. They go to the top {SPORTS_HACK_2026_CAPACITY}{" "}
+          ranked attendees on the website signup list — by{" "}
+          <strong>merged PRs to the community repo</strong>, with signup time as
+          the tiebreaker.
+        </p>
+        <ol className="grid gap-4 md:grid-cols-3">
+          <Step
+            num={1}
+            title="Claim your spot on the site"
+            body={
+              <>
+                Sign up at{" "}
+                <Link
+                  href={SIGNUP_URL}
+                  className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+                >
+                  /hackathons/sports-hack-2026/signup
+                </Link>
+                . Required even if you&apos;re already on Luma — this is the
+                list we rank from.
+              </>
+            }
+          />
+          <Step
+            num={2}
+            title="Merge PRs into cursor-boston"
+            body={
+              <>
+                Every merged PR moves you up the leaderboard.{" "}
+                <a
+                  href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+                >
+                  Browse open issues
+                </a>{" "}
+                — first-time contributors should look for{" "}
+                <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
+                  good first issue
+                </code>
+                .
+              </>
+            }
+          />
+          <Step
+            num={3}
+            title={`Stay in the top ${SPORTS_HACK_2026_CAPACITY}`}
+            body={
+              <>
+                On event day the top {SPORTS_HACK_2026_CAPACITY} get a Cursor
+                credit code. Watch your rank live on the signup page — Cohort 1
+                applicants get a priority boost.
+              </>
+            }
+          />
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+function HowToSubmit() {
+  return (
+    <section className="px-6 py-12 border-b border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-2">
+          How to submit your project
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-8 max-w-3xl">
+          On event day you submit by opening a PR into the{" "}
+          <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
+            {SPORTS_HACK_2026_SUBMISSIONS_BRANCH}
+          </code>{" "}
+          branch — one folder per attendee, named after your GitHub handle, with
+          a single <code className="font-mono">meta.json</code> describing the
+          project. Once a maintainer merges through to{" "}
+          <code className="font-mono">main</code>, your card appears in the grid
+          below.
+        </p>
+
+        <ol className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Step
+            num={1}
+            title="Fork the repo"
+            body={
+              <>
+                Click{" "}
+                <a
+                  href={FORK_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+                >
+                  Fork
+                </a>{" "}
+                on cursor-boston so you can push without write access to the
+                upstream repo.
+              </>
+            }
+          />
+          <Step
+            num={2}
+            title="Add your folder + meta.json"
+            body={
+              <>
+                Create{" "}
+                <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
+                  {SPORTS_HACK_2026_SUBMISSIONS_DIR}/&lt;your-gh-handle&gt;/meta.json
+                </code>{" "}
+                with title, description, video URL, repo URL, and deployed URL.
+              </>
+            }
+          />
+          <Step
+            num={3}
+            title={
+              <>
+                Open PR into{" "}
+                <code className="font-mono text-sm">
+                  {SPORTS_HACK_2026_SUBMISSIONS_BRANCH}
+                </code>
+              </>
+            }
+            body={
+              <>
+                Set the base branch to{" "}
+                <a
+                  href={BRANCH_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+                >
+                  {SPORTS_HACK_2026_SUBMISSIONS_BRANCH}
+                </a>
+                , not <code className="font-mono">main</code>.
+              </>
+            }
+          />
+          <Step
+            num={4}
+            title="Wait for the deploy"
+            body={
+              <>
+                A maintainer batches merges into{" "}
+                <code className="font-mono">
+                  {SPORTS_HACK_2026_SUBMISSIONS_BRANCH}
+                </code>
+                , then ships <code className="font-mono">develop</code> →{" "}
+                <code className="font-mono">main</code>. Your card appears below
+                after Vercel redeploys.
+              </>
+            }
+          />
+        </ol>
+
+        <div className="mt-8 rounded-xl border border-rose-300 bg-rose-50 p-5 dark:border-rose-900/50 dark:bg-rose-900/10">
+          <p className="text-sm font-semibold text-rose-900 dark:text-rose-200 mb-1">
+            ⏱ Hard deadline: 4:00 PM ET on Tuesday, May 26
+          </p>
+          <p className="text-sm text-rose-800 dark:text-rose-300">
+            Your PR must be <strong>opened before</strong> 4 PM ET (event end)
+            to be eligible for AI scoring. One second late and your AI eval is
+            gone — but human judges still review every merged submission, so
+            you can still win on the judges track.
+          </p>
+        </div>
+
+        <div className="mt-6 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <p className="text-sm font-semibold text-foreground mb-2">
+            meta.json template
+          </p>
+          <pre className="overflow-x-auto rounded bg-neutral-100 p-3 text-xs leading-relaxed text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+            <code>{META_TEMPLATE}</code>
+          </pre>
+          <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+            Full rules + field reference:{" "}
+            <a
+              href={README_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
+            >
+              {SPORTS_HACK_2026_SUBMISSIONS_DIR}/README.md
+            </a>
+          </p>
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <a
+            href={BRANCH_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+          >
+            Open the submission branch
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M7 17l9.2-9.2M17 17V7H7" />
+            </svg>
+          </a>
+          <a
+            href={README_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          >
+            Read the full rules
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const META_TEMPLATE = `{
+  "title": "Short, specific project title",
+  "description": "1–3 sentences. What did you build? What problem does it solve?",
+  "displayName": "Your name as you want it on the page",
+  "videoUrl": "https://www.loom.com/share/...",
+  "repoUrl": "https://github.com/your-handle/your-project",
+  "deployedUrl": "https://your-project.vercel.app",
+  "tags": ["nba", "live-stats", "next.js"],
+  "collaborators": [
+    { "displayName": "Pat Collaborator", "githubHandle": "pat-collab" }
+  ]
+}`;
+
+function Prizes() {
+  return (
+    <section className="px-6 py-12 border-b border-neutral-200 dark:border-neutral-800">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-6">
+          How winners are picked
+        </h2>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-8 max-w-3xl">
+          Two independent tracks, both running off the same submissions:
+        </p>
+        <div className="grid gap-6 md:grid-cols-2">
+          <PrizeCard
+            title="AI track — 3 winners"
+            body="After the 4 PM deadline, an AI agent reads every eligible meta.json + video/repo/deployed link and scores the projects 1–10 with a written rationale. Top 3 win."
+            badge="Closes 4 PM ET"
+          />
+          <PrizeCard
+            title="Judges track — 3 winners"
+            body="A panel of human judges reviews every merged submission — AI-eligible or not — and picks their top 3 based on the live presentations and the repo + deployed project."
+            badge="Open to late submissions"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PrizeCard({
+  title,
+  body,
+  badge,
+}: {
+  title: string;
+  body: string;
+  badge: string;
+}) {
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <h3 className="text-xl font-bold text-foreground">{title}</h3>
+        <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+          {badge}
+        </span>
+      </div>
+      <p className="text-sm text-neutral-700 dark:text-neutral-300">{body}</p>
+    </div>
+  );
+}
+
+function Step({
+  num,
+  title,
+  body,
+}: {
+  num: number;
+  title: React.ReactNode;
+  body: React.ReactNode;
+}) {
+  return (
+    <li className="relative rounded-xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+      <span className="absolute -top-3 left-4 inline-flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500 text-xs font-bold text-white">
+        {num}
+      </span>
+      <h3 className="mt-1 mb-2 text-base font-semibold text-foreground">
+        {title}
+      </h3>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400">{body}</p>
+    </li>
+  );
+}
+
+function SubmissionsGrid({ submissions }: { submissions: SportsHack2026Submission[] }) {
+  const eligible = submissions.filter((s) => s.aiEligible);
+  const afterDeadline = submissions.filter((s) => !s.aiEligible);
+  const empty = submissions.length === 0;
+
+  return (
+    <section className="px-6 py-12">
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-8 rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-5 dark:border-emerald-400/20 dark:bg-emerald-400/5">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:text-emerald-300">
+            Public submissions board
+          </p>
+          <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h2 className="text-2xl md:text-3xl font-bold text-foreground">
+                Merged submissions{" "}
+                <span className="text-neutral-500 font-normal tabular-nums">
+                  ({submissions.length})
+                </span>
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm text-neutral-600 dark:text-neutral-300">
+                Cards are sorted by combined AI + judge score. Only PRs opened
+                before 4 PM ET on May 26 are eligible for the AI track; later
+                PRs are shown separately and remain eligible for the judges
+                track.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-right">
+              <div className="rounded-xl bg-white px-4 py-3 shadow-sm dark:bg-neutral-950">
+                <p className="text-2xl font-bold tabular-nums text-emerald-700 dark:text-emerald-300">
+                  {eligible.length}
+                </p>
+                <p className="text-[11px] font-medium uppercase tracking-wide text-neutral-500">
+                  AI-eligible
+                </p>
+              </div>
+              <div className="rounded-xl bg-white px-4 py-3 shadow-sm dark:bg-neutral-950">
+                <p className="text-2xl font-bold tabular-nums text-amber-700 dark:text-amber-300">
+                  {afterDeadline.length}
+                </p>
+                <p className="text-[11px] font-medium uppercase tracking-wide text-neutral-500">
+                  After 4 PM
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {empty ? (
+          <EmptyState />
+        ) : (
+          <>
+            {eligible.length > 0 && (
+              <SubmissionBucket
+                title="AI-eligible submissions"
+                submissions={eligible}
+              />
+            )}
+            {afterDeadline.length > 0 && (
+              <SubmissionBucket
+                title="After-deadline submissions (judges track only)"
+                submissions={afterDeadline}
+                muted
+              />
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState() {
+  const cutoffPretty = new Date(
+    SPORTS_HACK_2026_WINNER_ELIGIBLE_CUTOFF_ISO
+  ).toLocaleString("en-US", {
+    timeZone: "America/New_York",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+  return (
+    <div className="rounded-xl border border-dashed border-neutral-300 bg-neutral-50 p-10 text-center dark:border-neutral-700 dark:bg-neutral-900">
+      <p className="text-lg font-semibold text-foreground">
+        No submissions yet.
+      </p>
+      <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400 max-w-xl mx-auto">
+        Submissions open on May 26 — yours could be the first. Project PRs must
+        be opened before <strong>{cutoffPretty}</strong> to be eligible for the
+        AI track.
+      </p>
+      <div className="mt-5">
+        <a
+          href={BRANCH_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+        >
+          Open the submission branch
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function SubmissionBucket({
+  title,
+  submissions,
+  muted = false,
+}: {
+  title: string;
+  submissions: SportsHack2026Submission[];
+  muted?: boolean;
+}) {
+  return (
+    <div className="mb-10">
+      <h3
+        className={`mb-4 text-sm font-semibold uppercase tracking-[0.18em] ${
+          muted
+            ? "text-amber-700 dark:text-amber-300"
+            : "text-emerald-700 dark:text-emerald-300"
+        }`}
+      >
+        {title}{" "}
+        <span className="font-mono normal-case text-neutral-500">
+          ({submissions.length})
+        </span>
+      </h3>
+      <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {submissions.map((s) => (
+          <SubmissionCard key={s.githubHandle} submission={s} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SubmissionCard({ submission }: { submission: SportsHack2026Submission }) {
+  return (
+    <li className="flex flex-col rounded-xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <h4 className="text-base font-bold text-foreground">{submission.title}</h4>
+        <ScoreBadges submission={submission} />
+      </div>
+      <p className="text-xs text-neutral-500 mb-3">
+        by{" "}
+        <a
+          href={`https://github.com/${submission.githubHandle}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400"
+        >
+          {submission.displayName}
+        </a>
+        {submission.collaborators.length > 0 ? (
+          <>
+            {" "}
+            with{" "}
+            {submission.collaborators.map((c, i) => (
+              <span key={i}>
+                {i > 0 ? ", " : ""}
+                {c.githubHandle ? (
+                  <a
+                    href={`https://github.com/${c.githubHandle}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-foreground"
+                  >
+                    {c.displayName}
+                  </a>
+                ) : (
+                  c.displayName
+                )}
+              </span>
+            ))}
+          </>
+        ) : null}
+      </p>
+      <p className="text-sm text-neutral-700 dark:text-neutral-300 mb-4 flex-1">
+        {submission.description}
+      </p>
+      {submission.tags.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {submission.tags.map((t) => (
+            <span
+              key={t}
+              className="rounded-full border border-neutral-200 bg-neutral-50 px-2 py-0.5 text-[11px] font-mono text-neutral-600 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2 text-xs">
+        {submission.videoUrl && (
+          <ExternalLink href={submission.videoUrl} label="Video" />
+        )}
+        {submission.repoUrl && (
+          <ExternalLink href={submission.repoUrl} label="Code" />
+        )}
+        {submission.deployedUrl && (
+          <ExternalLink href={submission.deployedUrl} label="Live demo" />
+        )}
+        <a
+          href={submission.folderUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-md border border-neutral-200 px-2 py-1 text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        >
+          Submission folder
+        </a>
+      </div>
+      {(submission.aiScore?.rationale || submission.judgeScore?.rationale) && (
+        <div className="mt-4 space-y-2 border-t border-neutral-200 pt-3 dark:border-neutral-800">
+          {submission.aiScore?.rationale && (
+            <p className="text-xs text-neutral-600 dark:text-neutral-400">
+              <span className="font-semibold text-foreground">AI judge:</span>{" "}
+              {submission.aiScore.rationale}
+            </p>
+          )}
+          {submission.judgeScore?.rationale && (
+            <p className="text-xs text-neutral-600 dark:text-neutral-400">
+              <span className="font-semibold text-foreground">Judges:</span>{" "}
+              {submission.judgeScore.rationale}
+            </p>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function ScoreBadges({ submission }: { submission: SportsHack2026Submission }) {
+  return (
+    <div className="flex shrink-0 flex-col items-end gap-1">
+      {submission.aiScore ? (
+        <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-bold text-emerald-700 dark:text-emerald-300">
+          AI {submission.aiScore.score.toFixed(1)}
+        </span>
+      ) : submission.aiEligible ? (
+        <span className="rounded-full border border-neutral-200 px-2 py-0.5 text-[10px] font-medium text-neutral-500 dark:border-neutral-700">
+          AI pending
+        </span>
+      ) : null}
+      {submission.judgeScore ? (
+        <span className="inline-flex items-center gap-1 rounded-full border border-violet-500/30 bg-violet-500/10 px-2 py-0.5 text-xs font-bold text-violet-700 dark:text-violet-300">
+          Judges {submission.judgeScore.average.toFixed(1)}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function ExternalLink({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="rounded-md bg-neutral-100 px-2 py-1 font-semibold text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+    >
+      {label} →
+    </a>
+  );
+}

--- a/app/hackathons/sports-hack-2026/page.tsx
+++ b/app/hackathons/sports-hack-2026/page.tsx
@@ -143,10 +143,11 @@ export default function SportsHack2026LandingPage() {
             </p>
 
             <div className="mt-10 rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
-              <h2 className="text-lg font-semibold">How selection works</h2>
+              <h2 className="text-lg font-semibold">How to win a Cursor credit</h2>
               <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-                Luma approves your registration. Cursor Boston then ranks registrants by
-                merged PRs to the{" "}
+                We have <strong>{SPORTS_HACK_2026_CAPACITY} Cursor credit codes</strong>{" "}
+                for participants. Luma approves your registration. Cursor Boston then
+                ranks registrants by merged PRs to the{" "}
                 <a
                   href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
                   target="_blank"
@@ -156,8 +157,40 @@ export default function SportsHack2026LandingPage() {
                   cursor-boston
                 </a>{" "}
                 community repo, with signup time as the tiebreaker. Top{" "}
-                {SPORTS_HACK_2026_CAPACITY} get a confirmed seat; the rest join the
-                waitlist. Merge a PR to move up.
+                {SPORTS_HACK_2026_CAPACITY} get a confirmed seat plus a Cursor credit
+                code; the rest join the waitlist. Merge a PR to move up.
+              </p>
+            </div>
+
+            <div className="mt-6 rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+              <h2 className="text-lg font-semibold">How to submit your project</h2>
+              <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+                On event day, open a PR into the{" "}
+                <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs font-mono dark:bg-neutral-800">
+                  sports-hack-2026-submissions
+                </code>{" "}
+                branch with a folder named after your GitHub handle containing one{" "}
+                <code className="font-mono">meta.json</code> describing the project:
+                title, description, video URL (Loom / YouTube / any explainer), GitHub
+                repo URL, and a deployed URL.
+              </p>
+              <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+                <strong className="text-rose-600 dark:text-rose-400">
+                  Hard deadline: 4:00 PM ET on Tuesday, May 26 (event end).
+                </strong>{" "}
+                Your PR must be opened before this moment to be eligible for AI scoring.
+                One second late and your AI eval is gone — but human judges still review
+                every merged submission, so the judges track stays open.
+              </p>
+              <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+                Winners: <strong>3 on the AI track</strong> + <strong>3 on the judges
+                track</strong> = 6 total.{" "}
+                <Link
+                  href="/events/cursor-boston-sports-hack-2026"
+                  className="text-emerald-600 underline dark:text-emerald-400"
+                >
+                  Full submission rules + public board →
+                </Link>
               </p>
             </div>
           </div>

--- a/content/events.json
+++ b/content/events.json
@@ -118,7 +118,7 @@
       "lumaUrl": "https://luma.com/t5vseeed",
       "lumaEventId": "t5vseeed",
       "registrationRequired": true,
-      "capacity": 80,
+      "capacity": 119,
       "perks": [
         "$50 Cursor credits (guaranteed for selected participants)",
         "Exclusive Red Bull merchandise",
@@ -196,7 +196,7 @@
           "answer": "Yes \u2014 Tuesday, May 26, 2026 at Hult International in Cambridge. The exact address appears on Luma after your registration is approved."
         },
         {
-          "question": "What if I don't make the top 80?",
+          "question": "What if I don't make the top 119?",
           "answer": "Join the waitlist \u2014 drop-outs happen. You can also contact the hosts on Luma to judge or partner."
         }
       ],

--- a/docs/SUBMISSION_BRANCHES.md
+++ b/docs/SUBMISSION_BRANCHES.md
@@ -18,6 +18,7 @@ You don't need to do anything to keep the branch fresh — that's a maintainer t
 |---|---|
 | Standard code, bug fix, feature work, docs | **`develop`** |
 | Submitting a PyData hackathon notebook | **`pydata-2026-submissions`** ([see README](../pydata-2026-submissions/README.md)) |
+| Submitting a Sports Hack 2026 project (May 26) | **`sports-hack-2026-submissions`** ([see README](../sports-hack-2026-submissions/README.md)) |
 | Submitting a Hack-a-Sprint showcase project | **`hack-a-sprint-2026-submissions`** ([see README](../content/hackathons/hack-a-sprint-2026/submissions/README.md)) |
 | Summer cohort 1 week N submission (PM / comms / marketing / education / startup / oss) | **`c1w1pm-submission`**, **`c1w2comms-submission`**, **`c1w3mkt-submission`**, **`c1w4edu-submission`**, **`c1w5startup-submission`**, or **`c1w6oss-submission`** |
 | Summer cohort 2 vote-format week N submission (PM / comms / marketing) | **`c2w1pm-submission`**, **`c2w2comms-submission`**, or **`c2w3mkt-submission`** |
@@ -38,6 +39,7 @@ If you're unsure, default to `develop` and a maintainer will redirect you in rev
 - `c2w2comms-submission` — summer cohort 2, week 2 (communications, vote format)
 - `c2w3mkt-submission` — summer cohort 2, week 3 (marketing, vote format)
 - `pydata-2026-submissions` — May 13, 2026 PyData × Cursor Boston hack at Moderna HQ
+- `sports-hack-2026-submissions` — May 26, 2026 Boston Tech Week Sports Hack project submissions (hard 4 PM ET AI-eligibility cutoff on event day)
 - `hack-a-sprint-2026-submissions` — Hack-a-Sprint 2026 showcase projects
 - `game-contributions` — ongoing in-game content (units, artifacts, lore)
 - `maintainer-application` — async maintainer applications

--- a/lib/sports-hack-2026-submissions.ts
+++ b/lib/sports-hack-2026-submissions.ts
@@ -1,0 +1,320 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Build-time loader for the Sports Hack 2026 submissions directory.
+ *
+ * Layout (see `sports-hack-2026-submissions/README.md`):
+ *
+ *   sports-hack-2026-submissions/
+ *     README.md
+ *     <gh-handle>/
+ *       meta.json       — title, description, videoUrl, repoUrl, deployedUrl
+ *       score.json      — maintainer-authored: { ai: {...}, judges?: {...} }
+ *
+ * The event page reads this list at build time. New submissions appear
+ * after `main` deploys:
+ *   attendee PR → `sports-hack-2026-submissions` branch → develop → main → deploy.
+ *
+ * Scoring is post-deadline. AI scores come from
+ * `scripts/score-sports-hack-2026-submission.ts`. Judge scores come from a
+ * follow-up admin path (TBD until a judge list is locked).
+ */
+
+export const SPORTS_HACK_2026_SUBMISSIONS_BRANCH = "sports-hack-2026-submissions";
+export const SPORTS_HACK_2026_SUBMISSIONS_DIR = "sports-hack-2026-submissions";
+export const SPORTS_HACK_2026_SUBMISSIONS_REPO_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+const META_FILENAME = "meta.json";
+const SCORE_FILENAME = "score.json";
+const MAX_TITLE = 120;
+const MAX_DESCRIPTION = 500;
+const MAX_TAGS = 6;
+const MAX_COLLABORATORS = 10;
+const MAX_RATIONALE = 1000;
+const MAX_URL = 500;
+
+/**
+ * Hard deadline: 4:00 PM ET on Tuesday, May 26, 2026 (event end).
+ * Submissions whose PR was opened at or after this instant are still
+ * eligible for the judges track but locked out of AI scoring.
+ */
+export const SPORTS_HACK_2026_WINNER_ELIGIBLE_CUTOFF_ISO =
+  "2026-05-26T20:00:00.000Z";
+
+/**
+ * Maintainer-filled map of PR creation timestamps, keyed by the submission
+ * folder name (lowercased GitHub handle). Fill this in as PRs land — the
+ * page uses it to render the AI-eligible vs after-deadline split. Same
+ * pattern as `lib/pydata-submissions.ts`.
+ */
+const SUBMISSION_PR_CREATED_AT: Record<string, string> = {};
+
+export interface SportsHack2026SubmissionCollaborator {
+  displayName: string;
+  githubHandle: string | null;
+}
+
+export interface SportsHack2026AiScore {
+  /** Numeric 1-10 score from the LLM judge; decimals are used for tie-breaks. */
+  score: number;
+  /** Short justification from the judge. */
+  rationale: string;
+  /** Model name that produced the score (e.g. `claude-opus-4-7`). */
+  model: string;
+  /** ISO timestamp of when the score was written. */
+  scoredAt: string;
+}
+
+export interface SportsHack2026JudgeScore {
+  /** Average human-judge score 1-10. */
+  average: number;
+  /** Number of judges who scored. */
+  count: number;
+  /** Optional consolidated rationale from the judge panel. */
+  rationale?: string;
+  /** ISO timestamp of when the score was finalized. */
+  scoredAt?: string;
+}
+
+export interface SportsHack2026Submission {
+  githubHandle: string;
+  displayName: string;
+  title: string;
+  description: string;
+  /** URL to a Loom/YouTube/Vimeo/etc. explainer video. */
+  videoUrl: string | null;
+  /** GitHub URL for the project repo. */
+  repoUrl: string | null;
+  /** Live URL for the deployed project. Empty string for not-deployed. */
+  deployedUrl: string | null;
+  tags: string[];
+  collaborators: SportsHack2026SubmissionCollaborator[];
+  /** GitHub URL pointing at the submission folder on `main`. */
+  folderUrl: string;
+  /** AI judge score. Absent if not yet scored or PR was after the deadline. */
+  aiScore: SportsHack2026AiScore | null;
+  /** Human judge score. Absent if not yet finalized. */
+  judgeScore: SportsHack2026JudgeScore | null;
+  /** PR creation time used for AI-eligibility cutoff decisions. */
+  submittedAt: string | null;
+  /** True when the original PR was opened before 4 PM ET on May 26. */
+  aiEligible: boolean;
+}
+
+function clampString(s: unknown, max: number): string {
+  if (typeof s !== "string") return "";
+  return s.trim().slice(0, max);
+}
+
+function parseTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const tags: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const cleaned = entry.trim().toLowerCase().slice(0, 32);
+    if (!cleaned) continue;
+    if (tags.includes(cleaned)) continue;
+    tags.push(cleaned);
+    if (tags.length >= MAX_TAGS) break;
+  }
+  return tags;
+}
+
+function parseCollaborators(raw: unknown): SportsHack2026SubmissionCollaborator[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SportsHack2026SubmissionCollaborator[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const displayName = clampString(obj.displayName, 80);
+    if (!displayName) continue;
+    const handleRaw = clampString(obj.githubHandle, 64);
+    out.push({
+      displayName,
+      githubHandle: handleRaw ? handleRaw.replace(/^@/, "") : null,
+    });
+    if (out.length >= MAX_COLLABORATORS) break;
+  }
+  return out;
+}
+
+function isValidHandleDirname(name: string): boolean {
+  if (name.startsWith(".") || name.startsWith("_")) return false;
+  return /^[a-z0-9][a-z0-9-_]{0,38}$/i.test(name);
+}
+
+function parseUrl(raw: unknown): string | null {
+  const s = clampString(raw, MAX_URL);
+  if (!s) return null;
+  if (!/^https?:\/\//i.test(s)) return null;
+  return s;
+}
+
+function readMeta(folderPath: string): unknown {
+  const metaPath = path.join(folderPath, META_FILENAME);
+  if (!fs.existsSync(metaPath)) return null;
+  try {
+    const text = fs.readFileSync(metaPath, "utf8");
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readScores(folderPath: string): {
+  aiScore: SportsHack2026AiScore | null;
+  judgeScore: SportsHack2026JudgeScore | null;
+} {
+  const scorePath = path.join(folderPath, SCORE_FILENAME);
+  if (!fs.existsSync(scorePath)) return { aiScore: null, judgeScore: null };
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(fs.readFileSync(scorePath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return { aiScore: null, judgeScore: null };
+  }
+  return {
+    aiScore: parseAiScoreBlock(parsed.ai),
+    judgeScore: parseJudgeScoreBlock(parsed.judges),
+  };
+}
+
+function parseAiScoreBlock(raw: unknown): SportsHack2026AiScore | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const score = Number(obj.score);
+  if (!Number.isFinite(score) || score < 1 || score > 10) return null;
+  const rationale = clampString(obj.rationale, MAX_RATIONALE);
+  if (!rationale) return null;
+  const model = clampString(obj.model, 80) || "unknown";
+  const scoredAt = clampString(obj.scoredAt, 40) || "";
+  return { score, rationale, model, scoredAt };
+}
+
+function parseJudgeScoreBlock(raw: unknown): SportsHack2026JudgeScore | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const average = Number(obj.average);
+  if (!Number.isFinite(average) || average < 1 || average > 10) return null;
+  const count = Number(obj.count);
+  if (!Number.isFinite(count) || count < 1) return null;
+  const rationale = clampString(obj.rationale, MAX_RATIONALE) || undefined;
+  const scoredAt = clampString(obj.scoredAt, 40) || undefined;
+  return { average, count, rationale, scoredAt };
+}
+
+function buildSubmission(
+  handleDir: string,
+  meta: Record<string, unknown>,
+  aiScore: SportsHack2026AiScore | null,
+  judgeScore: SportsHack2026JudgeScore | null
+): SportsHack2026Submission | null {
+  const title = clampString(meta.title, MAX_TITLE);
+  const description = clampString(meta.description, MAX_DESCRIPTION);
+  if (!title || !description) return null;
+  const displayName = clampString(meta.displayName, 80) || handleDir;
+  const submittedAt = SUBMISSION_PR_CREATED_AT[handleDir] ?? null;
+  const aiEligible = submittedAt
+    ? Date.parse(submittedAt) < Date.parse(SPORTS_HACK_2026_WINNER_ELIGIBLE_CUTOFF_ISO)
+    : false;
+
+  return {
+    githubHandle: handleDir,
+    displayName,
+    title,
+    description,
+    videoUrl: parseUrl(meta.videoUrl),
+    repoUrl: parseUrl(meta.repoUrl),
+    deployedUrl: parseUrl(meta.deployedUrl),
+    tags: parseTags(meta.tags),
+    collaborators: parseCollaborators(meta.collaborators),
+    folderUrl: `${SPORTS_HACK_2026_SUBMISSIONS_REPO_URL}/tree/main/${SPORTS_HACK_2026_SUBMISSIONS_DIR}/${handleDir}`,
+    aiScore,
+    judgeScore,
+    submittedAt,
+    aiEligible,
+  };
+}
+
+/**
+ * Read every valid submission from the directory on disk.
+ *
+ * Invalid entries (malformed meta.json, bad folder name) are silently skipped
+ * so a single broken submission can't take down the whole page. Build logs
+ * surface the skip via console.warn — visible in Vercel deploy output.
+ */
+export function getSportsHack2026Submissions(): SportsHack2026Submission[] {
+  const dir = path.join(process.cwd(), SPORTS_HACK_2026_SUBMISSIONS_DIR);
+  if (!fs.existsSync(dir)) return [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const submissions: SportsHack2026Submission[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const handleDir = entry.name;
+    if (!isValidHandleDirname(handleDir)) continue;
+
+    const folderPath = path.join(dir, handleDir);
+    const meta = readMeta(folderPath);
+    if (!meta || typeof meta !== "object") {
+      console.warn(
+        `[sports-hack-2026-submissions] ${handleDir}: missing or invalid ${META_FILENAME}, skipping`
+      );
+      continue;
+    }
+
+    const { aiScore, judgeScore } = readScores(folderPath);
+    const submission = buildSubmission(
+      handleDir,
+      meta as Record<string, unknown>,
+      aiScore,
+      judgeScore
+    );
+    if (!submission) {
+      console.warn(
+        `[sports-hack-2026-submissions] ${handleDir}: ${META_FILENAME} missing required fields, skipping`
+      );
+      continue;
+    }
+    submissions.push(submission);
+  }
+
+  // Sort: strongest combined score first (AI + judges if both present;
+  // otherwise whichever is set; unscored last). Stable tie-break on name.
+  submissions.sort((a, b) => {
+    const aRank = combinedRankScore(a);
+    const bRank = combinedRankScore(b);
+    if (bRank !== aRank) return bRank - aRank;
+    return a.displayName.localeCompare(b.displayName, undefined, {
+      sensitivity: "base",
+    });
+  });
+  return submissions;
+}
+
+function combinedRankScore(s: SportsHack2026Submission): number {
+  const ai = s.aiScore?.score ?? null;
+  const judge = s.judgeScore?.average ?? null;
+  if (ai != null && judge != null) return (ai + judge) / 2;
+  if (ai != null) return ai;
+  if (judge != null) return judge;
+  return -Infinity;
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -43,6 +43,7 @@ Licensed GPL-3.0-only.
     /events/cursor-boston-pydata-2026
     /events/cursor-boston-pydata-2026/admin
     /events/cursor-boston-pydata-2026/register
+    /events/cursor-boston-sports-hack-2026
     /events/request
     /game
     /game/armageddon

--- a/scripts/score-sports-hack-2026-submission.ts
+++ b/scripts/score-sports-hack-2026-submission.ts
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Boston Tech Week Sports Hack 2026 (May 26) — LLM scorer for hackathon
+ * submissions.
+ *
+ * Reads a `sports-hack-2026-submissions/<handle>/` folder, calls Claude with
+ * the hackathon rubric (sports + AI + Cursor brief), and writes (or extends)
+ * `score.json` in the same folder. The score file is what the public event
+ * page at `/events/cursor-boston-sports-hack-2026` renders on each card.
+ *
+ * The score layout differs from the pydata version: we keep both `ai` and
+ * `judges` blocks in the same file so a single submission can carry both
+ * tracks. This script only writes the `ai` block — judge scores land via a
+ * separate admin path post-event.
+ *
+ * Usage:
+ *   npx tsx scripts/score-sports-hack-2026-submission.ts --handle <gh-handle>
+ *   npx tsx scripts/score-sports-hack-2026-submission.ts --all
+ *   npx tsx scripts/score-sports-hack-2026-submission.ts --handle alice --force   # re-score
+ *   npx tsx scripts/score-sports-hack-2026-submission.ts --all --skip-existing
+ *
+ * Requires: ANTHROPIC_API_KEY
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import Anthropic from "@anthropic-ai/sdk";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  SPORTS_HACK_2026_SUBMISSIONS_DIR,
+} from "../lib/sports-hack-2026-submissions";
+
+const MODEL = "claude-opus-4-7";
+const SCORE_FILENAME = "score.json";
+const META_FILENAME = "meta.json";
+
+const RUBRIC = `You are the AI "black box" judge for the Boston Tech Week Sports Hack (May 26, 2026 at Hult International, Cambridge).
+
+## Challenge
+Attendees had a 2-hour build sprint to use Cursor as their AI co-pilot and ship a sports-tech project. They submit a short explainer video, a public GitHub repo, and ideally a live deployed URL.
+
+## What you're judging
+You get the submission's \`meta.json\` — title, description, video URL, repo URL, deployed URL, optional tags. You do NOT get to watch the video or browse the repo; you score based on what the team chose to communicate in their meta and on the inherent strength of the proposed project.
+
+## Evaluation Criteria — score holistically 1-10
+
+1. **Idea fit & sports relevance** — Is this clearly a sports-tech project? Loose interpretations are OK (training, fan engagement, analytics, broadcasting, equipment, betting markets, recovery, youth/community sports) but the project must be recognizably sports.
+2. **Specificity & clarity** — Is the description a single, sharp pitch ("X for Y user, doing Z") or a vague gesture? Sharp scores higher.
+3. **Cursor / AI leverage signal** — Does the description / repo name / project shape suggest the team actually leaned into AI co-piloting? Bonus for surprising or non-trivial AI use; nothing if the AI angle is missing.
+4. **Completeness signal** — Did they fill in video + repo + deployed URL? Missing pieces lower the score (especially missing deployed URL, since the brief includes shipping live). All three present + plausible scores higher.
+5. **Polish & ambition** — Does the title + description read like someone who took the brief seriously? Does the scope match what's achievable in 2 hours without being trivial?
+
+## Scoring guide
+- 1-2: Empty / off-topic / not recognizably sports / no video + no repo
+- 3-4: Minimal effort, vague pitch, generic idea, missing required URLs
+- 5-6: Solid attempt, clear idea, most URLs present, decent specificity
+- 7-8: Sharp pitch, all URLs present, evident AI leverage, ambitious but in-scope
+- 9-10: Exceptional — surprising / contrarian / genuinely useful sports application, clearly shipped, strong AI-leverage signal
+
+## Important notes
+- Judge fairly for a 2-hour event. Don't expect production polish.
+- An empty or broken meta.json is an automatic 1.
+- Be honest and differentiate. Not every submission deserves a 7.
+- If the project isn't recognizably sports-related, cap the score at 4.
+
+Respond with ONLY a JSON object (no markdown fencing, no prose around it):
+{"score": <integer 1-10>, "rationale": "<2-4 sentence justification calling out the specific idea, the strongest signal you saw, and the main weakness>"}`;
+
+interface AiScoreBlock {
+  score: number;
+  rationale: string;
+  model: string;
+  scoredAt: string;
+  scorerVersion: number;
+}
+
+interface ScoreFile {
+  ai?: AiScoreBlock;
+  judges?: unknown;
+}
+
+const SCORER_VERSION = 1;
+
+function parseArgs(argv: string[]) {
+  const handleIdx = argv.indexOf("--handle");
+  const handle =
+    handleIdx >= 0 ? argv[handleIdx + 1]?.trim().toLowerCase() ?? null : null;
+  const all = argv.includes("--all");
+  const force = argv.includes("--force");
+  const skipExisting = argv.includes("--skip-existing");
+
+  if (!handle && !all) {
+    console.error("Specify --handle <gh-handle> or --all");
+    process.exit(1);
+  }
+  if (handle && all) {
+    console.error("Specify only one of --handle or --all");
+    process.exit(1);
+  }
+  return { handle, all, force, skipExisting };
+}
+
+interface ScoreResult {
+  score: number;
+  rationale: string;
+}
+
+async function scoreSubmission(
+  client: Anthropic,
+  handle: string,
+  folderPath: string
+): Promise<ScoreResult> {
+  const metaPath = path.join(folderPath, META_FILENAME);
+  if (!fs.existsSync(metaPath)) {
+    throw new Error(`${handle}: missing ${META_FILENAME}`);
+  }
+  const meta = fs.readFileSync(metaPath, "utf8");
+
+  const context = [
+    `## Submission: ${handle}`,
+    `\n### meta.json\n${meta}`,
+  ].join("\n");
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: 500,
+    messages: [{ role: "user", content: `${RUBRIC}\n\n---\n\n${context}` }],
+  });
+
+  const text =
+    response.content[0]?.type === "text" ? response.content[0].text : "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) throw new Error(`Could not parse model response: ${text}`);
+  const parsed = JSON.parse(jsonMatch[0]) as {
+    score?: unknown;
+    rationale?: unknown;
+  };
+  const score = Number(parsed.score);
+  const rationale = String(parsed.rationale ?? "").trim();
+  if (!Number.isInteger(score) || score < 1 || score > 10) {
+    throw new Error(`Invalid score: ${String(parsed.score)}`);
+  }
+  if (!rationale) throw new Error("Empty rationale");
+  return { score, rationale };
+}
+
+function readScoreFile(folderPath: string): ScoreFile {
+  const scorePath = path.join(folderPath, SCORE_FILENAME);
+  if (!fs.existsSync(scorePath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(scorePath, "utf8")) as ScoreFile;
+  } catch {
+    return {};
+  }
+}
+
+function writeScoreFile(folderPath: string, result: ScoreResult): string {
+  // Preserve any existing `judges` block so this script can be re-run without
+  // clobbering human-judge scores written through a separate path.
+  const existing = readScoreFile(folderPath);
+  const out: ScoreFile = {
+    ...existing,
+    ai: {
+      score: result.score,
+      rationale: result.rationale,
+      model: MODEL,
+      scoredAt: new Date().toISOString(),
+      scorerVersion: SCORER_VERSION,
+    },
+  };
+  const scorePath = path.join(folderPath, SCORE_FILENAME);
+  fs.writeFileSync(scorePath, JSON.stringify(out, null, 2) + "\n");
+  return scorePath;
+}
+
+function hasExistingAiScore(folderPath: string): boolean {
+  const existing = readScoreFile(folderPath);
+  return Boolean(existing.ai);
+}
+
+function listHandles(rootDir: string): string[] {
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  const handles: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+    handles.push(entry.name);
+  }
+  handles.sort();
+  return handles;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("ANTHROPIC_API_KEY is required.");
+    process.exit(1);
+  }
+
+  const rootDir = path.join(process.cwd(), SPORTS_HACK_2026_SUBMISSIONS_DIR);
+  if (!fs.existsSync(rootDir)) {
+    console.error(`Directory not found: ${rootDir}`);
+    process.exit(1);
+  }
+
+  const handles = args.all ? listHandles(rootDir) : [args.handle!];
+  if (handles.length === 0) {
+    console.log("No submissions to score.");
+    return;
+  }
+
+  const client = new Anthropic();
+
+  for (const handle of handles) {
+    const folderPath = path.join(rootDir, handle);
+    if (!fs.existsSync(folderPath)) {
+      console.error(`${handle}: folder not found, skipping`);
+      continue;
+    }
+
+    if (hasExistingAiScore(folderPath) && !args.force) {
+      if (args.skipExisting || args.all) {
+        console.log(
+          `${handle}: ai score already exists, skipping (use --force to re-score)`
+        );
+        continue;
+      }
+      console.error(
+        `${handle}: ai score already exists. Use --force to overwrite.`
+      );
+      process.exit(1);
+    }
+
+    console.log(`Scoring ${handle}…`);
+    try {
+      const result = await scoreSubmission(client, handle, folderPath);
+      const scorePath = writeScoreFile(folderPath, result);
+      console.log(`  ${result.score}/10 — ${result.rationale}`);
+      console.log(`  wrote ${path.relative(process.cwd(), scorePath)}`);
+    } catch (e) {
+      console.error(
+        `  failed: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-sports-hack-2026-participation-rules.ts
+++ b/scripts/send-sports-hack-2026-participation-rules.ts
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Closing-comms blast to everyone on the May 26 list (Sports Hack 2026):
+ *
+ *   1. "See you Tuesday" — event reminder.
+ *   2. How to claim a Cursor credit — claim spot on signup page, climb into
+ *      top 119 via merged PRs to the community repo.
+ *   3. How to win the hackathon — PR a meta.json into
+ *      `sports-hack-2026-submissions` with video + repo + deployed URL +
+ *      description. Hard deadline 4 PM ET. Late = judges-only.
+ *   4. Link to the public submissions board.
+ *
+ * Recipient set mirrors `scripts/send-may26-attendee-action-prompts.ts`:
+ * union of website signups + Luma-only minus judges/declined/unsubscribed,
+ * deduped by email + matching GitHub login.
+ *
+ * Idempotent via `sportsHack2026ParticipationRulesEmailedAt` stamped on:
+ *   - `hackathonEventSignups/{id}` for website signups
+ *   - `hackathonLumaRegistrants/{id}` for Luma-only attendees
+ * Pass `--force` to re-send; `--only-email=foo@bar` to restrict to one.
+ *
+ * Usage:
+ *   npx tsx scripts/send-sports-hack-2026-participation-rules.ts --dry-run
+ *   npx tsx scripts/send-sports-hack-2026-participation-rules.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-sports-hack-2026-participation-rules.ts --send
+ *   npx tsx scripts/send-sports-hack-2026-participation-rules.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import {
+  getDeclinedEmailsForEvent,
+  getJudgeEmailsForEvent,
+} from "../lib/hackathon-event-signup";
+import {
+  SPORTS_HACK_2026_CAPACITY,
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_NAME,
+} from "../lib/sports-hack-2026";
+
+const EVENT_ID = SPORTS_HACK_2026_EVENT_ID;
+const STAMP_FIELD = "sportsHack2026ParticipationRulesEmailedAt";
+
+const SIGNUP_URL = `https://cursorboston.com/hackathons/${EVENT_ID}/signup`;
+const LANDING_URL = `https://cursorboston.com/hackathons/${EVENT_ID}`;
+const SUBMISSIONS_PAGE_URL =
+  "https://cursorboston.com/events/cursor-boston-sports-hack-2026";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const SUBMISSIONS_BRANCH = "sports-hack-2026-submissions";
+const README_URL = `${REPO_URL}/blob/main/${SUBMISSIONS_BRANCH}/README.md`;
+
+const DEADLINE_HUMAN = "4:00 PM ET on Tuesday, May 26";
+const EVENT_TIME_HUMAN = "Tuesday, May 26 · 10 AM – 4 PM ET · Hult International, Cambridge";
+
+interface Recipient {
+  /** Lowercased email, for both addressing and the stamp lookup. */
+  email: string;
+  firstName: string;
+  /** Source channel — determines which Firestore doc carries the stamp. */
+  source: "website" | "luma";
+  /** Firestore doc id for the stamp write. */
+  sourceDocId: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject =
+    "Sports Hack on Tuesday — 119 Cursor credits up for grabs + how to win";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick rundown for Tuesday's <strong>${escapeHtml(SPORTS_HACK_2026_NAME)}</strong> — looking forward to seeing you there.</p>
+
+<p><strong>${escapeHtml(EVENT_TIME_HUMAN)}.</strong></p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">1. Want a Cursor credit?</h3>
+<p>We have <strong>${SPORTS_HACK_2026_CAPACITY} Cursor credit codes</strong> for participants. They go to the top ${SPORTS_HACK_2026_CAPACITY} ranked attendees on the website signup list — ranked by <strong>merged PRs to the community repo</strong>, with signup time as the tiebreaker.</p>
+<p>Two things to do:</p>
+<ol>
+  <li><a href="${SIGNUP_URL}">Claim your spot on the site</a> if you haven&apos;t. Required even if you&apos;re already on Luma — this is the list we rank from.</li>
+  <li>Merge PRs to <a href="${REPO_URL}">cursor-boston</a>. Every merged PR moves you up. Look for <code>good first issue</code> if it&apos;s your first one.</li>
+</ol>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">2. How to win the hackathon</h3>
+<p>On event day, submit your project by opening a PR into the <a href="${REPO_URL}/tree/${SUBMISSIONS_BRANCH}"><code>${SUBMISSIONS_BRANCH}</code></a> branch with a folder named after your GitHub handle. Inside the folder: one <code>meta.json</code> with:</p>
+<ul>
+  <li><strong>title</strong> + <strong>description</strong> — what you built, in 1–3 sentences</li>
+  <li><strong>videoUrl</strong> — Loom, YouTube, or any link we can watch your explainer from</li>
+  <li><strong>repoUrl</strong> — your project&apos;s GitHub repo</li>
+  <li><strong>deployedUrl</strong> — a live URL we can open in a browser</li>
+</ul>
+<p style="font-size:14px;color:#555;"><a href="${README_URL}">Full template + field reference →</a></p>
+
+<div style="border:1px solid #fca5a5;border-radius:8px;padding:16px;margin:20px 0;background:#fef2f2;font-size:14px;color:#7f1d1d;">
+  <p style="margin:0 0 6px 0;"><strong>⏱ Hard deadline: ${escapeHtml(DEADLINE_HUMAN)}.</strong></p>
+  <p style="margin:0;">Your PR must be <strong>opened before</strong> 4 PM ET to be eligible for AI scoring. One second late and your AI eval is gone — but human judges still review every merged submission, so you can still win on the judges track.</p>
+</div>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">3. How winners are picked</h3>
+<p>Two independent tracks, both running off the same submissions:</p>
+<ul>
+  <li><strong>AI track</strong> — after the 4 PM deadline, an AI agent reads every eligible <code>meta.json</code> + your video/repo/deployed links and scores 1–10 with a written rationale. <strong>Top 3 win.</strong></li>
+  <li><strong>Judges track</strong> — a panel of human judges reviews every merged submission (AI-eligible or not) and picks their top 3 based on the live presentations and the repo + deployed project. <strong>Top 3 win.</strong></li>
+</ul>
+<p>That&apos;s 6 winners total. AI-eligible submissions can win on either track; late submissions are judges-only.</p>
+
+<p style="margin-top:24px;">Public submissions board: <a href="${SUBMISSIONS_PAGE_URL}">${SUBMISSIONS_PAGE_URL}</a> — empty right now, fills up as PRs land Tuesday.</p>
+
+<p>Reply if anything is unclear, you want to host or sponsor on the 26th, or you&apos;re looking for a way to get more involved with the community beyond the event itself.</p>
+
+<p>See you Tuesday —</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you registered for the Cursor Boston May 26 immersion event.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick rundown for Tuesday's ${SPORTS_HACK_2026_NAME} — looking forward to seeing you there.
+
+${EVENT_TIME_HUMAN}.
+
+1) WANT A CURSOR CREDIT?
+We have ${SPORTS_HACK_2026_CAPACITY} Cursor credit codes for participants. They go to the top ${SPORTS_HACK_2026_CAPACITY} ranked attendees on the website signup list — ranked by merged PRs to the community repo, with signup time as the tiebreaker.
+
+Two things to do:
+  - Claim your spot on the site: ${SIGNUP_URL}
+    Required even if you're already on Luma — this is the list we rank from.
+  - Merge PRs to cursor-boston: ${REPO_URL}
+    Every merged PR moves you up. Look for "good first issue" if it's your first one.
+
+2) HOW TO WIN THE HACKATHON
+On event day, submit your project by opening a PR into the "${SUBMISSIONS_BRANCH}" branch with a folder named after your GitHub handle. Inside the folder: one meta.json with:
+  - title + description (1–3 sentences)
+  - videoUrl  — Loom, YouTube, or any link we can watch from
+  - repoUrl   — your project's GitHub repo
+  - deployedUrl — a live URL we can open in a browser
+
+Full template + field reference: ${README_URL}
+
+⏱ HARD DEADLINE: ${DEADLINE_HUMAN}.
+Your PR must be opened before 4 PM ET to be eligible for AI scoring. One second late and your AI eval is gone — but human judges still review every merged submission, so you can still win on the judges track.
+
+3) HOW WINNERS ARE PICKED
+Two independent tracks, both running off the same submissions:
+  - AI track     — after the deadline, an AI agent reads every eligible meta.json + your video/repo/deployed links and scores 1–10 with a written rationale. Top 3 win.
+  - Judges track — a panel of human judges reviews every merged submission and picks their top 3 based on the live presentations and the repo + deployed project. Top 3 win.
+
+That's 6 winners total. AI-eligible submissions can win on either track; late submissions are judges-only.
+
+Public submissions board: ${SUBMISSIONS_PAGE_URL}
+Empty right now, fills up as PRs land Tuesday.
+
+Event landing page: ${LANDING_URL}
+
+Reply if anything is unclear, you want to host or sponsor on the 26th, or you're looking for a way to get more involved with the community beyond the event itself.
+
+See you Tuesday —
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you registered for the Cursor Boston May 26 immersion event.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function firstNameFrom(s: string | null | undefined): string {
+  if (!s) return "";
+  return s.trim().split(/\s+/)[0] ?? "";
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  if (send) await syncMailgunSuppressions(db);
+
+  // Website signups + their user docs.
+  const signupSnap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  const websiteUserIds = signupSnap.docs
+    .map((d) => d.data().userId as string | undefined)
+    .filter((u): u is string => Boolean(u));
+  const userMap = new Map<string, FirebaseFirestore.DocumentData>();
+  for (let i = 0; i < websiteUserIds.length; i += 10) {
+    const chunk = websiteUserIds.slice(i, i + 10);
+    const refs = chunk.map((id) => db.collection("users").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) if (s.exists) userMap.set(s.id, s.data() ?? {});
+  }
+  console.log(`Website signups (${EVENT_ID}): ${signupSnap.size}`);
+
+  // Luma registrants.
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  console.log(`Luma registrants (${EVENT_ID}): ${lumaSnap.size}`);
+
+  // Unsubscribed (global) — eventContacts.unsubscribed === true.
+  const ecSnap = await db.collection("eventContacts").get();
+  const unsubscribedEmails = new Set<string>();
+  for (const doc of ecSnap.docs) {
+    if (doc.data().unsubscribed === true) {
+      const e = (doc.data().email || doc.id).toString().trim().toLowerCase();
+      if (e) unsubscribedEmails.add(e);
+    }
+  }
+  console.log(`Unsubscribed emails (global): ${unsubscribedEmails.size}`);
+
+  const judgeEmails = getJudgeEmailsForEvent(EVENT_ID);
+  const declinedEmails = getDeclinedEmailsForEvent(EVENT_ID);
+
+  // Build recipients: website first, then Luma-only (skip dupes by email or
+  // GitHub login). Same dedup as rank-may26-attendees + send-may26-action.
+  const recipients: Recipient[] = [];
+  const seenEmails = new Set<string>();
+  const websiteGithubLogins = new Set<string>();
+
+  let skippedAlreadyEmailed = 0;
+  let skippedOnlyEmailFilter = 0;
+  let skippedJudgeOrDeclined = 0;
+  let skippedUnsubscribed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of signupSnap.docs) {
+    const data = doc.data();
+    const userId = data.userId as string | undefined;
+    if (!userId) {
+      skippedNoEmail++;
+      continue;
+    }
+    const profile = userMap.get(userId) ?? {};
+    const email =
+      typeof profile.email === "string"
+        ? profile.email.trim().toLowerCase()
+        : null;
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (judgeEmails.has(email) || declinedEmails.has(email)) {
+      skippedJudgeOrDeclined++;
+      continue;
+    }
+    if (unsubscribedEmails.has(email)) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    if (!force && data[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && email !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    seenEmails.add(email);
+    const ghLogin =
+      profile.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login ?? null
+        : null;
+    if (ghLogin) websiteGithubLogins.add(ghLogin.toLowerCase());
+    recipients.push({
+      email,
+      firstName: firstNameFrom(
+        typeof profile.displayName === "string" ? profile.displayName : ""
+      ),
+      source: "website",
+      sourceDocId: doc.id,
+    });
+  }
+
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (d.email as string | undefined)?.trim().toLowerCase() ?? "";
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (judgeEmails.has(email) || declinedEmails.has(email)) {
+      skippedJudgeOrDeclined++;
+      continue;
+    }
+    if (unsubscribedEmails.has(email)) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    if (seenEmails.has(email)) continue; // dedup with website channel
+    const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+    if (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase())) continue;
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && email !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    seenEmails.add(email);
+    recipients.push({
+      email,
+      firstName: firstNameFrom(typeof d.name === "string" ? d.name : ""),
+      source: "luma",
+      sourceDocId: doc.id,
+    });
+  }
+
+  console.log(
+    `\nRecipients: ${recipients.length}${onlyEmail ? ` (--only-email=${onlyEmail})` : ""}`
+  );
+  console.log(`Skipped — judge/declined:           ${skippedJudgeOrDeclined}`);
+  console.log(`Skipped — unsubscribed:             ${skippedUnsubscribed}`);
+  console.log(`Skipped — no email:                 ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (stamp):  ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter:      ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email} (${sample.source})`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      const collection =
+        r.source === "website" ? "hackathonEventSignups" : "hackathonLumaRegistrants";
+      await db
+        .collection(collection)
+        .doc(r.sourceDocId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() })
+        .catch((e) => {
+          // Stamp write is best-effort — the email already went out. Log and continue.
+          console.warn(`  [stamp-fail] ${r.email}`, e);
+        });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/sports-hack-2026-submissions/README.md
+++ b/sports-hack-2026-submissions/README.md
@@ -1,0 +1,98 @@
+# Boston Tech Week Sports Hack — submissions
+
+This directory holds project submissions for the **May 26, 2026 Cursor Boston ×
+Hult Sports Hack** at Hult International (Cambridge). The event runs **10 AM –
+4 PM ET** with a hard submission deadline at **4:00 PM ET sharp** (event end).
+
+Each subfolder is one attendee's submission. The public showcase page at
+[cursorboston.com/events/cursor-boston-sports-hack-2026](https://cursorboston.com/events/cursor-boston-sports-hack-2026)
+reads this directory at build time and renders a card per merged submission.
+
+---
+
+## How to submit your project
+
+1. **Fork the repo** at
+   <https://github.com/rogerSuperBuilderAlpha/cursor-boston>.
+
+2. **Create a folder under `sports-hack-2026-submissions/`** named after your
+   GitHub handle (lowercase, exactly as it appears in `github.com/<handle>`).
+   Example: `sports-hack-2026-submissions/jane-doe/`.
+
+3. **Add `meta.json` inside your folder** describing the project — see the
+   template below. That's the only required file.
+
+4. **Open a PR** targeting the branch **`sports-hack-2026-submissions`** (not
+   `develop` or `main`). We'll batch all PRs into that branch, merge it into
+   `develop`, then promote `develop` to `main` — your card appears on the
+   public event page after the final push to `main` deploys.
+
+5. **One folder per attendee.** If you collaborated, pick one handle for the
+   folder name and list collaborators inside `meta.json`.
+
+---
+
+## Deadlines + scoring
+
+- **Hard deadline: 4:00 PM ET on Tuesday, May 26 (2026-05-26T20:00:00Z).**
+  Your PR must be **opened before** this moment to be eligible for AI scoring.
+- **One second late and your AI eval is gone.** You can still be reviewed by
+  the human judges and win a judge-track prize — but the AI track is closed.
+- **Winners**: 3 from the AI track + 3 from the judges track = 6 total.
+
+---
+
+## `meta.json` template
+
+```json
+{
+  "title": "Short, specific project title",
+  "description": "1–3 sentences. What did you build? What problem does it solve?",
+  "displayName": "Your name as you want it on the page",
+  "videoUrl": "https://www.loom.com/share/...",
+  "repoUrl": "https://github.com/your-handle/your-project",
+  "deployedUrl": "https://your-project.vercel.app",
+  "tags": ["nba", "live-stats", "next.js"],
+  "collaborators": [
+    { "displayName": "Pat Collaborator", "githubHandle": "pat-collab" }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| `title` | yes | ≤120 chars. Shown as the card heading. |
+| `description` | yes | ≤500 chars. Plain text — markdown not rendered. |
+| `displayName` | recommended | Falls back to your GitHub handle if absent. |
+| `videoUrl` | yes | Loom, YouTube, Vimeo — any URL we can watch from. Keep it ≤3 minutes. |
+| `repoUrl` | yes | Public GitHub URL for the code. |
+| `deployedUrl` | yes | A live URL we can open in a browser. If you didn't deploy, leave as `""` and put a note in the description. |
+| `tags` | optional | Up to 6 short tags. |
+| `collaborators` | optional | Up to 10. Each has `displayName` + optional `githubHandle`. |
+
+---
+
+## What happens after you submit
+
+1. A maintainer reviews your PR for the basics (folder name matches handle,
+   `meta.json` parses, no secrets, no Hult/Cursor logos misused).
+2. PRs are batched into `develop` and promoted to `main` — your card goes live
+   on the public submissions page.
+3. After the 4:00 PM ET deadline, a maintainer runs the AI judge over every
+   eligible submission. The score lands as `score.json` in your folder; a card
+   badge reflects it.
+4. Human judges review every submission (AI-eligible or not) in parallel.
+5. Winners are announced on-stage shortly after.
+
+---
+
+## Common rejections
+
+- Folder name doesn't match the GitHub handle on the PR.
+- `meta.json` doesn't parse, or required fields are missing.
+- Secrets or API keys committed to the repo.
+- Branding misuse (Hult, Cursor, Moderna logos used where they shouldn't be).
+- PR opened after 4:00 PM ET → still mergeable for the judges track, but
+  flagged as after-deadline on the public page (no AI eval).


### PR DESCRIPTION
## Summary

Single-PR promotion to main so the Sports Hack closing-comms email can go out against a deployed page.

## Included PRs

- #1324 — feat(sports-hack): submissions flow + public board + closing-comms email · @rogerSuperBuilderAlpha

## What this unlocks

- `/events/cursor-boston-sports-hack-2026` becomes the dedicated public submissions board (empty state today, fills Tuesday).
- `sports-hack-2026-submissions/` root directory + README live on `main` so the email's "Open the submission branch" + README links resolve.
- After this merges: cut `sports-hack-2026-submissions` long-lived branch from `origin/develop`, fast-forward all existing submission branches, then run `send-sports-hack-2026-participation-rules.ts --send` against the ~217 May 26 attendees.

## Test plan

- [x] Local `SKIP_TYPECHECK=1 npm run build && npm start` walked through `/events/cursor-boston-sports-hack-2026` + `/hackathons/sports-hack-2026`
- [x] `--dry-run` of the email script: 217 recipients, dedup/filters working
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)