### PR TITLE
fix: stop public members snapshot rebuild

### DIFF
--- a/__tests__/app/api/members/public.route.test.ts
+++ b/__tests__/app/api/members/public.route.test.ts
@@ -73,7 +73,7 @@ describe("GET /api/members/public", () => {
     expect(mockRebuild).not.toHaveBeenCalled();
   });
 
-  it("rebuilds when snapshot is expired", async () => {
+  it("returns stale snapshot data when the snapshot is expired", async () => {
     setupSnapshot({
       exists: true,
       data: {
@@ -81,39 +81,44 @@ describe("GET /api/members/public", () => {
         expiresAt: new Date(Date.now() - 60_000),
       },
     });
-    mockRebuild.mockResolvedValue([{ uid: "fresh" }] as never);
 
     const res = await GET();
-    await expect(res.json()).resolves.toEqual({ members: [{ uid: "fresh" }] });
-    expect(mockRebuild).toHaveBeenCalledTimes(1);
+    await expect(res.json()).resolves.toEqual({ members: [{ uid: "stale" }] });
+    expect(res.headers.get("X-Members-Snapshot-Stale")).toBe("true");
+    expect(mockRebuild).not.toHaveBeenCalled();
   });
 
-  it("returns stale fallback when rebuild fails", async () => {
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  it("returns empty snapshot data without rebuilding", async () => {
     setupSnapshot({
       exists: true,
       data: {
-        members: [{ uid: "stale-fallback" }],
-        expiresAt: new Date(Date.now() - 60_000),
+        members: [],
+        expiresAt: new Date(Date.now() + 60_000),
       },
     });
-    mockRebuild.mockRejectedValue(new Error("rebuild failed"));
 
     const res = await GET();
     await expect(res.json()).resolves.toEqual({
-      members: [{ uid: "stale-fallback" }],
+      members: [],
     });
-
-    consoleErrorSpy.mockRestore();
+    expect(mockRebuild).not.toHaveBeenCalled();
   });
 
-  it("returns empty members when snapshot load fails and rebuild fails", async () => {
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    setupSnapshot({ getThrows: true });
-    mockRebuild.mockRejectedValue(new Error("rebuild failed"));
+  it("returns empty members when the snapshot doc is missing", async () => {
+    setupSnapshot({ exists: false });
 
     const res = await GET();
     await expect(res.json()).resolves.toEqual({ members: [] });
+    expect(mockRebuild).not.toHaveBeenCalled();
+  });
+
+  it("returns empty members when snapshot load fails", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    setupSnapshot({ getThrows: true });
+
+    const res = await GET();
+    await expect(res.json()).resolves.toEqual({ members: [] });
+    expect(mockRebuild).not.toHaveBeenCalled();
 
     consoleErrorSpy.mockRestore();
   });

--- a/__tests__/app/api/members/public/route.test.ts
+++ b/__tests__/app/api/members/public/route.test.ts
@@ -4,10 +4,7 @@
 
 import { GET } from "@/app/api/members/public/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import {
-  computePublicMembersSnapshot,
-  rebuildPublicMembersSnapshot,
-} from "@/lib/members-public-snapshot";
+import { rebuildPublicMembersSnapshot } from "@/lib/members-public-snapshot";
 import type { PublicMember } from "@/types/members";
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -16,14 +13,10 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 jest.mock("@/lib/members-public-snapshot", () => ({
   MEMBERS_SNAPSHOT_CACHE_TTL_MS: 6 * 60 * 60 * 1000,
-  computePublicMembersSnapshot: jest.fn(),
   rebuildPublicMembersSnapshot: jest.fn(),
 }));
 
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
-const mockComputePublicMembersSnapshot = computePublicMembersSnapshot as jest.MockedFunction<
-  typeof computePublicMembersSnapshot
->;
 const mockRebuildPublicMembersSnapshot = rebuildPublicMembersSnapshot as jest.MockedFunction<
   typeof rebuildPublicMembersSnapshot
 >;
@@ -53,6 +46,17 @@ function mockDbWithSnapshot(snapshotData: Record<string, unknown> | null) {
   return { db, get, set };
 }
 
+function mockDbWithSnapshotError(error: Error) {
+  const get = jest.fn().mockRejectedValue(error);
+  const db = {
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({ get })),
+    })),
+  };
+  mockGetAdminDb.mockReturnValue(db as never);
+  return { db, get };
+}
+
 describe("GET /api/members/public", () => {
   let consoleErrorSpy: jest.SpyInstance;
 
@@ -77,40 +81,64 @@ describe("GET /api/members/public", () => {
 
     expect(res.status).toBe(200);
     expect(body.members).toEqual([member]);
-    expect(mockComputePublicMembersSnapshot).not.toHaveBeenCalled();
     expect(mockRebuildPublicMembersSnapshot).not.toHaveBeenCalled();
     expect(set).not.toHaveBeenCalled();
   });
 
-  it("rebuilds and stores the snapshot when the existing snapshot is empty", async () => {
-    const member = buildMember({ uid: "u2", displayName: "Public Member" });
+  it("returns an empty stored snapshot without rebuilding", async () => {
     const { set } = mockDbWithSnapshot({
       members: [],
       expiresAt: new Date(Date.now() + 60_000),
     });
-    mockRebuildPublicMembersSnapshot.mockResolvedValue([member]);
 
     const res = await GET();
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.members).toEqual([member]);
-    expect(mockRebuildPublicMembersSnapshot).toHaveBeenCalledTimes(1);
+    expect(body.members).toEqual([]);
+    expect(mockRebuildPublicMembersSnapshot).not.toHaveBeenCalled();
     expect(set).not.toHaveBeenCalled();
   });
 
-  it("falls back to stale snapshot data if the rebuild fails", async () => {
+  it("serves stale snapshot data without rebuilding", async () => {
     const member = buildMember({ uid: "stale" });
     mockDbWithSnapshot({
       members: [member],
       expiresAt: new Date(Date.now() - 60_000),
     });
-    mockRebuildPublicMembersSnapshot.mockRejectedValue(new Error("rebuild failed"));
 
     const res = await GET();
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(body.members).toEqual([member]);
+    expect(res.headers.get("X-Members-Snapshot-Stale")).toBe("true");
+    expect(mockRebuildPublicMembersSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when no snapshot exists", async () => {
+    mockDbWithSnapshot(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.members).toEqual([]);
+    expect(mockRebuildPublicMembersSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when the snapshot read fails", async () => {
+    mockDbWithSnapshotError(new Error("snapshot read failed"));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.members).toEqual([]);
+    expect(mockRebuildPublicMembersSnapshot).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[api/members/public] Failed to load members snapshot",
+      expect.any(Error)
+    );
   });
 });

--- a/app/api/members/public/route.ts
+++ b/app/api/members/public/route.ts
@@ -7,10 +7,7 @@
 
 import { NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import {
-  rebuildPublicMembersSnapshot,
-  MEMBERS_SNAPSHOT_CACHE_TTL_MS,
-} from "@/lib/members-public-snapshot";
+import { MEMBERS_SNAPSHOT_CACHE_TTL_MS } from "@/lib/members-public-snapshot";
 import type { PublicMember } from "@/types/members";
 
 // @contracts: membersContract.publicList (lib/api-schemas/members.ts)
@@ -18,6 +15,9 @@ import type { PublicMember } from "@/types/members";
 export const runtime = "nodejs";
 
 const REVALIDATE_SECONDS = 300;
+const cacheHeaders = {
+  "Cache-Control": `public, max-age=60, s-maxage=${REVALIDATE_SECONDS}, stale-while-revalidate=${REVALIDATE_SECONDS * 2}`,
+};
 
 function snapshotTimeMs(value: unknown): number | null {
   if (!value) return null;
@@ -43,11 +43,14 @@ function snapshotIsFresh(data: Record<string, unknown> | undefined): boolean {
   return updatedAtMs !== null && Date.now() - updatedAtMs < MEMBERS_SNAPSHOT_CACHE_TTL_MS;
 }
 
-async function loadPublicMembersFromSnapshot(): Promise<PublicMember[]> {
-  const db = getAdminDb();
-  if (!db) return [];
+type PublicMembersSnapshotResult = {
+  members: PublicMember[];
+  isStale: boolean;
+};
 
-  let fallbackMembers: PublicMember[] = [];
+async function loadPublicMembersFromSnapshot(): Promise<PublicMembersSnapshotResult> {
+  const db = getAdminDb();
+  if (!db) return { members: [], isStale: false };
 
   try {
     const snap = await db.collection("members_snapshots").doc("latest").get();
@@ -55,35 +58,30 @@ async function loadPublicMembersFromSnapshot(): Promise<PublicMember[]> {
       const data = snap.data();
       const members = data?.members;
       if (Array.isArray(members)) {
-        fallbackMembers = members as PublicMember[];
-        if (members.length > 0 && snapshotIsFresh(data)) {
-          return fallbackMembers;
-        }
+        return {
+          members: members as PublicMember[],
+          isStale: !snapshotIsFresh(data),
+        };
       }
     }
   } catch (e) {
     console.error("[api/members/public] Failed to load members snapshot", e);
   }
 
-  try {
-    const members = await rebuildPublicMembersSnapshot(db);
-    return members;
-  } catch (e) {
-    console.error("[api/members/public] Failed to rebuild members snapshot fallback", e);
-    return fallbackMembers;
-  }
+  return { members: [], isStale: false };
 }
 
 export async function GET() {
   try {
-    const members = await loadPublicMembersFromSnapshot();
+    const { members, isStale } = await loadPublicMembersFromSnapshot();
+    const headers: Record<string, string> = { ...cacheHeaders };
+    if (isStale) {
+      headers["X-Members-Snapshot-Stale"] = "true";
+    }
+
     return NextResponse.json(
       { members },
-      {
-        headers: {
-          "Cache-Control": `public, max-age=60, s-maxage=${REVALIDATE_SECONDS}, stale-while-revalidate=${REVALIDATE_SECONDS * 2}`,
-        },
-      }
+      { headers }
     );
   } catch (e) {
     console.error("[api/members/public]", e);


### PR DESCRIPTION
## Summary

Removes a denial-of-service amplification path on the unauthenticated `GET /api/members/public` endpoint. Before this PR, when the cached `members_snapshots/latest` document was missing, empty, or stale, the public route would trigger `rebuildPublicMembersSnapshot(db)` — a full directory scan over `users` (filtered by `visibility.isPublic == true`) joined with `agents` (filtered by `visibility.isPublic == true && status == "claimed"`) — on the public request thread. A small flood of anonymous GETs against this endpoint during a brief cache lapse could drive a sustained large Firestore read storm.

`lib/members-public-snapshot.ts:36-37` already documented this constraint: *"Full directory read — run only from snapshot rebuild (cron/CLI), not from public GET."* The public route was violating that contract.

After this PR, the public GET serves whatever the stored snapshot contains (fresh or stale), returns an empty list when no snapshot exists or the read errors, and never triggers the heavy directory scan. A `X-Members-Snapshot-Stale: true` response header lets observability detect when the snapshot needs a cron-driven refresh.

## Affected surfaces

| Surface | Files | Change |
|---|---|---|
| Public members endpoint | `app/api/members/public/route.ts` | Drops the `rebuildPublicMembersSnapshot` import + call entirely. `loadPublicMembersFromSnapshot()` now returns `{ members, isStale }`; the GET handler serves the snapshot as-is and sets `X-Members-Snapshot-Stale: true` when freshness checks fail. Missing/erroring snapshot returns `{ members: [] }`. `Cache-Control` headers preserved. |
| Route tests | `__tests__/app/api/members/public.route.test.ts`, `__tests__/app/api/members/public/route.test.ts` | Removes the obsolete "rebuilds when snapshot is expired" / "rebuilds and stores the snapshot when the existing snapshot is empty" expectations. Adds explicit cases for: stale snapshot served as-is with `X-Members-Snapshot-Stale: true`, empty stored snapshot returned unchanged, missing snapshot doc returns `[]`, snapshot read failure returns `[]` and logs the error. Every test asserts `mockRebuild.not.toHaveBeenCalled()`. |

## Blast radius (before this fix)

| Vector | Pre-fix exposure |
|---|---|
| Snapshot doc missing (first deploy, post-incident wipe) | Every anonymous GET to `/api/members/public` triggered `rebuildPublicMembersSnapshot(db)`. The rebuild reads the entire `users` and `agents` collections (filtered, but unbounded) on each call until the first rebuild persists a snapshot. |
| Snapshot doc expired (TTL is 6h per `MEMBERS_SNAPSHOT_CACHE_TTL_MS`) | Same rebuild fired on the public path. With a small request flood, multiple concurrent rebuilds could pile on before any one wrote a fresh doc. |
| Snapshot members array empty (no public profiles yet) | Same rebuild fired. The directory scan continued on every public hit until at least one public profile existed AND the snapshot was rewritten. |
| Snapshot read errored (transient Firestore issue) | Fell through to a rebuild attempt — read storm during the underlying outage. |
| DoS amplification ratio | 1 unauthenticated request → 1 `where("visibility.isPublic", "==", true).orderBy("createdAt", "desc").get()` on `users` + the equivalent on `agents`. Linear in collection size; uncached; no rate limit on this surface (it's public). |

`docs/SECURITY_REVIEW.md` (2026-05-19) carved out "DOS / rate-limiting class issues" from its scope. This is squarely in that gap.

## Why it matters

The snapshot doc exists exactly so that the public path doesn't fan out into a directory-wide query — it's a cache materialised by a cron job (`MEMBERS_SNAPSHOT_CACHE_TTL_MS = 6 * 60 * 60 * 1000` = 6 hours). The public route was treating the cache as best-effort and silently degrading to the heavy read on miss, which inverted the design: under healthy conditions the snapshot is hot and the rebuild never fires, but under exactly the conditions you want the cache (cold start, recent deploy, traffic burst), the rebuild fired on the public path and amplified the load.

Decoupling the public path from the rebuild also makes the snapshot's freshness contract auditable: the snapshot is whatever the cron job last wrote, period. An operator who sees the `X-Members-Snapshot-Stale: true` header on responses can trigger an out-of-band rebuild via the existing cron-side entry point rather than relying on user traffic to refresh the cache.

## Reproduction (before fix)

```bash
# In a Firestore environment, manually clear or expire the snapshot:
gcloud firestore documents delete --project=cursor-boston members_snapshots/latest

# Then issue a small flood:
for i in $(seq 1 50); do
  curl -s -o /dev/null https://cursorboston.com/api/members/public &
done
wait

# Pre-fix, Firestore audit log shows ~50 full-collection scans of `users` and `agents`
# until the first parallel rebuild completes and writes the snapshot back.
```

After this PR, the same flood returns `{"members": []}` (with `X-Members-Snapshot-Stale: true` if a stale snapshot exists, omitted if no snapshot at all), with zero `users` / `agents` collection reads. Recovery is the responsibility of the cron job, not anonymous request handlers.

## Fix walkthrough

`app/api/members/public/route.ts`:

```ts
// Before: returned PublicMember[]; called rebuildPublicMembersSnapshot on miss.
async function loadPublicMembersFromSnapshot(): Promise<PublicMembersSnapshotResult> {
  const db = getAdminDb();
  if (!db) return { members: [], isStale: false };

  try {
    const snap = await db.collection("members_snapshots").doc("latest").get();
    if (snap.exists) {
      const data = snap.data();
      const members = data?.members;
      if (Array.isArray(members)) {
        return {
          members: members as PublicMember[],
          isStale: !snapshotIsFresh(data),
        };
      }
    }
  } catch (e) {
    console.error("[api/members/public] Failed to load members snapshot", e);
  }

  return { members: [], isStale: false };
}
```

The GET handler returns the snapshot as-is. When `isStale` is true, the response carries `X-Members-Snapshot-Stale: true`. `rebuildPublicMembersSnapshot` is no longer imported by this file — there is no code path from a public request to a full-directory read.

## Tests

| Command | Result |
|---|---|
| `npm test -- __tests__/app/api/members/public.route.test.ts __tests__/app/api/members/public/route.test.ts --runInBand` | New + updated cases — pass. |
| `npm run type-check` | Clean. |
| `npm run lint` | Clean for this patch (74 pre-existing warnings outside the diff). |
| `npx next build --webpack` with placeholder env | Pass; existing warnings only. |
| `git diff --check` | No whitespace errors. |

Highlighted test cases (both test files):

- `"returns stale snapshot data when the snapshot is expired"` — expired snapshot is served as-is, header `X-Members-Snapshot-Stale: true` is set, **`mockRebuild` is not called**.
- `"returns empty snapshot data without rebuilding"` (or `"returns an empty stored snapshot without rebuilding"`) — snapshot with `members: []` is served as `{ members: [] }`, **no rebuild**.
- `"returns empty members when the snapshot doc is missing"` (or `"returns an empty list when no snapshot exists"`) — missing snapshot returns `{ members: [] }`, **no rebuild**.
- `"returns empty members when snapshot load fails"` (or `"returns an empty list when the snapshot read fails"`) — Firestore read throws, the route returns `{ members: [] }` and logs the error, **no rebuild**.

The "rebuilds when snapshot is expired" / "rebuilds and stores the snapshot when the existing snapshot is empty" cases that previously locked in the buggy behavior are removed.

## Scope (what this PR does NOT cover, and why)

- **The cron rebuild itself is unchanged.** `rebuildPublicMembersSnapshot` and `computePublicMembersSnapshot` in `lib/members-public-snapshot.ts` still exist for the scheduled job that owns the cache. Only the public request handler is divorced from that path.
- **No new rate limiting on `/api/members/public`.** With the rebuild gone, the public path is now a single document read per request — well within Firestore's per-document quota. Adding a limiter on top is out of scope for this fix.
- **Cron alerting on stale snapshots.** The `X-Members-Snapshot-Stale: true` header is added, but a Prometheus / OpenTelemetry counter or alert rule is a separate operational PR.
- **No retroactive snapshot population on deploy.** If the cron has never run, the public endpoint will return `{ members: [] }` until the first cron pass. That's acceptable — a deploy-time bootstrap is out of scope and the cron handles it on its next tick.

## Audit and compliance

- License: GPL-3.0-only (unchanged; SPDX header preserved).
- DCO: every commit is `Signed-off-by`; no `Co-Authored-By` trailers (repository convention — single canonical author per PR).
- Local deterministic security baseline against this diff: P0 = 0, P1 = 8, P2 = 242, P3 = 0. The eight P1s are pre-existing baseline findings already triaged: five JSON-LD `dangerouslySetInnerHTML` blobs documented as safe in `docs/SECURITY_REVIEW.md:40`, three PyTorch `model.eval()` regex false positives in a pydata contributor submission. None are in this PR's diff.
- The contract in `lib/members-public-snapshot.ts:36-37` — "Full directory read — run only from snapshot rebuild (cron/CLI), not from public GET" — was already documented. This PR brings the code into compliance with the documented contract.

---

Carther Theogene · [linkedin.com/in/carther](https://linkedin.com/in/carther)
