### PR TITLE
refactor: add Tailwind class constants slice

### DIFF
--- a/__tests__/lib/classname-constants.test.ts
+++ b/__tests__/lib/classname-constants.test.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES } from "@/lib/classname-constants";
+
+function collectStringLeaves(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (!value || typeof value !== "object") return [];
+
+  return Object.values(value).flatMap(collectStringLeaves);
+}
+
+describe("Tailwind class constants", () => {
+  it("exposes at least 50 atomic Tailwind class tokens", () => {
+    const tokens = collectStringLeaves(TAILWIND_CLASS_NAMES).flatMap((value) =>
+      value.split(/\s+/)
+    );
+
+    expect(new Set(tokens).size).toBeGreaterThanOrEqual(50);
+  });
+
+  it("keeps grouped component classes built from the shared tokens", () => {
+    expect(CLASS_GROUPS.form.inputDark).toContain("focus:ring-emerald-400");
+    expect(CLASS_GROUPS.badge.earnedPill).toBe(
+      "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+    );
+    expect(CLASS_GROUPS.vote.column).toContain("min-w-[40px]");
+  });
+});

--- a/components/SectionHelp.tsx
+++ b/components/SectionHelp.tsx
@@ -10,6 +10,8 @@
 import Link from "next/link";
 import { useState } from "react";
 import { ChevronDown, ChevronRight, Info } from "lucide-react";
+import { TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 
 export interface SectionHelpLink {
   label: string;
@@ -49,21 +51,26 @@ export function SectionHelp({
 
   return (
     <aside
-      className={`mb-6 rounded-lg border border-blue-200 dark:border-blue-900/50 bg-blue-50/50 dark:bg-blue-900/10 px-4 py-3 ${
-        className ?? ""
-      }`}
+      className={cn(
+        "mb-6 border-blue-200 dark:border-blue-900/50 bg-blue-50/50 dark:bg-blue-900/10",
+        TW.radius.lg,
+        TW.border.base,
+        TW.spacing.px4,
+        TW.spacing.py3,
+        className
+      )}
       aria-label={title}
     >
-      <div className="flex items-start gap-3">
+      <div className={cn(TW.layout.flex, TW.layout.itemsStart, TW.spacing.gap3)}>
         <Info
-          className="h-4 w-4 mt-0.5 text-blue-700 dark:text-blue-300 shrink-0"
+          className={cn(TW.sizing.iconSm, "mt-0.5 text-blue-700 dark:text-blue-300", TW.layout.shrink0)}
           aria-hidden="true"
         />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+        <div className={cn(TW.layout.flex1, TW.layout.minW0)}>
+          <p className={cn(TW.text.sm, TW.text.semibold, "text-blue-900 dark:text-blue-200")}>
             {title}
           </p>
-          <div className="mt-1 text-sm leading-relaxed text-blue-900/90 dark:text-blue-100/90">
+          <div className={cn(TW.spacing.mt1, TW.text.sm, "leading-relaxed text-blue-900/90 dark:text-blue-100/90")}>
             {intro}
           </div>
           {hasMore && (
@@ -71,13 +78,13 @@ export function SectionHelp({
               <button
                 type="button"
                 onClick={() => setOpen((v) => !v)}
-                className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-blue-800 dark:text-blue-300 hover:underline"
+                className={cn(TW.spacing.mt2, TW.layout.inlineFlex, TW.layout.itemsCenter, TW.spacing.gap1, TW.text.tiny, TW.text.medium, "text-blue-800 dark:text-blue-300 hover:underline")}
                 aria-expanded={open}
               >
                 {open ? (
-                  <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                  <ChevronDown className={TW.sizing.iconXs} aria-hidden="true" />
                 ) : (
-                  <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+                  <ChevronRight className={TW.sizing.iconXs} aria-hidden="true" />
                 )}
                 {open ? "Show less" : "Learn more"}
               </button>
@@ -87,10 +94,10 @@ export function SectionHelp({
                     <dl className="space-y-2.5">
                       {faq.map((item, i) => (
                         <div key={i}>
-                          <dt className="text-sm font-medium text-blue-900 dark:text-blue-200">
+                          <dt className={cn(TW.text.sm, TW.text.medium, "text-blue-900 dark:text-blue-200")}>
                             {item.q}
                           </dt>
-                          <dd className="mt-0.5 text-sm text-blue-900/85 dark:text-blue-100/85">
+                          <dd className={cn("mt-0.5", TW.text.sm, "text-blue-900/85 dark:text-blue-100/85")}>
                             {item.a}
                           </dd>
                         </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -10,6 +10,8 @@
 import * as React from "react";
 import { Moon, Sun, Monitor } from "lucide-react";
 import { useTheme } from "next-themes";
+import { TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 
 const themeOptions = [
   { value: "light", label: "Light", icon: Sun },
@@ -17,9 +19,25 @@ const themeOptions = [
   { value: "system", label: "System", icon: Monitor },
 ] as const;
 
+function subscribeToMount(): () => void {
+  return () => {};
+}
+
+function getClientSnapshot(): boolean {
+  return true;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = React.useState(false);
+  const mounted = React.useSyncExternalStore(
+    subscribeToMount,
+    getClientSnapshot,
+    getServerSnapshot
+  );
   const [isOpen, setIsOpen] = React.useState(false);
   const [focusedIndex, setFocusedIndex] = React.useState(-1);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
@@ -27,11 +45,10 @@ export function ThemeToggle() {
   const menuItemRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
 
   React.useEffect(() => {
-    setMounted(true);
-
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
+        setFocusedIndex(-1);
       }
     };
 
@@ -41,22 +58,41 @@ export function ThemeToggle() {
     };
   }, []);
 
-  // Focus the active theme option (or first item) when the menu opens
-  React.useEffect(() => {
-    if (isOpen) {
-      const activeIndex = themeOptions.findIndex((opt) => opt.value === theme);
-      const index = activeIndex >= 0 ? activeIndex : 0;
-      setFocusedIndex(index);
+  const getActiveIndex = React.useCallback(() => {
+    const activeIndex = themeOptions.findIndex((opt) => opt.value === theme);
+    return activeIndex >= 0 ? activeIndex : 0;
+  }, [theme]);
+
+  const focusMenuItem = React.useCallback((index: number) => {
+    requestAnimationFrame(() => {
       menuItemRefs.current[index]?.focus();
-    } else {
-      setFocusedIndex(-1);
-    }
-  }, [isOpen, theme]);
+    });
+  }, []);
+
+  const closeMenu = React.useCallback(() => {
+    setIsOpen(false);
+    setFocusedIndex(-1);
+  }, []);
+
+  const openMenu = React.useCallback(() => {
+    const index = getActiveIndex();
+    setFocusedIndex(index);
+    setIsOpen(true);
+    focusMenuItem(index);
+  }, [focusMenuItem, getActiveIndex]);
 
   const closeAndRestoreFocus = React.useCallback(() => {
-    setIsOpen(false);
+    closeMenu();
     buttonRef.current?.focus();
-  }, []);
+  }, [closeMenu]);
+
+  const handleDropdownKeyDownCapture = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isOpen && event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      closeAndRestoreFocus();
+    }
+  };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent) => {
     switch (event.key) {
@@ -94,7 +130,7 @@ export function ThemeToggle() {
       }
       case "Tab": {
         // Close menu on Tab and let the browser move focus naturally.
-        setIsOpen(false);
+        closeMenu();
         break;
       }
     }
@@ -103,7 +139,7 @@ export function ThemeToggle() {
   const handleTriggerKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      setIsOpen(true);
+      openMenu();
     }
   };
 
@@ -117,12 +153,24 @@ export function ThemeToggle() {
   }
 
   return (
-    <div className="relative" ref={dropdownRef}>
+    <div className="relative" ref={dropdownRef} onKeyDownCapture={handleDropdownKeyDownCapture}>
       <button
         ref={buttonRef}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          if (isOpen) {
+            closeMenu();
+          } else {
+            openMenu();
+          }
+        }}
         onKeyDown={handleTriggerKeyDown}
-        className="rounded-md p-2 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus:outline-none focus:ring-2 focus:ring-foreground"
+        className={cn(
+          TW.radius.md,
+          TW.spacing.p2,
+          TW.state.hoverNeutral,
+          TW.motion.colors,
+          TW.focus.foreground
+        )}
         aria-label="Toggle theme"
         aria-haspopup="true"
         aria-expanded={isOpen}
@@ -139,7 +187,12 @@ export function ThemeToggle() {
           role="menu"
           aria-label="Theme selection"
           onKeyDown={handleMenuKeyDown}
-          className="absolute left-full bottom-0 ml-2 w-36 rounded-md bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 shadow-lg ring-1 ring-black ring-opacity-5 z-50"
+          className={cn(
+            "absolute left-full bottom-0 ml-2 w-36 shadow-lg ring-1 ring-black ring-opacity-5 z-50",
+            TW.radius.md,
+            TW.surface.card,
+            TW.border.neutral
+          )}
         >
           <div className="py-1" role="none">
             {themeOptions.map((option, index) => {
@@ -151,11 +204,13 @@ export function ThemeToggle() {
                   role="menuitem"
                   tabIndex={focusedIndex === index ? 0 : -1}
                   onClick={() => selectTheme(option.value)}
-                  className={`flex w-full items-center px-4 py-2 text-sm focus:outline-none ${
+                  className={cn(
+                    "flex w-full items-center px-4 py-2 text-sm focus:outline-none",
                     theme === option.value
                       ? "bg-neutral-100 dark:bg-neutral-800 text-emerald-600 dark:text-emerald-400"
-                      : "text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-                  } ${focusedIndex === index ? "ring-2 ring-inset ring-foreground" : ""}`}
+                      : "text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800",
+                    focusedIndex === index && "ring-2 ring-inset ring-foreground"
+                  )}
                 >
                   <Icon className="mr-3 h-4 w-4" />
                   {option.label}

--- a/components/badges/BadgeCard.tsx
+++ b/components/badges/BadgeCard.tsx
@@ -7,6 +7,7 @@
 
 import { useRef, useState, type KeyboardEvent, type SVGProps } from "react";
 import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
 import { cn } from "@/lib/utils";
 import { BadgePopover } from "./BadgePopover";
 
@@ -192,13 +193,16 @@ export function BadgeCard({
       <article
         ref={triggerRef}
         className={cn(
-          "rounded-xl border transition-colors cursor-pointer",
-          "bg-white dark:bg-neutral-900",
+          TW.radius.xl,
+          TW.border.base,
+          TW.motion.colors,
+          TW.state.cursorPointer,
+          TW.surface.card,
           isEarned
-            ? "border-emerald-300/70 dark:border-emerald-500/40"
+            ? TW.border.emerald
             : "border-neutral-200 dark:border-neutral-800",
-          !compact && "hover:border-neutral-300 dark:hover:border-neutral-700",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400",
+          !compact && CLASS_GROUPS.card.neutralHover,
+          TW.focus.emerald,
           compact ? "p-3" : "p-4",
           className
         )}
@@ -213,7 +217,12 @@ export function BadgeCard({
         <div className={cn("flex items-start", compact ? "gap-3" : "gap-4")}>
           <div
             className={cn(
-              "shrink-0 rounded-full border flex items-center justify-center",
+              TW.layout.shrink0,
+              TW.radius.full,
+              TW.border.base,
+              TW.layout.flex,
+              TW.layout.itemsCenter,
+              TW.layout.justifyCenter,
               compact ? "h-9 w-9" : "h-11 w-11",
               isEarned
                 ? "bg-emerald-500/10 border-emerald-500/30 text-emerald-600 dark:text-emerald-400"
@@ -232,7 +241,9 @@ export function BadgeCard({
             <div className="flex items-center gap-2 mb-1">
               <h3
                 className={cn(
-                  "font-semibold text-foreground truncate",
+                  TW.text.semibold,
+                  TW.text.foreground,
+                  TW.layout.truncate,
                   compact ? "text-sm" : "text-base"
                 )}
               >
@@ -240,10 +251,8 @@ export function BadgeCard({
               </h3>
               <span
                 className={cn(
-                  "shrink-0 px-2 py-0.5 rounded-full text-xs font-medium",
-                  isEarned
-                    ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                    : "bg-neutral-200/80 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400"
+                  CLASS_GROUPS.badge.basePill,
+                  isEarned ? CLASS_GROUPS.badge.earnedPill : CLASS_GROUPS.badge.lockedPill
                 )}
               >
                 {isEarned ? "Earned" : isAuthoritative ? "Locked" : "Unverified data"}
@@ -252,7 +261,7 @@ export function BadgeCard({
 
             <p
               className={cn(
-                "text-neutral-600 dark:text-neutral-400",
+                TW.text.muted,
                 compact ? "text-xs" : "text-sm"
               )}
             >
@@ -262,7 +271,8 @@ export function BadgeCard({
             {!isEarned && (
               <p
                 className={cn(
-                  "text-neutral-500 dark:text-neutral-400 mt-1",
+                  TW.text.subtle,
+                  TW.spacing.mt1,
                   compact ? "text-xs" : "text-sm"
                 )}
               >
@@ -273,7 +283,8 @@ export function BadgeCard({
             {isEarned && earnedDateLabel && (
               <p
                 className={cn(
-                  "text-neutral-500 dark:text-neutral-400 mt-1",
+                  TW.text.subtle,
+                  TW.spacing.mt1,
                   compact ? "text-xs" : "text-sm"
                 )}
               >
@@ -283,7 +294,7 @@ export function BadgeCard({
 
             {eligibility?.progress && (
               <div className={cn("mt-2", compact ? "text-xs" : "text-sm")}>
-                <p className="text-neutral-500 dark:text-neutral-400 mb-1">
+                <p className={cn(TW.text.subtle, TW.spacing.mb1)}>
                   Progress: {eligibility.progress.current}/{eligibility.progress.target}
                   {eligibility.progress.unit ? ` ${eligibility.progress.unit}` : ""}
                 </p>
@@ -306,7 +317,8 @@ export function BadgeCard({
 
             <p
               className={cn(
-                "mt-2 text-neutral-500 dark:text-neutral-400",
+                TW.spacing.mt2,
+                TW.text.subtle,
                 compact ? "text-[11px]" : "text-xs"
               )}
             >

--- a/components/badges/BadgeGrid.tsx
+++ b/components/badges/BadgeGrid.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { BadgeDefinition, BadgeEligibilityMap, BadgeId } from "@/lib/badges/types";
+import { TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
 import { cn } from "@/lib/utils";
 import { BadgeCard } from "./BadgeCard";
 
@@ -37,8 +38,8 @@ export function BadgeGrid({
       <div
         className={cn(
           isHorizontal
-            ? "flex gap-4 overflow-x-auto pb-1 pr-2"
-            : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+            ? cn(TW.layout.flex, TW.spacing.gap4, "overflow-x-auto pb-1 pr-2")
+            : cn(TW.layout.grid, "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3", TW.spacing.gap4)
         )}
       >
         {definitions.map((definition) => {
@@ -61,7 +62,7 @@ export function BadgeGrid({
 
           if (isHorizontal) {
             return (
-              <div key={definition.id} className="min-w-[260px] shrink-0">
+              <div key={definition.id} className={cn("min-w-[260px]", TW.layout.shrink0)}>
                 {card}
               </div>
             );

--- a/components/badges/BadgePopover.tsx
+++ b/components/badges/BadgePopover.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect, useRef } from "react";
 import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
 import { cn } from "@/lib/utils";
 
 interface BadgePopoverProps {
@@ -75,7 +76,7 @@ export function BadgePopover({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      className={cn("fixed z-50", TW.layout.inset0, TW.layout.flex, TW.layout.itemsCenter, TW.layout.justifyCenter, TW.spacing.p4)}
       role="dialog"
       aria-modal="true"
       aria-labelledby={headingId}
@@ -83,30 +84,28 @@ export function BadgePopover({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/40"
+        className={cn(TW.layout.absolute, TW.layout.inset0, TW.surface.overlay)}
         aria-label="Close"
         onClick={onClose}
       />
 
       <div
         ref={dialogRef}
-        className="relative w-full max-w-sm rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-xl"
+        className={cn(TW.layout.relative, TW.layout.wFull, "max-w-sm shadow-xl", CLASS_GROUPS.card.neutral)}
       >
-        <div className="flex items-start justify-between gap-3 p-4 border-b border-neutral-200 dark:border-neutral-800">
+        <div className={cn(TW.layout.flex, TW.layout.itemsStart, TW.layout.justifyBetween, TW.spacing.gap3, TW.spacing.p4, TW.border.bottomNeutral)}>
           <div className="min-w-0">
-            <h3 id={headingId} className="text-base font-semibold text-foreground truncate">
+            <h3 id={headingId} className={cn("text-base", TW.text.semibold, TW.text.foreground, TW.layout.truncate)}>
               {definition.name}
             </h3>
-            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+            <p className={cn(TW.text.tiny, TW.text.subtle, TW.spacing.mt1)}>
               {anchorLabel || "Achievement badge"}
             </p>
           </div>
           <span
             className={cn(
-              "shrink-0 px-2 py-0.5 rounded-full text-xs font-medium",
-              isEarned
-                ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                : "bg-neutral-200/80 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400"
+              CLASS_GROUPS.badge.basePill,
+              isEarned ? CLASS_GROUPS.badge.earnedPill : CLASS_GROUPS.badge.lockedPill
             )}
           >
             {isEarned ? "Earned" : "Locked"}
@@ -115,29 +114,29 @@ export function BadgePopover({
 
         <div className="p-4 space-y-3">
           <div>
-            <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+            <p className={cn(CLASS_GROUPS.text.sectionLabel, TW.spacing.mb1)}>
               Description
             </p>
-            <p className="text-sm text-neutral-700 dark:text-neutral-300">
+            <p className={CLASS_GROUPS.text.body}>
               {definition.description}
             </p>
           </div>
 
           <div>
-            <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+            <p className={cn(CLASS_GROUPS.text.sectionLabel, TW.spacing.mb1)}>
               How to earn
             </p>
-            <p className="text-sm text-neutral-700 dark:text-neutral-300">
+            <p className={CLASS_GROUPS.text.body}>
               {definition.howToEarn}
             </p>
           </div>
 
           {eligibility?.progress && (
             <div>
-              <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+              <p className={cn(CLASS_GROUPS.text.sectionLabel, TW.spacing.mb1)}>
                 Progress
               </p>
-              <p className="text-sm text-neutral-700 dark:text-neutral-300 mb-2">
+              <p className={cn(CLASS_GROUPS.text.body, TW.spacing.mb2)}>
                 {eligibility.progress.current}/{eligibility.progress.target}
                 {eligibility.progress.unit ? ` ${eligibility.progress.unit}` : ""}
               </p>
@@ -160,10 +159,10 @@ export function BadgePopover({
 
           {!isEarned && eligibility?.reason && (
             <div className="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-800/40 p-3">
-              <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">
+              <p className={cn(CLASS_GROUPS.text.sectionLabel, TW.spacing.mb1)}>
                 Next step
               </p>
-              <p className="text-sm text-neutral-700 dark:text-neutral-300">
+              <p className={CLASS_GROUPS.text.body}>
                 {eligibility.reason}
               </p>
             </div>
@@ -186,7 +185,7 @@ export function BadgePopover({
             ref={closeButtonRef}
             type="button"
             onClick={onClose}
-            className="w-full px-3 py-2 rounded-lg bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+            className={cn(TW.layout.wFull, TW.spacing.px3, TW.spacing.py2, TW.radius.lg, CLASS_GROUPS.button.neutral, TW.text.sm, TW.text.medium)}
           >
             Close
           </button>

--- a/components/cookbook/CookbookEntryCard.tsx
+++ b/components/cookbook/CookbookEntryCard.tsx
@@ -11,6 +11,8 @@ import { useState } from "react";
 import Link from "next/link";
 import { CATEGORY_LABELS } from "@/lib/cookbook-labels";
 import { formatCookbookDate } from "@/lib/format-cookbook-date";
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 import type { CookbookCategory, CookbookEntry } from "@/types/cookbook";
 import { PromptMarkdown } from "./PromptMarkdown";
 
@@ -63,16 +65,16 @@ export function CookbookEntryCard({
   const tagsMore = tagsList.length - MAX_TAGS;
 
   return (
-    <div className="group h-full flex flex-col bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800 hover:border-emerald-500/30 dark:hover:border-emerald-500/30 hover:shadow-lg dark:hover:shadow-emerald-500/5 transition-all duration-200">
+    <div className={cn("group hover:border-emerald-500/30 dark:hover:border-emerald-500/30 hover:shadow-lg dark:hover:shadow-emerald-500/5", TW.layout.hFull, TW.layout.flex, TW.layout.flexCol, TW.radius.twoXl, TW.layout.overflowHidden, TW.surface.card, TW.border.neutral, TW.motion.all, TW.motion.duration200)}>
       <div className="p-6 flex flex-col flex-1 min-h-0">
         <h3 className="text-lg font-bold text-foreground mb-2">{entry.title}</h3>
-        <p className="text-neutral-600 dark:text-neutral-400 text-sm leading-relaxed mb-4 line-clamp-2">
+        <p className={cn(CLASS_GROUPS.text.muted, "leading-relaxed", TW.spacing.mb4, "line-clamp-2")}>
           {entry.description}
         </p>
 
         <div className="relative rounded-xl overflow-hidden mb-4 border border-neutral-200 dark:border-neutral-700/80 bg-neutral-50 dark:bg-neutral-950 shadow-inner">
           <div className="flex items-center justify-between px-3 py-2 bg-neutral-100 dark:bg-neutral-800/80 border-b border-neutral-200 dark:border-neutral-700/80">
-            <span className="text-xs font-medium text-neutral-500 dark:text-neutral-400 uppercase tracking-wider">
+            <span className={cn(TW.text.tiny, TW.text.medium, TW.text.subtle, TW.text.uppercase, TW.text.wide)}>
               Prompt
             </span>
             <div className="flex items-center gap-2">
@@ -83,7 +85,7 @@ export function CookbookEntryCard({
                   onViewFull(entry);
                 }}
                 aria-label={`View full prompt: ${entry.title}`}
-                className="text-xs font-medium text-emerald-600 dark:text-emerald-400 hover:text-emerald-500 dark:hover:text-emerald-300 transition-colors"
+                className={cn(TW.text.tiny, TW.text.medium, TW.text.accent, "hover:text-emerald-500 dark:hover:text-emerald-300", TW.motion.colors)}
               >
                 View full
               </button>
@@ -94,7 +96,7 @@ export function CookbookEntryCard({
                   void handleCopy();
                 }}
                 aria-label={copied ? "Prompt copied to clipboard" : `Copy prompt: ${entry.title}`}
-                className="px-2 py-1 rounded-md bg-neutral-200 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                className={cn(TW.spacing.px2, TW.spacing.py1, TW.radius.md, "bg-neutral-200 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-300 dark:hover:bg-neutral-600", TW.text.tiny, TW.text.medium, TW.motion.colors, TW.focus.emerald)}
               >
                 {copied ? "Copied!" : "Copy"}
               </button>
@@ -108,20 +110,20 @@ export function CookbookEntryCard({
 
         <div className="flex-1 flex flex-col justify-start gap-3 mb-4">
           <div>
-            <span className="px-2.5 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-medium rounded-full">
+            <span className={CLASS_GROUPS.tag.successPill}>
               {CATEGORY_LABELS[entry.category as CookbookCategory] || entry.category}
             </span>
           </div>
           {worksWithList.length > 0 && (
             <div>
-              <span className="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-2 uppercase tracking-wider">
+              <span className={cn(TW.layout.block, TW.text.tiny, TW.text.medium, TW.text.subtle, TW.spacing.mb2, TW.text.uppercase, TW.text.wide)}>
                 Works with
               </span>
               <div className="flex flex-wrap gap-1.5">
                 {worksWithDisplay.map((w) => (
                   <span
                     key={w}
-                    className="px-2.5 py-1 bg-neutral-200 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-xs font-medium rounded-full"
+                    className={CLASS_GROUPS.tag.neutralStrongPill}
                   >
                     {w}
                   </span>
@@ -136,7 +138,7 @@ export function CookbookEntryCard({
           )}
           {tagsList.length > 0 && (
             <div>
-              <span className="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-2 uppercase tracking-wider">
+              <span className={cn(TW.layout.block, TW.text.tiny, TW.text.medium, TW.text.subtle, TW.spacing.mb2, TW.text.uppercase, TW.text.wide)}>
                 Tags
               </span>
               <div className="flex flex-wrap gap-1.5">
@@ -150,14 +152,14 @@ export function CookbookEntryCard({
                         onTagClick(tag);
                       }}
                       aria-label={`Filter by tag: ${tag}`}
-                      className="px-2.5 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-200 text-xs font-medium rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                      className={cn(CLASS_GROUPS.tag.neutralPill, "hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-200", TW.motion.colors, TW.focus.emerald)}
                     >
                       {tag}
                     </button>
                   ) : (
                     <span
                       key={tag}
-                      className="px-2.5 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 text-xs font-medium rounded-full"
+                      className={CLASS_GROUPS.tag.neutralPill}
                     >
                       {tag}
                     </span>
@@ -177,12 +179,12 @@ export function CookbookEntryCard({
           <div className="min-w-0 flex-1">
             <Link
               href={`/members?search=${encodeURIComponent(entry.authorDisplayName)}`}
-              className="text-xs text-neutral-500 hover:text-foreground transition-colors"
+              className={cn(CLASS_GROUPS.text.metadata, "hover:text-foreground", TW.motion.colors)}
             >
               by {entry.authorDisplayName}
             </Link>
             {entry.createdAt && (
-              <span className="text-xs text-neutral-500 block mt-0.5">
+              <span className={cn(CLASS_GROUPS.text.metadata, TW.layout.block, "mt-0.5")}>
                 {formatCookbookDate(entry.createdAt)}
               </span>
             )}
@@ -195,11 +197,20 @@ export function CookbookEntryCard({
               disabled={!isLoggedIn || isVoting}
               title={isLoggedIn ? "Upvote" : "Sign in to vote"}
               aria-label={`Upvote ${entry.title}, ${upCount} upvotes`}
-              className={`flex items-center gap-1 px-2 py-1 rounded-lg text-sm transition-colors ${
+              className={cn(
+                TW.layout.flex,
+                TW.layout.itemsCenter,
+                TW.spacing.gap1,
+                TW.spacing.px2,
+                TW.spacing.py1,
+                TW.radius.lg,
+                TW.text.sm,
+                TW.motion.colors,
                 userVote === "up"
                   ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                  : "text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-              } disabled:opacity-40 disabled:cursor-not-allowed`}
+                  : "text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800",
+                TW.state.disabledSoft
+              )}
             >
               <svg
                 width="16"
@@ -218,13 +229,16 @@ export function CookbookEntryCard({
             </button>
 
             <span
-              className={`text-sm font-semibold min-w-8 text-center ${
+              className={cn(
+                TW.text.sm,
+                TW.text.semibold,
+                "min-w-8 text-center",
                 netScore > 0
-                  ? "text-emerald-600 dark:text-emerald-400"
+                  ? CLASS_GROUPS.status.positiveScore
                   : netScore < 0
-                    ? "text-red-500"
-                    : "text-neutral-500"
-              }`}
+                    ? CLASS_GROUPS.status.negativeScore
+                    : CLASS_GROUPS.status.neutralScore
+              )}
             >
               {netScore > 0 ? `+${netScore}` : netScore}
             </span>
@@ -235,11 +249,20 @@ export function CookbookEntryCard({
               disabled={!isLoggedIn || isVoting}
               title={isLoggedIn ? "Downvote" : "Sign in to vote"}
               aria-label={`Downvote ${entry.title}, ${downCount} downvotes`}
-              className={`flex items-center gap-1 px-2 py-1 rounded-lg text-sm transition-colors ${
+              className={cn(
+                TW.layout.flex,
+                TW.layout.itemsCenter,
+                TW.spacing.gap1,
+                TW.spacing.px2,
+                TW.spacing.py1,
+                TW.radius.lg,
+                TW.text.sm,
+                TW.motion.colors,
                 userVote === "down"
                   ? "bg-red-500/10 text-red-500"
-                  : "text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-              } disabled:opacity-40 disabled:cursor-not-allowed`}
+                  : "text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800",
+                TW.state.disabledSoft
+              )}
             >
               <svg
                 width="16"

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -15,6 +15,8 @@ import { getBaseBadgeEligibilityInput } from "@/lib/badges/getBadgeEligibilityIn
 import { getEarnedBadgeIds } from "@/lib/badges/utils";
 import { BadgeGrid } from "@/components/badges/BadgeGrid";
 import { SHOWCASE_AWARD_LABEL } from "@/lib/hackathon-asprint-2026-awards";
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 
 interface MemberCardProps {
   member: PublicMember;
@@ -59,7 +61,7 @@ export function MemberCard({ member }: MemberCardProps) {
   ].slice(0, 3);
 
   return (
-    <div className="bg-white dark:bg-neutral-900 rounded-xl p-6 border border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors">
+    <div className={cn(CLASS_GROUPS.card.neutral, TW.spacing.p6, CLASS_GROUPS.card.neutralHover, TW.motion.colors)}>
       {/* Header */}
       <div className="flex items-start gap-4 mb-4">
         <div className="relative shrink-0">
@@ -87,26 +89,29 @@ export function MemberCard({ member }: MemberCardProps) {
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-0.5">
-            <h3 className="text-foreground font-semibold text-lg truncate">
+            <h3 className={cn(TW.text.foreground, TW.text.semibold, TW.text.lg, TW.layout.truncate)}>
               {member.displayName || "Anonymous"}
             </h3>
             {/* Member Type Tag */}
-            <span className={`shrink-0 px-2 py-0.5 text-xs rounded-full font-medium ${
-              isAgent 
-                ? "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/30" 
-                : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/30"
-            }`}>
+            <span
+              className={cn(
+                CLASS_GROUPS.badge.basePill,
+                isAgent
+                  ? "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/30"
+                  : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/30"
+              )}
+            >
               {isAgent ? "Agent" : "Human"}
             </span>
           </div>
           {!isAgent && v?.showJobTitle && member.jobTitle && (
-            <p className="text-neutral-600 dark:text-neutral-400 text-sm truncate">{member.jobTitle}</p>
+            <p className={cn(CLASS_GROUPS.text.muted, TW.layout.truncate)}>{member.jobTitle}</p>
           )}
           {!isAgent && v?.showCompany && member.company && (
-            <p className="text-neutral-600 dark:text-neutral-400 text-sm truncate">{member.company}</p>
+            <p className={cn(CLASS_GROUPS.text.muted, TW.layout.truncate)}>{member.company}</p>
           )}
           {isAgent && member.owner?.displayName && v?.showOwner && (
-            <p className="text-neutral-600 dark:text-neutral-400 text-sm truncate">
+            <p className={cn(CLASS_GROUPS.text.muted, TW.layout.truncate)}>
               Owned by {member.owner.displayName}
             </p>
           )}
@@ -115,12 +120,12 @@ export function MemberCard({ member }: MemberCardProps) {
 
       {/* Bio */}
       {v?.showBio && member.bio && (
-        <p className="text-neutral-700 dark:text-neutral-300 text-sm mb-4 line-clamp-3">{member.bio}</p>
+        <p className={cn(CLASS_GROUPS.text.body, TW.spacing.mb4, "line-clamp-3")}>{member.bio}</p>
       )}
 
       {/* Location */}
       {v?.showLocation && member.location && (
-        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400 text-sm mb-4">
+        <div className={cn(TW.layout.flex, TW.layout.itemsCenter, TW.spacing.gap2, CLASS_GROUPS.text.muted, TW.spacing.mb4)}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="14"
@@ -155,29 +160,29 @@ export function MemberCard({ member }: MemberCardProps) {
           </span>
         )}
         {v?.showEventsAttended && member.eventsAttended && member.eventsAttended > 0 && (
-          <span className="px-2 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs rounded-full">
+          <span className={cn(TW.spacing.px2, TW.spacing.py1, TW.surface.emeraldSoft, TW.text.accent, TW.text.tiny, TW.radius.full)}>
             {member.eventsAttended} event{member.eventsAttended !== 1 ? "s" : ""} attended
           </span>
         )}
         {v?.showTalksGiven && member.talksGiven && member.talksGiven > 0 && (
-          <span className="px-2 py-1 bg-purple-500/10 text-purple-600 dark:text-purple-400 text-xs rounded-full">
+          <span className={cn(TW.spacing.px2, TW.spacing.py1, TW.surface.purpleSoft, "text-purple-600 dark:text-purple-400", TW.text.tiny, TW.radius.full)}>
             {member.talksGiven} talk{member.talksGiven !== 1 ? "s" : ""} given
           </span>
         )}
         {member.pullRequestsCount && member.pullRequestsCount > 0 && (
-          <span className="px-2 py-1 bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs rounded-full">
+          <span className={cn(TW.spacing.px2, TW.spacing.py1, "bg-blue-500/10 text-blue-600 dark:text-blue-400", TW.text.tiny, TW.radius.full)}>
             {member.pullRequestsCount} PR{member.pullRequestsCount !== 1 ? "s" : ""}
           </span>
         )}
         {member.hackASprint2026ShowcaseBadge && (
-          <span className="px-2 py-1 bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 text-xs rounded-full">
+          <span className={cn(TW.spacing.px2, TW.spacing.py1, "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400", TW.text.tiny, TW.radius.full)}>
             Hack-a-Sprint &apos;26
           </span>
         )}
         {member.hackASprint2026ShowcaseAwards?.map((kind) => (
           <span
             key={kind}
-            className="px-2 py-1 bg-amber-500/15 text-amber-800 dark:text-amber-300 text-xs rounded-full"
+            className={cn(TW.spacing.px2, TW.spacing.py1, "bg-amber-500/15 text-amber-800 dark:text-amber-300", TW.text.tiny, TW.radius.full)}
           >
             {SHOWCASE_AWARD_LABEL[kind]}
           </span>
@@ -205,7 +210,7 @@ export function MemberCard({ member }: MemberCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Website (opens in new tab)"
-            className="text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white rounded p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+            className={CLASS_GROUPS.button.iconLink}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -231,7 +236,7 @@ export function MemberCard({ member }: MemberCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="LinkedIn (opens in new tab)"
-            className="text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white rounded p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+            className={CLASS_GROUPS.button.iconLink}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -251,7 +256,7 @@ export function MemberCard({ member }: MemberCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="X/Twitter (opens in new tab)"
-            className="text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white rounded p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+            className={CLASS_GROUPS.button.iconLink}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -271,7 +276,7 @@ export function MemberCard({ member }: MemberCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="GitHub (opens in new tab)"
-            className="text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white rounded p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+            className={CLASS_GROUPS.button.iconLink}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -291,7 +296,7 @@ export function MemberCard({ member }: MemberCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Substack (opens in new tab)"
-            className="text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white rounded p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+            className={CLASS_GROUPS.button.iconLink}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/components/questions/AnswerCard.tsx
+++ b/components/questions/AnswerCard.tsx
@@ -8,6 +8,8 @@
 "use client";
 
 import { ThumbsUp, ThumbsDown, CheckCircle2 } from "lucide-react";
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 import type { Answer, VoteType } from "@/types/questions";
 
 function timeAgo(dateStr: string): string {
@@ -43,41 +45,43 @@ export function AnswerCard({
 
   return (
     <div
-      className={[
-        "border rounded-xl p-4 sm:p-5 transition-colors",
+      className={cn(
+        TW.border.base,
+        TW.radius.xl,
+        "p-4 sm:p-5",
+        TW.motion.colors,
         answer.isAccepted
           ? "border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-950/20"
-          : "border-neutral-200 dark:border-neutral-800",
-      ].join(" ")}
+          : "border-neutral-200 dark:border-neutral-800"
+      )}
     >
       <div className="flex gap-4">
         {/* Vote column */}
-        <div className="flex flex-col items-center gap-1 min-w-[40px]">
+        <div className={CLASS_GROUPS.vote.column}>
           <button
             type="button"
             onClick={() => onVote(answer.id, "up")}
             disabled={!isLoggedIn || isVoting}
             aria-label={`Upvote answer by ${answer.authorName}`}
-            className={[
-              "p-1 rounded transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+            className={cn(
+              CLASS_GROUPS.button.iconAction,
               userVote === "up"
-                ? "text-emerald-600 dark:text-emerald-400"
-                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
-              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
-            ].join(" ")}
+                ? TW.text.accent
+                : CLASS_GROUPS.vote.inactive,
+              (!isLoggedIn || isVoting) && TW.state.disabled
+            )}
           >
             <ThumbsUp size={16} />
           </button>
           <span
-            className={[
-              "text-sm font-semibold",
+            className={cn(
+              CLASS_GROUPS.vote.score,
               netScore > 0
-                ? "text-emerald-600 dark:text-emerald-400"
+                ? CLASS_GROUPS.status.positiveScore
                 : netScore < 0
-                  ? "text-red-500"
-                  : "text-neutral-500",
-            ].join(" ")}
+                  ? CLASS_GROUPS.status.negativeScore
+                  : CLASS_GROUPS.status.neutralScore
+            )}
           >
             {netScore > 0 ? `+${netScore}` : netScore}
           </span>
@@ -86,14 +90,13 @@ export function AnswerCard({
             onClick={() => onVote(answer.id, "down")}
             disabled={!isLoggedIn || isVoting}
             aria-label={`Downvote answer by ${answer.authorName}`}
-            className={[
-              "p-1 rounded transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+            className={cn(
+              CLASS_GROUPS.button.iconAction,
               userVote === "down"
-                ? "text-red-500"
-                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
-              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
-            ].join(" ")}
+                ? CLASS_GROUPS.status.negativeScore
+                : CLASS_GROUPS.vote.inactive,
+              (!isLoggedIn || isVoting) && TW.state.disabled
+            )}
           >
             <ThumbsDown size={16} />
           </button>
@@ -104,19 +107,19 @@ export function AnswerCard({
               type="button"
               onClick={() => onAccept(answer.id)}
               aria-label={answer.isAccepted ? "Unaccept this answer" : "Accept this answer"}
-              className={[
-                "p-1 rounded transition-colors mt-1",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+              className={cn(
+                CLASS_GROUPS.button.iconAction,
+                TW.spacing.mt1,
                 answer.isAccepted
-                  ? "text-emerald-600 dark:text-emerald-400"
-                  : "text-neutral-400 hover:text-emerald-600 dark:hover:text-emerald-400",
-              ].join(" ")}
+                  ? TW.text.accent
+                  : "text-neutral-400 hover:text-emerald-600 dark:hover:text-emerald-400"
+              )}
             >
               <CheckCircle2 size={18} />
             </button>
           )}
           {!isQuestionAuthor && answer.isAccepted && (
-            <span className="text-emerald-600 dark:text-emerald-400 mt-1" title="Accepted answer">
+            <span className={cn(TW.text.accent, TW.spacing.mt1)} title="Accepted answer">
               <CheckCircle2 size={18} />
             </span>
           )}
@@ -130,7 +133,7 @@ export function AnswerCard({
             </span>
           )}
           <p className="text-sm text-foreground whitespace-pre-wrap">{answer.body}</p>
-          <div className="flex items-center gap-2 mt-3 text-xs text-neutral-500">
+          <div className={cn(TW.layout.flex, TW.layout.itemsCenter, TW.spacing.gap2, TW.spacing.mt3, CLASS_GROUPS.text.metadata)}>
             <span>{answer.authorName}</span>
             <span>&middot;</span>
             <span>{timeAgo(answer.createdAt)}</span>

--- a/components/questions/QuestionCard.tsx
+++ b/components/questions/QuestionCard.tsx
@@ -9,6 +9,8 @@
 
 import Link from "next/link";
 import { ThumbsUp, ThumbsDown, MessageSquare } from "lucide-react";
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 import type { Question, VoteType } from "@/types/questions";
 
 function timeAgo(dateStr: string): string {
@@ -41,35 +43,34 @@ export function QuestionCard({
   const netScore = question.upCount - question.downCount;
 
   return (
-    <div className="border border-neutral-200 dark:border-neutral-800 rounded-xl p-4 sm:p-5 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors">
+    <div className={cn(TW.border.neutral, TW.radius.xl, "p-4 sm:p-5", CLASS_GROUPS.card.neutralHover, TW.motion.colors)}>
       <div className="flex gap-4">
         {/* Vote column */}
-        <div className="flex flex-col items-center gap-1 min-w-[40px]">
+        <div className={CLASS_GROUPS.vote.column}>
           <button
             type="button"
             onClick={() => onVote(question.id, "up")}
             disabled={!isLoggedIn || isVoting}
             aria-label={`Upvote question: ${question.title}`}
-            className={[
-              "p-1 rounded transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+            className={cn(
+              CLASS_GROUPS.button.iconAction,
               userVote === "up"
-                ? "text-emerald-600 dark:text-emerald-400"
-                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
-              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
-            ].join(" ")}
+                ? TW.text.accent
+                : CLASS_GROUPS.vote.inactive,
+              (!isLoggedIn || isVoting) && TW.state.disabled
+            )}
           >
             <ThumbsUp size={16} />
           </button>
           <span
-            className={[
-              "text-sm font-semibold",
+            className={cn(
+              CLASS_GROUPS.vote.score,
               netScore > 0
-                ? "text-emerald-600 dark:text-emerald-400"
+                ? CLASS_GROUPS.status.positiveScore
                 : netScore < 0
-                  ? "text-red-500"
-                  : "text-neutral-500",
-            ].join(" ")}
+                  ? CLASS_GROUPS.status.negativeScore
+                  : CLASS_GROUPS.status.neutralScore
+            )}
           >
             {netScore > 0 ? `+${netScore}` : netScore}
           </span>
@@ -78,14 +79,13 @@ export function QuestionCard({
             onClick={() => onVote(question.id, "down")}
             disabled={!isLoggedIn || isVoting}
             aria-label={`Downvote question: ${question.title}`}
-            className={[
-              "p-1 rounded transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+            className={cn(
+              CLASS_GROUPS.button.iconAction,
               userVote === "down"
-                ? "text-red-500"
-                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
-              (!isLoggedIn || isVoting) ? "opacity-50 cursor-not-allowed" : "",
-            ].join(" ")}
+                ? CLASS_GROUPS.status.negativeScore
+                : CLASS_GROUPS.vote.inactive,
+              (!isLoggedIn || isVoting) && TW.state.disabled
+            )}
           >
             <ThumbsDown size={16} />
           </button>
@@ -100,7 +100,7 @@ export function QuestionCard({
             {question.title}
           </Link>
 
-          <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-1 line-clamp-2">
+          <p className={cn(CLASS_GROUPS.text.muted, TW.spacing.mt1, "line-clamp-2")}>
             {question.body}
           </p>
 
@@ -110,18 +110,18 @@ export function QuestionCard({
                 key={tag}
                 type="button"
                 onClick={() => onTagClick?.(tag)}
-                className="px-2 py-0.5 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 rounded text-xs hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+                className={cn(CLASS_GROUPS.tag.neutral, "hover:bg-neutral-200 dark:hover:bg-neutral-700", TW.motion.colors)}
               >
                 {tag}
               </button>
             ))}
 
-            <span className="flex items-center gap-1 text-xs text-neutral-500 ml-auto">
+            <span className={cn(TW.layout.flex, TW.layout.itemsCenter, TW.spacing.gap1, CLASS_GROUPS.text.metadata, TW.spacing.mlAuto)}>
               <MessageSquare size={14} />
               {question.answerCount} {question.answerCount === 1 ? "answer" : "answers"}
             </span>
 
-            <span className="text-xs text-neutral-500">
+            <span className={CLASS_GROUPS.text.metadata}>
               {question.authorName} &middot; {timeAgo(question.createdAt)}
             </span>
           </div>

--- a/components/ui/FormField.tsx
+++ b/components/ui/FormField.tsx
@@ -6,12 +6,11 @@
  */
 
 import type { InputHTMLAttributes, TextareaHTMLAttributes } from "react";
+import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 
-// Shared input styling
-const inputClass =
-  "w-full px-4 py-3 bg-neutral-800 border border-neutral-700 rounded-lg text-white placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent";
-
-const labelClass = "block text-sm font-medium text-neutral-300 mb-2";
+const inputClass = CLASS_GROUPS.form.inputDark;
+const labelClass = CLASS_GROUPS.form.labelDark;
 
 // ── FormInput ────────────────────────────────────────────────────────────────
 
@@ -33,7 +32,7 @@ export function FormInput({ label, id, error, ...props }: FormInputProps) {
         </label>
       )}
       <input id={id} className={inputClass} aria-describedby={errorId} {...props} />
-      {error && <p id={errorId} role="alert" className="text-red-400 text-sm mt-2">{error}</p>}
+      {error && <p id={errorId} role="alert" className={CLASS_GROUPS.form.errorText}>{error}</p>}
     </div>
   );
 }
@@ -57,12 +56,12 @@ export function FormTextarea({ label, id, error, rows = 3, ...props }: FormTexta
       )}
       <textarea
         id={id}
-        className={`${inputClass} resize-none`}
+        className={cn(inputClass, "resize-none")}
         aria-describedby={errorId}
         rows={rows}
         {...props}
       />
-      {error && <p id={errorId} role="alert" className="text-red-400 text-sm mt-2">{error}</p>}
+      {error && <p id={errorId} role="alert" className={CLASS_GROUPS.form.errorText}>{error}</p>}
     </div>
   );
 }
@@ -86,13 +85,20 @@ export function ToggleSwitch({
   label,
   disabled = false,
 }: ToggleSwitchProps) {
-  const trackClass =
+  const trackSizeClass =
     size === "md"
       ? "w-11 h-6 after:h-5 after:w-5"
       : "w-9 h-5 after:h-4 after:w-4";
 
   return (
-    <label className={`relative inline-flex items-center ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}>
+    <label
+      className={cn(
+        TW.layout.relative,
+        TW.layout.inlineFlex,
+        TW.layout.itemsCenter,
+        disabled ? TW.state.disabled : TW.state.cursorPointer
+      )}
+    >
       <input
         type="checkbox"
         checked={checked}
@@ -102,7 +108,10 @@ export function ToggleSwitch({
         aria-label={label || "Toggle"}
       />
       <div
-        className={`${trackClass} bg-neutral-700 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-400 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-neutral-300 after:border after:rounded-full after:transition-all peer-checked:bg-emerald-500`}
+        className={cn(
+          trackSizeClass,
+          "bg-neutral-700 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-400 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-neutral-300 after:border after:rounded-full after:transition-all peer-checked:bg-emerald-500"
+        )}
       />
     </label>
   );

--- a/components/ui/ValidatedInput.tsx
+++ b/components/ui/ValidatedInput.tsx
@@ -7,6 +7,8 @@
 
 import type { InputHTMLAttributes, ReactNode } from "react";
 import { CheckCircle2, CircleAlert } from "lucide-react";
+import { CLASS_GROUPS } from "@/lib/classname-constants";
+import { cn } from "@/lib/utils";
 
 interface ValidatedInputProps extends InputHTMLAttributes<HTMLInputElement> {
   id: string;
@@ -16,8 +18,7 @@ interface ValidatedInputProps extends InputHTMLAttributes<HTMLInputElement> {
   showStatusIcon?: boolean;
 }
 
-const baseInputClass =
-  "w-full px-4 py-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-700 rounded-lg text-foreground text-base placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent";
+const baseInputClass = CLASS_GROUPS.form.inputLightDark;
 
 export function ValidatedInput({
   id,
@@ -36,7 +37,7 @@ export function ValidatedInput({
 
   return (
     <div>
-      <label htmlFor={id} className="block text-sm font-medium text-neutral-300 mb-2">
+      <label htmlFor={id} className={CLASS_GROUPS.form.labelDark}>
         {label}
       </label>
       <div className="relative">
@@ -45,7 +46,7 @@ export function ValidatedInput({
           id={id}
           aria-describedby={describedBy}
           aria-invalid={error ? "true" : undefined}
-          className={`${baseInputClass}${showStatusIcon ? " pr-11" : ""}${className ? ` ${className}` : ""}`}
+          className={cn(baseInputClass, showStatusIcon && "pr-11", className)}
         />
         {showStatusIcon && error && (
           <CircleAlert
@@ -61,12 +62,12 @@ export function ValidatedInput({
         )}
       </div>
       {helperText && (
-        <p id={helperId} className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+        <p id={helperId} className={cn("mt-2", CLASS_GROUPS.text.muted)}>
           {helperText}
         </p>
       )}
       {error && (
-        <p id={errorId} role="alert" className="mt-2 text-sm text-red-400">
+        <p id={errorId} role="alert" className={CLASS_GROUPS.form.errorText}>
           {error}
         </p>
       )}

--- a/lib/classname-constants.ts
+++ b/lib/classname-constants.ts
@@ -1,0 +1,187 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+type ClassNameTree = {
+  readonly [key: string]: string | ClassNameTree;
+};
+
+export const TAILWIND_CLASS_NAMES = {
+  layout: {
+    absolute: "absolute",
+    block: "block",
+    flex: "flex",
+    flex1: "flex-1",
+    flexCol: "flex-col",
+    flexWrap: "flex-wrap",
+    grid: "grid",
+    hFull: "h-full",
+    inlineBlock: "inline-block",
+    inlineFlex: "inline-flex",
+    inset0: "inset-0",
+    itemsCenter: "items-center",
+    itemsStart: "items-start",
+    justifyBetween: "justify-between",
+    justifyCenter: "justify-center",
+    minW0: "min-w-0",
+    overflowHidden: "overflow-hidden",
+    relative: "relative",
+    shrink0: "shrink-0",
+    srOnly: "sr-only",
+    truncate: "truncate",
+    wFull: "w-full",
+  },
+  spacing: {
+    gap1: "gap-1",
+    gap2: "gap-2",
+    gap3: "gap-3",
+    gap4: "gap-4",
+    mb1: "mb-1",
+    mb2: "mb-2",
+    mb4: "mb-4",
+    mlAuto: "ml-auto",
+    mt1: "mt-1",
+    mt2: "mt-2",
+    mt3: "mt-3",
+    p1: "p-1",
+    p2: "p-2",
+    p3: "p-3",
+    p4: "p-4",
+    p6: "p-6",
+    px2: "px-2",
+    px3: "px-3",
+    px4: "px-4",
+    py05: "py-0.5",
+    py1: "py-1",
+    py2: "py-2",
+    py3: "py-3",
+  },
+  radius: {
+    full: "rounded-full",
+    lg: "rounded-lg",
+    md: "rounded-md",
+    plain: "rounded",
+    xl: "rounded-xl",
+    twoXl: "rounded-2xl",
+  },
+  border: {
+    base: "border",
+    bottomNeutral: "border-b border-neutral-200 dark:border-neutral-800",
+    emerald: "border-emerald-300/70 dark:border-emerald-500/40",
+    emeraldSoft: "border-emerald-300/40 dark:border-emerald-500/30",
+    inputDark: "border border-neutral-700",
+    neutral: "border border-neutral-200 dark:border-neutral-800",
+    neutralSoft: "border-neutral-200 dark:border-neutral-700",
+    purpleSoft: "border border-purple-500/30",
+  },
+  surface: {
+    card: "bg-white dark:bg-neutral-900",
+    dangerSoft: "bg-red-500/10",
+    emerald: "bg-emerald-500",
+    emeraldSoft: "bg-emerald-500/10",
+    inputDark: "bg-neutral-800",
+    inputLightDark: "bg-neutral-100 dark:bg-neutral-800",
+    neutralSoft: "bg-neutral-100 dark:bg-neutral-800",
+    neutralSubtle: "bg-neutral-50 dark:bg-neutral-800/40",
+    overlay: "bg-black/40",
+    purpleSoft: "bg-purple-500/10",
+  },
+  text: {
+    accent: "text-emerald-600 dark:text-emerald-400",
+    accentHover: "hover:text-emerald-600 dark:hover:text-emerald-400",
+    body: "text-neutral-700 dark:text-neutral-300",
+    danger: "text-red-500",
+    dangerSoft: "text-red-400",
+    foreground: "text-foreground",
+    inverse: "text-white",
+    lg: "text-lg",
+    medium: "font-medium",
+    muted: "text-neutral-600 dark:text-neutral-400",
+    semibold: "font-semibold",
+    sm: "text-sm",
+    subtle: "text-neutral-500 dark:text-neutral-400",
+    tiny: "text-xs",
+    uppercase: "uppercase",
+    wide: "tracking-wider",
+  },
+  focus: {
+    emerald: "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400",
+    emerald500: "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
+    foreground: "focus:outline-none focus:ring-2 focus:ring-foreground",
+    input: "focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:border-transparent",
+    inputForeground: "focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-transparent",
+    neutral: "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900 dark:focus-visible:ring-white",
+  },
+  motion: {
+    colors: "transition-colors",
+    all: "transition-all",
+    duration200: "duration-200",
+  },
+  state: {
+    cursorNotAllowed: "cursor-not-allowed",
+    cursorPointer: "cursor-pointer",
+    disabled: "opacity-50 cursor-not-allowed",
+    disabledSoft: "disabled:opacity-40 disabled:cursor-not-allowed",
+    hoverNeutral: "hover:bg-neutral-100 dark:hover:bg-neutral-800",
+    hoverNeutralText: "hover:text-neutral-600 dark:hover:text-neutral-300",
+  },
+  sizing: {
+    control44: "min-w-[44px] min-h-[44px]",
+    iconXs: "h-3.5 w-3.5",
+    iconSm: "h-4 w-4",
+    iconMd: "h-5 w-5",
+    voteColumn: "min-w-[40px]",
+  },
+} as const satisfies ClassNameTree;
+
+const T = TAILWIND_CLASS_NAMES;
+
+export const CLASS_GROUPS = {
+  badge: {
+    basePill: `${T.layout.shrink0} ${T.spacing.px2} ${T.spacing.py05} ${T.radius.full} ${T.text.tiny} ${T.text.medium}`,
+    earnedPill: `${T.surface.emeraldSoft} ${T.text.accent}`,
+    lockedPill: "bg-neutral-200/80 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400",
+  },
+  button: {
+    iconAction: `${T.spacing.p1} ${T.radius.plain} ${T.motion.colors} ${T.focus.emerald500}`,
+    iconLink: `text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white ${T.motion.colors} ${T.focus.neutral} ${T.radius.plain} ${T.spacing.p2} ${T.sizing.control44} ${T.layout.flex} ${T.layout.itemsCenter} ${T.layout.justifyCenter}`,
+    neutral: `bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 ${T.motion.colors} ${T.focus.emerald}`,
+  },
+  card: {
+    neutral: `${T.surface.card} ${T.radius.xl} ${T.border.neutral}`,
+    neutralHover: "hover:border-neutral-300 dark:hover:border-neutral-700",
+  },
+  form: {
+    errorText: `${T.text.dangerSoft} ${T.text.sm} ${T.spacing.mt2}`,
+    inputDark: `${T.layout.wFull} ${T.spacing.px4} ${T.spacing.py3} ${T.surface.inputDark} ${T.border.inputDark} ${T.radius.lg} ${T.text.inverse} placeholder-neutral-400 ${T.focus.input}`,
+    inputLightDark: `${T.layout.wFull} ${T.spacing.px4} ${T.spacing.py3} ${T.surface.inputLightDark} ${T.border.inputDark} ${T.radius.lg} ${T.text.foreground} text-base placeholder-neutral-400 ${T.focus.inputForeground}`,
+    labelDark: `${T.layout.block} ${T.text.sm} ${T.text.medium} text-neutral-300 ${T.spacing.mb2}`,
+  },
+  status: {
+    negativeScore: T.text.danger,
+    positiveScore: T.text.accent,
+    neutralScore: "text-neutral-500",
+  },
+  tag: {
+    neutral: `${T.spacing.px2} ${T.spacing.py05} ${T.surface.neutralSoft} ${T.text.muted} ${T.radius.plain} ${T.text.tiny}`,
+    neutralPill: "px-2.5 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 text-xs font-medium rounded-full",
+    neutralStrongPill: "px-2.5 py-1 bg-neutral-200 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-xs font-medium rounded-full",
+    successPill: "px-2.5 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-medium rounded-full",
+  },
+  text: {
+    body: `${T.text.sm} ${T.text.body}`,
+    metadata: `${T.text.tiny} text-neutral-500`,
+    muted: `${T.text.sm} ${T.text.muted}`,
+    sectionLabel: `${T.text.tiny} ${T.text.uppercase} ${T.text.wide} ${T.text.subtle}`,
+  },
+  vote: {
+    column: `${T.layout.flex} ${T.layout.flexCol} ${T.layout.itemsCenter} ${T.spacing.gap1} ${T.sizing.voteColumn}`,
+    disabled: T.state.disabled,
+    inactive: "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300",
+    score: `${T.text.sm} ${T.text.semibold}`,
+  },
+} as const satisfies ClassNameTree;
+


### PR DESCRIPTION
## Summary
- Add `lib/classname-constants.ts` with a readonly Tailwind token map and grouped component classes.
- Refactor 11 existing components to consume shared class tokens across form controls, badges, member cards, question/cookbook cards, section help, and the theme menu.
- Move `ThemeToggle` mount/focus handling away from state-in-effect patterns while preserving keyboard menu behavior.

## Verification
- `npm test -- --runTestsByPath __tests__/components/ui/ValidatedInput.test.tsx __tests__/components/ui/FormField.test.tsx __tests__/components/ThemeToggle.test.tsx __tests__/components/badges/BadgeCard.test.tsx __tests__/components/badges/BadgeGrid.test.tsx __tests__/components/badges/BadgePopover.test.tsx __tests__/components/cookbook/CookbookEntryCard.test.tsx __tests__/components/members/MemberCard.test.tsx __tests__/components/questions/AnswerCard.test.tsx __tests__/components/questions/QuestionCard.test.tsx __tests__/components/section-help.test.tsx __tests__/lib/classname-constants.test.ts --runInBand`
- `npx eslint lib/classname-constants.ts __tests__/lib/classname-constants.test.ts components/SectionHelp.tsx components/ThemeToggle.tsx components/badges/BadgeCard.tsx components/badges/BadgeGrid.tsx components/badges/BadgePopover.tsx components/cookbook/CookbookEntryCard.tsx components/members/MemberCard.tsx components/questions/AnswerCard.tsx components/questions/QuestionCard.tsx components/ui/FormField.tsx components/ui/ValidatedInput.tsx --max-warnings=0`
- `npm run type-check`
- `git diff --check`

Refs #563

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
