### PR TITLE
test: guard community feed contrast

### DIFF
--- a/__tests__/components/feed/color-contrast.test.ts
+++ b/__tests__/components/feed/color-contrast.test.ts
@@ -1,0 +1,149 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+
+const TAILWIND_NEUTRAL = {
+  50: "#fafafa",
+  100: "#f5f5f5",
+  200: "#e5e5e5",
+  300: "#d4d4d4",
+  400: "#a3a3a3",
+  500: "#737373",
+  600: "#525252",
+  700: "#404040",
+  800: "#262626",
+  900: "#171717",
+  950: "#0a0a0a",
+  white: "#ffffff",
+} as const;
+
+const TAILWIND_EMERALD = {
+  300: "#6ee7b7",
+  400: "#34d399",
+  700: "#047857",
+  800: "#065f46",
+} as const;
+
+const TAILWIND_RED = {
+  300: "#fca5a5",
+  400: "#f87171",
+  700: "#b91c1c",
+  800: "#991b1b",
+} as const;
+
+function relativeLuminance(hex: string): number {
+  const [red, green, blue] = [0, 2, 4]
+    .map((offset) => Number.parseInt(hex.slice(1 + offset, 3 + offset), 16) / 255)
+    .map((channel) =>
+      channel <= 0.03928
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const foregroundLum = relativeLuminance(foreground);
+  const backgroundLum = relativeLuminance(background);
+  const lighter = Math.max(foregroundLum, backgroundLum);
+  const darker = Math.min(foregroundLum, backgroundLum);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("community feed color contrast", () => {
+  it("keeps feed text above WCAG AA contrast in light and dark modes", () => {
+    const pairs = [
+      {
+        name: "secondary light text on white cards",
+        foreground: TAILWIND_NEUTRAL[600],
+        background: TAILWIND_NEUTRAL.white,
+      },
+      {
+        name: "secondary dark text on neutral-900 cards",
+        foreground: TAILWIND_NEUTRAL[400],
+        background: TAILWIND_NEUTRAL[900],
+      },
+      {
+        name: "secondary dark text on neutral-800 reply surfaces",
+        foreground: TAILWIND_NEUTRAL[400],
+        background: TAILWIND_NEUTRAL[800],
+      },
+      {
+        name: "empty-state headline light text on white surfaces",
+        foreground: TAILWIND_NEUTRAL[700],
+        background: TAILWIND_NEUTRAL.white,
+      },
+      {
+        name: "empty-state headline dark text on page background",
+        foreground: TAILWIND_NEUTRAL[300],
+        background: TAILWIND_NEUTRAL[950],
+      },
+      {
+        name: "primary button text on emerald-700",
+        foreground: TAILWIND_NEUTRAL.white,
+        background: TAILWIND_EMERALD[700],
+      },
+      {
+        name: "primary button text on emerald-800 hover",
+        foreground: TAILWIND_NEUTRAL.white,
+        background: TAILWIND_EMERALD[800],
+      },
+      {
+        name: "light-mode action text on white",
+        foreground: TAILWIND_EMERALD[700],
+        background: TAILWIND_NEUTRAL.white,
+      },
+      {
+        name: "dark-mode action text on neutral-900",
+        foreground: TAILWIND_EMERALD[400],
+        background: TAILWIND_NEUTRAL[900],
+      },
+      {
+        name: "light-mode danger text on white",
+        foreground: TAILWIND_RED[700],
+        background: TAILWIND_NEUTRAL.white,
+      },
+      {
+        name: "dark-mode danger text on neutral-900",
+        foreground: TAILWIND_RED[400],
+        background: TAILWIND_NEUTRAL[900],
+      },
+    ];
+
+    for (const pair of pairs) {
+      expect(contrastRatio(pair.foreground, pair.background)).toBeGreaterThanOrEqual(
+        4.5,
+      );
+    }
+  });
+
+  it("does not leave feed components on known failing contrast classes", () => {
+    const sourceFiles = [
+      "components/feed/CommunityFeed.tsx",
+      "components/feed/MessageCard.tsx",
+      "components/feed/ReplyCard.tsx",
+      "components/feed/PostComposer.tsx",
+    ];
+
+    for (const sourceFile of sourceFiles) {
+      const source = readFileSync(path.join(process.cwd(), sourceFile), "utf8");
+      const classTokens = source.match(/[A-Za-z0-9_:[\]/.-]+/g) ?? [];
+      const failingForegroundTokens = classTokens.filter(
+        (token) =>
+          !token.startsWith("dark:") &&
+          /\btext-(neutral-500|emerald-400|emerald-500|red-400)\b/.test(token),
+      );
+
+      expect(failingForegroundTokens).toEqual([]);
+      expect(source).not.toMatch(/bg-emerald-500\s+text-white/);
+      expect(source).not.toMatch(/hover:bg-emerald-400/);
+    }
+  });
+});

--- a/components/feed/CommunityFeed.tsx
+++ b/components/feed/CommunityFeed.tsx
@@ -83,7 +83,7 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-500"
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-neutral-600 dark:text-neutral-400"
             aria-hidden="true"
           >
             <circle cx="11" cy="11" r="8" />
@@ -99,7 +99,7 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
           {feedSearchQuery && (
             <button
               onClick={() => setFeedSearchQuery("")}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-white p-1"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white p-1"
               aria-label="Clear search"
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
@@ -111,7 +111,7 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
 
         {/* Search Results Count */}
         {feedSearchQuery && (
-          <p className="text-sm text-neutral-500 mb-4">
+          <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4">
             {filteredMessages.length} result{filteredMessages.length !== 1 ? "s" : ""} for &quot;{feedSearchQuery}&quot;
           </p>
         )}
@@ -128,10 +128,10 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
         {/* Error State */}
         {error && (
           <div className="flex items-center justify-between gap-4 p-4 mb-6 bg-red-500/10 border border-red-500/20 rounded-lg">
-            <p className="text-red-400 text-sm">{error}</p>
+            <p className="text-red-700 dark:text-red-400 text-sm">{error}</p>
             <button
               onClick={clearError}
-              className="text-sm text-red-400 hover:text-red-300 underline shrink-0"
+              className="text-sm text-red-700 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 underline shrink-0"
             >
               Dismiss
             </button>
@@ -147,14 +147,14 @@ export function CommunityFeed({ user, onViewMemberProfile }: CommunityFeedProps)
           </div>
         ) : filteredMessages.length === 0 ? (
           <div className="text-center py-12">
-            <p className="text-neutral-400 text-lg mb-2">
+            <p className="text-neutral-700 dark:text-neutral-300 text-lg mb-2">
               {feedSearchQuery ? "No messages match your search" : "No messages yet"}
             </p>
-            <p className="text-neutral-500 text-sm">
+            <p className="text-neutral-600 dark:text-neutral-400 text-sm">
               {feedSearchQuery ? (
                 <button
                   onClick={() => setFeedSearchQuery("")}
-                  className="text-emerald-400 hover:text-emerald-300"
+                  className="text-emerald-700 dark:text-emerald-400 hover:text-emerald-800 dark:hover:text-emerald-300"
                 >
                   Clear search
                 </button>

--- a/components/feed/MessageCard.tsx
+++ b/components/feed/MessageCard.tsx
@@ -72,7 +72,7 @@ export function MessageCard({
     <div className="bg-white dark:bg-neutral-900 rounded-xl p-4 border border-neutral-200 dark:border-neutral-800">
       {/* Repost Header */}
       {isRepost && (
-        <div className="flex items-center gap-2 text-neutral-500 text-sm mb-3 pb-3 border-b border-neutral-200 dark:border-neutral-800">
+        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400 text-sm mb-3 pb-3 border-b border-neutral-200 dark:border-neutral-800">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
             <path d="M17 1l4 4-4 4" />
             <path d="M3 11V9a4 4 0 0 1 4-4h14" />
@@ -82,7 +82,7 @@ export function MessageCard({
           <button
             onClick={onAuthorClick}
             aria-label={`View ${message.authorName}'s profile`}
-            className="hover:text-emerald-400 transition-colors"
+            className="hover:text-emerald-700 dark:hover:text-emerald-400 transition-colors"
           >
             {message.authorName}
           </button>
@@ -109,11 +109,11 @@ export function MessageCard({
               <button
                 onClick={onAuthorClick}
                 aria-label={`View ${message.authorName}'s profile`}
-                className="font-medium text-neutral-900 dark:text-white truncate hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors focus-visible:outline-none focus-visible:text-emerald-500 dark:focus-visible:text-emerald-400"
+                className="font-medium text-neutral-900 dark:text-white truncate hover:text-emerald-700 dark:hover:text-emerald-400 transition-colors focus-visible:outline-none focus-visible:text-emerald-700 dark:focus-visible:text-emerald-400"
               >
                 {message.authorName}
               </button>
-              <span className="text-neutral-500 text-sm shrink-0">
+              <span className="text-neutral-600 dark:text-neutral-400 text-sm shrink-0">
                 {formatRelativeDate(message.createdAt)}
               </span>
             </div>
@@ -126,13 +126,13 @@ export function MessageCard({
                         onDelete();
                         setShowDeleteConfirm(false);
                       }}
-                      className="px-3 py-2 text-sm text-red-400 hover:text-red-300 min-h-[44px] flex items-center"
+                      className="px-3 py-2 text-sm text-red-700 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 min-h-[44px] flex items-center"
                     >
                       Delete
                     </button>
                     <button
                       onClick={() => setShowDeleteConfirm(false)}
-                      className="px-3 py-2 text-sm text-neutral-400 hover:text-white min-h-[44px] flex items-center"
+                      className="px-3 py-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white min-h-[44px] flex items-center"
                     >
                       Cancel
                     </button>
@@ -140,7 +140,7 @@ export function MessageCard({
                 ) : (
                   <button
                     onClick={() => setShowDeleteConfirm(true)}
-                    className="text-neutral-500 hover:text-neutral-300 p-2 min-w-[44px] min-h-[44px] flex items-center justify-center transition-colors"
+                    className="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-300 p-2 min-w-[44px] min-h-[44px] flex items-center justify-center transition-colors"
                     aria-label="Delete message"
                   >
                     <svg
@@ -175,7 +175,7 @@ export function MessageCard({
           {isRepost && (
             <div className="mt-3 p-3 bg-neutral-100 dark:bg-neutral-800/50 rounded-lg border-l-4 border-emerald-500/50">
               <div className="flex items-center gap-2 mb-2">
-                <span className="text-sm font-medium text-neutral-400">
+                <span className="text-sm font-medium text-neutral-600 dark:text-neutral-400">
                   {message.repostOf!.originalAuthorName}
                 </span>
               </div>
@@ -193,8 +193,8 @@ export function MessageCard({
               disabled={!isLoggedIn}
               className={`flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors min-h-[44px] ${
                 userReaction === "like"
-                  ? "text-emerald-400 bg-emerald-500/10"
-                  : "text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                  ? "text-emerald-700 dark:text-emerald-400 bg-emerald-500/10"
+                  : "text-neutral-600 dark:text-neutral-400 hover:text-emerald-700 dark:hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
               aria-label={
                 userReaction === "like"
@@ -222,8 +222,8 @@ export function MessageCard({
               disabled={!isLoggedIn}
               className={`flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors min-h-[44px] ${
                 userReaction === "dislike"
-                  ? "text-red-400 bg-red-500/10"
-                  : "text-neutral-500 hover:text-red-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                  ? "text-red-700 dark:text-red-400 bg-red-500/10"
+                  : "text-neutral-600 dark:text-neutral-400 hover:text-red-700 dark:hover:text-red-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
               aria-label={
                 userReaction === "dislike"
@@ -251,8 +251,8 @@ export function MessageCard({
               disabled={!isLoggedIn}
               className={`flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors min-h-[44px] ${
                 showReplyInput
-                  ? "text-emerald-400 bg-emerald-500/10"
-                  : "text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                  ? "text-emerald-700 dark:text-emerald-400 bg-emerald-500/10"
+                  : "text-neutral-600 dark:text-neutral-400 hover:text-emerald-700 dark:hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
               aria-label={`Reply to ${message.authorName}'s message`}
             >
@@ -275,7 +275,7 @@ export function MessageCard({
               <button
                 onClick={onRepost}
                 disabled={!isLoggedIn}
-                className={`flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors min-h-[44px] text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 ${
+                className={`flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors min-h-[44px] text-neutral-600 dark:text-neutral-400 hover:text-emerald-700 dark:hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 ${
                   !isLoggedIn ? "opacity-50 cursor-not-allowed" : ""
                 }`}
                 aria-label={`Repost ${message.authorName}'s message`}
@@ -314,10 +314,10 @@ export function MessageCard({
               <div className="flex items-center justify-between mt-2">
                 <span className={`text-xs ${
                   replyContent.length < 100
-                    ? "text-red-400"
+                    ? "text-red-700 dark:text-red-400"
                     : replyContent.length > 500
-                    ? "text-red-400"
-                    : "text-neutral-500"
+                    ? "text-red-700 dark:text-red-400"
+                    : "text-neutral-600 dark:text-neutral-400"
                 }`}>
                   {replyContent.length}/500 (minimum 100)
                 </span>
@@ -325,14 +325,14 @@ export function MessageCard({
                   <button
                     type="button"
                     onClick={onReply}
-                    className="px-3 py-2 text-sm text-neutral-400 hover:text-white transition-colors min-h-[44px]"
+                    className="px-3 py-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors min-h-[44px]"
                   >
                     Cancel
                   </button>
                   <button
                     onClick={onSubmitReply}
                     disabled={postingReply || replyContent.trim().length < 100 || replyContent.trim().length > 500}
-                    className="px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
+                    className="px-4 py-2 bg-emerald-700 text-white rounded-lg text-sm font-medium hover:bg-emerald-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
                   >
                     {postingReply ? "Replying..." : "Reply"}
                   </button>
@@ -346,7 +346,7 @@ export function MessageCard({
             <button
               onClick={onToggleReplies}
               aria-expanded={showReplies}
-              className="mt-3 text-sm text-emerald-400 hover:text-emerald-300 transition-colors flex items-center gap-1"
+              className="mt-3 text-sm text-emerald-700 dark:text-emerald-400 hover:text-emerald-800 dark:hover:text-emerald-300 transition-colors flex items-center gap-1"
             >
               <svg
                 width="14"

--- a/components/feed/PostComposer.tsx
+++ b/components/feed/PostComposer.tsx
@@ -40,10 +40,10 @@ export function PostComposer({
   if (!user) {
     return (
       <div className="bg-white dark:bg-neutral-900 rounded-xl p-6 border border-neutral-200 dark:border-neutral-800 mb-6 text-center">
-        <p className="text-neutral-400 mb-4">Sign in to post messages</p>
+        <p className="text-neutral-600 dark:text-neutral-400 mb-4">Sign in to post messages</p>
         <Link
           href="/login?redirect=/members"
-          className="inline-block px-4 py-2 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors"
+          className="inline-block px-4 py-2 bg-emerald-700 text-white rounded-lg text-sm font-medium hover:bg-emerald-800 transition-colors"
         >
           Sign In
         </Link>
@@ -75,10 +75,10 @@ export function PostComposer({
           <div className="flex items-center justify-between pt-3 border-t border-neutral-200 dark:border-neutral-800">
             <span className={`text-xs ${
               trimmed.length < minLength
-                ? "text-red-400"
+                ? "text-red-700 dark:text-red-400"
                 : trimmed.length > maxLength
-                ? "text-red-400"
-                : "text-neutral-500"
+                ? "text-red-700 dark:text-red-400"
+                : "text-neutral-600 dark:text-neutral-400"
             }`}>
               {value.length}/{maxLength} (minimum {minLength})
             </span>
@@ -87,7 +87,7 @@ export function PostComposer({
               onClick={onSubmit}
               disabled={posting || !isValid}
               aria-label={posting ? "Posting message" : submitLabel}
-              className="px-5 py-2.5 bg-emerald-500 text-white rounded-lg text-sm font-medium hover:bg-emerald-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 min-h-[44px]"
+              className="px-5 py-2.5 bg-emerald-700 text-white rounded-lg text-sm font-medium hover:bg-emerald-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 min-h-[44px]"
             >
               {posting ? "Posting..." : submitLabel}
             </button>

--- a/components/feed/ReplyCard.tsx
+++ b/components/feed/ReplyCard.tsx
@@ -45,7 +45,7 @@ export function ReplyCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <span className="font-medium text-neutral-900 dark:text-white text-sm">{reply.authorName}</span>
-            <span className="text-neutral-500 text-xs">{formatRelativeDate(reply.createdAt)}</span>
+            <span className="text-neutral-600 dark:text-neutral-400 text-xs">{formatRelativeDate(reply.createdAt)}</span>
             {isOwner && (
               <>
                 {showDeleteConfirm ? (
@@ -53,14 +53,14 @@ export function ReplyCard({
                     <button
                       type="button"
                       onClick={() => { onDelete(); setShowDeleteConfirm(false); }}
-                      className="text-xs text-red-400 hover:text-red-300 px-2 py-1"
+                      className="text-xs text-red-700 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 px-2 py-1"
                     >
                       Delete
                     </button>
                     <button
                       type="button"
                       onClick={() => setShowDeleteConfirm(false)}
-                      className="text-xs text-neutral-400 hover:text-white px-2 py-1"
+                      className="text-xs text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white px-2 py-1"
                     >
                       Cancel
                     </button>
@@ -68,7 +68,7 @@ export function ReplyCard({
                 ) : (
                   <button
                     onClick={() => setShowDeleteConfirm(true)}
-                    className="ml-auto text-neutral-500 hover:text-neutral-300 p-1"
+                    className="ml-auto text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-300 p-1"
                     aria-label="Delete reply"
                   >
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
@@ -95,8 +95,8 @@ export function ReplyCard({
               }
               className={`flex items-center gap-1 px-2 py-1 rounded transition-colors text-xs ${
                 userReaction === "like"
-                  ? "text-emerald-400"
-                  : "text-neutral-500 hover:text-emerald-400"
+                  ? "text-emerald-700 dark:text-emerald-400"
+                  : "text-neutral-600 dark:text-neutral-400 hover:text-emerald-700 dark:hover:text-emerald-400"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
             >
               <svg
@@ -122,8 +122,8 @@ export function ReplyCard({
               }
               className={`flex items-center gap-1 px-2 py-1 rounded transition-colors text-xs ${
                 userReaction === "dislike"
-                  ? "text-red-400"
-                  : "text-neutral-500 hover:text-red-400"
+                  ? "text-red-700 dark:text-red-400"
+                  : "text-neutral-600 dark:text-neutral-400 hover:text-red-700 dark:hover:text-red-400"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
             >
               <svg


### PR DESCRIPTION
## Summary
- Add deterministic WCAG AA contrast regression coverage for community feed foreground/background class pairs in light and dark modes.
- Upgrade low-contrast feed neutral, danger, and action text classes to explicit light/dark AA-safe variants.
- Raise feed primary buttons from emerald-500/400 to emerald-700/800 so white button text passes contrast.

## Tests
- `npm test -- --runTestsByPath __tests__/components/feed/color-contrast.test.ts __tests__/components/feed/MessageCard.test.tsx __tests__/components/feed/ReplyCard.test.tsx __tests__/components/feed/PostComposer.test.tsx __tests__/components/feed/CommunityFeed.test.tsx --runInBand`
- `npm run type-check`
- `npx eslint components/feed/CommunityFeed.tsx components/feed/MessageCard.tsx components/feed/ReplyCard.tsx components/feed/PostComposer.tsx __tests__/components/feed/color-contrast.test.ts --max-warnings=0`
- `git diff --check`

Closes #555

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)