### PR TITLE
test(pairing): cover matching edge cases

### DIFF
--- a/__tests__/lib/pair-programming/matching.test.ts
+++ b/__tests__/lib/pair-programming/matching.test.ts
@@ -202,6 +202,73 @@ describe("getTopMatches", () => {
     expect(matches.length).toBe(5);
   });
 
+  it("returns every viable match in an odd-sized candidate pool", async () => {
+    const me = makeProfile({
+      userId: "me",
+      skillsCanTeach: ["React"],
+      skillsWantToLearn: ["Go"],
+      preferredLanguages: ["TypeScript"],
+    });
+    const profiles = [
+      makeProfile({ userId: "learn-react", skillsWantToLearn: ["React"] }),
+      makeProfile({ userId: "teach-go", skillsCanTeach: ["Go"] }),
+      makeProfile({
+        userId: "shared-typescript",
+        skillsCanTeach: ["Testing"],
+        preferredLanguages: ["TypeScript"],
+      }),
+    ];
+
+    const matches = await getTopMatches(me, profiles);
+
+    expect(matches).toHaveLength(3);
+    expect(matches.map((match) => match.userId)).toEqual(
+      expect.arrayContaining(["learn-react", "teach-go", "shared-typescript"])
+    );
+  });
+
+  it("does not mutate candidate eligibility between match requests", async () => {
+    const me = makeProfile({
+      userId: "me",
+      skillsCanTeach: ["React"],
+      skillsWantToLearn: ["Go"],
+    });
+    const profiles = [
+      makeProfile({ userId: "learn-react", skillsWantToLearn: ["React"] }),
+      makeProfile({ userId: "teach-go", skillsCanTeach: ["Go"] }),
+      makeProfile({
+        userId: "shared-session",
+        skillsWantToLearn: ["React"],
+        sessionTypes: ["build-together"],
+      }),
+    ];
+
+    const firstPass = await getTopMatches(me, profiles, 3);
+    const secondPass = await getTopMatches(me, profiles, 3);
+
+    expect(secondPass.map((match) => match.userId)).toEqual(
+      firstPass.map((match) => match.userId)
+    );
+    expect(secondPass).toHaveLength(3);
+  });
+
+  it("returns no matches when no candidate is eligible or scoreable", async () => {
+    const me = makeProfile({ userId: "me", timezone: "America/New_York" });
+    const profiles = [
+      me,
+      makeProfile({
+        userId: "inactive",
+        isActive: false,
+        skillsWantToLearn: ["React"],
+      }),
+      makeProfile({ userId: "zero-score", timezone: "Asia/Tokyo" }),
+    ];
+
+    const matches = await getTopMatches(me, profiles);
+
+    expect(matches).toHaveLength(0);
+  });
+
   it("excludes zero-score matches", async () => {
     const me = makeProfile({ userId: "me", timezone: "America/New_York" });
     const other = makeProfile({ userId: "other", timezone: "Asia/Tokyo" });


### PR DESCRIPTION
## Summary
- Adds matcher edge-case tests for odd candidate pools, stateless repeated matching, and no eligible or scoreable candidates.
- Extends existing pair matching coverage from 14 to 17 tests.
- Closes #593.

## Affected surfaces
- `__tests__/lib/pair-programming/matching.test.ts`

## Blast radius
- Test-only change; no production matching code changes.

## Why
- Issue #593 calls out missing coverage for pair programming matching edge cases and fairness/no-blocking behavior.

## Repro
- The existing suite covered scoring, sorting, limits, self-exclusion, inactive profiles, and zero-score filtering, but not odd candidate pools or repeated stateless calls.

## Fix
- Adds an odd-sized candidate pool assertion that keeps every viable active candidate eligible.
- Adds a repeated-call assertion proving `getTopMatches` does not consume or mutate candidate eligibility.
- Adds an explicit no-match edge case covering self, inactive, and zero-score profiles together.

## Tests
- `npm test -- --runTestsByPath __tests__/lib/pair-programming/matching.test.ts --runInBand`
- `npm run type-check`
- `npx eslint --max-warnings=0 __tests__/lib/pair-programming/matching.test.ts`
- `git diff --check`

## Scope
- Does not add a round-robin pairing allocator; the fairness check is scoped to the current stateless ranking helper.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)

