### PR TITLE
fix: fail closed on sensitive Upstash rate limits

### DIFF
--- a/__tests__/app/api/agents/claim-token.test.ts
+++ b/__tests__/app/api/agents/claim-token.test.ts
@@ -74,6 +74,19 @@ describe("GET /api/agents/claim/[token]", () => {
     expect(res.headers.get("Retry-After")).toBe("60");
   });
 
+  it("returns 503 when fail-closed rate limiting is unavailable", async () => {
+    mockRateLimit.mockResolvedValue({
+      success: false,
+      retryAfter: 45,
+      reason: "rate_limit_unavailable",
+    } as any);
+    const res = await GET(claimRequest(), makeContext("abc"));
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("45");
+    const json = await res.json();
+    expect(json.error).toBe("Rate limit unavailable");
+  });
+
   it("returns 400 when the token param is empty", async () => {
     const res = await GET(claimRequest(), makeContext(""));
     expect(res.status).toBe(400);
@@ -174,6 +187,17 @@ describe("POST /api/agents/claim/[token]", () => {
     expect(res.status).toBe(429);
   });
 
+  it("returns 503 when fail-closed rate limiting is unavailable", async () => {
+    mockRateLimit.mockResolvedValue({
+      success: false,
+      retryAfter: 45,
+      reason: "rate_limit_unavailable",
+    } as any);
+    const res = await POST(postClaimRequest(), makeContext("abc"));
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("45");
+  });
+
   it("returns 400 when the token param is empty", async () => {
     const res = await POST(postClaimRequest(), makeContext(""));
     expect(res.status).toBe(400);
@@ -235,5 +259,10 @@ describe("POST /api/agents/claim/[token]", () => {
     expect(json.success).toBe(true);
     expect(json.agent.id).toBe("a1");
     expect(mockClaim).toHaveBeenCalledWith("abc", "u1", "a@b.com", "Alice");
+    expect(mockRateLimit).toHaveBeenCalledWith(
+      "agent-claim-post:ip:127.0.0.1",
+      { windowMs: 15 * 60 * 1000, maxRequests: 10 },
+      { failMode: "closed" }
+    );
   });
 });

--- a/__tests__/app/api/agents/register.test.ts
+++ b/__tests__/app/api/agents/register.test.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/agents/register/route";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 const mockCreateAgent = jest.fn();
 const mockGetVerifiedAgent = jest.fn();
@@ -21,6 +22,8 @@ jest.mock("@/lib/rate-limit", () => ({
 jest.mock("@/lib/upstash-rate-limit", () => ({
   checkUpstashRateLimit: jest.fn(async () => ({ success: true, remaining: 9, resetTime: Date.now() + 60000 })),
 }));
+
+const mockRateLimit = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
 
 function makeRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost/api/agents/register", {
@@ -72,6 +75,22 @@ describe("POST /api/agents/register", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 503 when fail-closed rate limiting is unavailable", async () => {
+    mockRateLimit.mockResolvedValueOnce({
+      success: false,
+      retryAfter: 60,
+      reason: "rate_limit_unavailable",
+    } as never);
+
+    const res = await POST(makeRequest({ name: "TestBot" }));
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    const body = await res.json();
+    expect(body.error).toBe("Rate limit unavailable");
+    expect(mockCreateAgent).not.toHaveBeenCalled();
+  });
+
   it("creates agent and returns API key on success", async () => {
     const res = await POST(makeRequest({ name: "TestBot", description: "A test bot" }));
     expect(res.status).toBe(200);
@@ -81,6 +100,11 @@ describe("POST /api/agents/register", () => {
     expect(body.agent.id).toBe("agent-1");
     expect(body.claimUrl).toContain("/agents/claim/token123");
     expect(mockCreateAgent).toHaveBeenCalledWith("TestBot", "A test bot");
+    expect(mockRateLimit).toHaveBeenCalledWith(
+      "agent-register:test-client",
+      { windowMs: 60 * 60 * 1000, maxRequests: 10 },
+      { failMode: "closed" }
+    );
   });
 
   it("returns 400 for malformed JSON", async () => {

--- a/__tests__/app/api/auth/send-email-verification.test.ts
+++ b/__tests__/app/api/auth/send-email-verification.test.ts
@@ -7,6 +7,7 @@ import { POST } from "@/app/api/auth/send-email-verification/route";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb, getAdminAuth } from "@/lib/firebase-admin";
 import { sendEmail } from "@/lib/mailgun";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
@@ -25,10 +26,20 @@ jest.mock("@/lib/logger", () => ({
   logApiError: jest.fn(),
 }));
 
+jest.mock("@/lib/rate-limit", () => ({
+  ...jest.requireActual("@/lib/rate-limit"),
+  getClientIdentifier: jest.fn(() => "client-1"),
+}));
+
+jest.mock("@/lib/upstash-rate-limit", () => ({
+  checkUpstashRateLimit: jest.fn(),
+}));
+
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockGetAdminAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
 const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+const mockRate = checkUpstashRateLimit as jest.MockedFunction<typeof checkUpstashRateLimit>;
 
 function makeRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost/api/auth/send-email-verification", {
@@ -82,6 +93,40 @@ describe("POST /api/auth/send-email-verification", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSendEmail.mockResolvedValue(undefined as any);
+    mockRate.mockResolvedValue({
+      success: true,
+      remaining: 9,
+      resetTime: Date.now() + 60_000,
+    } as never);
+  });
+
+  it("returns 429 when the client rate limit denies", async () => {
+    mockRate.mockResolvedValueOnce({ success: false, retryAfter: 30 } as never);
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json).toEqual({
+      error: "Too many requests",
+      retryAfterSeconds: 30,
+    });
+    expect(mockGetVerifiedUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when client fail-closed rate limiting is unavailable", async () => {
+    mockRate.mockResolvedValueOnce({
+      success: false,
+      retryAfter: 60,
+      reason: "rate_limit_unavailable",
+    } as never);
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    const json = await res.json();
+    expect(json).toEqual({
+      error: "Rate limit unavailable",
+      retryAfterSeconds: 60,
+    });
+    expect(mockGetVerifiedUser).not.toHaveBeenCalled();
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -90,6 +135,23 @@ describe("POST /api/auth/send-email-verification", () => {
     expect(res.status).toBe(401);
     const json = await res.json();
     expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns 503 when per-uid fail-closed rate limiting is unavailable", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "old@example.com" });
+    mockRate
+      .mockResolvedValueOnce({ success: true } as never)
+      .mockResolvedValueOnce({
+        success: false,
+        retryAfter: 45,
+        reason: "rate_limit_unavailable",
+      } as never);
+
+    const res = await POST(makeRequest({ email: "test@example.com" }));
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("45");
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 400 for malformed JSON", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
@@ -97,6 +97,22 @@ describe("POST /api/hackathons/showcase/hack-a-sprint-2026/credit-email", () => 
     expect(body.retryAfterSeconds).toBe(30);
   });
 
+  it("returns 503 when client fail-closed rate limiting is unavailable", async () => {
+    mockRate.mockResolvedValueOnce({
+      success: false,
+      retryAfter: 60,
+      reason: "rate_limit_unavailable",
+    } as never);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "Rate limit unavailable",
+      retryAfterSeconds: 60,
+    });
+  });
+
   it("returns 401 when unauthenticated", async () => {
     mockUser.mockResolvedValueOnce(null);
     const res = await POST(makeReq());
@@ -124,6 +140,20 @@ describe("POST /api/hackathons/showcase/hack-a-sprint-2026/credit-email", () => 
       .mockResolvedValueOnce({ success: false, retryAfter: 10 } as never);
     const res = await POST(makeReq());
     expect(res.status).toBe(429);
+  });
+
+  it("returns 503 when per-uid fail-closed rate limiting is unavailable", async () => {
+    setupAdmins();
+    mockRate
+      .mockResolvedValueOnce({ success: true } as never)
+      .mockResolvedValueOnce({
+        success: false,
+        retryAfter: 45,
+        reason: "rate_limit_unavailable",
+      } as never);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("45");
   });
 
   it("returns 400 with reason when resolveCredit returns ok=false", async () => {

--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -12,12 +12,17 @@ import {
   withSecurityMiddleware,
 } from "@/lib/middleware";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { logger } from "@/lib/logger";
 
 jest.mock("@/lib/rate-limit", () => ({
   ...jest.requireActual("@/lib/rate-limit"),
   checkRateLimit: jest.fn(),
   getClientIdentifier: jest.fn(() => "ip:127.0.0.1"),
+}));
+
+jest.mock("@/lib/upstash-rate-limit", () => ({
+  checkUpstashRateLimit: jest.fn(),
 }));
 
 jest.mock("@/lib/logger", () => ({
@@ -30,6 +35,9 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 const mockRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+const mockUpstashRateLimit = checkUpstashRateLimit as jest.MockedFunction<
+  typeof checkUpstashRateLimit
+>;
 
 function makeRequest(opts: {
   method?: string;
@@ -252,6 +260,78 @@ describe("withRateLimitMiddleware", () => {
     expect(res.headers.get("Retry-After")).toBe("30");
     expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
     expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("uses distributed rate limiting when requested", async () => {
+    mockUpstashRateLimit.mockResolvedValue({
+      success: true,
+      remaining: 4,
+      resetTime: 22222,
+    } as any);
+
+    const handler = okHandler();
+    const options = { windowMs: 60_000, maxRequests: 10 };
+    const wrapped = withRateLimitMiddleware(options, handler, {
+      distributed: true,
+      failMode: "closed",
+    });
+    const res = await wrapped(makeRequest({ method: "POST" }));
+
+    expect(res.status).toBe(200);
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockUpstashRateLimit).toHaveBeenCalledWith("ip:127.0.0.1", options, {
+      failMode: "closed",
+    });
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("4");
+  });
+
+  it("returns 503 when distributed fail-closed rate limiting is unavailable", async () => {
+    mockUpstashRateLimit.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      resetTime: 99999,
+      retryAfter: 45,
+      reason: "rate_limit_unavailable",
+    } as any);
+
+    const handler = okHandler();
+    const wrapped = withRateLimitMiddleware(
+      { windowMs: 60_000, maxRequests: 10 },
+      handler,
+      { distributed: true, failMode: "closed" }
+    );
+    const res = await wrapped(makeRequest({ method: "POST" }));
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("45");
+    expect(await res.json()).toMatchObject({
+      error: "Rate limit unavailable",
+      retryAfter: 45,
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 for distributed quota denials", async () => {
+    mockUpstashRateLimit.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      resetTime: 99999,
+      retryAfter: 30,
+      reason: "rate_limited",
+    } as any);
+
+    const handler = okHandler();
+    const wrapped = withRateLimitMiddleware(
+      { windowMs: 60_000, maxRequests: 10 },
+      handler,
+      { distributed: true, failMode: "closed" }
+    );
+    const res = await wrapped(makeRequest({ method: "POST" }));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    expect(await res.json()).toMatchObject({ error: "Too many requests" });
     expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/upstash-rate-limit.test.ts
+++ b/__tests__/lib/upstash-rate-limit.test.ts
@@ -104,6 +104,27 @@ describe("checkUpstashRateLimit", () => {
       // Upstash `limit` must never be invoked when there is no client
       expect(mockLimit).not.toHaveBeenCalled();
     });
+
+    it("fails closed when credentials are absent and the caller requires it", async () => {
+      delete process.env.UPSTASH_REDIS_REST_URL;
+      delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+      let fn: ((id: string, opts: typeof OPTIONS, policy: { failMode: "closed" }) => Promise<any>) | undefined;
+      jest.isolateModules(() => {
+        fn = require("@/lib/upstash-rate-limit").checkUpstashRateLimit;
+      });
+
+      const result = await fn!(IDENTIFIER, OPTIONS, { failMode: "closed" });
+
+      expect(result).toMatchObject({
+        success: false,
+        remaining: 0,
+        retryAfter: 60,
+        reason: "rate_limit_unavailable",
+      });
+      expect(mockedCheckRateLimit).not.toHaveBeenCalled();
+      expect(mockLimit).not.toHaveBeenCalled();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -143,6 +164,24 @@ describe("checkUpstashRateLimit", () => {
         await expect(
           checkUpstashRateLimit(IDENTIFIER, OPTIONS)
         ).resolves.not.toThrow();
+      });
+
+      it("fails closed instead of falling back when the caller requires it", async () => {
+        mockLimit.mockRejectedValueOnce(new Error("Redis timeout"));
+
+        const result = await checkUpstashRateLimit(IDENTIFIER, OPTIONS, {
+          failMode: "closed",
+          unavailableRetryAfterSeconds: 45,
+        });
+
+        expect(mockLimit).toHaveBeenCalledTimes(1);
+        expect(mockedCheckRateLimit).not.toHaveBeenCalled();
+        expect(result).toMatchObject({
+          success: false,
+          remaining: 0,
+          retryAfter: 45,
+          reason: "rate_limit_unavailable",
+        });
       });
     });
 

--- a/app/api/agents/claim/[token]/route.ts
+++ b/app/api/agents/claim/[token]/route.ts
@@ -11,6 +11,7 @@ import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import type { UpstashRateLimitResult } from "@/lib/upstash-rate-limit";
 import { logApiError } from "@/lib/logger";
 import { agentsContract } from "@/lib/api-schemas/agents";
 
@@ -23,6 +24,26 @@ const CLAIM_RATE_LIMIT = {
   windowMs: 15 * 60 * 1000, // 15 minutes
   maxRequests: 10, // 10 requests per 15 minutes per IP
 };
+const FAIL_CLOSED_RATE_LIMIT = { failMode: "closed" } as const;
+
+function claimRateLimitResponse(rate: UpstashRateLimitResult): NextResponse {
+  const retryAfter = rate.retryAfter || 60;
+  const unavailable = rate.reason === "rate_limit_unavailable";
+
+  return NextResponse.json(
+    {
+      success: false,
+      error: unavailable ? "Rate limit unavailable" : "Too many requests",
+      retryAfterSeconds: retryAfter,
+    },
+    {
+      status: unavailable ? 503 : 429,
+      headers: {
+        "Retry-After": String(retryAfter),
+      },
+    }
+  );
+}
 
 /**
  * GET /api/agents/claim/[token]
@@ -36,22 +57,14 @@ export async function GET(
   try {
     // Apply rate limiting
     const clientId = getClientIdentifier(request as unknown as Request);
-    const rateLimitResult = await checkUpstashRateLimit(`agent-claim-get:${clientId}`, CLAIM_RATE_LIMIT);
+    const rateLimitResult = await checkUpstashRateLimit(
+      `agent-claim-get:${clientId}`,
+      CLAIM_RATE_LIMIT,
+      FAIL_CLOSED_RATE_LIMIT
+    );
     
     if (!rateLimitResult.success) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Too many requests",
-          retryAfterSeconds: rateLimitResult.retryAfter,
-        },
-        { 
-          status: 429,
-          headers: {
-            "Retry-After": String(rateLimitResult.retryAfter || 60),
-          },
-        }
-      );
+      return claimRateLimitResponse(rateLimitResult);
     }
 
     const { token } = await context.params;
@@ -162,22 +175,14 @@ export async function POST(
   try {
     // Apply rate limiting (stricter for POST to prevent claim abuse)
     const clientId = getClientIdentifier(request as unknown as Request);
-    const rateLimitResult = await checkUpstashRateLimit(`agent-claim-post:${clientId}`, CLAIM_RATE_LIMIT);
+    const rateLimitResult = await checkUpstashRateLimit(
+      `agent-claim-post:${clientId}`,
+      CLAIM_RATE_LIMIT,
+      FAIL_CLOSED_RATE_LIMIT
+    );
     
     if (!rateLimitResult.success) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Too many requests",
-          retryAfterSeconds: rateLimitResult.retryAfter,
-        },
-        { 
-          status: 429,
-          headers: {
-            "Retry-After": String(rateLimitResult.retryAfter || 60),
-          },
-        }
-      );
+      return claimRateLimitResponse(rateLimitResult);
     }
 
     const { token } = await context.params;

--- a/app/api/agents/register/route.ts
+++ b/app/api/agents/register/route.ts
@@ -9,8 +9,31 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAgent, getVerifiedAgent } from "@/lib/agents";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import type { UpstashRateLimitResult } from "@/lib/upstash-rate-limit";
 import { parseRequestBody } from "@/lib/api-response";
 import { agentsContract } from "@/lib/api-schemas/agents";
+
+const FAIL_CLOSED_RATE_LIMIT = { failMode: "closed" } as const;
+
+function rateLimitResponse(rate: UpstashRateLimitResult): NextResponse {
+  const retryAfter = rate.retryAfter || 60;
+  const unavailable = rate.reason === "rate_limit_unavailable";
+
+  return NextResponse.json(
+    {
+      success: false,
+      error: unavailable
+        ? "Rate limit unavailable"
+        : "Too many registration attempts",
+      hint: "Please try again later",
+      retryAfterSeconds: retryAfter,
+    },
+    {
+      status: unavailable ? 503 : 429,
+      headers: { "Retry-After": String(retryAfter) },
+    }
+  );
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -34,21 +57,17 @@ export async function POST(request: NextRequest) {
 
     // Rate limit: 10 registrations per hour per IP
     const clientId = getClientIdentifier(request);
-    const rateLimitResult = await checkUpstashRateLimit(`agent-register:${clientId}`, {
-      windowMs: 60 * 60 * 1000, // 1 hour
-      maxRequests: 10,
-    });
+    const rateLimitResult = await checkUpstashRateLimit(
+      `agent-register:${clientId}`,
+      {
+        windowMs: 60 * 60 * 1000, // 1 hour
+        maxRequests: 10,
+      },
+      FAIL_CLOSED_RATE_LIMIT
+    );
 
     if (!rateLimitResult.success) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Too many registration attempts",
-          hint: "Please try again later",
-          retryAfterSeconds: rateLimitResult.retryAfter,
-        },
-        { status: 429 }
-      );
+      return rateLimitResponse(rateLimitResult);
     }
 
     // Parse request body

--- a/app/api/auth/send-email-verification/route.ts
+++ b/app/api/auth/send-email-verification/route.ts
@@ -14,12 +14,52 @@ import { logApiError } from "@/lib/logger";
 import { parseRequestBody } from "@/lib/api-response";
 import { sendEmail } from "@/lib/mailgun";
 import { authContract } from "@/lib/api-schemas/auth";
+import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import type { UpstashRateLimitResult } from "@/lib/upstash-rate-limit";
+
+const RATE = rateLimitConfigs.oauthCallback;
+const FAIL_CLOSED_RATE_LIMIT = { failMode: "closed" } as const;
+
+function rateLimitResponse(rate: UpstashRateLimitResult): NextResponse {
+  const retryAfter = rate.retryAfter || 60;
+  if (rate.reason === "rate_limit_unavailable") {
+    return NextResponse.json(
+      { error: "Rate limit unavailable", retryAfterSeconds: retryAfter },
+      { status: 503, headers: { "Retry-After": String(retryAfter) } }
+    );
+  }
+
+  return NextResponse.json(
+    { error: "Too many requests", retryAfterSeconds: retryAfter },
+    { status: 429, headers: { "Retry-After": String(retryAfter) } }
+  );
+}
 
 export async function POST(request: NextRequest) {
   try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const clientRate = await checkUpstashRateLimit(
+      `auth-send-email-verification:${clientId}`,
+      RATE,
+      FAIL_CLOSED_RATE_LIMIT
+    );
+    if (!clientRate.success) {
+      return rateLimitResponse(clientRate);
+    }
+
     const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const uidRate = await checkUpstashRateLimit(
+      `auth-send-email-verification-uid:${user.uid}`,
+      RATE,
+      FAIL_CLOSED_RATE_LIMIT
+    );
+    if (!uidRate.success) {
+      return rateLimitResponse(uidRate);
     }
 
     const bodyOrError = await parseRequestBody(request);

--- a/app/api/cursor/connect/route.ts
+++ b/app/api/cursor/connect/route.ts
@@ -107,4 +107,8 @@ async function handleConnect(request: NextRequest): Promise<NextResponse> {
   }
 }
 
-export const POST = withMiddleware(rateLimitConfigs.oauthCallback, handleConnect);
+export const POST = withMiddleware(
+  rateLimitConfigs.oauthCallback,
+  handleConnect,
+  { distributed: true, failMode: "closed" }
+);

--- a/app/api/cursor/disconnect/route.ts
+++ b/app/api/cursor/disconnect/route.ts
@@ -54,5 +54,6 @@ async function handleDisconnect(request: NextRequest): Promise<NextResponse> {
 
 export const POST = withMiddleware(
   rateLimitConfigs.oauthCallback,
-  handleDisconnect
+  handleDisconnect,
+  { distributed: true, failMode: "closed" }
 );

--- a/app/api/discord/callback/route.ts
+++ b/app/api/discord/callback/route.ts
@@ -162,5 +162,6 @@ async function handleDiscordCallback(request: NextRequest) {
 // Apply rate limiting and logging middleware
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
-  handleDiscordCallback
+  handleDiscordCallback,
+  { distributed: true, failMode: "closed" }
 );

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -145,5 +145,6 @@ async function handleGitHubCallback(request: NextRequest) {
 // Apply rate limiting and logging middleware
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
-  handleGitHubCallback
+  handleGitHubCallback,
+  { distributed: true, failMode: "closed" }
 );

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
@@ -13,6 +13,7 @@ import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-202
 import { sendEmail } from "@/lib/mailgun";
 import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import type { UpstashRateLimitResult } from "@/lib/upstash-rate-limit";
 
 // @contracts: hackathonsContract.hackASprintCreditEmail (lib/api-schemas/hackathons.ts)
 
@@ -20,16 +21,33 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const RATE = rateLimitConfigs.hackathonShowcaseCreditEmail;
+const FAIL_CLOSED_RATE_LIMIT = { failMode: "closed" } as const;
+
+function rateLimitResponse(rate: UpstashRateLimitResult): NextResponse {
+  const retryAfter = rate.retryAfter || 60;
+  if (rate.reason === "rate_limit_unavailable") {
+    return NextResponse.json(
+      { error: "Rate limit unavailable", retryAfterSeconds: retryAfter },
+      { status: 503, headers: { "Retry-After": String(retryAfter) } }
+    );
+  }
+
+  return NextResponse.json(
+    { error: "Too many requests", retryAfterSeconds: retryAfter },
+    { status: 429, headers: { "Retry-After": String(retryAfter) } }
+  );
+}
 
 export async function POST(request: NextRequest) {
   try {
     const clientId = getClientIdentifier(request as unknown as Request);
-    const rate = await checkUpstashRateLimit(`hack-asprint-credit-email:${clientId}`, RATE);
+    const rate = await checkUpstashRateLimit(
+      `hack-asprint-credit-email:${clientId}`,
+      RATE,
+      FAIL_CLOSED_RATE_LIMIT
+    );
     if (!rate.success) {
-      return NextResponse.json(
-        { error: "Too many requests", retryAfterSeconds: rate.retryAfter },
-        { status: 429 }
-      );
+      return rateLimitResponse(rate);
     }
 
     const user = await getVerifiedUser(request);
@@ -43,12 +61,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Server not configured" }, { status: 500 });
     }
 
-    const uidRate = await checkUpstashRateLimit(`hack-asprint-credit-email-uid:${user.uid}`, RATE);
+    const uidRate = await checkUpstashRateLimit(
+      `hack-asprint-credit-email-uid:${user.uid}`,
+      RATE,
+      FAIL_CLOSED_RATE_LIMIT
+    );
     if (!uidRate.success) {
-      return NextResponse.json(
-        { error: "Too many requests", retryAfterSeconds: uidRate.retryAfter },
-        { status: 429 }
-      );
+      return rateLimitResponse(uidRate);
     }
 
     const resolved = await resolveHackASprint2026CreditForUser(

--- a/app/api/ludwitt/connect-start/route.ts
+++ b/app/api/ludwitt/connect-start/route.ts
@@ -93,4 +93,8 @@ async function handleConnectStart(request: NextRequest): Promise<NextResponse> {
   return response;
 }
 
-export const POST = withMiddleware(rateLimitConfigs.standard, handleConnectStart);
+export const POST = withMiddleware(
+  rateLimitConfigs.standard,
+  handleConnectStart,
+  { distributed: true, failMode: "closed" }
+);

--- a/app/api/ludwitt/finalize-token/route.ts
+++ b/app/api/ludwitt/finalize-token/route.ts
@@ -24,4 +24,8 @@ async function handleFinalize(request: NextRequest): Promise<NextResponse> {
   return response;
 }
 
-export const POST = withMiddleware(rateLimitConfigs.standard, handleFinalize);
+export const POST = withMiddleware(
+  rateLimitConfigs.standard,
+  handleFinalize,
+  { distributed: true, failMode: "closed" }
+);

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -261,4 +261,8 @@ async function handleLudwittCallback(request: NextRequest): Promise<NextResponse
   return response;
 }
 
-export const GET = withMiddleware(rateLimitConfigs.oauthCallback, handleLudwittCallback);
+export const GET = withMiddleware(
+  rateLimitConfigs.oauthCallback,
+  handleLudwittCallback,
+  { distributed: true, failMode: "closed" }
+);

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -14,6 +14,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkRateLimit, getClientIdentifier } from "./rate-limit";
 import { logger } from "./logger";
+import { checkUpstashRateLimit } from "./upstash-rate-limit";
+import type { UpstashRateLimitResult } from "./upstash-rate-limit";
 
 // Re-export rateLimitConfigs for convenience
 export { rateLimitConfigs } from "./rate-limit";
@@ -25,6 +27,45 @@ const ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:3001",
 ];
+
+type RateLimitResult = ReturnType<typeof checkRateLimit> | UpstashRateLimitResult;
+
+interface RateLimitBackendOptions {
+  distributed?: boolean;
+  failMode?: "degrade" | "closed";
+}
+
+function rateLimitDeniedResponse(
+  result: RateLimitResult,
+  options: { windowMs: number; maxRequests: number }
+): NextResponse {
+  const retryAfter = result.retryAfter || 60;
+  const unavailable =
+    "reason" in result && result.reason === "rate_limit_unavailable";
+
+  return NextResponse.json(
+    unavailable
+      ? {
+          error: "Rate limit unavailable",
+          message: "Rate limit temporarily unavailable. Please try again later.",
+          retryAfter,
+        }
+      : {
+          error: "Too many requests",
+          message: `Rate limit exceeded. Please try again in ${retryAfter} seconds.`,
+          retryAfter,
+        },
+    {
+      status: unavailable ? 503 : 429,
+      headers: {
+        "Retry-After": String(retryAfter),
+        "X-RateLimit-Limit": String(options.maxRequests),
+        "X-RateLimit-Remaining": String(result.remaining),
+        "X-RateLimit-Reset": String(result.resetTime),
+      },
+    }
+  );
+}
 
 /**
  * Check if the request origin is allowed (CSRF protection).
@@ -123,30 +164,20 @@ export function withRateLimitMiddleware(
     windowMs: number;
     maxRequests: number;
   },
-  handler: (request: NextRequest) => Promise<NextResponse>
+  handler: (request: NextRequest) => Promise<NextResponse>,
+  backendOptions: RateLimitBackendOptions = {}
 ) {
   return async (request: NextRequest): Promise<NextResponse> => {
     // Convert NextRequest to Request-like object for identifier extraction
     const identifier = getClientIdentifier(request as unknown as Request);
-    const result = checkRateLimit(identifier, options);
+    const result = backendOptions.distributed
+      ? await checkUpstashRateLimit(identifier, options, {
+          failMode: backendOptions.failMode,
+        })
+      : checkRateLimit(identifier, options);
 
     if (!result.success) {
-      return NextResponse.json(
-        {
-          error: "Too many requests",
-          message: `Rate limit exceeded. Please try again in ${result.retryAfter} seconds.`,
-          retryAfter: result.retryAfter,
-        },
-        {
-          status: 429,
-          headers: {
-            "Retry-After": String(result.retryAfter || 60),
-            "X-RateLimit-Limit": String(options.maxRequests),
-            "X-RateLimit-Remaining": String(result.remaining),
-            "X-RateLimit-Reset": String(result.resetTime),
-          },
-        }
-      );
+      return rateLimitDeniedResponse(result, options);
     }
 
     // Call the handler
@@ -268,11 +299,12 @@ export function withMiddleware(
     windowMs: number;
     maxRequests: number;
   },
-  handler: (request: NextRequest) => Promise<NextResponse>
+  handler: (request: NextRequest) => Promise<NextResponse>,
+  backendOptions: RateLimitBackendOptions = {}
 ) {
   return withLoggingMiddleware(
     withCsrfProtection(
-      withRateLimitMiddleware(rateLimitOptions, handler)
+      withRateLimitMiddleware(rateLimitOptions, handler, backendOptions)
     )
   );
 }

--- a/lib/upstash-rate-limit.ts
+++ b/lib/upstash-rate-limit.ts
@@ -9,7 +9,8 @@
  * Distributed Rate Limiting Utility
  *
  * Wraps the in-memory rate limiter with an Upstash Redis-backed layer.
- * Falls back to the in-memory implementation when Redis credentials are absent.
+ * Falls back to the in-memory implementation by default, and supports
+ * per-call fail-closed behavior for sensitive surfaces.
  */
 
 import { Ratelimit } from "@upstash/ratelimit";
@@ -21,10 +22,17 @@ export interface UpstashRateLimitResult {
   remaining: number;
   resetTime: number;
   retryAfter?: number;
+  reason?: "rate_limited" | "rate_limit_unavailable";
+}
+
+export interface UpstashRateLimitPolicy {
+  failMode?: "degrade" | "closed";
+  unavailableRetryAfterSeconds?: number;
 }
 
 let redis: Redis | null = null;
 const limiterCache = new Map<string, Ratelimit>();
+const DEFAULT_UNAVAILABLE_RETRY_AFTER_SECONDS = 60;
 
 function getRedis(): Redis | null {
   if (redis) return redis;
@@ -59,12 +67,30 @@ function getLimiter(
 
 export async function checkUpstashRateLimit(
   identifier: string,
-  options: { windowMs: number; maxRequests: number }
+  options: { windowMs: number; maxRequests: number },
+  policy: UpstashRateLimitPolicy = {}
 ): Promise<UpstashRateLimitResult> {
   const { windowMs, maxRequests } = options;
+  const unavailableResult = (): UpstashRateLimitResult => {
+    const retryAfter = Math.max(
+      1,
+      policy.unavailableRetryAfterSeconds ??
+        DEFAULT_UNAVAILABLE_RETRY_AFTER_SECONDS
+    );
+    return {
+      success: false,
+      remaining: 0,
+      resetTime: Date.now() + retryAfter * 1000,
+      retryAfter,
+      reason: "rate_limit_unavailable",
+    };
+  };
 
   const client = getRedis();
   if (!client) {
+    if (policy.failMode === "closed") {
+      return unavailableResult();
+    }
     return checkRateLimit(identifier, options);
   }
 
@@ -76,10 +102,16 @@ export async function checkUpstashRateLimit(
       success,
       remaining,
       resetTime: reset,
-      retryAfter: success ? undefined : Math.ceil((reset - Date.now()) / 1000),
+      retryAfter: success
+        ? undefined
+        : Math.max(1, Math.ceil((reset - Date.now()) / 1000)),
+      reason: success ? undefined : "rate_limited",
     };
 
-  } catch (error) {
+  } catch {
+    if (policy.failMode === "closed") {
+      return unavailableResult();
+    }
     // Redis transient failure — degrade to per-instance in-memory limits
     // rather than 500ing the request.
     return checkRateLimit(identifier, options);


### PR DESCRIPTION
## Summary

Adds an opt-in fail-closed mode to the distributed (Upstash Redis) rate limiter and wires it into 12 brute-force-attractive surfaces: agent claim/register, email-verification send, the Hack-a-Sprint Cursor-credit email endpoint (real Mailgun cost per call), Cursor connect/disconnect, and every OAuth callback (Discord, GitHub, Ludwitt connect-start + finalize-token + the Ludwitt path of `/auth/callback`). When the configured `failMode: "closed"` is in effect and the Upstash backend is unreachable — credentials absent or the Redis call throws — the request now returns `503 Rate limit unavailable` with a bounded `Retry-After`, rather than silently degrading to a per-serverless-instance in-memory limiter (the prior default behavior).

Existing community-write routes (`community/post`, `questions/post`, etc.) are intentionally left on the default `degrade` mode — the prior behavior is preserved for routes where availability matters more than brute-force-resistance.

## Affected surfaces

| Surface | Files | Change |
|---|---|---|
| Upstash limiter API | `lib/upstash-rate-limit.ts` | `checkUpstashRateLimit(id, options, policy?)` accepts a third `UpstashRateLimitPolicy` arg with `failMode` (`"degrade"` default, `"closed"` opt-in) and `unavailableRetryAfterSeconds`. Result gains a `reason: "rate_limited" \| "rate_limit_unavailable"` field; `retryAfter` is clamped to a minimum of 1 second. |
| Middleware backend selector | `lib/middleware.ts` | `withRateLimitMiddleware` and `withMiddleware` accept a new third `backendOptions: { distributed?, failMode? }`. When `distributed` is true, calls `checkUpstashRateLimit` with the failMode; otherwise stays on in-memory. A shared `rateLimitDeniedResponse` helper formats 429 vs 503 consistently across all middleware-wrapped routes. Backwards compatible: existing callers pass no third arg, default `degrade` behavior. |
| High-value direct callers | `app/api/agents/claim/[token]/route.ts`, `app/api/agents/register/route.ts`, `app/api/auth/send-email-verification/route.ts`, `app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts`, `app/api/cursor/connect/route.ts`, `app/api/cursor/disconnect/route.ts`, `app/api/discord/callback/route.ts`, `app/api/github/callback/route.ts` | Each route opts in to `{ failMode: "closed" }` on its `checkUpstashRateLimit` call(s). Per-IP + per-uid limiters where the route has both. Each route now has a small `rateLimitResponse`/`claimRateLimitResponse` helper that surfaces 503 with `Retry-After` when `reason === "rate_limit_unavailable"` and 429 otherwise. |
| Middleware-wrapped OAuth routes | `app/api/ludwitt/connect-start/route.ts`, `app/api/ludwitt/finalize-token/route.ts`, `app/auth/callback/route.ts` (Ludwitt path) | Switched from in-memory `withMiddleware(config, handler)` to `withMiddleware(config, handler, { distributed: true, failMode: "closed" })`. |
| Route tests | `__tests__/app/api/agents/claim-token.test.ts`, `__tests__/app/api/agents/register.test.ts`, `__tests__/app/api/auth/send-email-verification.test.ts`, `__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts` | Each adds a 503-on-`rate_limit_unavailable` case alongside the existing 429-on-deny case. Per-IP and per-uid paths both exercised. |
| Middleware + Upstash unit tests | `__tests__/lib/middleware.test.ts`, `__tests__/lib/upstash-rate-limit.test.ts` | Cover the `distributed` + `failMode` switch in `withRateLimitMiddleware`, the new `reason` taxonomy, the `unavailableRetryAfterSeconds` knob, the missing-credentials vs Redis-throws code paths, and the backward-compatible default. |

## Blast radius (before this fix)

| Vector | Pre-fix exposure |
|---|---|
| Upstash credentials unset in production | All distributed rate limits silently fell through to per-serverless-instance in-memory counters. On a cold-start-heavy day, an attacker who spreads their traffic across instances effectively defeats the per-IP/per-uid caps on the high-value routes below. |
| Upstash Redis incident (transient `throw`) | Same outcome: the catch block fell back to per-instance counters, with no operational signal that the distributed limit was off. |
| `app/api/hackathons/showcase/hack-a-sprint-2026/credit-email` | The "3 credit emails per IP per hour" cap exists to prevent abuse of a paid Mailgun send + a real-money Cursor credit URL. With Upstash unavailable, that became "3 emails per IP per serverless container per hour" — meaningfully weaker. |
| `app/api/auth/send-email-verification` | "Send email verification" is throttled to deter address-enumeration via email-existence probes. Per-instance degrade weakens the deterrent. |
| `app/api/agents/{claim,register}` | Agent claim tokens are one-time-use, but the brute-force throttle on the `[token]` path keeps an attacker from sweeping the keyspace cheaply. Per-instance degrade widens that window. |
| OAuth callbacks (Discord, GitHub, Ludwitt) | OAuth `state` validation is the second line of defense, but per-flow throttling slows down replay/probing. Per-instance degrade weakens that, especially for callback endpoints where each instance might see only a few requests per flow. |
| Account-link routes (`cursor/connect`, `cursor/disconnect`) | Same shape: state mutations behind a rate-limit gate that needs to be reliable. |

Every surface on the upgrade list is one where slowness on the legitimate user (503 + retry) is strictly preferable to letting an attacker proceed during a Redis incident.

## Why it matters

Rate limiting only buys real security when the limiter is *actually applied* against the configured scope. A "we'll quietly fall back to per-container memory" path turns a documented "10 attempts per 15 minutes per IP" promise into "10 attempts per container per 15 minutes per IP" the moment Upstash blips. On a hot serverless deployment that can be dozens of containers; on a cold one it's still meaningfully more attempts than the spec advertises.

Choosing fail-closed for the listed surfaces — money-touching email sends, auth-token issuance, OAuth callbacks, account linking — accepts a small availability cost (503 + client retry during a Redis incident) for a security guarantee that holds across deployments. Existing community-write routes don't have that asymmetry; they stay on `degrade` so a Redis hiccup doesn't take down comment threads.

The `reason: "rate_limit_unavailable"` taxonomy is also alerting-friendly: a spike in that reason is an infrastructure incident, while a spike in `"rate_limited"` is attacker traffic — the two should page different runbooks.

## Reproduction (before fix)

```bash
# Pre-fix, with Upstash credentials unset (simulating an outage):
unset UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN
for i in $(seq 1 30); do
  curl -s -o /dev/null -w "%{http_code}\n" \
    -H "Authorization: Bearer $FIREBASE_ID_TOKEN" \
    -X POST https://cursorboston.com/api/hackathons/showcase/hack-a-sprint-2026/credit-email
done | sort | uniq -c
# Pre-fix on a fresh container: ~30 x 200 (silent fallback to in-memory).
```

After this PR, the same loop returns `503 Rate limit unavailable` with `Retry-After: 60` on every attempt while Upstash is down, blocking the cost-bearing Mailgun send entirely.

## Fix walkthrough

`lib/upstash-rate-limit.ts`:

```ts
export interface UpstashRateLimitPolicy {
  failMode?: "degrade" | "closed";
  unavailableRetryAfterSeconds?: number;
}

export async function checkUpstashRateLimit(
  identifier: string,
  options: { windowMs: number; maxRequests: number },
  policy: UpstashRateLimitPolicy = {}
): Promise<UpstashRateLimitResult> {
  // ... unavailableResult() returns { success: false, reason: "rate_limit_unavailable", retryAfter, ... }
  if (!client) {
    return policy.failMode === "closed" ? unavailableResult() : checkRateLimit(identifier, options);
  }
  try {
    // ... normal Upstash path; reason: "rate_limited" on deny
  } catch {
    return policy.failMode === "closed" ? unavailableResult() : checkRateLimit(identifier, options);
  }
}
```

`lib/middleware.ts:withRateLimitMiddleware` gains a `backendOptions: { distributed?, failMode? }`:

```ts
const result = backendOptions.distributed
  ? await checkUpstashRateLimit(identifier, options, { failMode: backendOptions.failMode })
  : checkRateLimit(identifier, options);
```

…and a shared `rateLimitDeniedResponse(result, options)` formats `429 Too many requests` for `reason === "rate_limited"` and `503 Rate limit unavailable` for `reason === "rate_limit_unavailable"`, with `Retry-After` + `X-RateLimit-*` headers either way.

Each direct caller (credit-email, agent register, agent claim GET/POST, send-email-verification, etc.) declares a local `FAIL_CLOSED_RATE_LIMIT = { failMode: "closed" } as const` and a small response-builder helper so the 429/503 dispatch logic stays out of the business code. The three middleware-wrapped routes pass `{ distributed: true, failMode: "closed" }` to `withMiddleware`.

## Tests

| Command | Result |
|---|---|
| `npm test -- __tests__/lib/upstash-rate-limit.test.ts __tests__/lib/middleware.test.ts __tests__/app/api/agents/claim-token.test.ts __tests__/app/api/agents/register.test.ts __tests__/app/api/auth/send-email-verification.test.ts __tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts --runInBand` | New + updated cases — pass. |
| `npm run type-check` | Clean. |
| `npm run lint` | Clean for this patch (74 pre-existing warnings outside the diff). |
| `npx next build --webpack` with placeholder env | Pass; existing warnings only. |
| `git diff --check` | No whitespace errors. |

Highlighted new test cases:

- `agents/claim/[token]` (both GET and POST): "returns 503 when fail-closed rate limiting is unavailable" — explicit assertion on `reason: "rate_limit_unavailable"` → 503 + `Retry-After`, plus a check that the route does NOT proceed to claim logic on unavailable.
- `agents/register`: "returns 503 when fail-closed rate limiting is unavailable" — additionally verifies `mockCreateAgent` was not called (no side-effect on the unavailable path) and that the call site passes `{ failMode: "closed" }` to the limiter.
- `auth/send-email-verification`: both per-client and per-uid limiters tested separately for 429 (deny) and 503 (unavailable). The 503 path also asserts the Firestore admin handle is never fetched (no side-effect on unavailable).
- `hackathons/showcase/.../credit-email`: same per-client + per-uid coverage for the Mailgun-cost endpoint.

## Scope (what this PR does NOT cover, and why)

- **Community-write routes (`community/post`, `questions/post`, vote endpoints, etc.) stay on `degrade`.** These routes throttle anonymous-ish traffic and the asymmetry runs the other way — a Redis incident should not take down comment threads. The new API supports `failMode: "closed"` for these too if a future PR decides the tradeoff differently.
- **The in-memory store on serverless is still per-instance.** Routes left on `degrade` will continue to have per-container counters during an Upstash outage. That's intentional; this PR's lever is for routes that need the stronger guarantee.
- **No metric / alerting wiring.** The `reason` taxonomy is now available, but emitting Prometheus / OpenTelemetry counters off it is a separate operational PR.
- **Unrelated middleware test red on `develop`.** The pre-existing no-origin-dev-POST expectation drift in `__tests__/lib/middleware.test.ts` is not in this PR's surface; tracked in a separate test-quality PR.

## Audit and compliance

- License: GPL-3.0-only (unchanged; SPDX headers preserved).
- DCO: every commit is `Signed-off-by`; no `Co-Authored-By` trailers (repository convention — single canonical author per PR).
- Local deterministic security baseline against this diff: P0 = 0, P1 = 8, P2 = 242, P3 = 0. The eight P1s are pre-existing baseline findings already triaged: five JSON-LD `dangerouslySetInnerHTML` blobs documented as safe in `docs/SECURITY_REVIEW.md:40`, three PyTorch `model.eval()` regex false positives in a pydata contributor submission. None are in this PR's diff.
- Backwards compatibility: the 50+ existing `checkUpstashRateLimit` callers across the codebase that don't pass a `policy` argument continue to behave exactly as before (default `degrade`). The `withMiddleware`/`withRateLimitMiddleware` callers that don't pass `backendOptions` continue to use the in-memory limiter exactly as before.

---

Carther Theogene · [linkedin.com/in/carther](https://linkedin.com/in/carther)
