### PR TITLE
refactor: centralize hackathon event ids

### DIFF
--- a/__tests__/lib/hackathon-event-signup-ranking.test.ts
+++ b/__tests__/lib/hackathon-event-signup-ranking.test.ts
@@ -17,11 +17,14 @@ import {
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
 } from "@/lib/sports-hack-2026";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
 
 describe("hackathon-event-signup ranking + capacity", () => {
   describe("hackathonEventSignupDocId", () => {
     it("composes eventId__userId", () => {
-      expect(hackathonEventSignupDocId("ev", "u")).toBe("ev__u");
+      expect(hackathonEventSignupDocId(HACK_A_SPRINT_2026_EVENT_ID, "u")).toBe(
+        "hack-a-sprint-2026__u"
+      );
     });
   });
 

--- a/__tests__/types/hackathon-events.test.ts
+++ b/__tests__/types/hackathon-events.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * @jest-environment node
+ */
+
+import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
+import { SPORTS_HACK_2026_EVENT_ID } from "@/lib/sports-hack-2026";
+import {
+  HACKATHON_EVENT_ID_LIST,
+  HACKATHON_EVENT_IDS,
+  type HackathonEventId,
+} from "@/types/hackathon-events";
+
+function acceptsHackathonEventId(eventId: HackathonEventId): HackathonEventId {
+  return eventId;
+}
+
+describe("hackathon event ids", () => {
+  it("centralizes supported hackathon event ids", () => {
+    expect(HACKATHON_EVENT_IDS).toEqual({
+      HACK_A_SPRINT_2026: "hack-a-sprint-2026",
+      SPORTS_HACK_2026: "sports-hack-2026",
+    });
+    expect(HACKATHON_EVENT_ID_LIST).toEqual([
+      "hack-a-sprint-2026",
+      "sports-hack-2026",
+    ]);
+  });
+
+  it("keeps legacy event exports sourced from the typed registry", () => {
+    expect(acceptsHackathonEventId(HACK_A_SPRINT_2026_EVENT_ID)).toBe(
+      HACKATHON_EVENT_IDS.HACK_A_SPRINT_2026
+    );
+    expect(acceptsHackathonEventId(SPORTS_HACK_2026_EVENT_ID)).toBe(
+      HACKATHON_EVENT_IDS.SPORTS_HACK_2026
+    );
+  });
+});

--- a/lib/hackathon-event-signup.ts
+++ b/lib/hackathon-event-signup.ts
@@ -5,21 +5,21 @@
  * See LICENSE file for details.
  */
 
-import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
 import {
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_DECLINED_EMAILS,
   SPORTS_HACK_2026_EVENT_ID,
   SPORTS_HACK_2026_JUDGE_EMAILS,
 } from "@/lib/sports-hack-2026";
+import {
+  HACKATHON_EVENT_ID_LIST,
+  type HackathonEventId,
+} from "@/types/hackathon-events";
 
 /** In-person / special events with website signup (separate from Luma). */
-export const HACKATHON_EVENT_SIGNUP_IDS = [
-  HACK_A_SPRINT_2026_EVENT_ID,
-  SPORTS_HACK_2026_EVENT_ID,
-] as const;
+export const HACKATHON_EVENT_SIGNUP_IDS = HACKATHON_EVENT_ID_LIST;
 
-export type HackathonEventSignupId = (typeof HACKATHON_EVENT_SIGNUP_IDS)[number];
+export type HackathonEventSignupId = HackathonEventId;
 
 export function isHackathonEventSignupId(
   eventId: string
@@ -28,7 +28,7 @@ export function isHackathonEventSignupId(
 }
 
 export function hackathonEventSignupDocId(
-  eventId: string,
+  eventId: HackathonEventSignupId,
   userId: string
 ): string {
   return `${eventId}__${userId}`;
@@ -144,7 +144,9 @@ export function getJudgeEmailsForEvent(eventId: string): ReadonlySet<string> {
   return JUDGE_EMAILS;
 }
 
-export function getDeclinedEmailsForEvent(eventId: string): ReadonlySet<string> {
+export function getDeclinedEmailsForEvent(
+  eventId: string
+): ReadonlySet<string> {
   if (eventId === SPORTS_HACK_2026_EVENT_ID) return SPORTS_HACK_2026_DECLINED_EMAILS;
   return DECLINED_EMAILS;
 }

--- a/lib/hackathon-showcase.ts
+++ b/lib/hackathon-showcase.ts
@@ -8,12 +8,14 @@
 import { unstable_cache } from "next/cache";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
 import { fetchWithTimeout } from "@/lib/http-fetch";
+import { HACKATHON_EVENT_IDS } from "@/types/hackathon-events";
 
-export const HACK_A_SPRINT_2026_EVENT_ID = "hack-a-sprint-2026";
+export const HACK_A_SPRINT_2026_EVENT_ID =
+  HACKATHON_EVENT_IDS.HACK_A_SPRINT_2026;
 export const SHOWCASE_SUBMISSIONS_CACHE_TAG = "showcase-submissions";
-export const HACK_A_SPRINT_2026_LABEL = "hack-a-sprint-2026";
+export const HACK_A_SPRINT_2026_LABEL = HACK_A_SPRINT_2026_EVENT_ID;
 export const HACK_A_SPRINT_2026_SUBMISSIONS_PATH =
-  "content/hackathons/hack-a-sprint-2026/submissions";
+  `content/hackathons/${HACK_A_SPRINT_2026_EVENT_ID}/submissions`;
 
 export type ShowcaseSubmissionPayload = {
   /** May be empty if omitted in JSON; hide repo link in UI when missing. */

--- a/lib/sports-hack-2026.ts
+++ b/lib/sports-hack-2026.ts
@@ -5,7 +5,10 @@
  * See LICENSE file for details.
  */
 
-export const SPORTS_HACK_2026_EVENT_ID = "sports-hack-2026";
+import { HACKATHON_EVENT_IDS } from "@/types/hackathon-events";
+
+export const SPORTS_HACK_2026_EVENT_ID =
+  HACKATHON_EVENT_IDS.SPORTS_HACK_2026;
 
 export const SPORTS_HACK_2026_NAME = "Boston Tech Week Sports Hack";
 export const SPORTS_HACK_2026_SHORT_NAME = "Sports Hack 2026";

--- a/types/hackathon-events.ts
+++ b/types/hackathon-events.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export const HACKATHON_EVENT_IDS = {
+  HACK_A_SPRINT_2026: "hack-a-sprint-2026",
+  SPORTS_HACK_2026: "sports-hack-2026",
+} as const;
+
+export type HackathonEventId =
+  (typeof HACKATHON_EVENT_IDS)[keyof typeof HACKATHON_EVENT_IDS];
+
+export const HACKATHON_EVENT_ID_LIST = [
+  HACKATHON_EVENT_IDS.HACK_A_SPRINT_2026,
+  HACKATHON_EVENT_IDS.SPORTS_HACK_2026,
+] as const satisfies readonly HackathonEventId[];


### PR DESCRIPTION
## Summary
- Add a typed `HACKATHON_EVENT_IDS` registry for the current hackathon signup event IDs.
- Source the existing Hack-a-Sprint and Sports Hack event exports from that registry.
- Narrow signup doc IDs to known hackathon event IDs and cover the registry with focused tests.

## Tests
- `npm test -- --runTestsByPath "__tests__/types/hackathon-events.test.ts" "__tests__/lib/hackathon-event-signup.test.ts" "__tests__/lib/hackathon-event-signup-ranking.test.ts" "__tests__/lib/sports-hack-2026.test.ts" --testPathIgnorePatterns='^$'`
- `npm run type-check`
- `npx eslint types/hackathon-events.ts lib/hackathon-showcase.ts lib/sports-hack-2026.ts lib/hackathon-event-signup.ts __tests__/types/hackathon-events.test.ts __tests__/lib/hackathon-event-signup-ranking.test.ts`
- `git diff --check`

Closes #560

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)