### PR TITLE
submission: jonathanlittel c1w2comms — cohort chat app

### DIFF
--- a/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
@@ -2,7 +2,7 @@
   "githubHandle": "jonathanlittel",
   "name": "Jon Littel",
   "photoUrl": "https://avatars.githubusercontent.com/jonathanlittel",
-  "repoUrl": "https://github.com/jonathanlittel/cursor-boston/tree/backup/jonathanlittel-c1w2-comms-app/projects/c1w2-comms",
+  "repoUrl": "https://github.com/jonathanlittel/cursor-boston/tree/c1w2-comms/projects/c1w2-comms",
   "liveUrl": "https://c1w2-comms.vercel.app",
   "loomUrl": "https://www.loom.com/share/placeholder-update-before-submit",
   "pitch": "Three channels. The electronic version of sticky notes on a fridge.",

--- a/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
@@ -6,5 +6,5 @@
   "liveUrl": "https://c1w2-comms.vercel.app",
   "loomUrl": "https://www.loom.com/share/placeholder-update-before-submit",
   "pitch": "Three channels. The electronic version of sticky notes on a fridge.",
-  "competeForWin": true
+  "competeForWin": false
 }

--- a/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "jonathanlittel",
+  "name": "Jon Littel",
+  "photoUrl": "https://avatars.githubusercontent.com/jonathanlittel",
+  "repoUrl": "https://github.com/jonathanlittel/cursor-boston/tree/backup/jonathanlittel-c1w2-comms-app/projects/c1w2-comms",
+  "liveUrl": "https://c1w2-comms.vercel.app",
+  "loomUrl": "https://www.loom.com/share/placeholder-update-before-submit",
+  "pitch": "Three channels. The electronic version of sticky notes on a fridge.",
+  "competeForWin": true
+}


### PR DESCRIPTION
## Summary
- Adds `projects/c1w2-comms`, a standalone cohort communication app with three focused channels: `#general`, `#cursor-help`, and `#app-feedback`.
- Honor-system GitHub handle login gated by a cohort roster built from submission JSON files and merged PR authors on `c1w*-submission` branches.
- Firestore-backed live messages (`cohortCommsMessages`) with server-only writes via API routes; public read for real-time `onSnapshot` updates.
- Includes Week 2 submission metadata at `content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json`.

## Test plan
- [ ] Open app locally: `cd projects/c1w2-comms && npm install && npm run dev` → http://localhost:3001
- [ ] Log in with a roster handle (e.g. `jonathanlittel`) — rejected handles should fail at login
- [ ] Post in `#general` and confirm message appears in a second browser/session
- [ ] Switch channels and confirm messages are scoped correctly
- [ ] Verify deployed live URL once Vercel env vars are set (`NEXT_PUBLIC_FIREBASE_*`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `GITHUB_TOKEN`)


Made with [Cursor](https://cursor.com)