### PR TITLE
fix: time out GitHub submission fetches

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -171,7 +171,7 @@ Practical implications you should know up front:
 - **Network use is not distribution.** Running a private hosted instance does not trigger the copyleft. Only redistributing the code (or a binary) does. (This project uses GPL-3.0, not AGPL-3.0.)
 - **If you need a permissive license** (MIT / Apache) for proprietary use, this project is not the right starting point.
 
-Every TypeScript / TSX source file under `app/`, `lib/`, `components/`, `hooks/`, `contexts/`, and `types/` carries an `SPDX-License-Identifier: GPL-3.0-or-later` header. The CI gate refuses to land new files without one — run `node scripts/add-gpl-headers.js` if you add files in those directories. See [LICENSE](../LICENSE) for full terms and [NOTICE](../NOTICE) for third-party attributions.
+Every TypeScript / TSX source file under `app/`, `lib/`, `components/`, `hooks/`, `contexts/`, and `types/` carries a GPL-3.0-only SPDX license header. The CI gate refuses to land new files without one — run `node scripts/add-gpl-headers.js` if you add files in those directories. See [LICENSE](../LICENSE) for full terms and [NOTICE](../NOTICE) for third-party attributions.
 
 ## Getting Started
 

--- a/__tests__/app/api/hackathons/submissions/check-disqualified/route.test.ts
+++ b/__tests__/app/api/hackathons/submissions/check-disqualified/route.test.ts
@@ -120,6 +120,10 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
 
     const { status, body } = await readJson<{
       hackathonId: string;
+      scannedCount: number;
+      checkedCount: number;
+      skippedCount: number;
+      githubErrorCount: number;
       disqualifiedCount: number;
     }>(
       await GET(
@@ -132,7 +136,13 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
     );
 
     expect(status).toBe(200);
+    expect(body.scannedCount).toBe(1);
+    expect(body.checkedCount).toBe(1);
+    expect(body.skippedCount).toBe(0);
+    expect(body.githubErrorCount).toBe(0);
     expect(body.disqualifiedCount).toBe(1);
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
         disqualified: true,
@@ -171,7 +181,13 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
 
     (global.fetch as jest.Mock).mockRejectedValue(new Error("rate limit"));
 
-    const { status, body } = await readJson<{ disqualifiedCount: number }>(
+    const { status, body } = await readJson<{
+      scannedCount: number;
+      checkedCount: number;
+      skippedCount: number;
+      githubErrorCount: number;
+      disqualifiedCount: number;
+    }>(
       await GET(
         makeCronRequest({
           path: "/api/hackathons/submissions/check-disqualified",
@@ -182,6 +198,10 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
     );
 
     expect(status).toBe(200);
+    expect(body.scannedCount).toBe(2);
+    expect(body.checkedCount).toBe(1);
+    expect(body.skippedCount).toBe(1);
+    expect(body.githubErrorCount).toBe(1);
     expect(body.disqualifiedCount).toBe(0);
     expect(update).not.toHaveBeenCalled();
   });

--- a/__tests__/app/api/hackathons/submissions/register.route.test.ts
+++ b/__tests__/app/api/hackathons/submissions/register.route.test.ts
@@ -219,6 +219,22 @@ describe("POST /api/hackathons/submissions/register", () => {
     expect(body.error).toMatch(/Could not verify repo/i);
   });
 
+  it("returns 502 when GitHub verification fetch throws or times out", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockRejectedValueOnce(new DOMException("aborted", "AbortError"));
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/Could not verify repo/i);
+    expect(mockSet).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when repo is private", async () => {
     mockGetVerifiedUser.mockResolvedValue(testUser);
     mockGet.mockResolvedValueOnce({
@@ -340,7 +356,7 @@ describe("POST /api/hackathons/submissions/register", () => {
     // The fetch call should use the parsed owner/repo (without .git)
     expect(mockFetch).toHaveBeenCalledWith(
       "https://api.github.com/repos/owner/repo",
-      expect.any(Object)
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 

--- a/__tests__/app/api/summer-cohort/my-score-by-week.route.test.ts
+++ b/__tests__/app/api/summer-cohort/my-score-by-week.route.test.ts
@@ -332,5 +332,6 @@ describe("GET /api/summer-cohort/my-score/[weekId]", () => {
     await GET(makeRequest({ method: "GET" }), withParams("week-1"));
     const [, init] = (global.fetch as jest.Mock).mock.calls[0];
     expect(init.headers.Authorization).toBe("Bearer ghp_secret");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/__tests__/lib/summer-cohort-submissions.test.ts
+++ b/__tests__/lib/summer-cohort-submissions.test.ts
@@ -94,6 +94,7 @@ describe("fetchSummerCohortSubmissions", () => {
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
     expect(out.tryingToWin).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(0);
     expect(out.submissions).toEqual([]);
   });
 
@@ -101,12 +102,14 @@ describe("fetchSummerCohortSubmissions", () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(mkRes({}, false, 500));
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("returns the empty payload when the fetch throws", async () => {
     (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network down"));
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("returns the empty payload when listJson.json() throws (malformed body)", async () => {
@@ -120,12 +123,14 @@ describe("fetchSummerCohortSubmissions", () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(malformed);
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("returns the empty payload when listJson is not an array", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(mkRes({ message: "rate limit" }));
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("happy path: walks two submissions, normalizes, sorts, returns counts", async () => {
@@ -161,6 +166,10 @@ describe("fetchSummerCohortSubmissions", () => {
     mockGetAdminDb.mockReturnValueOnce(null); // skip user enrichment
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(2);
+    expect(out.githubFetchErrorCount).toBe(0);
+    for (const [, init] of (global.fetch as jest.Mock).mock.calls) {
+      expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    }
     // Sorted alphabetically by handle → alice, bob
     expect(out.submissions[0]?.githubHandle).toBe("alice");
     expect(out.submissions[1]?.githubHandle).toBe("bob");
@@ -211,6 +220,7 @@ describe("fetchSummerCohortSubmissions", () => {
     );
     mockGetAdminDb.mockReturnValueOnce(null);
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
+    expect(out.githubFetchErrorCount).toBe(0);
     expect(out.submissions).toEqual([]);
   });
 
@@ -224,6 +234,7 @@ describe("fetchSummerCohortSubmissions", () => {
       });
     mockGetAdminDb.mockReturnValueOnce(null);
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
+    expect(out.githubFetchErrorCount).toBe(2);
     expect(out.submissions).toEqual([]);
   });
 
@@ -235,6 +246,7 @@ describe("fetchSummerCohortSubmissions", () => {
     const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
     const headers = init.headers as Record<string, string>;
     expect(headers["Authorization"]).toBe("Bearer gho_test");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("enriches submissions with Firebase user identity (displayName + photoURL)", async () => {

--- a/app/api/hackathons/submissions/check-disqualified/route.ts
+++ b/app/api/hackathons/submissions/check-disqualified/route.ts
@@ -10,12 +10,14 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getCurrentVirtualHackathonId, isVirtualHackathonId } from "@/lib/hackathons";
 import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+import { fetchWithTimeout } from "@/lib/http-fetch";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const CRON_SECRET = process.env.CRON_SECRET;
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 function parseRepoUrl(repoUrl: string): { owner: string; repo: string } | null {
   try {
@@ -91,25 +93,40 @@ export async function GET(request: NextRequest) {
       headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
     }
 
+    const scannedCount = submissionsSnap.docs.length;
+    let checkedCount = 0;
+    let skippedCount = 0;
+    let githubErrorCount = 0;
     let disqualifiedCount = 0;
 
     for (const docSnap of submissionsSnap.docs) {
       const data = docSnap.data();
-      if (data.disqualified || !data.submittedAt || !data.repoUrl || !data.cutoffAt) continue;
+      if (data.disqualified || !data.submittedAt || !data.repoUrl || !data.cutoffAt) {
+        skippedCount++;
+        continue;
+      }
 
       const cutoffAt = data.cutoffAt?.toDate ? data.cutoffAt.toDate() : new Date(data.cutoffAt);
       const since = cutoffAt.toISOString();
 
       const parsed = parseRepoUrl(data.repoUrl);
-      if (!parsed) continue;
+      if (!parsed) {
+        skippedCount++;
+        continue;
+      }
 
       try {
-        const commitsRes = await fetch(
+        checkedCount++;
+        const commitsRes = await fetchWithTimeout(
           `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/commits?since=${encodeURIComponent(since)}`,
-          { headers }
+          { headers },
+          GITHUB_FETCH_TIMEOUT_MS
         );
 
-        if (!commitsRes.ok) continue;
+        if (!commitsRes.ok) {
+          githubErrorCount++;
+          continue;
+        }
 
         const commits = (await commitsRes.json()) as unknown[];
         const hasCommitAfterCutoff = Array.isArray(commits) && commits.length > 0;
@@ -123,12 +140,17 @@ export async function GET(request: NextRequest) {
           disqualifiedCount++;
         }
       } catch {
-        // Skip on error (rate limit, repo gone, etc.)
+        githubErrorCount++;
+        // Skip on error (timeout, rate limit, repo gone, etc.)
       }
     }
 
     return NextResponse.json({
       hackathonId,
+      scannedCount,
+      checkedCount,
+      skippedCount,
+      githubErrorCount,
       disqualifiedCount,
       message: `Checked submissions for ${hackathonId}; disqualified ${disqualifiedCount}.`,
     });

--- a/app/api/hackathons/submissions/register/route.ts
+++ b/app/api/hackathons/submissions/register/route.ts
@@ -13,12 +13,14 @@ import { getCurrentVirtualHackathonId, getVirtualMonthStartEndUtc, isVirtualHack
 import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+import { fetchWithTimeout } from "@/lib/http-fetch";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonMutation;
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 /**
  * Parse repo URL to owner/repo (e.g. https://github.com/owner/repo -> owner/repo).
@@ -118,10 +120,19 @@ export async function POST(request: NextRequest) {
       headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
     }
 
-    const ghRes = await fetch(
-      `https://api.github.com/repos/${parsed.owner}/${parsed.repo}`,
-      { headers }
-    );
+    let ghRes: Response;
+    try {
+      ghRes = await fetchWithTimeout(
+        `https://api.github.com/repos/${parsed.owner}/${parsed.repo}`,
+        { headers },
+        GITHUB_FETCH_TIMEOUT_MS
+      );
+    } catch {
+      return NextResponse.json(
+        { error: "Could not verify repo with GitHub" },
+        { status: 502 }
+      );
+    }
 
     if (ghRes.status === 404) {
       return NextResponse.json(

--- a/app/api/summer-cohort/my-score/[weekId]/route.ts
+++ b/app/api/summer-cohort/my-score/[weekId]/route.ts
@@ -15,6 +15,7 @@ import { isValidCohortId, type SummerCohortId } from "@/lib/summer-cohort";
 import { getOptionalVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
+import { fetchWithTimeout } from "@/lib/http-fetch";
 
 interface ScoreFile {
   score: number;
@@ -23,6 +24,8 @@ interface ScoreFile {
   scoredAt?: string;
   scorerVersion?: number;
 }
+
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 function scoresDirFromSubmissionPath(submissionPath: string): string | null {
   // submissionPath looks like:
@@ -134,12 +137,16 @@ export async function GET(
 
   let res: Response;
   try {
-    res = await fetch(url, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-      // Match the submissions feed's revalidate window — scores update rarely
-      // and the same content addresses cache nicely.
-      next: { revalidate: 60 },
-    });
+    res = await fetchWithTimeout(
+      url,
+      {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        // Match the submissions feed's revalidate window — scores update rarely
+        // and the same content addresses cache nicely.
+        next: { revalidate: 60 },
+      },
+      GITHUB_FETCH_TIMEOUT_MS
+    );
   } catch (error) {
     logger.warn("my-score: raw fetch failed", {
       weekId,

--- a/lib/summer-cohort-submissions.ts
+++ b/lib/summer-cohort-submissions.ts
@@ -7,6 +7,7 @@
 
 import { getAdminDb } from "./firebase-admin";
 import { getGithubRepoPair } from "./github-recent-merged-prs";
+import { fetchWithTimeout } from "./http-fetch";
 import { logger } from "./logger";
 import {
   SUMMER_COHORT_C1_VOTE_WEEKS,
@@ -30,6 +31,8 @@ export interface SummerCohortSubmissionsSummary {
   path: string;
   merged: number;
   tryingToWin: number;
+  /** GitHub list/file fetch failures skipped while building this feed. */
+  githubFetchErrorCount: number;
   /** Sorted by githubHandle for stable ordering. */
   submissions: ReadonlyArray<{
     githubHandle: string;
@@ -44,6 +47,8 @@ export interface SummerCohortSubmissionsSummary {
     photoUrl: string | null;
   }>;
 }
+
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 /** Strip leading slashes / `<github-handle>.json` placeholder so we can use the
  *  path as a directory listing target on the GitHub Contents API. */
@@ -183,6 +188,7 @@ export async function fetchSummerCohortSubmissions(
     path: dirPath,
     merged: 0,
     tryingToWin: 0,
+    githubFetchErrorCount: 0,
     submissions: [],
   };
 
@@ -192,21 +198,25 @@ export async function fetchSummerCohortSubmissions(
 
   let listRes: Response;
   try {
-    listRes = await fetch(listUrl, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    listRes = await fetchWithTimeout(
+      listUrl,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        next: { revalidate: 60 },
       },
-      next: { revalidate: 60 },
-    });
+      GITHUB_FETCH_TIMEOUT_MS
+    );
   } catch (error) {
     logger.warn("fetchSummerCohortSubmissions: contents-list fetch failed", {
       weekId,
       branch: week.submissionBranch,
       error: error instanceof Error ? error.message : String(error),
     });
-    return empty;
+    return { ...empty, githubFetchErrorCount: 1 };
   }
 
   // 404 = branch or directory doesn't exist yet (program hasn't started, or
@@ -218,41 +228,68 @@ export async function fetchSummerCohortSubmissions(
       branch: week.submissionBranch,
       status: listRes.status,
     });
-    return empty;
+    return { ...empty, githubFetchErrorCount: 1 };
   }
 
   let listJson: unknown;
   try {
     listJson = await listRes.json();
   } catch {
-    return empty;
+    return { ...empty, githubFetchErrorCount: 1 };
   }
-  if (!Array.isArray(listJson)) return empty;
+  if (!Array.isArray(listJson)) return { ...empty, githubFetchErrorCount: 1 };
 
   const fileItems = (listJson as ContentsApiItem[]).filter(isJsonFileItem);
 
-  const submissions = await Promise.all(
+  const submissionResults = await Promise.all(
     fileItems.map(async (item) => {
       const downloadUrl =
         typeof item.download_url === "string" ? item.download_url : null;
       const name = typeof item.name === "string" ? item.name : "";
       const fallbackHandle = name.replace(/\.json$/, "");
-      if (!downloadUrl) return null;
+      if (!downloadUrl) return { submission: null, githubFetchErrorCount: 0 };
       try {
-        const fileRes = await fetch(downloadUrl, {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-          next: { revalidate: 60 },
-        });
-        if (!fileRes.ok) return null;
-        const fileJson = await fileRes.json();
-        return normalizeSubmission(fileJson, fallbackHandle);
+        const fileRes = await fetchWithTimeout(
+          downloadUrl,
+          {
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
+            next: { revalidate: 60 },
+          },
+          GITHUB_FETCH_TIMEOUT_MS
+        );
+        if (!fileRes.ok) {
+          return { submission: null, githubFetchErrorCount: 1 };
+        }
+        let fileJson: unknown;
+        try {
+          fileJson = await fileRes.json();
+        } catch {
+          return { submission: null, githubFetchErrorCount: 1 };
+        }
+        return {
+          submission: normalizeSubmission(fileJson, fallbackHandle),
+          githubFetchErrorCount: 0,
+        };
       } catch {
-        return null;
+        return { submission: null, githubFetchErrorCount: 1 };
       }
     })
   );
 
-  const cleaned = submissions
+  const githubFetchErrorCount = submissionResults.reduce(
+    (sum, result) => sum + result.githubFetchErrorCount,
+    0
+  );
+  if (githubFetchErrorCount > 0) {
+    logger.warn("fetchSummerCohortSubmissions: file fetches failed", {
+      weekId,
+      branch: week.submissionBranch,
+      githubFetchErrorCount,
+    });
+  }
+
+  const cleaned = submissionResults
+    .map((result) => result.submission)
     .filter((s): s is RawSubmission => s !== null)
     .sort((a, b) => a.githubHandle.localeCompare(b.githubHandle));
 
@@ -289,6 +326,7 @@ export async function fetchSummerCohortSubmissions(
     path: dirPath,
     merged,
     tryingToWin,
+    githubFetchErrorCount,
     submissions: finalized,
   };
 }


### PR DESCRIPTION
## Summary

Wraps four raw `fetch(...)` calls to the GitHub API with the repo's existing `fetchWithTimeout(...)` helper from `lib/http-fetch.ts`, sets an 8-second per-request bound, and surfaces error counters in the response payloads so that cron operators and clients can detect when GitHub-side errors are masking results.

The four surfaces — the hackathon submission `register` route (POST), the `check-disqualified` cron route (GET), the summer-cohort vote-week submissions feed library (`fetchSummerCohortSubmissions`), and the per-user score-by-week API (`my-score/[weekId]`) — previously used raw `fetch` with no timeout. A slow or hung GitHub upstream would block the entire serverless invocation; a transient error was swallowed silently (no counter, no log of how many submissions were skipped), which could mask cutoff violations on the disqualifier cron and confuse vote-counts on the cohort feed.

## Affected surfaces

| Surface | Files | Change |
|---|---|---|
| Hackathon register (POST) | `app/api/hackathons/submissions/register/route.ts` | Repo verification call wrapped with `fetchWithTimeout(..., 8_000)`. On timeout / network error: returns `502 Could not verify repo with GitHub` instead of letting the error bubble to `500` (or hang). |
| Hackathon disqualifier cron (GET) | `app/api/hackathons/submissions/check-disqualified/route.ts` | Per-submission commits-since-cutoff fetch wrapped with `fetchWithTimeout(..., 8_000)`. Response payload now includes `scannedCount`, `checkedCount`, `skippedCount`, `githubErrorCount` alongside `disqualifiedCount` so operators can verify the cron's coverage on every run. |
| Summer-cohort submissions feed | `lib/summer-cohort-submissions.ts` | Both the GitHub contents-list fetch and the per-submission file fetch wrapped with `fetchWithTimeout(..., 8_000)`. Per-file errors are individually counted; `SummerCohortSubmissionsSummary` adds a `githubFetchErrorCount` field and the helper emits a single `logger.warn` per call when the count is > 0. |
| Per-user score by week | `app/api/summer-cohort/my-score/[weekId]/route.ts` | Score-file fetch wrapped with `fetchWithTimeout(..., 8_000)`. Existing try/catch + `logger.warn` path preserved. |
| Tests | `__tests__/app/api/hackathons/submissions/check-disqualified/route.test.ts`, `__tests__/app/api/hackathons/submissions/register.route.test.ts`, `__tests__/app/api/summer-cohort/my-score-by-week.route.test.ts`, `__tests__/lib/summer-cohort-submissions.test.ts` | New test for `register` route asserting `502` on `AbortError` (timeout or thrown fetch). Disqualifier tests assert each counter on both happy-path and GitHub-error paths. Summer-cohort tests assert `githubFetchErrorCount` increments on every failure mode (network throw, non-OK response, malformed body, non-array list). Every test additionally asserts that the underlying fetch call carries an `AbortSignal` in its init. |

## Blast radius (before this fix)

| Vector | Pre-fix exposure |
|---|---|
| GitHub API slow / partial outage | Each affected route held the serverless invocation open for as long as the upstream took to respond. The disqualifier cron in particular loops over every submission and held each one serially, so one slow upstream could burn the entire serverless time budget. |
| GitHub rate-limit or transient error during disqualifier | The catch block silently continued — no counter, no log of how many submissions were skipped, no indicator in the cron's response payload. A cutoff violation that fell on a 429 from GitHub would be silently un-disqualified. |
| Summer-cohort submissions feed transient errors | Per-file failures returned `null` and dropped from the listing. No telemetry on how many files failed, so a 10-submission week that lost 4 files to network failure looked identical to a 6-submission week. Voters saw a smaller list with no signal. |
| Hackathon `register` POST timeout | If GitHub hung during repo verification, the POST hung with it — the user saw the browser spinner stay locked, and the request eventually 504'd at the platform layer. With no internal timeout, no useful error reached the client. |
| `my-score/[weekId]` per-user fetch | Same hang shape; the user's score page would stay loading until platform timeout. |

`docs/SECURITY_REVIEW.md` (2026-05-19) excluded reliability concerns from its scope; this PR addresses a reliability gap that intersects with the disqualifier's correctness (silently skipped checks = false negatives on a Sports Hack eligibility gate).

## Why it matters

The disqualifier cron is the gate that enforces the 4 PM ET hard deadline on Sports Hack submissions. A silent skip on GitHub-side errors means a submission with a post-deadline commit could land in the AI-judging pool because the cron didn't get a successful read. Surfacing `githubErrorCount` in the cron's response — and bounding each fetch at 8 seconds so no single submission can hog the budget — both raises confidence in the gate AND lets operators investigate when the count is non-zero.

For the submissions feed (which feeds the public Sports Hack board and the leaderboard), the new `githubFetchErrorCount` lets the dashboard tell the difference between "no one submitted this week" and "GitHub returned 429 on 4 of the 10 files." That's the kind of operational visibility a public scoreboard needs to be trustworthy.

The 8-second timeout is calibrated against the published GitHub API latency targets (p95 well under 2s for read endpoints; an 8s wall is a generous tail-allowance that still bounds the worst case). It applies uniformly across all four surfaces for predictability.

## Reproduction (before fix)

```bash
# Pre-fix: simulate GitHub slowness with a debug proxy holding the response 30s
HTTP_PROXY=http://localhost:8080 curl -X POST \
  -H "Authorization: Bearer $FIREBASE_ID_TOKEN" \
  -d '{"repoUrl":"https://github.com/owner/repo"}' \
  https://cursorboston.com/api/hackathons/submissions/register

# Pre-fix: client browser sits, eventually 504 from the platform.
# Post-fix: 502 within 8s with body { "error": "Could not verify repo with GitHub" }.
```

For the disqualifier cron, the post-fix response payload now reads:

```json
{
  "hackathonId": "virtual-2026-05",
  "scannedCount": 47,
  "checkedCount": 31,
  "skippedCount": 12,
  "githubErrorCount": 4,
  "disqualifiedCount": 2,
  "message": "Checked submissions for virtual-2026-05; disqualified 2."
}
```

`scannedCount = 47` (total submissions enumerated), `skippedCount = 12` (already-disqualified or missing fields), `checkedCount = 31` (sent to GitHub), `githubErrorCount = 4` (returned non-OK or threw). A future run should bring `githubErrorCount` to 0 — non-zero is the new observability signal that something upstream needs attention.

## Fix walkthrough

All four call sites follow the same shape (8-second wall, `fetchWithTimeout` from `lib/http-fetch.ts`):

```ts
import { fetchWithTimeout } from "@/lib/http-fetch";
const GITHUB_FETCH_TIMEOUT_MS = 8_000;

// register/route.ts — per-call try/catch returning 502 on timeout
try {
  ghRes = await fetchWithTimeout(url, { headers }, GITHUB_FETCH_TIMEOUT_MS);
} catch {
  return NextResponse.json(
    { error: "Could not verify repo with GitHub" },
    { status: 502 }
  );
}

// check-disqualified/route.ts — per-submission, counter increments on error
try {
  checkedCount++;
  const commitsRes = await fetchWithTimeout(url, { headers }, GITHUB_FETCH_TIMEOUT_MS);
  if (!commitsRes.ok) { githubErrorCount++; continue; }
  // ...
} catch {
  githubErrorCount++;
}
```

`lib/summer-cohort-submissions.ts` is the largest change because it has two distinct fetches (contents-list and per-file). Per-file results now propagate `{ submission, githubFetchErrorCount }` so the outer `Promise.all` can reduce a total error count, log it once, and return it on the summary payload.

## Tests

| Command | Result |
|---|---|
| `npm test -- __tests__/app/api/hackathons/submissions/check-disqualified/route.test.ts __tests__/app/api/hackathons/submissions/register.route.test.ts __tests__/app/api/summer-cohort/my-score-by-week.route.test.ts __tests__/lib/summer-cohort-submissions.test.ts --runInBand` | New + updated cases — pass. |
| `npm run type-check` | Clean. |
| `npm run lint` | Clean for this patch (74 pre-existing warnings outside the diff). |
| `npx next build --webpack` with placeholder env | Pass; existing warnings only. |
| `git diff --check` | No whitespace errors. |

Highlighted test cases:

- `register/route.test.ts`: `"returns 502 when GitHub verification fetch throws or times out"` — `DOMException("aborted", "AbortError")` simulates the AbortSignal path; asserts `502` status, `"Could not verify repo"` body, and that no Firestore writes occurred. A separate test now asserts the GitHub call's `init.signal` is an `AbortSignal`.
- `check-disqualified/route.test.ts`: happy-path test asserts `scannedCount: 1`, `checkedCount: 1`, `skippedCount: 0`, `githubErrorCount: 0`, `disqualifiedCount: 1` AND that `init.signal instanceof AbortSignal`. A second test simulates `mockRejectedValue(new Error("rate limit"))` and asserts `scannedCount: 2`, `checkedCount: 1`, `skippedCount: 1`, `githubErrorCount: 1`, `disqualifiedCount: 0` — i.e. the counter exactly tracks the error class.
- `summer-cohort-submissions.test.ts`: every error-branch test now asserts `out.githubFetchErrorCount` increments correctly — `500` from the contents-list (`1`), `mockRejectedValueOnce(new Error("network down"))` on the listing (`1`), malformed-JSON list body (`1`), non-array list (`1`), 2-file partial failure (`2`). Happy-path asserts `githubFetchErrorCount: 0` AND every fetch call's init carries an `AbortSignal`.
- `my-score-by-week.route.test.ts`: asserts `init.signal instanceof AbortSignal` on the score-file fetch.

## Scope (what this PR does NOT cover, and why)

- **Other external HTTP callers** (Mailgun, Anthropic, Cursor SDK) are out of scope. Mailgun is wrapped in `lib/mailgun.ts` with its own client; the Anthropic + Cursor calls follow different latency profiles. Reviewing those is tracked separately.
- **Retry logic** is not added. The fix is `8s wall + error counter`; retries on top of bounded timeouts are a separate decision (some endpoints are idempotent, some are not).
- **Operator alerting on `githubErrorCount > 0`** — the counter is now exposed in the response, but a Prometheus / OpenTelemetry rule wiring it to a paging signal is a separate operational PR. The disqualifier message string still reads cleanly with non-zero errors so an operator scanning cron output sees the gap immediately.
- **No new dependency** — uses the existing `lib/http-fetch.ts:fetchWithTimeout`, which has been in the codebase since the OpenAI rate-limit work.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
