### PR TITLE
fix: filter community feed through server safety gate

### DIFF
--- a/__tests__/app/api/community/feed.test.ts
+++ b/__tests__/app/api/community/feed.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/community/feed/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getOptionalVerifiedUser } from "@/lib/server-auth";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+jest.mock("@/lib/server-auth", () => ({
+  getOptionalVerifiedUser: jest.fn(),
+}));
+jest.mock("@/lib/rate-limit", () => ({
+  getClientIdentifier: jest.fn(() => "client-1"),
+  checkRateLimit: jest.fn(() => ({ success: true })),
+}));
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockGetOptionalVerifiedUser = getOptionalVerifiedUser as jest.MockedFunction<
+  typeof getOptionalVerifiedUser
+>;
+const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
+
+type Row = {
+  id: string;
+  data: Record<string, unknown>;
+};
+
+function doc(row: Row) {
+  return {
+    id: row.id,
+    exists: true,
+    data: () => row.data,
+  };
+}
+
+function makeRequest(path = "/api/community/feed") {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+function buildDb(opts: {
+  rows: Row[];
+  users?: Record<string, Record<string, unknown>>;
+  blocked?: string[];
+}) {
+  const query: any = {
+    limit: jest.fn(() => query),
+    startAfter: jest.fn(() => query),
+    get: jest.fn(async () => ({ docs: opts.rows.map(doc) })),
+  };
+  const communityMessages = {
+    orderBy: jest.fn(() => query),
+    doc: jest.fn((id: string) => ({
+      get: jest.fn(async () => {
+        const row = opts.rows.find((candidate) => candidate.id === id);
+        return row ? doc(row) : { id, exists: false, data: () => undefined };
+      }),
+    })),
+  };
+  const users = {
+    doc: jest.fn((id: string) => ({
+      get: jest.fn(async () => {
+        const data = opts.users?.[id];
+        return { id, exists: Boolean(data), data: () => data };
+      }),
+    })),
+  };
+  const blocked = {
+    limit: jest.fn(() => blocked),
+    get: jest.fn(async () => ({
+      docs: (opts.blocked ?? []).map((id) => doc({ id, data: { targetUid: id } })),
+    })),
+  };
+  const userBlocks = {
+    doc: jest.fn(() => ({ collection: jest.fn(() => blocked) })),
+  };
+  const db = {
+    collection: jest.fn((name: string) => {
+      if (name === "communityMessages") return communityMessages;
+      if (name === "users") return users;
+      if (name === "userBlocks") return userBlocks;
+      throw new Error(`unexpected collection ${name}`);
+    }),
+  };
+  return { db, query, communityMessages, users, blocked };
+}
+
+const createdAt = { toDate: () => new Date("2026-01-01T00:00:00.000Z") };
+
+function row(id: string, overrides: Record<string, unknown> = {}): Row {
+  return {
+    id,
+    data: {
+      content: `message ${id}`,
+      authorId: `author-${id}`,
+      authorName: `Author ${id}`,
+      authorPhoto: null,
+      createdAt,
+      likeCount: 0,
+      dislikeCount: 0,
+      replyCount: 0,
+      repostCount: 0,
+      ...overrides,
+    },
+  };
+}
+
+describe("GET /api/community/feed", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetOptionalVerifiedUser.mockResolvedValue({ uid: "viewer" });
+    mockCheckRateLimit.mockReturnValue({ success: true } as never);
+  });
+
+  it("filters hidden messages, replies, suspended authors, and blocked authors", async () => {
+    const { db } = buildDb({
+      rows: [
+        row("visible-1", { authorId: "author-visible-1" }),
+        row("hidden", { hidden: true, authorId: "author-hidden" }),
+        row("reply", { parentId: "parent-1", authorId: "author-reply" }),
+        row("suspended", { authorId: "author-suspended" }),
+        row("blocked", { authorId: "author-blocked" }),
+        row("visible-2", { authorId: "author-visible-2" }),
+      ],
+      users: {
+        "author-suspended": { suspended: true },
+      },
+      blocked: ["author-blocked"],
+    });
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.messages.map((message: { id: string }) => message.id)).toEqual([
+      "visible-1",
+      "visible-2",
+    ]);
+  });
+
+  it("returns visible replies for a requested parent in ascending order", async () => {
+    const { db, communityMessages } = buildDb({
+      rows: [
+        row("top-level", { authorId: "author-top" }),
+        row("reply-1", { parentId: "parent-1", authorId: "author-reply-1" }),
+        row("reply-hidden", { parentId: "parent-1", hidden: true, authorId: "author-hidden" }),
+        row("reply-2", { parentId: "parent-1", authorId: "author-reply-2" }),
+      ],
+    });
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest("/api/community/feed?parentId=parent-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.messages.map((message: { id: string }) => message.id)).toEqual([
+      "reply-1",
+      "reply-2",
+    ]);
+    expect(communityMessages.orderBy).toHaveBeenCalledWith("createdAt", "asc");
+  });
+
+  it("uses the last returned visible message as the next cursor when a page fills", async () => {
+    const { db } = buildDb({
+      rows: [
+        row("first", { authorId: "author-first" }),
+        row("second", { authorId: "author-second" }),
+      ],
+    });
+    mockGetAdminDb.mockReturnValue(db as never);
+
+    const res = await GET(makeRequest("/api/community/feed?limit=1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.messages.map((message: { id: string }) => message.id)).toEqual(["first"]);
+    expect(body.hasMore).toBe(true);
+    expect(body.nextCursor).toBe("first");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockCheckRateLimit.mockReturnValue({ success: false, retryAfter: 42 } as never);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("42");
+  });
+});

--- a/app/api/community/feed/route.ts
+++ b/app/api/community/feed/route.ts
@@ -1,0 +1,216 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import type { DocumentData, Firestore, QueryDocumentSnapshot } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getOptionalVerifiedUser } from "@/lib/server-auth";
+import { logger } from "@/lib/logger";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import {
+  clampLimit,
+  DEFAULT_PAGE_LIMIT,
+  MAX_PAGE_LIMIT,
+  parseCursor,
+} from "@/lib/firestore-pagination";
+import { communityContract } from "@/lib/api-schemas/community";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 120 };
+const MAX_SCAN_DOCS = 250;
+
+function timestampToIso(value: unknown): string {
+  if (value && typeof value === "object" && "toDate" in value) {
+    const date = (value as { toDate: () => Date }).toDate();
+    return Number.isFinite(date.getTime()) ? date.toISOString() : new Date(0).toISOString();
+  }
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.toISOString() : new Date(0).toISOString();
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : new Date(0).toISOString();
+  }
+  return new Date(0).toISOString();
+}
+
+async function getBlockedAuthorIds(db: Firestore, uid?: string): Promise<Set<string>> {
+  if (!uid) return new Set();
+  const snap = await db
+    .collection("userBlocks")
+    .doc(uid)
+    .collection("blocked")
+    .limit(500)
+    .get();
+
+  return new Set(
+    snap.docs
+      .map((doc) => {
+        const data = doc.data();
+        return typeof data.targetUid === "string" ? data.targetUid : doc.id;
+      })
+      .filter(Boolean)
+  );
+}
+
+async function getSuspendedAuthorIds(db: Firestore, authorIds: string[]): Promise<Set<string>> {
+  const uniqueIds = [...new Set(authorIds)].filter(Boolean);
+  if (uniqueIds.length === 0) return new Set();
+
+  const snaps = await Promise.all(
+    uniqueIds.map((authorId) => db.collection("users").doc(authorId).get())
+  );
+  return new Set(
+    snaps
+      .filter((snap) => snap.exists && snap.data()?.suspended === true)
+      .map((snap) => snap.id)
+  );
+}
+
+function isRequestedThread(data: DocumentData, parentId: string | null): boolean {
+  if (parentId) return data.parentId === parentId;
+  return !data.parentId;
+}
+
+function toFeedMessage(doc: QueryDocumentSnapshot) {
+  const data = doc.data();
+  return {
+    id: doc.id,
+    content: typeof data.content === "string" ? data.content : "",
+    authorId: typeof data.authorId === "string" ? data.authorId : "",
+    authorName: typeof data.authorName === "string" ? data.authorName : "Anonymous",
+    authorPhoto: typeof data.authorPhoto === "string" ? data.authorPhoto : null,
+    createdAt: timestampToIso(data.createdAt),
+    ...(typeof data.parentId === "string" ? { parentId: data.parentId } : {}),
+    ...(data.repostOf && typeof data.repostOf === "object" ? { repostOf: data.repostOf } : {}),
+    likeCount: typeof data.likeCount === "number" ? data.likeCount : 0,
+    dislikeCount: typeof data.dislikeCount === "number" ? data.dislikeCount : 0,
+    replyCount: typeof data.replyCount === "number" ? data.replyCount : 0,
+    repostCount: typeof data.repostCount === "number" ? data.repostCount : 0,
+    bookmarkCount: typeof data.bookmarkCount === "number" ? data.bookmarkCount : 0,
+  };
+}
+
+async function filterVisibleDocs(
+  db: Firestore,
+  docs: QueryDocumentSnapshot[],
+  blockedAuthorIds: Set<string>
+): Promise<QueryDocumentSnapshot[]> {
+  const notHidden = docs.filter((doc) => doc.data().hidden !== true);
+  const suspendedAuthorIds = await getSuspendedAuthorIds(
+    db,
+    notHidden.map((doc) => doc.data().authorId).filter((id): id is string => typeof id === "string")
+  );
+
+  return notHidden.filter((doc) => {
+    const authorId = doc.data().authorId;
+    return (
+      typeof authorId === "string" &&
+      !blockedAuthorIds.has(authorId) &&
+      !suspendedAuthorIds.has(authorId)
+    );
+  });
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`community-feed:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rateResult.retryAfter || 60) } }
+      );
+    }
+
+    const parsed = communityContract.feed.query.safeParse({
+      cursor: request.nextUrl.searchParams.get("cursor") ?? undefined,
+      limit: request.nextUrl.searchParams.get("limit") ?? undefined,
+      parentId: request.nextUrl.searchParams.get("parentId") ?? undefined,
+    });
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid query" },
+        { status: 400 }
+      );
+    }
+
+    const db = getAdminDb();
+    if (!db) return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+
+    const user = await getOptionalVerifiedUser(request);
+    const blockedAuthorIds = await getBlockedAuthorIds(db, user?.uid);
+    const limit = clampLimit(parsed.data.limit, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT);
+    const parentId = parsed.data.parentId ?? null;
+    const requestedCursor = parseCursor(parsed.data.cursor);
+
+    const messagesRef = db.collection("communityMessages");
+    let lastScannedDoc: QueryDocumentSnapshot | null = null;
+    let lastReturnedDoc: QueryDocumentSnapshot | null = null;
+    let cursorDoc: QueryDocumentSnapshot | null = null;
+
+    if (requestedCursor) {
+      const snap = await messagesRef.doc(requestedCursor).get();
+      if (snap.exists) cursorDoc = snap as QueryDocumentSnapshot;
+    }
+
+    const messages: ReturnType<typeof toFeedMessage>[] = [];
+    const orderDirection = parentId ? "asc" : "desc";
+    let scanned = 0;
+    let hasMore = false;
+
+    while (messages.length < limit && scanned < MAX_SCAN_DOCS) {
+      const batchSize = Math.min(Math.max(limit * 2, 20), MAX_SCAN_DOCS - scanned);
+      let q = messagesRef.orderBy("createdAt", orderDirection).limit(batchSize);
+      const startAfterDoc = lastScannedDoc ?? cursorDoc;
+      if (startAfterDoc) q = q.startAfter(startAfterDoc);
+
+      const snap = await q.get();
+      if (snap.docs.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      scanned += snap.docs.length;
+      lastScannedDoc = snap.docs[snap.docs.length - 1] ?? lastScannedDoc;
+      hasMore = snap.docs.length === batchSize;
+
+      const threadDocs = snap.docs.filter((doc) => isRequestedThread(doc.data(), parentId));
+      const visibleDocs = await filterVisibleDocs(db, threadDocs, blockedAuthorIds);
+
+      for (const doc of visibleDocs) {
+        if (messages.length >= limit) {
+          hasMore = true;
+          break;
+        }
+        messages.push(toFeedMessage(doc));
+        lastReturnedDoc = doc;
+      }
+
+      if (!hasMore || messages.length >= limit) break;
+    }
+
+    if (scanned >= MAX_SCAN_DOCS && messages.length < limit && lastScannedDoc) {
+      hasMore = true;
+    }
+
+    const cursorSource = lastReturnedDoc ?? lastScannedDoc;
+    return NextResponse.json(
+      {
+        messages,
+        nextCursor: hasMore && cursorSource ? cursorSource.id : null,
+        hasMore,
+      },
+      { headers: { "Cache-Control": "private, max-age=15" } }
+    );
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/community/feed", area: "community-safety" });
+    return NextResponse.json({ error: "Failed to load feed" }, { status: 500 });
+  }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**179 paths, 215 operations across 32 areas.**
+**180 paths, 216 operations across 32 areas.**
 
 ---
 
@@ -89,6 +89,7 @@ _Community posts, replies, reactions, moderation._
 | DELETE | `/api/community/block` | Yes | Unblock another user |
 | POST | `/api/community/block` | Yes | Block another user |
 | POST | `/api/community/delete` | Yes | Delete the current user's own community message |
+| GET | `/api/community/feed` | No | List visible community feed messages |
 | GET | `/api/community/moderate` | Yes | Admin: list community reports (paginated) |
 | POST | `/api/community/moderate` | Yes | Admin: act on a community report (dismiss / hide / suspend) |
 | GET | `/api/community/my-reactions` | Yes | Get the current user's reactions for a batch of messages |

--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -7,13 +7,30 @@
 
 "use client";
 
-import { useEffect, useState, useCallback, useMemo, useRef } from "react";
-import { collection, query, where, getDocs, orderBy, limit, startAfter, Timestamp, QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { Timestamp } from "firebase/firestore";
 import { User } from "firebase/auth";
 import type { Message, ReactionType } from "@/types/feed";
 
 const PAGE_SIZE = 20;
+
+interface FeedApiMessage extends Omit<Message, "createdAt"> {
+  createdAt: string;
+}
+
+interface FeedApiResponse {
+  messages?: FeedApiMessage[];
+  nextCursor?: string | null;
+  hasMore?: boolean;
+}
+
+function toMessage(message: FeedApiMessage): Message {
+  const parsed = Date.parse(message.createdAt);
+  return {
+    ...message,
+    createdAt: Timestamp.fromDate(Number.isFinite(parsed) ? new Date(parsed) : new Date()),
+  };
+}
 
 export function useFeed(user: User | null, isActive: boolean) {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -34,80 +51,92 @@ export function useFeed(user: User | null, isActive: boolean) {
 
   const [hasMore, setHasMore] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
-  const lastDocRef = useRef<QueryDocumentSnapshot<DocumentData> | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
 
   const [error, setError] = useState<string | null>(null);
   const clearError = useCallback(() => setError(null), []);
 
-  // Fetch messages with a one-shot getDocs (avoids real-time listener fan-out
-  // that was causing 399K+ Firestore reads/day).
+  const authHeaders = useCallback(async (): Promise<HeadersInit> => {
+    if (!user) return {};
+    const token = await user.getIdToken();
+    return { Authorization: `Bearer ${token}` };
+  }, [user]);
+
+  const loadFeedPage = useCallback(
+    async (params: URLSearchParams) => {
+      const headers = await authHeaders();
+      const response = await fetch(`/api/community/feed?${params.toString()}`, { headers });
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      const data = (await response.json()) as FeedApiResponse;
+      return {
+        messages: (data.messages ?? []).map(toMessage),
+        nextCursor: data.nextCursor ?? null,
+        hasMore: data.hasMore ?? false,
+      };
+    },
+    [authHeaders]
+  );
+
+  // Fetch messages through the server feed endpoint so moderation and block
+  // filters are applied consistently instead of relying on public Firestore reads.
   const fetchMessages = useCallback(async () => {
-    if (!db) return;
     setLoading(true);
     try {
-      const messagesRef = collection(db, "communityMessages");
-      const q = query(messagesRef, orderBy("createdAt", "desc"), limit(PAGE_SIZE));
-      const snapshot = await getDocs(q);
-      const fetchedMessages = snapshot.docs
-        .map((d) => ({
-          id: d.id,
-          ...d.data(),
-        } as Message))
-        .filter((msg) => !msg.parentId);
-      setMessages(fetchedMessages);
-      setHasMore(snapshot.docs.length === PAGE_SIZE);
-      lastDocRef.current = snapshot.docs[snapshot.docs.length - 1] ?? null;
+      const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+      const page = await loadFeedPage(params);
+      setMessages(page.messages);
+      setHasMore(page.hasMore);
+      setNextCursor(page.nextCursor);
     } catch (error) {
       console.error("Error fetching messages:", error);
       setError("Failed to load feed. Please refresh.");
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [loadFeedPage]);
 
-  // Load messages on mount and poll every 30s while active (replaces onSnapshot)
+  // Load messages on mount and poll every 30s while active (server endpoint,
+  // not onSnapshot, to avoid real-time listener fan-out).
   useEffect(() => {
-    if (!isActive || !db) return;
-    fetchMessages();
+    if (!isActive) return;
+    const timeout = window.setTimeout(() => {
+      void fetchMessages();
+    }, 0);
     const interval = setInterval(fetchMessages, 30_000);
-    return () => clearInterval(interval);
+    return () => {
+      window.clearTimeout(timeout);
+      clearInterval(interval);
+    };
   }, [isActive, fetchMessages]);
 
   // Load more messages using cursor-based pagination
   const loadMore = useCallback(async () => {
-    if (!db || !lastDocRef.current || loadingMore || !hasMore) return;
+    if (!nextCursor || loadingMore || !hasMore) return;
 
     setLoadingMore(true);
     try {
-      const messagesRef = collection(db, "communityMessages");
-      const q = query(
-        messagesRef,
-        orderBy("createdAt", "desc"),
-        startAfter(lastDocRef.current),
-        limit(PAGE_SIZE)
-      );
-      const snapshot = await getDocs(q);
-      const olderMessages = snapshot.docs
-        .map((d) => ({
-          id: d.id,
-          ...d.data(),
-        } as Message))
-        .filter((msg) => !msg.parentId);
+      const params = new URLSearchParams({
+        cursor: nextCursor,
+        limit: String(PAGE_SIZE),
+      });
+      const page = await loadFeedPage(params);
 
       setMessages((prev) => {
         const existingIds = new Set(prev.map((m) => m.id));
-        const deduped = olderMessages.filter((m) => !existingIds.has(m.id));
+        const deduped = page.messages.filter((m) => !existingIds.has(m.id));
         return [...prev, ...deduped];
       });
-      setHasMore(snapshot.docs.length === PAGE_SIZE);
-      lastDocRef.current = snapshot.docs[snapshot.docs.length - 1] ?? null;
+      setHasMore(page.hasMore);
+      setNextCursor(page.nextCursor);
     } catch (error) {
       console.error("Error loading more messages:", error);
       setError("Failed to load more messages.");
     } finally {
       setLoadingMore(false);
     }
-  }, [loadingMore, hasMore]);
+  }, [loadingMore, hasMore, loadFeedPage, nextCursor]);
 
   const visibleMessageIdsKey = useMemo(
     () => [...messages.map((m) => m.id)].sort().join("\0"),
@@ -117,12 +146,15 @@ export function useFeed(user: User | null, isActive: boolean) {
   // Reactions for visible feed messages only (bounded reads vs. full user history scan).
   useEffect(() => {
     if (!isActive || !user) {
-      if (!user) setUserReactions({});
+      if (!user) {
+        const timeout = window.setTimeout(() => setUserReactions({}), 0);
+        return () => window.clearTimeout(timeout);
+      }
       return;
     }
     if (messages.length === 0) {
-      setUserReactions({});
-      return;
+      const timeout = window.setTimeout(() => setUserReactions({}), 0);
+      return () => window.clearTimeout(timeout);
     }
 
     (async () => {
@@ -140,6 +172,7 @@ export function useFeed(user: User | null, isActive: boolean) {
         console.error("Error fetching reactions:", error);
       }
     })();
+    return undefined;
     // `visibleMessageIdsKey` is derived from `messages` and limits refetches to id-set changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: deps via visibleMessageIdsKey
   }, [isActive, user, visibleMessageIdsKey]);
@@ -308,26 +341,17 @@ export function useFeed(user: User | null, isActive: boolean) {
 
   // Fetch replies for a message
   const fetchReplies = useCallback(async (parentId: string) => {
-    if (!db) return;
-    
     try {
-      const messagesRef = collection(db, "communityMessages");
-      const q = query(
-        messagesRef,
-        where("parentId", "==", parentId),
-        orderBy("createdAt", "asc"),
-        limit(100)
-      );
-      const snapshot = await getDocs(q);
-      const replies = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-      })) as Message[];
-      setMessageReplies((prev) => ({ ...prev, [parentId]: replies }));
+      const params = new URLSearchParams({
+        parentId,
+        limit: "100",
+      });
+      const page = await loadFeedPage(params);
+      setMessageReplies((prev) => ({ ...prev, [parentId]: page.messages }));
     } catch (error) {
       console.error("Error fetching replies:", error);
     }
-  }, []);
+  }, [loadFeedPage]);
 
   // Toggle reply expansion
   const toggleReplies = useCallback((messageId: string) => {

--- a/lib/api-schemas/community.ts
+++ b/lib/api-schemas/community.ts
@@ -102,6 +102,14 @@ const MyReactionsQuery = z.object({
     .describe("Comma-separated message ids, up to 60"),
 });
 
+const FeedQuery = PaginationQuerySchema.extend({
+  parentId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Optional parent message id. Omit for top-level feed messages."),
+});
+
 const ModerateQuery = PaginationQuerySchema.extend({
   status: z.string().optional().describe("Filter status; default 'open', or 'all'"),
 });
@@ -140,6 +148,36 @@ const MyReactionsResponse = z.object({
   reactions: z.record(z.string(), z.enum(["like", "dislike"])),
 });
 
+const FeedMessage = z
+  .object({
+    id: z.string(),
+    content: z.string(),
+    authorId: z.string(),
+    authorName: z.string(),
+    authorPhoto: z.string().nullable(),
+    createdAt: z.string(),
+    parentId: z.string().optional(),
+    repostOf: z
+      .object({
+        originalId: z.string(),
+        originalAuthorId: z.string(),
+        originalAuthorName: z.string(),
+        originalContent: z.string(),
+      })
+      .optional(),
+    likeCount: z.number().optional(),
+    dislikeCount: z.number().optional(),
+    replyCount: z.number().optional(),
+    repostCount: z.number().optional(),
+    bookmarkCount: z.number().optional(),
+  })
+  .openapi("CommunityFeedMessage");
+
+const FeedResponse = z
+  .object({ messages: z.array(FeedMessage) })
+  .merge(PaginationFieldsSchema)
+  .openapi("CommunityFeedResponse");
+
 // ──────────────────── Contract ────────────────────
 
 export const communityContract = c.router(
@@ -161,6 +199,21 @@ export const communityContract = c.router(
           "NOT_CONFIGURED",
         ] as const,
       },
+    },
+    feed: {
+      method: "GET",
+      path: "/api/community/feed",
+      summary: "List visible community feed messages",
+      description:
+        "Returns top-level messages or replies after applying hidden-message, suspended-author, and viewer block filters.",
+      query: FeedQuery,
+      responses: {
+        200: FeedResponse,
+        400: ApiErrorSchema.openapi({ description: "Validation error" }),
+        429: RateLimitedErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: { errorCodes: ["VALIDATION_ERROR", "RATE_LIMITED", "SERVER_ERROR"] as const },
     },
     createReply: {
       method: "POST",


### PR DESCRIPTION
## Summary
- Add `/api/community/feed` so feed reads go through the server before reaching the browser
- Apply the existing P1 follow-up from `app/api/community/block/route.ts` and `app/api/community/moderate/route.ts`: hide blocked authors, hidden messages, and suspended authors from feed results
- Move the client feed hook off direct `communityMessages` reads while preserving polling, replies, and cursor-based load more
- Add the new feed route to the community API contract so OpenAPI generation includes it

## Validation
- `npm test -- --runTestsByPath __tests__/components/feed/MessageCard.test.tsx __tests__/components/feed/ReplyCard.test.tsx __tests__/components/feed/CommunityFeed.test.tsx __tests__/app/api/community/feed.test.ts --runInBand`
- `npm run type-check`
- `npx eslint app/api/community/feed/route.ts hooks/useFeed.ts lib/api-schemas/community.ts __tests__/app/api/community/feed.test.ts --max-warnings=0`
- `npm run generate:openapi`
- `git diff --check origin/develop..HEAD`

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)