### PR TITLE
fix: gate localhost csrf origins to development

### DIFF
--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -89,6 +89,32 @@ describe("isOriginAllowed", () => {
     ).toBe(true);
   });
 
+  it("returns false for production POST from localhost to a production URL", () => {
+    Object.defineProperty(process.env, "NODE_ENV", { value: "production", configurable: true });
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          origin: "http://localhost:3000",
+          url: "https://cursorboston.com/api/x",
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("returns false for production POST with only a localhost referer", () => {
+    Object.defineProperty(process.env, "NODE_ENV", { value: "production", configurable: true });
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          referer: "http://localhost:3000/form",
+          url: "https://cursorboston.com/api/x",
+        })
+      )
+    ).toBe(false);
+  });
+
   it("returns true when origin matches NEXT_PUBLIC_APP_URL", () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
     expect(

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -21,10 +21,14 @@ import type { UpstashRateLimitResult } from "./upstash-rate-limit";
 // Re-export rateLimitConfigs for convenience
 export { rateLimitConfigs } from "./rate-limit";
 
-// Allowed origins for CSRF protection
+// Allowed production origins for CSRF protection.
 const ALLOWED_ORIGINS = [
   "https://cursorboston.com",
   "https://www.cursorboston.com",
+];
+
+// Local development origins are never accepted in production.
+const DEVELOPMENT_ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:3001",
 ];
@@ -34,6 +38,17 @@ type RateLimitResult = ReturnType<typeof checkRateLimit> | UpstashRateLimitResul
 interface RateLimitBackendOptions {
   distributed?: boolean;
   failMode?: "degrade" | "closed";
+}
+
+function isDevelopmentEnvironment(): boolean {
+  return process.env["NODE_ENV"] === "development";
+}
+
+function isListedOriginAllowed(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) {
+    return true;
+  }
+  return isDevelopmentEnvironment() && DEVELOPMENT_ALLOWED_ORIGINS.includes(origin);
 }
 
 function rateLimitDeniedResponse(
@@ -87,7 +102,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
   // If no origin header, check referer (some browsers don't send origin)
   if (!origin && !referer) {
     // Allow requests without origin/referer in development only
-    return process.env.NODE_ENV === "development";
+    return isDevelopmentEnvironment();
   }
 
   // Check if origin matches allowed list
@@ -95,7 +110,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
     if (origin === new URL(request.url).origin) {
       return true;
     }
-    if (ALLOWED_ORIGINS.includes(origin)) {
+    if (isListedOriginAllowed(origin)) {
       return true;
     }
     // Allow if origin matches the app URL from environment
@@ -113,7 +128,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
       if (refererOrigin === new URL(request.url).origin) {
         return true;
       }
-      if (ALLOWED_ORIGINS.includes(refererOrigin)) {
+      if (isListedOriginAllowed(refererOrigin)) {
         return true;
       }
       const appUrl = process.env.NEXT_PUBLIC_APP_URL;


### PR DESCRIPTION
## Summary
- Restricts localhost CSRF origins to development mode instead of accepting them from the global allowlist.
- Keeps production domains allowed in every environment.

## Affected Areas
- `lib/middleware.ts`
- `__tests__/lib/middleware.test.ts`

## Blast Radius
- CSRF origin validation for state-changing API requests only.
- No route handler, rate-limit, caching, or auth behavior changes.

## Why
- `http://localhost:3000` and `http://localhost:3001` were accepted by the shared CSRF allowlist even when the request targeted production.
- Production should not trust localhost Origin or Referer headers just because local dev needs them.

## Reproduction
- Send a production POST request to `https://cursorboston.com/api/x` with `Origin: http://localhost:3000`.
- The old allowlist path treated the localhost origin as allowed.

## Fix
- Splits production origins from development-only localhost origins.
- Adds a small helper so localhost is only accepted when `NODE_ENV === "development"`.
- Applies the same rule to both Origin and Referer checks.

## Tests
- `npm test -- --runTestsByPath __tests__/lib/middleware.test.ts --runInBand -t "production POST"`
- `npm run type-check`
- `npx eslint --max-warnings=0 lib/middleware.ts __tests__/lib/middleware.test.ts`
- `git diff --check`

## Scope Control
- Does not change the existing same-origin shortcut.
- Does not change `NEXT_PUBLIC_APP_URL` origin handling.
- Does not alter the production domain allowlist.

Carther Theogene · https://linkedin.com/in/carther
