### PR TITLE
test(pair-page): stable Next router mock identity to avoid spinner retrigger

### DIFF
--- a/__tests__/app/pages-gap-fill-wave-4.test.tsx
+++ b/__tests__/app/pages-gap-fill-wave-4.test.tsx
@@ -8,20 +8,24 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { doc, getDoc } from "firebase/firestore";
 
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
+jest.mock("next/navigation", () => {
+  const mockRouter = {
     push: jest.fn(),
     replace: jest.fn(),
     back: jest.fn(),
     refresh: jest.fn(),
     prefetch: jest.fn(),
-  }),
-  useSearchParams: () => new URLSearchParams(),
-  usePathname: () => "/",
-  useParams: () => ({ sessionId: "sess-pair-wave4" }),
-  redirect: jest.fn(),
-  notFound: jest.fn(),
-}));
+  };
+
+  return {
+    useRouter: () => mockRouter,
+    useSearchParams: () => new URLSearchParams(),
+    usePathname: () => "/",
+    useParams: () => ({ sessionId: "sess-pair-wave4" }),
+    redirect: jest.fn(),
+    notFound: jest.fn(),
+  };
+});
 
 jest.mock("@/lib/firebase", () => ({
   auth: {},


### PR DESCRIPTION
## Summary

Stabilizes the pair-session page test by returning a stable mocked Next router object.

## Affected Surfaces

| Surface | Change |
| --- | --- |
| `__tests__/app/pages-gap-fill-wave-4.test.tsx` | Hoists the mocked router object so `useRouter()` returns a stable identity. |

## Blast Radius

Test-only. No production page behavior changes.

## Why

The page-gap suite could retrigger effects when the router mock returned a fresh object on every render, leaving the pair-session case stuck on the loading state in larger runs.

## Repro

Run the broader Windows Jest sweep after smoke-path normalization; the pair-session case can fail while waiting for loaded text.

## Fix

Hoist the mock router object inside the `next/navigation` mock and return the same object for each `useRouter()` call.

## Tests

- Focused page-gap suite: 16/16 passed
- Changed-file ESLint with `--max-warnings=0`
- `git diff --check`

## Scope

One test file only.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
