### PR TITLE
feat: add prompt template library

### DIFF
--- a/__tests__/lib/prompt-templates.test.ts
+++ b/__tests__/lib/prompt-templates.test.ts
@@ -1,0 +1,55 @@
+import {
+  PROMPT_TEMPLATES,
+  getPromptTemplateById,
+  getTemplatePlaceholderTokens,
+  getTemplateStacks,
+} from "@/lib/prompt-templates";
+
+describe("prompt templates", () => {
+  it("uses unique ids for templates and variants", () => {
+    const templateIds = new Set<string>();
+    const variantIds = new Set<string>();
+
+    for (const template of PROMPT_TEMPLATES) {
+      expect(templateIds.has(template.id)).toBe(false);
+      templateIds.add(template.id);
+      expect(template.variants.length).toBeGreaterThanOrEqual(2);
+
+      for (const variant of template.variants) {
+        const variantKey = `${template.id}:${variant.id}`;
+        expect(variantIds.has(variantKey)).toBe(false);
+        variantIds.add(variantKey);
+      }
+    }
+  });
+
+  it("finds templates by id", () => {
+    expect(getPromptTemplateById("feature-slice-planner")?.title).toBe(
+      "Feature Slice Planner"
+    );
+    expect(getPromptTemplateById("missing-template")).toBeNull();
+  });
+
+  it("extracts placeholder tokens from base and variant prompts", () => {
+    const template = getPromptTemplateById("bug-reproduction-brief");
+    expect(template).not.toBeNull();
+
+    const tokens = getTemplatePlaceholderTokens(template!);
+
+    expect(tokens).toEqual([
+      "ACTUAL_BEHAVIOR",
+      "BUG_SUMMARY",
+      "EXPECTED_BEHAVIOR",
+      "RELEVANT_STACK",
+    ]);
+  });
+
+  it("returns a sorted stack list", () => {
+    const stacks = getTemplateStacks();
+
+    expect(stacks).toEqual([...stacks].sort((a, b) => a.localeCompare(b)));
+    expect(stacks).toEqual(
+      expect.arrayContaining(["Next.js + Firebase", "TypeScript Shared Library"])
+    );
+  });
+});

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@
 
 import { MetadataRoute } from 'next';
 import { getAllPostSlugs } from '@/lib/blog';
+import { PROMPT_TEMPLATES } from '@/lib/prompt-templates';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://cursorboston.com';
@@ -102,6 +103,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${baseUrl}/templates`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/showcase`,
       lastModified,
       changeFrequency: 'weekly',
@@ -191,5 +198,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  return [...staticPages, ...blogPages];
+  const templatePages: MetadataRoute.Sitemap = PROMPT_TEMPLATES.map((template) => ({
+    url: `${baseUrl}/templates/${template.id}`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }));
+
+  return [...staticPages, ...blogPages, ...templatePages];
 }

--- a/app/templates/[templateId]/page.tsx
+++ b/app/templates/[templateId]/page.tsx
@@ -1,0 +1,223 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { PromptMarkdown } from "@/components/cookbook/PromptMarkdown";
+import {
+  PROMPT_TEMPLATE_CATEGORIES,
+  PROMPT_TEMPLATES,
+  getPromptTemplateById,
+  getTemplatePlaceholderTokens,
+} from "@/lib/prompt-templates";
+
+const SITE_URL = "https://cursorboston.com";
+
+interface Props {
+  params: Promise<{ templateId: string }>;
+}
+
+export function generateStaticParams() {
+  return PROMPT_TEMPLATES.map((template) => ({
+    templateId: template.id,
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { templateId } = await params;
+  const template = getPromptTemplateById(templateId);
+
+  if (!template) {
+    return {
+      title: "Prompt Template Not Found",
+    };
+  }
+
+  const title = `${template.title} | Cursor Boston Templates`;
+  const url = `${SITE_URL}/templates/${template.id}`;
+
+  return {
+    title,
+    description: template.summary,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description: template.summary,
+      type: "article",
+      url,
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description: template.summary,
+    },
+  };
+}
+
+function buildJsonLd(template: NonNullable<ReturnType<typeof getPromptTemplateById>>) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: template.title,
+    description: template.summary,
+    text: template.basePrompt,
+    url: `${SITE_URL}/templates/${template.id}`,
+    isPartOf: {
+      "@type": "CreativeWorkSeries",
+      name: "Cursor Boston Prompt Template Library",
+      url: `${SITE_URL}/templates`,
+    },
+    keywords: [
+      PROMPT_TEMPLATE_CATEGORIES[template.category],
+      ...template.placeholders,
+      ...template.variants.map((variant) => variant.stack),
+    ].join(", "),
+    publisher: {
+      "@type": "Organization",
+      name: "Cursor Boston",
+      url: SITE_URL,
+    },
+  };
+}
+
+export default async function PromptTemplateDetailPage({ params }: Props) {
+  const { templateId } = await params;
+  const template = getPromptTemplateById(templateId);
+
+  if (!template) {
+    notFound();
+  }
+
+  const placeholderTokens = getTemplatePlaceholderTokens(template);
+  const jsonLd = buildJsonLd(template);
+
+  return (
+    <main className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <nav
+        aria-label="Breadcrumb"
+        className="border-b border-neutral-200 bg-white px-6 py-4 dark:border-neutral-800 dark:bg-neutral-900"
+      >
+        <ol className="mx-auto flex max-w-5xl items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+          <li>
+            <Link href="/templates" className="hover:text-foreground">
+              Templates
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="truncate text-foreground">{template.title}</li>
+        </ol>
+      </nav>
+
+      <article className="mx-auto max-w-5xl px-6 py-10">
+        <header className="mb-8">
+          <div className="mb-4 flex flex-wrap items-center gap-2 text-sm">
+            <span className="rounded-full bg-emerald-500/10 px-3 py-1 font-medium text-emerald-700 dark:text-emerald-300">
+              {PROMPT_TEMPLATE_CATEGORIES[template.category]}
+            </span>
+            <span className="rounded-full bg-neutral-200 px-3 py-1 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+              {template.difficulty}
+            </span>
+            <span className="rounded-full bg-neutral-200 px-3 py-1 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+              {template.variants.length} variants
+            </span>
+          </div>
+
+          <h1 className="text-3xl font-bold text-neutral-950 dark:text-white md:text-5xl">
+            {template.title}
+          </h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-neutral-700 dark:text-neutral-300">
+            {template.summary}
+          </p>
+        </header>
+
+        <section className="mb-8 rounded-lg border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <h2 className="text-lg font-semibold text-foreground">
+            Placeholders
+          </h2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {placeholderTokens.map((placeholder) => (
+              <code
+                key={placeholder}
+                className="rounded-md bg-neutral-100 px-2.5 py-1 text-sm text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+              >
+                {`{{${placeholder}}}`}
+              </code>
+            ))}
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="base-template-heading"
+          className="mb-8 overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
+        >
+          <div className="border-b border-neutral-200 bg-neutral-100 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-800/70">
+            <h2
+              id="base-template-heading"
+              className="text-sm font-semibold uppercase text-neutral-500 dark:text-neutral-400"
+            >
+              Base template
+            </h2>
+          </div>
+          <PromptMarkdown
+            content={template.basePrompt}
+            className="px-4 py-4 text-sm md:px-6 md:py-5"
+          />
+        </section>
+
+        <section aria-labelledby="variant-heading">
+          <h2 id="variant-heading" className="mb-4 text-lg font-semibold text-foreground">
+            Stack Variants
+          </h2>
+          <div className="space-y-5">
+            {template.variants.map((variant) => (
+              <article
+                key={variant.id}
+                className="overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
+              >
+                <div className="border-b border-neutral-200 px-4 py-4 dark:border-neutral-800">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="font-semibold text-foreground">
+                        {variant.stack}
+                      </h3>
+                      <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+                        {variant.useCase}
+                      </p>
+                    </div>
+                    <span className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200">
+                      Variant
+                    </span>
+                  </div>
+                </div>
+
+                <PromptMarkdown
+                  content={variant.prompt}
+                  className="px-4 py-4 text-sm md:px-6 md:py-5"
+                />
+
+                <div className="border-t border-neutral-200 bg-neutral-50 px-4 py-4 dark:border-neutral-800 dark:bg-neutral-950">
+                  <h4 className="text-sm font-semibold text-foreground">Notes</h4>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-neutral-600 dark:text-neutral-400">
+                    {variant.notes.map((note) => (
+                      <li key={note}>{note}</li>
+                    ))}
+                  </ul>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/app/templates/layout.tsx
+++ b/app/templates/layout.tsx
@@ -1,0 +1,25 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Prompt Templates | Cursor Boston",
+  description:
+    "Browse reusable Cursor prompt templates with stack-specific variants from the Cursor Boston community.",
+  alternates: {
+    canonical: "https://cursorboston.com/templates",
+  },
+};
+
+export default function TemplatesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,0 +1,117 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import Link from "next/link";
+import {
+  Layers3,
+  LibraryBig,
+  ListChecks,
+  Tags,
+} from "lucide-react";
+import {
+  PROMPT_TEMPLATE_CATEGORIES,
+  PROMPT_TEMPLATES,
+  getTemplateStacks,
+} from "@/lib/prompt-templates";
+
+export default function PromptTemplatesPage() {
+  const stacks = getTemplateStacks();
+  const variantCount = PROMPT_TEMPLATES.reduce(
+    (count, template) => count + template.variants.length,
+    0
+  );
+
+  return (
+    <main className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
+      <section className="border-b border-neutral-200 bg-white px-6 py-12 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="mx-auto max-w-6xl">
+          <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-700 dark:text-emerald-300">
+            <LibraryBig className="h-4 w-4" aria-hidden="true" />
+            Prompt Template Library
+          </div>
+          <div className="grid gap-8 lg:grid-cols-[1fr_340px]">
+            <div>
+              <h1 className="max-w-3xl text-3xl font-bold text-foreground md:text-5xl">
+                Reusable Cursor prompts with stack variants
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-neutral-600 dark:text-neutral-400 md:text-lg">
+                Start from structured templates, then choose the variant that
+                matches your app stack and workflow.
+              </p>
+            </div>
+            <div className="grid grid-cols-3 gap-3 self-start">
+              <StatCard label="Templates" value={String(PROMPT_TEMPLATES.length)} />
+              <StatCard label="Variants" value={String(variantCount)} />
+              <StatCard label="Stacks" value={String(stacks.length)} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-10">
+        <div className="mb-5 flex items-center gap-2 text-sm font-medium text-neutral-600 dark:text-neutral-400">
+          <Tags className="h-4 w-4" aria-hidden="true" />
+          {stacks.join(" / ")}
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {PROMPT_TEMPLATES.map((template) => (
+            <article
+              key={template.id}
+              className="flex min-h-[320px] flex-col rounded-lg border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900"
+            >
+              <div className="mb-4 flex items-start justify-between gap-3">
+                <span className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200">
+                  {PROMPT_TEMPLATE_CATEGORIES[template.category]}
+                </span>
+                <span className="text-xs text-neutral-500 dark:text-neutral-400">
+                  {template.difficulty}
+                </span>
+              </div>
+
+              <h2 className="text-xl font-semibold text-foreground">
+                {template.title}
+              </h2>
+              <p className="mt-3 flex-1 text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+                {template.summary}
+              </p>
+
+              <div className="mt-5 space-y-3">
+                <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400">
+                  <Layers3 className="h-4 w-4" aria-hidden="true" />
+                  {template.variants.length} stack variants
+                </div>
+                <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400">
+                  <ListChecks className="h-4 w-4" aria-hidden="true" />
+                  {template.placeholders.length} placeholders
+                </div>
+              </div>
+
+              <Link
+                href={`/templates/${template.id}`}
+                className="mt-6 inline-flex items-center justify-center rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                Open template
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-center dark:border-neutral-800 dark:bg-neutral-950">
+      <div className="text-2xl font-semibold text-foreground">{value}</div>
+      <div className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -35,6 +35,7 @@ import {
   HelpCircle,
   Info,
   LayoutGrid,
+  LibraryBig,
   LogIn,
   Menu,
   MessageSquare,
@@ -84,6 +85,7 @@ const NAV_GROUPS: NavGroup[] = [
     items: [
       { href: "/events", label: "Events", icon: Calendar },
       { href: "/cookbook", label: "Cookbook", icon: ChefHat },
+      { href: "/templates", label: "Templates", icon: LibraryBig },
       { href: "/questions", label: "Q&A", icon: HelpCircle },
       { href: "/pr-ideas", label: "PR Studio", icon: Bot },
       { href: "/opportunities", label: "Opportunities", icon: Briefcase },

--- a/lib/prompt-templates.ts
+++ b/lib/prompt-templates.ts
@@ -1,0 +1,300 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export interface PromptTemplateVariant {
+  id: string;
+  stack: string;
+  useCase: string;
+  prompt: string;
+  notes: string[];
+}
+
+export interface PromptTemplate {
+  id: string;
+  title: string;
+  summary: string;
+  category: "debugging" | "planning" | "refactoring";
+  difficulty: "Beginner" | "Intermediate";
+  placeholders: string[];
+  basePrompt: string;
+  variants: PromptTemplateVariant[];
+}
+
+export const PROMPT_TEMPLATE_CATEGORIES: Record<
+  PromptTemplate["category"],
+  string
+> = {
+  debugging: "Debugging",
+  planning: "Planning",
+  refactoring: "Refactoring",
+};
+
+export const PROMPT_TEMPLATES: PromptTemplate[] = [
+  {
+    id: "bug-reproduction-brief",
+    title: "Bug Reproduction Brief",
+    summary:
+      "Turn a vague bug report into a minimal reproduction plan, likely causes, and targeted files to inspect.",
+    category: "debugging",
+    difficulty: "Beginner",
+    placeholders: [
+      "BUG_SUMMARY",
+      "EXPECTED_BEHAVIOR",
+      "ACTUAL_BEHAVIOR",
+      "RELEVANT_STACK",
+    ],
+    basePrompt: `You are helping me debug a production issue.
+
+Bug summary:
+{{BUG_SUMMARY}}
+
+Expected behavior:
+{{EXPECTED_BEHAVIOR}}
+
+Actual behavior:
+{{ACTUAL_BEHAVIOR}}
+
+Relevant stack:
+{{RELEVANT_STACK}}
+
+Please produce:
+1. A minimal reproduction checklist.
+2. The most likely files or modules to inspect first.
+3. Three hypotheses ranked by probability.
+4. A focused test plan that can prove or disprove each hypothesis.`,
+    variants: [
+      {
+        id: "next-firebase",
+        stack: "Next.js + Firebase",
+        useCase: "Client/server auth or Firestore data bugs",
+        prompt: `Use this repo context as a Next.js App Router + Firebase app.
+
+Issue:
+{{BUG_SUMMARY}}
+
+Expected:
+{{EXPECTED_BEHAVIOR}}
+
+Actual:
+{{ACTUAL_BEHAVIOR}}
+
+Inspect likely boundaries across route handlers, Firebase client calls, server auth helpers, Firestore rules, and React state. Return a reproduction checklist, likely files, and the smallest Jest or Playwright test that should fail before the fix.`,
+        notes: [
+          "Call out whether the bug is likely client state, route-handler auth, or Firestore rule behavior.",
+          "Prefer focused Jest for route/data logic and Playwright only for browser-only flows.",
+        ],
+      },
+      {
+        id: "python-django",
+        stack: "Python + Django",
+        useCase: "View, form, and ORM behavior bugs",
+        prompt: `Use this as a Django debugging brief.
+
+Bug:
+{{BUG_SUMMARY}}
+
+Expected:
+{{EXPECTED_BEHAVIOR}}
+
+Actual:
+{{ACTUAL_BEHAVIOR}}
+
+Identify the smallest failing request or model operation, the view/form/model boundary most likely involved, and the focused pytest cases needed for the reproduction.`,
+        notes: [
+          "Ask Cursor to inspect migrations when the symptom involves missing fields or unexpected defaults.",
+          "Include permission and queryset hypotheses before changing view logic.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "feature-slice-planner",
+    title: "Feature Slice Planner",
+    summary:
+      "Convert a broad feature idea into incremental PR slices with clear contracts, tests, and risk boundaries.",
+    category: "planning",
+    difficulty: "Beginner",
+    placeholders: [
+      "FEATURE_GOAL",
+      "USER_JOURNEY",
+      "EXISTING_SURFACES",
+      "KNOWN_CONSTRAINTS",
+    ],
+    basePrompt: `I want to ship this feature safely.
+
+Feature goal:
+{{FEATURE_GOAL}}
+
+Primary user journey:
+{{USER_JOURNEY}}
+
+Existing surfaces to reuse:
+{{EXISTING_SURFACES}}
+
+Known constraints:
+{{KNOWN_CONSTRAINTS}}
+
+Break this into 3-5 PR slices. For each slice include scope, files likely touched, tests, rollout risk, and what should explicitly stay out of scope.`,
+    variants: [
+      {
+        id: "community-product",
+        stack: "Community Product",
+        useCase: "Member-facing features in a community app",
+        prompt: `Act as a pragmatic product engineer. Break the feature below into PRs that each create visible user value without overbuilding data contracts.
+
+Goal:
+{{FEATURE_GOAL}}
+
+Journey:
+{{USER_JOURNEY}}
+
+Existing app surfaces:
+{{EXISTING_SURFACES}}
+
+Constraints:
+{{KNOWN_CONSTRAINTS}}
+
+Return a staged plan with one read-only or low-risk first slice, one persistence/API slice if needed, and one polish/observability slice.`,
+        notes: [
+          "Useful when the issue asks for APIs but the data model is not settled yet.",
+          "Keeps early PRs reviewable while still moving the feature forward.",
+        ],
+      },
+      {
+        id: "saas-dashboard",
+        stack: "SaaS Dashboard",
+        useCase: "Operational workflow additions",
+        prompt: `Plan this dashboard feature as small operational increments.
+
+Feature:
+{{FEATURE_GOAL}}
+
+Workflow:
+{{USER_JOURNEY}}
+
+Current modules:
+{{EXISTING_SURFACES}}
+
+Constraints:
+{{KNOWN_CONSTRAINTS}}
+
+Prioritize dense, scan-friendly UI, deterministic server contracts, audit-friendly state changes, and tests at the API plus component boundary.`,
+        notes: [
+          "Ask for empty, loading, permission-denied, and partial-data states in the first UI slice.",
+          "Useful for admin dashboards and repeated workflow screens.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "refactor-safety-review",
+    title: "Refactor Safety Review",
+    summary:
+      "Ask Cursor to identify behavior-preserving refactor risks before touching shared modules.",
+    category: "refactoring",
+    difficulty: "Intermediate",
+    placeholders: [
+      "CURRENT_MODULE",
+      "REFACTOR_GOAL",
+      "CALLERS",
+      "TESTS_AVAILABLE",
+    ],
+    basePrompt: `I am planning a behavior-preserving refactor.
+
+Current module:
+{{CURRENT_MODULE}}
+
+Refactor goal:
+{{REFACTOR_GOAL}}
+
+Known callers:
+{{CALLERS}}
+
+Existing tests:
+{{TESTS_AVAILABLE}}
+
+Before writing code, identify the invariants that must not change, missing tests to add first, migration steps, and rollback risks.`,
+    variants: [
+      {
+        id: "typescript-shared-lib",
+        stack: "TypeScript Shared Library",
+        useCase: "Extracting helpers used across app routes and components",
+        prompt: `Review this TypeScript refactor plan for shared-library risk.
+
+Module:
+{{CURRENT_MODULE}}
+
+Goal:
+{{REFACTOR_GOAL}}
+
+Callers:
+{{CALLERS}}
+
+Tests:
+{{TESTS_AVAILABLE}}
+
+List type-level invariants, runtime behavior invariants, import-cycle risks, and the minimum test matrix before code changes.`,
+        notes: [
+          "Helps prevent broad helper refactors from changing response text or error semantics.",
+          "Ask for caller categories rather than a single happy-path test.",
+        ],
+      },
+      {
+        id: "react-component-split",
+        stack: "React Component Split",
+        useCase: "Breaking up large UI components",
+        prompt: `Evaluate this React component split before implementation.
+
+Component:
+{{CURRENT_MODULE}}
+
+Goal:
+{{REFACTOR_GOAL}}
+
+Callers:
+{{CALLERS}}
+
+Tests:
+{{TESTS_AVAILABLE}}
+
+Identify prop boundaries, state that should stay colocated, accessibility behaviors that must be preserved, and RTL tests that should be added before the split.`,
+        notes: [
+          "Use this before decomposing page components with forms, modals, or keyboard behavior.",
+          "Keep state ownership explicit so the split does not create sync bugs.",
+        ],
+      },
+    ],
+  },
+];
+
+export function getPromptTemplateById(id: string): PromptTemplate | null {
+  return PROMPT_TEMPLATES.find((template) => template.id === id) ?? null;
+}
+
+export function getTemplateStacks(): string[] {
+  const stacks = new Set<string>();
+  for (const template of PROMPT_TEMPLATES) {
+    for (const variant of template.variants) {
+      stacks.add(variant.stack);
+    }
+  }
+  return [...stacks].sort((a, b) => a.localeCompare(b));
+}
+
+export function getTemplatePlaceholderTokens(template: PromptTemplate): string[] {
+  const tokens = new Set(template.placeholders);
+  const pattern = /\{\{([A-Z0-9_]+)\}\}/g;
+  for (const prompt of [
+    template.basePrompt,
+    ...template.variants.map((variant) => variant.prompt),
+  ]) {
+    for (const match of prompt.matchAll(pattern)) {
+      tokens.add(match[1]);
+    }
+  }
+  return [...tokens].sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
Summary
- Add a public `/templates` prompt-template gallery with seeded templates, categories, stack counts, and variant counts.
- Add template detail pages with placeholders, base prompt, stack-specific variants, metadata, and CreativeWork JSON-LD.
- Add prompt-template data helpers, sitemap coverage for gallery/detail routes, and sidebar navigation.

Tests
- npm test -- --runTestsByPath __tests__/lib/prompt-templates.test.ts --runInBand
- npx eslint lib/prompt-templates.ts __tests__/lib/prompt-templates.test.ts app/templates/page.tsx app/templates/layout.tsx app/templates/[templateId]/page.tsx components/AppShell.tsx app/sitemap.ts --max-warnings=0
- npm run type-check
- git diff --check

Refs #255

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)