### PR TITLE
fix: refresh hackathon signup leaderboard after merges

### DIFF
--- a/__tests__/app/api/github/webhook/route.test.ts
+++ b/__tests__/app/api/github/webhook/route.test.ts
@@ -20,6 +20,7 @@ import {
   notifyHackASprintSubmissionMerged,
 } from "@/lib/discord";
 import { getAdminDb } from "@/lib/firebase-admin";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
 import { makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 // Quiet the next/cache revalidate calls in jest while preserving the rest
@@ -54,6 +55,10 @@ jest.mock("@/lib/hackathon-showcase-admin", () => ({
   awardHackASprint2026ShowcaseBadge: jest.fn(),
 }));
 
+jest.mock("@/lib/hackathon-leaderboard-snapshot", () => ({
+  refreshSnapshot: jest.fn(),
+}));
+
 jest.mock("@/lib/summer-cohort-auto-admit", () => ({
   maybeAutoAdmitOnPRMerge: jest.fn(),
 }));
@@ -82,6 +87,7 @@ const mockProcessPullRequest = processPullRequest as jest.MockedFunction<
 const mockIsTargetRepository = isTargetRepository as jest.MockedFunction<
   typeof isTargetRepository
 >;
+const mockRefreshSnapshot = refreshSnapshot as jest.MockedFunction<typeof refreshSnapshot>;
 
 describe("GET /api/github/webhook", () => {
   it("returns ok status", async () => {
@@ -95,6 +101,13 @@ describe("GET /api/github/webhook", () => {
 describe("POST /api/github/webhook", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRefreshSnapshot.mockResolvedValue({
+      entries: [],
+      totalCount: 0,
+      websiteSignupCount: 0,
+      creditTopN: 0,
+      generatedAt: "2026-05-22T00:00:00.000Z",
+    });
   });
 
   it("returns 401 when signature is invalid", async () => {
@@ -399,6 +412,40 @@ describe("POST /api/github/webhook", () => {
       authorLogin: "octocat",
       prNumber: 6,
     });
+  });
+
+  it("refreshes persisted hackathon signup leaderboard snapshots on target repo merge", async () => {
+    mockVerify.mockReturnValue(true);
+    mockIsTargetRepository.mockReturnValue(true);
+    (fetchPullRequestChangedFilenames as jest.Mock).mockResolvedValue([]);
+    const req = makeRequest({
+      method: "POST",
+      path: "/api/github/webhook",
+      body: {
+        action: "closed",
+        pull_request: {
+          number: 66,
+          title: "Merged",
+          state: "closed",
+          merged: true,
+          merged_at: "2026-05-01",
+          user: { login: "octocat", avatar_url: "x" },
+          html_url: "u",
+          created_at: "2026-04-30",
+          updated_at: "2026-05-01",
+        },
+        repository: { owner: { login: "o" }, name: "r" },
+      },
+      headers: {
+        "x-hub-signature-256": "sha256=abc",
+        "x-github-event": "pull_request",
+      },
+    });
+
+    await POST(req);
+
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith("hack-a-sprint-2026");
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith("sports-hack-2026");
   });
 
   it("swallows processPullRequest errors and still returns 200", async () => {

--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -18,6 +18,8 @@ import {
   SHOWCASE_SUBMISSIONS_CACHE_TAG,
 } from "@/lib/hackathon-showcase";
 import { MERGED_PR_COUNTS_CACHE_TAG } from "@/lib/github-merged-pr-count";
+import { HACKATHON_EVENT_SIGNUP_IDS } from "@/lib/hackathon-event-signup";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
 import { ensureHackASprint2026ScoreDoc } from "@/lib/hackathon-asprint-2026-scores";
 import { awardHackASprint2026ShowcaseBadge } from "@/lib/hackathon-showcase-admin";
 import { maybeAutoAdmitOnPRMerge } from "@/lib/summer-cohort-auto-admit";
@@ -206,6 +208,24 @@ async function handleWebhook(request: NextRequest) {
         // Merged PR counts caches go stale on every merge — refresh.
         try {
           revalidateTag(MERGED_PR_COUNTS_CACHE_TAG, { expire: 0 });
+        } catch {
+          // non-fatal
+        }
+
+        // GET /api/hackathons/events/:eventId/signup serves a persisted
+        // Firestore snapshot. Refresh it after PR merges so the public
+        // leaderboard reflects newly earned merged-PR credit.
+        try {
+          const refreshResults = await Promise.allSettled(
+            HACKATHON_EVENT_SIGNUP_IDS.map((eventId) => refreshSnapshot(eventId))
+          );
+          const failed = refreshResults.filter((r) => r.status === "rejected").length;
+          if (failed > 0) {
+            logger.warn("Hackathon signup leaderboard snapshot refresh failed", {
+              failed,
+              total: refreshResults.length,
+            });
+          }
         } catch {
           // non-fatal
         }


### PR DESCRIPTION
## Summary

The public Sports Hack and Hack-a-Sprint signup leaderboards served from `GET /api/hackathons/events/:eventId/signup` are computed from a persisted Firestore snapshot (`hackathonLeaderboardSnapshots/<eventId>`), refreshed today only by direct signup mutations (POST/PATCH/DELETE on the same route) and an out-of-band cron script. Merged-PR counts therefore lag the actual GitHub state until the next signup mutation or scheduled rebuild — visibly, a contributor whose PRs land between their last website signup interaction and the next cron tick shows a stale `mergedPrCount` and a stale rank on the public board.

This PR closes that gap inside the existing GitHub-webhook merge handler: when a target-repo PR is merged (the same event that already triggers `processPullRequest` and the merged-PR-count cache invalidation), the webhook now also calls `refreshSnapshot(eventId)` for every event listed in `HACKATHON_EVENT_SIGNUP_IDS`. Snapshot writes are wrapped in `Promise.allSettled` + a `logger.warn` on any failure so a Firestore hiccup against one event doesn't break the webhook's 200 response or block the other event's refresh.

## Affected surfaces

| File | Change |
|---|---|
| `app/api/github/webhook/route.ts` | After the existing `MERGED_PR_COUNTS_CACHE_TAG` invalidation in `handleWebhook`, add a new block that iterates `HACKATHON_EVENT_SIGNUP_IDS` and calls `refreshSnapshot(eventId)` for each via `Promise.allSettled`. Failures are logged via `logger.warn` with `{ failed, total }`; the outer try/catch keeps the webhook's existing "non-fatal side effects" contract intact. |
| `__tests__/app/api/github/webhook/route.test.ts` | Mocks `@/lib/hackathon-leaderboard-snapshot` (`refreshSnapshot`); adds the test case "refreshes persisted hackathon signup leaderboard snapshots on target repo merge" asserting `refreshSnapshot` is called with both `hack-a-sprint-2026` and `sports-hack-2026`; preserves all existing 15 cases. |

Net diff: 2 files, +67/-0. No production-route surface changed beyond the webhook handler's existing merge-time side-effect block.

## Blast radius (before this fix)

| Vector | Pre-fix exposure |
|---|---|
| Contributor merges a PR to `cursor-boston` between snapshot refreshes | Their `mergedPrCount` on the public Sports Hack / Hack-a-Sprint signup boards stays at the previous snapshot's value until either (a) someone signs up / changes signup status / withdraws on that event (any mutation on `/api/hackathons/events/:eventId/signup`), or (b) the cron-driven `scripts/snapshot-hackathon-leaderboard.ts` runs. Window can be hours. |
| Sports Hack ranking visibility on event day | Top-119 cutoff for Cursor credit eligibility is decided from this snapshot. A contributor whose merged PR landed close to the cutoff window could be ranked one position lower than their actual GitHub count would imply, and the `creditEligible` flag could be wrong on the displayed board. |
| Contributor experience | The "merged PRs to the community repo" signal that ranks the leaderboard is the contributor's primary feedback loop. A long staleness window erodes that signal — contributors couldn't see their work reflected after a merge, which both demoralizes (silent merges) and incentivizes the wrong workaround (re-saving signup to force a recompute). |

The defect is structural: the leaderboard's freshness contract was tied to signup-route mutations and a periodic cron, but the *cause* of rank change is PR merge on GitHub. Refreshing the snapshot on the exact event that changes the data is the right shape; it also removes one of the operational reasons to manually run the snapshot script.

## Why it matters

The leaderboard is the public surface through which `cursor-boston` rewards contribution. The whole ranking is keyed off "merged PRs," so the loop "contributor merges → leaderboard updates" needs to be tight. Today that loop can be hours long; this PR makes it ~seconds (the time between GitHub firing the webhook and Firestore committing the recomputed snapshot doc).

`Promise.allSettled` rather than `Promise.all` ensures one slow / failing event refresh doesn't take the others down with it — important because both `hack-a-sprint-2026` and `sports-hack-2026` are live signup boards. Logging the failure count gives operators a metric to alert on if the refresh path starts breaking. The outer try/catch preserves the webhook's existing "non-fatal side effects" contract — GitHub's webhook delivery semantics are at-least-once, so a transient Firestore error here doesn't block the request.

## Reproduction (before fix)

```bash
# As a contributor with `mrrCarter:1` cursor-boston merged PRs, watch the public board:
curl -s https://cursorboston.com/api/hackathons/events/sports-hack-2026/signup \
  | jq '.entries[] | select(.githubLogin == "mrrcarter") | { rank, mergedPrCount }'
# Pre-fix on a stale snapshot: { "rank": 216, "mergedPrCount": 0 }
# Even though GitHub shows 4 merged PRs for mrrCarter on the target repo.

# Merge another PR to cursor-boston via the GitHub UI. Wait 30 seconds.
# Pre-fix: same output. Snapshot did not refresh on the merge event.
# Post-fix: snapshot refreshed by the webhook; mergedPrCount and rank reflect reality.
```

## Fix walkthrough

`app/api/github/webhook/route.ts` adds a block immediately after the existing `MERGED_PR_COUNTS_CACHE_TAG` revalidation:

```ts
// GET /api/hackathons/events/:eventId/signup serves a persisted Firestore
// snapshot. Refresh it after PR merges so the public leaderboard reflects
// newly earned merged-PR credit.
try {
  const refreshResults = await Promise.allSettled(
    HACKATHON_EVENT_SIGNUP_IDS.map((eventId) => refreshSnapshot(eventId))
  );
  const failed = refreshResults.filter((r) => r.status === "rejected").length;
  if (failed > 0) {
    logger.warn("Hackathon signup leaderboard snapshot refresh failed", {
      failed,
      total: refreshResults.length,
    });
  }
} catch {
  // non-fatal
}
```

`HACKATHON_EVENT_SIGNUP_IDS` is the canonical list of event IDs that serve this snapshot — currently `["hack-a-sprint-2026", "sports-hack-2026"]`. Importing from the existing module rather than hard-coding the IDs means a future event addition (e.g. `sports-hack-2027`) automatically inherits this freshness contract by adding itself to that array.

`refreshSnapshot(eventId)` is the existing helper at `lib/hackathon-leaderboard-snapshot.ts` that already powers both signup-mutation-triggered refreshes and the cron script — same code path, third caller now.

## Tests

| Command | Result |
|---|---|
| `npm test -- __tests__/app/api/github/webhook/route.test.ts --runInBand` | 16/16 pass — the existing 15 cases plus the new "refreshes persisted hackathon signup leaderboard snapshots on target repo merge" assertion. |
| `npm run type-check` (`tsc --noEmit`) | Clean. |
| `npm run lint` on the touched files (`--max-warnings=0`) | Clean. |
| `git diff --check origin/develop..HEAD` | No whitespace errors. |

The new test mocks `@/lib/hackathon-leaderboard-snapshot.refreshSnapshot`, fires a target-repo merge webhook, and asserts the mock was called with both event IDs in `HACKATHON_EVENT_SIGNUP_IDS`. It doesn't drive the real Firestore write path (that's the existing snapshot helper's responsibility, tested separately).

## Scope (what this PR does NOT cover, and why)

- **The cron snapshot rebuild** (`scripts/snapshot-hackathon-leaderboard.ts`) is unchanged. It remains the safety net for any non-webhook trigger of snapshot drift (e.g. a Firestore restore, a missed webhook delivery, a contributor's GitHub login linkage being repaired retroactively). Both refresh paths converge on the same `refreshSnapshot()` helper.
- **Webhook events other than `pull_request.closed.merged`** don't trigger refresh. Issue events, comment events, etc. don't change the merge count. The block sits inside the existing merged-PR branch.
- **Backfill of currently stale rows** isn't in this PR. The fix is forward-looking: future merges keep the snapshot fresh. The stale rows that existed before this lands either get fixed by the next signup mutation on each event, by the cron, or by maintainer-run snapshot script. That backfill is out of scope here.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
