### PR TITLE
fix: declare sizes on next images

### DIFF
--- a/__tests__/app/next-image-sizes-audit.test.ts
+++ b/__tests__/app/next-image-sizes-audit.test.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment node
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const SOURCE_DIRS = ["app", "components"];
+const IMAGE_TAG_RE = /<Image\b[\s\S]*?\/>/g;
+
+function listTsxFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) return listTsxFiles(fullPath);
+    return fullPath.endsWith(".tsx") ? [fullPath] : [];
+  });
+}
+
+function importsNextImage(source: string): boolean {
+  return source.includes('"next/image"') || source.includes("'next/image'");
+}
+
+describe("next/image sizing audit", () => {
+  it("declares sizes on every next/image component usage", () => {
+    const violations = SOURCE_DIRS.flatMap((dir) => listTsxFiles(dir)).flatMap(
+      (filePath) => {
+        const source = readFileSync(filePath, "utf8");
+        if (!importsNextImage(source)) return [];
+        return [...source.matchAll(IMAGE_TAG_RE)]
+          .filter((match) => !/\ssizes\s*=/.test(match[0]))
+          .map((match) => `${filePath}:${source.slice(0, match.index).split("\n").length}`);
+      }
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/app/(auth)/profile/_components/EditProfileModal.tsx
+++ b/app/(auth)/profile/_components/EditProfileModal.tsx
@@ -114,7 +114,14 @@ export function EditProfileModal({ user, onSave, onClose }: EditProfileModalProp
           <div className="flex items-center gap-4">
             <div className="shrink-0">
               {photoPreview ? (
-                <Image src={photoPreview} alt="Preview" width={80} height={80} className="rounded-full object-cover w-20 h-20" />
+                <Image
+                  src={photoPreview}
+                  alt="Preview"
+                  width={80}
+                  height={80}
+                  sizes="80px"
+                  className="rounded-full object-cover w-20 h-20"
+                />
               ) : (
                 <Avatar src={user.photoURL} name={user.displayName} email={user.email} size="lg" />
               )}

--- a/app/(auth)/profile/_components/OverviewTab.tsx
+++ b/app/(auth)/profile/_components/OverviewTab.tsx
@@ -112,7 +112,14 @@ export function OverviewTab({
                 <div key={agent.id} className="flex items-center gap-4 p-4 bg-neutral-800/50 rounded-xl">
                   <div className="w-12 h-12 rounded-full bg-purple-500/20 flex items-center justify-center shrink-0">
                     {agent.avatarUrl ? (
-                      <Image src={agent.avatarUrl} alt={agent.name} width={48} height={48} className="rounded-full" />
+                      <Image
+                        src={agent.avatarUrl}
+                        alt={agent.name}
+                        width={48}
+                        height={48}
+                        sizes="48px"
+                        className="rounded-full"
+                      />
                     ) : (
                       <UserCardIcon size={24} className="text-purple-400" />
                     )}

--- a/app/(auth)/profile/_components/SecurityTab.tsx
+++ b/app/(auth)/profile/_components/SecurityTab.tsx
@@ -257,7 +257,14 @@ export function SecurityTab({
                   <div key={agent.id} className="flex items-center gap-3 p-3 bg-neutral-800/50 rounded-lg">
                     <div className="w-8 h-8 rounded-full bg-purple-500/20 flex items-center justify-center shrink-0">
                       {agent.avatarUrl ? (
-                        <Image src={agent.avatarUrl} alt={agent.name} width={32} height={32} className="rounded-full" />
+                        <Image
+                          src={agent.avatarUrl}
+                          alt={agent.name}
+                          width={32}
+                          height={32}
+                          sizes="32px"
+                          className="rounded-full"
+                        />
                       ) : (
                         <AgentIcon className="text-purple-400 w-4 h-4" />
                       )}

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -272,6 +272,7 @@ export default async function EventPage({
               fill
               className="object-contain"
               priority
+              sizes="(max-width: 1023px) 100vw, 50vw"
             />
             {/* QR Code */}
             <div className="absolute bottom-4 right-4 w-24 h-24 bg-white p-1 rounded-lg shadow-lg">
@@ -280,6 +281,7 @@ export default async function EventPage({
                 alt="Scan to register"
                 fill
                 className="object-contain"
+                sizes="96px"
               />
             </div>
           </div>
@@ -620,6 +622,7 @@ export default async function EventPage({
                         alt={speaker.name}
                         fill
                         className="object-cover"
+                        sizes="96px"
                       />
                     </div>
                   )}
@@ -774,6 +777,7 @@ export default async function EventPage({
                     alt={sponsor.name}
                     width={120}
                     height={60}
+                    sizes="120px"
                     className="object-contain opacity-80 hover:opacity-100 transition-opacity"
                   />
                 </a>

--- a/app/live/[sessionId]/emcee/page.tsx
+++ b/app/live/[sessionId]/emcee/page.tsx
@@ -328,6 +328,7 @@ export default function EmceeLiveSessionPage({
                   alt="QR code for audience live queue"
                   width={224}
                   height={224}
+                  sizes="224px"
                   unoptimized
                   className="mx-auto h-56 w-56"
                 />

--- a/app/showcase/page.tsx
+++ b/app/showcase/page.tsx
@@ -966,6 +966,7 @@ function ProjectCard({
             alt={project.name}
             fill
             className="object-cover"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             onError={() => setImgError(true)}
           />
         ) : (

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -108,6 +108,7 @@ export default function Avatar({
         alt={name || "Profile"}
         width={px}
         height={px}
+        sizes={`${px}px`}
         className={`rounded-full object-cover ${boxClass} ${className}`.trim()}
         style={boxStyle}
         onError={() => setImgError(true)}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -271,6 +271,7 @@ export default function Footer() {
                     alt="Gauntlet"
                     width={32}
                     height={32}
+                    sizes="32px"
                     className="object-contain"
                   />
                 </div>

--- a/components/events/EventsBrowse.tsx
+++ b/components/events/EventsBrowse.tsx
@@ -230,6 +230,7 @@ function FeaturedEventCard({ event }: { event: Event }) {
               alt="Scan to register"
               fill
               className="object-contain"
+              sizes="(max-width: 768px) 15vw, 96px"
             />
           </div>
         </div>

--- a/docs/NEXT_IMAGE_AUDIT.md
+++ b/docs/NEXT_IMAGE_AUDIT.md
@@ -1,0 +1,41 @@
+<!--
+SPDX-License-Identifier: GPL-3.0-only
+Copyright (C) 2026 Cursor Boston
+This file is part of Cursor Boston, licensed under GPL-3.0.
+See LICENSE file for details.
+-->
+
+# Next/Image Optimization Audit
+
+This audit covers `next/image` usage under `app/` and `components/`.
+
+## Policy
+
+- Every `next/image` component declares `sizes`.
+- `fill` images use responsive viewport sizes that match their layout columns.
+- Fixed-size icons, avatars, logos, QR codes, and sponsor marks use exact pixel `sizes`.
+- Only above-the-fold brand or event hero images should use `priority`.
+- Other images rely on the Next.js default lazy loading behavior.
+
+## Inventory
+
+| Surface | Image usage | Sizing |
+| --- | --- | --- |
+| `components/Logo.tsx` | Header, footer, and hero logo | Existing exact logo sizes |
+| `components/Avatar.tsx` | Member profile avatars | Exact resolved avatar pixel size |
+| `components/Footer.tsx` | Gauntlet sponsor mark | `32px` |
+| `components/events/EventsBrowse.tsx` | Featured event art | Existing responsive column sizes |
+| `components/events/EventsBrowse.tsx` | Luma QR overlay | Mobile viewport overlay size, capped near `96px` |
+| `app/events/[slug]/page.tsx` | Event hero art | Full width on mobile, half viewport on desktop |
+| `app/events/[slug]/page.tsx` | Luma QR overlay | `96px` |
+| `app/events/[slug]/page.tsx` | Speaker headshots | `96px` |
+| `app/events/[slug]/page.tsx` | Sponsor logos | `120px` |
+| `app/showcase/page.tsx` | Project cards | One, two, or three columns by breakpoint |
+| `app/live/[sessionId]/emcee/page.tsx` | Live-session QR code | `224px` |
+| Profile agent/previews | Avatar and preview images | Exact rendered pixel sizes |
+
+## Regression Guard
+
+`__tests__/app/next-image-sizes-audit.test.ts` scans `app/` and
+`components/` for `next/image` usage and fails if any `<Image />` is missing a
+`sizes` prop.


### PR DESCRIPTION
## Summary
- declare responsive sizes on event and showcase fill images
- declare exact sizes on fixed avatar, QR, logo, and sponsor image uses
- add a next/image audit doc and Jest guard for missing sizes props

## Tests
- npm test -- --runTestsByPath __tests__/app/next-image-sizes-audit.test.ts __tests__/components/events/EventsBrowse.test.tsx __tests__/app/showcase/page.test.tsx __tests__/app/events/slug-page.test.tsx __tests__/components/ui/Avatar.test.tsx __tests__/components/Footer.test.tsx __tests__/app/live/emcee-page.test.tsx __tests__/app/profile/OverviewTab.test.tsx __tests__/app/profile/EditProfileModal.test.tsx __tests__/app/profile/security-tab.test.tsx
- npm run type-check
- npx eslint components/Avatar.tsx components/Footer.tsx components/events/EventsBrowse.tsx app/events/[slug]/page.tsx app/live/[sessionId]/emcee/page.tsx app/(auth)/profile/_components/EditProfileModal.tsx app/(auth)/profile/_components/OverviewTab.tsx app/(auth)/profile/_components/SecurityTab.tsx app/showcase/page.tsx __tests__/app/next-image-sizes-audit.test.ts
- git diff --check

Closes #568

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)