### PR TITLE
fix: harden husky hooks for spaced paths

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+if [ "${HUSKY:-1}" = "0" ]; then
+  exit 0
+fi
 
-npx --no -- commitlint --edit ${1}
+husky_sh="$(dirname -- "$0")/_/husky.sh"
+if [ -f "$husky_sh" ]; then
+  . "$husky_sh"
+fi
+
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,12 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+if [ "${HUSKY:-1}" = "0" ]; then
+  exit 0
+fi
+
+husky_sh="$(dirname -- "$0")/_/husky.sh"
+if [ -f "$husky_sh" ]; then
+  . "$husky_sh"
+fi
 
 # Scan for secrets in staged files (if gitleaks is installed)
 if command -v gitleaks > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Hardens the Husky hooks so local commits work from worktrees and repository paths that contain spaces.

## Affected Areas
- `.husky/commit-msg`
- `.husky/pre-commit`

## Why
The hooks should be portable across Windows paths with spaces and fresh worktrees where Husky's generated shim has not been created yet.

## Fix
- Honors `HUSKY=0` before running hook logic.
- Sources the generated Husky shim only when it exists.
- Quotes the commit-message path passed to commitlint.

## Verification
- Normal `git commit -s` completed with the patched hooks enabled.
- Direct `commit-msg` invocation passed with a commit-message file path containing spaces.
- `HUSKY=0` pre-commit invocation exited cleanly when the generated shim was absent.
- `git diff --check`

## Scope Control
Developer tooling only. No production code, CI workflow, or runtime behavior changes.

Carther Theogene · https://linkedin.com/in/carther