### PR TITLE
test: harden environment validation coverage

### DIFF
--- a/__tests__/scripts/validate-env.test.ts
+++ b/__tests__/scripts/validate-env.test.ts
@@ -1,138 +1,275 @@
-import { validateEnvVar, requiredEnvVars } from '@/scripts/validate-env';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  optionalEnvVars,
+  requiredEnvVars,
+  validateEnvVar,
+} from '@/scripts/validate-env';
+
+const requiredEnvValues: Record<string, string> = {
+  NEXT_PUBLIC_FIREBASE_API_KEY: 'actual-api-key',
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: 'actual-project.firebaseapp.com',
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: 'actual-project-id',
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: 'actual-project.appspot.com',
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: '123456789',
+  NEXT_PUBLIC_FIREBASE_APP_ID: '1:123456789:web:abcdef',
+  NEXT_PUBLIC_FIREBASE_DATABASE_URL: 'https://actual-project.firebaseio.com',
+  UNSUBSCRIBE_SECRET: 'u'.repeat(32),
+};
+
+const expectedOptionalEnvNames = [
+  'NEXT_PUBLIC_DISCORD_CLIENT_ID',
+  'DISCORD_CLIENT_SECRET',
+  'NEXT_PUBLIC_DISCORD_REDIRECT_URI',
+  'CURSOR_BOSTON_DISCORD_SERVER_ID',
+  'NEXT_PUBLIC_GITHUB_CLIENT_ID',
+  'GITHUB_CLIENT_SECRET',
+  'NEXT_PUBLIC_GITHUB_REDIRECT_URI',
+  'GITHUB_WEBHOOK_SECRET',
+  'GITHUB_REPO_OWNER',
+  'GITHUB_REPO_NAME',
+  'HACK_A_SPRINT_2026_JUDGE_UIDS',
+  'HACK_A_SPRINT_2026_JUDGE_EMAILS',
+  'HACK_A_SPRINT_2026_EVENT_PASSCODE',
+  'FIREBASE_SERVICE_ACCOUNT_JSON',
+  'ADMIN_EMAIL',
+  'SUMMER_COHORT_ADMIN_EMAILS',
+  'MAILGUN_API_KEY',
+  'MAILGUN_DOMAIN',
+];
+
+const repoRoot = process.cwd();
+const validateEnvScript = path.join(repoRoot, 'scripts', 'validate-env.ts');
+const tsxCli = path.join(path.dirname(require.resolve('tsx')), 'cli.mjs');
+
+function findRequiredEnvVar(name: string) {
+  const envVar = requiredEnvVars.find((candidate) => candidate.name === name);
+  expect(envVar).toBeDefined();
+  return envVar!;
+}
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function setRequiredEnv(overrides: Record<string, string | undefined> = {}) {
+  for (const [name, value] of Object.entries({
+    ...requiredEnvValues,
+    ...overrides,
+  })) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+}
+
+function childEnv(env: Record<string, string | undefined>) {
+  const preservedKeys = [
+    'PATH',
+    'Path',
+    'SYSTEMROOT',
+    'SystemRoot',
+    'COMSPEC',
+    'ComSpec',
+    'TEMP',
+    'TMP',
+    'HOME',
+    'USERPROFILE',
+  ];
+  const baseEnv: NodeJS.ProcessEnv = {};
+
+  for (const key of preservedKeys) {
+    if (process.env[key]) {
+      baseEnv[key] = process.env[key];
+    }
+  }
+
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete baseEnv[key];
+    } else {
+      baseEnv[key] = value;
+    }
+  }
+
+  return baseEnv;
+}
+
+function runValidateEnv(env: Record<string, string | undefined>) {
+  const tempCwd = mkdtempSync(path.join(tmpdir(), 'validate-env-'));
+
+  try {
+    return spawnSync(process.execPath, [tsxCli, validateEnvScript], {
+      cwd: tempCwd,
+      env: childEnv(env),
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+  } finally {
+    rmSync(tempCwd, { recursive: true, force: true });
+  }
+}
 
 describe('Environment Variable Validation', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
-    // Reset process.env
-    jest.resetModules();
     process.env = { ...originalEnv };
+    setNodeEnv('production');
+    setRequiredEnv();
   });
 
   afterEach(() => {
     process.env = originalEnv;
   });
 
-  describe('validateEnvVar', () => {
-    it('should validate required variables that are set', () => {
-      process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'actual-api-key';
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'NEXT_PUBLIC_FIREBASE_API_KEY'
-      );
-      
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(true);
-      }
-    });
+  it('keeps the test matrix aligned with validate-env declarations', () => {
+    expect(requiredEnvVars.map((envVar) => envVar.name).sort()).toEqual(
+      Object.keys(requiredEnvValues).sort()
+    );
+    expect(optionalEnvVars.map((envVar) => envVar.name).sort()).toEqual(
+      [...expectedOptionalEnvNames].sort()
+    );
+  });
 
-    it('should reject required variables that are not set', () => {
-      delete process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'NEXT_PUBLIC_FIREBASE_API_KEY'
-      );
-      
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(false);
-        expect(result.error).toContain('not set');
-      }
-    });
+  it.each(Object.entries(requiredEnvValues))(
+    'accepts a valid value for %s',
+    (name, value) => {
+      process.env[name] = value;
 
-    it('should reject placeholder values', () => {
-      process.env.NEXT_PUBLIC_FIREBASE_API_KEY = 'your-api-key';
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'NEXT_PUBLIC_FIREBASE_API_KEY'
-      );
-      
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(false);
-        expect(result.error).toContain('Must be set');
-      }
-    });
+      expect(validateEnvVar(findRequiredEnvVar(name))).toEqual({ valid: true });
+    }
+  );
 
-    it('should accept valid values', () => {
-      process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'my-real-project-id';
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'NEXT_PUBLIC_FIREBASE_PROJECT_ID'
-      );
-      
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(true);
-      }
-    });
+  it.each(Object.keys(requiredEnvValues))(
+    'rejects missing required production value for %s',
+    (name) => {
+      delete process.env[name];
 
-    it('should accept a strong unsubscribe secret', () => {
-      process.env.UNSUBSCRIBE_SECRET = 'u'.repeat(32);
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'UNSUBSCRIBE_SECRET'
-      );
+      const result = validateEnvVar(findRequiredEnvVar(name));
 
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(true);
-      }
-    });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('not set');
+    }
+  );
 
-    it('should require unsubscribe secret outside development and test', () => {
-      Object.defineProperty(process.env, 'NODE_ENV', {
-        value: 'production',
-        configurable: true,
-      });
+  it.each([
+    [
+      'NEXT_PUBLIC_FIREBASE_API_KEY',
+      'your-api-key',
+      'actual Firebase API key',
+    ],
+    [
+      'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
+      'your-project.firebaseapp.com',
+      'actual Firebase project domain',
+    ],
+    [
+      'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+      'your-project-id',
+      'actual Firebase project ID',
+    ],
+    [
+      'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
+      'your-project.appspot.com',
+      'actual Firebase storage bucket',
+    ],
+    [
+      'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+      'your-sender-id',
+      'actual Firebase sender ID',
+    ],
+    [
+      'NEXT_PUBLIC_FIREBASE_APP_ID',
+      'your-app-id',
+      'actual Firebase app ID',
+    ],
+    [
+      'NEXT_PUBLIC_FIREBASE_DATABASE_URL',
+      'https://your-project.firebaseio.com',
+      'actual Firebase database URL',
+    ],
+    ['UNSUBSCRIBE_SECRET', 'cursor-boston-unsub', 'legacy public fallback'],
+    ['UNSUBSCRIBE_SECRET', 'short-secret', '32 bytes'],
+    [
+      'UNSUBSCRIBE_SECRET',
+      'your-unsubscribe-secret-value-over-thirty-two-bytes',
+      'actual unsubscribe secret',
+    ],
+  ])('rejects invalid %s value', (name, value, expectedError) => {
+    process.env[name] = value;
+
+    const result = validateEnvVar(findRequiredEnvVar(name));
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(expectedError);
+  });
+
+  it.each(expectedOptionalEnvNames)(
+    'does not require optional variable %s',
+    (name) => {
+      const envVar = optionalEnvVars.find((candidate) => candidate.name === name);
+      expect(envVar).toBeDefined();
+      delete process.env[name];
+
+      expect(validateEnvVar(envVar!)).toEqual({ valid: true });
+    }
+  );
+
+  it.each(['development', 'test'])(
+    'allows missing unsubscribe secret in %s',
+    (nodeEnv) => {
+      setNodeEnv(nodeEnv);
       delete process.env.UNSUBSCRIBE_SECRET;
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'UNSUBSCRIBE_SECRET'
-      );
 
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(false);
-        expect(result.error).toContain('not set');
-      }
-    });
-
-    it('should allow missing unsubscribe secret in development', () => {
-      Object.defineProperty(process.env, 'NODE_ENV', {
-        value: 'development',
-        configurable: true,
+      expect(validateEnvVar(findRequiredEnvVar('UNSUBSCRIBE_SECRET'))).toEqual({
+        valid: true,
       });
-      delete process.env.UNSUBSCRIBE_SECRET;
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'UNSUBSCRIBE_SECRET'
-      );
+    }
+  );
 
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(true);
-      }
+  describe('script integration', () => {
+    it('exits 0 for a valid production config without optional variables', () => {
+      const result = runValidateEnv({
+        NODE_ENV: 'production',
+        ...requiredEnvValues,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('All required environment variables');
     });
 
-    it('should reject the legacy public unsubscribe fallback secret', () => {
-      process.env.UNSUBSCRIBE_SECRET = 'cursor-boston-unsub';
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'UNSUBSCRIBE_SECRET'
-      );
+    it('exits 1 when a required variable is missing', () => {
+      const result = runValidateEnv({
+        NODE_ENV: 'production',
+        ...requiredEnvValues,
+        NEXT_PUBLIC_FIREBASE_API_KEY: undefined,
+      });
 
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(false);
-        expect(result.error).toContain('legacy public fallback');
-      }
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        'NEXT_PUBLIC_FIREBASE_API_KEY'
+      );
     });
 
-    it('should reject short unsubscribe secrets', () => {
-      process.env.UNSUBSCRIBE_SECRET = 'short-secret';
-      const envVar = requiredEnvVars.find(
-        (v) => v.name === 'UNSUBSCRIBE_SECRET'
-      );
+    it('exits 1 when a required variable has an invalid format', () => {
+      const result = runValidateEnv({
+        NODE_ENV: 'production',
+        ...requiredEnvValues,
+        UNSUBSCRIBE_SECRET: 'short-secret',
+      });
 
-      if (envVar) {
-        const result = validateEnvVar(envVar);
-        expect(result.valid).toBe(false);
-        expect(result.error).toContain('32 bytes');
-      }
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}\n${result.stderr}`).toContain('32 bytes');
     });
   });
 });


### PR DESCRIPTION
## Security / Business Impact
- Hardens startup configuration checks so missing Firebase settings, placeholder Firebase values, and weak unsubscribe secrets fail predictably before deploy/startup.
- Keeps the env validation test matrix locked to every declared required and optional variable so future env additions cannot silently skip tests.

## Threat Model
- A deploy with a missing or placeholder public Firebase variable can boot with broken auth/data behavior.
- A weak or legacy unsubscribe secret can make HMAC-protected unsubscribe/withdraw links easier to forge.
- Optional integrations should be allowed to stay unset without blocking unrelated deployments.

## Change
- Expands `__tests__/scripts/validate-env.test.ts` to cover every declared required and optional env var.
- Adds invalid-format coverage for Firebase placeholders and unsubscribe secret edge cases.
- Adds child-process integration tests for `scripts/validate-env.ts` exit code 0 and exit code 1 behavior from an isolated temp cwd, so local `.env` files cannot mask failures.

## Verification
- `npm test -- --runTestsByPath __tests__/scripts/validate-env.test.ts --runInBand` (`50 passed`)
- `npx eslint __tests__/scripts/validate-env.test.ts --max-warnings=0`
- `npm run type-check`
- `git diff --check`
- Commit hook: `tsc --noEmit` and `eslint --fix --max-warnings=0`

Closes #561.

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
