### PR TITLE
chore: unblock base CI hygiene checks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -171,7 +171,7 @@ Practical implications you should know up front:
 - **Network use is not distribution.** Running a private hosted instance does not trigger the copyleft. Only redistributing the code (or a binary) does. (This project uses GPL-3.0, not AGPL-3.0.)
 - **If you need a permissive license** (MIT / Apache) for proprietary use, this project is not the right starting point.
 
-Every TypeScript / TSX source file under `app/`, `lib/`, `components/`, `hooks/`, `contexts/`, and `types/` carries an `SPDX-License-Identifier: GPL-3.0-or-later` header. The CI gate refuses to land new files without one — run `node scripts/add-gpl-headers.js` if you add files in those directories. See [LICENSE](../LICENSE) for full terms and [NOTICE](../NOTICE) for third-party attributions.
+Every TypeScript / TSX source file under `app/`, `lib/`, `components/`, `hooks/`, `contexts/`, and `types/` carries a GPL-3.0-only SPDX license header. The CI gate refuses to land new files without one — run `node scripts/add-gpl-headers.js` if you add files in those directories. See [LICENSE](../LICENSE) for full terms and [NOTICE](../NOTICE) for third-party attributions.
 
 ## Getting Started
 

--- a/__tests__/app/summer-cohort/page-coverage.test.tsx
+++ b/__tests__/app/summer-cohort/page-coverage.test.tsx
@@ -804,11 +804,11 @@ describe("summer-cohort page (extra coverage)", () => {
     void user; // keep linter happy
   });
 
-  it("renders the Mon May 18 zoom banner when Date.now() is before cutoff", async () => {
+  it("renders the Fri May 22 zoom banner when Date.now() is before cutoff", async () => {
     const realNow = Date.now;
-    // Mon May 18 2026 21:00:00 UTC ≈ 5pm EST — before the May 19 04:00Z cutoff.
+    // Fri May 22 2026 21:00:00 UTC is before the May 23 04:00Z cutoff.
     jest.spyOn(Date, "now").mockReturnValue(
-      new Date("2026-05-18T21:00:00Z").getTime(),
+      new Date("2026-05-22T21:00:00Z").getTime(),
     );
     setupFetch(admittedReady());
     const Page = (await import("@/app/summer-cohort/page")).default;
@@ -817,7 +817,7 @@ describe("summer-cohort page (extra coverage)", () => {
 
     await screen.findByText(/Status: Admitted/i);
     expect(
-      await screen.findByText(/Tonight · Mon May 18 · 6 pm EST/i),
+      await screen.findByText(/Tonight · Fri May 22 · 6 pm EST/i),
     ).toBeInTheDocument();
     // Clicking "Open Week 2 →" switches to the Week 2 tab.
     await user.click(screen.getByRole("button", { name: /Open Week 2/i }));

--- a/lib/game/content/hero-backstories/_index.ts
+++ b/lib/game/content/hero-backstories/_index.ts
@@ -1,4 +1,5 @@
 /**
+ * SPDX-License-Identifier: GPL-3.0-only
  * Copyright (C) 2026 Cursor Boston
  * This file is part of Cursor Boston, licensed under GPL-3.0.
  * See LICENSE file for details.

--- a/scripts/build-hero-backstory-index.ts
+++ b/scripts/build-hero-backstory-index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /**
+ * SPDX-License-Identifier: GPL-3.0-only
  * Copyright (C) 2026 Cursor Boston
  * This file is part of Cursor Boston, licensed under GPL-3.0.
  * See LICENSE file for details.
@@ -35,6 +36,7 @@ function main(): void {
   const heroIds = entries.map((f) => f.replace(/\.md$/, "")).sort();
   const lines = heroIds.map((id) => `  ${JSON.stringify(id)},`).join("\n");
   const next = `/**
+ * SPDX-License-Identifier: GPL-3.0-only
  * Copyright (C) 2026 Cursor Boston
  * This file is part of Cursor Boston, licensed under GPL-3.0.
  * See LICENSE file for details.


### PR DESCRIPTION
## SummaryFixes four CI failures already present on `develop` so fork PRs can be evaluated on their own changes again.## Affected Areas- `lib/game/content/hero-backstories/_index.ts`- `scripts/build-hero-backstory-index.ts`- `.github/CONTRIBUTING.md`- `__tests__/app/summer-cohort/page-coverage.test.tsx`## WhyThe current base branch fails independent checks for SPDX header coverage, REUSE parsing, and a stale summer-cohort banner date assertion. Those failures make unrelated contributor PRs look broken.## Fix- Adds the missing GPL SPDX header to the generated hero-backstory index and its generator template.- Updates the generator script header so future generated output keeps the same license header.- Rewords one CONTRIBUTING sentence so REUSE does not parse prose as an SPDX declaration.- Updates the summer-cohort banner fixture from May 18 to the May 22 banner currently rendered by the page.## Verification- `npm test -- __tests__/app/summer-cohort/page-coverage.test.tsx --runInBand`- `npm run type-check`- `npm run lint`- `python -m reuse lint`- `npx tsx scripts/build-hero-backstory-index.ts`- `git diff --check origin/develop..HEAD`## Scope ControlThis PR does not change runtime product behavior. It only repairs base-branch hygiene and a stale test fixture.## Merge NotesThe CONTRIBUTING.md wording matches the same hunk carried by #1341, so merge order should converge cleanly.Carther Theogene · https://linkedin.com/in/carther