### PR TITLE
chore: remove dead showcase unlock rate-limit presets

### DIFF
--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -156,7 +156,7 @@ describe('Rate Limiting', () => {
       });
     });
 
-    it('should keep distinct showcase presets where the behavior differs', () => {
+    it('should keep distinct live showcase presets where the behavior differs', () => {
       expect(rateLimitConfigs.hackathonShowcaseAiScore).toEqual({
         windowMs: 60 * 1000,
         maxRequests: 30,
@@ -164,14 +164,6 @@ describe('Rate Limiting', () => {
       expect(rateLimitConfigs.hackathonShowcaseJudgeScore).toEqual({
         windowMs: 60 * 1000,
         maxRequests: 40,
-      });
-      expect(rateLimitConfigs.hackathonShowcaseUnlock).toEqual({
-        windowMs: 60 * 1000,
-        maxRequests: 20,
-      });
-      expect(rateLimitConfigs.hackathonShowcaseUnlockAttempts).toEqual({
-        windowMs: 5 * 60 * 1000,
-        maxRequests: 15,
       });
       expect(rateLimitConfigs.hackathonShowcaseVote).toEqual({
         windowMs: 60 * 1000,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -314,20 +314,6 @@ export const rateLimitConfigs = {
     maxRequests: 40, // 40 requests per minute
   },
   /**
-   * Rate limiting for unlocking Hackathon Showcase voting functionality.
-   */
-  hackathonShowcaseUnlock: {
-    windowMs: 60 * 1000, // 1 minute
-    maxRequests: 20, // 20 requests per minute
-  },
-  /**
-   * Strict rate limiting for brute-force prevention on Showcase unlock attempts.
-   */
-  hackathonShowcaseUnlockAttempts: {
-    windowMs: 5 * 60 * 1000, // 5 minutes
-    maxRequests: 15, // 15 attempts per 5 minutes
-  },
-  /**
    * Rate limiting for casting votes in the Hackathon Showcase.
    */
   hackathonShowcaseVote: {


### PR DESCRIPTION
## Summary
Remove two dead Hack-a-Sprint showcase unlock rate-limit presets after the passcode unlock endpoint was permanently retired.

## Affected surfaces
- `lib/rate-limit.ts`
- `__tests__/lib/rate-limit.test.ts`

## Blast radius
Low. This only deletes unused configuration keys and updates the config regression test. No live API route references these presets.

## Why
The unlock endpoint now returns `410 Gone`; keeping `hackathonShowcaseUnlock` and `hackathonShowcaseUnlockAttempts` makes the security config look broader than the runtime surface and creates stale maintenance paths.

## Repro
Before this change, `rg "hackathonShowcaseUnlock"` found only the config and its own assertion test, not any live route use.

## Fix
Delete the obsolete unlock presets and keep the showcase preset test focused on currently live showcase rate limits.

## Tests
- `npm test -- --runTestsByPath __tests__/lib/rate-limit.test.ts --runInBand`
- `npm run type-check`
- `npx eslint --max-warnings=0 lib/rate-limit.ts __tests__/lib/rate-limit.test.ts`
- `git diff --check`

## Scope
This PR intentionally does not change live vote, judge-score, AI-score, participant-score, or credit-email rate limits.

Carther Theogene · https://linkedin.com/in/carther
