### PR TITLE
feat: add cookbook entry SEO pages

### DIFF
--- a/__tests__/app/cookbook/[slug]/page.test.tsx
+++ b/__tests__/app/cookbook/[slug]/page.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { notFound } from "next/navigation";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/components/cookbook/PromptMarkdown", () => ({
+  PromptMarkdown: ({ content }: { content: string }) => (
+    <pre data-testid="prompt-markdown">{content}</pre>
+  ),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockNotFound = notFound as jest.MockedFunction<typeof notFound>;
+
+function makeDoc(data: Record<string, unknown> | undefined) {
+  return {
+    id: "entry-1",
+    exists: data !== undefined,
+    data: () => data,
+  };
+}
+
+function installEntry(data: Record<string, unknown> | undefined) {
+  mockGetAdminDb.mockReturnValue({
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(makeDoc(data)),
+      })),
+    })),
+  } as never);
+}
+
+const entryData = {
+  title: "Review React render paths",
+  description: "A prompt for finding expensive React render work.",
+  promptContent: "Find avoidable rerenders and suggest measured fixes.",
+  category: "performance",
+  tags: ["react", "profiling"],
+  worksWith: ["React", "TypeScript"],
+  authorId: "user-1",
+  authorDisplayName: "Ada",
+  createdAt: { toMillis: () => Date.parse("2026-05-01T00:00:00.000Z") },
+  upCount: 7,
+  downCount: 2,
+  seo: {
+    title: "React Render Review Prompt",
+    description: "Find expensive render paths with this Cursor prompt.",
+    image: "/showcase/react-review.png",
+  },
+};
+
+describe("cookbook entry page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installEntry(entryData);
+  });
+
+  it("generateMetadata returns title, canonical, and social preview data", async () => {
+    const { generateMetadata } = await import("@/app/cookbook/[slug]/page");
+
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "entry-1" }),
+    });
+
+    expect(meta.title).toBe("React Render Review Prompt");
+    expect(meta.description).toBe(
+      "Find expensive render paths with this Cursor prompt.",
+    );
+    expect(meta.alternates?.canonical).toBe(
+      "https://cursorboston.com/cookbook/entry-1",
+    );
+    expect(meta.openGraph?.images).toEqual([
+      {
+        url: "https://cursorboston.com/showcase/react-review.png",
+        width: 1200,
+        height: 630,
+        alt: "Review React render paths",
+      },
+    ]);
+  });
+
+  it("renders the entry page with CreativeWork JSON-LD", async () => {
+    const Page = (await import("@/app/cookbook/[slug]/page")).default;
+
+    const ui = await Page({ params: Promise.resolve({ slug: "entry-1" }) });
+    const { container } = render(ui);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Review React render paths",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Performance")).toBeInTheDocument();
+    expect(screen.getByTestId("prompt-markdown")).toHaveTextContent(
+      "Find avoidable rerenders",
+    );
+    expect(screen.getByRole("link", { name: "#react" })).toHaveAttribute(
+      "href",
+      "/cookbook?search=react",
+    );
+
+    const jsonLd = container.querySelector('script[type="application/ld+json"]');
+    expect(jsonLd?.textContent).toContain('"@type":"CreativeWork"');
+    expect(jsonLd?.textContent).toContain('"keywords":"react, profiling, React, TypeScript"');
+  });
+
+  it("returns not-found metadata and calls notFound for missing entries", async () => {
+    installEntry(undefined);
+    mockNotFound.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    });
+
+    const pageModule = await import("@/app/cookbook/[slug]/page");
+    await expect(
+      pageModule.generateMetadata({
+        params: Promise.resolve({ slug: "missing" }),
+      }),
+    ).resolves.toEqual({ title: "Cookbook Entry Not Found" });
+
+    await expect(
+      pageModule.default({ params: Promise.resolve({ slug: "missing" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+});

--- a/app/api/cookbook/entries/route.ts
+++ b/app/api/cookbook/entries/route.ts
@@ -10,7 +10,6 @@ import type {
   DocumentSnapshot,
   Firestore,
   Query,
-  QueryDocumentSnapshot,
 } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
@@ -20,12 +19,16 @@ import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { matchesCookbookSearchTerms } from "@/lib/cookbook-search";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import {
-  COOKBOOK_CATEGORIES,
-  WORKS_WITH_LANGUAGES,
   type CookbookCategory,
+  type CookbookEntry,
   type WorksWithTag,
 } from "@/types/cookbook";
 import { cookbookContract } from "@/lib/api-schemas/cookbook";
+import {
+  isValidCookbookCategory,
+  isValidWorksWithTag,
+  mapCookbookDocToEntry,
+} from "@/lib/cookbook-entries";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -33,11 +36,11 @@ export const dynamic = "force-dynamic";
 const COOKBOOK_SUBMIT_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
 
 function isValidCategory(v: string): v is CookbookCategory {
-  return COOKBOOK_CATEGORIES.includes(v as CookbookCategory);
+  return isValidCookbookCategory(v);
 }
 
 function isValidWorksWith(v: string): v is WorksWithTag {
-  return WORKS_WITH_LANGUAGES.includes(v as WorksWithTag);
+  return isValidWorksWithTag(v);
 }
 
 const PAGE_SIZE = 12;
@@ -74,43 +77,6 @@ function isFirestoreIndexError(err: unknown): boolean {
     code === 9 ||
     (message.includes("FAILED_PRECONDITION") && message.includes("index"))
   );
-}
-
-interface CookbookEntryRow {
-  id: string;
-  title: string;
-  description: string;
-  promptContent: string;
-  category: string;
-  tags: string[];
-  worksWith: string[];
-  authorId: string;
-  authorDisplayName: string;
-  createdAt: string;
-  upCount: number;
-  downCount: number;
-}
-
-function mapDocToEntry(doc: QueryDocumentSnapshot): CookbookEntryRow {
-  const d = doc.data();
-  const upCount = Number(d.upCount ?? 0);
-  const downCount = Number(d.downCount ?? 0);
-  return {
-    id: doc.id,
-    title: d.title || "",
-    description: d.description || "",
-    promptContent: d.promptContent || "",
-    category: d.category || "other",
-    tags: Array.isArray(d.tags) ? d.tags : [],
-    worksWith: Array.isArray(d.worksWith) ? d.worksWith : [],
-    authorId: d.authorId || "",
-    authorDisplayName: d.authorDisplayName || "",
-    createdAt: d.createdAt?.toMillis?.()
-      ? new Date(d.createdAt.toMillis()).toISOString()
-      : "",
-    upCount,
-    downCount,
-  };
 }
 
 function buildFilteredQuery(
@@ -170,7 +136,7 @@ export async function GET(request: NextRequest) {
     const searchTerms = hasSearch ? searchRaw.split(/\s+/).filter(Boolean) : [];
 
     if (hasSearch) {
-      const results: CookbookEntryRow[] = [];
+      const results: CookbookEntry[] = [];
       let resumeAfter: DocumentSnapshot | null = null;
       if (cursor) {
         const cdoc = await db.collection("cookbook_entries").doc(cursor).get();
@@ -200,7 +166,7 @@ export async function GET(request: NextRequest) {
 
         for (const doc of snap.docs) {
           resumeAfter = doc;
-          const entry = mapDocToEntry(doc);
+          const entry = mapCookbookDocToEntry(doc);
           if (
             !matchesCookbookSearchTerms(
               entry.title,
@@ -276,7 +242,7 @@ export async function GET(request: NextRequest) {
     }
 
     const docs = snap.docs.slice(0, limit);
-    const entries = docs.map(mapDocToEntry);
+    const entries = docs.map(mapCookbookDocToEntry);
     const hasMore = snap.docs.length > limit;
     const nextCursor =
       hasMore && entries.length > 0 ? entries[entries.length - 1].id : null;

--- a/app/cookbook/[slug]/page.tsx
+++ b/app/cookbook/[slug]/page.tsx
@@ -1,0 +1,252 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { PromptMarkdown } from "@/components/cookbook/PromptMarkdown";
+import { CATEGORY_LABELS } from "@/lib/cookbook-labels";
+import { getCookbookEntryById } from "@/lib/cookbook-entries";
+import { formatCookbookDate } from "@/lib/format-cookbook-date";
+import type { CookbookEntry } from "@/types/cookbook";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SITE_URL = "https://cursorboston.com";
+const DEFAULT_IMAGE = "/cursor-boston-logo.png";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function absoluteUrl(pathOrUrl: string): string {
+  if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://")) {
+    return pathOrUrl;
+  }
+  return `${SITE_URL}${pathOrUrl.startsWith("/") ? "" : "/"}${pathOrUrl}`;
+}
+
+function cookbookEntryUrl(entry: CookbookEntry): string {
+  return absoluteUrl(entry.seo?.canonicalUrl ?? `/cookbook/${entry.id}`);
+}
+
+function metadataTitle(entry: CookbookEntry): string {
+  return entry.seo?.title ?? `${entry.title} | Cursor Boston Cookbook`;
+}
+
+function metadataDescription(entry: CookbookEntry): string {
+  return entry.seo?.description ?? entry.description;
+}
+
+function metadataImage(entry: CookbookEntry): string {
+  return absoluteUrl(entry.seo?.image ?? DEFAULT_IMAGE);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getCookbookEntryById(slug);
+
+  if (!entry) {
+    return {
+      title: "Cookbook Entry Not Found",
+    };
+  }
+
+  const title = metadataTitle(entry);
+  const description = metadataDescription(entry);
+  const image = metadataImage(entry);
+  const canonical = cookbookEntryUrl(entry);
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: entry.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+    alternates: {
+      canonical,
+    },
+  };
+}
+
+function buildJsonLd(entry: CookbookEntry) {
+  const url = cookbookEntryUrl(entry);
+  const keywords = [...entry.tags, ...entry.worksWith].filter(Boolean);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: entry.title,
+    description: entry.description,
+    text: entry.promptContent,
+    url,
+    image: metadataImage(entry),
+    dateCreated: entry.createdAt || undefined,
+    keywords: keywords.length > 0 ? keywords.join(", ") : undefined,
+    creator: {
+      "@type": "Person",
+      name: entry.authorDisplayName || "Cursor Boston member",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Cursor Boston",
+      url: SITE_URL,
+      logo: {
+        "@type": "ImageObject",
+        url: absoluteUrl(DEFAULT_IMAGE),
+      },
+    },
+    isPartOf: {
+      "@type": "CreativeWorkSeries",
+      name: "Cursor Boston Prompt & Rules Cookbook",
+      url: `${SITE_URL}/cookbook`,
+    },
+    about: CATEGORY_LABELS[entry.category],
+    interactionStatistic: [
+      {
+        "@type": "InteractionCounter",
+        interactionType: "https://schema.org/LikeAction",
+        userInteractionCount: entry.upCount,
+      },
+      {
+        "@type": "InteractionCounter",
+        interactionType: "https://schema.org/DislikeAction",
+        userInteractionCount: entry.downCount,
+      },
+    ],
+  };
+}
+
+export default async function CookbookEntryPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = await getCookbookEntryById(slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  const jsonLd = buildJsonLd(entry);
+  const netScore = entry.upCount - entry.downCount;
+
+  return (
+    <main className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <nav
+        className="border-b border-neutral-200 dark:border-neutral-800 px-6 py-4"
+        aria-label="Breadcrumb"
+      >
+        <ol className="mx-auto flex max-w-4xl items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+          <li>
+            <Link href="/cookbook" className="hover:text-foreground">
+              Cookbook
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="truncate text-foreground">{entry.title}</li>
+        </ol>
+      </nav>
+
+      <article className="mx-auto max-w-4xl px-6 py-12">
+        <header className="mb-8">
+          <div className="mb-4 flex flex-wrap items-center gap-2 text-sm">
+            <span className="rounded-full bg-emerald-500/10 px-3 py-1 font-medium text-emerald-700 dark:text-emerald-300">
+              {CATEGORY_LABELS[entry.category]}
+            </span>
+            {entry.worksWith.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-neutral-200 px-3 py-1 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+
+          <h1 className="text-3xl font-bold tracking-normal text-neutral-950 dark:text-white md:text-5xl">
+            {entry.title}
+          </h1>
+          <p className="mt-4 text-lg leading-8 text-neutral-700 dark:text-neutral-300">
+            {entry.description}
+          </p>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-neutral-500 dark:text-neutral-400">
+            <Link
+              href={`/members?search=${encodeURIComponent(entry.authorDisplayName)}`}
+              className="hover:text-foreground"
+            >
+              by {entry.authorDisplayName || "Cursor Boston member"}
+            </Link>
+            {entry.createdAt ? (
+              <>
+                <span aria-hidden="true">/</span>
+                <time dateTime={entry.createdAt}>
+                  {formatCookbookDate(entry.createdAt)}
+                </time>
+              </>
+            ) : null}
+            <span aria-hidden="true">/</span>
+            <span>{netScore >= 0 ? `+${netScore}` : netScore} net score</span>
+          </div>
+        </header>
+
+        <section
+          aria-labelledby="cookbook-entry-prompt"
+          className="overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
+        >
+          <div className="border-b border-neutral-200 bg-neutral-100 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-800/70">
+            <h2
+              id="cookbook-entry-prompt"
+              className="text-sm font-semibold uppercase text-neutral-500 dark:text-neutral-400"
+            >
+              Full prompt
+            </h2>
+          </div>
+          <PromptMarkdown
+            content={entry.promptContent}
+            className="px-4 py-4 text-sm md:px-6 md:py-5"
+          />
+        </section>
+
+        {entry.tags.length > 0 ? (
+          <section aria-label="Tags" className="mt-8 flex flex-wrap gap-2">
+            {entry.tags.map((tag) => (
+              <Link
+                key={tag}
+                href={`/cookbook?search=${encodeURIComponent(tag)}`}
+                className="rounded-full bg-neutral-200 px-3 py-1 text-sm text-neutral-700 hover:bg-neutral-300 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+              >
+                #{tag}
+              </Link>
+            ))}
+          </section>
+        ) : null}
+      </article>
+    </main>
+  );
+}

--- a/lib/cookbook-entries.ts
+++ b/lib/cookbook-entries.ts
@@ -1,0 +1,101 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { DocumentSnapshot, QueryDocumentSnapshot } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { sanitizeDocId } from "@/lib/sanitize";
+import {
+  COOKBOOK_CATEGORIES,
+  WORKS_WITH_LANGUAGES,
+  type CookbookCategory,
+  type CookbookEntry,
+  type CookbookEntrySeo,
+  type WorksWithTag,
+} from "@/types/cookbook";
+
+type CookbookDoc = DocumentSnapshot | QueryDocumentSnapshot;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+export function isValidCookbookCategory(value: string): value is CookbookCategory {
+  return COOKBOOK_CATEGORIES.includes(value as CookbookCategory);
+}
+
+export function isValidWorksWithTag(value: string): value is WorksWithTag {
+  return WORKS_WITH_LANGUAGES.includes(value as WorksWithTag);
+}
+
+function timestampToIso(value: unknown): string {
+  if (!isRecord(value) || typeof value.toMillis !== "function") return "";
+  return new Date(value.toMillis()).toISOString();
+}
+
+function normalizeSeo(data: Record<string, unknown>): CookbookEntrySeo | undefined {
+  const seoSource = isRecord(data.seo) ? data.seo : {};
+  const seo: CookbookEntrySeo = {
+    title: readString(seoSource.title) ?? readString(data.seoTitle),
+    description:
+      readString(seoSource.description) ?? readString(data.seoDescription),
+    image:
+      readString(seoSource.image) ??
+      readString(seoSource.ogImage) ??
+      readString(data.ogImageUrl),
+    canonicalUrl:
+      readString(seoSource.canonicalUrl) ?? readString(data.canonicalUrl),
+  };
+
+  return Object.values(seo).some(Boolean) ? seo : undefined;
+}
+
+export function mapCookbookDocToEntry(doc: CookbookDoc): CookbookEntry {
+  const rawData = doc.data();
+  const data = isRecord(rawData) ? rawData : {};
+  const category = readString(data.category) ?? "other";
+  const upCount = Number(data.upCount ?? 0);
+  const downCount = Number(data.downCount ?? 0);
+
+  return {
+    id: doc.id,
+    title: readString(data.title) ?? "",
+    description: readString(data.description) ?? "",
+    promptContent: readString(data.promptContent) ?? "",
+    category: isValidCookbookCategory(category) ? category : "other",
+    tags: readStringArray(data.tags),
+    worksWith: readStringArray(data.worksWith).filter(isValidWorksWithTag),
+    authorId: readString(data.authorId) ?? "",
+    authorDisplayName: readString(data.authorDisplayName) ?? "",
+    createdAt: timestampToIso(data.createdAt),
+    upCount,
+    downCount,
+    seo: normalizeSeo(data),
+  };
+}
+
+export async function getCookbookEntryById(id: string): Promise<CookbookEntry | null> {
+  const sanitizedId = sanitizeDocId(id);
+  if (!sanitizedId) return null;
+
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const doc = await db.collection("cookbook_entries").doc(sanitizedId).get();
+  if (!doc.exists) return null;
+
+  return mapCookbookDocToEntry(doc);
+}

--- a/types/cookbook.ts
+++ b/types/cookbook.ts
@@ -37,6 +37,13 @@ export const WORKS_WITH_LANGUAGES = [
 
 export type WorksWithTag = (typeof WORKS_WITH_LANGUAGES)[number];
 
+export interface CookbookEntrySeo {
+  title?: string;
+  description?: string;
+  image?: string;
+  canonicalUrl?: string;
+}
+
 export interface CookbookEntry {
   id: string;
   title: string;
@@ -50,4 +57,5 @@ export interface CookbookEntry {
   createdAt: string;
   upCount: number;
   downCount: number;
+  seo?: CookbookEntrySeo;
 }


### PR DESCRIPTION
## Summary
- Add shareable `/cookbook/[slug]` pages for individual cookbook entries.
- Generate entry-level title, description, canonical URL, Open Graph/Twitter metadata, and CreativeWork JSON-LD.
- Share the Firestore entry mapping between the existing list API and the new page route, including optional SEO fields.

## Tests
- `npm test -- --runTestsByPath "__tests__/app/cookbook/[slug]/page.test.tsx" "__tests__/app/api/cookbook/entries/route.test.ts" --testPathIgnorePatterns='^$'`
- `npm run type-check`
- `npx eslint app/api/cookbook/entries/route.ts app/cookbook/[slug]/page.tsx lib/cookbook-entries.ts types/cookbook.ts __tests__/app/cookbook/[slug]/page.test.tsx`
- `git diff --check`

Closes #565

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)