### PR TITLE
release: Research expanded to 5 types + sparkle on nav

### DIFF
--- a/app/research/[slug]/page.tsx
+++ b/app/research/[slug]/page.tsx
@@ -14,16 +14,21 @@ import {
   FileText,
   GitBranch,
   Globe,
+  Handshake,
   Mail,
+  Megaphone,
   MessageSquare,
 } from "lucide-react";
 import {
   RESEARCH_REPO_README_URL,
   RESEARCH_TYPE_LABEL,
+  isActiveResearch,
+  isActiveResearchPastDeadline,
+  isCfp,
+  isCfpPastDeadline,
+  isCollaboration,
   isDataset,
-  isPreprint,
-  isRecruiting,
-  isRecruitingPastDeadline,
+  isWorkingPaper,
   loadAllResearchEntries,
   repoFileUrlForSlug,
   type ResearchEntry,
@@ -76,11 +81,16 @@ function formatDateTime(iso: string): string {
 
 function TypeBadge({ type }: { type: ResearchEntry["type"] }) {
   const styles: Record<ResearchEntry["type"], string> = {
-    recruiting:
+    "active-research":
       "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
-    preprint: "bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-300",
+    "working-paper":
+      "bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-300",
     dataset:
       "bg-purple-100 text-purple-800 dark:bg-purple-950/40 dark:text-purple-300",
+    collaboration:
+      "bg-rose-100 text-rose-800 dark:bg-rose-950/40 dark:text-rose-300",
+    cfp:
+      "bg-indigo-100 text-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-300",
   };
   return (
     <span
@@ -89,6 +99,10 @@ function TypeBadge({ type }: { type: ResearchEntry["type"] }) {
       {RESEARCH_TYPE_LABEL[type]}
     </span>
   );
+}
+
+function humanizeEnum(s: string): string {
+  return s.replace(/-/g, " ");
 }
 
 function MetaTable({
@@ -119,8 +133,18 @@ export default async function ResearchEntryPage({ params }: PageProps) {
   if (!entry) notFound();
 
   const fileUrl = repoFileUrlForSlug(entry.slug);
-  const isExpired = isRecruiting(entry) && isRecruitingPastDeadline(entry);
-  const isClosed = isRecruiting(entry) && entry.status === "closed";
+  const isExpiredActiveResearch =
+    isActiveResearch(entry) && isActiveResearchPastDeadline(entry);
+  const isExpiredCfp = isCfp(entry) && isCfpPastDeadline(entry);
+  const isExpired = isExpiredActiveResearch || isExpiredCfp;
+  const isClosed =
+    (isActiveResearch(entry) && entry.status === "closed") ||
+    (isCfp(entry) && entry.status === "closed") ||
+    (isCollaboration(entry) && entry.status === "closed");
+  const isPaused =
+    (isActiveResearch(entry) && entry.status === "paused") ||
+    (isCfp(entry) && entry.status === "paused") ||
+    (isCollaboration(entry) && entry.status === "paused");
   const sample = entry.isSample === true;
 
   return (
@@ -146,7 +170,7 @@ export default async function ResearchEntryPage({ params }: PageProps) {
       <header className="mt-4 mb-6">
         <div className="flex flex-wrap items-center gap-2">
           <TypeBadge type={entry.type} />
-          {isRecruiting(entry) && entry.status === "paused" ? (
+          {isPaused ? (
             <span className="rounded-md bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
               Paused
             </span>
@@ -161,9 +185,9 @@ export default async function ResearchEntryPage({ params }: PageProps) {
               Past deadline
             </span>
           ) : null}
-          {isPreprint(entry) && entry.peerReviewStatus ? (
+          {isWorkingPaper(entry) && entry.peerReviewStatus ? (
             <span className="rounded-md border border-sky-200 bg-sky-50 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-sky-800 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300">
-              {entry.peerReviewStatus.replace(/-/g, " ")}
+              {humanizeEnum(entry.peerReviewStatus)}
             </span>
           ) : null}
         </div>
@@ -204,7 +228,7 @@ export default async function ResearchEntryPage({ params }: PageProps) {
         <p>{entry.summary}</p>
       </section>
 
-      {isRecruiting(entry) ? (
+      {isActiveResearch(entry) ? (
         <section className="mb-6">
           <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
             Study details
@@ -214,7 +238,7 @@ export default async function ResearchEntryPage({ params }: PageProps) {
               {
                 label: "Deadline",
                 value: (
-                  <span className={isExpired ? "line-through opacity-70" : ""}>
+                  <span className={isExpiredActiveResearch ? "line-through opacity-70" : ""}>
                     {formatDateTime(entry.deadline)}
                   </span>
                 ),
@@ -244,7 +268,7 @@ export default async function ResearchEntryPage({ params }: PageProps) {
                 : []),
             ]}
           />
-          {entry.studyUrl && !isExpired && !isClosed && !sample ? (
+          {entry.studyUrl && !isExpiredActiveResearch && !isClosed && !sample ? (
             <a
               href={entry.studyUrl}
               target="_blank"
@@ -261,7 +285,7 @@ export default async function ResearchEntryPage({ params }: PageProps) {
         </section>
       ) : null}
 
-      {isPreprint(entry) ? (
+      {isWorkingPaper(entry) ? (
         <section className="mb-6">
           <h2 className="mb-3 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
             Paper details
@@ -275,7 +299,7 @@ export default async function ResearchEntryPage({ params }: PageProps) {
                 ? [
                     {
                       label: "Peer review",
-                      value: entry.peerReviewStatus.replace(/-/g, " "),
+                      value: humanizeEnum(entry.peerReviewStatus),
                     },
                   ]
                 : []),
@@ -323,6 +347,93 @@ export default async function ResearchEntryPage({ params }: PageProps) {
               </p>
             </div>
           ) : null}
+        </section>
+      ) : null}
+
+      {isCollaboration(entry) ? (
+        <section className="mb-6">
+          <h2 className="mb-3 inline-flex items-center gap-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+            <Handshake className="h-5 w-5 text-rose-600 dark:text-rose-400" />
+            Collaboration details
+          </h2>
+          <MetaTable
+            rows={[
+              {
+                label: "Type",
+                value: (
+                  <span className="capitalize">
+                    {humanizeEnum(entry.collaborationType)}
+                  </span>
+                ),
+              },
+              {
+                label: "Project stage",
+                value: (
+                  <span className="capitalize">
+                    {humanizeEnum(entry.projectStage)}
+                  </span>
+                ),
+              },
+              { label: "Seeking", value: entry.seeking },
+              { label: "Time commitment", value: entry.timeCommitment },
+              ...(entry.deadline
+                ? [
+                    {
+                      label: "Need someone by",
+                      value: formatDateTime(entry.deadline),
+                    },
+                  ]
+                : []),
+            ]}
+          />
+        </section>
+      ) : null}
+
+      {isCfp(entry) ? (
+        <section className="mb-6">
+          <h2 className="mb-3 inline-flex items-center gap-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+            <Megaphone className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+            Call-for-papers details
+          </h2>
+          <MetaTable
+            rows={[
+              {
+                label: "Submission deadline",
+                value: (
+                  <span className={isExpiredCfp ? "line-through opacity-70" : ""}>
+                    {formatDateTime(entry.submissionDeadline)}
+                  </span>
+                ),
+              },
+              { label: "Conference dates", value: entry.conferenceDates },
+              { label: "Location", value: entry.location },
+              { label: "Organizing body", value: entry.organizingBody },
+              {
+                label: "Submission types",
+                value: (
+                  <ul className="list-disc pl-5">
+                    {entry.submissionTypes.map((t) => (
+                      <li key={t}>{t}</li>
+                    ))}
+                  </ul>
+                ),
+              },
+            ]}
+          />
+          {sample ? (
+            <span className="mt-4 inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-dashed border-amber-300 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+              <Megaphone className="h-4 w-4" /> Conference site (disabled on sample)
+            </span>
+          ) : (
+            <a
+              href={entry.conferenceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-indigo-500"
+            >
+              <Megaphone className="h-4 w-4" /> Conference site
+            </a>
+          )}
         </section>
       ) : null}
 

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -30,18 +30,22 @@ type FilterValue = ResearchType | "all" | "samples";
 
 const FILTERS: Array<{ value: FilterValue; label: string }> = [
   { value: "all", label: "All" },
-  { value: "recruiting", label: RESEARCH_TYPE_PLURAL.recruiting },
-  { value: "preprint", label: RESEARCH_TYPE_PLURAL.preprint },
+  { value: "active-research", label: RESEARCH_TYPE_PLURAL["active-research"] },
+  { value: "working-paper", label: RESEARCH_TYPE_PLURAL["working-paper"] },
   { value: "dataset", label: RESEARCH_TYPE_PLURAL.dataset },
+  { value: "collaboration", label: RESEARCH_TYPE_PLURAL.collaboration },
+  { value: "cfp", label: RESEARCH_TYPE_PLURAL.cfp },
   { value: "samples", label: "Samples" },
 ];
 
 function parseFilter(raw: string | string[] | undefined): FilterValue {
   const v = Array.isArray(raw) ? raw[0] : raw;
   if (
-    v === "recruiting" ||
-    v === "preprint" ||
+    v === "active-research" ||
+    v === "working-paper" ||
     v === "dataset" ||
+    v === "collaboration" ||
+    v === "cfp" ||
     v === "samples"
   )
     return v;
@@ -71,9 +75,11 @@ export default async function ResearchPage({ searchParams }: ResearchPageProps) 
 
   const counts: Record<FilterValue, number> = {
     all: real.length,
-    recruiting: real.filter((l) => l.entry.type === "recruiting").length,
-    preprint: real.filter((l) => l.entry.type === "preprint").length,
+    "active-research": real.filter((l) => l.entry.type === "active-research").length,
+    "working-paper": real.filter((l) => l.entry.type === "working-paper").length,
     dataset: real.filter((l) => l.entry.type === "dataset").length,
+    collaboration: real.filter((l) => l.entry.type === "collaboration").length,
+    cfp: real.filter((l) => l.entry.type === "cfp").length,
     samples: samples.length,
   };
 

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -85,18 +85,21 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/events", label: "Events", icon: Calendar },
       { href: "/cookbook", label: "Cookbook", icon: ChefHat },
       { href: "/questions", label: "Q&A", icon: HelpCircle },
-      { 
-        href: "/pr-ideas", 
-        title: "PR Studio",
+      { href: "/pr-ideas", label: "PR Studio", icon: Bot },
+      { href: "/opportunities", label: "Opportunities", icon: Briefcase },
+      { href: "/ecosystem", label: "Ecosystem", icon: Building2 },
+      {
+        href: "/research",
+        title: "Research",
         label: (
           <span className="inline-flex items-center gap-1">
-            PR Studio
+            Research
             <span className="relative ml-1 flex h-4 w-4 items-center justify-center">
               <span
                 className="absolute inline-block h-4 w-4 animate-spin rounded-full bg-gradient-to-tr from-yellow-400 via-orange-300 to-pink-500 opacity-70"
                 style={{
                   animationDuration: "2.4s",
-                  filter: "blur(1.5px)"
+                  filter: "blur(1.5px)",
                 }}
               ></span>
               <svg
@@ -117,13 +120,9 @@ const NAV_GROUPS: NavGroup[] = [
               </svg>
             </span>
           </span>
-        ), 
-        icon: Bot 
+        ),
+        icon: FlaskConical,
       },
-
-      { href: "/opportunities", label: "Opportunities", icon: Briefcase },
-      { href: "/ecosystem", label: "Ecosystem", icon: Building2 },
-      { href: "/research", label: "Research", icon: FlaskConical },
       { href: "/blog", label: "Blog", icon: BookOpen },
       { href: "/certificate", label: "Certificate", icon: Award },
     ],

--- a/components/research/ResearchCard.tsx
+++ b/components/research/ResearchCard.tsx
@@ -8,21 +8,28 @@
 import Link from "next/link";
 import {
   Calendar,
+  CalendarDays,
   Clock,
   ExternalLink,
   FileText,
+  Handshake,
   MapPin,
+  Megaphone,
   ScrollText,
   Tag,
   Users,
 } from "lucide-react";
 import {
   RESEARCH_TYPE_LABEL,
-  isRecruiting,
-  isPreprint,
+  isActiveResearch,
+  isActiveResearchPastDeadline,
+  isCfp,
+  isCfpPastDeadline,
+  isCollaboration,
   isDataset,
-  isRecruitingPastDeadline,
+  isWorkingPaper,
   type ResearchEntry,
+  type ResearchType,
 } from "@/lib/research";
 
 interface ResearchCardProps {
@@ -50,29 +57,30 @@ function relativeFromNow(iso: string, now: Date = new Date()): string {
   return formatDate(iso);
 }
 
+const TYPE_BADGE_STYLES: Record<ResearchType, string> = {
+  "active-research":
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+  "working-paper":
+    "bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-300",
+  dataset:
+    "bg-purple-100 text-purple-800 dark:bg-purple-950/40 dark:text-purple-300",
+  collaboration:
+    "bg-rose-100 text-rose-800 dark:bg-rose-950/40 dark:text-rose-300",
+  cfp:
+    "bg-indigo-100 text-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-300",
+};
+
 function TypeBadge({ entry }: { entry: ResearchEntry }) {
-  const styles: Record<typeof entry.type, string> = {
-    recruiting:
-      "bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
-    preprint:
-      "bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-300",
-    dataset:
-      "bg-purple-100 text-purple-800 dark:bg-purple-950/40 dark:text-purple-300",
-  };
   return (
     <span
-      className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold ${styles[entry.type]}`}
+      className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold ${TYPE_BADGE_STYLES[entry.type]}`}
     >
       {RESEARCH_TYPE_LABEL[entry.type]}
     </span>
   );
 }
 
-function MetadataRow({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+function MetadataRow({ children }: { children: React.ReactNode }) {
   return (
     <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-neutral-600 dark:text-neutral-400">
       {children}
@@ -94,9 +102,7 @@ function MetaItem({
   return (
     <span
       className={`inline-flex items-center gap-1 ${
-        emphasis
-          ? "font-semibold text-neutral-900 dark:text-neutral-100"
-          : ""
+        emphasis ? "font-semibold text-neutral-900 dark:text-neutral-100" : ""
       } ${strike ? "line-through opacity-60" : ""}`}
     >
       <Icon className="h-3.5 w-3.5 shrink-0" />
@@ -105,11 +111,22 @@ function MetaItem({
   );
 }
 
+function humanizeEnum(s: string): string {
+  return s.replace(/-/g, " ");
+}
+
 export function ResearchCard({ entry }: ResearchCardProps) {
   const detailHref = `/research/${entry.slug}`;
-  const isExpired = isRecruiting(entry) && isRecruitingPastDeadline(entry);
-  const isClosed = isRecruiting(entry) && entry.status === "closed";
   const sample = entry.isSample === true;
+
+  const isExpiredActiveResearch =
+    isActiveResearch(entry) && isActiveResearchPastDeadline(entry);
+  const isExpiredCfp = isCfp(entry) && isCfpPastDeadline(entry);
+  const isExpired = isExpiredActiveResearch || isExpiredCfp;
+  const isClosed =
+    (isActiveResearch(entry) && entry.status === "closed") ||
+    (isCfp(entry) && entry.status === "closed") ||
+    (isCollaboration(entry) && entry.status === "closed");
 
   return (
     <article
@@ -143,9 +160,7 @@ export function ResearchCard({ entry }: ResearchCardProps) {
 
       <p className="mt-1.5 text-xs text-neutral-600 dark:text-neutral-400">
         {entry.authors
-          .map((a) =>
-            a.affiliation ? `${a.name} (${a.affiliation})` : a.name
-          )
+          .map((a) => (a.affiliation ? `${a.name} (${a.affiliation})` : a.name))
           .join(" · ")}
       </p>
 
@@ -153,34 +168,32 @@ export function ResearchCard({ entry }: ResearchCardProps) {
         {entry.summary}
       </p>
 
-      {isRecruiting(entry) ? (
+      {isActiveResearch(entry) ? (
         <MetadataRow>
           <MetaItem
             icon={Calendar}
-            emphasis={!isExpired}
-            strike={isExpired}
+            emphasis={!isExpiredActiveResearch}
+            strike={isExpiredActiveResearch}
           >
-            {isExpired ? "Closed " : "Deadline "}
+            {isExpiredActiveResearch ? "Closed " : "Deadline "}
             {relativeFromNow(entry.deadline)}
           </MetaItem>
           <MetaItem icon={Clock}>{entry.timeCommitment}</MetaItem>
           <MetaItem icon={MapPin}>{entry.location}</MetaItem>
           {typeof entry.slotsRemaining === "number" ? (
-            <MetaItem icon={Users}>
-              {entry.slotsRemaining} slots left
-            </MetaItem>
+            <MetaItem icon={Users}>{entry.slotsRemaining} slots left</MetaItem>
           ) : null}
         </MetadataRow>
       ) : null}
 
-      {isPreprint(entry) ? (
+      {isWorkingPaper(entry) ? (
         <MetadataRow>
           <MetaItem icon={ScrollText}>
             {entry.version} · {entry.license}
           </MetaItem>
           {entry.peerReviewStatus ? (
             <span className="inline-flex items-center rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-800 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300">
-              {entry.peerReviewStatus.replace(/-/g, " ")}
+              {humanizeEnum(entry.peerReviewStatus)}
             </span>
           ) : null}
           {sample ? (
@@ -221,6 +234,38 @@ export function ResearchCard({ entry }: ResearchCardProps) {
         </MetadataRow>
       ) : null}
 
+      {isCollaboration(entry) ? (
+        <MetadataRow>
+          <MetaItem icon={Handshake} emphasis>
+            {humanizeEnum(entry.collaborationType)}
+          </MetaItem>
+          <span className="inline-flex items-center rounded border border-rose-200 bg-rose-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-rose-800 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-300">
+            stage: {humanizeEnum(entry.projectStage)}
+          </span>
+          <MetaItem icon={Clock}>{entry.timeCommitment}</MetaItem>
+          {entry.deadline ? (
+            <MetaItem icon={Calendar}>
+              Need by {relativeFromNow(entry.deadline)}
+            </MetaItem>
+          ) : null}
+        </MetadataRow>
+      ) : null}
+
+      {isCfp(entry) ? (
+        <MetadataRow>
+          <MetaItem
+            icon={Calendar}
+            emphasis={!isExpiredCfp}
+            strike={isExpiredCfp}
+          >
+            {isExpiredCfp ? "Submission closed " : "Submit by "}
+            {relativeFromNow(entry.submissionDeadline)}
+          </MetaItem>
+          <MetaItem icon={CalendarDays}>{entry.conferenceDates}</MetaItem>
+          <MetaItem icon={MapPin}>{entry.location}</MetaItem>
+        </MetadataRow>
+      ) : null}
+
       <div className="mt-4 flex flex-wrap gap-1.5">
         {entry.disciplines.slice(0, 4).map((d) => (
           <span
@@ -239,6 +284,21 @@ export function ResearchCard({ entry }: ResearchCardProps) {
         >
           Details →
         </Link>
+        {isCfp(entry) && !sample ? (
+          <a
+            href={entry.conferenceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-indigo-700 hover:underline dark:text-indigo-300"
+          >
+            <Megaphone className="h-3 w-3" /> Conference site
+          </a>
+        ) : null}
+        {isCfp(entry) && sample ? (
+          <span className="inline-flex items-center gap-1 text-neutral-400 dark:text-neutral-600">
+            <Megaphone className="h-3 w-3" /> Conference site (sample)
+          </span>
+        ) : null}
         {sample ? (
           <span className="inline-flex items-center gap-1 text-neutral-400 dark:text-neutral-600">
             <ExternalLink className="h-3 w-3" /> Source repo (sample)

--- a/content/research/README.md
+++ b/content/research/README.md
@@ -3,9 +3,13 @@
 This directory powers the **/research** page on cursorboston.com — a
 community space where academic researchers can:
 
-- **Recruit participants** for studies (compensated, IRB-approved).
-- **Share pre-prints** and working theory papers for community discussion.
+- **Recruit participants** for active studies (compensated, IRB-approved).
+- **Share working papers** for community discussion.
 - **Publish datasets** for the community to explore, cite, or build on.
+- **Find collaborators** — co-authors, replication partners, grant
+  co-investigators, data-sharing arrangements.
+- **Post calls for papers** — upcoming conferences, journal special
+  issues, workshops.
 
 Everything here is community-curated through GitHub. **There is no in-app
 form, no Firestore record, no login required.** A research entry exists if
@@ -35,9 +39,10 @@ source repo. The detail page links out to both.
 ## Editing an existing entry
 
 PR an update to the JSON file. Bump `updatedAt` to the current ISO
-timestamp. For preprints, also bump `version`. For recruiting entries,
-update `slotsRemaining` or `status` as the study progresses; set `status`
-to `"closed"` when complete.
+timestamp. For working papers, also bump `version`. For active-research
+entries, update `slotsRemaining` or `status` as the study progresses; set
+`status` to `"closed"` when complete. For CFP entries, set `status` to
+`"closed"` once the deadline passes (or rely on the 21-day auto-hide).
 
 ## JSON schema
 
@@ -51,7 +56,7 @@ time; a malformed entry breaks the build, not the page.
 ```jsonc
 {
   "slug": "kebab-case-slug",            // matches filename, lowercase
-  "type": "recruiting" | "preprint" | "dataset",
+  "type": "active-research" | "working-paper" | "dataset" | "collaboration" | "cfp",
   "title": "Short human title",
   "authors": [
     { "name": "Full Name", "affiliation": "University / Lab", "url": "https://..." }
@@ -70,11 +75,13 @@ time; a malformed entry breaks the build, not the page.
 > The `isSample` flag is for **placeholder / demo entries only**.
 > Sample entries are hidden from the main feed and from type-specific
 > filters; they only appear under the dedicated "Samples" filter, and
-> their external CTAs (study link, PDF, source repo, contact) are visually
-> disabled so visitors don&apos;t click through to fake URLs. Maintainers
-> set this on seed data; real submissions should not include it.
+> their external CTAs are visually disabled so visitors don't click
+> through to fake URLs. Maintainers set this on seed data; real
+> submissions should not include it.
 
-### `type: "recruiting"` — add
+### `type: "active-research"` — add
+
+For studies currently recruiting participants.
 
 ```jsonc
 {
@@ -93,7 +100,10 @@ time; a malformed entry breaks the build, not the page.
 }
 ```
 
-### `type: "preprint"` — add
+### `type: "working-paper"` — add
+
+For pre-prints, drafts, and theory papers open to community feedback
+before formal peer review.
 
 ```jsonc
 {
@@ -117,18 +127,59 @@ time; a malformed entry breaks the build, not the page.
 }
 ```
 
+### `type: "collaboration"` — add
+
+For requests to find peer collaborators — co-authors, co-investigators,
+replication partners, data-sharing arrangements, code-collaboration,
+grant partners.
+
+```jsonc
+{
+  "collaborationType": "co-author" | "co-investigator" | "replication-partner" | "data-sharing" | "code-collaboration" | "grant-partner" | "other",
+  "projectStage": "idea" | "proposal" | "data-collection" | "analysis" | "writing" | "revising",
+  "seeking": "Plain-language description of the skills / expertise / commitment you're looking for.",
+  "timeCommitment": "~10 hr/week × 8 weeks",
+  "deadline": "2026-07-15T23:59:00-04:00",    // optional — grant deadline, conference target, etc.
+  "status": "open" | "paused" | "closed"      // optional, defaults to "open"
+}
+```
+
+### `type: "cfp"` — add
+
+For upcoming conferences, journal special issues, and workshops. (Cursor
+Boston's own flagship CFP has a dedicated banner on the page; this type
+is for peer / external CFPs.)
+
+```jsonc
+{
+  "conferenceDates": "April 25–29, 2027",      // free-text date range; ok to say "TBD"
+  "location": "Yokohama, Japan (hybrid)",      // "City, Country" or "Virtual" or "Hybrid — ..."
+  "submissionDeadline": "2026-12-15T23:59:00-05:00", // REQUIRED — auto-strikes when past; auto-hides 21 days later
+  "conferenceUrl": "https://chi2027.acm.org/...",
+  "organizingBody": "ACM SIGCHI",
+  "submissionTypes": ["Full paper", "Poster", "Workshop position paper"],
+  "status": "open" | "paused" | "closed"       // optional, defaults to "open"
+}
+```
+
 ## Anti-patterns (please don't)
 
 - **Don't host paper PDFs or large dataset files in this repo.** Use your
   source repo, Zenodo, OSF, arXiv, etc. This repo only holds the metadata.
-- **Don't lead with compensation** in recruiting summaries — lead with the
-  research question. Cursor Boston is a community, not a marketplace.
-- **Don't post entries without a license** for preprints or datasets.
-  Without a license, others cannot legally reuse the work.
-- **Don't omit `deadline` on recruiting entries.** Past-deadline studies
-  auto-strike and auto-hide so the feed stays alive.
-- **Don't open multiple entries for the same study.** Update the existing
-  entry instead.
+- **Don't lead with compensation** in active-research summaries — lead
+  with the research question. Cursor Boston is a community, not a
+  marketplace.
+- **Don't post entries without a license** for working papers or
+  datasets. Without a license, others cannot legally reuse the work.
+- **Don't omit `deadline` on active-research entries or
+  `submissionDeadline` on CFPs.** Past-deadline entries auto-strike and
+  auto-hide so the feed stays alive.
+- **Don't open multiple entries for the same study / paper / CFP.**
+  Update the existing entry instead.
+- **Don't post personal CFPs through this surface that you yourself
+  organize as a stand-alone banner.** The page banner is for the
+  community's flagship CFP; the `cfp` type is for sharing other people's
+  conferences.
 
 ## Moderation
 

--- a/content/research/entries/ai-assisted-prs-preprint.json
+++ b/content/research/entries/ai-assisted-prs-preprint.json
@@ -1,6 +1,6 @@
 {
   "slug": "ai-assisted-prs-preprint",
-  "type": "preprint",
+  "type": "working-paper",
   "isSample": true,
   "title": "Reviewing AI-Assisted Pull Requests: A Field Study of Open-Source Maintainers",
   "authors": [

--- a/content/research/entries/algorithmacy-scale-coauthor-search.json
+++ b/content/research/entries/algorithmacy-scale-coauthor-search.json
@@ -1,0 +1,23 @@
+{
+  "slug": "algorithmacy-scale-coauthor-search",
+  "type": "collaboration",
+  "isSample": true,
+  "title": "Seeking co-author for algorithmacy scale validation study",
+  "authors": [
+    {
+      "name": "Example Lead Researcher",
+      "affiliation": "Example University — Industrial-Organizational Psychology"
+    }
+  ],
+  "postedAt": "2026-05-22T10:00:00-04:00",
+  "disciplines": ["psychometrics", "platform-work", "scale-development"],
+  "summary": "Looking for a co-author with psychometric / SEM expertise to help validate a 24-item algorithmacy scale across rideshare and AI-engineering populations (N = ~1,200 collected). Authorship by contribution; targeting a Q1 journal.",
+  "sourceRepoUrl": "https://github.com/example-org/algorithmacy-scale-study",
+  "contactEmail": "lead@example.edu",
+  "collaborationType": "co-author",
+  "projectStage": "analysis",
+  "seeking": "PhD-level psychometrician comfortable with CFA, measurement invariance testing, and reviewer-response writing. ~10 hr/week for 8–10 weeks. Familiarity with platform-work literature a plus but not required.",
+  "timeCommitment": "~10 hr/week × 8–10 weeks",
+  "deadline": "2026-07-15T23:59:00-04:00",
+  "status": "open"
+}

--- a/content/research/entries/asq-special-issue-platform-work-cfp.json
+++ b/content/research/entries/asq-special-issue-platform-work-cfp.json
@@ -1,0 +1,24 @@
+{
+  "slug": "asq-special-issue-platform-work-cfp",
+  "type": "cfp",
+  "isSample": true,
+  "title": "Administrative Science Quarterly — Special Issue on Platform Work and Worker Coordination",
+  "authors": [
+    {
+      "name": "Example Special-Issue Editor",
+      "affiliation": "Example University — Management"
+    }
+  ],
+  "postedAt": "2026-05-12T09:30:00-04:00",
+  "disciplines": ["organization-studies", "platform-work", "labor"],
+  "summary": "Call for full papers on platform work, algorithmic management, and worker-level coordination outcomes. Empirical and theoretical contributions welcome; mixed-methods strongly encouraged.",
+  "sourceRepoUrl": "https://github.com/example-org/asq-platform-work-special-issue",
+  "contactUrl": "https://journals.sagepub.com/example/asq-special-issue",
+  "conferenceDates": "Journal special issue — publication target Q3 2027",
+  "location": "Virtual (journal)",
+  "submissionDeadline": "2027-02-01T23:59:00-05:00",
+  "conferenceUrl": "https://journals.sagepub.com/example/asq-special-issue",
+  "organizingBody": "Administrative Science Quarterly",
+  "submissionTypes": ["Full paper (8,000–12,000 words)"],
+  "status": "open"
+}

--- a/content/research/entries/chi-2027-workshop-cfp.json
+++ b/content/research/entries/chi-2027-workshop-cfp.json
@@ -1,0 +1,28 @@
+{
+  "slug": "chi-2027-workshop-cfp",
+  "type": "cfp",
+  "isSample": true,
+  "title": "CHI 2027 Workshop — Designing for Triadic Human-AI-Human Coordination",
+  "authors": [
+    {
+      "name": "Example Workshop Organizer",
+      "affiliation": "Example University — HCI Lab"
+    },
+    {
+      "name": "Example Co-Organizer",
+      "affiliation": "Example Industry Lab"
+    }
+  ],
+  "postedAt": "2026-05-20T08:00:00-04:00",
+  "disciplines": ["HCI", "AI", "design"],
+  "summary": "One-day workshop at CHI 2027 on the design challenges of three-party human-AI-human coordination — interfaces where one human acts on another through an algorithmic intermediary. Position papers and design provocations welcome.",
+  "sourceRepoUrl": "https://github.com/example-org/chi-2027-triadic-workshop",
+  "contactEmail": "workshop@example.edu",
+  "conferenceDates": "April 25–29, 2027",
+  "location": "Yokohama, Japan (hybrid)",
+  "submissionDeadline": "2026-12-15T23:59:00-05:00",
+  "conferenceUrl": "https://chi2027.acm.org/workshop-triadic-example",
+  "organizingBody": "ACM SIGCHI",
+  "submissionTypes": ["Position paper (2–4 pages)", "Design provocation (1 page + figure)"],
+  "status": "open"
+}

--- a/content/research/entries/cohort-shipping-cadence-theory.json
+++ b/content/research/entries/cohort-shipping-cadence-theory.json
@@ -1,6 +1,6 @@
 {
   "slug": "cohort-shipping-cadence-theory",
-  "type": "preprint",
+  "type": "working-paper",
   "isSample": true,
   "title": "Weekly shipping deadlines as a coordination mechanism in async builder cohorts",
   "authors": [

--- a/content/research/entries/cohort-survey-followup-2026.json
+++ b/content/research/entries/cohort-survey-followup-2026.json
@@ -1,6 +1,6 @@
 {
   "slug": "cohort-survey-followup-2026",
-  "type": "recruiting",
+  "type": "active-research",
   "isSample": true,
   "title": "Diary study: 6-week cohort participation patterns",
   "authors": [

--- a/content/research/entries/devtool-usability-study-2026.json
+++ b/content/research/entries/devtool-usability-study-2026.json
@@ -1,6 +1,6 @@
 {
   "slug": "devtool-usability-study-2026",
-  "type": "recruiting",
+  "type": "active-research",
   "isSample": true,
   "title": "Usability study: AI pair-programming workflows in Cursor",
   "authors": [

--- a/content/research/entries/replication-ai-pr-review-partner.json
+++ b/content/research/entries/replication-ai-pr-review-partner.json
@@ -1,0 +1,22 @@
+{
+  "slug": "replication-ai-pr-review-partner",
+  "type": "collaboration",
+  "isSample": true,
+  "title": "Replication partner sought — AI-assisted PR review study (Python ecosystem)",
+  "authors": [
+    {
+      "name": "Example Author One",
+      "affiliation": "Example University"
+    }
+  ],
+  "postedAt": "2026-05-18T15:00:00-04:00",
+  "disciplines": ["software-engineering", "open-source", "replication"],
+  "summary": "Original study sampled 14 maintainers from JavaScript / TypeScript OSS projects. Seeking a researcher to replicate the protocol in the Python / data-science ecosystem (~12 interviews). Interview protocol + codebook provided; replication report would be co-authored.",
+  "sourceRepoUrl": "https://github.com/example-org/ai-pr-review-preprint",
+  "contactEmail": "author1@example.edu",
+  "collaborationType": "replication-partner",
+  "projectStage": "data-collection",
+  "seeking": "Qualitative researcher with experience conducting maintainer / OSS interviews. Comfortable with NVivo or Atlas.ti for coding. Native or near-native English; Python community access (PyData, scikit-learn, pandas, etc.) preferred.",
+  "timeCommitment": "~6 hr/week × 16 weeks (recruitment, interviews, coding)",
+  "status": "open"
+}

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -51,8 +51,13 @@ const BaseSchema = z.object({
   isSample: z.boolean().optional(),
 });
 
-const RecruitingSchema = BaseSchema.extend({
-  type: z.literal("recruiting"),
+/**
+ * Active Research — calls for study participants. Renamed from "recruiting"
+ * to communicate the surface plainly to non-academic readers: this is the
+ * research that's actively running and looking for participants.
+ */
+const ActiveResearchSchema = BaseSchema.extend({
+  type: z.literal("active-research"),
   deadline: z.string().datetime({ offset: true }),
   compensation: z.string().min(1).max(200),
   timeCommitment: z.string().min(1).max(120),
@@ -69,8 +74,12 @@ const RecruitingSchema = BaseSchema.extend({
   status: z.enum(["open", "paused", "closed"]).default("open"),
 });
 
-const PreprintSchema = BaseSchema.extend({
-  type: z.literal("preprint"),
+/**
+ * Working Paper — formerly "preprint." Same schema; renamed to a term that
+ * carries less institutional baggage and reads cleanly to practitioners.
+ */
+const WorkingPaperSchema = BaseSchema.extend({
+  type: z.literal("working-paper"),
   version: z.string().min(1).max(20),
   license: z.string().min(1).max(60),
   pdfUrl: z.string().url(),
@@ -89,17 +98,75 @@ const DatasetSchema = BaseSchema.extend({
   citation: z.string().max(800).optional(),
 });
 
+/**
+ * Collaboration — request for co-authors, co-investigators, replication
+ * partners, or other co-research arrangements. Different from active
+ * research (which seeks subjects) in that it seeks peer collaborators.
+ */
+const CollaborationSchema = BaseSchema.extend({
+  type: z.literal("collaboration"),
+  collaborationType: z.enum([
+    "co-author",
+    "co-investigator",
+    "replication-partner",
+    "data-sharing",
+    "code-collaboration",
+    "grant-partner",
+    "other",
+  ]),
+  projectStage: z.enum([
+    "idea",
+    "proposal",
+    "data-collection",
+    "analysis",
+    "writing",
+    "revising",
+  ]),
+  seeking: z.string().min(1).max(400),
+  timeCommitment: z.string().min(1).max(120),
+  /** Optional deadline (grant deadline, conference target, etc.). */
+  deadline: z.string().datetime({ offset: true }).optional(),
+  status: z.enum(["open", "paused", "closed"]).default("open"),
+});
+
+/**
+ * Call for Papers — community-posted upcoming conference, journal special
+ * issue, or workshop. For Cursor Boston's own flagship CFP, see the
+ * dedicated banner on the page; this type is for peer/external CFPs.
+ */
+const CfpSchema = BaseSchema.extend({
+  type: z.literal("cfp"),
+  conferenceDates: z.string().min(1).max(120),
+  /** "City, Country" or "Virtual" or "Hybrid — City, Country". */
+  location: z.string().min(1).max(120),
+  /** Hard deadline for paper / abstract submission. */
+  submissionDeadline: z.string().datetime({ offset: true }),
+  conferenceUrl: z.string().url(),
+  organizingBody: z.string().min(1).max(200),
+  submissionTypes: z.array(z.string().min(1).max(60)).min(1).max(8),
+  status: z.enum(["open", "paused", "closed"]).default("open"),
+});
+
 export const ResearchEntrySchema = z.discriminatedUnion("type", [
-  RecruitingSchema,
-  PreprintSchema,
+  ActiveResearchSchema,
+  WorkingPaperSchema,
   DatasetSchema,
+  CollaborationSchema,
+  CfpSchema,
 ]);
 
-export type ResearchType = "recruiting" | "preprint" | "dataset";
+export type ResearchType =
+  | "active-research"
+  | "working-paper"
+  | "dataset"
+  | "collaboration"
+  | "cfp";
 export type ResearchEntry = z.infer<typeof ResearchEntrySchema>;
-export type RecruitingEntry = z.infer<typeof RecruitingSchema>;
-export type PreprintEntry = z.infer<typeof PreprintSchema>;
+export type ActiveResearchEntry = z.infer<typeof ActiveResearchSchema>;
+export type WorkingPaperEntry = z.infer<typeof WorkingPaperSchema>;
 export type DatasetEntry = z.infer<typeof DatasetSchema>;
+export type CollaborationEntry = z.infer<typeof CollaborationSchema>;
+export type CfpEntry = z.infer<typeof CfpSchema>;
 
 export interface LoadedResearchEntry {
   entry: ResearchEntry;
@@ -108,39 +175,65 @@ export interface LoadedResearchEntry {
 }
 
 /**
- * Past-deadline recruiting entries are visually struck-through and auto-hidden
- * after this many days unless the entry's status is explicitly "paused".
- * Keeps the feed alive — every recruitment platform that didn't enforce this
- * ends up with a graveyard of dead listings.
+ * Past-deadline active-research entries are visually struck-through and
+ * auto-hidden after this many days unless explicitly paused. Keeps the
+ * feed alive — every recruitment platform that didn't enforce this ends
+ * up with a graveyard of dead listings.
  */
 export const RECRUITING_AUTO_HIDE_DAYS_PAST_DEADLINE = 14;
+/** CFP past-deadline auto-hide window — slightly longer than studies. */
+export const CFP_AUTO_HIDE_DAYS_PAST_DEADLINE = 21;
 
-export function isRecruiting(e: ResearchEntry): e is RecruitingEntry {
-  return e.type === "recruiting";
+export function isActiveResearch(e: ResearchEntry): e is ActiveResearchEntry {
+  return e.type === "active-research";
 }
-export function isPreprint(e: ResearchEntry): e is PreprintEntry {
-  return e.type === "preprint";
+export function isWorkingPaper(e: ResearchEntry): e is WorkingPaperEntry {
+  return e.type === "working-paper";
 }
 export function isDataset(e: ResearchEntry): e is DatasetEntry {
   return e.type === "dataset";
 }
+export function isCollaboration(e: ResearchEntry): e is CollaborationEntry {
+  return e.type === "collaboration";
+}
+export function isCfp(e: ResearchEntry): e is CfpEntry {
+  return e.type === "cfp";
+}
 
-export function isRecruitingPastDeadline(
-  e: RecruitingEntry,
+export function isActiveResearchPastDeadline(
+  e: ActiveResearchEntry,
   now: Date = new Date()
 ): boolean {
   return new Date(e.deadline).getTime() < now.getTime();
 }
 
-export function shouldAutoHideRecruiting(
-  e: RecruitingEntry,
+export function shouldAutoHideActiveResearch(
+  e: ActiveResearchEntry,
   now: Date = new Date()
 ): boolean {
-  if (!isRecruitingPastDeadline(e, now)) return false;
+  if (!isActiveResearchPastDeadline(e, now)) return false;
   const deadlineMs = new Date(e.deadline).getTime();
   const cutoffMs =
     deadlineMs +
     RECRUITING_AUTO_HIDE_DAYS_PAST_DEADLINE * 24 * 60 * 60 * 1000;
+  return now.getTime() > cutoffMs;
+}
+
+export function isCfpPastDeadline(
+  e: CfpEntry,
+  now: Date = new Date()
+): boolean {
+  return new Date(e.submissionDeadline).getTime() < now.getTime();
+}
+
+export function shouldAutoHideCfp(
+  e: CfpEntry,
+  now: Date = new Date()
+): boolean {
+  if (!isCfpPastDeadline(e, now)) return false;
+  const deadlineMs = new Date(e.submissionDeadline).getTime();
+  const cutoffMs =
+    deadlineMs + CFP_AUTO_HIDE_DAYS_PAST_DEADLINE * 24 * 60 * 60 * 1000;
   return now.getTime() > cutoffMs;
 }
 
@@ -205,15 +298,24 @@ export function sortByRecentlyActive(
   });
 }
 
-/** Visible feed: drops auto-hidden expired recruiting entries. */
+/** Visible feed: drops auto-hidden expired entries and explicit closures. */
 export function filterVisible(
   entries: LoadedResearchEntry[],
   now: Date = new Date()
 ): LoadedResearchEntry[] {
   return entries.filter(({ entry }) => {
-    if (entry.type !== "recruiting") return true;
-    if (entry.status === "closed") return false;
-    return !shouldAutoHideRecruiting(entry, now);
+    if (isActiveResearch(entry)) {
+      if (entry.status === "closed") return false;
+      return !shouldAutoHideActiveResearch(entry, now);
+    }
+    if (isCfp(entry)) {
+      if (entry.status === "closed") return false;
+      return !shouldAutoHideCfp(entry, now);
+    }
+    if (isCollaboration(entry)) {
+      return entry.status !== "closed";
+    }
+    return true;
   });
 }
 
@@ -222,15 +324,19 @@ export function isSample(entry: ResearchEntry): boolean {
 }
 
 export const RESEARCH_TYPE_LABEL: Record<ResearchType, string> = {
-  recruiting: "Recruiting",
-  preprint: "Preprint",
+  "active-research": "Active Research",
+  "working-paper": "Working Paper",
   dataset: "Dataset",
+  collaboration: "Collaboration",
+  cfp: "Call for Papers",
 };
 
 export const RESEARCH_TYPE_PLURAL: Record<ResearchType, string> = {
-  recruiting: "Recruiting calls",
-  preprint: "Preprints",
+  "active-research": "Active Research",
+  "working-paper": "Working Papers",
   dataset: "Datasets",
+  collaboration: "Collaboration",
+  cfp: "Calls for Papers",
 };
 
 /**


### PR DESCRIPTION
## Summary
Promotes the Research surface expansion to production.

## Included PRs
- **#1332** — feat(research): expand to 5 entry types + sparkle on Research nav — _Roger Hunt_
  - Renames: `recruiting` → `active-research`, `preprint` → `working-paper`
  - New types: `collaboration` (co-authors / co-investigators / replication partners) and `cfp` (upcoming conferences)
  - 7-pill filter row with per-type counts and per-type color coding
  - New collaboration + CFP detail sections; CFP gets a Conference site CTA
  - Gold sparkle indicator moved from PR Studio to Research
  - 4 new sample seed entries (2 collab, 2 CFP), all flagged `isSample`

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `SKIP_TYPECHECK=1 npm run build` — all 10 seed entries SSG'd
- [x] Local QA via browser: all 7 filter pills, collaboration + CFP detail pages render, sparkle moved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)