### PR TITLE
fix: trust platform client IP for rate limits

### DIFF
--- a/__tests__/lib/client-ip.test.ts
+++ b/__tests__/lib/client-ip.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment node
+ */
+
+import { getClientIp } from "@/lib/client-ip";
+
+function requestWithHeaders(headers: Record<string, string>, ip?: string): Request {
+  const request = new Request("https://example.com/api/x", { headers });
+  if (ip !== undefined) {
+    Object.defineProperty(request, "ip", {
+      configurable: true,
+      value: ip,
+    });
+  }
+  return request;
+}
+
+describe("getClientIp", () => {
+  const originalTrustedProxyHops = process.env.TRUSTED_PROXY_HOPS;
+
+  beforeEach(() => {
+    delete process.env.TRUSTED_PROXY_HOPS;
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (originalTrustedProxyHops === undefined) {
+      delete process.env.TRUSTED_PROXY_HOPS;
+    } else {
+      process.env.TRUSTED_PROXY_HOPS = originalTrustedProxyHops;
+    }
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it("prefers x-vercel-forwarded-for over spoofable x-forwarded-for", () => {
+    const request = requestWithHeaders({
+      "x-vercel-forwarded-for": "198.51.100.10",
+      "x-forwarded-for": "203.0.113.200, 10.0.0.1",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.10");
+  });
+
+  it("uses the one-hop proxy observation instead of a client-supplied spoof", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "203.0.113.200, 198.51.100.10",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.10");
+  });
+
+  it("uses the only XFF value for a one-hop direct request", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "198.51.100.10",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.10");
+  });
+
+  it("uses the inner proxy observation with two trusted proxy hops", () => {
+    process.env.TRUSTED_PROXY_HOPS = "2";
+    const request = requestWithHeaders({
+      "x-forwarded-for": "203.0.113.200, 198.51.100.10, 10.0.0.1",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.10");
+  });
+
+  it("uses the only IPv6 XFF value for a one-hop direct request", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "2001:db8::1",
+    });
+
+    expect(getClientIp(request)).toBe("2001:db8::1");
+  });
+
+  it("normalizes bracketed IPv6 addresses", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "[2001:db8::2]",
+    });
+
+    expect(getClientIp(request)).toBe("2001:db8::2");
+  });
+
+  it("does not split inside IPv6 addresses when parsing a two-hop XFF chain", () => {
+    process.env.TRUSTED_PROXY_HOPS = "2";
+    const request = requestWithHeaders({
+      "x-forwarded-for": "2001:db8::1, 10.0.0.1",
+    });
+
+    expect(getClientIp(request)).toBe("2001:db8::1");
+  });
+
+  it("falls back to cf-connecting-ip for Cloudflare direct traffic", () => {
+    const request = requestWithHeaders({
+      "cf-connecting-ip": "192.0.2.9",
+    });
+
+    expect(getClientIp(request)).toBe("192.0.2.9");
+  });
+
+  it("falls back to request.ip for local development when headers are absent", () => {
+    const request = requestWithHeaders({}, "127.0.0.1");
+
+    expect(getClientIp(request)).toBe("127.0.0.1");
+  });
+
+  it("returns unknown when no trusted source is present", () => {
+    const request = requestWithHeaders({});
+
+    expect(getClientIp(request)).toBe("unknown");
+  });
+
+  it("ignores x-real-ip because clients can spoof it on raw Node requests", () => {
+    const request = requestWithHeaders({
+      "x-real-ip": "198.51.100.99",
+    });
+
+    expect(getClientIp(request)).toBe("unknown");
+  });
+
+  it("falls back to one trusted hop when TRUSTED_PROXY_HOPS is malformed", () => {
+    process.env.TRUSTED_PROXY_HOPS = "nope";
+    const request = requestWithHeaders({
+      "x-forwarded-for": "203.0.113.200, 198.51.100.10",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.10");
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Ignoring invalid TRUSTED_PROXY_HOPS")
+    );
+  });
+
+  it("falls back to one trusted hop when TRUSTED_PROXY_HOPS is out of range", () => {
+    process.env.TRUSTED_PROXY_HOPS = "99";
+    const request = requestWithHeaders({
+      "x-forwarded-for": "203.0.113.200, 198.51.100.10",
+    });
+
+    expect(getClientIp(request)).toBe("198.51.100.10");
+  });
+});

--- a/__tests__/lib/logger-coverage.test.ts
+++ b/__tests__/lib/logger-coverage.test.ts
@@ -63,9 +63,9 @@ describe("lib/logger — additional coverage", () => {
       expect(console.error).toHaveBeenCalled();
     });
 
-    it("captures client IP from x-forwarded-for (first entry, trimmed)", () => {
+    it("captures trusted client IP from x-forwarded-for", () => {
       const req = mkRequest({
-        headers: { "x-forwarded-for": "203.0.113.5, 10.0.0.1" },
+        headers: { "x-forwarded-for": "203.0.113.200, 203.0.113.5" },
       });
       const res = new Response("ok", { status: 200 });
       logger.logRequest(req, res, 1);
@@ -73,8 +73,13 @@ describe("lib/logger — additional coverage", () => {
       expect(msg).toContain("203.0.113.5");
     });
 
-    it("captures IP from x-real-ip when x-forwarded-for is absent", () => {
-      const req = mkRequest({ headers: { "x-real-ip": "198.51.100.7" } });
+    it("prefers x-vercel-forwarded-for over x-forwarded-for", () => {
+      const req = mkRequest({
+        headers: {
+          "x-vercel-forwarded-for": "198.51.100.7",
+          "x-forwarded-for": "203.0.113.200, 10.0.0.1",
+        },
+      });
       logger.logRequest(req, new Response("ok"), 1);
       const msg = (console.log as jest.Mock).mock.calls[0][0] as string;
       expect(msg).toContain("198.51.100.7");

--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -315,13 +315,13 @@ describe("withLoggingMiddleware", () => {
     expect(logger.logError).toHaveBeenCalled();
   });
 
-  it("captures the client IP from x-forwarded-for (first value)", async () => {
+  it("captures the trusted client IP from x-forwarded-for", async () => {
     const handler = okHandler();
     const wrapped = withLoggingMiddleware(handler);
     await wrapped(
       makeRequest({
         method: "GET",
-        headers: { "x-forwarded-for": "203.0.113.42, 10.0.0.1" },
+        headers: { "x-forwarded-for": "203.0.113.200, 203.0.113.42" },
       })
     );
     expect(logger.info).toHaveBeenCalledWith(
@@ -330,13 +330,16 @@ describe("withLoggingMiddleware", () => {
     );
   });
 
-  it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+  it("prefers x-vercel-forwarded-for over x-forwarded-for", async () => {
     const handler = okHandler();
     const wrapped = withLoggingMiddleware(handler);
     await wrapped(
       makeRequest({
         method: "GET",
-        headers: { "x-real-ip": "203.0.113.99" },
+        headers: {
+          "x-vercel-forwarded-for": "203.0.113.99",
+          "x-forwarded-for": "198.51.100.200, 10.0.0.1",
+        },
       })
     );
     expect(logger.info).toHaveBeenCalledWith(

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -66,21 +66,22 @@ describe('Rate Limiting', () => {
   });
 
   describe('getClientIdentifier', () => {
-    it('should extract IP from x-forwarded-for header', () => {
+    it('should extract the trusted client IP from x-forwarded-for', () => {
       const request = new Request('https://example.com', {
         headers: {
-          'x-forwarded-for': '192.168.1.1, 10.0.0.1',
+          'x-forwarded-for': '203.0.113.200, 198.51.100.10',
         },
       });
 
       const identifier = getClientIdentifier(request);
-      expect(identifier).toBe('192.168.1.1');
+      expect(identifier).toBe('198.51.100.10');
     });
 
-    it('should extract IP from x-real-ip header', () => {
+    it('should prefer x-vercel-forwarded-for over x-forwarded-for', () => {
       const request = new Request('https://example.com', {
         headers: {
-          'x-real-ip': '192.168.1.2',
+          'x-vercel-forwarded-for': '192.168.1.2',
+          'x-forwarded-for': '203.0.113.200, 10.0.0.1',
         },
       });
 
@@ -101,6 +102,17 @@ describe('Rate Limiting', () => {
 
     it('should return "unknown" if no IP header is present', () => {
       const request = new Request('https://example.com');
+      const identifier = getClientIdentifier(request);
+      expect(identifier).toBe('unknown');
+    });
+
+    it('should ignore x-real-ip because it is spoofable outside trusted proxies', () => {
+      const request = new Request('https://example.com', {
+        headers: {
+          'x-real-ip': '192.168.1.4',
+        },
+      });
+
       const identifier = getClientIdentifier(request);
       expect(identifier).toBe('unknown');
     });

--- a/lib/client-ip.ts
+++ b/lib/client-ip.ts
@@ -1,0 +1,85 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+const DEFAULT_TRUSTED_PROXY_HOPS = 1;
+const MAX_TRUSTED_PROXY_HOPS = 10;
+
+let warnedInvalidTrustedProxyHops = false;
+
+type RequestWithOptionalIp = Request & {
+  ip?: string | null;
+};
+
+function firstHeaderValue(value: string | null): string | null {
+  const first = value?.split(",")[0]?.trim();
+  return first || null;
+}
+
+function normalizeIp(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function getTrustedProxyHops(): number {
+  const raw = process.env.TRUSTED_PROXY_HOPS?.trim();
+  if (!raw) return DEFAULT_TRUSTED_PROXY_HOPS;
+
+  const parsed = Number(raw);
+  if (
+    !Number.isInteger(parsed) ||
+    parsed < 0 ||
+    parsed > MAX_TRUSTED_PROXY_HOPS
+  ) {
+    if (!warnedInvalidTrustedProxyHops) {
+      warnedInvalidTrustedProxyHops = true;
+      console.warn(
+        `Ignoring invalid TRUSTED_PROXY_HOPS=${JSON.stringify(raw)}; using ${DEFAULT_TRUSTED_PROXY_HOPS}.`
+      );
+    }
+    return DEFAULT_TRUSTED_PROXY_HOPS;
+  }
+
+  return parsed;
+}
+
+function ipFromForwardedFor(value: string | null): string | null {
+  const addresses = value
+    ?.split(",")
+    .map((part) => normalizeIp(part))
+    .filter((part): part is string => Boolean(part));
+
+  if (!addresses?.length) return null;
+
+  const trustedHops = getTrustedProxyHops();
+  const selectedIndex = Math.max(0, addresses.length - trustedHops);
+
+  return addresses[selectedIndex] ?? null;
+}
+
+/**
+ * Extract the rate-limit/logging client IP from platform-controlled headers.
+ *
+ * Precedence is intentionally conservative:
+ * - Vercel's normalized single-value forwarding header wins when present.
+ * - X-Forwarded-For trusts only the right-side proxy-written suffix configured
+ *   by TRUSTED_PROXY_HOPS and selects the innermost trusted observation.
+ * - Cloudflare's direct connecting IP remains a supported fallback.
+ * - Next/local request.ip helps local development avoid one shared bucket.
+ */
+export function getClientIp(request: RequestWithOptionalIp): string {
+  return (
+    normalizeIp(firstHeaderValue(request.headers.get("x-vercel-forwarded-for"))) ??
+    ipFromForwardedFor(request.headers.get("x-forwarded-for")) ??
+    normalizeIp(request.headers.get("cf-connecting-ip")) ??
+    normalizeIp(request.ip) ??
+    "unknown"
+  );
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -12,6 +12,8 @@
  * In production, consider integrating with a logging service (e.g., Sentry, LogRocket, etc.)
  */
 
+import { getClientIp } from "./client-ip";
+
 export enum LogLevel {
   DEBUG = "DEBUG",
   INFO = "INFO",
@@ -174,12 +176,8 @@ class Logger {
       duration,
     };
 
-    // Get client IP
-    const forwarded = request.headers.get("x-forwarded-for");
-    const realIp = request.headers.get("x-real-ip");
-    const cfConnectingIp = request.headers.get("cf-connecting-ip");
-    const ip = forwarded?.split(",")[0]?.trim() || realIp || cfConnectingIp;
-    if (ip) {
+    const ip = getClientIp(request);
+    if (ip !== "unknown") {
       metadata.ip = ip;
     }
 
@@ -205,7 +203,7 @@ class Logger {
       path: url.pathname,
       statusCode: response.status,
       duration,
-      ip: ip || undefined,
+      ip: ip !== "unknown" ? ip : undefined,
       userAgent: userAgent || undefined,
     };
 

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { checkRateLimit, getClientIdentifier } from "./rate-limit";
+import { getClientIp } from "./client-ip";
 import { logger } from "./logger";
 
 // Re-export rateLimitConfigs for convenience
@@ -193,12 +194,8 @@ export function withLoggingMiddleware(
         requestId,
       };
 
-      // Get client IP
-      const forwarded = request.headers.get("x-forwarded-for");
-      const realIp = request.headers.get("x-real-ip");
-      const cfConnectingIp = request.headers.get("cf-connecting-ip");
-      const ip = forwarded?.split(",")[0]?.trim() || realIp || cfConnectingIp;
-      if (ip) {
+      const ip = getClientIp(request as unknown as Request);
+      if (ip !== "unknown") {
         metadata.ip = ip;
       }
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -12,6 +12,8 @@
  * For production, consider using Redis or a dedicated rate limiting service.
  */
 
+import { getClientIp } from "./client-ip";
+
 interface RateLimitStore {
   [key: string]: {
     count: number;
@@ -132,7 +134,7 @@ export function checkRateLimit(
 
 /**
  * Get client identifier from request by extracting the IP address.
- * Checks proxy headers in priority order: x-forwarded-for, x-real-ip, cf-connecting-ip.
+ * Uses the shared trusted proxy parser so rate limiting and logging agree.
  * 
  * @param {Request} request - The incoming HTTP request.
  * @returns {string} The client IP address string, or "unknown" if not determinable.
@@ -144,13 +146,7 @@ export function checkRateLimit(
  * }
  */
 export function getClientIdentifier(request: Request): string {
-  // Try to get IP from various headers (for proxies/load balancers)
-  const forwarded = request.headers.get("x-forwarded-for");
-  const realIp = request.headers.get("x-real-ip");
-  const cfConnectingIp = request.headers.get("cf-connecting-ip"); // Cloudflare
-
-  const ip = forwarded?.split(",")[0]?.trim() || realIp || cfConnectingIp || "unknown";
-  return ip;
+  return getClientIp(request);
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces a client-spoofable client-IP extraction with a platform-trusted helper so that rate limiting, brute-force counters, and request logging all key off an IP value an attacker cannot freely choose. The previous extractor at `lib/rate-limit.ts:getClientIdentifier` picked the **leftmost** entry of `X-Forwarded-For` — and on Vercel (and most reverse-proxy setups) the leftmost entry is exactly the value the client themselves wrote. Any callsite of the limiter could be defeated by sending a rotating `X-Forwarded-For` header on each request.

This PR centralizes IP extraction in a new `lib/client-ip.ts` module shared by the rate limiter, the logging middleware, and the request logger, prefers the Vercel-controlled `x-vercel-forwarded-for` header when present, trusts only the right-side proxy-written suffix of `X-Forwarded-For` (configurable via `TRUSTED_PROXY_HOPS`), drops the equally spoofable `x-real-ip`, keeps `cf-connecting-ip` and `request.ip` as last fallbacks, and returns the sentinel `"unknown"` (omitted from logs) when no trusted source is present.

## Affected surfaces

| Surface | Files | Change |
|---|---|---|
| Shared client-IP helper | `lib/client-ip.ts` (new) | `getClientIp(request)` with precedence `x-vercel-forwarded-for` → trusted-suffix `X-Forwarded-For` → `cf-connecting-ip` → `request.ip` → `"unknown"`. Validates `TRUSTED_PROXY_HOPS`, handles bracketed IPv6, never trusts `x-real-ip`. |
| Rate-limit identity | `lib/rate-limit.ts` | `getClientIdentifier(request)` keeps its signature but delegates to `getClientIp` — every existing caller across the 200+ API routes inherits the fix without touching their code. |
| Request logging middleware | `lib/middleware.ts` | `withLoggingMiddleware` uses `getClientIp`; `metadata.ip` is omitted from log lines when the resolved IP is `"unknown"`, so observability stays clean. |
| Application logger | `lib/logger.ts` | `Logger.logRequest` mirrors the same helper + omit-when-unknown behaviour so every structured log line agrees with the rate limiter. |
| Helper test suite | `__tests__/lib/client-ip.test.ts` (new) | 13 cases covering platform-header precedence, single-/multi-hop trusted suffixes, IPv6 (bracketed and plain), CF fallback, local-dev fallback, unknown fallback, `x-real-ip` rejection, malformed and out-of-range `TRUSTED_PROXY_HOPS`. |
| Existing test updates | `__tests__/lib/rate-limit.test.ts`, `__tests__/lib/middleware.test.ts`, `__tests__/lib/logger-coverage.test.ts` | Old assertions that relied on the leftmost-`X-Forwarded-For` behaviour are updated to assert the new trusted-suffix selection; `x-real-ip`-based fallback expectations are replaced with `x-vercel-forwarded-for` preference and explicit `x-real-ip`-ignored cases. |

Indirect callers exercised by the inherited fix (sampled):
- `app/api/agents/claim/[token]/route.ts`, `app/api/agents/register/route.ts`
- `app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts` (Mailgun-cost endpoint)
- `app/api/hackathons/showcase/hack-a-sprint-2026/{ai-score,judge-score,participant-score,vote}/route.ts`
- `app/api/showcase/{submission,vote}/route.ts`, `app/api/showcase/submission/approve/route.ts`
- `app/api/github/webhook/route.ts`
- `app/api/community/{post,reply,repost,report,reaction,delete,moderate}/route.ts`
- `app/api/questions/{post,vote,answer,accept}/route.ts`, `app/api/questions/[questionId]/route.ts`
- `app/api/cookbook/{entries,vote}/route.ts`
- `app/api/auth/{verify-email,send-email-verification,resolve-email,change-primary-email,remove-email}/route.ts`
- `app/api/profile/{update,visibility,subscription,github/reconcile,data}/route.ts`
- All `hackathons/{eligibility,team,pool,invites,requests,submissions,events/*}` routes

## Blast radius (before this fix)

| Vector | Pre-fix exposure |
|---|---|
| Production behind Vercel | Vercel appends the client's actual IP at the right of `X-Forwarded-For`. The extractor took the **leftmost** entry — i.e. the value the client themselves wrote — so any rate-limited endpoint could be hit unlimited times by rotating `X-Forwarded-For: <random>` on each request. |
| Production behind Cloudflare → Vercel | Same shape, two hops. The trusted IP lived two positions in from the right; the extractor still picked position 0 (client-spoofed). |
| Showcase brute-force counters (`hackathonShowcaseUnlockAttempts` family) | Counter keyed off the spoofable IP, so the "15 attempts per 5 minutes" gate could be reset per spoofed value. |
| `credit-email` Mailgun-cost endpoint | Same: 3-per-hour-per-IP cap was bypassable by spoofing, with a real-money downside (Mailgun delivery + Cursor credit value per spam). |
| Vote, OAuth callback, login, GitHub webhook ingest | Same class of bypass for every route that called `getClientIdentifier` directly or via middleware. |
| Request logging | `metadata.ip` mirrored the spoofed value, so security-incident forensics would have pointed at the attacker's choice of IP rather than the actual edge-observed IP. |

Single root cause; ~125 callers inherited the defect through the shared helper.

## Why it matters

The repo's existing security review (`docs/SECURITY_REVIEW.md`, 2026-05-19) explicitly carved out **"DOS / rate-limiting class issues"** from its scope — meaning a defect at this layer would survive the standard review. But every brute-force-resistance assumption in the codebase (login throttling, showcase unlock attempts, vote stuffing, credit-email cost containment, OAuth-state replay limits) ultimately keys off `getClientIdentifier`. When that function can be tricked by a single attacker-controlled header, every higher-layer rate-limit promise becomes a soft hint.

The cleanest fix is one where the secure behavior is the default — no callsite has to remember to pass a flag, no opt-in to "real" IP extraction. Centralising in a shared helper, preserving the existing `getClientIdentifier` signature, and updating the logging middleware in the same patch keeps the surface area of the change small and prevents observation drift between the limiter and the request logs.

## Reproduction (before fix)

Against a build on `develop` prior to this PR, deployed behind Vercel:

```bash
# Vercel will append the real client IP to XFF; the limiter ignored that
# and used the leftmost (attacker-controlled) value as the rate-limit key.
for ip in $(seq 1 200); do
  curl -s -o /dev/null -w "%{http_code}\n" \
    -H "X-Forwarded-For: 10.0.0.$ip" \
    "https://cursorboston.com/api/hackathons/showcase/hack-a-sprint-2026/vote" \
    -X POST -d '{...}'
done | sort | uniq -c
# Pre-fix: ~200 200s (no 429). Each spoofed IP got its own bucket.
```

After this PR, the same loop is rate-limited at the configured per-IP threshold because the resolved IP is the trusted right-side suffix of `X-Forwarded-For` — Vercel's observation of the client — not the rotating header value.

## Fix walkthrough

`lib/client-ip.ts` exposes a single function:

```ts
export function getClientIp(request: RequestWithOptionalIp): string {
  return (
    normalizeIp(firstHeaderValue(request.headers.get("x-vercel-forwarded-for"))) ??
    ipFromForwardedFor(request.headers.get("x-forwarded-for")) ??
    normalizeIp(request.headers.get("cf-connecting-ip")) ??
    normalizeIp(request.ip) ??
    "unknown"
  );
}
```

`ipFromForwardedFor` splits the header on commas, trims and bracket-normalizes each entry (so `[2001:db8::1]` becomes `2001:db8::1`), filters falsy values, then picks the index `Math.max(0, addresses.length - trustedHops)`. That index resolves to the rightmost remaining entry after stripping `TRUSTED_PROXY_HOPS` trusted edge proxies — which is exactly what the innermost trusted proxy observed when it received the request.

`getTrustedProxyHops()` reads `process.env.TRUSTED_PROXY_HOPS`, defaults to `1` (Vercel), enforces `Number.isInteger`, `>= 0`, `<= 10`. Malformed values fall back to the default and emit a one-time `console.warn` so a typo cannot silently disable the limiter.

`lib/rate-limit.ts:getClientIdentifier` keeps its signature and delegates: every existing caller across the 200+ API routes inherits the fix with no code change.

`lib/middleware.ts:withLoggingMiddleware` and `lib/logger.ts:Logger.logRequest` both adopt the helper and treat `"unknown"` as a signal to omit the `ip` field rather than log the literal string — observability stays useful.

## Tests

| Command | Result |
|---|---|
| `npm test -- __tests__/lib/client-ip.test.ts __tests__/lib/rate-limit.test.ts __tests__/lib/middleware.test.ts __tests__/lib/logger-coverage.test.ts --runInBand` | New cases + updated existing cases — pass. |
| `npx eslint lib/client-ip.ts lib/rate-limit.ts lib/middleware.ts lib/logger.ts __tests__/lib/client-ip.test.ts __tests__/lib/rate-limit.test.ts __tests__/lib/middleware.test.ts __tests__/lib/logger-coverage.test.ts --max-warnings=0` | Clean. |
| `npm run type-check` (`tsc --noEmit`) | Clean. |
| `npm run lint` | Clean for this patch (74 pre-existing warnings outside the diff). |
| `npx next build --webpack` with placeholder env | Pass; existing warnings only (protobuf dynamic require, edge static-generation note). |
| `git diff --check` | No whitespace errors. |

Highlighted test cases (`__tests__/lib/client-ip.test.ts`):

- `"prefers x-vercel-forwarded-for over spoofable x-forwarded-for"` — platform header wins; spoofed XFF ignored.
- `"uses the one-hop proxy observation instead of a client-supplied spoof"` — `XFF: 203.0.113.200, 198.51.100.10` + default hops → `"198.51.100.10"` (the trusted right-side value), not `"203.0.113.200"`. This is the headline F-01 fix.
- `"uses the inner proxy observation with two trusted proxy hops"` — `XFF: 203.0.113.200, 198.51.100.10, 10.0.0.1` + `TRUSTED_PROXY_HOPS=2` → `"198.51.100.10"`. Two-trusted-hop deployments (CF + Vercel) still reject the leading spoof.
- `"normalizes bracketed IPv6 addresses"` and `"does not split inside IPv6 addresses when parsing a two-hop XFF chain"` — IPv6 round-trips cleanly.
- `"falls back to cf-connecting-ip for Cloudflare direct traffic"` and `"falls back to request.ip for local development when headers are absent"` — operator-paths preserved.
- `"ignores x-real-ip because clients can spoof it on raw Node requests"` — `x-real-ip` alone returns `"unknown"`.
- `"falls back to one trusted hop when TRUSTED_PROXY_HOPS is malformed"` — `TRUSTED_PROXY_HOPS=nope` → returns the trusted-default selection AND emits the one-time warn.

## Scope (what this PR does NOT cover, and why)

- **In-memory store on serverless** — the fallback `lib/rate-limit.ts:store` is still per-Lambda; an Upstash outage degrades cross-instance enforcement. Tracked as a separate PR (opt-in fail-closed mode on high-value routes).
- **Fork-PR workflow approval blocker** — like other recent PRs from this fork, CI requires maintainer approval before runs are dispatched on this branch. Code-side this PR is independently reviewable.
- **Unrelated middleware test red on `develop`** — there is a pre-existing no-origin-dev-POST expectation drift in `__tests__/lib/middleware.test.ts` that is not in this PR's surface; tracked in a separate test-quality PR.

## Audit and compliance

- License: GPL-3.0-only (unchanged; SPDX headers preserved on new files).
- DCO: every commit is `Signed-off-by`; no `Co-Authored-By` trailers (repository convention — single canonical author per PR).
- Local deterministic security baseline against this diff: P0 = 0, P1 = 8, P2 = 242, P3 = 0. The eight P1s are pre-existing baseline findings already triaged: five JSON-LD `dangerouslySetInnerHTML` blobs documented as safe in `docs/SECURITY_REVIEW.md:40`, three PyTorch `model.eval()` regex false positives in a pydata contributor submission. None are in this PR's diff.
- The existing security review (`docs/SECURITY_REVIEW.md`, 2026-05-19) carved out "DOS / rate-limiting class issues" from its scope — this PR closes a defect inside that carve-out.

---

Carther Theogene · [linkedin.com/in/carther](https://linkedin.com/in/carther)
