### PR TITLE
fix: normalize route contract paths on Windows

### DIFF
--- a/scripts/check-route-contracts.js
+++ b/scripts/check-route-contracts.js
@@ -57,6 +57,7 @@ let withContract = 0;
 for (const file of walk(API_DIR)) {
   const rel = path
     .relative(API_DIR, file)
+    .replace(/\\/g, "/")
     .replace(/[\\/]route\.tsx?$/, "");
   const src = fs.readFileSync(file, "utf8");
   const hasContract =


### PR DESCRIPTION
## Summary
- Normalize API route ids before comparing them with `contract-exemptions.json`
- Keeps the route-contract migration gate portable across Windows and POSIX paths

## Validation
- `node scripts/check-route-contracts.js`
- `npx eslint scripts/check-route-contracts.js --max-warnings=0`
- `npm run type-check`
- `git diff --check`

Part of #234.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
