### PR TITLE
fix: trap focus in content modals

### DIFF
--- a/__tests__/components/cookbook/EntryDetailModal.test.tsx
+++ b/__tests__/components/cookbook/EntryDetailModal.test.tsx
@@ -59,6 +59,19 @@ function defaultProps(overrides: Record<string, unknown> = {}) {
 describe("EntryDetailModal", () => {
   let writeText: jest.Mock;
 
+  function getModalContent(): HTMLElement {
+    return screen.getByRole("dialog") as HTMLElement;
+  }
+
+  function getFocusableElements(): HTMLElement[] {
+    const modal = getModalContent();
+    return Array.from(
+      modal.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+  }
+
   beforeEach(() => {
     writeText = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", {
@@ -145,7 +158,7 @@ describe("EntryDetailModal", () => {
     const props = defaultProps();
     render(<EntryDetailModal {...props} />);
 
-    fireEvent.click(screen.getByRole("dialog"));
+    fireEvent.click(screen.getByRole("button", { name: "Close entry details backdrop" }));
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -153,7 +166,39 @@ describe("EntryDetailModal", () => {
     const props = defaultProps();
     render(<EntryDetailModal {...props} />);
 
-    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    fireEvent.keyDown(getModalContent(), { key: "Escape" });
     expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("focuses the first modal control on open and restores prior focus on unmount", async () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Open modal";
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(<EntryDetailModal {...defaultProps()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
+    });
+
+    unmount();
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+  });
+
+  it("wraps Tab and Shift+Tab inside the modal", () => {
+    render(<EntryDetailModal {...defaultProps()} />);
+    const focusable = getFocusableElements();
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const modal = getModalContent();
+
+    first.focus();
+    fireEvent.keyDown(modal, { key: "Tab", shiftKey: true });
+    expect(last).toHaveFocus();
+
+    fireEvent.keyDown(modal, { key: "Tab" });
+    expect(first).toHaveFocus();
   });
 });

--- a/__tests__/components/feed/RepostModal.test.tsx
+++ b/__tests__/components/feed/RepostModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Message } from "@/types/feed";
 import { Timestamp } from "firebase/firestore";
@@ -32,6 +32,21 @@ function defaultProps(overrides: Record<string, unknown> = {}) {
 }
 
 describe("RepostModal", () => {
+  function getModalContent(): HTMLElement {
+    return screen
+      .getByRole("dialog")
+      .querySelector("[data-modal-content]") as HTMLElement;
+  }
+
+  function getFocusableElements(): HTMLElement[] {
+    const modal = getModalContent();
+    return Array.from(
+      modal.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+  }
+
   it("renders without crashing", () => {
     render(<RepostModal {...defaultProps()} />);
     expect(screen.getByText("Repost with comment")).toBeInTheDocument();
@@ -118,5 +133,37 @@ describe("RepostModal", () => {
       />,
     );
     expect(screen.getByText("4/200 (minimum 5)")).toBeInTheDocument();
+  });
+
+  it("focuses the comment textarea on open and restores prior focus on unmount", async () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Open repost";
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(<RepostModal {...defaultProps()} />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Add your comment...")).toHaveFocus();
+    });
+
+    unmount();
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+  });
+
+  it("wraps Tab and Shift+Tab inside the modal", () => {
+    render(<RepostModal {...defaultProps({ comment: "a".repeat(100) })} />);
+    const focusable = getFocusableElements();
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const modal = getModalContent();
+
+    first.focus();
+    fireEvent.keyDown(modal, { key: "Tab", shiftKey: true });
+    expect(last).toHaveFocus();
+
+    fireEvent.keyDown(modal, { key: "Tab" });
+    expect(first).toHaveFocus();
   });
 });

--- a/components/cookbook/EntryDetailModal.tsx
+++ b/components/cookbook/EntryDetailModal.tsx
@@ -7,8 +7,9 @@
 
 "use client";
 
-import { useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useState } from "react";
 import Link from "next/link";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { CATEGORY_LABELS } from "@/lib/cookbook-labels";
 import { formatCookbookDate } from "@/lib/format-cookbook-date";
 import type { CookbookCategory, CookbookEntry } from "@/types/cookbook";
@@ -33,6 +34,9 @@ export function EntryDetailModal({
   onClose: () => void;
 }) {
   const [copied, setCopied] = useState(false);
+  const { containerRef } = useFocusTrap<HTMLDivElement>({
+    onEscape: onClose,
+  });
   const upCount = votes?.upCount || 0;
   const downCount = votes?.downCount || 0;
   const netScore = upCount - downCount;
@@ -48,39 +52,22 @@ export function EntryDetailModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="entry-modal-title"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-      onKeyDown={(e: ReactKeyboardEvent) => {
-        if (e.key === "Escape") onClose();
-        if (e.key === "Tab") {
-          const modal = e.currentTarget.querySelector("[data-modal-content]");
-          if (!modal) return;
-          const focusable = modal.querySelectorAll<HTMLElement>(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-          );
-          if (focusable.length === 0) return;
-          const first = focusable[0];
-          const last = focusable[focusable.length - 1];
-          if (e.shiftKey && document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          } else if (!e.shiftKey && document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
-        }
-      }}
-    >
+    <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4 relative">
+      <button
+        type="button"
+        aria-label="Close entry details backdrop"
+        tabIndex={-1}
+        onClick={onClose}
+        className="absolute inset-0 h-full w-full cursor-default bg-transparent"
+      />
       <div
+        ref={containerRef}
         data-modal-content
-        onClick={(e) => e.stopPropagation()}
-        className="relative w-full max-w-3xl max-h-[90vh] flex flex-col bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-2xl shadow-2xl overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="entry-modal-title"
+        tabIndex={-1}
+        className="relative z-10 w-full max-w-3xl max-h-[90vh] flex flex-col bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-2xl shadow-2xl overflow-hidden"
       >
         <div className="shrink-0 px-6 py-4 border-b border-neutral-200 dark:border-neutral-800 flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">

--- a/components/feed/RepostModal.tsx
+++ b/components/feed/RepostModal.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 import type { Message } from "@/types/feed";
 
 interface RepostModalProps {
@@ -31,6 +31,9 @@ export function RepostModal({
   minLength = 100,
   maxLength = 500,
 }: RepostModalProps) {
+  const { containerRef } = useFocusTrap<HTMLDivElement>({
+    onEscape: onCancel,
+  });
   const trimmed = comment.trim();
   const isValid = trimmed.length >= minLength && trimmed.length <= maxLength;
 
@@ -39,30 +42,13 @@ export function RepostModal({
       className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
       role="dialog"
       aria-modal="true"
-      onKeyDown={(e: ReactKeyboardEvent) => {
-        if (e.key === "Escape") {
-          onCancel();
-        }
-        if (e.key === "Tab") {
-          const modal = e.currentTarget.querySelector("[data-modal-content]");
-          if (!modal) return;
-          const focusable = modal.querySelectorAll<HTMLElement>(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-          );
-          if (focusable.length === 0) return;
-          const first = focusable[0];
-          const last = focusable[focusable.length - 1];
-          if (e.shiftKey && document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          } else if (!e.shiftKey && document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
-        }
-      }}
     >
-      <div data-modal-content className="bg-neutral-900 rounded-xl p-6 border border-neutral-800 max-w-lg w-full">
+      <div
+        ref={containerRef}
+        data-modal-content
+        tabIndex={-1}
+        className="bg-neutral-900 rounded-xl p-6 border border-neutral-800 max-w-lg w-full"
+      >
         <h3 className="text-lg font-semibold text-white mb-4">Repost with comment</h3>
         <div className="bg-neutral-800 rounded-lg p-4 mb-4">
           <div className="flex items-center gap-2 mb-2">

--- a/hooks/useFocusTrap.ts
+++ b/hooks/useFocusTrap.ts
@@ -1,0 +1,101 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import {
+  useEffect,
+  useRef,
+} from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "iframe",
+  "object",
+  "embed",
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => element.getAttribute("aria-hidden") !== "true");
+}
+
+export function useFocusTrap<T extends HTMLElement>({
+  onEscape,
+}: {
+  onEscape?: () => void;
+} = {}) {
+  const containerRef = useRef<T | null>(null);
+  const onEscapeRef = useRef(onEscape);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    onEscapeRef.current = onEscape;
+  }, [onEscape]);
+
+  useEffect(() => {
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    const [first] = getFocusableElements(container);
+    (first ?? container).focus({ preventScroll: true });
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onEscapeRef.current?.();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusable = getFocusableElements(container);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        container.focus({ preventScroll: true });
+        return;
+      }
+
+      const firstFocusable = focusable[0];
+      const lastFocusable = focusable[focusable.length - 1];
+      const activeElement =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+      if (!activeElement || !container.contains(activeElement)) {
+        event.preventDefault();
+        (event.shiftKey ? lastFocusable : firstFocusable).focus({ preventScroll: true });
+        return;
+      }
+
+      if (event.shiftKey && activeElement === firstFocusable) {
+        event.preventDefault();
+        lastFocusable.focus({ preventScroll: true });
+      } else if (!event.shiftKey && activeElement === lastFocusable) {
+        event.preventDefault();
+        firstFocusable.focus({ preventScroll: true });
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+      previouslyFocusedRef.current?.focus({ preventScroll: true });
+    };
+  }, []);
+
+  return { containerRef };
+}


### PR DESCRIPTION
## Summary
- Add a reusable `useFocusTrap` hook that focuses the first modal control on open, wraps Tab/Shift+Tab inside the modal, handles Escape, and restores prior focus on unmount.
- Wire the hook into the live issue-scoped cookbook entry and feed repost modals, replacing duplicated inline Tab-wrap logic.
- Add keyboard regression coverage for initial focus, focus restoration, and Tab/Shift+Tab wrapping.

## Notes
- `components/WelcomeModal.tsx` no longer exists on current `develop`; this PR covers the two live issue-named modal components that still exist.

## Tests
- `npm test -- --runTestsByPath __tests__/components/cookbook/EntryDetailModal.test.tsx __tests__/components/feed/RepostModal.test.tsx --runInBand`
- `npm run type-check`
- `npx eslint hooks/useFocusTrap.ts components/cookbook/EntryDetailModal.tsx components/feed/RepostModal.tsx __tests__/components/cookbook/EntryDetailModal.test.tsx __tests__/components/feed/RepostModal.test.tsx --max-warnings=0`
- `git diff --check`

Closes #556.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)