### PR TITLE
release: Week 2 comms submissions (Paramjeet, jfleck25, nebullii)

### DIFF
--- a/content/summer-cohort/c1/w2-comms/submissions/Paramjeet-singh-neu.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/Paramjeet-singh-neu.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "Paramjeet-singh-neu",
+  "name": "Paramjeet Singh",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocJy-fOlrK8jePZm6XpOrcjfaZSj8vJ0LAJv-pt0QeexmrRjNJ4KKQ=s96-c",
+  "repoUrl": "https://github.com/Paramjeet-singh-neu/WorkLog",
+  "liveUrl": "https://web-rust-alpha-21.vercel.app",
+  "loomUrl": "https://www.loom.com/share/5d06849a3ca2480fa48c6906cc565851",
+  "pitch": "Worklog turns Discord cohort updates into structured progress, skill-matched blocker routing, ranked feeds, social feedback, and weekly digests so builders stay visible and unstuck.",
+  "competeForWin": true
+}

--- a/content/summer-cohort/c1/w2-comms/submissions/jfleck25.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/jfleck25.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "jfleck25",
+  "name": "James Fleck",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocI7UrFQkgpdy5j5NGP31hlEBPrT93Ybs-d321NsLp7kjd-Xkg=s96-c",
+  "repoUrl": "https://github.com/jfleck25/your-week-2-build",
+  "liveUrl": "https://yourthing.example.com",
+  "loomUrl": "https://www.loom.com/share/...",
+  "pitch": "One sentence on why you should win this week.",
+  "competeForWin": false
+}

--- a/content/summer-cohort/c1/w2-comms/submissions/nebullii.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/nebullii.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "nebullii",
+  "name": "Neha Chaudhari",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocL7lUmR1B71l9kqbcggS2ik1rswuvJ48rOm5QZjBkl2okUbraA=s96-c",
+  "repoUrl": "https://github.com/nebullii/cohort-sos.git",
+  "liveUrl": "https://cohort-sos.vercel.app",
+  "loomUrl": "https://www.loom.com/share/4faa4fe6e4374d2fb9c75906dfccb825",
+  "pitch": "Cohort SOS unblocks stuck builders in minutes and turns every rescue into searchable cohort memory so no one solves the same problem twice.",
+  "competeForWin": true
+}


### PR DESCRIPTION
## Summary
Promotes three Cohort 1 Week 2 comms submissions to production. All three were submitted before the 5:00 pm ET deadline on 2026-05-22.

## Included PRs
- **#1336** submission: Paramjeet-singh-neu c1w2comms — @Paramjeet-singh-neu
- **#1319** feat(summer-cohort): add w2-comms submission for jfleck25 — @jfleck25
- **#1343** feat: add nebullii cohort submission — @nebullii
- **#1348** release: c1w2comms submissions to develop (rollup PR)

## Test plan
- [x] Each contributor PR was CLEAN/MERGEABLE with no failing checks
- [x] Diff is 3 JSON files under `content/summer-cohort/c1/w2-comms/submissions/` — no code changes
- [x] Local `SKIP_TYPECHECK=1 npm run build` succeeded; `npm start` on :3001 served `/summer-cohort` 200 OK
- [x] All three submitted before 21:00 UTC (5:00 pm ET) — no `competeForWin` flips needed