### PR TITLE
feat: track CTA analytics events

### DIFF
--- a/__tests__/app/cta-analytics-instrumentation.test.ts
+++ b/__tests__/app/cta-analytics-instrumentation.test.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+function readSource(path: string): string {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("CTA analytics instrumentation", () => {
+  it("tracks the NeedsWork banner view and all contributor CTAs", () => {
+    const source = readSource("components/NeedsWorkBanner.tsx");
+
+    expect(source).toContain('trackEvent("feature_banner_view"');
+    for (const cta of [
+      "open_source_roadmap",
+      "edit_github",
+      "open_issue",
+      "browse_repo",
+    ]) {
+      expect(source).toContain(`trackCta("${cta}")`);
+    }
+  });
+
+  it("tracks signed-out hackathon auth CTAs", () => {
+    for (const path of [
+      "app/hackathons/hack-a-sprint-2026/signup/page.tsx",
+      "app/hackathons/sports-hack-2026/signup/page.tsx",
+    ]) {
+      const source = readSource(path);
+
+      expect(source).toContain('trackAuthCta("sign_in")');
+      expect(source).toContain('trackAuthCta("create_account")');
+    }
+  });
+
+  it("tracks PR Studio issue-backed launches without issue titles or bodies", () => {
+    const source = readSource("app/pr-ideas/_hooks/useIdeaRuns.ts");
+
+    expect(source).toContain('trackEvent("issue_claimed"');
+    expect(source).toContain("issue_number");
+    expect(source).toContain("label_count");
+    expect(source).not.toContain("issue_title");
+    expect(source).not.toContain("issue_body");
+  });
+});

--- a/__tests__/lib/analytics.test.ts
+++ b/__tests__/lib/analytics.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { logEvent } from "firebase/analytics";
+import {
+  sanitizeAnalyticsProperties,
+  trackEvent,
+} from "@/lib/analytics";
+
+jest.mock("firebase/analytics", () => ({
+  logEvent: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase", () => ({
+  analyticsReady: Promise.resolve({ app: "analytics" }),
+}));
+
+const mockLogEvent = logEvent as jest.MockedFunction<typeof logEvent>;
+
+describe("analytics event tracking", () => {
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(global, "window", {
+      value: {},
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(global, "window", {
+      value: originalWindow,
+      configurable: true,
+    });
+  });
+
+  it("filters PII-shaped keys and unsupported values before logging", () => {
+    const properties = sanitizeAnalyticsProperties({
+      area: "Analytics",
+      cta: "open_issue",
+      issue_number: 592,
+      userId: "uid-123",
+      email: "person@example.com",
+      displayName: "Person",
+      empty: null,
+      unsupported: undefined,
+      finite: Number.POSITIVE_INFINITY,
+      enabled: true,
+    });
+
+    expect(properties).toEqual({
+      area: "Analytics",
+      cta: "open_issue",
+      issue_number: 592,
+      enabled: true,
+    });
+  });
+
+  it("truncates long string properties", () => {
+    const properties = sanitizeAnalyticsProperties({
+      path: "x".repeat(150),
+    });
+
+    expect(properties.path).toHaveLength(120);
+  });
+
+  it("logs events when Firebase Analytics is available in the browser", async () => {
+    await expect(
+      trackEvent("sign_in_cta_click", {
+        surface: "hackathon_signup",
+        event_id: "sports-hack-2026",
+      })
+    ).resolves.toBe(true);
+
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      { app: "analytics" },
+      "sign_in_cta_click",
+      {
+        surface: "hackathon_signup",
+        event_id: "sports-hack-2026",
+      }
+    );
+  });
+
+  it("does not log events during server-side execution", async () => {
+    delete (global as typeof globalThis & { window?: unknown }).window;
+
+    await expect(trackEvent("feature_banner_view")).resolves.toBe(false);
+
+    expect(mockLogEvent).not.toHaveBeenCalled();
+  });
+});

--- a/app/hackathons/hack-a-sprint-2026/signup/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/signup/page.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
+import { trackEvent } from "@/lib/analytics";
 import {
   CURSOR_CREDIT_TOP_N,
 } from "@/lib/hackathon-event-signup";
@@ -90,6 +91,17 @@ export default function HackASprint2026SignupPage() {
 
   const eventId = HACK_A_SPRINT_2026_EVENT_ID;
   const apiUrl = `/api/hackathons/events/${eventId}/signup`;
+
+  const trackAuthCta = (cta: "sign_in" | "create_account") => {
+    void trackEvent(
+      cta === "sign_in" ? "sign_in_cta_click" : "sign_up_cta_click",
+      {
+        cta,
+        event_id: eventId,
+        surface: "hackathon_signup",
+      }
+    );
+  };
 
   // Seed from auth context as soon as userProfile arrives (instant, no API call)
   useEffect(() => {
@@ -381,12 +393,14 @@ export default function HackASprint2026SignupPage() {
                 <Link
                   href={`/login?redirect=${encodeURIComponent("/hackathons/hack-a-sprint-2026/signup")}`}
                   className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+                  onClick={() => trackAuthCta("sign_in")}
                 >
                   Sign in
                 </Link>
                 <Link
                   href={`/signup?redirect=${encodeURIComponent("/hackathons/hack-a-sprint-2026/signup")}`}
                   className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+                  onClick={() => trackAuthCta("create_account")}
                 >
                   Create account
                 </Link>

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
+import { trackEvent } from "@/lib/analytics";
 import {
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
@@ -143,6 +144,17 @@ export default function SportsHack2026SignupPage() {
   const eventId = SPORTS_HACK_2026_EVENT_ID;
   const capacity = SPORTS_HACK_2026_CAPACITY;
   const apiUrl = `/api/hackathons/events/${eventId}/signup`;
+
+  const trackAuthCta = (cta: "sign_in" | "create_account") => {
+    void trackEvent(
+      cta === "sign_in" ? "sign_in_cta_click" : "sign_up_cta_click",
+      {
+        cta,
+        event_id: eventId,
+        surface: "hackathon_signup",
+      }
+    );
+  };
 
   useEffect(() => {
     const fromCtx = profileFromContext(userProfile);
@@ -432,12 +444,14 @@ export default function SportsHack2026SignupPage() {
                 <Link
                   href={`/login?redirect=${encodeURIComponent(`/hackathons/${eventId}/signup`)}`}
                   className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
+                  onClick={() => trackAuthCta("sign_in")}
                 >
                   Sign in
                 </Link>
                 <Link
                   href={`/signup?redirect=${encodeURIComponent(`/hackathons/${eventId}/signup`)}`}
                   className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+                  onClick={() => trackAuthCta("create_account")}
                 >
                   Create account
                 </Link>

--- a/app/pr-ideas/_hooks/useIdeaRuns.ts
+++ b/app/pr-ideas/_hooks/useIdeaRuns.ts
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { User } from "firebase/auth";
+import { trackEvent } from "@/lib/analytics";
 import type { LaunchFormState, CursorIdeaRun, GithubIssueOption, LoadingState } from "../_lib/types";
 import {
   formatIdeaRunsApiError,
@@ -280,6 +281,13 @@ export function useIdeaRuns({ user, cursorConnected }: UseIdeaRunsArgs) {
         setPollFailCount(0);
         setRuns((current) => [body.run!, ...current.filter((run) => run.id !== body.run!.id)]);
         setSelectedRunId(body.run.id);
+        if (ideaForm.mode === "issue" && ideaForm.issue) {
+          void trackEvent("issue_claimed", {
+            issue_number: ideaForm.issue.number,
+            label_count: ideaForm.issue.labels.length,
+            source: "pr_studio",
+          });
+        }
         return body.run;
       } catch {
         setError("Network error while launching the idea explorer.");

--- a/components/NeedsWorkBanner.tsx
+++ b/components/NeedsWorkBanner.tsx
@@ -7,8 +7,10 @@
 
 "use client";
 
+import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { Construction } from "lucide-react";
+import { trackEvent } from "@/lib/analytics";
 import { getEditOnGitHubUrl, getNewIssueUrl, getRepoUrl } from "@/lib/github-edit-link";
 
 /**
@@ -33,6 +35,21 @@ export function NeedsWorkBanner({
   });
   const roadmapUrl = "/open-source";
 
+  useEffect(() => {
+    void trackEvent("feature_banner_view", {
+      area,
+      path: pathname,
+    });
+  }, [area, pathname]);
+
+  const trackCta = (cta: string) => {
+    void trackEvent("feature_banner_cta_click", {
+      area,
+      path: pathname,
+      cta,
+    });
+  };
+
   return (
     <div
       role="note"
@@ -50,16 +67,38 @@ export function NeedsWorkBanner({
             </p>
           ) : null}
           <p className="text-sm text-amber-800 dark:text-amber-300/90 mt-2 flex flex-wrap gap-x-4 gap-y-1">
-            <a className="underline hover:no-underline" href={roadmapUrl}>
+            <a
+              className="underline hover:no-underline"
+              href={roadmapUrl}
+              onClick={() => trackCta("open_source_roadmap")}
+            >
               Open-source roadmap
             </a>
-            <a className="underline hover:no-underline" href={editUrl} target="_blank" rel="noopener noreferrer">
+            <a
+              className="underline hover:no-underline"
+              href={editUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackCta("edit_github")}
+            >
               Edit this page on GitHub
             </a>
-            <a className="underline hover:no-underline" href={issueUrl} target="_blank" rel="noopener noreferrer">
+            <a
+              className="underline hover:no-underline"
+              href={issueUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackCta("open_issue")}
+            >
               Open an issue
             </a>
-            <a className="underline hover:no-underline" href={getRepoUrl()} target="_blank" rel="noopener noreferrer">
+            <a
+              className="underline hover:no-underline"
+              href={getRepoUrl()}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackCta("browse_repo")}
+            >
               Browse the repo
             </a>
           </p>

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -1,0 +1,32 @@
+# Analytics Event Taxonomy
+
+Cursor Boston uses Firebase Analytics for lightweight product instrumentation.
+Client code should emit events through `lib/analytics.ts` so unsupported
+environments, missing Firebase Analytics support, and unsafe properties are
+handled consistently.
+
+## Property Rules
+
+- Do not send email addresses, user ids, display names, phone numbers, tokens,
+  or raw free-form user input.
+- Prefer stable surface names, route paths, event ids, issue numbers, counts,
+  and boolean state.
+- Keep strings short. The shared helper truncates string properties at 120
+  characters and drops PII-shaped keys.
+
+## Events
+
+| Event | Trigger | Required properties | Notes |
+| --- | --- | --- | --- |
+| `feature_banner_view` | A `NeedsWorkBanner` renders. | `area`, `path` | Tracks contributor-improvement banner exposure. |
+| `feature_banner_cta_click` | A `NeedsWorkBanner` link is clicked. | `area`, `path`, `cta` | `cta` is one of `open_source_roadmap`, `edit_github`, `open_issue`, `browse_repo`. |
+| `sign_in_cta_click` | A signed-out user clicks a sign-in CTA. | `surface`, `cta` | Hackathon signup pages also include `event_id`. |
+| `sign_up_cta_click` | A signed-out user clicks a create-account CTA. | `surface`, `cta` | Hackathon signup pages also include `event_id`. |
+| `issue_claimed` | PR Studio successfully launches a run from a GitHub issue. | `source`, `issue_number`, `label_count` | Does not include issue title, body, user id, or user input. |
+
+## Instrumented Surfaces
+
+- `components/NeedsWorkBanner.tsx`: banner view plus four contributor CTAs.
+- `app/hackathons/hack-a-sprint-2026/signup/page.tsx`: sign-in and create-account CTAs.
+- `app/hackathons/sports-hack-2026/signup/page.tsx`: sign-in and create-account CTAs.
+- `app/pr-ideas/_hooks/useIdeaRuns.ts`: successful issue-backed PR Studio launch.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,60 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export type AnalyticsEventName =
+  | "feature_banner_view"
+  | "feature_banner_cta_click"
+  | "issue_claimed"
+  | "sign_in_cta_click"
+  | "sign_up_cta_click";
+
+type AnalyticsPropertyValue = string | number | boolean | null | undefined;
+export type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;
+
+const PII_KEY_PATTERN = /(email|phone|token|uid|user_?id|display_?name)/i;
+const MAX_STRING_PROPERTY_LENGTH = 120;
+
+export function sanitizeAnalyticsProperties(
+  properties: AnalyticsProperties = {}
+): Record<string, string | number | boolean> {
+  const sanitized: Record<string, string | number | boolean> = {};
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (PII_KEY_PATTERN.test(key) || value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === "string") {
+      sanitized[key] = value.slice(0, MAX_STRING_PROPERTY_LENGTH);
+    } else if (typeof value === "number") {
+      if (Number.isFinite(value)) sanitized[key] = value;
+    } else if (typeof value === "boolean") {
+      sanitized[key] = value;
+    }
+  }
+
+  return sanitized;
+}
+
+export async function trackEvent(
+  eventName: AnalyticsEventName,
+  properties: AnalyticsProperties = {}
+): Promise<boolean> {
+  if (typeof window === "undefined") return false;
+
+  try {
+    const [{ logEvent }, { analyticsReady }] = await Promise.all([
+      import("firebase/analytics"),
+      import("@/lib/firebase"),
+    ]);
+    const analytics = await analyticsReady;
+    if (!analytics) return false;
+    logEvent(analytics, eventName, sanitizeAnalyticsProperties(properties));
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a client-safe Firebase Analytics wrapper that filters PII-shaped properties before logging.
- Track NeedsWorkBanner view/clicks, hackathon signup sign-in/create-account CTAs, and PR Studio issue-backed launches.
- Document the event taxonomy and add regression tests for helper behavior plus CTA instrumentation coverage.

## Tests
- `npm test -- --runTestsByPath __tests__/lib/analytics.test.ts __tests__/app/cta-analytics-instrumentation.test.ts`
- `npm run type-check`
- `npx eslint lib/analytics.ts components/NeedsWorkBanner.tsx app/hackathons/hack-a-sprint-2026/signup/page.tsx app/hackathons/sports-hack-2026/signup/page.tsx app/pr-ideas/_hooks/useIdeaRuns.ts __tests__/lib/analytics.test.ts __tests__/app/cta-analytics-instrumentation.test.ts` (passes with pre-existing react-hooks warnings in the Hack-a-Sprint signup page)
- `git diff --check`

Closes #592.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
