### PR TITLE
feat: extract community post mentions

### DIFF
--- a/__tests__/app/api/community/post.test.ts
+++ b/__tests__/app/api/community/post.test.ts
@@ -51,6 +51,13 @@ function makeRequest(body: Record<string, unknown>) {
 }
 
 const validContent = "A".repeat(150);
+const padContent = (content: string) => `${content} ${"A".repeat(120)}`;
+
+async function expectStoredPostFor(content: string) {
+  const res = await POST(makeRequest({ content }));
+  expect(res.status).toBe(200);
+  return mockSet.mock.calls[mockSet.mock.calls.length - 1]?.[0] as Record<string, unknown>;
+}
 
 describe("POST /api/community/post", () => {
   beforeEach(() => {
@@ -99,6 +106,7 @@ describe("POST /api/community/post", () => {
     expect(mockSet).toHaveBeenCalledWith(
       expect.objectContaining({
         content: validContent,
+        mentions: [],
         authorId: "u1",
         authorName: "Test User",
         likeCount: 0,
@@ -121,6 +129,53 @@ describe("POST /api/community/post", () => {
         content: htmlContent,
       })
     );
+  });
+
+  it("stores valid mentions as normalized Firestore-queryable handles", async () => {
+    const stored = await expectStoredPostFor(
+      padContent("Shipping this with @Alice and @bob_2 for review.")
+    );
+
+    expect(stored.mentions).toEqual(["alice", "bob_2"]);
+  });
+
+  it("deduplicates repeated mentions case-insensitively", async () => {
+    const stored = await expectStoredPostFor(
+      padContent("Looping in @ALICE, @alice, and @Alice again for visibility.")
+    );
+
+    expect(stored.mentions).toEqual(["alice"]);
+  });
+
+  it("ignores invalid mention syntax and email addresses", async () => {
+    const stored = await expectStoredPostFor(
+      padContent("Invalid handles: @a @bad-handle contact alice@example.com and @ok_name.")
+    );
+
+    expect(stored.mentions).toEqual(["ok_name"]);
+  });
+
+  it("does not store XSS-looking mention payloads as executable metadata", async () => {
+    const stored = await expectStoredPostFor(
+      padContent("Heads up @Alice<script>alert(1)</script> @<img src=x onerror=alert(1)>")
+    );
+
+    expect(stored.content).toContain("<script>alert(1)</script>");
+    expect(stored.mentions).toEqual(["alice"]);
+  });
+
+  it("caps stored mention metadata to keep array-contains queries bounded", async () => {
+    const handles = Array.from({ length: 30 }, (_, index) => `@user_${index}`);
+    const stored = await expectStoredPostFor(padContent(handles.join(" ")));
+
+    expect(stored.mentions).toHaveLength(25);
+    expect(stored.mentions).toEqual(handles.slice(0, 25).map((handle) => handle.slice(1)));
+  });
+
+  it("stores an empty mentions array when content has no valid handles", async () => {
+    const stored = await expectStoredPostFor(validContent);
+
+    expect(stored.mentions).toEqual([]);
   });
 
   it("returns 400 for malformed JSON", async () => {

--- a/app/api/community/post/route.ts
+++ b/app/api/community/post/route.ts
@@ -16,6 +16,7 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { communityContract } from "@/lib/api-schemas/community";
+import { extractCommunityMentions } from "@/lib/community-mentions";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -62,12 +63,14 @@ export async function POST(request: NextRequest) {
       );
     }
     const sanitizedContent = parsed.data.content;
+    const mentions = extractCommunityMentions(sanitizedContent);
 
     const authorName = getDisplayName(user);
 
     const messageRef = db.collection("communityMessages").doc();
     await messageRef.set({
       content: sanitizedContent,
+      mentions,
       authorId: user.uid,
       authorName,
       authorPhoto: user.picture || null,

--- a/lib/community-mentions.ts
+++ b/lib/community-mentions.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+const MENTION_PATTERN = /(^|[^A-Za-z0-9_])@([A-Za-z0-9_]{2,30})(?![A-Za-z0-9_-])/g;
+const MAX_MENTIONS_PER_POST = 25;
+
+/**
+ * Extract normalized mention handles from community post content.
+ *
+ * Handles are stored without the leading `@`, lowercased, deduplicated, and
+ * restricted to ASCII letters, numbers, and underscores so the resulting
+ * Firestore array is safe to query with `array-contains`.
+ */
+export function extractCommunityMentions(content: string): string[] {
+  if (typeof content !== "string" || content.length === 0) return [];
+
+  const mentions: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of content.matchAll(MENTION_PATTERN)) {
+    const handle = match[2]?.toLowerCase();
+    if (!handle || seen.has(handle)) continue;
+
+    seen.add(handle);
+    mentions.push(handle);
+
+    if (mentions.length >= MAX_MENTIONS_PER_POST) break;
+  }
+
+  return mentions;
+}


### PR DESCRIPTION
## Summary
- Add deterministic community post mention extraction for ASCII handles in `@handle` form.
- Store normalized, deduped, capped `mentions` arrays on `communityMessages` documents so Firestore can query them with `array-contains`.
- Add route coverage for valid mentions, duplicates, invalid syntax, email-address false positives, XSS-looking payloads, and no-mention posts.

## Risk / Blast Radius
- Narrow write-path change for `POST /api/community/post`; existing `content` storage and response shape stay unchanged.
- New metadata is additive and bounded to 25 handles per post.

## Verification
- `npm test -- --runTestsByPath __tests__/app/api/community/post.test.ts --runInBand`
- `npm run type-check`
- `npx eslint app/api/community/post/route.ts lib/community-mentions.ts __tests__/app/api/community/post.test.ts --max-warnings=0`
- `git diff --check`

Closes #559.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)