### PR TITLE
release: /research tab + Algorithmacy Conference CFP

### DIFF
--- a/app/research/[slug]/page.tsx
+++ b/app/research/[slug]/page.tsx
@@ -1,0 +1,434 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  ArrowLeft,
+  ExternalLink,
+  FileText,
+  GitBranch,
+  Globe,
+  Mail,
+  MessageSquare,
+} from "lucide-react";
+import {
+  RESEARCH_REPO_README_URL,
+  RESEARCH_TYPE_LABEL,
+  isDataset,
+  isPreprint,
+  isRecruiting,
+  isRecruitingPastDeadline,
+  loadAllResearchEntries,
+  repoFileUrlForSlug,
+  type ResearchEntry,
+} from "@/lib/research";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return loadAllResearchEntries().map(({ entry }) => ({ slug: entry.slug }));
+}
+
+function getEntry(slug: string): ResearchEntry | null {
+  const all = loadAllResearchEntries();
+  return all.find((l) => l.entry.slug === slug)?.entry ?? null;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getEntry(slug);
+  if (!entry) return { title: "Research entry not found" };
+  return {
+    title: `${entry.title} — Research`,
+    description: entry.summary,
+    alternates: { canonical: `https://cursorboston.com/research/${entry.slug}` },
+  };
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function TypeBadge({ type }: { type: ResearchEntry["type"] }) {
+  const styles: Record<ResearchEntry["type"], string> = {
+    recruiting:
+      "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+    preprint: "bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-300",
+    dataset:
+      "bg-purple-100 text-purple-800 dark:bg-purple-950/40 dark:text-purple-300",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-2.5 py-1 text-xs font-semibold ${styles[type]}`}
+    >
+      {RESEARCH_TYPE_LABEL[type]}
+    </span>
+  );
+}
+
+function MetaTable({
+  rows,
+}: {
+  rows: Array<{ label: string; value: React.ReactNode }>;
+}) {
+  return (
+    <dl className="grid grid-cols-1 gap-x-6 gap-y-3 rounded-lg border border-neutral-200 bg-neutral-50 p-5 text-sm dark:border-neutral-800 dark:bg-neutral-900/50 sm:grid-cols-[max-content_1fr]">
+      {rows.map((r, i) => (
+        <div
+          key={i}
+          className="contents sm:contents"
+        >
+          <dt className="font-semibold text-neutral-700 dark:text-neutral-300">
+            {r.label}
+          </dt>
+          <dd className="text-neutral-800 dark:text-neutral-200">{r.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export default async function ResearchEntryPage({ params }: PageProps) {
+  const { slug } = await params;
+  const entry = getEntry(slug);
+  if (!entry) notFound();
+
+  const fileUrl = repoFileUrlForSlug(entry.slug);
+  const isExpired = isRecruiting(entry) && isRecruitingPastDeadline(entry);
+  const isClosed = isRecruiting(entry) && entry.status === "closed";
+  const sample = entry.isSample === true;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+      <Link
+        href="/research"
+        className="inline-flex items-center gap-1 text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to Research
+      </Link>
+
+      {sample ? (
+        <div className="mt-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+          <strong>Sample entry.</strong> This is a placeholder that shows
+          how a real submission renders. The authors, links, deadlines,
+          and IRB numbers are fictional — please don&apos;t contact, sign
+          up, or download. Sample entries are hidden from the main feed
+          and only appear under the &quot;Samples&quot; filter; they will
+          be removed once real research lands.
+        </div>
+      ) : null}
+
+      <header className="mt-4 mb-6">
+        <div className="flex flex-wrap items-center gap-2">
+          <TypeBadge type={entry.type} />
+          {isRecruiting(entry) && entry.status === "paused" ? (
+            <span className="rounded-md bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+              Paused
+            </span>
+          ) : null}
+          {isClosed ? (
+            <span className="rounded-md bg-neutral-200 px-2 py-0.5 text-xs font-semibold text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+              Closed
+            </span>
+          ) : null}
+          {isExpired && !isClosed ? (
+            <span className="rounded-md bg-neutral-200 px-2 py-0.5 text-xs font-semibold text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+              Past deadline
+            </span>
+          ) : null}
+          {isPreprint(entry) && entry.peerReviewStatus ? (
+            <span className="rounded-md border border-sky-200 bg-sky-50 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-sky-800 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300">
+              {entry.peerReviewStatus.replace(/-/g, " ")}
+            </span>
+          ) : null}
+        </div>
+        <h1 className="mt-3 text-3xl font-bold leading-tight text-neutral-900 dark:text-neutral-100">
+          {entry.title}
+        </h1>
+        <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+          {entry.authors.map((a, i) => (
+            <span key={i}>
+              {i > 0 && " · "}
+              {a.url ? (
+                <a
+                  href={a.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-emerald-700 hover:underline dark:hover:text-emerald-400"
+                >
+                  {a.name}
+                </a>
+              ) : (
+                a.name
+              )}
+              {a.affiliation ? (
+                <span className="text-neutral-500"> ({a.affiliation})</span>
+              ) : null}
+            </span>
+          ))}
+        </p>
+        <p className="mt-1 text-xs text-neutral-500">
+          Posted {formatDate(entry.postedAt)}
+          {entry.updatedAt
+            ? ` · Updated ${formatDate(entry.updatedAt)}`
+            : ""}
+        </p>
+      </header>
+
+      <section className="prose prose-neutral mb-6 max-w-none text-neutral-800 dark:prose-invert dark:text-neutral-200">
+        <p>{entry.summary}</p>
+      </section>
+
+      {isRecruiting(entry) ? (
+        <section className="mb-6">
+          <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+            Study details
+          </h2>
+          <MetaTable
+            rows={[
+              {
+                label: "Deadline",
+                value: (
+                  <span className={isExpired ? "line-through opacity-70" : ""}>
+                    {formatDateTime(entry.deadline)}
+                  </span>
+                ),
+              },
+              { label: "Compensation", value: entry.compensation },
+              { label: "Time commitment", value: entry.timeCommitment },
+              {
+                label: "Location",
+                value: <span className="capitalize">{entry.location}</span>,
+              },
+              { label: "Eligibility", value: entry.eligibility },
+              ...(typeof entry.slotsRemaining === "number"
+                ? [
+                    {
+                      label: "Slots remaining",
+                      value: `${entry.slotsRemaining}`,
+                    },
+                  ]
+                : []),
+              ...(entry.irb
+                ? [
+                    {
+                      label: "IRB",
+                      value: `${entry.irb.institution} — Protocol #${entry.irb.protocolNumber}`,
+                    },
+                  ]
+                : []),
+            ]}
+          />
+          {entry.studyUrl && !isExpired && !isClosed && !sample ? (
+            <a
+              href={entry.studyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-500"
+            >
+              <Globe className="h-4 w-4" /> Go to study
+            </a>
+          ) : sample && entry.studyUrl ? (
+            <span className="mt-4 inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-dashed border-amber-300 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+              <Globe className="h-4 w-4" /> Go to study (disabled on sample)
+            </span>
+          ) : null}
+        </section>
+      ) : null}
+
+      {isPreprint(entry) ? (
+        <section className="mb-6">
+          <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+            Paper details
+          </h2>
+          <MetaTable
+            rows={[
+              { label: "Version", value: entry.version },
+              { label: "License", value: entry.license },
+              ...(entry.doi ? [{ label: "DOI", value: entry.doi }] : []),
+              ...(entry.peerReviewStatus
+                ? [
+                    {
+                      label: "Peer review",
+                      value: entry.peerReviewStatus.replace(/-/g, " "),
+                    },
+                  ]
+                : []),
+            ]}
+          />
+          {sample ? (
+            <span className="mt-4 inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-dashed border-amber-300 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+              <FileText className="h-4 w-4" /> Read PDF (disabled on sample)
+            </span>
+          ) : (
+            <a
+              href={entry.pdfUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-500"
+            >
+              <FileText className="h-4 w-4" /> Read PDF
+            </a>
+          )}
+        </section>
+      ) : null}
+
+      {isDataset(entry) ? (
+        <section className="mb-6">
+          <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+            Dataset details
+          </h2>
+          <MetaTable
+            rows={[
+              { label: "License", value: entry.license },
+              ...(entry.size ? [{ label: "Size", value: entry.size }] : []),
+              ...(entry.format && entry.format.length > 0
+                ? [{ label: "Formats", value: entry.format.join(", ") }]
+                : []),
+              ...(entry.doi ? [{ label: "DOI", value: entry.doi }] : []),
+            ]}
+          />
+          {entry.citation ? (
+            <div className="mt-4 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/50">
+              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                Citation
+              </p>
+              <p className="font-mono text-sm text-neutral-800 dark:text-neutral-200">
+                {entry.citation}
+              </p>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+          Where the content lives
+        </h2>
+        <p className="mb-3 text-sm text-neutral-700 dark:text-neutral-300">
+          Cursor Boston hosts the metadata — the actual files, materials,
+          and documentation live in the researcher&apos;s own GitHub repo.
+        </p>
+        {sample ? (
+          <span className="inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-dashed border-amber-300 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+            <GitBranch className="h-4 w-4" />{" "}
+            {entry.sourceRepoUrl.replace(/^https?:\/\//, "")}{" "}
+            <span className="opacity-70">(sample · disabled)</span>
+          </span>
+        ) : (
+          <a
+            href={entry.sourceRepoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-semibold text-neutral-800 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+          >
+            <GitBranch className="h-4 w-4" />{" "}
+            {entry.sourceRepoUrl.replace(/^https?:\/\//, "")}
+            <ExternalLink className="h-3.5 w-3.5 opacity-60" />
+          </a>
+        )}
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+          Contact & discussion
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          {entry.contactEmail ? (
+            sample ? (
+              <span className="inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-dashed border-amber-300 bg-amber-50 px-3.5 py-2 text-sm font-medium text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                <Mail className="h-4 w-4" /> {entry.contactEmail} (sample)
+              </span>
+            ) : (
+              <a
+                href={`mailto:${entry.contactEmail}`}
+                className="inline-flex items-center gap-2 rounded-lg border border-neutral-300 bg-white px-3.5 py-2 text-sm font-medium text-neutral-800 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <Mail className="h-4 w-4" /> {entry.contactEmail}
+              </a>
+            )
+          ) : null}
+          {entry.contactUrl ? (
+            sample ? (
+              <span className="inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-dashed border-amber-300 bg-amber-50 px-3.5 py-2 text-sm font-medium text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                <Globe className="h-4 w-4" /> Contact link (sample)
+              </span>
+            ) : (
+              <a
+                href={entry.contactUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg border border-neutral-300 bg-white px-3.5 py-2 text-sm font-medium text-neutral-800 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <Globe className="h-4 w-4" /> Contact link
+              </a>
+            )
+          ) : null}
+          <a
+            href={fileUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-emerald-300 bg-emerald-50 px-3.5 py-2 text-sm font-medium text-emerald-800 transition-colors hover:bg-emerald-100 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300 dark:hover:bg-emerald-950/50"
+          >
+            <MessageSquare className="h-4 w-4" /> Discuss via PR / issue
+          </a>
+        </div>
+        <p className="mt-3 text-xs text-neutral-500">
+          Community discussion happens through pull requests against this
+          entry&apos;s JSON file, or as issues / PRs on the researcher&apos;s
+          linked source repo. See the{" "}
+          <a
+            href={RESEARCH_REPO_README_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-emerald-700 hover:underline dark:text-emerald-400"
+          >
+            submission guide
+          </a>{" "}
+          for the review process.
+        </p>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+          Disciplines
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {entry.disciplines.map((d) => (
+            <span
+              key={d}
+              className="rounded-full bg-neutral-100 px-3 py-1 text-xs text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+            >
+              {d}
+            </span>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,0 +1,304 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { Metadata } from "next";
+import Link from "next/link";
+import { FlaskConical, GitPullRequest, Info, Megaphone, MapPin, CalendarDays } from "lucide-react";
+import {
+  RESEARCH_REPO_NEW_FILE_URL,
+  RESEARCH_REPO_README_URL,
+  RESEARCH_TYPE_PLURAL,
+  filterVisible,
+  loadAllResearchEntries,
+  sortByRecentlyActive,
+  type ResearchType,
+} from "@/lib/research";
+import { ResearchCard } from "@/components/research/ResearchCard";
+
+export const metadata: Metadata = {
+  title: "Research",
+  description:
+    "Community space for academic researchers to recruit study participants, share pre-prints, and publish datasets for the Cursor Boston community to explore.",
+  alternates: { canonical: "https://cursorboston.com/research" },
+};
+
+type FilterValue = ResearchType | "all" | "samples";
+
+const FILTERS: Array<{ value: FilterValue; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "recruiting", label: RESEARCH_TYPE_PLURAL.recruiting },
+  { value: "preprint", label: RESEARCH_TYPE_PLURAL.preprint },
+  { value: "dataset", label: RESEARCH_TYPE_PLURAL.dataset },
+  { value: "samples", label: "Samples" },
+];
+
+function parseFilter(raw: string | string[] | undefined): FilterValue {
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (
+    v === "recruiting" ||
+    v === "preprint" ||
+    v === "dataset" ||
+    v === "samples"
+  )
+    return v;
+  return "all";
+}
+
+interface ResearchPageProps {
+  searchParams: Promise<{ type?: string }>;
+}
+
+export default async function ResearchPage({ searchParams }: ResearchPageProps) {
+  const { type } = await searchParams;
+  const filter = parseFilter(type);
+
+  const all = filterVisible(sortByRecentlyActive(loadAllResearchEntries()));
+  const real = all.filter((l) => l.entry.isSample !== true);
+  const samples = all.filter((l) => l.entry.isSample === true);
+
+  let filtered: typeof all;
+  if (filter === "samples") {
+    filtered = samples;
+  } else if (filter === "all") {
+    filtered = real;
+  } else {
+    filtered = real.filter((l) => l.entry.type === filter);
+  }
+
+  const counts: Record<FilterValue, number> = {
+    all: real.length,
+    recruiting: real.filter((l) => l.entry.type === "recruiting").length,
+    preprint: real.filter((l) => l.entry.type === "preprint").length,
+    dataset: real.filter((l) => l.entry.type === "dataset").length,
+    samples: samples.length,
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+      <header className="mb-8">
+        <div className="flex items-center gap-3">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+            <FlaskConical className="h-5 w-5" />
+          </span>
+          <h1 className="text-3xl font-bold text-neutral-900 dark:text-neutral-100">
+            Research
+          </h1>
+        </div>
+        <p className="mt-3 max-w-3xl text-base leading-relaxed text-neutral-600 dark:text-neutral-400">
+          A community surface for academic research happening in and around
+          Cursor Boston. Researchers post calls for study participants, share
+          pre-prints for community discussion, and publish datasets the
+          community can explore, cite, or build on. All entries are
+          repo-backed — content lives in each researcher&apos;s own GitHub
+          repo; this page is the discovery layer.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href={RESEARCH_REPO_NEW_FILE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-500"
+          >
+            <GitPullRequest className="h-4 w-4" /> Submit via PR
+          </a>
+          <a
+            href={RESEARCH_REPO_README_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-semibold text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+          >
+            <Info className="h-4 w-4" /> Schema & submission guide
+          </a>
+        </div>
+      </header>
+
+      <section
+        aria-labelledby="cfp-headline"
+        className="mb-8 overflow-hidden rounded-2xl border border-indigo-300 bg-gradient-to-br from-indigo-50 via-sky-50 to-white shadow-sm dark:border-indigo-900 dark:from-indigo-950/40 dark:via-sky-950/30 dark:to-neutral-900"
+      >
+        <div className="bg-indigo-600 px-5 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-indigo-50 dark:bg-indigo-700">
+          <span className="inline-flex items-center gap-2">
+            <Megaphone className="h-3.5 w-3.5" /> Open call for papers — submit via PR
+          </span>
+        </div>
+        <div className="px-5 py-5 sm:px-7 sm:py-6">
+          <h2
+            id="cfp-headline"
+            className="text-xl font-bold leading-snug text-neutral-900 dark:text-neutral-100 sm:text-2xl"
+          >
+            The First Global Algorithmacy Conference
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
+            A new conference convening the scholars, practitioners,
+            educators, and worker advocates whose work bears on{" "}
+            <em>algorithmacy</em> — the communication competency through which
+            a worker coordinates with another human party through an
+            algorithmic third party. Convened by{" "}
+            <strong>Roger Hunt III</strong> (Bentley University), hosted by{" "}
+            <strong>GauntleTT</strong> in partnership with a Trinidad
+            institutional partner.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-neutral-700 dark:text-neutral-300">
+            <span className="inline-flex items-center gap-1.5">
+              <CalendarDays className="h-3.5 w-3.5 text-indigo-700 dark:text-indigo-300" />
+              <strong>Late Oct / early Nov 2026</strong>
+              <span className="text-neutral-500">— exact dates TBD, finalizing within the next ~2 weeks</span>
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <MapPin className="h-3.5 w-3.5 text-indigo-700 dark:text-indigo-300" />
+              La Brea Pitch Lake, Trinidad and Tobago
+            </span>
+          </div>
+
+          <div className="mt-5 rounded-lg border border-indigo-200 bg-white/70 p-4 text-sm text-neutral-800 backdrop-blur dark:border-indigo-900 dark:bg-neutral-900/40 dark:text-neutral-200">
+            <p className="font-semibold text-indigo-900 dark:text-indigo-200">
+              Submitting now: open a pull request.
+            </p>
+            <p className="mt-1.5 leading-relaxed">
+              While the formal submission portal is being set up, the program
+              committee is already accepting <strong>proposed-talk
+              submissions through this repository</strong>. Add one
+              Markdown file at{" "}
+              <code className="rounded bg-indigo-100 px-1.5 py-0.5 text-[11px] dark:bg-indigo-950/50">
+                content/research/cfp/algorithmacy-conference/submissions/&lt;your-handle&gt;.md
+              </code>{" "}
+              including three things:
+            </p>
+            <ol className="mt-2 list-decimal space-y-0.5 pl-5 text-[13px] leading-relaxed">
+              <li>A <strong>300–500-word abstract</strong>.</li>
+              <li>A <strong>detailed outline</strong> of the proposed talk (sections, arguments, evidence).</li>
+              <li><strong>References</strong> in APA 7 format.</li>
+            </ol>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2.5">
+            <a
+              href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/new/develop/content/research/cfp/algorithmacy-conference/submissions"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-500"
+            >
+              <GitPullRequest className="h-4 w-4" /> Start a submission PR
+            </a>
+            <a
+              href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/content/research/cfp/algorithmacy-conference/submissions/TEMPLATE.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-indigo-300 bg-white px-4 py-2 text-sm font-semibold text-indigo-800 transition-colors hover:bg-indigo-50 dark:border-indigo-800 dark:bg-neutral-900 dark:text-indigo-200 dark:hover:bg-indigo-950/40"
+            >
+              <Info className="h-4 w-4" /> Submission template
+            </a>
+            <a
+              href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/content/research/cfp/algorithmacy-conference/CFP.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-semibold text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            >
+              Read the full CFP →
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <nav
+        aria-label="Filter by entry type"
+        className="mb-6 flex flex-wrap gap-2"
+      >
+        {FILTERS.map((f) => {
+          const active = filter === f.value;
+          const href = f.value === "all" ? "/research" : `/research?type=${f.value}`;
+          const isSampleFilter = f.value === "samples";
+          const activeClass = isSampleFilter
+            ? "bg-amber-500 text-white"
+            : "bg-emerald-600 text-white";
+          const inactiveClass = isSampleFilter
+            ? "bg-amber-50 text-amber-800 hover:bg-amber-100 dark:bg-amber-950/30 dark:text-amber-300 dark:hover:bg-amber-950/50"
+            : "bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700";
+          const activeBadgeClass = isSampleFilter
+            ? "bg-amber-600 text-amber-50"
+            : "bg-emerald-700 text-emerald-50";
+          return (
+            <Link
+              key={f.value}
+              href={href}
+              className={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                active ? activeClass : inactiveClass
+              }`}
+            >
+              {f.label}
+              <span
+                className={`rounded-full px-1.5 text-xs ${
+                  active
+                    ? activeBadgeClass
+                    : "bg-white text-neutral-600 dark:bg-neutral-900 dark:text-neutral-400"
+                }`}
+              >
+                {counts[f.value]}
+              </span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      {filter === "samples" ? (
+        <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+          <strong>Sample entries.</strong> These are placeholders that show
+          how a real submission renders. Authors, links, deadlines, and
+          IRB numbers are fictional — please don&apos;t contact, sign up,
+          or download. They&apos;ll be removed once real research lands.
+        </div>
+      ) : null}
+
+      {filtered.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-neutral-300 bg-neutral-50 p-12 text-center dark:border-neutral-700 dark:bg-neutral-900/40">
+          {filter === "samples" ? (
+            <p className="text-sm text-neutral-600 dark:text-neutral-400">
+              No sample entries — that&apos;s a good sign.
+            </p>
+          ) : (
+            <p className="text-sm text-neutral-600 dark:text-neutral-400">
+              {filter === "all"
+                ? "No research entries yet."
+                : `No ${RESEARCH_TYPE_PLURAL[filter].toLowerCase()} yet.`}{" "}
+              <a
+                href={RESEARCH_REPO_NEW_FILE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-emerald-700 hover:underline dark:text-emerald-400"
+              >
+                Be the first to post →
+              </a>
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map(({ entry }) => (
+            <ResearchCard key={entry.slug} entry={entry} />
+          ))}
+        </div>
+      )}
+
+      <footer className="mt-12 border-t border-neutral-200 pt-6 text-sm text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
+        <p>
+          Discussion of any entry happens through pull requests in this repo,
+          or as issues / PRs on the researcher&apos;s linked source repo. See
+          the{" "}
+          <a
+            href={RESEARCH_REPO_README_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold text-emerald-700 hover:underline dark:text-emerald-400"
+          >
+            submission guide
+          </a>{" "}
+          for the schema and review process.
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -30,6 +30,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  FlaskConical,
   GraduationCap,
   HelpCircle,
   Info,
@@ -122,6 +123,7 @@ const NAV_GROUPS: NavGroup[] = [
 
       { href: "/opportunities", label: "Opportunities", icon: Briefcase },
       { href: "/ecosystem", label: "Ecosystem", icon: Building2 },
+      { href: "/research", label: "Research", icon: FlaskConical },
       { href: "/blog", label: "Blog", icon: BookOpen },
       { href: "/certificate", label: "Certificate", icon: Award },
     ],

--- a/components/research/ResearchCard.tsx
+++ b/components/research/ResearchCard.tsx
@@ -1,0 +1,259 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import Link from "next/link";
+import {
+  Calendar,
+  Clock,
+  ExternalLink,
+  FileText,
+  MapPin,
+  ScrollText,
+  Tag,
+  Users,
+} from "lucide-react";
+import {
+  RESEARCH_TYPE_LABEL,
+  isRecruiting,
+  isPreprint,
+  isDataset,
+  isRecruitingPastDeadline,
+  type ResearchEntry,
+} from "@/lib/research";
+
+interface ResearchCardProps {
+  entry: ResearchEntry;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function relativeFromNow(iso: string, now: Date = new Date()): string {
+  const target = new Date(iso).getTime();
+  const diffMs = target - now.getTime();
+  const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays === 0) return "today";
+  if (diffDays === 1) return "tomorrow";
+  if (diffDays === -1) return "yesterday";
+  if (diffDays > 1 && diffDays < 30) return `in ${diffDays} days`;
+  if (diffDays < -1 && diffDays > -30) return `${Math.abs(diffDays)} days ago`;
+  return formatDate(iso);
+}
+
+function TypeBadge({ entry }: { entry: ResearchEntry }) {
+  const styles: Record<typeof entry.type, string> = {
+    recruiting:
+      "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+    preprint:
+      "bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-300",
+    dataset:
+      "bg-purple-100 text-purple-800 dark:bg-purple-950/40 dark:text-purple-300",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold ${styles[entry.type]}`}
+    >
+      {RESEARCH_TYPE_LABEL[entry.type]}
+    </span>
+  );
+}
+
+function MetadataRow({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-neutral-600 dark:text-neutral-400">
+      {children}
+    </div>
+  );
+}
+
+function MetaItem({
+  icon: Icon,
+  children,
+  emphasis = false,
+  strike = false,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+  emphasis?: boolean;
+  strike?: boolean;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 ${
+        emphasis
+          ? "font-semibold text-neutral-900 dark:text-neutral-100"
+          : ""
+      } ${strike ? "line-through opacity-60" : ""}`}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span>{children}</span>
+    </span>
+  );
+}
+
+export function ResearchCard({ entry }: ResearchCardProps) {
+  const detailHref = `/research/${entry.slug}`;
+  const isExpired = isRecruiting(entry) && isRecruitingPastDeadline(entry);
+  const isClosed = isRecruiting(entry) && entry.status === "closed";
+  const sample = entry.isSample === true;
+
+  return (
+    <article
+      className={`group relative flex h-full flex-col overflow-hidden rounded-xl border bg-white p-5 shadow-sm transition-colors dark:bg-neutral-900 ${
+        sample
+          ? "border-amber-300 dark:border-amber-900"
+          : "border-neutral-200 hover:border-neutral-300 dark:border-neutral-800 dark:hover:border-neutral-700"
+      } ${isExpired || isClosed ? "opacity-75" : ""}`}
+    >
+      {sample ? (
+        <div className="-mx-5 -mt-5 mb-3 bg-amber-100 px-5 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-amber-900 dark:bg-amber-950/50 dark:text-amber-200">
+          Sample · placeholder entry
+        </div>
+      ) : null}
+      <header className="mb-2 flex items-start justify-between gap-3">
+        <TypeBadge entry={entry} />
+        <span className="text-xs text-neutral-500 dark:text-neutral-500">
+          {formatDate(entry.updatedAt ?? entry.postedAt)}
+          {entry.updatedAt ? " · updated" : ""}
+        </span>
+      </header>
+
+      <Link
+        href={detailHref}
+        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        <h3 className="text-base font-semibold leading-snug text-neutral-900 transition-colors group-hover:text-emerald-700 dark:text-neutral-100 dark:group-hover:text-emerald-400">
+          {entry.title}
+        </h3>
+      </Link>
+
+      <p className="mt-1.5 text-xs text-neutral-600 dark:text-neutral-400">
+        {entry.authors
+          .map((a) =>
+            a.affiliation ? `${a.name} (${a.affiliation})` : a.name
+          )
+          .join(" · ")}
+      </p>
+
+      <p className="mt-3 text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
+        {entry.summary}
+      </p>
+
+      {isRecruiting(entry) ? (
+        <MetadataRow>
+          <MetaItem
+            icon={Calendar}
+            emphasis={!isExpired}
+            strike={isExpired}
+          >
+            {isExpired ? "Closed " : "Deadline "}
+            {relativeFromNow(entry.deadline)}
+          </MetaItem>
+          <MetaItem icon={Clock}>{entry.timeCommitment}</MetaItem>
+          <MetaItem icon={MapPin}>{entry.location}</MetaItem>
+          {typeof entry.slotsRemaining === "number" ? (
+            <MetaItem icon={Users}>
+              {entry.slotsRemaining} slots left
+            </MetaItem>
+          ) : null}
+        </MetadataRow>
+      ) : null}
+
+      {isPreprint(entry) ? (
+        <MetadataRow>
+          <MetaItem icon={ScrollText}>
+            {entry.version} · {entry.license}
+          </MetaItem>
+          {entry.peerReviewStatus ? (
+            <span className="inline-flex items-center rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-800 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300">
+              {entry.peerReviewStatus.replace(/-/g, " ")}
+            </span>
+          ) : null}
+          {sample ? (
+            <span className="inline-flex items-center gap-1 text-neutral-400 dark:text-neutral-600">
+              <FileText className="h-3.5 w-3.5" /> PDF
+            </span>
+          ) : (
+            <a
+              href={entry.pdfUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-emerald-700 hover:underline dark:text-emerald-400"
+            >
+              <FileText className="h-3.5 w-3.5" /> PDF
+            </a>
+          )}
+        </MetadataRow>
+      ) : null}
+
+      {isDataset(entry) ? (
+        <MetadataRow>
+          <MetaItem icon={Tag} emphasis>
+            {entry.license}
+          </MetaItem>
+          {entry.size ? <MetaItem icon={FileText}>{entry.size}</MetaItem> : null}
+          {entry.format && entry.format.length > 0 ? (
+            <span className="inline-flex items-center gap-1">
+              {entry.format.map((f) => (
+                <span
+                  key={f}
+                  className="rounded bg-neutral-100 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+                >
+                  {f}
+                </span>
+              ))}
+            </span>
+          ) : null}
+        </MetadataRow>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {entry.disciplines.slice(0, 4).map((d) => (
+          <span
+            key={d}
+            className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+          >
+            {d}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-neutral-100 pt-3 text-xs dark:border-neutral-800">
+        <Link
+          href={detailHref}
+          className="font-semibold text-emerald-700 hover:underline dark:text-emerald-400"
+        >
+          Details →
+        </Link>
+        {sample ? (
+          <span className="inline-flex items-center gap-1 text-neutral-400 dark:text-neutral-600">
+            <ExternalLink className="h-3 w-3" /> Source repo (sample)
+          </span>
+        ) : (
+          <a
+            href={entry.sourceRepoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          >
+            <ExternalLink className="h-3 w-3" /> Source repo
+          </a>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/content/research/README.md
+++ b/content/research/README.md
@@ -1,0 +1,138 @@
+# Cursor Boston — Research
+
+This directory powers the **/research** page on cursorboston.com — a
+community space where academic researchers can:
+
+- **Recruit participants** for studies (compensated, IRB-approved).
+- **Share pre-prints** and working theory papers for community discussion.
+- **Publish datasets** for the community to explore, cite, or build on.
+
+Everything here is community-curated through GitHub. **There is no in-app
+form, no Firestore record, no login required.** A research entry exists if
+and only if there is a JSON file in `content/research/entries/` on `main`.
+
+## How submissions work
+
+1. Fork [`rogerSuperBuilderAlpha/cursor-boston`](https://github.com/rogerSuperBuilderAlpha/cursor-boston).
+2. Create your external "source repo" — a GitHub repository **you own** that
+   holds the actual content (paper PDFs, dataset files, study materials,
+   participant-recruitment landing page, etc.). The entry in this repo only
+   points to your source repo; it does not host the content itself. This
+   keeps Cursor Boston as the discovery layer and leaves authorship,
+   licensing, and updates with the researcher.
+3. Add a single new file at `content/research/entries/<your-slug>.json`
+   following the schema below. The filename's slug must match the `slug`
+   field in the JSON.
+4. Open a pull request against `develop`. Reviewers will check the schema,
+   make sure the source repo is reachable, and merge.
+5. After the next `develop → main` release, your entry appears on
+   cursorboston.com/research.
+
+**Discussion of any entry happens via pull-request comments**, either on
+your entry's JSON file in this repo or as issues / PRs on your external
+source repo. The detail page links out to both.
+
+## Editing an existing entry
+
+PR an update to the JSON file. Bump `updatedAt` to the current ISO
+timestamp. For preprints, also bump `version`. For recruiting entries,
+update `slotsRemaining` or `status` as the study progresses; set `status`
+to `"closed"` when complete.
+
+## JSON schema
+
+Every entry shares a base + adds type-specific fields. The full Zod schema
+lives in [`lib/research.ts`](../../lib/research.ts) and is the source of
+truth — the listing here is for convenience. Validation runs at build
+time; a malformed entry breaks the build, not the page.
+
+### Shared (every entry)
+
+```jsonc
+{
+  "slug": "kebab-case-slug",            // matches filename, lowercase
+  "type": "recruiting" | "preprint" | "dataset",
+  "title": "Short human title",
+  "authors": [
+    { "name": "Full Name", "affiliation": "University / Lab", "url": "https://..." }
+  ],
+  "postedAt": "2026-05-22T13:00:00-04:00",  // ISO with offset
+  "updatedAt": "2026-05-22T13:00:00-04:00", // optional; bump on edits
+  "disciplines": ["HCI", "developer-tools"], // 1-8 tags
+  "summary": "Two-sentence description that appears on the card.",
+  "sourceRepoUrl": "https://github.com/<you>/<your-repo>",
+  "contactEmail": "you@university.edu",      // either contactEmail
+  "contactUrl": "https://forms.gle/...",     // or contactUrl (or both)
+  "isSample": true                            // omit on real entries
+}
+```
+
+> The `isSample` flag is for **placeholder / demo entries only**.
+> Sample entries are hidden from the main feed and from type-specific
+> filters; they only appear under the dedicated "Samples" filter, and
+> their external CTAs (study link, PDF, source repo, contact) are visually
+> disabled so visitors don&apos;t click through to fake URLs. Maintainers
+> set this on seed data; real submissions should not include it.
+
+### `type: "recruiting"` — add
+
+```jsonc
+{
+  "deadline": "2026-06-30T23:59:00-04:00",    // REQUIRED — past-deadline auto-strikes; auto-hides after 14 days
+  "compensation": "$25 Amazon gift card",
+  "timeCommitment": "45 minutes",
+  "location": "remote" | "in-person" | "hybrid",
+  "eligibility": "One-line summary of who qualifies.",
+  "slotsRemaining": 28,                       // optional
+  "irb": {                                    // optional but strongly encouraged
+    "institution": "Bentley University",
+    "protocolNumber": "IRB-2026-XYZ"
+  },
+  "studyUrl": "https://qualtrics...",         // optional — link to the actual study
+  "status": "open" | "paused" | "closed"      // optional, defaults to "open"
+}
+```
+
+### `type: "preprint"` — add
+
+```jsonc
+{
+  "version": "v1",                            // bump on revisions
+  "license": "CC-BY-4.0",                     // your license; required
+  "pdfUrl": "https://your-repo/.../paper.pdf",
+  "doi": "10.31234/osf.io/xyz",               // optional
+  "peerReviewStatus": "awaiting" | "approved" | "approved-with-reservations" | "rejected"
+}
+```
+
+### `type: "dataset"` — add
+
+```jsonc
+{
+  "license": "CC-BY-4.0",                     // REQUIRED
+  "size": "1.2M rows · 480 MB",               // optional, free text
+  "format": ["CSV", "Parquet"],               // optional, 1-8 entries
+  "doi": "10.5281/zenodo.123456",             // optional
+  "citation": "Author, A. (2026). Dataset name. Zenodo. doi:10.5281/zenodo.123456"
+}
+```
+
+## Anti-patterns (please don't)
+
+- **Don't host paper PDFs or large dataset files in this repo.** Use your
+  source repo, Zenodo, OSF, arXiv, etc. This repo only holds the metadata.
+- **Don't lead with compensation** in recruiting summaries — lead with the
+  research question. Cursor Boston is a community, not a marketplace.
+- **Don't post entries without a license** for preprints or datasets.
+  Without a license, others cannot legally reuse the work.
+- **Don't omit `deadline` on recruiting entries.** Past-deadline studies
+  auto-strike and auto-hide so the feed stays alive.
+- **Don't open multiple entries for the same study.** Update the existing
+  entry instead.
+
+## Moderation
+
+Maintainers reserve the right to close PRs that don't meet the schema, are
+off-topic for an academic-research surface, or post personal data of
+participants. If your entry is removed and you think it was in error, open
+an issue.

--- a/content/research/cfp/algorithmacy-conference/CFP.md
+++ b/content/research/cfp/algorithmacy-conference/CFP.md
@@ -1,0 +1,313 @@
+# Call for papers
+
+## The First Global Algorithmacy Conference
+
+**La Brea Pitch Lake, Trinidad and Tobago**
+
+**Conference dates: late October / early November 2026 — exact dates TBD, finalizing within the next two weeks**
+
+**Hosted by GauntleTT in partnership with [Trinidad institutional partner — TBA]**
+
+---
+
+> ## Submitting right now: open a PR
+>
+> While the formal portal is being set up, the program committee is
+> already accepting **proposed-talk submissions through this repository**.
+> Open a pull request adding a single Markdown file at
+> `content/research/cfp/algorithmacy-conference/submissions/<your-handle>.md`
+> following [the submission template](./submissions/TEMPLATE.md). Your PR
+> should include three things:
+>
+> 1. **A 300–500-word abstract.**
+> 2. **A detailed outline** of the proposed talk (sections, arguments,
+>    evidence).
+> 3. **References** in APA 7 format.
+>
+> Add a Discord handle or contact email in the PR so the program
+> committee can reach you. The PR review thread is the discussion venue
+> while we stand up the formal review pipeline. See
+> [`submissions/README.md`](./submissions/README.md) for the full
+> step-by-step.
+
+---
+
+## The argument the conference convenes around
+
+Algorithmacy is the communication competency through which a worker coordinates with another human party through an algorithmic third party. The construct names what the platform-work literature has been documenting without naming: a worker-level capacity that explains why equivalently positioned participants on identical algorithmic systems achieve divergent coordination outcomes (Cook, Diamond, Hall, List, & Oyer, 2021; Möhlmann, Alves de Lima Salge, & Marabelli, 2023; Rahman, 2021). The competency vocabulary the field inherited from computer-mediated communication, human-machine communication, and AI-mediated communication was built around a worker on one side of a medium, partner, or sender-side agent. It does not reach the form in which the algorithm sits between two human parties and acts on inputs from both in pursuit of its own objectives (Stark & Vanden Broeck, 2024).
+
+A new coordination form has produced a new competency before, and the new competency was not a refinement of the prior one. Oracy and literacy are the historical precedents. Oracy was the competency a face-to-face speaker exercised in front of a listener present in the same place at the same time. Writing introduced a third structural position the speaker had not occupied: an author addressed a reader through a document that conveyed without acting, and the competency the form required was not more proficient speech but reading, writing, citing, and working through institutions that ran on text. Literacy stayed the name for two centuries because the form stayed in place. The algorithmic form is not a more sophisticated channel through which writing happens. It is a third party with its own objectives that transforms each input as part of its operation, and the competency it requires has not been named in the field's existing vocabulary.
+
+Institutions are building curricula for the new form, and the vocabulary academic scholarship hands them will determine what those institutions train. Bootcamps, certification regimes, gig-worker advocacy organizations, platform-cooperative experiments, AI engineering programs, and state-level workforce-development efforts converge on what they variously call algorithmic skill, AI fluency, or platform literacy. Each of these terms names something the algorithm does or shows, and the curricula built around them train workers to read what the algorithm displays rather than coordinate with another person through it. The vocabulary the field supplies over the next several years will determine whether the workers who pass through these programs are trained for the coordination they will actually have to do.
+
+The conference convenes the scholars, practitioners, educators, and worker advocates whose work bears on this question. It asks what algorithmacy is, how it develops, how it should be measured, how it distributes across worker populations, how it transfers across architectures, how it aggregates to teams and institutions, and what training, certification, and labor protection look like once the construct is in place. Trinidad and Tobago is the site, La Brea Pitch Lake is the venue, and the Caribbean's position as a region developing AI talent under conditions distinct from the centers of platform capital is the empirical and political ground the convening sits on.
+
+---
+
+## Why La Brea
+
+La Brea Pitch Lake is the world's largest natural deposit of asphalt, an opaque substrate that has produced the roads of empires while remaining itself unreadable to those who walked over it. The choice of venue is not metaphor for its own sake. The conference convenes in a Caribbean nation whose talent is being recruited into the global algorithmic economy under terms its workers and institutions did not author. The argument that algorithmacy is the competency triadic algorithmic coordination requires has more at stake in Port of Spain than in Palo Alto, because the question of whether the competency develops uniformly across populations or replicates existing stratification will be answered first in the regions whose workers enter the form last. La Brea grounds the convening in that stake.
+
+---
+
+## Tracks and suggested topics
+
+Submissions are invited in the following tracks. The topics listed under each track are suggestive rather than exhaustive. Authors working at the intersection of two or more tracks should choose the closest fit and note the secondary track in the submission.
+
+### Track 1. Construct and theory
+
+The construct itself is the first object of the conference. Submissions in this track develop, refine, contest, or extend algorithmacy as a theoretical object.
+
+1. The conceptual domain of algorithmacy and the four elements of construct clarity (Suddaby, 2010)
+2. Algorithmacy and the variance puzzle: why equivalently positioned workers achieve divergent outcomes on identical algorithmic infrastructure
+3. The triadic form as a coordination form structurally distinct from dyadic precedents
+4. Algorithmacy's discriminant position relative to CMC competence, HMC, AI-MC, algorithmic literacy, AI literacy, algorithm sensemaking, and algorithmic competency
+5. The jingle and jangle problems in the human-AI interaction construct family (Larsen & Bong, 2016)
+6. Co-optation as a fourth coordination mechanism alongside hierarchy, market, and network (Stark & Vanden Broeck, 2024)
+7. Algorithmacy as competency rather than literacy, sensemaking, or knowledge
+8. Boundary conditions of algorithmacy: where the construct applies and where it does not
+9. Levels-of-analysis questions: algorithmacy at the individual, team, organizational, and institutional levels
+10. Definitions, dimensions, and the nomological network
+
+### Track 2. Historical and philosophical foundations
+
+The oracy → literacy → algorithmacy sequence treats each transition as a coordination shift in kind. Submissions in this track defend, complicate, or contest the historical reading.
+
+11. Oracy, literacy, and algorithmacy as ontological transitions in coordination
+12. The Ong, Goody, Havelock lineage and the cognitive neuroscience of literacy (Dehaene, 2009; Wolf, 2018)
+13. The New Literacy Studies critique and what survives it (Heath, 1983; Scribner & Cole, 1981; Street, 2003)
+14. Print as a structural transition and the slow construction of literate institutions (Eisenstein, 1979; Johns, 1998)
+15. Algorithmic culture and the question of cultural-epistemic rupture (Hallinan & Striphas, 2016; Striphas, 2015)
+16. Floridi, Stiegler, Hui, Hansen, Chun: contemporary articulations of the algorithmic epoch
+17. The actor-network distinction between intermediaries and mediators, and its limits in reaching the triadic algorithmic case (Latour, 2005)
+18. Peirce's reduction thesis, higher-order networks, and the irreducibility of triads
+19. The sociology of paperwork, accounting, and the bureaucratic file as a coordination-historical precedent
+20. The mediated triad as an organizational form distinct from brokerage and tertius traditions (Simmel, 1908/1950)
+
+### Track 3. Measurement and scale development
+
+The construct is the first move; the measurement program is the second. Submissions in this track develop instruments, validate dimensions, or test the measurement assumptions algorithmacy depends on.
+
+21. Item generation and content validation for algorithmacy
+22. Discriminant validity testing against algorithmic literacy, AI literacy, algorithm sensemaking, and algorithmic competency
+23. Measurement invariance across cohorts, populations, platforms, and languages
+24. Longitudinal trajectory analysis of competency acquisition
+25. Mixed-methods designs for situated communication competency
+26. Ethnographic methods for observing algorithmacy in real-time platform interaction
+27. The construct identity fallacy in human-AI interaction measurement (Larsen & Bong, 2016)
+28. Lambert and Newman's (2023) three-step framework applied to triadic competency constructs
+29. Convergent validity against adjacent measures (Campbell & Fiske, 1959)
+30. Cohort-based replication strategies for confirmatory factor structure
+
+### Track 4. Empirical settings
+
+The construct travels across settings, and the conference invites empirical work that tests, refines, or extends it.
+
+31. Rideshare, food delivery, and on-demand labor platforms
+32. Freelance platforms and the opaque-evaluation cases (Rahman, 2021)
+33. AI engineering and software development through AI-augmented IDEs
+34. Knowledge work with large language models in legal, medical, and consulting contexts
+35. Healthcare diagnostic and triage systems mediated by clinical decision-support
+36. Customer service mediated by recommendation and routing algorithms
+37. Education and learning under AI tutoring and assessment systems
+38. Content creation, news production, and journalism under recommender mediation
+39. Logistics, warehousing, and last-mile delivery under algorithmic dispatch
+40. Financial services, lending, and credit under algorithmic decisioning
+
+### Track 5. Antecedents
+
+Algorithmacy develops, and the question of how it develops is the question of what the institutions training for the form should actually do.
+
+41. Exposure to mediated coordination as the primary engine (Cameron, 2024; Sutherland, Jarrahi, Dunn, & Nelson, 2020)
+42. Reflective practice and feedback interpretation as developmental accelerant
+43. Motivational engagement and the algorithm-as-partner versus algorithm-as-constraint framing
+44. Social support from peers and cognitive job crafting (Zhou, Lei, Liu, Huang, & Hou, 2025)
+45. Implicit acquisition: competency that develops without curriculum
+46. Prior digital exposure, computational background, and the question of transfer from other domains
+47. The role of mentorship, apprenticeship, and shadow learning (Beane, 2019)
+48. Folk theorization and adaptive practice on changing platforms (DeVito, 2021)
+49. Reflection-in-action and the Schönian tradition under algorithmic conditions (Schön, 1983)
+50. Workplace social ecologies as antecedents to individual competency
+
+### Track 6. Outcomes
+
+The construct earns its place through what it predicts. Submissions in this track test, extend, or contest the outcome side of the nomological network.
+
+51. Coordination success on platforms with measurable outcomes
+52. Earnings and the worker-level economics of algorithmic mediation
+53. Retention and persistence through algorithmic disruption (Möhlmann, Zalmanson, Henfridsson, & Gregory, 2021)
+54. AI burnout as a competency problem rather than a workload problem
+55. Service behavior and worker-customer interaction under algorithmic mediation
+56. Identification with platform work and the formation of work identity
+57. Career trajectories and worker mobility within and across platforms
+58. Psychological outcomes: well-being, autonomy, anxiety, social isolation
+59. Resistance, voice, and the political mobilization of algorithmically mediated workers (Cameron & Rahman, 2022)
+60. Performance benchmarking and the measurement of coordination quality
+
+### Track 7. Distribution and stratification
+
+The question of who develops algorithmacy and under what conditions is the political-economy question the construct cannot defer.
+
+61. Algorithmic awareness, knowledge gaps, and digital divides (Cotter & Reisdorf, 2020; Gran, Booth, & Bucher, 2021)
+62. Gender, race, class, and the distribution of platform coordination outcomes
+63. Regional and national variation in algorithmic capacity development
+64. The coding elite and the cybertariat as differentiated political-economy positions (Burrell & Fourcade, 2021)
+65. Algorithmacy as human capital versus algorithmacy as access to developmental conditions
+66. Algorithmic stratification as a new vector of labor-market inequality
+67. The Global South and the algorithmic frontier
+68. Indigenous, diasporic, and minoritized communities and algorithmic coordination
+69. Generational differences in algorithmic competency acquisition
+70. Disability, neurodivergence, and triadic coordination
+
+### Track 8. Transferability
+
+The question of whether algorithmacy transfers across architectures decides whether platform-mobile work is a coherent labor-market category.
+
+71. Multi-homing and platform-portable competency (Bryan & Gans, 2019)
+72. Architecture-specific versus architecture-general capacity
+73. Generalization of algorithmic management features across platforms (Jarrahi, Newlands, Lee, Wolf, Kinder, & Sutherland, 2021; Sun, 2019)
+74. The encoding problem: workers and the abstraction the form imposes
+75. Worker-skill-transfer mechanisms in algorithmic coordination
+76. Cross-architectural learning curves and the costs of platform switching
+77. Generalized algorithmacy versus platform-specific repertoires
+78. The relation between algorithmacy and broader sociotechnical competencies
+79. Transfer across human and algorithmic interlocutors
+80. Transfer across natural-language and code-based algorithmic systems
+
+### Track 9. Aggregation, institutions, and curriculum
+
+A competency that holds at the individual level may or may not aggregate, and the answer determines whether organizational and institutional interventions are possible.
+
+81. Team-level algorithmacy and collective coordination capacity
+82. Organizational algorithmacy as a firm-level capability
+83. Curriculum design for algorithmacy: what training programs should actually teach
+84. Certification regimes and credentialing of algorithmic competency
+85. The AI engineering bootcamp as a developmental setting
+86. Higher education and the algorithmic curriculum question
+87. K-12 education, oracy, literacy, and the case for algorithmacy in primary instruction
+88. Workforce development under platform displacement
+89. Apprenticeship models for participatory competency acquisition
+90. The role of professional associations and learned societies
+
+### Track 10. Labor protections, policy, and political economy
+
+Labor protections written for the employer-employee relation do not fit the platform, and the legal vocabulary has not named the arrangement. The conference invites work that engages the policy and political-economy implications.
+
+91. Algorithmacy and the legal recognition of platform-mediated work
+92. Unions, worker centers, and the organization of algorithmically mediated workers
+93. Platform cooperativism and alternative ownership structures
+94. State-level regulation of algorithmic management
+95. International labor law and the cross-border platform
+96. Worker data rights and algorithmic accountability
+97. Wage transparency, gig pay, and the platform's information asymmetries
+98. National AI strategies and worker development
+99. The sovereignty question: small states, platform infrastructure, and economic self-determination
+100. Algorithmacy as the micro-foundation of organizational and national sovereignty
+
+### Track 11. Caribbean, Global South, and frontier perspectives
+
+The conference is held in Trinidad and Tobago because the Caribbean's position in the global algorithmic economy is itself a research site, not a backdrop.
+
+101. Caribbean labor markets and the platform economy
+102. AI talent development in small island developing states
+103. Trinidad and Tobago, GauntleTT, and the Caribbean AI engineering pipeline
+104. Diaspora networks, remote work, and algorithmically mediated coordination across borders
+105. Postcolonial frameworks for reading platform capital
+106. Language, code-switching, and natural-language interfaces in multilingual Caribbean settings
+107. Caribbean creative industries under algorithmic distribution
+108. Resource economies, the energy demands of AI, and the Caribbean's position in the supply chain
+109. South-South cooperation on algorithmic competency development
+110. The Bandung, the New International Economic Order, and the question of an algorithmic equivalent
+
+### Track 12. Critique, limits, and the conference's own commitments
+
+Algorithmacy is a construct under construction, and the conference invites work that contests it from within and from outside.
+
+111. The case for refining existing constructs rather than naming a new one
+112. The case against the literacy-historical analogy
+113. Materialist and labor-process critiques of the competency framing
+114. Critical algorithm studies and the question of whether competency is the right unit
+115. Phenomenological and existential readings of algorithmic mediation
+116. The limits of measurement and the case for ethnographic primacy
+117. Decolonial critiques of competency-development frameworks
+118. The political risks of credentialing algorithmacy
+119. What algorithmacy cannot reach: domains where the triadic form does not hold
+120. The conference's own complicity: scholarly convening under the conditions it studies
+
+---
+
+## Submission types
+
+The conference accepts five submission types.
+
+**Full papers.** Empirical, theoretical, or review papers between 7,000 and 12,000 words. Full papers undergo double-blind peer review and are eligible for the conference proceedings volume and the journal special issue.
+
+**Research notes.** Shorter empirical or theoretical contributions between 3,000 and 5,000 words. Suitable for work-in-progress, methodological innovations, or single-case studies.
+
+**Posters.** Visual presentations with a 500-word abstract. Suitable for doctoral and early-career work, scale-development pilots, and ethnographic field reports.
+
+**Panel proposals.** Coordinated three-to-five-speaker sessions with a unifying argument. Panel proposals require a 1,000-word framing statement and 300-word abstracts from each speaker.
+
+**Practitioner reports.** Submissions from worker advocates, platform-cooperative organizers, curriculum designers, and policy practitioners. 2,000 to 4,000 words. Reviewed for relevance and substance rather than academic form.
+
+---
+
+## Submission requirements
+
+Manuscripts follow APA 7 citation format. Headings in sentence case. Submissions in English at the conference, with translation support available for presenters whose first language is not English. Authors of accepted submissions agree to make the work available open-access through the conference repository.
+
+**Current intake is via this repository** — see the highlighted callout at the top. Formal portal-based submission, abstract deadlines, full-submission deadlines, and notification dates will be announced once the conference dates are finalized (within the next two weeks of this CFP going live).
+
+---
+
+## Awards
+
+Three awards are issued at the conference.
+
+The **Founders' Paper Award** recognizes the best full paper. The **Pitch Lake Prize** recognizes the most theoretically generative early-career contribution. The **GauntleTT Practitioner Award** recognizes the practitioner report that most advances the institutional translation of algorithmacy into curriculum, policy, or worker advocacy.
+
+---
+
+## Conference committee
+
+**Conference convener:** Roger Hunt III, Bentley University
+
+**Program committee:** [committee to be confirmed]
+
+**Caribbean host committee:** [to be confirmed in consultation with the Trinidad institutional partner]
+
+**Advisory board:** [to be confirmed]
+
+---
+
+## Travel, venue, and logistics
+
+The conference is held at [venue at La Brea Pitch Lake, to be confirmed]. The venue is approximately 90 minutes by road from Piarco International Airport. The conference negotiates a room block at [hotel partner to be confirmed] and provides ground transportation between the airport, the hotel, and the venue for the duration of the conference. A site visit to the Pitch Lake itself is built into the program.
+
+Limited travel support is available for scholars from low-income and middle-income countries, doctoral students, and worker representatives. Applications for travel support are submitted with the abstract.
+
+---
+
+## Contact
+
+Inquiries to [conference email placeholder] — until the formal address is announced, contact the convener through this repository (open an issue or PR-thread mention).
+
+---
+
+## Selected references
+
+Burrell, J., & Fourcade, M. (2021). The society of algorithms. *Annual Review of Sociology, 47*, 213–237.
+
+Cameron, L. D. (2024). The making of the "good bad" job: How algorithmic management manufactures consent through constant and confined choices. *Administrative Science Quarterly, 69*(2), 458–514.
+
+Cook, C., Diamond, R., Hall, J. V., List, J. A., & Oyer, P. (2021). The gender earnings gap in the gig economy: Evidence from over a million rideshare drivers. *The Review of Economic Studies, 88*(5), 2210–2238.
+
+Latour, B. (2005). *Reassembling the social: An introduction to actor-network-theory*. Oxford University Press.
+
+Möhlmann, M., Alves de Lima Salge, C., & Marabelli, M. (2023). Algorithm sensemaking: How platform workers make sense of algorithmic management. *Journal of the Association for Information Systems, 24*(1), 35–64.
+
+Rahman, H. A. (2021). The invisible cage: Workers' reactivity to opaque algorithmic evaluations. *Administrative Science Quarterly, 66*(4), 945–988.
+
+Stark, D., & Vanden Broeck, P. (2024). Principles of algorithmic management. *Organization Theory, 5*(2).
+
+Zhou, L., Lei, X., Liu, M., Huang, X., & Hou, R. (2025). Algorithmic competency of on-demand labor platform workers: Scale development, antecedents, and consequences. *Asia Pacific Journal of Human Resources, 63*(2), e70004.

--- a/content/research/cfp/algorithmacy-conference/submissions/README.md
+++ b/content/research/cfp/algorithmacy-conference/submissions/README.md
@@ -1,0 +1,72 @@
+# Algorithmacy Conference — Talk Submissions
+
+This is the **current intake** for the First Global Algorithmacy Conference
+while the formal submission portal is being set up. Conference dates are
+late October / early November 2026 — exact dates TBD and will be confirmed
+within two weeks of this CFP going live.
+
+The full call for papers is in [`../CFP.md`](../CFP.md).
+
+## How to submit
+
+1. **Read the CFP** — particularly the [tracks and suggested topics](../CFP.md#tracks-and-suggested-topics).
+2. **Fork** the [cursor-boston repository](https://github.com/rogerSuperBuilderAlpha/cursor-boston).
+3. **Copy** [`TEMPLATE.md`](./TEMPLATE.md) to
+   `content/research/cfp/algorithmacy-conference/submissions/<your-github-handle>.md`.
+   The filename must match your GitHub handle exactly.
+4. **Fill in** the three required sections:
+   - **Abstract** (300–500 words)
+   - **Detailed outline** of the proposed talk — sections, arguments,
+     and the empirical or theoretical evidence each section rests on
+   - **References** in APA 7 format
+5. **Open a pull request** against `develop`. Title your PR
+   `cfp(algorithmacy): <surname> — <short title>`.
+6. **Include a contact** — Discord handle or email — in the PR
+   description so the program committee can reach you.
+7. **Discuss in the PR thread.** Reviewers will ask clarifying questions
+   in the PR review interface. The thread is the conversation venue
+   until the formal portal is live.
+
+## What we're looking for
+
+Submissions that engage the construct, contest it, extend it, or apply
+it. The CFP lists twelve tracks and 120 suggested topics — those are
+suggestive rather than exhaustive. Submissions that bridge tracks or
+introduce new angles are welcome; just note the closest fit.
+
+We particularly welcome contributions from:
+- Caribbean and Global South scholars and practitioners
+- Doctoral students and early-career researchers
+- Worker advocates, platform-cooperative organizers, curriculum
+  designers, and policy practitioners (see "Practitioner reports" in
+  the CFP)
+
+## What happens after you submit
+
+- The program committee reviews PRs as they come in. Expect a first
+  response within two weeks of submission.
+- Reviewer comments live in the PR review thread. You can revise by
+  pushing additional commits.
+- Once the formal portal launches, your repository submission will be
+  ported over with the program committee's review attached, so PRing
+  now does not put you behind in the queue.
+
+## Withdrawal
+
+If you need to withdraw before the formal portal launches, comment on
+your PR with `withdrawn` and the maintainers will close it. You can
+re-open or re-submit at any time.
+
+## Anti-patterns (please don't)
+
+- **Don't paste a full paper in.** A talk proposal is an abstract +
+  outline + references. Full-paper review happens through the formal
+  portal once it's live.
+- **Don't submit a co-authored talk through one author's handle without
+  consent.** Either submit through the presenting author's handle and
+  list co-authors in the abstract, or open a single PR co-authored via
+  Git's `Co-authored-by:` trailer.
+- **Don't include unpublished participant data, IRB protocol numbers,
+  or anything that should not be in a public repo.** If your evidence
+  base includes any of that, describe it at the level of method and
+  result without attaching the raw materials.

--- a/content/research/cfp/algorithmacy-conference/submissions/TEMPLATE.md
+++ b/content/research/cfp/algorithmacy-conference/submissions/TEMPLATE.md
@@ -1,0 +1,58 @@
+# <Talk title>
+
+**Presenting author:** <First Last, affiliation>
+**Co-authors:** <First Last (affiliation); First Last (affiliation)>  *(remove if none)*
+**Primary track:** Track <N> — <track name from CFP>
+**Secondary track (optional):** Track <N> — <track name>
+**Submission type:** Talk proposal *(full paper / research note / poster / panel / practitioner report — pick one)*
+**Contact:** <Discord handle, email, or both>
+
+---
+
+## Abstract (300–500 words)
+
+<Replace with your abstract. Lead with the question, then the move
+your talk makes on it. State the empirical or theoretical evidence
+you'll bring, and end on what the talk adds to the track conversation.>
+
+---
+
+## Detailed outline
+
+<Replace with a section-by-section outline of the talk. For each
+section, state what you argue and what evidence the argument rests on.
+A reader should be able to follow the spine of the talk from this
+outline alone.>
+
+### 1. <Section title>
+
+<2–4 sentences on what this section argues and what it rests on.>
+
+### 2. <Section title>
+
+<2–4 sentences.>
+
+### 3. <Section title>
+
+<2–4 sentences.>
+
+*(Add more sections as your talk requires. Most 20-minute talks have
+4–6 sections; 45-minute keynotes have 6–10.)*
+
+---
+
+## References (APA 7)
+
+<Replace with your references. APA 7 format. Alphabetize by first
+author's surname. Include DOIs where available.>
+
+Example, R. R. (2026). Example title of cited work. *Journal Name,
+12*(3), 100–120. https://doi.org/10.0000/example
+
+---
+
+## Notes for reviewers (optional)
+
+<Anything the program committee should know — work-in-progress status,
+related submissions you've made elsewhere, accessibility or scheduling
+constraints, requests for travel support, etc.>

--- a/content/research/entries/ai-assisted-prs-preprint.json
+++ b/content/research/entries/ai-assisted-prs-preprint.json
@@ -1,0 +1,23 @@
+{
+  "slug": "ai-assisted-prs-preprint",
+  "type": "preprint",
+  "isSample": true,
+  "title": "Reviewing AI-Assisted Pull Requests: A Field Study of Open-Source Maintainers",
+  "authors": [
+    {
+      "name": "Example Author One",
+      "affiliation": "Example University",
+      "url": "https://example.edu/~author1"
+    },
+    { "name": "Example Author Two", "affiliation": "Example Lab" }
+  ],
+  "postedAt": "2026-05-18T11:00:00-04:00",
+  "disciplines": ["software-engineering", "AI", "open-source"],
+  "summary": "Field interviews with 14 OSS maintainers on how AI-generated pull requests change review workload, trust calibration, and project governance. Working paper — feedback welcome before journal submission.",
+  "sourceRepoUrl": "https://github.com/example-org/ai-pr-review-preprint",
+  "contactEmail": "author1@example.edu",
+  "version": "v1",
+  "license": "CC-BY-4.0",
+  "pdfUrl": "https://example-org.github.io/ai-pr-review-preprint/v1.pdf",
+  "peerReviewStatus": "awaiting"
+}

--- a/content/research/entries/ai-pr-review-traces-dataset.json
+++ b/content/research/entries/ai-pr-review-traces-dataset.json
@@ -1,0 +1,18 @@
+{
+  "slug": "ai-pr-review-traces-dataset",
+  "type": "dataset",
+  "isSample": true,
+  "title": "AI PR Review Traces — 200 sampled review threads with annotations",
+  "authors": [
+    { "name": "Example Author One", "affiliation": "Example University" }
+  ],
+  "postedAt": "2026-05-12T12:00:00-04:00",
+  "disciplines": ["software-engineering", "AI", "open-source"],
+  "summary": "Companion dataset to the AI-assisted PR review preprint. 200 anonymized review threads from public OSS repos, hand-annotated with review-action types and reviewer-trust signals.",
+  "sourceRepoUrl": "https://github.com/example-org/ai-pr-review-traces",
+  "contactEmail": "author1@example.edu",
+  "license": "CC-BY-NC-4.0",
+  "size": "200 review threads · ~3 MB",
+  "format": ["JSONL"],
+  "citation": "Example Author One. (2026). AI PR Review Traces [Data set]. https://github.com/example-org/ai-pr-review-traces"
+}

--- a/content/research/entries/cohort-shipping-cadence-theory.json
+++ b/content/research/entries/cohort-shipping-cadence-theory.json
@@ -1,0 +1,23 @@
+{
+  "slug": "cohort-shipping-cadence-theory",
+  "type": "preprint",
+  "isSample": true,
+  "title": "Weekly shipping deadlines as a coordination mechanism in async builder cohorts",
+  "authors": [
+    {
+      "name": "Example Theory Researcher",
+      "affiliation": "Example University — Org Behavior"
+    }
+  ],
+  "postedAt": "2026-05-15T16:30:00-04:00",
+  "updatedAt": "2026-05-21T10:00:00-04:00",
+  "disciplines": ["organizational-behavior", "community", "coordination"],
+  "summary": "Theory paper proposing weekly synchronized deadlines as a coordination primitive in otherwise async distributed cohorts. Draws on coordination theory and free-rider literature.",
+  "sourceRepoUrl": "https://github.com/example-org/cohort-cadence-theory",
+  "contactUrl": "https://example.edu/contact",
+  "version": "v2",
+  "license": "CC-BY-SA-4.0",
+  "pdfUrl": "https://example-org.github.io/cohort-cadence-theory/v2.pdf",
+  "doi": "10.31234/osf.io/placeholder-v2",
+  "peerReviewStatus": "approved-with-reservations"
+}

--- a/content/research/entries/cohort-survey-followup-2026.json
+++ b/content/research/entries/cohort-survey-followup-2026.json
@@ -1,0 +1,27 @@
+{
+  "slug": "cohort-survey-followup-2026",
+  "type": "recruiting",
+  "isSample": true,
+  "title": "Diary study: 6-week cohort participation patterns",
+  "authors": [
+    {
+      "name": "Example Researcher Two",
+      "affiliation": "Example University — Learning Sciences"
+    }
+  ],
+  "postedAt": "2026-05-20T09:00:00-04:00",
+  "disciplines": ["learning-sciences", "community", "developer-tools"],
+  "summary": "Diary study following Cursor Boston cohort participants weekly for 6 weeks. We're interested in why people start, persist, or drop out of community shipping commitments.",
+  "sourceRepoUrl": "https://github.com/example-org/cohort-diary-2026",
+  "contactEmail": "researcher2@example.edu",
+  "deadline": "2026-06-15T23:59:00-04:00",
+  "compensation": "$60 total ($10/weekly entry × 6 weeks)",
+  "timeCommitment": "10 min/week × 6 weeks",
+  "location": "remote",
+  "eligibility": "Anyone enrolled in the Cursor Boston summer cohort (any week).",
+  "irb": {
+    "institution": "Example University",
+    "protocolNumber": "IRB-2026-DIARY-PLACEHOLDER"
+  },
+  "status": "open"
+}

--- a/content/research/entries/cursor-boston-cohort1-events-dataset.json
+++ b/content/research/entries/cursor-boston-cohort1-events-dataset.json
@@ -1,0 +1,19 @@
+{
+  "slug": "cursor-boston-cohort1-events-dataset",
+  "type": "dataset",
+  "isSample": true,
+  "title": "Cursor Boston Cohort 1 — Anonymized weekly submission + voting events",
+  "authors": [
+    { "name": "Cursor Boston Maintainers", "url": "https://cursorboston.com/about" }
+  ],
+  "postedAt": "2026-05-19T18:00:00-04:00",
+  "disciplines": ["community", "developer-tools", "coordination"],
+  "summary": "Anonymized event log from Cursor Boston summer cohort 1: weekly submission timestamps, PR sizes, and voting results across six weeks. No PII; opt-in basis. For researchers studying community shipping behavior.",
+  "sourceRepoUrl": "https://github.com/example-org/cursor-boston-cohort1-events",
+  "contactEmail": "data@example.org",
+  "license": "CC-BY-4.0",
+  "size": "~5,200 rows · 1.2 MB",
+  "format": ["CSV", "Parquet"],
+  "doi": "10.5281/zenodo.placeholder",
+  "citation": "Cursor Boston Maintainers. (2026). Cursor Boston Cohort 1 — Anonymized weekly submission + voting events [Data set]. Zenodo. https://doi.org/10.5281/zenodo.placeholder"
+}

--- a/content/research/entries/devtool-usability-study-2026.json
+++ b/content/research/entries/devtool-usability-study-2026.json
@@ -1,0 +1,30 @@
+{
+  "slug": "devtool-usability-study-2026",
+  "type": "recruiting",
+  "isSample": true,
+  "title": "Usability study: AI pair-programming workflows in Cursor",
+  "authors": [
+    {
+      "name": "Example Researcher",
+      "affiliation": "Example University — HCI Lab",
+      "url": "https://example.edu/~researcher"
+    }
+  ],
+  "postedAt": "2026-05-22T14:00:00-04:00",
+  "disciplines": ["HCI", "developer-tools", "AI"],
+  "summary": "We're studying how developers structure conversations with AI assistants during real coding tasks. Looking for 30 working developers comfortable with VS Code or Cursor; 45-minute remote session, screen-recorded.",
+  "sourceRepoUrl": "https://github.com/example-org/devtool-usability-2026",
+  "contactEmail": "researcher@example.edu",
+  "deadline": "2026-06-30T23:59:00-04:00",
+  "compensation": "$25 Amazon gift card",
+  "timeCommitment": "45 minutes (single session)",
+  "location": "remote",
+  "eligibility": "Working developers with 1+ year of professional experience, comfortable thinking aloud while coding in English.",
+  "slotsRemaining": 24,
+  "irb": {
+    "institution": "Example University",
+    "protocolNumber": "IRB-2026-PLACEHOLDER"
+  },
+  "studyUrl": "https://example-university.qualtrics.com/jfe/form/SV_placeholder",
+  "status": "open"
+}

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -1,0 +1,242 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+export const RESEARCH_ENTRIES_DIR = "content/research/entries";
+export const RESEARCH_README_PATH = "content/research/README.md";
+export const RESEARCH_REPO_FILE_BASE =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/content/research/entries";
+export const RESEARCH_REPO_NEW_FILE_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/new/develop/content/research/entries";
+export const RESEARCH_REPO_README_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/content/research/README.md";
+
+const AuthorSchema = z.object({
+  name: z.string().min(1).max(120),
+  affiliation: z.string().max(160).optional(),
+  url: z.string().url().optional(),
+});
+
+const BaseSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .max(80)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+      message: "slug must be kebab-case (lowercase, digits, hyphens)",
+    }),
+  title: z.string().min(3).max(200),
+  authors: z.array(AuthorSchema).min(1).max(20),
+  postedAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }).optional(),
+  disciplines: z.array(z.string().min(1).max(40)).min(1).max(8),
+  summary: z.string().min(20).max(500),
+  /** External GitHub repo that hosts the actual content / files / data. */
+  sourceRepoUrl: z.string().url(),
+  contactEmail: z.string().email().optional(),
+  contactUrl: z.string().url().optional(),
+  /**
+   * Placeholder / demo entry. Sample entries are hidden from the main feed
+   * and from type-specific filters; they only appear under the dedicated
+   * "Samples" filter. Cards visibly mark them and disable external CTAs so
+   * users don't click through to fake URLs. Real entries omit this field.
+   */
+  isSample: z.boolean().optional(),
+});
+
+const RecruitingSchema = BaseSchema.extend({
+  type: z.literal("recruiting"),
+  deadline: z.string().datetime({ offset: true }),
+  compensation: z.string().min(1).max(200),
+  timeCommitment: z.string().min(1).max(120),
+  location: z.enum(["remote", "in-person", "hybrid"]),
+  eligibility: z.string().min(1).max(400),
+  slotsRemaining: z.number().int().nonnegative().optional(),
+  irb: z
+    .object({
+      institution: z.string().min(1).max(160),
+      protocolNumber: z.string().min(1).max(60),
+    })
+    .optional(),
+  studyUrl: z.string().url().optional(),
+  status: z.enum(["open", "paused", "closed"]).default("open"),
+});
+
+const PreprintSchema = BaseSchema.extend({
+  type: z.literal("preprint"),
+  version: z.string().min(1).max(20),
+  license: z.string().min(1).max(60),
+  pdfUrl: z.string().url(),
+  doi: z.string().max(100).optional(),
+  peerReviewStatus: z
+    .enum(["awaiting", "approved", "approved-with-reservations", "rejected"])
+    .optional(),
+});
+
+const DatasetSchema = BaseSchema.extend({
+  type: z.literal("dataset"),
+  license: z.string().min(1).max(60),
+  size: z.string().max(60).optional(),
+  format: z.array(z.string().min(1).max(20)).max(8).optional(),
+  doi: z.string().max(100).optional(),
+  citation: z.string().max(800).optional(),
+});
+
+export const ResearchEntrySchema = z.discriminatedUnion("type", [
+  RecruitingSchema,
+  PreprintSchema,
+  DatasetSchema,
+]);
+
+export type ResearchType = "recruiting" | "preprint" | "dataset";
+export type ResearchEntry = z.infer<typeof ResearchEntrySchema>;
+export type RecruitingEntry = z.infer<typeof RecruitingSchema>;
+export type PreprintEntry = z.infer<typeof PreprintSchema>;
+export type DatasetEntry = z.infer<typeof DatasetSchema>;
+
+export interface LoadedResearchEntry {
+  entry: ResearchEntry;
+  /** Relative path from repo root (e.g. content/research/entries/<slug>.json). */
+  sourcePath: string;
+}
+
+/**
+ * Past-deadline recruiting entries are visually struck-through and auto-hidden
+ * after this many days unless the entry's status is explicitly "paused".
+ * Keeps the feed alive — every recruitment platform that didn't enforce this
+ * ends up with a graveyard of dead listings.
+ */
+export const RECRUITING_AUTO_HIDE_DAYS_PAST_DEADLINE = 14;
+
+export function isRecruiting(e: ResearchEntry): e is RecruitingEntry {
+  return e.type === "recruiting";
+}
+export function isPreprint(e: ResearchEntry): e is PreprintEntry {
+  return e.type === "preprint";
+}
+export function isDataset(e: ResearchEntry): e is DatasetEntry {
+  return e.type === "dataset";
+}
+
+export function isRecruitingPastDeadline(
+  e: RecruitingEntry,
+  now: Date = new Date()
+): boolean {
+  return new Date(e.deadline).getTime() < now.getTime();
+}
+
+export function shouldAutoHideRecruiting(
+  e: RecruitingEntry,
+  now: Date = new Date()
+): boolean {
+  if (!isRecruitingPastDeadline(e, now)) return false;
+  const deadlineMs = new Date(e.deadline).getTime();
+  const cutoffMs =
+    deadlineMs +
+    RECRUITING_AUTO_HIDE_DAYS_PAST_DEADLINE * 24 * 60 * 60 * 1000;
+  return now.getTime() > cutoffMs;
+}
+
+/**
+ * Build-time loader. Reads every JSON file under content/research/entries/,
+ * validates against ResearchEntrySchema, and returns the typed entries.
+ *
+ * Throws on validation errors so a malformed PR breaks the build rather than
+ * silently dropping the entry.
+ */
+export function loadAllResearchEntries(): LoadedResearchEntry[] {
+  const dir = path.join(process.cwd(), RESEARCH_ENTRIES_DIR);
+  if (!fs.existsSync(dir)) return [];
+
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json") && !f.startsWith("."));
+
+  const loaded: LoadedResearchEntry[] = [];
+  for (const file of files) {
+    const fullPath = path.join(dir, file);
+    const text = fs.readFileSync(fullPath, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      throw new Error(
+        `Invalid JSON in ${RESEARCH_ENTRIES_DIR}/${file}: ${(err as Error).message}`
+      );
+    }
+    const result = ResearchEntrySchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(
+        `Schema validation failed for ${RESEARCH_ENTRIES_DIR}/${file}:\n${result.error.message}`
+      );
+    }
+    const expectedSlug = file.replace(/\.json$/, "");
+    if (result.data.slug !== expectedSlug) {
+      throw new Error(
+        `Slug mismatch in ${RESEARCH_ENTRIES_DIR}/${file}: file slug "${expectedSlug}" does not match entry slug "${result.data.slug}"`
+      );
+    }
+    loaded.push({
+      entry: result.data,
+      sourcePath: `${RESEARCH_ENTRIES_DIR}/${file}`,
+    });
+  }
+  return loaded;
+}
+
+/**
+ * Sort entries by "recently active" — preferring updatedAt when present,
+ * falling back to postedAt. Newer first.
+ */
+export function sortByRecentlyActive(
+  entries: LoadedResearchEntry[]
+): LoadedResearchEntry[] {
+  return [...entries].sort((a, b) => {
+    const aTs = new Date(a.entry.updatedAt ?? a.entry.postedAt).getTime();
+    const bTs = new Date(b.entry.updatedAt ?? b.entry.postedAt).getTime();
+    return bTs - aTs;
+  });
+}
+
+/** Visible feed: drops auto-hidden expired recruiting entries. */
+export function filterVisible(
+  entries: LoadedResearchEntry[],
+  now: Date = new Date()
+): LoadedResearchEntry[] {
+  return entries.filter(({ entry }) => {
+    if (entry.type !== "recruiting") return true;
+    if (entry.status === "closed") return false;
+    return !shouldAutoHideRecruiting(entry, now);
+  });
+}
+
+export function isSample(entry: ResearchEntry): boolean {
+  return entry.isSample === true;
+}
+
+export const RESEARCH_TYPE_LABEL: Record<ResearchType, string> = {
+  recruiting: "Recruiting",
+  preprint: "Preprint",
+  dataset: "Dataset",
+};
+
+export const RESEARCH_TYPE_PLURAL: Record<ResearchType, string> = {
+  recruiting: "Recruiting calls",
+  preprint: "Preprints",
+  dataset: "Datasets",
+};
+
+/**
+ * Path inside the cursor-boston repo for the entry's JSON. PR-based comments
+ * happen against this path — the detail page deep-links here.
+ */
+export function repoFileUrlForSlug(slug: string): string {
+  return `${RESEARCH_REPO_FILE_BASE}/${slug}.json`;
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -100,6 +100,8 @@ Licensed GPL-3.0-only.
     /questions
     /questions/[questionId]
     /questions/ask
+    /research
+    /research/[slug]
     /showcase
     /signup
     /summer-cohort


### PR DESCRIPTION
## Summary
Promotes the new Research tab and the First Global Algorithmacy Conference CFP to production.

## Included PRs
- **#1330** — feat(research): new /research tab — recruiting · preprints · datasets via PR — _Roger Hunt_
  - New `/research` sidebar tab in the Live group
  - Unified feed with type filter (All / Recruiting / Preprints / Datasets / Samples)
  - PR-only submission model — entries are JSON files under `content/research/entries/`, validated by Zod, with all actual content hosted in each researcher's own GitHub repo
  - Six seed entries flagged as samples (hidden from main feed, surfaced under "Samples" filter, external CTAs disabled)
  - Indigo CFP banner announcing the First Global Algorithmacy Conference (La Brea Pitch Lake, Trinidad and Tobago, late Oct / early Nov 2026 — exact dates TBD) with PR-based talk-proposal intake (abstract + outline + APA 7 references)
  - Full CFP doc + submission template under `content/research/cfp/algorithmacy-conference/`

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `SKIP_TYPECHECK=1 npm run build && npm start` — verified `/research`, `/research?type=samples`, sample detail pages, and the CFP banner rendering
- [x] Loader validates 6 seed entries at build time
- [x] All seed entries classified as samples; default `/research` shows empty state inviting first real submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)