### PR TITLE
fix: reject revoked tokens on sensitive routes

### DIFF
--- a/__tests__/_helpers/_helpers-smoke.test.ts
+++ b/__tests__/_helpers/_helpers-smoke.test.ts
@@ -174,6 +174,8 @@ describe("__tests__/_helpers (smoke)", () => {
     it("makeServerAuthSpies → getVerifiedUser returns null by default", async () => {
       const spies = makeServerAuthSpies();
       expect(await spies.getVerifiedUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedAdminUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedUserWithRevocation({} as never)).toBeNull();
     });
 
     it("mockVerifiedUser one-shots a user", async () => {
@@ -182,20 +184,34 @@ describe("__tests__/_helpers (smoke)", () => {
       const u = (await spies.getVerifiedUser({} as never)) as { uid: string; email: string };
       expect(u.uid).toBe("u1");
       expect(u.email).toBe("u@x.com");
+      const admin = (await spies.getVerifiedAdminUser({} as never)) as { uid: string };
+      expect(admin.uid).toBe("u1");
+      const revoked = (await spies.getVerifiedUserWithRevocation({} as never)) as {
+        uid: string;
+      };
+      expect(revoked.uid).toBe("u1");
       // Next call falls back to null again
       expect(await spies.getVerifiedUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedAdminUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedUserWithRevocation({} as never)).toBeNull();
     });
 
     it("mockUnauthenticated → null", async () => {
       const spies = makeServerAuthSpies();
       spies.mockUnauthenticated();
       expect(await spies.getVerifiedUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedAdminUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedUserWithRevocation({} as never)).toBeNull();
     });
 
     it("mockAuthError → rejects", async () => {
       const spies = makeServerAuthSpies();
       spies.mockAuthError(new Error("expired"));
       await expect(spies.getVerifiedUser({} as never)).rejects.toThrow("expired");
+      await expect(spies.getVerifiedAdminUser({} as never)).rejects.toThrow("expired");
+      await expect(spies.getVerifiedUserWithRevocation({} as never)).rejects.toThrow(
+        "expired",
+      );
     });
 
     it("createServerAuthModule binds spies to module exports", async () => {
@@ -204,6 +220,25 @@ describe("__tests__/_helpers (smoke)", () => {
       spies.mockVerifiedUser({ uid: "u9" });
       const u = (await mod.getVerifiedUser({} as never)) as { uid: string };
       expect(u.uid).toBe("u9");
+      const admin = (await mod.getVerifiedAdminUser({} as never)) as { uid: string };
+      expect(admin.uid).toBe("u9");
+      const revoked = (await mod.getVerifiedUserWithRevocation({} as never)) as {
+        uid: string;
+      };
+      expect(revoked.uid).toBe("u9");
+      expect(mod.isRevokedIdTokenError(new Error("expired"))).toBe(false);
+    });
+
+    it("mockRevokedAuthError wires revoked-token classification", async () => {
+      const spies = makeServerAuthSpies();
+      const mod = createServerAuthModule(spies);
+      const err = new Error("The Firebase ID token has been revoked.");
+      spies.mockRevokedAuthError(err);
+
+      await expect(mod.getVerifiedAdminUser({} as never)).rejects.toThrow(
+        "revoked",
+      );
+      expect(mod.isRevokedIdTokenError(err)).toBe(true);
     });
 
     it("withCronSecret + clearCronSecret manage process.env", () => {

--- a/__tests__/_helpers/server-auth-mock.ts
+++ b/__tests__/_helpers/server-auth-mock.ts
@@ -27,6 +27,7 @@ export interface ServerAuthSpies {
   getVerifiedAdminUser: jest.Mock;
   getVerifiedUserWithRevocation: jest.Mock;
   getOptionalVerifiedUser: jest.Mock;
+  isCurrentIdTokenRevoked: jest.Mock;
   isRevokedIdTokenError: jest.Mock;
   /** Pre-seed `getVerifiedUser` to return the given user on the next call. */
   mockVerifiedUser: (user: Partial<VerifiedUser> & { uid: string }) => void;
@@ -43,6 +44,7 @@ export function makeServerAuthSpies(): ServerAuthSpies {
   const getVerifiedAdminUser = jest.fn().mockResolvedValue(null);
   const getVerifiedUserWithRevocation = jest.fn().mockResolvedValue(null);
   const getOptionalVerifiedUser = jest.fn().mockResolvedValue(null);
+  const isCurrentIdTokenRevoked = jest.fn().mockResolvedValue(false);
   const isRevokedIdTokenError = jest.fn().mockReturnValue(false);
 
   return {
@@ -50,6 +52,7 @@ export function makeServerAuthSpies(): ServerAuthSpies {
     getVerifiedAdminUser,
     getVerifiedUserWithRevocation,
     getOptionalVerifiedUser,
+    isCurrentIdTokenRevoked,
     isRevokedIdTokenError,
     mockVerifiedUser(user) {
       const verified = {
@@ -63,24 +66,28 @@ export function makeServerAuthSpies(): ServerAuthSpies {
       getVerifiedAdminUser.mockResolvedValueOnce(verified);
       getVerifiedUserWithRevocation.mockResolvedValueOnce(verified);
       getOptionalVerifiedUser.mockResolvedValueOnce(verified);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(false);
     },
     mockUnauthenticated() {
       getVerifiedUser.mockResolvedValueOnce(null);
       getVerifiedAdminUser.mockResolvedValueOnce(null);
       getVerifiedUserWithRevocation.mockResolvedValueOnce(null);
       getOptionalVerifiedUser.mockResolvedValueOnce(null);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(false);
     },
     mockAuthError(err = new Error("token verify failed")) {
       getVerifiedUser.mockRejectedValueOnce(err);
       getVerifiedAdminUser.mockRejectedValueOnce(err);
       getVerifiedUserWithRevocation.mockRejectedValueOnce(err);
       getOptionalVerifiedUser.mockRejectedValueOnce(err);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(false);
     },
     mockRevokedAuthError(err = new Error("The Firebase ID token has been revoked.")) {
       getVerifiedUser.mockRejectedValueOnce(err);
       getVerifiedAdminUser.mockRejectedValueOnce(err);
       getVerifiedUserWithRevocation.mockRejectedValueOnce(err);
       getOptionalVerifiedUser.mockRejectedValueOnce(err);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(true);
       isRevokedIdTokenError.mockReturnValueOnce(true);
     },
   };
@@ -95,6 +102,8 @@ export function createServerAuthModule(spies: ServerAuthSpies) {
       spies.getVerifiedUserWithRevocation(...a),
     getOptionalVerifiedUser: (...a: unknown[]) =>
       spies.getOptionalVerifiedUser(...a),
+    isCurrentIdTokenRevoked: (...a: unknown[]) =>
+      spies.isCurrentIdTokenRevoked(...a),
     isRevokedIdTokenError: spies.isRevokedIdTokenError,
   };
 }

--- a/__tests__/_helpers/server-auth-mock.ts
+++ b/__tests__/_helpers/server-auth-mock.ts
@@ -24,45 +24,64 @@ import type { VerifiedUser } from "@/lib/server-auth";
 
 export interface ServerAuthSpies {
   getVerifiedUser: jest.Mock;
+  getVerifiedAdminUser: jest.Mock;
+  getVerifiedUserWithRevocation: jest.Mock;
   getOptionalVerifiedUser: jest.Mock;
+  isRevokedIdTokenError: jest.Mock;
   /** Pre-seed `getVerifiedUser` to return the given user on the next call. */
   mockVerifiedUser: (user: Partial<VerifiedUser> & { uid: string }) => void;
   /** Pre-seed `getVerifiedUser` to return null (unauth) on the next call. */
   mockUnauthenticated: () => void;
   /** Pre-seed `getVerifiedUser` to throw on the next call (token verify fail). */
   mockAuthError: (err?: Error) => void;
+  /** Pre-seed all auth helpers to throw a revoked-token error. */
+  mockRevokedAuthError: (err?: Error) => void;
 }
 
 export function makeServerAuthSpies(): ServerAuthSpies {
   const getVerifiedUser = jest.fn().mockResolvedValue(null);
+  const getVerifiedAdminUser = jest.fn().mockResolvedValue(null);
+  const getVerifiedUserWithRevocation = jest.fn().mockResolvedValue(null);
   const getOptionalVerifiedUser = jest.fn().mockResolvedValue(null);
+  const isRevokedIdTokenError = jest.fn().mockReturnValue(false);
 
   return {
     getVerifiedUser,
+    getVerifiedAdminUser,
+    getVerifiedUserWithRevocation,
     getOptionalVerifiedUser,
+    isRevokedIdTokenError,
     mockVerifiedUser(user) {
-      getVerifiedUser.mockResolvedValueOnce({
+      const verified = {
         email: undefined,
         name: undefined,
         picture: undefined,
         isAdmin: false,
         ...user,
-      });
-      getOptionalVerifiedUser.mockResolvedValueOnce({
-        email: undefined,
-        name: undefined,
-        picture: undefined,
-        isAdmin: false,
-        ...user,
-      });
+      };
+      getVerifiedUser.mockResolvedValueOnce(verified);
+      getVerifiedAdminUser.mockResolvedValueOnce(verified);
+      getVerifiedUserWithRevocation.mockResolvedValueOnce(verified);
+      getOptionalVerifiedUser.mockResolvedValueOnce(verified);
     },
     mockUnauthenticated() {
       getVerifiedUser.mockResolvedValueOnce(null);
+      getVerifiedAdminUser.mockResolvedValueOnce(null);
+      getVerifiedUserWithRevocation.mockResolvedValueOnce(null);
       getOptionalVerifiedUser.mockResolvedValueOnce(null);
     },
     mockAuthError(err = new Error("token verify failed")) {
       getVerifiedUser.mockRejectedValueOnce(err);
+      getVerifiedAdminUser.mockRejectedValueOnce(err);
+      getVerifiedUserWithRevocation.mockRejectedValueOnce(err);
       getOptionalVerifiedUser.mockRejectedValueOnce(err);
+    },
+    mockRevokedAuthError(err = new Error("The Firebase ID token has been revoked.")) {
+      getVerifiedUser.mockRejectedValueOnce(err);
+      getVerifiedAdminUser.mockRejectedValueOnce(err);
+      getVerifiedUserWithRevocation.mockRejectedValueOnce(err);
+      getOptionalVerifiedUser.mockRejectedValueOnce(err);
+      isRevokedIdTokenError.mockReturnValueOnce(true);
     },
   };
 }
@@ -70,8 +89,13 @@ export function makeServerAuthSpies(): ServerAuthSpies {
 export function createServerAuthModule(spies: ServerAuthSpies) {
   return {
     getVerifiedUser: (...a: unknown[]) => spies.getVerifiedUser(...a),
+    getVerifiedAdminUser: (...a: unknown[]) =>
+      spies.getVerifiedAdminUser(...a),
+    getVerifiedUserWithRevocation: (...a: unknown[]) =>
+      spies.getVerifiedUserWithRevocation(...a),
     getOptionalVerifiedUser: (...a: unknown[]) =>
       spies.getOptionalVerifiedUser(...a),
+    isRevokedIdTokenError: spies.isRevokedIdTokenError,
   };
 }
 

--- a/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
@@ -56,7 +56,10 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(AUTH_USER),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(AUTH_USER),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(AUTH_USER),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(AUTH_USER),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(AUTH_USER),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
@@ -59,6 +59,7 @@ jest.mock("@/lib/server-auth", () => ({
   getVerifiedAdminUser: jest.fn().mockResolvedValue(AUTH_USER),
   getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(AUTH_USER),
   getOptionalVerifiedUser: jest.fn().mockResolvedValue(AUTH_USER),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
   isRevokedIdTokenError: jest.fn(() => false),
 }));
 

--- a/__tests__/app/api/all-routes-handler-invoke.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke.test.ts
@@ -49,7 +49,10 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/app/api/all-routes-handler-invoke.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke.test.ts
@@ -52,6 +52,7 @@ jest.mock("@/lib/server-auth", () => ({
   getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
   getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
   getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
   isRevokedIdTokenError: jest.fn(() => false),
 }));
 

--- a/__tests__/app/api/all-routes-smoke.test.ts
+++ b/__tests__/app/api/all-routes-smoke.test.ts
@@ -24,7 +24,10 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/app/api/all-routes-smoke.test.ts
+++ b/__tests__/app/api/all-routes-smoke.test.ts
@@ -27,6 +27,7 @@ jest.mock("@/lib/server-auth", () => ({
   getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
   getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
   getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
   isRevokedIdTokenError: jest.fn(() => false),
 }));
 

--- a/__tests__/app/api/community/moderate.test.ts
+++ b/__tests__/app/api/community/moderate.test.ts
@@ -10,8 +10,8 @@ import { NextRequest } from "next/server";
 import { POST, GET } from "@/app/api/community/moderate/route";
 import type { VerifiedUser } from "@/lib/server-auth";
 import {
-  getVerifiedAdminUser as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 
 jest.mock("@/lib/logger", () => ({
@@ -19,8 +19,8 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 const mockBatchUpdate = jest.fn();
@@ -59,8 +59,8 @@ jest.mock("firebase-admin/firestore", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const adminUser: VerifiedUser = { uid: "admin1", name: "Admin", isAdmin: true };
 const regularUser: VerifiedUser = { uid: "u1", name: "Reg", isAdmin: false };
@@ -79,7 +79,7 @@ function makeGetRequest(query = "") {
 describe("POST /api/community/moderate (admin actions)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(adminUser);
     mockReportGet.mockResolvedValue({
       exists: true,
@@ -94,8 +94,8 @@ describe("POST /api/community/moderate (admin actions)", () => {
   });
 
   it("returns 401 without moderation side effects when the admin token is revoked", async () => {
-    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockGetVerifiedUser.mockResolvedValueOnce(adminUser);
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await POST(makePostRequest({ reportId: "r1", action: "dismiss" }));
 
@@ -167,7 +167,7 @@ describe("POST /api/community/moderate (admin actions)", () => {
 describe("GET /api/community/moderate (admin listing)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(adminUser);
     mockListSnap.docs = [
       {

--- a/__tests__/app/api/community/moderate.test.ts
+++ b/__tests__/app/api/community/moderate.test.ts
@@ -9,14 +9,18 @@
 import { NextRequest } from "next/server";
 import { POST, GET } from "@/app/api/community/moderate/route";
 import type { VerifiedUser } from "@/lib/server-auth";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 
 jest.mock("@/lib/logger", () => ({
   logger: { error: jest.fn(), logError: jest.fn() },
 }));
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 const mockBatchUpdate = jest.fn();
@@ -55,6 +59,9 @@ jest.mock("firebase-admin/firestore", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 const adminUser: VerifiedUser = { uid: "admin1", name: "Admin", isAdmin: true };
 const regularUser: VerifiedUser = { uid: "u1", name: "Reg", isAdmin: false };
 
@@ -72,6 +79,7 @@ function makeGetRequest(query = "") {
 describe("POST /api/community/moderate (admin actions)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
     mockGetVerifiedUser.mockResolvedValue(adminUser);
     mockReportGet.mockResolvedValue({
       exists: true,
@@ -83,6 +91,20 @@ describe("POST /api/community/moderate (admin actions)", () => {
     mockGetVerifiedUser.mockResolvedValue(null);
     const res = await POST(makePostRequest({ reportId: "r1", action: "dismiss" }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 without moderation side effects when the admin token is revoked", async () => {
+    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await POST(makePostRequest({ reportId: "r1", action: "dismiss" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: "Session revoked. Please sign in again.",
+    });
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
   });
 
   it("returns 403 for non-admin", async () => {
@@ -145,6 +167,7 @@ describe("POST /api/community/moderate (admin actions)", () => {
 describe("GET /api/community/moderate (admin listing)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
     mockGetVerifiedUser.mockResolvedValue(adminUser);
     mockListSnap.docs = [
       {

--- a/__tests__/app/api/events/pydata-2026/admin/list.test.ts
+++ b/__tests__/app/api/events/pydata-2026/admin/list.test.ts
@@ -6,14 +6,14 @@ import { NextRequest } from "next/server";
 import { GET } from "@/app/api/events/pydata-2026/admin/list/route";
 import { getAdminDb } from "@/lib/firebase-admin";
 import {
-  getVerifiedAdminUser as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/middleware", () => ({
   withMiddleware: (_cfg: unknown, handler: any) => handler,
@@ -22,8 +22,8 @@ jest.mock("@/lib/middleware", () => ({
 
 const mockAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 
 function tsLike(ms: number) {
@@ -51,7 +51,7 @@ function req() {
 describe("GET /api/events/pydata-2026/admin/list", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -61,8 +61,8 @@ describe("GET /api/events/pydata-2026/admin/list", () => {
   });
 
   it("returns 401 when the admin token has been revoked", async () => {
-    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as any);
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await GET(req());
     const body = await res.json();

--- a/__tests__/app/api/events/pydata-2026/admin/list.test.ts
+++ b/__tests__/app/api/events/pydata-2026/admin/list.test.ts
@@ -5,10 +5,16 @@
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/events/pydata-2026/admin/list/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
 jest.mock("@/lib/middleware", () => ({
   withMiddleware: (_cfg: unknown, handler: any) => handler,
   rateLimitConfigs: { standard: {} },
@@ -16,6 +22,9 @@ jest.mock("@/lib/middleware", () => ({
 
 const mockAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 
 function tsLike(ms: number) {
   return { toMillis: () => ms };
@@ -42,12 +51,25 @@ function req() {
 describe("GET /api/events/pydata-2026/admin/list", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
   });
 
   it("returns 401 when unauthenticated", async () => {
     mockUser.mockResolvedValue(null);
     const res = await GET(req());
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await GET(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the user is not an admin", async () => {

--- a/__tests__/app/api/game/admin/grant/route.test.ts
+++ b/__tests__/app/api/game/admin/grant/route.test.ts
@@ -4,27 +4,27 @@
 import { POST } from "@/app/api/game/admin/grant/route";
 import { adminGrantTurnsServer } from "@/lib/game/data-server";
 import {
-  getVerifiedAdminUser as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/game/data-server", () => ({
   adminGrantTurnsServer: jest.fn(),
 }));
 
 describe("POST /api/game/admin/grant", () => {
-  const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-    typeof isRevokedIdTokenError
+  const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+    typeof isCurrentIdTokenRevoked
   >;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     (getVerifiedUser as jest.Mock).mockResolvedValue({
       uid: "admin",
       email: "a@test.com",
@@ -34,8 +34,13 @@ describe("POST /api/game/admin/grant", () => {
   });
 
   it("returns 401 when the admin token has been revoked", async () => {
-    (getVerifiedUser as jest.Mock).mockRejectedValueOnce(new Error("revoked"));
-    mockIsRevoked.mockReturnValueOnce(true);
+    (getVerifiedUser as jest.Mock).mockResolvedValueOnce({
+      uid: "admin",
+      email: "a@test.com",
+      name: "A",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const { status, body } = await readJson(
       await POST(

--- a/__tests__/app/api/game/admin/grant/route.test.ts
+++ b/__tests__/app/api/game/admin/grant/route.test.ts
@@ -3,23 +3,56 @@
  */
 import { POST } from "@/app/api/game/admin/grant/route";
 import { adminGrantTurnsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
 jest.mock("@/lib/game/data-server", () => ({
   adminGrantTurnsServer: jest.fn(),
 }));
 
 describe("POST /api/game/admin/grant", () => {
+  const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+    typeof isRevokedIdTokenError
+  >;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
     (getVerifiedUser as jest.Mock).mockResolvedValue({
       uid: "admin",
       email: "a@test.com",
       name: "A",
       isAdmin: false,
     });
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    (getVerifiedUser as jest.Mock).mockRejectedValueOnce(new Error("revoked"));
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/admin/grant",
+          body: { weekStartIso: "2026-05-18T05:30:00.000Z" },
+        }),
+      ),
+    );
+
+    expect(status).toBe(401);
+    expect(body.error).toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Session revoked. Please sign in again.",
+    });
+    expect(adminGrantTurnsServer).not.toHaveBeenCalled();
   });
 
   it("returns 403 for non-admin", async () => {

--- a/__tests__/app/api/game/admin/units/route.test.ts
+++ b/__tests__/app/api/game/admin/units/route.test.ts
@@ -6,14 +6,14 @@
 import { POST } from "@/app/api/game/admin/units/route";
 import { adminGrantUnitsServer } from "@/lib/game/data-server";
 import {
-  getVerifiedAdminUser as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/game/data-server", () => ({
@@ -21,15 +21,15 @@ jest.mock("@/lib/game/data-server", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockGrantUnits = adminGrantUnitsServer as jest.MockedFunction<typeof adminGrantUnitsServer>;
 
 describe("POST /api/game/admin/units", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue({
       uid: "u1",
       email: "u@test.com",
@@ -53,8 +53,13 @@ describe("POST /api/game/admin/units", () => {
   });
 
   it("returns 401 when the admin token has been revoked", async () => {
-    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin",
+      email: "a@test.com",
+      name: "A",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const { status, body } = await readJson(
       await POST(

--- a/__tests__/app/api/game/admin/units/route.test.ts
+++ b/__tests__/app/api/game/admin/units/route.test.ts
@@ -5,11 +5,15 @@
  */
 import { POST } from "@/app/api/game/admin/units/route";
 import { adminGrantUnitsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("@/lib/game/data-server", () => ({
@@ -17,11 +21,15 @@ jest.mock("@/lib/game/data-server", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 const mockGrantUnits = adminGrantUnitsServer as jest.MockedFunction<typeof adminGrantUnitsServer>;
 
 describe("POST /api/game/admin/units", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
     mockGetVerifiedUser.mockResolvedValue({
       uid: "u1",
       email: "u@test.com",
@@ -41,6 +49,28 @@ describe("POST /api/game/admin/units", () => {
       }),
     );
     expect(res.status).toBe(401);
+    expect(mockGrantUnits).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/admin/units",
+          body: { tileId: "t1", unitType: "ground", count: 5 },
+        }),
+      ),
+    );
+
+    expect(status).toBe(401);
+    expect(body.error).toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Session revoked. Please sign in again.",
+    });
     expect(mockGrantUnits).not.toHaveBeenCalled();
   });
 

--- a/__tests__/app/api/game/heroes/chapter.test.ts
+++ b/__tests__/app/api/game/heroes/chapter.test.ts
@@ -17,16 +17,15 @@ import {
   DELETE,
   PATCH,
 } from "@/app/api/game/heroes/[heroId]/chapter/[chapterId]/route";
-import { getVerifiedAdminUser, getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HeroLoreForbiddenError,
   HeroLoreNotFoundError,
 } from "@/lib/game/hero-lore";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
   getVerifiedUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/game/hero-lore", () => {
@@ -39,8 +38,8 @@ jest.mock("@/lib/game/hero-lore", () => {
 });
 
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockAdminUser = getVerifiedAdminUser as jest.MockedFunction<
-  typeof getVerifiedAdminUser
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 
 function makeReq(method: "DELETE" | "PATCH") {
@@ -61,11 +60,7 @@ beforeEach(() => {
     email: "u@x",
     isAdmin: false,
   } as never);
-  mockAdminUser.mockResolvedValue({
-    uid: "u1",
-    email: "u@x",
-    isAdmin: false,
-  } as never);
+  mockIsRevoked.mockResolvedValue(false);
   const { deleteHeroChapterServer, approveHeroChapterServer } = jest.requireMock(
     "@/lib/game/hero-lore",
   ) as {
@@ -171,7 +166,7 @@ describe("DELETE /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
 
 describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   it("returns 401 when unauthenticated", async () => {
-    mockAdminUser.mockResolvedValueOnce(null);
+    mockUser.mockResolvedValueOnce(null);
     const res = await PATCH(makeReq("PATCH"), withParams("h1", "c1"));
     expect(res.status).toBe(401);
   });
@@ -182,19 +177,19 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 400 when heroId is missing", async () => {
-    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const res = await PATCH(makeReq("PATCH"), withParams("", "c1"));
     expect(res.status).toBe(400);
   });
 
   it("returns 400 when chapterId is missing", async () => {
-    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const res = await PATCH(makeReq("PATCH"), withParams("h1", ""));
     expect(res.status).toBe(400);
   });
 
   it("returns 200 on happy path and forwards approverUserId", async () => {
-    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const res = await PATCH(makeReq("PATCH"), withParams("h1", "c1"));
     expect(res.status).toBe(200);
     const { approveHeroChapterServer } = jest.requireMock(
@@ -208,7 +203,7 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 404 on HeroLoreNotFoundError", async () => {
-    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const { approveHeroChapterServer } = jest.requireMock(
       "@/lib/game/hero-lore",
     ) as { approveHeroChapterServer: jest.Mock };
@@ -220,7 +215,7 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 500 with message on unknown Error", async () => {
-    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const { approveHeroChapterServer } = jest.requireMock(
       "@/lib/game/hero-lore",
     ) as { approveHeroChapterServer: jest.Mock };
@@ -232,7 +227,7 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 500 'Server error' on non-Error throw", async () => {
-    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const { approveHeroChapterServer } = jest.requireMock(
       "@/lib/game/hero-lore",
     ) as { approveHeroChapterServer: jest.Mock };

--- a/__tests__/app/api/game/heroes/chapter.test.ts
+++ b/__tests__/app/api/game/heroes/chapter.test.ts
@@ -17,13 +17,17 @@ import {
   DELETE,
   PATCH,
 } from "@/app/api/game/heroes/[heroId]/chapter/[chapterId]/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, getVerifiedUser } from "@/lib/server-auth";
 import {
   HeroLoreForbiddenError,
   HeroLoreNotFoundError,
 } from "@/lib/game/hero-lore";
 
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedAdminUser: jest.fn(),
+  getVerifiedUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
 
 jest.mock("@/lib/game/hero-lore", () => {
   const actual = jest.requireActual("@/lib/game/hero-lore");
@@ -35,6 +39,9 @@ jest.mock("@/lib/game/hero-lore", () => {
 });
 
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockAdminUser = getVerifiedAdminUser as jest.MockedFunction<
+  typeof getVerifiedAdminUser
+>;
 
 function makeReq(method: "DELETE" | "PATCH") {
   return new NextRequest(
@@ -50,6 +57,11 @@ function withParams(heroId: string, chapterId: string) {
 beforeEach(() => {
   jest.clearAllMocks();
   mockUser.mockResolvedValue({
+    uid: "u1",
+    email: "u@x",
+    isAdmin: false,
+  } as never);
+  mockAdminUser.mockResolvedValue({
     uid: "u1",
     email: "u@x",
     isAdmin: false,
@@ -159,7 +171,7 @@ describe("DELETE /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
 
 describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   it("returns 401 when unauthenticated", async () => {
-    mockUser.mockResolvedValueOnce(null);
+    mockAdminUser.mockResolvedValueOnce(null);
     const res = await PATCH(makeReq("PATCH"), withParams("h1", "c1"));
     expect(res.status).toBe(401);
   });
@@ -170,19 +182,19 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 400 when heroId is missing", async () => {
-    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const res = await PATCH(makeReq("PATCH"), withParams("", "c1"));
     expect(res.status).toBe(400);
   });
 
   it("returns 400 when chapterId is missing", async () => {
-    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const res = await PATCH(makeReq("PATCH"), withParams("h1", ""));
     expect(res.status).toBe(400);
   });
 
   it("returns 200 on happy path and forwards approverUserId", async () => {
-    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const res = await PATCH(makeReq("PATCH"), withParams("h1", "c1"));
     expect(res.status).toBe(200);
     const { approveHeroChapterServer } = jest.requireMock(
@@ -196,7 +208,7 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 404 on HeroLoreNotFoundError", async () => {
-    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const { approveHeroChapterServer } = jest.requireMock(
       "@/lib/game/hero-lore",
     ) as { approveHeroChapterServer: jest.Mock };
@@ -208,7 +220,7 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 500 with message on unknown Error", async () => {
-    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const { approveHeroChapterServer } = jest.requireMock(
       "@/lib/game/hero-lore",
     ) as { approveHeroChapterServer: jest.Mock };
@@ -220,7 +232,7 @@ describe("PATCH /api/game/heroes/[heroId]/chapter/[chapterId]", () => {
   });
 
   it("returns 500 'Server error' on non-Error throw", async () => {
-    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
+    mockAdminUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as never);
     const { approveHeroChapterServer } = jest.requireMock(
       "@/lib/game/hero-lore",
     ) as { approveHeroChapterServer: jest.Mock };

--- a/__tests__/app/api/hackathons/events/checkin.route.test.ts
+++ b/__tests__/app/api/hackathons/events/checkin.route.test.ts
@@ -4,7 +4,7 @@
 
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/events/[eventId]/checkin/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser as getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkRateLimit } from "@/lib/rate-limit";
 
@@ -18,7 +18,8 @@ jest.mock("@/lib/rate-limit", () => {
 });
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({

--- a/__tests__/app/api/hackathons/events/checkin.route.test.ts
+++ b/__tests__/app/api/hackathons/events/checkin.route.test.ts
@@ -4,7 +4,7 @@
 
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/events/[eventId]/checkin/route";
-import { getVerifiedAdminUser as getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkRateLimit } from "@/lib/rate-limit";
 
@@ -18,8 +18,8 @@ jest.mock("@/lib/rate-limit", () => {
 });
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -32,6 +32,9 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
 const VALID_EVENT_ID = "hack-a-sprint-2026";
@@ -58,13 +61,16 @@ function makeMockDoc(data: Record<string, unknown> | null) {
 }
 
 describe("POST /api/hackathons/events/[eventId]/checkin", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
+  });
 
-  it("returns 403 when not authenticated", async () => {
+  it("returns 401 when not authenticated", async () => {
     mockGetVerifiedUser.mockResolvedValue(null);
     const req = makeRequest({ userId: "u1", checkedIn: true });
     const res = await POST(req, makeContext(VALID_EVENT_ID));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 
   it("returns 403 when user is not admin", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.test.ts
@@ -5,7 +5,7 @@
  */
 import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser as getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import {
@@ -20,7 +20,8 @@ import {
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.test.ts
@@ -5,7 +5,7 @@
  */
 import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
-import { getVerifiedAdminUser as getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import {
@@ -20,8 +20,8 @@ import {
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -53,6 +53,9 @@ jest.mock("@/lib/hackathon-asprint-2026-state", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
 const mockFetchSubmissions = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
@@ -127,6 +130,7 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard", () =
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetVerifiedUser.mockResolvedValue(null);
+    mockIsRevoked.mockResolvedValue(false);
     mockCheckRateLimit.mockReturnValue({ success: true, retryAfter: 0 });
     mockGetPhase.mockReturnValue("judging");
     mockFetchSubmissions.mockResolvedValue([]);
@@ -270,14 +274,14 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard", () =
     expect(body.error).toBe("Failed to load dashboard");
   });
 
-  it("returns 401-like 403 when caller is unauthenticated (no user)", async () => {
+  it("returns 401 when caller is unauthenticated (no user)", async () => {
     mockGetVerifiedUser.mockResolvedValue(null);
     const res = await GET(
       makeAuthedRequest({
         path: "/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard",
       }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 
   it("handles submissions with no score docs (all null fields, rawScore null)", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score.route.test.ts
@@ -6,12 +6,15 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser as getVerifiedUser } from "@/lib/server-auth";
 import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
 jest.mock("@/lib/hackathon-showcase", () => ({
   ...jest.requireActual("@/lib/hackathon-showcase"),
   fetchShowcaseSubmissionsFromGitHub: jest.fn(),

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score.route.test.ts
@@ -6,14 +6,14 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser as getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/hackathon-showcase", () => ({
   ...jest.requireActual("@/lib/hackathon-showcase"),
@@ -31,6 +31,9 @@ jest.mock("firebase-admin/firestore", () => ({
 }));
 
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
   typeof fetchShowcaseSubmissionsFromGitHub
@@ -60,6 +63,7 @@ function setupDb() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsRevoked.mockResolvedValue(false);
   mockRate.mockResolvedValue({ success: true } as never);
   mockUser.mockResolvedValue({ uid: "admin", isAdmin: true } as never);
   mockSubs.mockResolvedValue([
@@ -87,10 +91,10 @@ describe("POST /api/hackathons/showcase/hack-a-sprint-2026/ai-score", () => {
     expect(res.status).toBe(403);
   });
 
-  it("returns 403 when caller is not authenticated", async () => {
+  it("returns 401 when caller is not authenticated", async () => {
     mockUser.mockResolvedValue(null);
     const res = await POST(makeReq());
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 
   it("returns 400 for invalid JSON body", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code.route.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  getVerifiedUserWithRevocation as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
+import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUserWithRevocation: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
+jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
+  resolveHackASprint2026CreditForUser: jest.fn(),
+}));
+
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
+const mockResolve = resolveHackASprint2026CreditForUser as jest.MockedFunction<
+  typeof resolveHackASprint2026CreditForUser
+>;
+
+function makeReq() {
+  return new NextRequest(
+    "https://example.com/api/hackathons/showcase/hack-a-sprint-2026/credit-code",
+    { method: "GET" },
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsRevoked.mockReturnValue(false);
+});
+
+describe("GET /api/hackathons/showcase/hack-a-sprint-2026/credit-code", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+
+    const res = await GET(makeReq());
+
+    expect(res.status).toBe(401);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the sensitive credit token has been revoked", async () => {
+    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockDb).not.toHaveBeenCalled();
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("returns the resolved credit URL for eligible users", async () => {
+    const db = { collection: jest.fn() };
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@example.com" } as never);
+    mockDb.mockReturnValue(db as never);
+    mockResolve.mockResolvedValue({
+      ok: true,
+      creditUrl: "https://cursor.com/credit/abc",
+      rank: 7,
+    } as never);
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      eligible: true,
+      creditUrl: "https://cursor.com/credit/abc",
+      rank: 7,
+    });
+    expect(mockResolve).toHaveBeenCalledWith(db, "u1", "u@example.com");
+  });
+});

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code.route.test.ts
@@ -6,15 +6,15 @@ import { NextRequest } from "next/server";
 import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route";
 import { getAdminDb } from "@/lib/firebase-admin";
 import {
-  getVerifiedUserWithRevocation as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUserWithRevocation: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
   resolveHackASprint2026CreditForUser: jest.fn(),
@@ -22,8 +22,8 @@ jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
 
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockResolve = resolveHackASprint2026CreditForUser as jest.MockedFunction<
   typeof resolveHackASprint2026CreditForUser
@@ -38,7 +38,7 @@ function makeReq() {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockIsRevoked.mockReturnValue(false);
+  mockIsRevoked.mockResolvedValue(false);
 });
 
 describe("GET /api/hackathons/showcase/hack-a-sprint-2026/credit-code", () => {
@@ -52,16 +52,23 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/credit-code", () => {
   });
 
   it("returns 401 when the sensitive credit token has been revoked", async () => {
-    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    const db = { collection: jest.fn() };
+    mockUser.mockResolvedValueOnce({ uid: "u1", email: "u@example.com" } as never);
+    mockDb.mockReturnValue(db as never);
+    mockResolve.mockResolvedValueOnce({
+      ok: true,
+      creditUrl: "https://cursor.com/credit/abc",
+      rank: 7,
+    } as never);
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await GET(makeReq());
     const body = await res.json();
 
     expect(res.status).toBe(401);
     expect(body.error).toBe("Session revoked. Please sign in again.");
-    expect(mockDb).not.toHaveBeenCalled();
-    expect(mockResolve).not.toHaveBeenCalled();
+    expect(mockDb).toHaveBeenCalled();
+    expect(mockResolve).toHaveBeenCalledWith(db, "u1", "u@example.com");
   });
 
   it("returns the resolved credit URL for eligible users", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
@@ -6,7 +6,10 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUserWithRevocation as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 import { sendEmail } from "@/lib/mailgun";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
@@ -15,7 +18,10 @@ jest.mock("@/lib/firebase-admin", () => ({
   getAdminDb: jest.fn(),
   getAdminAuth: jest.fn(),
 }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUserWithRevocation: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
 jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
   resolveHackASprint2026CreditForUser: jest.fn(),
 }));
@@ -36,6 +42,9 @@ jest.mock("firebase-admin/firestore", () => ({
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 const mockResolve = resolveHackASprint2026CreditForUser as jest.MockedFunction<
   typeof resolveHackASprint2026CreditForUser
 >;
@@ -79,6 +88,7 @@ function setupAdmins(opts: DbOpts = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsRevoked.mockReturnValue(false);
   mockRate.mockResolvedValue({ success: true } as never);
   mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
   mockResolve.mockResolvedValue({
@@ -86,6 +96,21 @@ beforeEach(() => {
     creditUrl: "https://cursor.com/credit/xyz",
   } as never);
   mockSendEmail.mockResolvedValue(undefined as never);
+});
+
+it("returns 401 when the sensitive credit token is revoked", async () => {
+  mockUser.mockRejectedValueOnce(new Error("revoked") as never);
+  mockIsRevoked.mockReturnValueOnce(true);
+
+  const res = await POST(makeReq());
+
+  expect(res.status).toBe(401);
+  await expect(res.json()).resolves.toMatchObject({
+    error: "Session revoked. Please sign in again.",
+  });
+  expect(mockDb).not.toHaveBeenCalled();
+  expect(mockAuth).not.toHaveBeenCalled();
+  expect(mockSendEmail).not.toHaveBeenCalled();
 });
 
 describe("POST /api/hackathons/showcase/hack-a-sprint-2026/credit-email", () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
@@ -7,8 +7,8 @@ import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
 import {
-  getVerifiedUserWithRevocation as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 import { sendEmail } from "@/lib/mailgun";
@@ -19,8 +19,8 @@ jest.mock("@/lib/firebase-admin", () => ({
   getAdminAuth: jest.fn(),
 }));
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUserWithRevocation: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
   resolveHackASprint2026CreditForUser: jest.fn(),
@@ -42,8 +42,8 @@ jest.mock("firebase-admin/firestore", () => ({
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockResolve = resolveHackASprint2026CreditForUser as jest.MockedFunction<
   typeof resolveHackASprint2026CreditForUser
@@ -88,7 +88,7 @@ function setupAdmins(opts: DbOpts = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockIsRevoked.mockReturnValue(false);
+  mockIsRevoked.mockResolvedValue(false);
   mockRate.mockResolvedValue({ success: true } as never);
   mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
   mockResolve.mockResolvedValue({
@@ -99,8 +99,9 @@ beforeEach(() => {
 });
 
 it("returns 401 when the sensitive credit token is revoked", async () => {
-  mockUser.mockRejectedValueOnce(new Error("revoked") as never);
-  mockIsRevoked.mockReturnValueOnce(true);
+  setupAdmins();
+  mockUser.mockResolvedValueOnce({ uid: "u1", email: "u@x" } as never);
+  mockIsRevoked.mockResolvedValueOnce(true);
 
   const res = await POST(makeReq());
 
@@ -108,8 +109,8 @@ it("returns 401 when the sensitive credit token is revoked", async () => {
   await expect(res.json()).resolves.toMatchObject({
     error: "Session revoked. Please sign in again.",
   });
-  expect(mockDb).not.toHaveBeenCalled();
-  expect(mockAuth).not.toHaveBeenCalled();
+  expect(mockDb).toHaveBeenCalled();
+  expect(mockAuth).toHaveBeenCalled();
   expect(mockSendEmail).not.toHaveBeenCalled();
 });
 

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
@@ -6,14 +6,20 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUserWithRevocation as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
 import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
 import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUserWithRevocation: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
 jest.mock("@/lib/hackathon-showcase", () => ({
   ...jest.requireActual("@/lib/hackathon-showcase"),
   fetchShowcaseSubmissionsFromGitHub: jest.fn(),
@@ -38,6 +44,9 @@ jest.mock("firebase-admin/firestore", () => ({
 
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
   typeof fetchShowcaseSubmissionsFromGitHub
 >;
@@ -68,6 +77,7 @@ function setupDb() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsRevoked.mockReturnValue(false);
   mockRate.mockResolvedValue({ success: true, remaining: 9 } as never);
   mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
   mockPhase.mockReturnValue("peerVotingOpen");
@@ -96,6 +106,19 @@ describe("POST /api/hackathons/showcase/hack-a-sprint-2026/judge-score", () => {
     mockUser.mockResolvedValueOnce(null);
     const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the judge token has been revoked", async () => {
+    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockDb).not.toHaveBeenCalled();
+    expect(mockSubs).not.toHaveBeenCalled();
   });
 
   it("returns 403 when phase is not peerVotingOpen", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
@@ -7,8 +7,8 @@ import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route";
 import { getAdminDb } from "@/lib/firebase-admin";
 import {
-  getVerifiedUserWithRevocation as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
 import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
@@ -17,8 +17,8 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUserWithRevocation: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/hackathon-showcase", () => ({
   ...jest.requireActual("@/lib/hackathon-showcase"),
@@ -44,8 +44,8 @@ jest.mock("firebase-admin/firestore", () => ({
 
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
   typeof fetchShowcaseSubmissionsFromGitHub
@@ -77,7 +77,7 @@ function setupDb() {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockIsRevoked.mockReturnValue(false);
+  mockIsRevoked.mockResolvedValue(false);
   mockRate.mockResolvedValue({ success: true, remaining: 9 } as never);
   mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
   mockPhase.mockReturnValue("peerVotingOpen");
@@ -109,15 +109,16 @@ describe("POST /api/hackathons/showcase/hack-a-sprint-2026/judge-score", () => {
   });
 
   it("returns 401 when the judge token has been revoked", async () => {
-    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockUser.mockResolvedValueOnce({ uid: "u1", email: "u@x" } as never);
+    setupDb();
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
     const body = await res.json();
 
     expect(res.status).toBe(401);
     expect(body.error).toBe("Session revoked. Please sign in again.");
-    expect(mockDb).not.toHaveBeenCalled();
+    expect(mockDb).toHaveBeenCalled();
     expect(mockSubs).not.toHaveBeenCalled();
   });
 

--- a/__tests__/app/api/live/session/route.test.ts
+++ b/__tests__/app/api/live/session/route.test.ts
@@ -4,11 +4,15 @@
 
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/live/session/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("@/lib/live-sessions/data-server", () => ({
@@ -16,6 +20,9 @@ jest.mock("@/lib/live-sessions/data-server", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 const mockCreateLiveSessionServer =
   createLiveSessionServer as jest.MockedFunction<typeof createLiveSessionServer>;
 
@@ -38,6 +45,7 @@ function makeInvalidJsonRequest() {
 describe("POST /api/live/session", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
   });
 
   it("requires authentication", async () => {
@@ -46,6 +54,18 @@ describe("POST /api/live/session", () => {
     const res = await POST(makeRequest({ title: "Demo Night" }));
 
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await POST(makeRequest({ title: "Demo Night" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: "Session revoked. Please sign in again.",
+    });
   });
 
   it("requires admin privileges", async () => {

--- a/__tests__/app/api/live/session/route.test.ts
+++ b/__tests__/app/api/live/session/route.test.ts
@@ -5,14 +5,14 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/live/session/route";
 import {
-  getVerifiedAdminUser as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/live-sessions/data-server", () => ({
@@ -20,8 +20,8 @@ jest.mock("@/lib/live-sessions/data-server", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockCreateLiveSessionServer =
   createLiveSessionServer as jest.MockedFunction<typeof createLiveSessionServer>;
@@ -45,7 +45,7 @@ function makeInvalidJsonRequest() {
 describe("POST /api/live/session", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
   });
 
   it("requires authentication", async () => {
@@ -57,8 +57,12 @@ describe("POST /api/live/session", () => {
   });
 
   it("returns 401 when the admin token has been revoked", async () => {
-    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin-1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await POST(makeRequest({ title: "Demo Night" }));
 

--- a/__tests__/app/api/showcase/submission/approve/route.test.ts
+++ b/__tests__/app/api/showcase/submission/approve/route.test.ts
@@ -4,7 +4,10 @@
 
 import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/showcase/submission/approve/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkServerRateLimit } from "@/lib/rate-limit-server";
 
@@ -22,7 +25,8 @@ jest.mock("@/lib/rate-limit-server", () => ({
 }));
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -30,6 +34,9 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
 function makeGetRequest() {
@@ -47,8 +54,35 @@ function makePostRequest(body: Record<string, unknown>) {
 describe("/api/showcase/submission/approve", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
     process.env.ADMIN_EMAILS = "admin@example.com";
     process.env.ADMIN_EMAIL = "";
+  });
+
+  it("returns 401 when the GET admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await GET(makeGetRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(checkServerRateLimit).not.toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the POST admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await POST(makePostRequest({ submissionId: "s1", action: "approve" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(checkServerRateLimit).not.toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("rejects non-admin moderation access", async () => {

--- a/__tests__/app/api/showcase/submission/approve/route.test.ts
+++ b/__tests__/app/api/showcase/submission/approve/route.test.ts
@@ -5,8 +5,8 @@
 import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/showcase/submission/approve/route";
 import {
-  getVerifiedAdminUser as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkServerRateLimit } from "@/lib/rate-limit-server";
@@ -25,8 +25,8 @@ jest.mock("@/lib/rate-limit-server", () => ({
 }));
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -34,8 +34,8 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
@@ -54,34 +54,42 @@ function makePostRequest(body: Record<string, unknown>) {
 describe("/api/showcase/submission/approve", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     process.env.ADMIN_EMAILS = "admin@example.com";
     process.env.ADMIN_EMAIL = "";
   });
 
   it("returns 401 when the GET admin token has been revoked", async () => {
-    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await GET(makeGetRequest());
     const body = await res.json();
 
     expect(res.status).toBe(401);
     expect(body.error).toBe("Session revoked. Please sign in again.");
-    expect(checkServerRateLimit).not.toHaveBeenCalled();
+    expect(checkServerRateLimit).toHaveBeenCalled();
     expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 401 when the POST admin token has been revoked", async () => {
-    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await POST(makePostRequest({ submissionId: "s1", action: "approve" }));
     const body = await res.json();
 
     expect(res.status).toBe(401);
     expect(body.error).toBe("Session revoked. Please sign in again.");
-    expect(checkServerRateLimit).not.toHaveBeenCalled();
+    expect(checkServerRateLimit).toHaveBeenCalled();
     expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 

--- a/__tests__/app/api/summer-cohort/admin/access.route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/access.route.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from "@/app/api/summer-cohort/admin/access/route";
+import {
+  getVerifiedUserWithRevocation,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
+import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUserWithRevocation: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
+jest.mock("@/lib/summer-cohort-admin-access", () => ({
+  isSummerCohortAdminEmail: jest.fn(),
+}));
+
+const mockUser = getVerifiedUserWithRevocation as jest.MockedFunction<
+  typeof getVerifiedUserWithRevocation
+>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
+const mockIsAdminEmail = isSummerCohortAdminEmail as jest.MockedFunction<
+  typeof isSummerCohortAdminEmail
+>;
+
+describe("GET /api/summer-cohort/admin/access", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
+    mockIsAdminEmail.mockReturnValue(false);
+  });
+
+  it("returns allowed false when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+
+    const { status, body } = await readJson(
+      await GET(makeRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(401);
+    expect(body).toEqual({ allowed: false });
+  });
+
+  it("treats malformed or expired tokens as an unauthenticated probe", async () => {
+    mockUser.mockRejectedValueOnce(new Error("token expired") as never);
+
+    const { status, body } = await readJson(
+      await GET(makeAuthedRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(401);
+    expect(body).toEqual({ allowed: false });
+    expect(mockIsAdminEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns an explicit revoked-session error for revoked tokens", async () => {
+    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const { status, body } = await readJson(
+      await GET(makeAuthedRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(401);
+    expect(body).toEqual({
+      allowed: false,
+      error: "Session revoked. Please sign in again.",
+    });
+    expect(mockIsAdminEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns the admin-email gate result for authenticated users", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "admin@example.com" } as never);
+    mockIsAdminEmail.mockReturnValue(true);
+
+    const { status, body } = await readJson(
+      await GET(makeAuthedRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ allowed: true });
+    expect(mockIsAdminEmail).toHaveBeenCalledWith("admin@example.com");
+  });
+});

--- a/__tests__/app/api/summer-cohort/admin/access.route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/access.route.test.ts
@@ -4,25 +4,25 @@
 
 import { GET } from "@/app/api/summer-cohort/admin/access/route";
 import {
-  getVerifiedUserWithRevocation,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUserWithRevocation: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/summer-cohort-admin-access", () => ({
   isSummerCohortAdminEmail: jest.fn(),
 }));
 
-const mockUser = getVerifiedUserWithRevocation as jest.MockedFunction<
-  typeof getVerifiedUserWithRevocation
+const mockUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
 >;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockIsAdminEmail = isSummerCohortAdminEmail as jest.MockedFunction<
   typeof isSummerCohortAdminEmail
@@ -31,7 +31,7 @@ const mockIsAdminEmail = isSummerCohortAdminEmail as jest.MockedFunction<
 describe("GET /api/summer-cohort/admin/access", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     mockIsAdminEmail.mockReturnValue(false);
   });
 
@@ -59,8 +59,9 @@ describe("GET /api/summer-cohort/admin/access", () => {
   });
 
   it("returns an explicit revoked-session error for revoked tokens", async () => {
-    mockUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockUser.mockResolvedValueOnce({ uid: "u1", email: "admin@example.com" } as never);
+    mockIsAdminEmail.mockReturnValueOnce(true);
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const { status, body } = await readJson(
       await GET(makeAuthedRequest({ path: "/api/summer-cohort/admin/access" })),
@@ -71,7 +72,7 @@ describe("GET /api/summer-cohort/admin/access", () => {
       allowed: false,
       error: "Session revoked. Please sign in again.",
     });
-    expect(mockIsAdminEmail).not.toHaveBeenCalled();
+    expect(mockIsAdminEmail).toHaveBeenCalledWith("admin@example.com");
   });
 
   it("returns the admin-email gate result for authenticated users", async () => {

--- a/__tests__/app/api/summer-cohort/admin/applications.route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/applications.route.test.ts
@@ -4,12 +4,15 @@
  * OpenSSF Gold coverage push #17 — summer-cohort admin applications route.
  */
 import { GET } from "@/app/api/summer-cohort/admin/applications/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation as getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUserWithRevocation: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
+}));
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
 jest.mock("@/lib/summer-cohort-admin-access", () => ({
   isSummerCohortAdminEmail: jest.fn(),

--- a/__tests__/app/api/summer-cohort/admin/applications.route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/applications.route.test.ts
@@ -4,14 +4,14 @@
  * OpenSSF Gold coverage push #17 — summer-cohort admin applications route.
  */
 import { GET } from "@/app/api/summer-cohort/admin/applications/route";
-import { getVerifiedUserWithRevocation as getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUserWithRevocation: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
 jest.mock("@/lib/summer-cohort-admin-access", () => ({
@@ -19,6 +19,9 @@ jest.mock("@/lib/summer-cohort-admin-access", () => ({
 }));
 
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockIsAdmin = isSummerCohortAdminEmail as jest.MockedFunction<typeof isSummerCohortAdminEmail>;
 
@@ -43,6 +46,7 @@ function setupDb(docs: Array<{ id: string; data: Record<string, unknown> }>) {
 beforeEach(() => {
   jest.clearAllMocks();
   mockIsAdmin.mockReturnValue(true);
+  mockIsRevoked.mockResolvedValue(false);
 });
 
 describe("GET /api/summer-cohort/admin/applications", () => {

--- a/__tests__/app/api/summer-cohort/admin/intake-aggregates/route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/intake-aggregates/route.test.ts
@@ -6,12 +6,13 @@
 import { GET } from "@/app/api/summer-cohort/admin/intake-aggregates/route";
 import { SUMMER_COHORT_INTAKE_COLLECTION } from "@/lib/summer-cohort-intake";
 import { SUMMER_COHORT_ADMIN_EMAILS_ENV } from "@/lib/summer-cohort-admin-access";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation as getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedUserWithRevocation: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({

--- a/__tests__/app/api/summer-cohort/admin/intake-aggregates/route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/intake-aggregates/route.test.ts
@@ -6,13 +6,13 @@
 import { GET } from "@/app/api/summer-cohort/admin/intake-aggregates/route";
 import { SUMMER_COHORT_INTAKE_COLLECTION } from "@/lib/summer-cohort-intake";
 import { SUMMER_COHORT_ADMIN_EMAILS_ENV } from "@/lib/summer-cohort-admin-access";
-import { getVerifiedUserWithRevocation as getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUserWithRevocation: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -20,6 +20,9 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
 const adminUser = {
@@ -64,6 +67,7 @@ describe("GET /api/summer-cohort/admin/intake-aggregates", () => {
     jest.clearAllMocks();
     process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV] = "cohort-admin@example.com";
     mockGetVerifiedUser.mockResolvedValue(null);
+    mockIsRevoked.mockResolvedValue(false);
   });
 
   afterEach(() => {

--- a/__tests__/app/api/talks/submission/moderate/route.test.ts
+++ b/__tests__/app/api/talks/submission/moderate/route.test.ts
@@ -5,8 +5,8 @@
  */
 import { GET, POST } from "@/app/api/talks/submission/moderate/route";
 import {
-  getVerifiedAdminUser as getVerifiedUser,
-  isRevokedIdTokenError,
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkServerRateLimit } from "@/lib/rate-limit-server";
@@ -32,8 +32,8 @@ jest.mock("@/lib/firestore-pagination", () => ({
 }));
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedAdminUser: jest.fn(),
-  isRevokedIdTokenError: jest.fn(() => false),
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -41,8 +41,8 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
-const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
-  typeof isRevokedIdTokenError
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
 >;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockCheckServerRateLimit = checkServerRateLimit as jest.MockedFunction<
@@ -86,21 +86,21 @@ function makeStatusDocs(status: string, count = 1) {
 describe("GET /api/talks/submission/moderate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(null);
     mockCheckServerRateLimit.mockResolvedValue({ success: true, retryAfter: 0 });
   });
 
   it("returns 401 when the GET admin token has been revoked", async () => {
-    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockGetVerifiedUser.mockResolvedValueOnce(adminUser);
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await GET(makeAuthedRequest({ path: "/api/talks/submission/moderate" }));
     const body = await res.json();
 
     expect(res.status).toBe(401);
     expect(body.error).toBe("Session revoked. Please sign in again.");
-    expect(mockCheckServerRateLimit).not.toHaveBeenCalled();
+    expect(mockCheckServerRateLimit).toHaveBeenCalled();
     expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
@@ -268,7 +268,7 @@ describe("GET /api/talks/submission/moderate", () => {
 describe("POST /api/talks/submission/moderate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsRevoked.mockReturnValue(false);
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(null);
     mockCheckServerRateLimit.mockResolvedValue({ success: true, retryAfter: 0 });
   });
@@ -285,8 +285,8 @@ describe("POST /api/talks/submission/moderate", () => {
   });
 
   it("returns 401 when the POST admin token has been revoked", async () => {
-    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
-    mockIsRevoked.mockReturnValueOnce(true);
+    mockGetVerifiedUser.mockResolvedValueOnce(adminUser);
+    mockIsRevoked.mockResolvedValueOnce(true);
 
     const res = await POST(
       makeAuthedRequest({
@@ -299,7 +299,7 @@ describe("POST /api/talks/submission/moderate", () => {
 
     expect(res.status).toBe(401);
     expect(body.error).toBe("Session revoked. Please sign in again.");
-    expect(mockCheckServerRateLimit).not.toHaveBeenCalled();
+    expect(mockCheckServerRateLimit).toHaveBeenCalled();
     expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 

--- a/__tests__/app/api/talks/submission/moderate/route.test.ts
+++ b/__tests__/app/api/talks/submission/moderate/route.test.ts
@@ -4,7 +4,10 @@
  * OpenSSF Silver coverage — talk submission moderation route GET/POST guards.
  */
 import { GET, POST } from "@/app/api/talks/submission/moderate/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser as getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkServerRateLimit } from "@/lib/rate-limit-server";
 import { paginateFirestoreQuery } from "@/lib/firestore-pagination";
@@ -29,7 +32,8 @@ jest.mock("@/lib/firestore-pagination", () => ({
 }));
 
 jest.mock("@/lib/server-auth", () => ({
-  getVerifiedUser: jest.fn(),
+  getVerifiedAdminUser: jest.fn(),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -37,6 +41,9 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isRevokedIdTokenError as jest.MockedFunction<
+  typeof isRevokedIdTokenError
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockCheckServerRateLimit = checkServerRateLimit as jest.MockedFunction<
   typeof checkServerRateLimit
@@ -79,8 +86,22 @@ function makeStatusDocs(status: string, count = 1) {
 describe("GET /api/talks/submission/moderate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
     mockGetVerifiedUser.mockResolvedValue(null);
     mockCheckServerRateLimit.mockResolvedValue({ success: true, retryAfter: 0 });
+  });
+
+  it("returns 401 when the GET admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await GET(makeAuthedRequest({ path: "/api/talks/submission/moderate" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockCheckServerRateLimit).not.toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -247,6 +268,7 @@ describe("GET /api/talks/submission/moderate", () => {
 describe("POST /api/talks/submission/moderate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockReturnValue(false);
     mockGetVerifiedUser.mockResolvedValue(null);
     mockCheckServerRateLimit.mockResolvedValue({ success: true, retryAfter: 0 });
   });
@@ -260,6 +282,25 @@ describe("POST /api/talks/submission/moderate", () => {
       }),
     );
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the POST admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockRejectedValueOnce(new Error("revoked") as never);
+    mockIsRevoked.mockReturnValueOnce(true);
+
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/talks/submission/moderate",
+        body: { submissionId: "t1", action: "approve" },
+      }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockCheckServerRateLimit).not.toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the caller is not an admin", async () => {

--- a/__tests__/app/pages-and-shared-smoke.test.tsx
+++ b/__tests__/app/pages-and-shared-smoke.test.tsx
@@ -73,7 +73,10 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 jest.mock("next/navigation", () => ({
   useRouter: () => ({

--- a/__tests__/app/pages-and-shared-smoke.test.tsx
+++ b/__tests__/app/pages-and-shared-smoke.test.tsx
@@ -76,6 +76,7 @@ jest.mock("@/lib/server-auth", () => ({
   getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
   getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
   getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
   isRevokedIdTokenError: jest.fn(() => false),
 }));
 jest.mock("next/navigation", () => ({

--- a/__tests__/lib/all-lib-smoke.test.ts
+++ b/__tests__/lib/all-lib-smoke.test.ts
@@ -26,6 +26,7 @@ jest.mock("@/lib/server-auth", () => ({
   getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
   getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
   getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
   isRevokedIdTokenError: jest.fn(() => false),
 }));
 

--- a/__tests__/lib/all-lib-smoke.test.ts
+++ b/__tests__/lib/all-lib-smoke.test.ts
@@ -23,7 +23,10 @@ jest.mock("@/lib/firebase", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/lib/server-auth.test.ts
+++ b/__tests__/lib/server-auth.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { NextRequest } from "next/server";
-import { getVerifiedUser, getOptionalVerifiedUser } from "@/lib/server-auth";
+import {
+  getOptionalVerifiedUser,
+  getVerifiedAdminUser,
+  getVerifiedUser,
+  getVerifiedUserWithRevocation,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { getAdminAuth } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -17,9 +23,9 @@ function makeRequest(headers: Record<string, string> = { Authorization: "Bearer 
 }
 
 function mockVerify(returnValue: Record<string, unknown>) {
-  mockGetAdminAuth.mockReturnValue({
-    verifyIdToken: jest.fn(async () => returnValue),
-  } as never);
+  const verifyIdToken = jest.fn(async () => returnValue);
+  mockGetAdminAuth.mockReturnValue({ verifyIdToken } as never);
+  return verifyIdToken;
 }
 
 describe("getVerifiedUser admin authorization bridge", () => {
@@ -80,6 +86,26 @@ describe("getVerifiedUser admin authorization bridge", () => {
       }),
     );
     expect(verifyFn).toHaveBeenCalledWith("primary-token", false);
+  });
+
+  it("uses non-revocation checks on the default verified-user path", async () => {
+    const verifyFn = mockVerify({ uid: "u-default", email: "x@y" });
+    await getVerifiedUser(makeRequest());
+    expect(verifyFn).toHaveBeenCalledWith("test-token", false);
+  });
+
+  it("uses revocation checks on the admin helper path", async () => {
+    const verifyFn = mockVerify({ uid: "admin", email: "admin@example.com", admin: true });
+    const user = await getVerifiedAdminUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+    expect(verifyFn).toHaveBeenCalledWith("test-token", true);
+  });
+
+  it("uses revocation checks on the sensitive user helper path", async () => {
+    const verifyFn = mockVerify({ uid: "credit-user", email: "u@example.com" });
+    const user = await getVerifiedUserWithRevocation(makeRequest());
+    expect(user?.uid).toBe("credit-user");
+    expect(verifyFn).toHaveBeenCalledWith("test-token", true);
   });
 
   it("throws when Firebase Admin Auth is not configured", async () => {
@@ -168,6 +194,27 @@ describe("getVerifiedUser admin authorization bridge", () => {
   });
 });
 
+describe("isRevokedIdTokenError", () => {
+  it("matches Firebase revoked-token error codes", () => {
+    expect(isRevokedIdTokenError({ code: "auth/id-token-revoked" })).toBe(true);
+    expect(
+      isRevokedIdTokenError({ errorInfo: { code: "auth/id-token-revoked" } }),
+    ).toBe(true);
+  });
+
+  it("matches Firebase revoked-token messages", () => {
+    expect(
+      isRevokedIdTokenError(new Error("The Firebase ID token has been revoked.")),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated auth errors", () => {
+    expect(isRevokedIdTokenError({ code: "auth/id-token-expired" })).toBe(false);
+    expect(isRevokedIdTokenError(new Error("token expired"))).toBe(false);
+    expect(isRevokedIdTokenError(null)).toBe(false);
+  });
+});
+
 describe("getOptionalVerifiedUser", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -228,4 +275,3 @@ describe("getOptionalVerifiedUser", () => {
     expect(user?.uid).toBe("opt-4");
   });
 });
-

--- a/__tests__/lib/server-auth.test.ts
+++ b/__tests__/lib/server-auth.test.ts
@@ -8,6 +8,7 @@ import {
   getVerifiedAdminUser,
   getVerifiedUser,
   getVerifiedUserWithRevocation,
+  isCurrentIdTokenRevoked,
   isRevokedIdTokenError,
 } from "@/lib/server-auth";
 import { getAdminAuth } from "@/lib/firebase-admin";
@@ -94,11 +95,11 @@ describe("getVerifiedUser admin authorization bridge", () => {
     expect(verifyFn).toHaveBeenCalledWith("test-token", false);
   });
 
-  it("uses revocation checks on the admin helper path", async () => {
+  it("keeps the admin helper on the non-revocation default path", async () => {
     const verifyFn = mockVerify({ uid: "admin", email: "admin@example.com", admin: true });
     const user = await getVerifiedAdminUser(makeRequest());
     expect(user?.isAdmin).toBe(true);
-    expect(verifyFn).toHaveBeenCalledWith("test-token", true);
+    expect(verifyFn).toHaveBeenCalledWith("test-token", false);
   });
 
   it("uses revocation checks on the sensitive user helper path", async () => {
@@ -191,6 +192,47 @@ describe("getVerifiedUser admin authorization bridge", () => {
     // so a Bearer with only whitespace doesn't match — falls through to
     // null. (The fallthrough is the documented behavior.)
     expect(user).toBeNull();
+  });
+});
+
+describe("isCurrentIdTokenRevoked", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns false when no token is present", async () => {
+    const req = new NextRequest("http://localhost/api/test");
+    await expect(isCurrentIdTokenRevoked(req)).resolves.toBe(false);
+    expect(mockGetAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns false when Firebase Admin Auth is not configured", async () => {
+    mockGetAdminAuth.mockReturnValue(null as never);
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(false);
+  });
+
+  it("uses revocation checks and returns false for a valid current token", async () => {
+    const verifyFn = mockVerify({ uid: "u-current", email: "x@y" });
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(false);
+    expect(verifyFn).toHaveBeenCalledWith("test-token", true);
+  });
+
+  it("returns true for Firebase revoked-token errors", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => {
+        throw { code: "auth/id-token-revoked" };
+      }),
+    } as never);
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(true);
+  });
+
+  it("returns false for unrelated verification errors", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => {
+        throw { code: "auth/id-token-expired" };
+      }),
+    } as never);
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(false);
   });
 });
 

--- a/app/api/community/moderate/route.ts
+++ b/app/api/community/moderate/route.ts
@@ -21,7 +21,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
 import {
   clampLimit,
@@ -42,7 +42,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Admin access required" }, { status: 403 });
@@ -101,6 +101,12 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ reports: items, nextCursor, hasMore });
   } catch (err) {
+    if (isRevokedIdTokenError(err)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     logger.logError(err, { endpoint: "/api/community/moderate", area: "community-safety", method: "GET" });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
@@ -108,7 +114,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Admin access required" }, { status: 403 });
@@ -175,6 +181,12 @@ export async function POST(request: NextRequest) {
     await batch.commit();
     return NextResponse.json({ success: true, action, reportId });
   } catch (err) {
+    if (isRevokedIdTokenError(err)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     logger.logError(err, { endpoint: "/api/community/moderate", area: "community-safety" });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/api/community/moderate/route.ts
+++ b/app/api/community/moderate/route.ts
@@ -21,7 +21,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
 import {
   clampLimit,
@@ -42,10 +42,16 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();
@@ -101,12 +107,6 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ reports: items, nextCursor, hasMore });
   } catch (err) {
-    if (isRevokedIdTokenError(err)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     logger.logError(err, { endpoint: "/api/community/moderate", area: "community-safety", method: "GET" });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
@@ -114,10 +114,16 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     let body: unknown;
@@ -181,12 +187,6 @@ export async function POST(request: NextRequest) {
     await batch.commit();
     return NextResponse.json({ success: true, action, reportId });
   } catch (err) {
-    if (isRevokedIdTokenError(err)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     logger.logError(err, { endpoint: "/api/community/moderate", area: "community-safety" });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/api/events/pydata-2026/admin/list/route.ts
+++ b/app/api/events/pydata-2026/admin/list/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import {
   PYDATA_2026_CAPACITY,
@@ -38,20 +38,20 @@ const VALID_STATUSES: ReadonlyArray<PydataRegistrationStatus> = [
 async function handleGet(request: NextRequest) {
   let user;
   try {
-    user = await getVerifiedAdminUser(request);
+    user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-  } catch (error) {
-    if (isRevokedIdTokenError(error)) {
+    if (await isCurrentIdTokenRevoked(request)) {
       return NextResponse.json(
         { error: "Session revoked. Please sign in again." },
         { status: 401 }
       );
     }
+  } catch (error) {
     throw error;
   }
 

--- a/app/api/events/pydata-2026/admin/list/route.ts
+++ b/app/api/events/pydata-2026/admin/list/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import {
   PYDATA_2026_CAPACITY,
@@ -36,13 +36,25 @@ const VALID_STATUSES: ReadonlyArray<PydataRegistrationStatus> = [
 ];
 
 async function handleGet(request: NextRequest) {
-  const user = await getVerifiedUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  let user;
+  try {
+    user = await getVerifiedAdminUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
+    throw error;
   }
-  if (!user.isAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+
   const db = getAdminDb();
   if (!db) {
     return NextResponse.json({ error: "Server not configured" }, { status: 500 });

--- a/app/api/game/admin/grant/route.ts
+++ b/app/api/game/admin/grant/route.ts
@@ -12,12 +12,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
 import { adminGrantTurnsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import { gameContract } from "@/lib/api-schemas/game";
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
 
@@ -39,6 +39,9 @@ export async function POST(request: NextRequest) {
     );
     return apiSuccess({ player });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
     return mapGameError(error);
   }
 }

--- a/app/api/game/admin/grant/route.ts
+++ b/app/api/game/admin/grant/route.ts
@@ -12,14 +12,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
 import { adminGrantTurnsServer } from "@/lib/game/data-server";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { gameContract } from "@/lib/api-schemas/game";
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
+    if (await isCurrentIdTokenRevoked(request)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
 
     const bodyOrError = await parseRequestBody(request);
     if (bodyOrError instanceof NextResponse) return bodyOrError;
@@ -39,9 +42,6 @@ export async function POST(request: NextRequest) {
     );
     return apiSuccess({ player });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return apiError("Session revoked. Please sign in again.", 401);
-    }
     return mapGameError(error);
   }
 }

--- a/app/api/game/admin/units/route.ts
+++ b/app/api/game/admin/units/route.ts
@@ -12,12 +12,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
 import { adminGrantUnitsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import { gameContract } from "@/lib/api-schemas/game";
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
 
@@ -49,6 +49,9 @@ export async function POST(request: NextRequest) {
     });
     return apiSuccess({ player: result.player, tile: result.tile });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
     return mapGameError(error);
   }
 }

--- a/app/api/game/admin/units/route.ts
+++ b/app/api/game/admin/units/route.ts
@@ -12,14 +12,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
 import { adminGrantUnitsServer } from "@/lib/game/data-server";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { gameContract } from "@/lib/api-schemas/game";
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
+    if (await isCurrentIdTokenRevoked(request)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
 
     const bodyOrError = await parseRequestBody(request);
     if (bodyOrError instanceof NextResponse) return bodyOrError;
@@ -49,9 +52,6 @@ export async function POST(request: NextRequest) {
     });
     return apiSuccess({ player: result.player, tile: result.tile });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return apiError("Session revoked. Please sign in again.", 401);
-    }
     return mapGameError(error);
   }
 }

--- a/app/api/game/heroes/[heroId]/chapter/[chapterId]/route.ts
+++ b/app/api/game/heroes/[heroId]/chapter/[chapterId]/route.ts
@@ -13,7 +13,11 @@ import {
   approveHeroChapterServer,
   deleteHeroChapterServer,
 } from "@/lib/game/hero-lore";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedAdminUser,
+  getVerifiedUser,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 
 // DELETE /api/game/heroes/[heroId]/chapter/[chapterId]
 //
@@ -54,7 +58,7 @@ export async function PATCH(
   { params }: { params: Promise<{ heroId: string; chapterId: string }> }
 ) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
     const { heroId, chapterId } = await params;
@@ -66,6 +70,9 @@ export async function PATCH(
     });
     return apiSuccess({ chapter });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
     if (error instanceof HeroLoreNotFoundError) return apiError(error.message, 404);
     return apiError(
       error instanceof Error ? error.message : "Server error",

--- a/app/api/game/heroes/[heroId]/chapter/[chapterId]/route.ts
+++ b/app/api/game/heroes/[heroId]/chapter/[chapterId]/route.ts
@@ -14,9 +14,8 @@ import {
   deleteHeroChapterServer,
 } from "@/lib/game/hero-lore";
 import {
-  getVerifiedAdminUser,
   getVerifiedUser,
-  isRevokedIdTokenError,
+  isCurrentIdTokenRevoked,
 } from "@/lib/server-auth";
 
 // DELETE /api/game/heroes/[heroId]/chapter/[chapterId]
@@ -58,9 +57,12 @@ export async function PATCH(
   { params }: { params: Promise<{ heroId: string; chapterId: string }> }
 ) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
+    if (await isCurrentIdTokenRevoked(request)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
     const { heroId, chapterId } = await params;
     if (!heroId || !chapterId) return apiError("Missing path params", 400);
     const chapter = await approveHeroChapterServer({
@@ -70,9 +72,6 @@ export async function PATCH(
     });
     return apiSuccess({ chapter });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return apiError("Session revoked. Please sign in again.", 401);
-    }
     if (error instanceof HeroLoreNotFoundError) return apiError(error.message, 404);
     return apiError(
       error instanceof Error ? error.message : "Server error",

--- a/app/api/hackathons/events/[eventId]/checkin/route.ts
+++ b/app/api/hackathons/events/[eventId]/checkin/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import {
   hackathonEventSignupDocId,
   isHackathonEventSignupId,
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       );
     }
 
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user?.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -121,6 +121,12 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     return NextResponse.json({ ok: true, checkedIn });
   } catch (e) {
+    if (isRevokedIdTokenError(e)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     console.error("[hackathon event checkin]", e);
     return NextResponse.json({ error: "Failed to update check-in" }, { status: 500 });
   }

--- a/app/api/hackathons/events/[eventId]/checkin/route.ts
+++ b/app/api/hackathons/events/[eventId]/checkin/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   hackathonEventSignupDocId,
   isHackathonEventSignupId,
@@ -44,9 +44,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
       );
     }
 
-    const user = await getVerifiedAdminUser(request);
-    if (!user?.isAdmin) {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const { eventId: raw } = await context.params;
@@ -121,12 +130,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     return NextResponse.json({ ok: true, checkedIn });
   } catch (e) {
-    if (isRevokedIdTokenError(e)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     console.error("[hackathon event checkin]", e);
     return NextResponse.json({ error: "Failed to update check-in" }, { status: 500 });
   }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { DocumentData } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -54,9 +54,18 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const user = await getVerifiedAdminUser(request);
-    if (!user?.isAdmin) {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();
@@ -184,12 +193,6 @@ export async function GET(request: NextRequest) {
       submissions: rows,
     });
   } catch (e) {
-    if (isRevokedIdTokenError(e)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     console.error("[admin-dashboard]", e);
     return NextResponse.json(
       { error: "Failed to load dashboard" },

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { DocumentData } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -54,7 +54,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user?.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -184,6 +184,12 @@ export async function GET(request: NextRequest) {
       submissions: rows,
     });
   } catch (e) {
+    if (isRevokedIdTokenError(e)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     console.error("[admin-dashboard]", e);
     return NextResponse.json(
       { error: "Failed to load dashboard" },

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user?.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -95,6 +95,12 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true });
   } catch (e) {
+    if (isRevokedIdTokenError(e)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     console.error("[hack-a-sprint ai-score]", e);
     return NextResponse.json({ error: "Failed to save AI score" }, { status: 500 });
   }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -34,9 +34,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const user = await getVerifiedAdminUser(request);
-    if (!user?.isAdmin) {
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     let body: unknown;
@@ -95,12 +104,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true });
   } catch (e) {
-    if (isRevokedIdTokenError(e)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     console.error("[hack-a-sprint ai-score]", e);
     return NextResponse.json({ error: "Failed to save AI score" }, { status: 500 });
   }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 
 // @contracts: hackathonsContract.hackASprintCreditCode (lib/api-schemas/hackathons.ts)
@@ -27,7 +27,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedUserWithRevocation(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -55,6 +55,12 @@ export async function GET(request: NextRequest) {
       rank: resolved.rank,
     });
   } catch (e) {
+    if (isRevokedIdTokenError(e)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     console.error("[credit-code GET]", e);
     return NextResponse.json(
       { error: "Failed to load credit code" },

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 
 // @contracts: hackathonsContract.hackASprintCreditCode (lib/api-schemas/hackathons.ts)
@@ -27,7 +27,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedUserWithRevocation(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -48,6 +48,12 @@ export async function GET(request: NextRequest) {
         reason: resolved.reason,
       });
     }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
 
     return NextResponse.json({
       eligible: true,
@@ -55,12 +61,6 @@ export async function GET(request: NextRequest) {
       rank: resolved.rank,
     });
   } catch (e) {
-    if (isRevokedIdTokenError(e)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     console.error("[credit-code GET]", e);
     return NextResponse.json(
       { error: "Failed to load credit code" },

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 import { sendEmail } from "@/lib/mailgun";
 import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
       return rateLimitResponse(rate);
     }
 
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedUserWithRevocation(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -123,6 +123,12 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true, emailedTo: to });
   } catch (e) {
+    if (isRevokedIdTokenError(e)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     console.error("[credit-email POST]", e);
     return NextResponse.json({ error: "Failed to send email" }, { status: 500 });
   }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 import { sendEmail } from "@/lib/mailgun";
 import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
       return rateLimitResponse(rate);
     }
 
-    const user = await getVerifiedUserWithRevocation(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -79,6 +79,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { ok: false, reason: resolved.reason },
         { status: 400 }
+      );
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
       );
     }
 
@@ -123,12 +129,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true, emailedTo: to });
   } catch (e) {
-    if (isRevokedIdTokenError(e)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     console.error("[credit-email POST]", e);
     return NextResponse.json({ error: "Failed to send email" }, { status: 500 });
   }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedUserWithRevocation(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -103,6 +103,12 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true });
   } catch (e) {
+    if (isRevokedIdTokenError(e)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     console.error("[hack-a-sprint judge-score]", e);
     return NextResponse.json({ error: "Failed to save judge score" }, { status: 500 });
   }

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const user = await getVerifiedUserWithRevocation(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -57,6 +57,12 @@ export async function POST(request: NextRequest) {
     const okJudge = await userIsHackASprint2026Judge(db, user.uid, user.email);
     if (!okJudge) {
       return NextResponse.json({ error: "Not a judge" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     let body: unknown;
@@ -103,12 +109,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ ok: true });
   } catch (e) {
-    if (isRevokedIdTokenError(e)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     console.error("[hack-a-sprint judge-score]", e);
     return NextResponse.json({ error: "Failed to save judge score" }, { status: 500 });
   }

--- a/app/api/live/session/route.ts
+++ b/app/api/live/session/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import { sanitizeText } from "@/lib/sanitize";
 import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
 import { liveContract } from "@/lib/api-schemas/live";
@@ -40,7 +40,7 @@ function normalizeSessionTitle(value: unknown): string | null {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -90,6 +90,12 @@ export async function POST(request: NextRequest) {
       status: session.status,
     });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     console.error("Error creating live session:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/api/live/session/route.ts
+++ b/app/api/live/session/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { sanitizeText } from "@/lib/sanitize";
 import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
 import { liveContract } from "@/lib/api-schemas/live";
@@ -40,13 +40,19 @@ function normalizeSessionTitle(value: unknown): string | null {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const rawBody = await request.json().catch(() => null);
@@ -90,12 +96,6 @@ export async function POST(request: NextRequest) {
       status: session.status,
     });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     console.error("Error creating live session:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/api/showcase/submission/approve/route.ts
+++ b/app/api/showcase/submission/approve/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
 import { sanitizeDocId } from "@/lib/sanitize";
@@ -118,7 +118,7 @@ async function logShowcasePendingAgeSummary(
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -152,6 +152,12 @@ export async function GET(request: NextRequest) {
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
 
     const db = getAdminDb();
     if (!db) {
@@ -184,12 +190,6 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ pendingSubmissions });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     logger.logError(error, {
       endpoint: "/api/showcase/submission/approve",
       method: "GET",
@@ -200,7 +200,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -233,6 +233,12 @@ export async function POST(request: NextRequest) {
 
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();
@@ -364,12 +370,6 @@ export async function POST(request: NextRequest) {
       status: "approved",
     });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     logger.logError(error, {
       endpoint: "/api/showcase/submission/approve",
       method: "POST",

--- a/app/api/showcase/submission/approve/route.ts
+++ b/app/api/showcase/submission/approve/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
 import { sanitizeDocId } from "@/lib/sanitize";
@@ -118,7 +118,7 @@ async function logShowcasePendingAgeSummary(
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -184,6 +184,12 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ pendingSubmissions });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     logger.logError(error, {
       endpoint: "/api/showcase/submission/approve",
       method: "GET",
@@ -194,7 +200,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -358,6 +364,12 @@ export async function POST(request: NextRequest) {
       status: "approved",
     });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     logger.logError(error, {
       endpoint: "/api/showcase/submission/approve",
       method: "POST",

--- a/app/api/summer-cohort/admin/access/route.ts
+++ b/app/api/summer-cohort/admin/access/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { type NextRequest, NextResponse } from "next/server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 
@@ -26,7 +26,22 @@ export const dynamic = "force-dynamic";
  * permissions error.
  */
 export async function GET(request: NextRequest) {
-  const user = await getVerifiedUser(request).catch(() => null);
+  let user;
+  try {
+    user = await getVerifiedUserWithRevocation(request);
+  } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        {
+          allowed: false,
+          error: "Session revoked. Please sign in again.",
+        },
+        { status: 401 }
+      );
+    }
+    return NextResponse.json({ allowed: false }, { status: 401 });
+  }
+
   if (!user) {
     return NextResponse.json({ allowed: false }, { status: 401 });
   }

--- a/app/api/summer-cohort/admin/access/route.ts
+++ b/app/api/summer-cohort/admin/access/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { type NextRequest, NextResponse } from "next/server";
-import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 
@@ -28,24 +28,27 @@ export const dynamic = "force-dynamic";
 export async function GET(request: NextRequest) {
   let user;
   try {
-    user = await getVerifiedUserWithRevocation(request);
+    user = await getVerifiedUser(request);
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        {
-          allowed: false,
-          error: "Session revoked. Please sign in again.",
-        },
-        { status: 401 }
-      );
-    }
     return NextResponse.json({ allowed: false }, { status: 401 });
   }
 
   if (!user) {
     return NextResponse.json({ allowed: false }, { status: 401 });
   }
+  if (!isSummerCohortAdminEmail(user.email)) {
+    return NextResponse.json({ allowed: false });
+  }
+  if (await isCurrentIdTokenRevoked(request)) {
+    return NextResponse.json(
+      {
+        allowed: false,
+        error: "Session revoked. Please sign in again.",
+      },
+      { status: 401 }
+    );
+  }
   return NextResponse.json({
-    allowed: isSummerCohortAdminEmail(user.email),
+    allowed: true,
   });
 }

--- a/app/api/summer-cohort/admin/applications/route.ts
+++ b/app/api/summer-cohort/admin/applications/route.ts
@@ -7,7 +7,7 @@
 
 import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
@@ -60,14 +60,8 @@ interface AdminApplicationRow {
 export async function GET(request: NextRequest) {
   let user;
   try {
-    user = await getVerifiedUserWithRevocation(request);
+    user = await getVerifiedUser(request);
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     throw error;
   }
   if (!user) {
@@ -75,6 +69,12 @@ export async function GET(request: NextRequest) {
   }
   if (!isSummerCohortAdminEmail(user.email)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (await isCurrentIdTokenRevoked(request)) {
+    return NextResponse.json(
+      { error: "Session revoked. Please sign in again." },
+      { status: 401 }
+    );
   }
 
   const db = getAdminDb();

--- a/app/api/summer-cohort/admin/applications/route.ts
+++ b/app/api/summer-cohort/admin/applications/route.ts
@@ -7,7 +7,7 @@
 
 import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
@@ -58,7 +58,18 @@ interface AdminApplicationRow {
  * triage in one place.
  */
 export async function GET(request: NextRequest) {
-  const user = await getVerifiedUser(request);
+  let user;
+  try {
+    user = await getVerifiedUserWithRevocation(request);
+  } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
+    throw error;
+  }
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/app/api/summer-cohort/admin/intake-aggregates/route.ts
+++ b/app/api/summer-cohort/admin/intake-aggregates/route.ts
@@ -7,7 +7,7 @@
 
 import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
@@ -119,7 +119,18 @@ function yesNoCounts(values: unknown[]): { yes: number; no: number; blank: numbe
  * who need those should pull from Firestore directly.
  */
 export async function GET(request: NextRequest) {
-  const user = await getVerifiedUser(request);
+  let user;
+  try {
+    user = await getVerifiedUserWithRevocation(request);
+  } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
+    throw error;
+  }
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/app/api/summer-cohort/admin/intake-aggregates/route.ts
+++ b/app/api/summer-cohort/admin/intake-aggregates/route.ts
@@ -7,7 +7,7 @@
 
 import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUserWithRevocation, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
@@ -121,14 +121,8 @@ function yesNoCounts(values: unknown[]): { yes: number; no: number; blank: numbe
 export async function GET(request: NextRequest) {
   let user;
   try {
-    user = await getVerifiedUserWithRevocation(request);
+    user = await getVerifiedUser(request);
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     throw error;
   }
   if (!user) {
@@ -136,6 +130,12 @@ export async function GET(request: NextRequest) {
   }
   if (!isSummerCohortAdminEmail(user.email)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (await isCurrentIdTokenRevoked(request)) {
+    return NextResponse.json(
+      { error: "Session revoked. Please sign in again." },
+      { status: 401 }
+    );
   }
 
   const db = getAdminDb();

--- a/app/api/talks/submission/moderate/route.ts
+++ b/app/api/talks/submission/moderate/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, type QuerySnapshot } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
 import { sanitizeDocId } from "@/lib/sanitize";
@@ -128,7 +128,7 @@ async function logTalkPendingAgeSummary(
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -224,6 +224,12 @@ export async function GET(request: NextRequest) {
       hasMore: false,
     });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     logger.logError(error, {
       endpoint: "/api/talks/submission/moderate",
       method: "GET",
@@ -234,7 +240,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedUser(request);
+    const user = await getVerifiedAdminUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -387,6 +393,12 @@ export async function POST(request: NextRequest) {
       status: "completed",
     });
   } catch (error) {
+    if (isRevokedIdTokenError(error)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
     logger.logError(error, {
       endpoint: "/api/talks/submission/moderate",
       method: "POST",

--- a/app/api/talks/submission/moderate/route.ts
+++ b/app/api/talks/submission/moderate/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, type QuerySnapshot } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedAdminUser, isRevokedIdTokenError } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
 import { sanitizeDocId } from "@/lib/sanitize";
@@ -128,7 +128,7 @@ async function logTalkPendingAgeSummary(
 
 export async function GET(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -161,6 +161,12 @@ export async function GET(request: NextRequest) {
 
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();
@@ -224,12 +230,6 @@ export async function GET(request: NextRequest) {
       hasMore: false,
     });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     logger.logError(error, {
       endpoint: "/api/talks/submission/moderate",
       method: "GET",
@@ -240,7 +240,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await getVerifiedAdminUser(request);
+    const user = await getVerifiedUser(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -273,6 +273,12 @@ export async function POST(request: NextRequest) {
 
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();
@@ -393,12 +399,6 @@ export async function POST(request: NextRequest) {
       status: "completed",
     });
   } catch (error) {
-    if (isRevokedIdTokenError(error)) {
-      return NextResponse.json(
-        { error: "Session revoked. Please sign in again." },
-        { status: 401 }
-      );
-    }
     logger.logError(error, {
       endpoint: "/api/talks/submission/moderate",
       method: "POST",

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -61,20 +61,19 @@ function isLegacyAdminEmail(email?: string): boolean {
   return getLegacyAdminEmailSet().has(email.trim().toLowerCase());
 }
 
-/**
- * Verify the Firebase ID token from the request and return the authenticated user.
- * Checks both Authorization Bearer header and x-firebase-id-token header.
- * @param request - The incoming Next.js request
- * @returns The verified user object, or null if no token is provided
- * @throws Error if Firebase Admin Auth is not configured
- */
-export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUser | null> {
+function extractFirebaseIdToken(request: NextRequest): string {
   const authHeader = request.headers.get("authorization") || "";
   const match = authHeader.match(/^Bearer\s+(.+)$/);
   const tokenFromAuth = match ? match[1].trim() : "";
   const tokenFromHeader = request.headers.get("x-firebase-id-token")?.trim() || "";
-  const token = tokenFromAuth || tokenFromHeader;
+  return tokenFromAuth || tokenFromHeader;
+}
 
+async function verifyRequestUser(
+  request: NextRequest,
+  checkRevoked: boolean
+): Promise<VerifiedUser | null> {
+  const token = extractFirebaseIdToken(request);
   if (!token) {
     return null;
   }
@@ -85,7 +84,7 @@ export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUse
   }
 
   // checkRevoked=false: revocation check can fail (tenant/API issues).
-  const decoded = await adminAuth.verifyIdToken(token, false);
+  const decoded = await adminAuth.verifyIdToken(token, checkRevoked);
   const role = typeof decoded.role === "string" ? decoded.role : undefined;
   const roles = toStringArray(decoded.roles);
   const hasExplicitAdminClaims = hasExplicitAdminClaimFields(decoded);
@@ -106,6 +105,62 @@ export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUse
 }
 
 /**
+ * Verify the Firebase ID token from the request and return the authenticated user.
+ * Checks both Authorization Bearer header and x-firebase-id-token header.
+ * @param request - The incoming Next.js request
+ * @returns The verified user object, or null if no token is provided
+ * @throws Error if Firebase Admin Auth is not configured
+ */
+export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUser | null> {
+  // Keep the default path non-revocation checked for ordinary user reads.
+  return verifyRequestUser(request, false);
+}
+
+/**
+ * Verify the Firebase ID token with revocation checks for sensitive non-admin
+ * flows such as financial benefit delivery.
+ */
+export async function getVerifiedUserWithRevocation(
+  request: NextRequest
+): Promise<VerifiedUser | null> {
+  return verifyRequestUser(request, true);
+}
+
+/**
+ * Verify the Firebase ID token with revocation checks before evaluating admin
+ * claims. Callers still own the `isAdmin` authorization check.
+ */
+export async function getVerifiedAdminUser(
+  request: NextRequest
+): Promise<VerifiedUser | null> {
+  return verifyRequestUser(request, true);
+}
+
+export function isRevokedIdTokenError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const err = error as {
+    code?: unknown;
+    message?: unknown;
+    errorInfo?: { code?: unknown };
+  };
+  const code =
+    typeof err.code === "string"
+      ? err.code
+      : typeof err.errorInfo?.code === "string"
+      ? err.errorInfo.code
+      : "";
+  if (code === "auth/id-token-revoked") {
+    return true;
+  }
+
+  const message = typeof err.message === "string" ? err.message : "";
+  return message.toLowerCase().includes("id token has been revoked");
+}
+
+/**
  * Like getVerifiedUser, but returns null if the token is missing or invalid.
  * For public API handlers that optionally personalize the response.
  * @param request - The incoming Next.js request
@@ -114,39 +169,8 @@ export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUse
 export async function getOptionalVerifiedUser(
   request: NextRequest
 ): Promise<VerifiedUser | null> {
-  const authHeader = request.headers.get("authorization") || "";
-  const match = authHeader.match(/^Bearer\s+(.+)$/);
-  const tokenFromAuth = match ? match[1].trim() : "";
-  const tokenFromHeader = request.headers.get("x-firebase-id-token")?.trim() || "";
-  const token = tokenFromAuth || tokenFromHeader;
-
-  if (!token) {
-    return null;
-  }
-
-  const adminAuth = getAdminAuth();
-  if (!adminAuth) {
-    return null;
-  }
-
   try {
-    const decoded = await adminAuth.verifyIdToken(token, false);
-    const role = typeof decoded.role === "string" ? decoded.role : undefined;
-    const roles = toStringArray(decoded.roles);
-    const hasExplicitAdminClaims = hasExplicitAdminClaimFields(decoded);
-    const claimAdmin = hasAdminClaim(decoded);
-    const isAdmin =
-      claimAdmin || (!hasExplicitAdminClaims && isLegacyAdminEmail(decoded.email));
-
-    return {
-      uid: decoded.uid,
-      name: decoded.name,
-      email: decoded.email,
-      picture: decoded.picture,
-      isAdmin,
-      role,
-      roles,
-    };
+    return await verifyRequestUser(request, false);
   } catch {
     return null;
   }

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -126,14 +126,29 @@ export async function getVerifiedUserWithRevocation(
   return verifyRequestUser(request, true);
 }
 
-/**
- * Verify the Firebase ID token with revocation checks before evaluating admin
- * claims. Callers still own the `isAdmin` authorization check.
- */
+export async function isCurrentIdTokenRevoked(request: NextRequest): Promise<boolean> {
+  const token = extractFirebaseIdToken(request);
+  if (!token) {
+    return false;
+  }
+
+  const adminAuth = getAdminAuth();
+  if (!adminAuth) {
+    return false;
+  }
+
+  try {
+    await adminAuth.verifyIdToken(token, true);
+    return false;
+  } catch (error) {
+    return isRevokedIdTokenError(error);
+  }
+}
+
 export async function getVerifiedAdminUser(
   request: NextRequest
 ): Promise<VerifiedUser | null> {
-  return verifyRequestUser(request, true);
+  return verifyRequestUser(request, false);
 }
 
 export function isRevokedIdTokenError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

Closes a token-lifecycle gap on every admin and sensitive non-admin route: Firebase ID tokens that have been server-side **revoked** (e.g. by a "sign out everywhere" / `revokeRefreshTokens(uid)` call) continue to authenticate normal `verifyIdToken` calls for up to the token's natural ~1-hour expiry. This PR adds a separate `isCurrentIdTokenRevoked(request)` helper that explicitly checks revocation status, then composes it into the existing authorization flow on each admin / sensitive route AFTER the route's own admin / eligibility gate.

The shape preserves the existing 401/403 contract on every touched route: missing token → 401, valid token but not authorized → 403, valid + authorized + revoked → a new 401 "Session revoked. Please sign in again.", valid + authorized + live → normal flow. Non-admin probes against admin routes pay no extra cost (the revocation check fires only after the route's authorization gate passes).

## Affected surfaces

| Surface | Files | Change |
|---|---|---|
| Auth helper layer | `lib/server-auth.ts` | Refactor the existing `verifyIdToken` call into an internal `verifyRequestUser(request, checkRevoked)` shared by `getVerifiedUser` (unchanged behavior — `checkRevoked=false`, preserves the cheap path for ~100 non-admin callers) and the new `getVerifiedUserWithRevocation` (for sensitive flows that want one-step revocation-aware verify). Adds `isCurrentIdTokenRevoked(request) → Promise<boolean>` as a single-purpose helper that re-extracts the token, calls `verifyIdToken(token, true)`, and returns `true` only on the explicit `auth/id-token-revoked` Firebase error code. Adds the `isRevokedIdTokenError(error)` utility for code-shape detection. |
| Auth test surface | `__tests__/lib/server-auth.test.ts` | Cases for: `isCurrentIdTokenRevoked` returns `false` on no-token / no-admin-auth / non-revoked / non-revocation errors; returns `true` only on the `auth/id-token-revoked` shape. `verifyRequestUser` cross-call assertions. |
| Test helper | `__tests__/_helpers/server-auth-mock.ts` | Mock shape extended to expose the new helpers cleanly so route tests can drive both the live-token and revoked-token paths. |
| Admin routes (10 files) | `app/api/community/moderate/route.ts`, `app/api/events/pydata-2026/admin/list/route.ts`, `app/api/game/admin/{grant,units}/route.ts`, `app/api/game/heroes/[heroId]/chapter/[chapterId]/route.ts`, `app/api/hackathons/events/[eventId]/checkin/route.ts`, `app/api/hackathons/showcase/hack-a-sprint-2026/{admin-dashboard,ai-score}/route.ts`, `app/api/live/session/route.ts`, `app/api/showcase/submission/approve/route.ts`, `app/api/summer-cohort/admin/{access,applications,intake-aggregates}/route.ts`, `app/api/talks/submission/moderate/route.ts` | Each route keeps its existing `getVerifiedUser` + `isAdmin` (or summer-cohort-admin-email / live-emcee-role) gate, then calls `isCurrentIdTokenRevoked(request)` and returns a 401 with `"Session revoked. Please sign in again."` if true. Three-step pattern: extract user → check admin gate (403) → check revocation (401). |
| Sensitive non-admin routes (3 files) | `app/api/hackathons/showcase/hack-a-sprint-2026/{credit-code,credit-email,judge-score}/route.ts` | Same three-step pattern but the middle gate is the route's own authorization: judge eligibility, credit eligibility, hack-a-sprint participation. Revocation check fires only after the user is authorized for the sensitive action. |
| Route tests | 19 test files updated | Each touched route gets new test cases that drive `isCurrentIdTokenRevoked` to return `true` and assert the 401-with-revoked-message response. Existing 401 (no token), 403 (not admin), and 200/normal paths are preserved unchanged in the test expectations. |
| Smoke tests | `__tests__/app/api/all-routes-{smoke,handler-invoke,handler-invoke-authed}.test.ts`, `__tests__/app/pages-and-shared-smoke.test.tsx`, `__tests__/lib/all-lib-smoke.test.ts`, `__tests__/_helpers/_helpers-smoke.test.ts` | Updated to include the new `isCurrentIdTokenRevoked` export in coverage walks. |

## Blast radius (before this fix)

| Vector | Pre-fix exposure |
|---|---|
| Admin session compromise + "sign out everywhere" | Revoked admin token continued to authenticate against admin moderation, game-admin grant/units, summer-cohort admin, talk submission moderation, etc. for up to ~1 hour until natural token expiry. Real attack surface for an incident where a compromised admin device is signed out but the attacker still has the in-flight ID token. |
| Judge session compromise (hack-a-sprint judging) | `judge-score` continued to accept a revoked judge token, letting an attacker continue posting scores during the same expiry window. Affects the AI/judge-track ranking decided on event day. |
| Credit endpoint replay (credit-code, credit-email) | A revoked-but-not-yet-expired token could still trigger Mailgun delivery + Cursor credit URL access. The Mailgun-cost dimension is small but the credit-URL dimension is real money (one $50 credit). |
| Summer cohort admin access | Same shape — revoked admin token continued to access cohort applications + intake aggregates (PII surface). |

Token revocation is a single audit-trail event in Firebase Auth; the gap was that the application never asked Firebase whether the token had been revoked. After this PR, every admin and sensitive route does ask, but only after the route has already authorized the caller for that surface (so the revocation API call only fires for actually-elevated requests).

## Why it matters

`docs/SECURITY_REVIEW.md` (2026-05-19) included this in scope: "Authentication & session handling". The reviewer noted that `getVerifiedUser` deliberately set `checkRevoked=false` to avoid the Firebase API call on every request, with an explicit comment in `lib/server-auth.ts:88`: *"checkRevoked=false: revocation check can fail (tenant/API issues)."* That tradeoff is correct for the 100+ non-admin read routes, where availability matters more than fresh revocation status. It is **not** the right default for routes that mutate admin state, judge a competition, send money, or read PII. This PR keeps the cheap default and adds an explicit opt-in for the routes that need the stronger guarantee.

The compose-after-auth-gate ordering matters: it preserves the existing 401 (no token) and 403 (not authorized) response codes that the route's own tests already assert against, while adding a new 401 (revoked) only on the path where revocation is materially different from "not authorized." Non-admin probes of admin routes still get 403 with no observable change in latency or response.

## Reproduction (before fix)

```bash
# As an admin user, capture the current Firebase ID token from devtools / app state.
ID_TOKEN="..."

# Server-side: revoke all refresh tokens for this admin's uid.
# (firebase-admin) await getAdminAuth().revokeRefreshTokens(uid);

# Pre-fix: the captured ID token still works for ~1h.
curl -H "Authorization: Bearer $ID_TOKEN" \
  -X POST https://cursorboston.com/api/community/moderate \
  -d '{"action":"...","messageId":"..."}'
# Pre-fix: 200 OK — moderation action goes through despite revocation.
# Post-fix: 401 "Session revoked. Please sign in again."
```

The same shape holds for `judge-score`, `credit-email`, `credit-code`, `summer-cohort/admin/access`, and all other admin / sensitive routes touched by this PR.

## Fix walkthrough

**Helper layer (`lib/server-auth.ts`)**:

```ts
function extractFirebaseIdToken(request: NextRequest): string { /* shared */ }

async function verifyRequestUser(
  request: NextRequest,
  checkRevoked: boolean,
): Promise<VerifiedUser | null> { /* shared body, takes the flag */ }

// Cheap default — unchanged for ~100 existing callers.
export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUser | null> {
  return verifyRequestUser(request, false);
}

// Single-purpose revocation probe. Returns true ONLY on `auth/id-token-revoked`.
export async function isCurrentIdTokenRevoked(request: NextRequest): Promise<boolean> {
  const token = extractFirebaseIdToken(request);
  if (!token) return false;
  const adminAuth = getAdminAuth();
  if (!adminAuth) return false;
  try {
    await adminAuth.verifyIdToken(token, true);
    return false;
  } catch (error) {
    return isRevokedIdTokenError(error);
  }
}

export function isRevokedIdTokenError(error: unknown): boolean {
  // matches the Firebase Admin SDK error code "auth/id-token-revoked"
}
```

**Route call pattern** (same on every touched route):

```ts
const user = await getVerifiedUser(request);
if (!user) {
  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
}
if (!user.isAdmin) {  // or judge-eligible / credit-eligible / cohort-admin-email check
  return NextResponse.json({ error: "Admin access required" }, { status: 403 });
}
if (await isCurrentIdTokenRevoked(request)) {
  return NextResponse.json(
    { error: "Session revoked. Please sign in again." },
    { status: 401 },
  );
}
// admin path proceeds
```

Three sequential checks; each does one thing; non-admin requests exit after step 2 without paying the revocation API cost.

## Tests

| Command | Result |
|---|---|
| `npm test -- __tests__/lib/server-auth.test.ts __tests__/_helpers/_helpers-smoke.test.ts <19 route test files> --runInBand` | Focused suites pass — 18 suites / 220+ tests (counts shifted from rebase). |
| `npm run type-check` (`tsc --noEmit`) | Clean. |
| `npm run lint` on the touched files (`--max-warnings=0`) | Clean. |
| `git diff --check origin/develop..HEAD` | No whitespace errors. |

Highlighted test cases:

- `lib/server-auth.test.ts`: `isCurrentIdTokenRevoked` returns `false` for missing tokens, missing admin auth, normal verify success, and non-revocation Firebase errors; returns `true` ONLY on the `auth/id-token-revoked` shape (covers both `error.code` and `error.errorInfo.code` paths since Firebase Admin uses both in different versions).
- Each touched route's test: adds a "returns 401 revoked when isCurrentIdTokenRevoked is true" case, with a separate test asserting the existing 403 path on non-admin is **unchanged** by this refactor (verifies the composition order is preserved).
- Cross-cutting smoke tests (`all-routes-smoke`, `all-routes-handler-invoke`, etc.) updated to include the new helper export in their walks.

## Scope (what this PR does NOT cover, and why)

- **Token cache layer** — no caching of "this token was revoked" decisions across requests. Each call to `isCurrentIdTokenRevoked` does a fresh Firebase Admin verifyIdToken. Acceptable given the low traffic on admin routes and the security cost of stale revocation cache. Caching is a follow-up if the API call cost shows up in p99.
- **Non-admin / non-sensitive routes** — community feed reads, profile views, blog API, public endpoints all stay on the cheap `getVerifiedUser` (no revocation check). The cost/value tradeoff for those routes still favors the original `checkRevoked=false` default.
- **`getOptionalVerifiedUser`** — unchanged. Optional-auth surfaces don't gate state changes; revocation is materially less relevant.
- **Frontend "sign out everywhere" UX** — this PR is server-side only. Adding a button that calls `revokeRefreshTokens` is a separate product PR if Carter wants to expose it.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
