### PR TITLE
fix: gate localhost CSRF origins to development

### DIFF
--- a/__tests__/lib/middleware-localhost-csrf.test.ts
+++ b/__tests__/lib/middleware-localhost-csrf.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest } from "next/server";
+import { isOriginAllowed } from "@/lib/middleware";
+
+function setNodeEnv(value: string | undefined) {
+  if (value === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = value;
+  }
+}
+
+function makeRequest(opts: {
+  origin?: string;
+  referer?: string;
+  url?: string;
+}) {
+  const headers: Record<string, string> = {};
+  if (opts.origin !== undefined) headers.origin = opts.origin;
+  if (opts.referer !== undefined) headers.referer = opts.referer;
+
+  return new NextRequest(opts.url ?? "https://cursorboston.com/api/x", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("isOriginAllowed localhost CSRF allowlist", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+  });
+
+  it("rejects localhost origins outside development for cross-origin writes", () => {
+    setNodeEnv("production");
+
+    expect(
+      isOriginAllowed(makeRequest({ origin: "http://localhost:3000" }))
+    ).toBe(false);
+  });
+
+  it("allows localhost origins during development for cross-origin writes", () => {
+    setNodeEnv("development");
+
+    expect(
+      isOriginAllowed(makeRequest({ origin: "http://localhost:3000" }))
+    ).toBe(true);
+  });
+
+  it("rejects localhost referers outside development for cross-origin writes", () => {
+    setNodeEnv("production");
+
+    expect(
+      isOriginAllowed(
+        makeRequest({ referer: "http://localhost:3001/dashboard" })
+      )
+    ).toBe(false);
+  });
+
+  it("allows localhost referers during development for cross-origin writes", () => {
+    setNodeEnv("development");
+
+    expect(
+      isOriginAllowed(
+        makeRequest({ referer: "http://localhost:3001/dashboard" })
+      )
+    ).toBe(true);
+  });
+});

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -21,13 +21,24 @@ import type { UpstashRateLimitResult } from "./upstash-rate-limit";
 // Re-export rateLimitConfigs for convenience
 export { rateLimitConfigs } from "./rate-limit";
 
-// Allowed origins for CSRF protection
-const ALLOWED_ORIGINS = [
+// Allowed origins for CSRF protection in every environment.
+const PRODUCTION_ALLOWED_ORIGINS = [
   "https://cursorboston.com",
   "https://www.cursorboston.com",
+];
+
+// Local development origins are valid only while running the dev server.
+const DEVELOPMENT_ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:3001",
 ];
+
+function getAllowedOrigins(): string[] {
+  if (process.env.NODE_ENV === "development") {
+    return [...PRODUCTION_ALLOWED_ORIGINS, ...DEVELOPMENT_ALLOWED_ORIGINS];
+  }
+  return PRODUCTION_ALLOWED_ORIGINS;
+}
 
 type RateLimitResult = ReturnType<typeof checkRateLimit> | UpstashRateLimitResult;
 
@@ -95,7 +106,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
     if (origin === new URL(request.url).origin) {
       return true;
     }
-    if (ALLOWED_ORIGINS.includes(origin)) {
+    if (getAllowedOrigins().includes(origin)) {
       return true;
     }
     // Allow if origin matches the app URL from environment
@@ -113,7 +124,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
       if (refererOrigin === new URL(request.url).origin) {
         return true;
       }
-      if (ALLOWED_ORIGINS.includes(refererOrigin)) {
+      if (getAllowedOrigins().includes(refererOrigin)) {
         return true;
       }
       const appUrl = process.env.NEXT_PUBLIC_APP_URL;


### PR DESCRIPTION
## Summary
- Gates localhost CSRF allowlist entries to `NODE_ENV === "development"`.
- Keeps same-origin requests allowed, including local production builds where the request URL origin is localhost.
- Adds focused coverage for localhost origin and referer handling in production versus development.

## Affected surfaces
- `lib/middleware.ts`
- `__tests__/lib/middleware-localhost-csrf.test.ts`

## Blast radius
- State-changing API requests from `http://localhost:3000` or `http://localhost:3001` are no longer trusted as configured cross-origin callers outside development.
- Same-origin and configured production origins are unchanged.

## Why
- F-04 called out that localhost was in the unconditional CSRF allowlist, which weakens production origin checks.

## Repro
- Before this change, a production request URL could accept a cross-origin POST with `Origin: http://localhost:3000` because localhost was always in the global allowlist.

## Fix
- Splits the allowlist into production origins and development-only localhost origins.
- Uses the environment-aware list for both `Origin` and `Referer` fallback checks.

## Tests
- `npm test -- --runTestsByPath __tests__/lib/middleware-localhost-csrf.test.ts --runInBand`
- `npm run type-check`
- `npx eslint --max-warnings=0 lib/middleware.ts __tests__/lib/middleware-localhost-csrf.test.ts`
- `git diff --check`

## Scope
- Does not change same-origin CSRF behavior.
- The existing broader `__tests__/lib/middleware.test.ts` still has the current-base `NODE_ENV` mutation failure fixed separately by #1353; this PR adds isolated coverage for the new F-04 behavior.

## Audit and compliance

- License: GPL-3.0-only (unchanged).
- DCO sign-off present on the commit.

