### PR TITLE
test: guard typecheck bypass from CI

### DIFF
--- a/__tests__/config/next-config-skip-typecheck.test.ts
+++ b/__tests__/config/next-config-skip-typecheck.test.ts
@@ -1,0 +1,78 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+jest.mock("@next/bundle-analyzer", () => () => (config: unknown) => config);
+jest.mock("child_process", () => ({
+  execSync: jest.fn(() => "test-build-id\n"),
+}));
+
+const ORIGINAL_ENV = process.env;
+const TOGGLED_ENV_KEYS = [
+  "ANALYZE",
+  "CI",
+  "DOCKER_BUILD",
+  "GITHUB_ACTIONS",
+  "NEXT_BUILD_ID",
+  "SKIP_TYPECHECK",
+] as const;
+
+function loadNextConfig(env: Record<string, string | undefined> = {}) {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+  for (const key of TOGGLED_ENV_KEYS) {
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  let config: {
+    typescript?: { ignoreBuildErrors?: boolean };
+    eslint?: { ignoreDuringBuilds?: boolean };
+  };
+  jest.isolateModules(() => {
+    config = require("../../next.config.js");
+  });
+  return config!;
+}
+
+describe("next.config.js SKIP_TYPECHECK guard", () => {
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.resetModules();
+  });
+
+  it("leaves build checks enabled by default", () => {
+    const config = loadNextConfig();
+
+    expect(config.typescript?.ignoreBuildErrors).not.toBe(true);
+    expect(config.eslint?.ignoreDuringBuilds).not.toBe(true);
+  });
+
+  it("allows SKIP_TYPECHECK only for local builds", () => {
+    const config = loadNextConfig({ SKIP_TYPECHECK: "1" });
+
+    expect(config.typescript).toEqual({ ignoreBuildErrors: true });
+    expect(config.eslint).toEqual({ ignoreDuringBuilds: true });
+  });
+
+  it("rejects SKIP_TYPECHECK in generic CI", () => {
+    expect(() =>
+      loadNextConfig({ CI: "true", SKIP_TYPECHECK: "1" })
+    ).toThrow("SKIP_TYPECHECK=1 is local-only and must not be set in CI");
+  });
+
+  it("rejects SKIP_TYPECHECK in GitHub Actions", () => {
+    expect(() =>
+      loadNextConfig({ GITHUB_ACTIONS: "true", SKIP_TYPECHECK: "1" })
+    ).toThrow("SKIP_TYPECHECK=1 is local-only and must not be set in CI");
+  });
+});

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,18 @@ function reproducibleBuildId() {
   }
 }
 
+function isCiEnvironment() {
+  return process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true'
+}
+
+function shouldSkipTypecheck() {
+  if (process.env.SKIP_TYPECHECK !== '1') return false
+  if (isCiEnvironment()) {
+    throw new Error('SKIP_TYPECHECK=1 is local-only and must not be set in CI')
+  }
+  return true
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // If a package-lock.json exists above this repo (e.g. in $HOME), Next.js would pick that
@@ -39,7 +51,7 @@ const nextConfig = {
   // unrelated type/lint errors. NEVER set this in CI; CI is the boundary
   // that catches real type errors. See CLAUDE.md "Local production
   // verification — emergency typecheck bypass".
-  ...(process.env.SKIP_TYPECHECK === '1'
+  ...(shouldSkipTypecheck()
     ? {
         typescript: { ignoreBuildErrors: true },
         eslint: { ignoreDuringBuilds: true },


### PR DESCRIPTION
## Summary
- Adds a CI guard for the emergency `SKIP_TYPECHECK=1` Next build bypass.
- Keeps the bypass available for local visual QA only.
- Adds focused config tests for default, local bypass, generic CI, and GitHub Actions behavior.

## Affected surfaces
- `next.config.js`
- `__tests__/config/next-config-skip-typecheck.test.ts`

## Blast radius
- `next build` config evaluation now throws if `SKIP_TYPECHECK=1` is used with `CI=true` or `GITHUB_ACTIONS=true`.
- Local `SKIP_TYPECHECK=1` behavior is unchanged.

## Why
- F-02 identified that the local typecheck/lint bypass was documented as local-only but not enforced.

## Repro
- Before this change, setting `SKIP_TYPECHECK=1` in CI would silently disable both TypeScript and ESLint checks during `next build`.

## Fix
- Adds `shouldSkipTypecheck()` and `isCiEnvironment()` helpers.
- Throws a clear error when CI tries to use the bypass.
- Uses the helper for the existing `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` config block.

## Tests
- `npm test -- --runTestsByPath __tests__/config/next-config-skip-typecheck.test.ts --runInBand`
- `npm run type-check`
- `npx eslint --max-warnings=0 next.config.js __tests__/config/next-config-skip-typecheck.test.ts`
- `git diff --check`

## Scope
- Does not remove the local emergency bypass.
- Does not change normal build config when `SKIP_TYPECHECK` is unset.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
