### PR TITLE
test(middleware): portable NODE_ENV assignment in dev no-origin case

### DIFF
--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -63,8 +63,16 @@ describe("isOriginAllowed", () => {
   const originalEnv = process.env.NODE_ENV;
   const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
 
+  function setNodeEnv(value: string | undefined) {
+    if (value === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = value;
+    }
+  }
+
   afterEach(() => {
-    Object.defineProperty(process.env, "NODE_ENV", { value: originalEnv, configurable: true });
+    setNodeEnv(originalEnv);
     if (originalAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
     else process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
   });
@@ -129,12 +137,12 @@ describe("isOriginAllowed", () => {
   });
 
   it("returns false for POST with no origin/referer in production", () => {
-    Object.defineProperty(process.env, "NODE_ENV", { value: "production", configurable: true });
+    setNodeEnv("production");
     expect(isOriginAllowed(makeRequest({ method: "POST" }))).toBe(false);
   });
 
   it("returns true for POST with no origin/referer in development", () => {
-    Object.defineProperty(process.env, "NODE_ENV", { value: "development", configurable: true });
+    setNodeEnv("development");
     expect(isOriginAllowed(makeRequest({ method: "POST" }))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Makes the middleware test suite set `NODE_ENV` through normal `process.env` assignment instead of partial property descriptors.

## Affected Surfaces

| Surface | Change |
| --- | --- |
| `__tests__/lib/middleware.test.ts` | Adds a small helper for portable `NODE_ENV` setup and restoration. |

## Blast Radius

Test-only. No production middleware behavior changes.

## Why

The dev no-origin CSRF test relied on partial `Object.defineProperty` descriptors for `process.env.NODE_ENV`, which is brittle across Node/Jest environments.

## Repro

Run the middleware suite on Windows/Node 24 and the development no-origin case can fail even though the test intends to set development mode.

## Fix

Use a helper that assigns or deletes `process.env.NODE_ENV` directly, then restores the original value after each test.

## Tests

- Focused middleware suite: 33/33 passed
- Changed-file ESLint with `--max-warnings=0`
- `git diff --check`

## Scope

One test file only.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
