### PR TITLE
test: align summer cohort banner date expectation

### DIFF
--- a/__tests__/app/summer-cohort/page-coverage.test.tsx
+++ b/__tests__/app/summer-cohort/page-coverage.test.tsx
@@ -804,11 +804,11 @@ describe("summer-cohort page (extra coverage)", () => {
     void user; // keep linter happy
   });
 
-  it("renders the Mon May 18 zoom banner when Date.now() is before cutoff", async () => {
+  it("renders the Fri May 22 zoom banner when Date.now() is before cutoff", async () => {
     const realNow = Date.now;
-    // Mon May 18 2026 21:00:00 UTC ≈ 5pm EST — before the May 19 04:00Z cutoff.
+    // Fri May 22 2026 21:00:00 UTC ≈ 5pm EST — before the May 23 04:00Z cutoff.
     jest.spyOn(Date, "now").mockReturnValue(
-      new Date("2026-05-18T21:00:00Z").getTime(),
+      new Date("2026-05-22T21:00:00Z").getTime(),
     );
     setupFetch(admittedReady());
     const Page = (await import("@/app/summer-cohort/page")).default;
@@ -817,7 +817,7 @@ describe("summer-cohort page (extra coverage)", () => {
 
     await screen.findByText(/Status: Admitted/i);
     expect(
-      await screen.findByText(/Tonight · Mon May 18 · 6 pm EST/i),
+      await screen.findByText(/Tonight · Fri May 22 · 6 pm EST/i),
     ).toBeInTheDocument();
     // Clicking "Open Week 2 →" switches to the Week 2 tab.
     await user.click(screen.getByRole("button", { name: /Open Week 2/i }));


### PR DESCRIPTION
## Summary

Aligns the summer-cohort page-coverage test's mocked `Date.now()` and the asserted banner text with the current production banner copy. The test was pinned to "Mon May 18 2026" when written; the banner was rolled forward to "Fri May 22 2026" in PR #1328 (`feat(summer-cohort): Fri May 22 Week 2 voting banner + final-call reminder script`) but the corresponding test fixture wasn't updated, leaving the `Test` CI job red on every PR to `develop`.

## Affected surfaces

| File | Change |
|---|---|
| `__tests__/app/summer-cohort/page-coverage.test.tsx` | One test case (`"renders the … zoom banner when Date.now() is before cutoff"`): mocked `Date.now()` shifts from `2026-05-18T21:00:00Z` to `2026-05-22T21:00:00Z`, the cutoff comment updates from May 19 04:00Z to May 23 04:00Z, the test description and the `findByText` assertion shift from `"Mon May 18 · 6 pm EST"` to `"Fri May 22 · 6 pm EST"`. Four-line net change. |

No production code touched; the page component itself already renders the correct text — only the test fixture was stale.

## Blast radius (before this fix)

| Vector | Pre-fix exposure |
|---|---|
| `Test` CI job on every fork PR to `develop` | Failed on this one stale assertion since #1328 merged. PR #1341 (reliability/timeout work) and any other open PR sat with a Test-job red blocking merge even though their own diffs passed. |
| Local `npm test -- __tests__/app/summer-cohort/page-coverage.test.tsx` | Same red locally. |
| Contributor experience | New contributors hitting the Test red on PRs unrelated to summer-cohort had to either fix this drift first or ask why CI was unreliable. |

No correctness impact on the rendered banner — production code already had the right copy. The defect is purely in the test fixture's pinned date.

## Why it matters

Banner copy with a hard date is a known stale-test pattern. When the banner moved forward in #1328, the test should have moved with it; it didn't, and a stale assertion blocking everyone else's CI is exactly the "broken-window" failure mode that erodes trust in green CI.

Fixing it now (a) unblocks PR #1341's `Test` job specifically, (b) restores `npm test` as a reliable signal on `develop`, and (c) is a single self-contained PR so the fix is bisectable and the date-shift logic is easy to follow.

## Reproduction (before fix)

```bash
git checkout develop
git pull
npm test -- __tests__/app/summer-cohort/page-coverage.test.tsx
# Pre-fix: one failure on the "Mon May 18 zoom banner" case — the page now
# renders "Fri May 22" so the findByText times out looking for the May 18 text.
```

After this PR the suite exits clean (33/33 in the focused run).

## Fix walkthrough

The test mocks `Date.now()` to a point before the cohort cutoff so the banner renders. The mocked time and the asserted text both need to track the current cohort's banner date:

- Mocked time: `new Date("2026-05-18T21:00:00Z")` → `new Date("2026-05-22T21:00:00Z")`
- Comment about cutoff: "before the May 19 04:00Z cutoff" → "before the May 23 04:00Z cutoff"
- Test description + `findByText` regex: `Mon May 18 · 6 pm EST` → `Fri May 22 · 6 pm EST`

Each shift is parallel; no other test in the file references the May 18 date.

## Tests

| Command | Result |
|---|---|
| `npm test -- __tests__/app/summer-cohort/page-coverage.test.tsx` | 33/33 pass. |
| `npx eslint __tests__/app/summer-cohort/page-coverage.test.tsx --max-warnings=0` | Clean. |
| `npm run type-check` | Clean. |
| `git diff --check` | No whitespace errors. |

Pre-existing React `act()` warnings in the suite are unchanged by this patch (not introduced or removed).

## Scope (what this PR does NOT cover, and why)

- **The next cohort date shift.** Whenever the banner moves forward again (Week 3, Week 4), this test will need another date update or a refactor to derive the expected date from the page's own constants. That's a follow-up if the pattern keeps recurring — out of scope here.
- **Other pinned-date tests in the suite or elsewhere.** Quick repo-wide scan didn't surface other dates pinned to May 18 / May 19 in test fixtures, but a thorough date-fixture audit is a separate refactor.
- **The `act()` warnings in the suite output.** Pre-existing, unrelated to this date drift.

## Audit and compliance

- License: GPL-3.0-only (unchanged).
- DCO: every commit is `Signed-off-by`; no `Co-Authored-By` trailers.
- This PR unblocks the `Test` CI job for the in-flight reliability fix (#1341); merging it is on the critical path for the security-hardening wave.

---

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
