### PR TITLE
refactor: extract reusable konami listener

### DIFF
--- a/__tests__/app/api/hunt/oracle/route.test.ts
+++ b/__tests__/app/api/hunt/oracle/route.test.ts
@@ -5,9 +5,8 @@
 import { createHash } from "crypto";
 import { GET as getOracle } from "@/app/api/hunt/oracle/route";
 import { GET as getKonami } from "@/app/api/hunt/oracle/konami/route";
+import { KONAMI_SEQUENCE_HEADER } from "@/lib/konami-handler";
 import { getKonamiToken, getOracleAnswer } from "@/lib/treasure-hunt-paths";
-
-const KONAMI_SEQUENCE = "UUDDLRLRBA";
 
 function konamiRequest(sequence?: string) {
   const headers: Record<string, string> = {};
@@ -69,7 +68,7 @@ describe("GET /api/hunt/oracle/konami", () => {
   });
 
   it("returns the daily token when sequence is correct", async () => {
-    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE));
+    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE_HEADER));
     const body = await res.json();
 
     expect(res.status).toBe(200);
@@ -78,7 +77,7 @@ describe("GET /api/hunt/oracle/konami", () => {
   });
 
   it("is case-sensitive for the Konami sequence header", async () => {
-    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE.toLowerCase()));
+    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE_HEADER.toLowerCase()));
     expect(res.status).toBe(404);
   });
 });

--- a/__tests__/components/hunt/KonamiListener.test.tsx
+++ b/__tests__/components/hunt/KonamiListener.test.tsx
@@ -10,21 +10,12 @@ jest.mock("@/contexts/AuthContext", () => ({
 
 import { useAuth } from "@/contexts/AuthContext";
 import { KonamiListener } from "@/components/hunt/KonamiListener";
+import {
+  KONAMI_SEQUENCE,
+  KONAMI_SEQUENCE_HEADER,
+} from "@/lib/konami-handler";
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
-
-const KONAMI_SEQUENCE = [
-  "ArrowUp",
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowLeft",
-  "ArrowRight",
-  "b",
-  "a",
-];
 
 function mockAuthUser(user: typeof mockUser | null) {
   mockedUseAuth.mockReturnValue({
@@ -77,7 +68,7 @@ describe("KonamiListener", () => {
     expect(screen.getByText("🎮 You found a path.")).toBeInTheDocument();
     expect(screen.getByText(/token: konami-secret-token/)).toBeInTheDocument();
     expect(mockFetchFn).toHaveBeenCalledWith("/api/hunt/oracle/konami", {
-      headers: { "X-Konami-Sequence": "UUDDLRLRBA" },
+      headers: { "X-Konami-Sequence": KONAMI_SEQUENCE_HEADER },
     });
   });
 

--- a/__tests__/lib/konami-handler.test.tsx
+++ b/__tests__/lib/konami-handler.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * @jest-environment jsdom
+ */
+
+import { useCallback, useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  KONAMI_SEQUENCE,
+  KONAMI_SEQUENCE_HEADER,
+  nextSequenceIndex,
+  sequenceToHeaderProof,
+  type KonamiSequence,
+} from "@/lib/konami-handler";
+import { useKonamiListener } from "@/hooks/use-konami-listener";
+
+function CustomSequenceProbe({ sequence }: { sequence: KonamiSequence }) {
+  const [completions, setCompletions] = useState(0);
+  const onComplete = useCallback(() => {
+    setCompletions((value) => value + 1);
+  }, []);
+
+  useKonamiListener(sequence, onComplete);
+
+  return <output aria-label="Completions">{completions}</output>;
+}
+
+function pressKeys(sequence: KonamiSequence) {
+  for (const key of sequence) {
+    fireEvent.keyDown(window, { key });
+  }
+}
+
+describe("konami handler", () => {
+  it("serializes the current sequence proof for the oracle header", () => {
+    expect(sequenceToHeaderProof(KONAMI_SEQUENCE)).toBe("UUDDLRLRBA");
+    expect(KONAMI_SEQUENCE_HEADER).toBe("UUDDLRLRBA");
+  });
+
+  it("advances and resets progress for partial key sequences", () => {
+    let index = nextSequenceIndex(KONAMI_SEQUENCE, 0, "ArrowUp");
+    expect(index).toBe(1);
+
+    index = nextSequenceIndex(KONAMI_SEQUENCE, index, "ArrowUp");
+    expect(index).toBe(2);
+
+    index = nextSequenceIndex(KONAMI_SEQUENCE, index, "Escape");
+    expect(index).toBe(0);
+  });
+
+  it("restarts progress when the wrong key is also the sequence prefix", () => {
+    const sequence = ["a", "b", "a"] as const;
+    let index = nextSequenceIndex(sequence, 0, "a");
+    index = nextSequenceIndex(sequence, index, "a");
+
+    expect(index).toBe(1);
+  });
+
+  it("calls onComplete for a custom sequence", () => {
+    render(<CustomSequenceProbe sequence={["x", "y", "z"]} />);
+
+    pressKeys(["x", "y", "z"]);
+
+    expect(screen.getByLabelText("Completions")).toHaveTextContent("1");
+  });
+
+  it("does not complete on an incomplete custom sequence", () => {
+    render(<CustomSequenceProbe sequence={["q", "w"]} />);
+
+    pressKeys(["q"]);
+
+    expect(screen.getByLabelText("Completions")).toHaveTextContent("0");
+  });
+});

--- a/app/api/hunt/oracle/konami/route.ts
+++ b/app/api/hunt/oracle/konami/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { KONAMI_SEQUENCE_HEADER } from "@/lib/konami-handler";
 import { getKonamiToken } from "@/lib/treasure-hunt-paths";
 
 // @contracts: huntContract.oracleKonami (lib/api-schemas/hunt.ts)
@@ -20,7 +21,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(request: Request) {
   const sequence = request.headers.get("x-konami-sequence") || "";
-  if (sequence !== "UUDDLRLRBA") {
+  if (sequence !== KONAMI_SEQUENCE_HEADER) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   return NextResponse.json({ token: getKonamiToken() });

--- a/components/hunt/KonamiListener.tsx
+++ b/components/hunt/KonamiListener.tsx
@@ -7,21 +7,13 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-
-const SEQUENCE = [
-  "ArrowUp",
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowLeft",
-  "ArrowRight",
-  "b",
-  "a",
-];
+import {
+  KONAMI_SEQUENCE,
+  KONAMI_SEQUENCE_HEADER,
+} from "@/lib/konami-handler";
+import { useKonamiListener } from "@/hooks/use-konami-listener";
 
 export function KonamiListener() {
   const { user } = useAuth();
@@ -29,34 +21,22 @@ export function KonamiListener() {
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<null | string>(null);
 
-  useEffect(() => {
-    let index = 0;
-    function onKey(e: KeyboardEvent) {
-      const expected = SEQUENCE[index];
-      if (e.key.toLowerCase() === expected?.toLowerCase()) {
-        index += 1;
-        if (index === SEQUENCE.length) {
-          index = 0;
-          void fetch("/api/hunt/oracle/konami", {
-            headers: { "X-Konami-Sequence": "UUDDLRLRBA" },
-          })
-            .then(async (r) => {
-              if (!r.ok) {
-                setRevealed({ error: "Not today." });
-                return;
-              }
-              const j = (await r.json()) as { token?: string };
-              if (j.token) setRevealed({ token: j.token });
-            })
-            .catch(() => setRevealed({ error: "Network error." }));
+  const revealToken = useCallback(() => {
+    void fetch("/api/hunt/oracle/konami", {
+      headers: { "X-Konami-Sequence": KONAMI_SEQUENCE_HEADER },
+    })
+      .then(async (r) => {
+        if (!r.ok) {
+          setRevealed({ error: "Not today." });
+          return;
         }
-      } else {
-        index = 0;
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+        const j = (await r.json()) as { token?: string };
+        if (j.token) setRevealed({ token: j.token });
+      })
+      .catch(() => setRevealed({ error: "Network error." }));
   }, []);
+
+  useKonamiListener(KONAMI_SEQUENCE, revealToken);
 
   async function submit() {
     if (!user || !revealed?.token) return;

--- a/hooks/use-konami-listener.ts
+++ b/hooks/use-konami-listener.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect } from "react";
+import {
+  nextSequenceIndex,
+  type KonamiSequence,
+} from "@/lib/konami-handler";
+
+export function useKonamiListener(
+  sequence: KonamiSequence,
+  onComplete: () => void
+) {
+  useEffect(() => {
+    let index = 0;
+
+    function onKey(event: KeyboardEvent) {
+      index = nextSequenceIndex(sequence, index, event.key);
+      if (index === sequence.length) {
+        index = 0;
+        onComplete();
+      }
+    }
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onComplete, sequence]);
+}

--- a/lib/konami-handler.ts
+++ b/lib/konami-handler.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export type KonamiSequence = readonly string[];
+
+export const KONAMI_SEQUENCE = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+] as const satisfies KonamiSequence;
+
+const SEQUENCE_PROOF_KEYS: Record<string, string> = {
+  ArrowUp: "U",
+  ArrowDown: "D",
+  ArrowLeft: "L",
+  ArrowRight: "R",
+  b: "B",
+  a: "A",
+};
+
+export function sequenceToHeaderProof(sequence: KonamiSequence): string {
+  return sequence
+    .map((key) => SEQUENCE_PROOF_KEYS[key] ?? key.slice(0, 1).toUpperCase())
+    .join("");
+}
+
+export const KONAMI_SEQUENCE_HEADER = sequenceToHeaderProof(KONAMI_SEQUENCE);
+
+export function keyMatchesSequenceValue(key: string, expected: string): boolean {
+  return key.toLowerCase() === expected.toLowerCase();
+}
+
+export function nextSequenceIndex(
+  sequence: KonamiSequence,
+  currentIndex: number,
+  key: string
+): number {
+  const expected = sequence[currentIndex];
+  if (expected && keyMatchesSequenceValue(key, expected)) {
+    return currentIndex + 1;
+  }
+
+  const first = sequence[0];
+  return first && keyMatchesSequenceValue(key, first) ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Extract the Konami key sequence and oracle header proof into `lib/konami-handler.ts`.
- Add a reusable `useKonamiListener(sequence, onComplete)` hook for future Easter eggs.
- Keep the current hunt listener and oracle route on the shared sequence constants.

## Tests
- `npm test -- --runTestsByPath "__tests__/lib/konami-handler.test.tsx" "__tests__/components/hunt/KonamiListener.test.tsx" "__tests__/app/api/hunt/oracle/route.test.ts" --testPathIgnorePatterns='^$'`
- `npm run type-check`
- `npx eslint lib/konami-handler.ts hooks/use-konami-listener.ts components/hunt/KonamiListener.tsx app/api/hunt/oracle/konami/route.ts __tests__/lib/konami-handler.test.tsx __tests__/components/hunt/KonamiListener.test.tsx __tests__/app/api/hunt/oracle/route.test.ts`
- `git diff --check`

Closes #583

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)