### PR TITLE
feat: add route loading skeletons

### DIFF
--- a/__tests__/app/loading-pages.test.tsx
+++ b/__tests__/app/loading-pages.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import MembersLoading from "@/app/members/loading";
+import QuestionsLoading from "@/app/questions/loading";
+import CookbookLoading from "@/app/cookbook/loading";
+
+describe("route loading skeletons", () => {
+  it("renders the members loading route with member card placeholders", () => {
+    render(<MembersLoading />);
+
+    expect(screen.getAllByLabelText("Loading member card")).toHaveLength(6);
+  });
+
+  it("renders the questions loading route with a question list skeleton", () => {
+    const { container } = render(<QuestionsLoading />);
+
+    expect(screen.getByRole("status", { name: "Loading questions" })).toBeInTheDocument();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("renders the cookbook loading route with entry card placeholders", () => {
+    const { container } = render(<CookbookLoading />);
+
+    expect(
+      screen.getByRole("status", { name: "Loading cookbook entries" })
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThanOrEqual(30);
+  });
+});

--- a/app/cookbook/loading.tsx
+++ b/app/cookbook/loading.tsx
@@ -1,0 +1,12 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { CookbookPageSkeleton } from "@/components/skeletons/CookbookPageSkeleton";
+
+export default function Loading() {
+  return <CookbookPageSkeleton />;
+}

--- a/app/cookbook/page.tsx
+++ b/app/cookbook/page.tsx
@@ -17,6 +17,7 @@ import { CookbookEntries } from "@/components/cookbook/CookbookEntries";
 import { EntryDetailModal } from "@/components/cookbook/EntryDetailModal";
 import { SubmitForm } from "@/components/cookbook/SubmitForm";
 import { SectionHelp } from "@/components/SectionHelp";
+import { CookbookEntryCardsSkeleton } from "@/components/skeletons/CookbookPageSkeleton";
 
 type CookbookSort = "newest" | "oldest" | "top";
 
@@ -419,9 +420,7 @@ export default function CookbookPage() {
             </div>
 
             {loading ? (
-              <div className="flex items-center justify-center py-20">
-                <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-emerald-500" />
-              </div>
+              <CookbookEntryCardsSkeleton count={6} />
             ) : showFilteredEmpty ? (
               <div className="text-center py-20">
                 <p className="text-neutral-600 dark:text-neutral-400 text-lg">

--- a/app/members/loading.tsx
+++ b/app/members/loading.tsx
@@ -1,0 +1,12 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { MembersPageSkeleton } from "@/components/skeletons/MembersPageSkeleton";
+
+export default function Loading() {
+  return <MembersPageSkeleton />;
+}

--- a/app/questions/loading.tsx
+++ b/app/questions/loading.tsx
@@ -1,0 +1,12 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { QuestionsPageSkeleton } from "@/components/skeletons/QuestionsPageSkeleton";
+
+export default function Loading() {
+  return <QuestionsPageSkeleton />;
+}

--- a/components/questions/QuestionsListing.tsx
+++ b/components/questions/QuestionsListing.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import Link from "next/link";
 import { Search, Plus, Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { QuestionCardsSkeleton } from "@/components/skeletons/QuestionsPageSkeleton";
 import type { Question, QuestionSort, VoteType } from "@/types/questions";
 import { QuestionCard } from "./QuestionCard";
 import { TagFilter } from "./TagFilter";
@@ -203,9 +204,7 @@ export function QuestionsListing() {
 
       {/* Question list */}
       {loading ? (
-        <div className="flex justify-center py-12">
-          <Loader2 size={24} className="animate-spin text-neutral-400" />
-        </div>
+        <QuestionCardsSkeleton />
       ) : questions.length === 0 ? (
         <div className="text-center py-16 px-4 border border-neutral-200 dark:border-neutral-800 rounded-xl border-dashed">
           {search || tag ? (

--- a/components/skeletons/CookbookPageSkeleton.tsx
+++ b/components/skeletons/CookbookPageSkeleton.tsx
@@ -1,0 +1,136 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { Skeleton } from "@/components/ui/Skeleton";
+
+function CookbookHeroSkeleton() {
+  return (
+    <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800 bg-gradient-to-b from-transparent via-neutral-50/50 dark:via-neutral-950/30 to-transparent">
+      <div className="max-w-4xl mx-auto text-center">
+        <Skeleton className="h-7 w-40 mx-auto mb-6 rounded-full" />
+        <Skeleton className="h-12 w-full max-w-xl mx-auto mb-6" />
+        <Skeleton className="h-5 w-full max-w-2xl mx-auto mb-2" />
+        <Skeleton className="h-5 w-3/4 max-w-xl mx-auto" />
+      </div>
+    </section>
+  );
+}
+
+function CookbookHelpSkeleton() {
+  return (
+    <div className="px-6 py-6 max-w-4xl mx-auto w-full">
+      <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-5">
+        <Skeleton className="h-6 w-52 mb-3" />
+        <Skeleton className="h-4 w-full mb-2" />
+        <Skeleton className="h-4 w-4/5 mb-5" />
+        <div className="grid gap-3 sm:grid-cols-3">
+          {[1, 2, 3].map((item) => (
+            <div key={item} className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-3">
+              <Skeleton className="h-4 w-24 mb-2" />
+              <Skeleton className="h-3 w-full mb-1" />
+              <Skeleton className="h-3 w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SubmitPanelSkeleton() {
+  return (
+    <section className="px-6 py-10 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950/50">
+      <div className="max-w-6xl mx-auto">
+        <div className="bg-white dark:bg-neutral-900 rounded-2xl border border-neutral-200 dark:border-neutral-800 p-6 md:p-8">
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-12 w-12 rounded-xl shrink-0" />
+            <div className="flex-1 min-w-0">
+              <Skeleton className="h-7 w-56 mb-2" />
+              <Skeleton className="h-4 w-80 max-w-full" />
+            </div>
+            <Skeleton className="h-6 w-6 shrink-0" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CookbookFiltersSkeleton() {
+  return (
+    <aside className="lg:w-56 shrink-0">
+      <div className="sticky top-24 space-y-6 p-5 rounded-xl bg-neutral-100 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800">
+        {[1, 2, 3].map((item) => (
+          <div key={item}>
+            <Skeleton className="h-4 w-24 mb-2" />
+            <Skeleton className="h-10 w-full rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+export function CookbookEntryCardsSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading cookbook entries"
+      className="grid sm:grid-cols-2 gap-6"
+    >
+      {Array.from({ length: count }, (_, index) => (
+        <div
+          key={index}
+          className="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5"
+        >
+          <div className="flex items-center justify-between gap-3 mb-4">
+            <Skeleton className="h-6 w-24 rounded-full" />
+            <Skeleton className="h-5 w-16" />
+          </div>
+          <Skeleton className="h-6 w-4/5 mb-3" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-5/6 mb-5" />
+          <div className="flex flex-wrap gap-2 mb-5">
+            <Skeleton className="h-6 w-20 rounded-full" />
+            <Skeleton className="h-6 w-24 rounded-full" />
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-9 w-24 rounded-lg" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function CookbookPageSkeleton() {
+  return (
+    <div className="flex flex-col">
+      <CookbookHeroSkeleton />
+      <CookbookHelpSkeleton />
+      <SubmitPanelSkeleton />
+      <section className="py-12 md:py-16 px-6">
+        <div className="max-w-6xl mx-auto flex flex-col lg:flex-row gap-8">
+          <CookbookFiltersSkeleton />
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+              <div className="space-y-2">
+                <Skeleton className="h-9 w-56" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              <Skeleton className="h-10 w-40 rounded-lg" />
+            </div>
+            <CookbookEntryCardsSkeleton />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/skeletons/QuestionsPageSkeleton.tsx
+++ b/components/skeletons/QuestionsPageSkeleton.tsx
@@ -1,0 +1,96 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { Skeleton } from "@/components/ui/Skeleton";
+
+function SectionHelpSkeleton() {
+  return (
+    <div className="mb-8 rounded-xl border border-neutral-200 dark:border-neutral-800 p-5">
+      <Skeleton className="h-6 w-44 mb-3" />
+      <Skeleton className="h-4 w-full max-w-2xl mb-2" />
+      <Skeleton className="h-4 w-3/4 max-w-xl mb-5" />
+      <div className="grid gap-3 sm:grid-cols-3">
+        {[1, 2, 3].map((item) => (
+          <div key={item} className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-3">
+            <Skeleton className="h-4 w-28 mb-2" />
+            <Skeleton className="h-3 w-full mb-1" />
+            <Skeleton className="h-3 w-4/5" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function QuestionControlsSkeleton() {
+  return (
+    <div className="mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-80 max-w-full" />
+        </div>
+        <Skeleton className="h-10 w-32 rounded-lg" />
+      </div>
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <Skeleton className="h-10 flex-1 rounded-lg" />
+        <Skeleton className="h-10 w-full sm:w-40 rounded-lg" />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {[1, 2, 3, 4].map((item) => (
+          <Skeleton key={item} className="h-8 w-24 rounded-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function QuestionCardsSkeleton() {
+  return (
+    <div role="status" aria-label="Loading questions" className="space-y-3">
+      {[1, 2, 3, 4].map((item) => (
+        <div
+          key={item}
+          className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-4"
+        >
+          <div className="flex gap-4">
+            <div className="flex flex-col items-center gap-2">
+              <Skeleton className="h-6 w-8" />
+              <Skeleton className="h-6 w-8" />
+              <Skeleton className="h-4 w-8" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <Skeleton className="h-5 w-3/4 mb-3" />
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-5/6 mb-4" />
+              <div className="flex flex-wrap gap-2 mb-4">
+                <Skeleton className="h-6 w-20 rounded-full" />
+                <Skeleton className="h-6 w-24 rounded-full" />
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function QuestionsPageSkeleton() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
+      <SectionHelpSkeleton />
+      <QuestionControlsSkeleton />
+      <QuestionCardsSkeleton />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add route loading skeletons for members, questions, and cookbook pages
- reuse question and cookbook card skeletons during client-side fetch loading

## Tests
- npm test -- --runTestsByPath __tests__/app/loading-pages.test.tsx __tests__/components/skeletons/Skeletons.test.tsx __tests__/components/questions/QuestionsListing.test.tsx __tests__/app/cookbook/page.test.tsx
- npm run type-check
- npx eslint app/members/loading.tsx app/questions/loading.tsx app/cookbook/loading.tsx components/skeletons/QuestionsPageSkeleton.tsx components/skeletons/CookbookPageSkeleton.tsx components/questions/QuestionsListing.tsx app/cookbook/page.tsx __tests__/app/loading-pages.test.tsx
- git diff --check

Closes #557

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)