### PR TITLE
refactor: centralize API validation messages

### DIFF
--- a/app/api/community/reply/route.ts
+++ b/app/api/community/reply/route.ts
@@ -15,6 +15,7 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { communityContract } from "@/lib/api-schemas/community";
+import { COMMUNITY_CONTENT_LENGTH_ERROR } from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
     const sanitizedContent = sanitizeText(content);
     if (sanitizedContent.length < 100 || sanitizedContent.length > 500) {
       return NextResponse.json(
-        { error: "Content must be between 100 and 500 characters" },
+        { error: COMMUNITY_CONTENT_LENGTH_ERROR },
         { status: 400 }
       );
     }

--- a/app/api/community/repost/route.ts
+++ b/app/api/community/repost/route.ts
@@ -15,6 +15,7 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { communityContract } from "@/lib/api-schemas/community";
+import { COMMUNITY_CONTENT_LENGTH_ERROR } from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
     const sanitizedContent = sanitizeText(content);
     if (sanitizedContent.length < 100 || sanitizedContent.length > 500) {
       return NextResponse.json(
-        { error: "Content must be between 100 and 500 characters" },
+        { error: COMMUNITY_CONTENT_LENGTH_ERROR },
         { status: 400 }
       );
     }

--- a/app/api/profile/update/route.ts
+++ b/app/api/profile/update/route.ts
@@ -13,6 +13,14 @@ import { getClientIdentifier } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeName, sanitizeText, sanitizeUrl } from "@/lib/sanitize";
 import { profileContract } from "@/lib/api-schemas/profile";
+import {
+  PROFILE_BIO_MAX_LENGTH_ERROR,
+  PROFILE_COMPANY_MAX_LENGTH_ERROR,
+  PROFILE_DISPLAY_NAME_MAX_LENGTH_ERROR,
+  PROFILE_DISPLAY_NAME_MIN_LENGTH_ERROR,
+  PROFILE_JOB_TITLE_MAX_LENGTH_ERROR,
+  PROFILE_LOCATION_MAX_LENGTH_ERROR,
+} from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -66,13 +74,13 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeName(body.displayName);
       if (sanitized.length < 2) {
         return NextResponse.json(
-          { error: "Display name must be at least 2 characters" },
+          { error: PROFILE_DISPLAY_NAME_MIN_LENGTH_ERROR },
           { status: 400 }
         );
       }
       if (sanitized.length > 50) {
         return NextResponse.json(
-          { error: "Display name must be 50 characters or less" },
+          { error: PROFILE_DISPLAY_NAME_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -84,7 +92,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.bio);
       if (sanitized.length > 500) {
         return NextResponse.json(
-          { error: "Bio must be 500 characters or less" },
+          { error: PROFILE_BIO_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -96,7 +104,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.location);
       if (sanitized.length > 100) {
         return NextResponse.json(
-          { error: "Location must be 100 characters or less" },
+          { error: PROFILE_LOCATION_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -108,7 +116,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.company);
       if (sanitized.length > 100) {
         return NextResponse.json(
-          { error: "Company must be 100 characters or less" },
+          { error: PROFILE_COMPANY_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -120,7 +128,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.jobTitle);
       if (sanitized.length > 100) {
         return NextResponse.json(
-          { error: "Job title must be 100 characters or less" },
+          { error: PROFILE_JOB_TITLE_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }

--- a/app/api/questions/answer/route.ts
+++ b/app/api/questions/answer/route.ts
@@ -17,6 +17,7 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { questionsContract } from "@/lib/api-schemas/questions";
+import { QUESTION_ANSWER_RANGE_ERROR } from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -62,7 +63,7 @@ export async function POST(request: NextRequest) {
     const sanitizedBody = sanitizeText(parsed.data.body);
     if (sanitizedBody.length < 20 || sanitizedBody.length > 5000) {
       return NextResponse.json(
-        { error: "Answer must be between 20 and 5000 characters" },
+        { error: QUESTION_ANSWER_RANGE_ERROR },
         { status: 400 }
       );
     }

--- a/app/api/questions/post/route.ts
+++ b/app/api/questions/post/route.ts
@@ -15,6 +15,10 @@ import { sanitizeText } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { QUESTION_TAGS, type QuestionTag } from "@/types/questions";
 import { questionsContract } from "@/lib/api-schemas/questions";
+import {
+  QUESTION_BODY_RANGE_ERROR,
+  QUESTION_TITLE_RANGE_ERROR,
+} from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -57,14 +61,14 @@ export async function POST(request: NextRequest) {
 
     if (sanitizedTitle.length < 10 || sanitizedTitle.length > 200) {
       return NextResponse.json(
-        { error: "Title must be between 10 and 200 characters" },
+        { error: QUESTION_TITLE_RANGE_ERROR },
         { status: 400 }
       );
     }
 
     if (sanitizedBody.length < 20 || sanitizedBody.length > 5000) {
       return NextResponse.json(
-        { error: "Body must be between 20 and 5000 characters" },
+        { error: QUESTION_BODY_RANGE_ERROR },
         { status: 400 }
       );
     }

--- a/lib/api-schemas/community.ts
+++ b/lib/api-schemas/community.ts
@@ -14,6 +14,7 @@ import {
   PaginationQuerySchema,
   RateLimitedErrorSchema,
 } from "./common";
+import { COMMUNITY_CONTENT_LENGTH_ERROR } from "@/lib/error-messages";
 
 const c = initContract();
 
@@ -40,8 +41,8 @@ const PostBody = z
   .object({
     content: z
       .string()
-      .min(100, "Content must be between 100 and 500 characters")
-      .max(500, "Content must be between 100 and 500 characters"),
+      .min(100, COMMUNITY_CONTENT_LENGTH_ERROR)
+      .max(500, COMMUNITY_CONTENT_LENGTH_ERROR),
   })
   .openapi("CommunityPostBody", {
     example: {

--- a/lib/api-schemas/questions.ts
+++ b/lib/api-schemas/questions.ts
@@ -14,6 +14,14 @@ import {
   PaginationQuerySchema,
   RateLimitedErrorSchema,
 } from "./common";
+import {
+  QUESTION_ANSWER_MAX_LENGTH_ERROR,
+  QUESTION_ANSWER_MIN_LENGTH_ERROR,
+  QUESTION_BODY_MAX_LENGTH_ERROR,
+  QUESTION_BODY_MIN_LENGTH_ERROR,
+  QUESTION_TITLE_MAX_LENGTH_ERROR,
+  QUESTION_TITLE_MIN_LENGTH_ERROR,
+} from "@/lib/error-messages";
 
 const c = initContract();
 
@@ -45,12 +53,12 @@ const PostBody = z
   .object({
     title: z
       .string()
-      .min(10, "Title must be at least 10 characters")
-      .max(200, "Title must be at most 200 characters"),
+      .min(10, QUESTION_TITLE_MIN_LENGTH_ERROR)
+      .max(200, QUESTION_TITLE_MAX_LENGTH_ERROR),
     body: z
       .string()
-      .min(20, "Body must be at least 20 characters")
-      .max(5000, "Body must be at most 5000 characters"),
+      .min(20, QUESTION_BODY_MIN_LENGTH_ERROR)
+      .max(5000, QUESTION_BODY_MAX_LENGTH_ERROR),
     tags: z.array(z.string()).max(10).optional(),
   })
   .openapi("QuestionsPostBody");
@@ -60,8 +68,8 @@ const AnswerBody = z
     questionId: z.string().min(1),
     body: z
       .string()
-      .min(20, "Answer must be at least 20 characters")
-      .max(5000, "Answer must be at most 5000 characters"),
+      .min(20, QUESTION_ANSWER_MIN_LENGTH_ERROR)
+      .max(5000, QUESTION_ANSWER_MAX_LENGTH_ERROR),
   })
   .openapi("QuestionsAnswerBody");
 

--- a/lib/error-messages.ts
+++ b/lib/error-messages.ts
@@ -1,0 +1,90 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Build the standard API validation message for fields with inclusive
+ * character-count bounds.
+ */
+export function lengthBetweenError(
+  label: string,
+  min: number,
+  max: number
+): string {
+  return `${label} must be between ${min} and ${max} characters`;
+}
+
+/**
+ * Build the standard API validation message for minimum character counts.
+ */
+export function minLengthError(label: string, min: number): string {
+  return `${label} must be at least ${min} characters`;
+}
+
+/**
+ * Build the standard schema validation message for maximum character counts.
+ */
+export function maxLengthError(label: string, max: number): string {
+  return `${label} must be at most ${max} characters`;
+}
+
+/**
+ * Build the route-level validation message used by legacy profile endpoints.
+ */
+export function lengthOrLessError(label: string, max: number): string {
+  return `${label} must be ${max} characters or less`;
+}
+
+export const COMMUNITY_CONTENT_LENGTH_ERROR = lengthBetweenError(
+  "Content",
+  100,
+  500
+);
+
+export const QUESTION_TITLE_MIN_LENGTH_ERROR = minLengthError("Title", 10);
+export const QUESTION_TITLE_MAX_LENGTH_ERROR = maxLengthError("Title", 200);
+export const QUESTION_TITLE_RANGE_ERROR = lengthBetweenError(
+  "Title",
+  10,
+  200
+);
+
+export const QUESTION_BODY_MIN_LENGTH_ERROR = minLengthError("Body", 20);
+export const QUESTION_BODY_MAX_LENGTH_ERROR = maxLengthError("Body", 5000);
+export const QUESTION_BODY_RANGE_ERROR = lengthBetweenError("Body", 20, 5000);
+
+export const QUESTION_ANSWER_MIN_LENGTH_ERROR = minLengthError("Answer", 20);
+export const QUESTION_ANSWER_MAX_LENGTH_ERROR = maxLengthError(
+  "Answer",
+  5000
+);
+export const QUESTION_ANSWER_RANGE_ERROR = lengthBetweenError(
+  "Answer",
+  20,
+  5000
+);
+
+export const PROFILE_DISPLAY_NAME_MIN_LENGTH_ERROR = minLengthError(
+  "Display name",
+  2
+);
+export const PROFILE_DISPLAY_NAME_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Display name",
+  50
+);
+export const PROFILE_BIO_MAX_LENGTH_ERROR = lengthOrLessError("Bio", 500);
+export const PROFILE_LOCATION_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Location",
+  100
+);
+export const PROFILE_COMPANY_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Company",
+  100
+);
+export const PROFILE_JOB_TITLE_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Job title",
+  100
+);


### PR DESCRIPTION
## Summary
- Adds `lib/error-messages.ts` with shared API validation message helpers and constants.
- Replaces duplicated community, questions, and profile length-error strings while preserving response text.
- Closes #558.

## Affected surfaces
- `lib/error-messages.ts`
- `lib/api-schemas/community.ts`
- `lib/api-schemas/questions.ts`
- `app/api/community/reply/route.ts`
- `app/api/community/repost/route.ts`
- `app/api/questions/post/route.ts`
- `app/api/questions/answer/route.ts`
- `app/api/profile/update/route.ts`

## Blast radius
- Validation message source only; API response strings remain unchanged.
- No schema bounds, status codes, auth, rate-limit, or database behavior changes.

## Why
- Issue #558 called out repeated character-count validation messages across API routes and schemas.

## Repro
- Community content, question title/body/answer, and profile field length errors were repeated as hardcoded strings in multiple files.

## Fix
- Centralizes reusable length-message builders and named constants.
- Reuses constants from Zod schemas and route-level sanitized-length rechecks.
- Leaves test expectations as literal public API assertions.

## Tests
- `npm test -- --runTestsByPath __tests__/app/api/community/post.test.ts __tests__/app/api/community/reply.test.ts __tests__/app/api/community/repost.test.ts __tests__/app/api/questions/post/route.test.ts __tests__/app/api/questions/answer/route.test.ts __tests__/app/api/profile/update/route.test.ts --runInBand`
- `npm run type-check`
- `npx eslint --max-warnings=0 lib/error-messages.ts lib/api-schemas/community.ts lib/api-schemas/questions.ts app/api/community/reply/route.ts app/api/community/repost/route.ts app/api/questions/post/route.ts app/api/questions/answer/route.ts app/api/profile/update/route.ts`
- `git diff --check`

## Scope
- Does not centralize unrelated one-off route errors.
- Does not change existing test expectation strings.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)

