### PR TITLE
test: normalize Windows module-ID paths in smoke harness

### DIFF
--- a/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
@@ -5,7 +5,7 @@
  * past the 401 guard than the unauthenticated invoke in #74).
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { NextRequest } from "next/server";
 import { makeCronRequest } from "@/__tests__/_helpers/route-test-utils";
 
@@ -103,13 +103,14 @@ function walk(dir: string, out: string[] = []): string[] {
 const ROUTE_FILES = walk(APP_API);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
 function apiPathFromFile(absPath: string): string {
-  const rel = absPath.replace(join(process.cwd(), "app"), "").replace(/\\/g, "/");
-  return rel.replace(/\/route\.ts$/, "") || "/api";
+  const rel = relative(join(process.cwd(), "app"), absPath).replace(/\\/g, "/");
+  const withoutRoute = rel.replace(/\/route\.ts$/, "");
+  return `/${withoutRoute}` || "/api";
 }
 
 function buildRouteContext(apiPath: string) {

--- a/__tests__/app/api/all-routes-handler-invoke.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke.test.ts
@@ -7,7 +7,7 @@
  * the import-only sweep in all-routes-smoke.test.ts.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { NextRequest } from "next/server";
 import { makeCronRequest } from "@/__tests__/_helpers/route-test-utils";
 
@@ -96,15 +96,15 @@ function walk(dir: string, out: string[] = []): string[] {
 const ROUTE_FILES = walk(APP_API);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
 /** Build `/api/...` path from absolute route file path. */
 function apiPathFromFile(absPath: string): string {
-  const rel = absPath.replace(join(process.cwd(), "app"), "").replace(/\\/g, "/");
+  const rel = relative(join(process.cwd(), "app"), absPath).replace(/\\/g, "/");
   const withoutRoute = rel.replace(/\/route\.ts$/, "");
-  return withoutRoute || "/api";
+  return `/${withoutRoute}` || "/api";
 }
 
 /** Next.js 15+ dynamic route context from `[param]` and `[...slug]` segments. */

--- a/__tests__/app/api/all-routes-smoke.test.ts
+++ b/__tests__/app/api/all-routes-smoke.test.ts
@@ -13,7 +13,7 @@
  * follow-up.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 // Heavyweight dependencies that many routes pull in. Mock them up-front
 // so a route's module init can succeed without real Firebase / cron / etc.
@@ -79,7 +79,7 @@ const ROUTE_FILES = walk(APP_API);
 
 // Convert an absolute path to the `@/...` module-id form Jest resolves.
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
@@ -102,7 +102,7 @@ describe("app/api smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/app/components-smoke.test.tsx
+++ b/__tests__/app/components-smoke.test.tsx
@@ -11,7 +11,7 @@
  * otherwise has no dedicated tests.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 // Mock all of Firebase + client SDK calls so nothing dies at import time.
 jest.mock("firebase/auth", () => ({
@@ -95,13 +95,14 @@ function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const s = statSync(full);
+    const normalized = full.replace(/\\/g, "/");
     if (s.isDirectory()) walk(full, out);
     else if (
       (entry.endsWith(".tsx") || entry.endsWith(".ts")) &&
       // Only target _components / _hooks / _lib helper directories
-      (full.includes("/_components/") ||
-        full.includes("/_hooks/") ||
-        full.includes("/_lib/"))
+      (normalized.includes("/_components/") ||
+        normalized.includes("/_hooks/") ||
+        normalized.includes("/_lib/"))
     ) {
       out.push(full);
     }
@@ -112,7 +113,7 @@ function walk(dir: string, out: string[] = []): string[] {
 const FILES = walk(APP_DIR);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return (
     "@/" +
     rel
@@ -137,7 +138,7 @@ describe("app/**/_components smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/app/pages-and-shared-smoke.test.tsx
+++ b/__tests__/app/pages-and-shared-smoke.test.tsx
@@ -11,7 +11,7 @@
  * lift coverage without exercising the React render.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 jest.mock("firebase/auth", () => ({
   onAuthStateChanged: jest.fn(() => jest.fn()),
@@ -131,11 +131,11 @@ const COMPONENT_FILES = walk(COMPONENTS_DIR, (f) =>
   f.endsWith(".tsx") || f.endsWith(".ts")
 );
 const PAGE_FILES = walk(APP_DIR, (f) =>
-  /\/(page|layout)\.tsx$/.test(f)
+  /\/(page|layout)\.tsx$/.test(f.replace(/\\/g, "/"))
 );
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.tsx$/, "").replace(/\.ts$/, "");
 }
 
@@ -156,7 +156,7 @@ function runSweep(label: string, files: string[]) {
           });
         } catch (e) {
           failures.push({
-            path: file.replace(process.cwd() + "/", ""),
+            path: relative(process.cwd(), file).replace(/\\/g, "/"),
             err: e instanceof Error ? e.message.split("\n")[0] : String(e),
           });
         }

--- a/__tests__/app/pages-shallow-render.test.tsx
+++ b/__tests__/app/pages-shallow-render.test.tsx
@@ -6,7 +6,7 @@
  * (async RSC defaults cannot be rendered in jsdom).
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import React from "react";
 import { render } from "@testing-library/react";
 
@@ -139,7 +139,7 @@ function isUseClientPage(absPath: string): boolean {
 }
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.tsx$/, "");
 }
 
@@ -167,7 +167,7 @@ describe("app/**/page.tsx shallow render (use client only)", () => {
         rendered++;
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/components-and-contexts-smoke.test.tsx
+++ b/__tests__/components-and-contexts-smoke.test.tsx
@@ -19,7 +19,7 @@
  * this alone moves statement and line coverage off zero.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 jest.mock("firebase/auth", () => ({
   onAuthStateChanged: jest.fn(() => jest.fn()),
@@ -196,7 +196,7 @@ function findAppMetaFiles(): string[] {
 const APP_META_FILES = findAppMetaFiles();
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(ROOT + "/", "");
+  const rel = relative(ROOT, absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.tsx$/, "").replace(/\.ts$/, "");
 }
 
@@ -215,7 +215,7 @@ describe("components/** + contexts/** smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(ROOT + "/", ""),
+          path: relative(ROOT, file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }
@@ -254,7 +254,7 @@ describe("app-router meta files smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(ROOT + "/", ""),
+          path: relative(ROOT, file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/lib/all-lib-smoke.test.ts
+++ b/__tests__/lib/all-lib-smoke.test.ts
@@ -6,7 +6,7 @@
  * lifts coverage on modules that have no dedicated unit tests yet.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 jest.mock("@/lib/firebase-admin", () => ({
   getAdminDb: () => null,
@@ -66,7 +66,7 @@ function walkTs(dir: string, out: string[] = []): string[] {
 const LIB_FILES = walkTs(LIB_DIR);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
@@ -85,7 +85,7 @@ describe("lib/* smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }


### PR DESCRIPTION
## Summary

Normalizes Windows-derived absolute paths in the Jest smoke harness before building dynamic module IDs.

## Affected Surfaces

| Surface | Change |
| --- | --- |
| Smoke/sweep tests | Use `path.relative(process.cwd(), absPath).replace(/\\/g, "/")` instead of slash-only prefix removal. |

## Blast Radius

Test-only. No production code or runtime behavior changes.

## Why

Windows absolute paths were leaking into dynamic imports as `@/C:\...`, hiding real test failures behind module-resolution noise.

## Repro

Run the smoke harness suites on Windows before this patch and the dynamic imports can resolve malformed module IDs.

## Fix

Use Node path normalization to produce repo-relative POSIX-style module IDs across platforms.

## Tests

- Focused 8-suite smoke sweep: 20/20 passed
- `npm run type-check`
- Changed-file ESLint with `--max-warnings=0`
- `git diff --check`

## Scope

Eight smoke/sweep test files only. No app, API, or shared library behavior changes.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
