### PR TITLE
fix: label community feed action buttons

### DIFF
--- a/__tests__/components/feed/MessageCard.test.tsx
+++ b/__tests__/components/feed/MessageCard.test.tsx
@@ -7,7 +7,7 @@ jest.mock("next/image", () => ({
   __esModule: true,
   default: (props: Record<string, unknown>) => {
     const { fill, ...rest } = props;
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    // eslint-disable-next-line @next/next/no-img-element
     return <img data-fill={fill ? "true" : undefined} {...rest} />;
   },
 }));
@@ -106,7 +106,7 @@ describe("MessageCard", () => {
 
   it("shows repost button for non-repost messages", () => {
     render(<MessageCard {...defaultProps()} />);
-    expect(screen.getByLabelText("Repost")).toBeInTheDocument();
+    expect(screen.getByLabelText("Repost Alice's message")).toBeInTheDocument();
   });
 
   it("hides repost button for repost messages", () => {
@@ -119,7 +119,7 @@ describe("MessageCard", () => {
       },
     });
     render(<MessageCard {...defaultProps({ message: msg })} />);
-    expect(screen.queryByLabelText("Repost")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Repost Alice's message")).not.toBeInTheDocument();
   });
 
   it("shows repost header for reposted messages", () => {
@@ -180,18 +180,31 @@ describe("MessageCard", () => {
     const onDislike = jest.fn();
     render(<MessageCard {...defaultProps({ onLike, onDislike })} />);
 
-    await user.click(screen.getByLabelText("Like"));
+    await user.click(screen.getByLabelText("Like Alice's message"));
     expect(onLike).toHaveBeenCalledTimes(1);
 
-    await user.click(screen.getByLabelText("Dislike"));
+    await user.click(screen.getByLabelText("Dislike Alice's message"));
     expect(onDislike).toHaveBeenCalledTimes(1);
   });
 
   it("disables reaction buttons when not logged in", () => {
     render(<MessageCard {...defaultProps({ isLoggedIn: false })} />);
-    expect(screen.getByLabelText("Like")).toBeDisabled();
-    expect(screen.getByLabelText("Dislike")).toBeDisabled();
-    expect(screen.getByLabelText("Reply")).toBeDisabled();
+    expect(screen.getByLabelText("Like Alice's message")).toBeDisabled();
+    expect(screen.getByLabelText("Dislike Alice's message")).toBeDisabled();
+    expect(screen.getByLabelText("Reply to Alice's message")).toBeDisabled();
+  });
+
+  it("exposes context-specific action labels", () => {
+    render(<MessageCard {...defaultProps()} />);
+    expect(
+      screen.getByRole("button", { name: "Like Alice's message" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Dislike Alice's message" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reply to Alice's message" }),
+    ).toBeInTheDocument();
   });
 
   it("calls onAuthorClick when author name clicked", async () => {
@@ -262,11 +275,11 @@ describe("MessageCard", () => {
 
   it("shows active like state", () => {
     render(<MessageCard {...defaultProps({ userReaction: "like" as const })} />);
-    expect(screen.getByLabelText("Remove like")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove like from Alice's message")).toBeInTheDocument();
   });
 
   it("shows active dislike state", () => {
     render(<MessageCard {...defaultProps({ userReaction: "dislike" as const })} />);
-    expect(screen.getByLabelText("Remove dislike")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove dislike from Alice's message")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/feed/ReplyCard.test.tsx
+++ b/__tests__/components/feed/ReplyCard.test.tsx
@@ -9,6 +9,7 @@ jest.mock("next/image", () => ({
   __esModule: true,
   default: (props: Record<string, unknown>) => {
     const { fill, priority, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element
     return <img data-fill={fill ? "true" : undefined} {...rest} />;
   },
 }));
@@ -69,7 +70,7 @@ describe("ReplyCard", () => {
     const user = userEvent.setup();
     const props = defaultProps();
     render(<ReplyCard {...props} />);
-    await user.click(screen.getByRole("button", { name: "Like" }));
+    await user.click(screen.getByRole("button", { name: "Like Bob's reply" }));
     expect(props.onLike).toHaveBeenCalledTimes(1);
   });
 
@@ -77,16 +78,22 @@ describe("ReplyCard", () => {
     const user = userEvent.setup();
     const props = defaultProps();
     render(<ReplyCard {...props} />);
-    await user.click(screen.getByRole("button", { name: "Dislike" }));
+    await user.click(screen.getByRole("button", { name: "Dislike Bob's reply" }));
     expect(props.onDislike).toHaveBeenCalledTimes(1);
   });
 
   it("disables reaction buttons when not logged in", () => {
     render(<ReplyCard {...defaultProps({ isLoggedIn: false })} />);
-    const likeBtn = screen.getByRole("button", { name: "Like" });
-    const dislikeBtn = screen.getByRole("button", { name: "Dislike" });
+    const likeBtn = screen.getByRole("button", { name: "Like Bob's reply" });
+    const dislikeBtn = screen.getByRole("button", { name: "Dislike Bob's reply" });
     expect(likeBtn).toBeDisabled();
     expect(dislikeBtn).toBeDisabled();
+  });
+
+  it("exposes context-specific action labels", () => {
+    render(<ReplyCard {...defaultProps()} />);
+    expect(screen.getByRole("button", { name: "Like Bob's reply" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dislike Bob's reply" })).toBeInTheDocument();
   });
 
   it("shows delete confirm flow for owner", async () => {
@@ -116,5 +123,19 @@ describe("ReplyCard", () => {
   it("does not show delete button for non-owners", () => {
     render(<ReplyCard {...defaultProps({ isOwner: false })} />);
     expect(screen.queryByRole("button", { name: /delete reply/i })).not.toBeInTheDocument();
+  });
+
+  it("labels active reaction removal with reply context", () => {
+    const { rerender } = render(
+      <ReplyCard {...defaultProps({ userReaction: "like" as const })} />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Remove like from Bob's reply" }),
+    ).toBeInTheDocument();
+
+    rerender(<ReplyCard {...defaultProps({ userReaction: "dislike" as const })} />);
+    expect(
+      screen.getByRole("button", { name: "Remove dislike from Bob's reply" }),
+    ).toBeInTheDocument();
   });
 });

--- a/components/feed/MessageCard.tsx
+++ b/components/feed/MessageCard.tsx
@@ -196,7 +196,11 @@ export function MessageCard({
                   ? "text-emerald-400 bg-emerald-500/10"
                   : "text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
-              aria-label={userReaction === "like" ? "Remove like" : "Like"}
+              aria-label={
+                userReaction === "like"
+                  ? `Remove like from ${message.authorName}'s message`
+                  : `Like ${message.authorName}'s message`
+              }
             >
               <svg
                 width="18"
@@ -221,7 +225,11 @@ export function MessageCard({
                   ? "text-red-400 bg-red-500/10"
                   : "text-neutral-500 hover:text-red-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
-              aria-label={userReaction === "dislike" ? "Remove dislike" : "Dislike"}
+              aria-label={
+                userReaction === "dislike"
+                  ? `Remove dislike from ${message.authorName}'s message`
+                  : `Dislike ${message.authorName}'s message`
+              }
             >
               <svg
                 width="18"
@@ -246,7 +254,7 @@ export function MessageCard({
                   ? "text-emerald-400 bg-emerald-500/10"
                   : "text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
-              aria-label="Reply"
+              aria-label={`Reply to ${message.authorName}'s message`}
             >
               <svg
                 width="18"
@@ -270,7 +278,7 @@ export function MessageCard({
                 className={`flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors min-h-[44px] text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 ${
                   !isLoggedIn ? "opacity-50 cursor-not-allowed" : ""
                 }`}
-                aria-label="Repost"
+                aria-label={`Repost ${message.authorName}'s message`}
               >
                 <svg
                   width="18"

--- a/components/feed/ReplyCard.tsx
+++ b/components/feed/ReplyCard.tsx
@@ -88,7 +88,11 @@ export function ReplyCard({
             <button
               onClick={onLike}
               disabled={!isLoggedIn}
-              aria-label={userReaction === "like" ? "Remove like" : "Like"}
+              aria-label={
+                userReaction === "like"
+                  ? `Remove like from ${reply.authorName}'s reply`
+                  : `Like ${reply.authorName}'s reply`
+              }
               className={`flex items-center gap-1 px-2 py-1 rounded transition-colors text-xs ${
                 userReaction === "like"
                   ? "text-emerald-400"
@@ -111,7 +115,11 @@ export function ReplyCard({
             <button
               onClick={onDislike}
               disabled={!isLoggedIn}
-              aria-label={userReaction === "dislike" ? "Remove dislike" : "Dislike"}
+              aria-label={
+                userReaction === "dislike"
+                  ? `Remove dislike from ${reply.authorName}'s reply`
+                  : `Dislike ${reply.authorName}'s reply`
+              }
               className={`flex items-center gap-1 px-2 py-1 rounded transition-colors text-xs ${
                 userReaction === "dislike"
                   ? "text-red-400"


### PR DESCRIPTION
## Summary
- Adds context-specific accessible names to community feed message action buttons.
- Covers top-level like, dislike, reply, and repost controls plus reply-card like/dislike controls.

## Affected Areas
- `components/feed/MessageCard.tsx`
- `components/feed/ReplyCard.tsx`
- `__tests__/components/feed/MessageCard.test.tsx`
- `__tests__/components/feed/ReplyCard.test.tsx`

## Blast Radius
- Community feed button accessible names only.
- No visual layout, reaction state, mutation, or API behavior changes.

## Why
- Generic accessible names like "Like", "Dislike", and "Reply" make repeated feed controls ambiguous for screen reader and keyboard users.
- Issue #553 asks for context-specific labels on community feed buttons.

## Reproduction
- Render multiple community feed messages.
- Before this change, each message exposed repeated generic action names such as "Like" and "Reply" with no author/message context.

## Fix
- Labels top-level message actions with the author context, for example `Like Alice's message` and `Reply to Alice's message`.
- Labels reply-card actions with reply context, for example `Like Bob's reply`.
- Keeps active reaction removal labels context-specific as well.

## Tests
- `npm test -- --runTestsByPath __tests__/components/feed/MessageCard.test.tsx __tests__/components/feed/ReplyCard.test.tsx --runInBand`
- `npm run type-check`
- `npx eslint --max-warnings=0 components/feed/MessageCard.tsx components/feed/ReplyCard.tsx __tests__/components/feed/MessageCard.test.tsx __tests__/components/feed/ReplyCard.test.tsx`
- `git diff --check origin/develop..HEAD`

## Scope Control
- Does not change button text, icon rendering, disabled states, or handlers.
- Uses Testing Library role/name queries plus the repo ESLint accessibility rules to lock the accessible-name contract.

Carther Theogene · https://linkedin.com/in/carther
