### PR TITLE
refactor: share eligibility threshold helpers

### DIFF
--- a/__tests__/lib/badges/eligibility.test.ts
+++ b/__tests__/lib/badges/eligibility.test.ts
@@ -2,6 +2,7 @@ import {
   normalizeBadgeEligibilityInput,
   evaluateBadgeEligibility,
 } from "@/lib/badges/eligibility";
+import { checkPullRequestThreshold } from "@/lib/eligibility-base";
 
 describe("badge eligibility", () => {
   describe("normalizeBadgeEligibilityInput", () => {
@@ -111,11 +112,21 @@ describe("badge eligibility", () => {
   });
 
   describe("contributor", () => {
-    it("is eligible at 1 pull request and has no reason when eligible", () => {
+    it("is eligible at 1 pull request and matches the base PR threshold", () => {
       const result = evaluateBadgeEligibility({ pullRequestsCount: 1 });
+      const threshold = checkPullRequestThreshold({
+        pullRequestsCount: 1,
+        target: 1,
+        reason: "Get at least 1 pull request merged to this repo.",
+      });
 
       expect(result.contributor.isEligible).toBe(true);
       expect(result.contributor.reason).toBeUndefined();
+      expect(result.contributor.progress).toEqual({
+        current: threshold.current,
+        target: threshold.target,
+        unit: "pull requests",
+      });
     });
   });
 

--- a/__tests__/lib/eligibility-base.test.ts
+++ b/__tests__/lib/eligibility-base.test.ts
@@ -1,0 +1,87 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  checkCountThreshold,
+  checkEventMembership,
+  checkPullRequestThreshold,
+} from "@/lib/eligibility-base";
+
+describe("eligibility-base", () => {
+  describe("checkCountThreshold", () => {
+    it("caps progress at the threshold and omits the reason when eligible", () => {
+      expect(
+        checkCountThreshold({
+          current: 5,
+          target: 3,
+          reason: "too_low",
+        }),
+      ).toEqual({
+        isEligible: true,
+        current: 3,
+        target: 3,
+        reason: undefined,
+      });
+    });
+
+    it("returns the failure reason when the threshold is not met", () => {
+      expect(
+        checkCountThreshold({
+          current: 2,
+          target: 3,
+          reason: "too_low",
+        }),
+      ).toEqual({
+        isEligible: false,
+        current: 2,
+        target: 3,
+        reason: "too_low",
+      });
+    });
+  });
+
+  describe("checkPullRequestThreshold", () => {
+    it("delegates pull request counts through the shared threshold shape", () => {
+      expect(
+        checkPullRequestThreshold({
+          pullRequestsCount: 1,
+          target: 1,
+          reason: "not_submitted",
+        }),
+      ).toEqual({
+        isEligible: true,
+        current: 1,
+        target: 1,
+        reason: undefined,
+      });
+    });
+  });
+
+  describe("checkEventMembership", () => {
+    it("checks signup, check-in, and confirmation gates in order", () => {
+      expect(checkEventMembership({ exists: false })).toEqual({
+        ok: false,
+        reason: "not_signed_up",
+      });
+      expect(
+        checkEventMembership({
+          exists: true,
+          confirmedAt: new Date("2026-05-01T00:00:00Z"),
+          rank: 1,
+        }),
+      ).toEqual({ ok: false, reason: "not_checked_in" });
+      expect(
+        checkEventMembership({
+          exists: true,
+          checkedInAt: new Date("2026-05-01T00:00:00Z"),
+          confirmedAt: new Date("2026-05-01T00:00:00Z"),
+          rank: 7,
+        }),
+      ).toEqual({ ok: true, rank: 7 });
+    });
+  });
+});

--- a/__tests__/lib/hackathon-asprint-2026-credit-eligibility.test.ts
+++ b/__tests__/lib/hackathon-asprint-2026-credit-eligibility.test.ts
@@ -23,6 +23,10 @@ jest.mock("@/lib/hackathon-event-signup", () => ({
 }));
 
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
+import {
+  checkEventMembership,
+  checkPullRequestThreshold,
+} from "@/lib/eligibility-base";
 import { makeDoc, makeFakeDb } from "@/__tests__/_helpers/firebase-admin-mock";
 
 beforeEach(() => {
@@ -87,7 +91,13 @@ describe("resolveHackASprint2026CreditForUser", () => {
       user: { github: { login: "u1" } },
     });
     const out = await resolveHackASprint2026CreditForUser(db, "u1");
-    expect(out).toEqual({ ok: false, reason: "not_checked_in" });
+    const membership = checkEventMembership({
+      exists: true,
+      confirmedAt: new Date(),
+      rank: 1,
+    });
+
+    expect(out).toEqual(membership);
   });
 
   it("bypasses the check-in gate when the user is a judge-exception", async () => {
@@ -140,7 +150,13 @@ describe("resolveHackASprint2026CreditForUser", () => {
       user: { github: { login: "u1" } },
     });
     const out = await resolveHackASprint2026CreditForUser(db, "u1");
-    expect(out).toEqual({ ok: false, reason: "not_submitted" });
+    const threshold = checkPullRequestThreshold({
+      pullRequestsCount: 0,
+      target: 1,
+      reason: "not_submitted",
+    });
+
+    expect(out).toEqual({ ok: false, reason: threshold.reason });
     expect(mockHasMergedPR).toHaveBeenCalledWith("u1");
   });
 

--- a/lib/badges/eligibility.ts
+++ b/lib/badges/eligibility.ts
@@ -6,6 +6,11 @@
  */
 
 import type { BadgeEligibilityInput, BadgeEligibilityMap } from "./types";
+import {
+  checkCountThreshold,
+  checkPullRequestThreshold,
+  type ThresholdEligibilityResult,
+} from "@/lib/eligibility-base";
 
 type NormalizedBadgeEligibilityInput = Required<BadgeEligibilityInput>;
 
@@ -31,8 +36,19 @@ export function normalizeBadgeEligibilityInput(
   };
 }
 
-function cap(current: number, target: number): number {
-  return Math.min(current, target);
+function countBadge<Reason extends string>(
+  check: ThresholdEligibilityResult<Reason>,
+  unit: string
+) {
+  return {
+    isEligible: check.isEligible,
+    progress: {
+      current: check.current,
+      target: check.target,
+      unit,
+    },
+    reason: check.reason,
+  };
 }
 
 export function evaluateBadgeEligibility(
@@ -46,13 +62,62 @@ export function evaluateBadgeEligibility(
   const connectedCurrent = Number(n.hasDiscordConnected) + Number(n.hasGithubConnected);
   const connectedEligible = connectedCurrent >= 2;
 
-  const speakerEligible = n.talksGivenCount >= 1;
-  const hackerEligible = n.hackathonParticipationCount >= 1;
-  const showcaseStarEligible = n.showcaseSubmissionsCount >= 1;
-  const conversationStarterEligible = n.communityMessagesCount >= 5;
-  const regularEligible = n.eventsAttendedCount >= 3;
-  const mentorEligible = n.mentorMatchesCount >= 1;
-  const contributorEligible = n.pullRequestsCount >= 1;
+  const speaker = countBadge(
+    checkCountThreshold({
+      current: n.talksGivenCount,
+      target: 1,
+      reason: "Deliver at least 1 talk.",
+    }),
+    "talks"
+  );
+  const hacker = countBadge(
+    checkCountThreshold({
+      current: n.hackathonParticipationCount,
+      target: 1,
+      reason: "Participate in at least 1 hackathon.",
+    }),
+    "hackathons"
+  );
+  const showcaseStar = countBadge(
+    checkCountThreshold({
+      current: n.showcaseSubmissionsCount,
+      target: 1,
+      reason: "Submit at least 1 showcase project.",
+    }),
+    "showcases"
+  );
+  const conversationStarter = countBadge(
+    checkCountThreshold({
+      current: n.communityMessagesCount,
+      target: 5,
+      reason: "Post at least 5 community messages.",
+    }),
+    "messages"
+  );
+  const regular = countBadge(
+    checkCountThreshold({
+      current: n.eventsAttendedCount,
+      target: 3,
+      reason: "Attend at least 3 events.",
+    }),
+    "events"
+  );
+  const mentor = countBadge(
+    checkCountThreshold({
+      current: n.mentorMatchesCount,
+      target: 1,
+      reason: "Complete at least 1 mentor match.",
+    }),
+    "matches"
+  );
+  const contributor = countBadge(
+    checkPullRequestThreshold({
+      pullRequestsCount: n.pullRequestsCount,
+      target: 1,
+      reason: "Get at least 1 pull request merged to this repo.",
+    }),
+    "pull requests"
+  );
 
   return {
     "first-steps": {
@@ -79,79 +144,31 @@ export function evaluateBadgeEligibility(
     },
     speaker: {
       badgeId: "speaker",
-      isEligible: speakerEligible,
-      progress: {
-        current: cap(n.talksGivenCount, 1),
-        target: 1,
-        unit: "talks",
-      },
-      reason: speakerEligible ? undefined : "Deliver at least 1 talk.",
+      ...speaker,
     },
     hacker: {
       badgeId: "hacker",
-      isEligible: hackerEligible,
-      progress: {
-        current: cap(n.hackathonParticipationCount, 1),
-        target: 1,
-        unit: "hackathons",
-      },
-      reason: hackerEligible ? undefined : "Participate in at least 1 hackathon.",
+      ...hacker,
     },
     "showcase-star": {
       badgeId: "showcase-star",
-      isEligible: showcaseStarEligible,
-      progress: {
-        current: cap(n.showcaseSubmissionsCount, 1),
-        target: 1,
-        unit: "showcases",
-      },
-      reason: showcaseStarEligible
-        ? undefined
-        : "Submit at least 1 showcase project.",
+      ...showcaseStar,
     },
     "conversation-starter": {
       badgeId: "conversation-starter",
-      isEligible: conversationStarterEligible,
-      progress: {
-        current: cap(n.communityMessagesCount, 5),
-        target: 5,
-        unit: "messages",
-      },
-      reason: conversationStarterEligible
-        ? undefined
-        : "Post at least 5 community messages.",
+      ...conversationStarter,
     },
     regular: {
       badgeId: "regular",
-      isEligible: regularEligible,
-      progress: {
-        current: cap(n.eventsAttendedCount, 3),
-        target: 3,
-        unit: "events",
-      },
-      reason: regularEligible ? undefined : "Attend at least 3 events.",
+      ...regular,
     },
     mentor: {
       badgeId: "mentor",
-      isEligible: mentorEligible,
-      progress: {
-        current: cap(n.mentorMatchesCount, 1),
-        target: 1,
-        unit: "matches",
-      },
-      reason: mentorEligible ? undefined : "Complete at least 1 mentor match.",
+      ...mentor,
     },
     contributor: {
       badgeId: "contributor",
-      isEligible: contributorEligible,
-      progress: {
-        current: cap(n.pullRequestsCount, 1),
-        target: 1,
-        unit: "pull requests",
-      },
-      reason: contributorEligible
-        ? undefined
-        : "Get at least 1 pull request merged to this repo.",
+      ...contributor,
     },
   };
 }

--- a/lib/eligibility-base.ts
+++ b/lib/eligibility-base.ts
@@ -1,0 +1,85 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export interface ThresholdEligibilityOptions<Reason extends string = string> {
+  current: number;
+  target: number;
+  reason: Reason;
+}
+
+export interface ThresholdEligibilityResult<Reason extends string = string> {
+  isEligible: boolean;
+  current: number;
+  target: number;
+  reason?: Reason;
+}
+
+export function checkCountThreshold<Reason extends string = string>({
+  current,
+  target,
+  reason,
+}: ThresholdEligibilityOptions<Reason>): ThresholdEligibilityResult<Reason> {
+  const isEligible = current >= target;
+
+  return {
+    isEligible,
+    current: Math.min(current, target),
+    target,
+    reason: isEligible ? undefined : reason,
+  };
+}
+
+export function checkPullRequestThreshold<Reason extends string = string>(
+  options: Omit<ThresholdEligibilityOptions<Reason>, "current"> & {
+    pullRequestsCount: number;
+  },
+): ThresholdEligibilityResult<Reason> {
+  return checkCountThreshold({
+    current: options.pullRequestsCount,
+    target: options.target,
+    reason: options.reason,
+  });
+}
+
+export type EventMembershipFailureReason =
+  | "not_signed_up"
+  | "not_checked_in"
+  | "not_confirmed";
+
+export interface EventMembershipOptions {
+  exists: boolean;
+  checkedInAt?: unknown;
+  checkInExempt?: boolean;
+  confirmedAt?: unknown;
+  rank?: unknown;
+}
+
+export type EventMembershipResult =
+  | { ok: true; rank: number }
+  | { ok: false; reason: EventMembershipFailureReason };
+
+export function checkEventMembership({
+  exists,
+  checkedInAt,
+  checkInExempt = false,
+  confirmedAt,
+  rank,
+}: EventMembershipOptions): EventMembershipResult {
+  if (!exists) {
+    return { ok: false, reason: "not_signed_up" };
+  }
+
+  if (!checkedInAt && !checkInExempt) {
+    return { ok: false, reason: "not_checked_in" };
+  }
+
+  if (!rank || !confirmedAt) {
+    return { ok: false, reason: "not_confirmed" };
+  }
+
+  return { ok: true, rank: rank as number };
+}

--- a/lib/hackathon-asprint-2026-credit-eligibility.ts
+++ b/lib/hackathon-asprint-2026-credit-eligibility.ts
@@ -14,6 +14,10 @@ import {
   hackathonEventSignupDocId,
   profileMatchesHackathonJudgeCheckinException,
 } from "@/lib/hackathon-event-signup";
+import {
+  checkEventMembership,
+  checkPullRequestThreshold,
+} from "@/lib/eligibility-base";
 
 const EVENT_ID = HACK_A_SPRINT_2026_EVENT_ID;
 
@@ -33,7 +37,8 @@ export async function resolveHackASprint2026CreditForUser(
   const signupSnap = await db.collection("hackathonEventSignups").doc(signupDocId).get();
 
   if (!signupSnap.exists) {
-    return { ok: false, reason: "not_signed_up" };
+    const membership = checkEventMembership({ exists: false });
+    if (!membership.ok) return membership;
   }
 
   const signupData = signupSnap.data()!;
@@ -41,20 +46,18 @@ export async function resolveHackASprint2026CreditForUser(
   const userSnap = await db.collection("users").doc(uid).get();
   const ud = userSnap.data();
 
-  if (!signupData.checkedInAt) {
-    if (
-      !profileMatchesHackathonJudgeCheckinException(
-        tokenEmail ?? null,
-        ud as Record<string, unknown> | undefined
-      )
-    ) {
-      return { ok: false, reason: "not_checked_in" };
-    }
-  }
+  const membership = checkEventMembership({
+    exists: true,
+    checkedInAt: signupData.checkedInAt,
+    checkInExempt: profileMatchesHackathonJudgeCheckinException(
+      tokenEmail ?? null,
+      ud as Record<string, unknown> | undefined
+    ),
+    confirmedAt: signupData.confirmedAt,
+    rank: signupData.frozenRank,
+  });
+  if (!membership.ok) return membership;
 
-  if (!signupData.frozenRank || !signupData.confirmedAt) {
-    return { ok: false, reason: "not_confirmed" };
-  }
   const githubLogin =
     ud?.github && typeof ud.github === "object"
       ? (ud.github as { login?: string }).login
@@ -65,11 +68,16 @@ export async function resolveHackASprint2026CreditForUser(
   }
 
   const hasSubmitted = await githubUserHasMergedLabeledShowcasePr(githubLogin);
-  if (!hasSubmitted) {
-    return { ok: false, reason: "not_submitted" };
+  const submitted = checkPullRequestThreshold({
+    pullRequestsCount: Number(hasSubmitted),
+    target: 1,
+    reason: "not_submitted",
+  });
+  if (!submitted.isEligible) {
+    return { ok: false, reason: submitted.reason ?? "not_submitted" };
   }
 
-  const rank = signupData.frozenRank as number;
+  const rank = membership.rank;
   const codeDoc = await db
     .collection("hackathonCreditCodes")
     .doc(`${EVENT_ID}__${rank}`)


### PR DESCRIPTION
## Summary
- Add `lib/eligibility-base.ts` for shared count thresholds, pull-request thresholds, and event membership gates.
- Refactor badge eligibility and Hack-A-Sprint credit eligibility through the shared helpers without changing returned reasons or progress shapes.
- Add consistency coverage for the base helpers, badge contributor eligibility, and credit eligibility gates.

## Tests
- `npm test -- --runTestsByPath __tests__/lib/eligibility-base.test.ts __tests__/lib/badges/eligibility.test.ts __tests__/lib/hackathon-asprint-2026-credit-eligibility.test.ts --runInBand`
- `npm run type-check`
- `npx eslint lib/eligibility-base.ts lib/badges/eligibility.ts lib/hackathon-asprint-2026-credit-eligibility.ts __tests__/lib/eligibility-base.test.ts __tests__/lib/badges/eligibility.test.ts __tests__/lib/hackathon-asprint-2026-credit-eligibility.test.ts --max-warnings=0`
- `git diff --check`

Closes #567.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)