### PR TITLE
docs(firebase): clarify client and admin helper usage

### DIFF
--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -58,9 +58,15 @@ function getAdminApp(): App | null {
 }
 
 /**
- * Get the Firebase Admin Firestore instance.
+ * Get the server-only Firebase Admin Firestore instance.
+ *
+ * Use this helper from Route Handlers, server actions, scripts, and other
+ * trusted Node.js code that needs elevated Firebase Admin privileges. Never
+ * import or expose this helper from client components because Admin SDK
+ * credentials can bypass Firestore security rules.
+ *
  * Initializes the instance on first call and reuses it on subsequent calls.
- * @returns The Firestore instance, or null if Firebase Admin could not be initialized
+ * @returns The Firestore instance, or null when no supported Admin SDK credentials are configured.
  */
 export function getAdminDb(): Firestore | null {
   if (adminDb) {
@@ -87,9 +93,14 @@ export function getAdminDb(): Firestore | null {
 }
 
 /**
- * Get the Firebase Admin Auth instance.
+ * Get the server-only Firebase Admin Auth instance.
+ *
+ * Use this helper only from trusted server-side code that verifies or manages
+ * Firebase Auth users with Admin SDK privileges. Client code should use the
+ * browser SDK `auth` export from `lib/firebase` instead.
+ *
  * Initializes the instance on first call and reuses it on subsequent calls.
- * @returns The Auth instance, or null if Firebase Admin could not be initialized
+ * @returns The Auth instance, or null when no supported Admin SDK credentials are configured.
  */
 export function getAdminAuth(): Auth | null {
   if (adminAuth) {
@@ -106,9 +117,14 @@ export function getAdminAuth(): Auth | null {
 }
 
 /**
- * Get the Firebase Admin Realtime Database instance.
+ * Get the server-only Firebase Admin Realtime Database instance.
+ *
+ * Use this helper from trusted Node.js code that needs Admin SDK access to
+ * Realtime Database. Never import it from client components; browser code
+ * should use the client `rtdb` export from `lib/firebase`.
+ *
  * Initializes the instance on first call and reuses it on subsequent calls.
- * @returns The Database instance, or null if Firebase Admin could not be initialized
+ * @returns The Database instance, or null when no supported Admin SDK credentials are configured.
  */
 export function getAdminRtdb(): Database | null {
   if (adminRtdb) {

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -35,14 +35,63 @@ const isPlaceholderKey =
   (firebaseConfig.projectId?.startsWith("your-") ?? false) ||
   (firebaseConfig.projectId?.startsWith("demo-") ?? false);
 
+/**
+ * Client-side Firebase app singleton.
+ *
+ * Available only in the browser when public Firebase config is present.
+ * Remains `undefined` during server rendering, tests, and local runs that use
+ * placeholder env values. Server-side code that needs privileged Firebase
+ * access should use `lib/firebase-admin` instead.
+ */
 let app: FirebaseApp | undefined;
+
+/**
+ * Client-side Firebase Auth singleton.
+ *
+ * Use from browser components and hooks after checking it is defined. This is
+ * not an Admin SDK auth instance and cannot verify or manage users on the
+ * server.
+ */
 let auth: Auth | undefined;
+
+/**
+ * Client-side Firestore singleton.
+ *
+ * Use from browser code that should obey Firestore security rules. It is
+ * `undefined` outside the browser or when public Firebase env is missing.
+ */
 let db: Firestore | undefined;
+
+/**
+ * Client-side Realtime Database singleton.
+ *
+ * Use from browser code that should obey database security rules. It is
+ * `undefined` outside the browser or when public Firebase env is missing.
+ */
 let rtdb: Database | undefined;
+
+/**
+ * Client-side Firebase Storage singleton.
+ *
+ * Use from browser code that should obey Storage security rules. It is
+ * `undefined` outside the browser or when public Firebase env is missing.
+ */
 let storage: FirebaseStorage | undefined;
+
+/**
+ * Client-side Firebase Analytics singleton.
+ *
+ * Analytics is loaded only in supported browsers with non-placeholder public
+ * Firebase config, so callers must handle `undefined`.
+ */
 let analytics: Analytics | undefined;
 
-// Promise that resolves when analytics is ready (or resolves to undefined if not supported)
+/**
+ * Promise that resolves to Analytics when browser support and config allow it.
+ *
+ * Resolves to `undefined` on the server, in unsupported browsers, or when local
+ * placeholder Firebase env values are configured.
+ */
 const analyticsReady: Promise<Analytics | undefined> = (async () => {
   if (!isConfigured || typeof window === "undefined" || isPlaceholderKey) {
     return undefined;


### PR DESCRIPTION
## Summary
- Expands Firebase Admin helper JSDoc with server-only usage, null-return, and credential safety guidance.
- Adds JSDoc to the exported client Firebase singletons in `lib/firebase.ts`.
- Closes #562.

## Affected surfaces
- `lib/firebase-admin.ts`
- `lib/firebase.ts`

## Blast radius
- Documentation-only code comments; no runtime behavior changes.

## Why
- Issue #562 asks for clearer Firebase utility documentation so contributors know which APIs are client-safe, server-only, and nullable.

## Repro
- The existing Admin helper docs were brief, and the client singleton exports did not document browser-only availability or `undefined` cases.

## Fix
- Documents when to use Admin SDK helpers versus browser SDK singletons.
- Calls out null/undefined handling for missing credentials, server rendering, unsupported analytics, and placeholder env.
- Adds explicit warnings not to expose Admin SDK helpers to client code.

## Tests
- `npm run type-check`
- `npx eslint --max-warnings=0 lib/firebase-admin.ts lib/firebase.ts`
- `git diff --check`

## Scope
- Does not rename Firebase exports or add `getFirebaseApp()` helpers; it documents the current exported surface.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)

