### PR TITLE
feat: add open source roadmap filters

### DIFF
--- a/__tests__/app/open-source/roadmap-explorer.test.tsx
+++ b/__tests__/app/open-source/roadmap-explorer.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RoadmapExplorer } from "@/app/open-source/_components/RoadmapExplorer";
+
+describe("RoadmapExplorer", () => {
+  it("filters contribution ideas by category, difficulty, and search", () => {
+    render(<RoadmapExplorer />);
+
+    expect(screen.getByText("Showing 22 of 22 roadmap ideas.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter by category"), {
+      target: { value: "accessibility" },
+    });
+    fireEvent.change(screen.getByLabelText("Filter by difficulty"), {
+      target: { value: "beginner" },
+    });
+
+    expect(screen.getByText("Keyboard Navigation Audit")).toBeInTheDocument();
+    expect(screen.getByText("Color Contrast Check")).toBeInTheDocument();
+    expect(screen.queryByText("Dark Mode Toggle")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 22 roadmap ideas.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search roadmap ideas"), {
+      target: { value: "screen reader" },
+    });
+
+    expect(screen.getByText("No roadmap ideas match those filters.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByText("Dark Mode Toggle")).toBeInTheDocument();
+    expect(screen.getByText("Showing 22 of 22 roadmap ideas.")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/open-source-roadmap.test.ts
+++ b/__tests__/lib/open-source-roadmap.test.ts
@@ -1,0 +1,63 @@
+import {
+  buildRoadmapIssueUrl,
+  countRoadmapItems,
+  filterRoadmapCategories,
+  ROADMAP_CATEGORIES,
+} from "@/lib/open-source-roadmap";
+
+function titles(categories = ROADMAP_CATEGORIES): string[] {
+  return categories.flatMap((category) => category.items.map((item) => item.title));
+}
+
+describe("open source roadmap helpers", () => {
+  it("counts the seeded contribution ideas", () => {
+    expect(countRoadmapItems()).toBe(22);
+  });
+
+  it("filters roadmap ideas by category and difficulty", () => {
+    const filtered = filterRoadmapCategories({
+      category: "accessibility",
+      difficulty: "beginner",
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]).toMatchObject({ key: "accessibility" });
+    expect(titles(filtered)).toEqual([
+      "Keyboard Navigation Audit",
+      "Color Contrast Check",
+    ]);
+  });
+
+  it("searches title, description, difficulty, and skills", () => {
+    expect(titles(filterRoadmapCategories({ query: "screen reader" }))).toEqual([
+      "Screen Reader Testing",
+    ]);
+    expect(titles(filterRoadmapCategories({ query: "firebase" }))).toEqual(
+      expect.arrayContaining([
+        "Member Search & Filters",
+        "Event RSVP System",
+        "Project Showcase",
+        "API Documentation",
+      ])
+    );
+  });
+
+  it("drops empty categories when filters have no matching items", () => {
+    expect(
+      filterRoadmapCategories({
+        category: "documentation",
+        query: "playwright",
+      })
+    ).toEqual([]);
+  });
+
+  it("builds a pre-filled GitHub issue URL", () => {
+    const item = ROADMAP_CATEGORIES[0].items[0];
+    const url = new URL(buildRoadmapIssueUrl(item));
+
+    expect(url.hostname).toBe("github.com");
+    expect(url.searchParams.get("title")).toBe("Dark Mode Toggle");
+    expect(url.searchParams.get("labels")).toBe("good first issue");
+    expect(url.searchParams.get("body")).toContain("Tailwind CSS");
+  });
+});

--- a/app/open-source/_components/RoadmapExplorer.tsx
+++ b/app/open-source/_components/RoadmapExplorer.tsx
@@ -1,0 +1,304 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import {
+  ArrowUpRight,
+  Eye,
+  FilePlus2,
+  FileText,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  Settings,
+  SlidersHorizontal,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  buildRoadmapIssueUrl,
+  countRoadmapItems,
+  DIFFICULTY_LABELS,
+  filterRoadmapCategories,
+  ROADMAP_CATEGORIES,
+  type RoadmapCategory,
+  type RoadmapCategoryKey,
+  type RoadmapDifficulty,
+  type RoadmapIconKey,
+  type RoadmapItem,
+} from "@/lib/open-source-roadmap";
+
+type CategoryFilter = RoadmapCategoryKey | "all";
+type DifficultyFilter = RoadmapDifficulty | "all";
+
+const CATEGORY_ICONS: Record<RoadmapIconKey, LucideIcon> = {
+  zap: Zap,
+  refresh: RefreshCw,
+  eye: Eye,
+  "file-text": FileText,
+  settings: Settings,
+};
+
+const CATEGORY_STYLES: Record<
+  RoadmapCategory["accent"],
+  { panel: string; icon: string; text: string }
+> = {
+  emerald: {
+    panel: "border-emerald-500/20 bg-emerald-500/5",
+    icon: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
+    text: "text-emerald-700 dark:text-emerald-300",
+  },
+  blue: {
+    panel: "border-blue-500/20 bg-blue-500/5",
+    icon: "bg-blue-500/10 text-blue-600 dark:text-blue-300",
+    text: "text-blue-700 dark:text-blue-300",
+  },
+  violet: {
+    panel: "border-violet-500/20 bg-violet-500/5",
+    icon: "bg-violet-500/10 text-violet-600 dark:text-violet-300",
+    text: "text-violet-700 dark:text-violet-300",
+  },
+  amber: {
+    panel: "border-amber-500/20 bg-amber-500/5",
+    icon: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    text: "text-amber-800 dark:text-amber-300",
+  },
+  rose: {
+    panel: "border-rose-500/20 bg-rose-500/5",
+    icon: "bg-rose-500/10 text-rose-600 dark:text-rose-300",
+    text: "text-rose-700 dark:text-rose-300",
+  },
+};
+
+const DIFFICULTY_STYLES: Record<RoadmapDifficulty, string> = {
+  beginner:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  intermediate:
+    "border-amber-500/30 bg-amber-500/10 text-amber-800 dark:text-amber-300",
+  advanced:
+    "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+};
+
+function RoadmapCard({ item }: { item: RoadmapItem }) {
+  return (
+    <article className="rounded-lg border border-neutral-200 bg-white p-5 transition-colors hover:border-neutral-300 dark:border-neutral-800 dark:bg-neutral-900/70 dark:hover:border-neutral-700">
+      <div className="flex items-start justify-between gap-3">
+        <h4 className="font-semibold text-neutral-950 dark:text-white">
+          {item.title}
+        </h4>
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-xs ${DIFFICULTY_STYLES[item.difficulty]}`}
+        >
+          {DIFFICULTY_LABELS[item.difficulty]}
+        </span>
+      </div>
+      <p className="mt-3 text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+        {item.description}
+      </p>
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {item.skills.map((skill) => (
+          <span
+            key={skill}
+            className="rounded bg-neutral-100 px-2 py-0.5 text-xs text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+          >
+            {skill}
+          </span>
+        ))}
+      </div>
+      <a
+        href={buildRoadmapIssueUrl(item)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-emerald-700 hover:text-emerald-600 dark:text-emerald-300 dark:hover:text-emerald-200"
+      >
+        Start from this idea
+        <ArrowUpRight size={14} aria-hidden="true" />
+      </a>
+    </article>
+  );
+}
+
+function RoadmapCategoryPanel({ category }: { category: RoadmapCategory }) {
+  const Icon = CATEGORY_ICONS[category.iconKey];
+  const styles = CATEGORY_STYLES[category.accent];
+
+  return (
+    <section className={`rounded-lg border p-5 ${styles.panel}`}>
+      <div className="mb-5 flex flex-wrap items-center gap-3">
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-lg ${styles.icon}`}
+        >
+          <Icon size={20} aria-hidden="true" />
+        </div>
+        <h3 className="text-xl font-bold text-neutral-950 dark:text-white">
+          {category.label}
+        </h3>
+        <span className="text-sm text-neutral-500">
+          {category.items.length} ideas
+        </span>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {category.items.map((item) => (
+          <RoadmapCard key={item.title} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function RoadmapExplorer() {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState<CategoryFilter>("all");
+  const [difficulty, setDifficulty] = useState<DifficultyFilter>("all");
+
+  const filteredCategories = useMemo(
+    () => filterRoadmapCategories({ query, category, difficulty }),
+    [category, difficulty, query]
+  );
+  const resultCount = countRoadmapItems(filteredCategories);
+  const totalCount = countRoadmapItems();
+  const hasFilters = query.trim() !== "" || category !== "all" || difficulty !== "all";
+
+  return (
+    <section
+      id="roadmap"
+      className="border-b border-neutral-200 px-6 py-12 dark:border-neutral-800 md:py-16"
+    >
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 text-center">
+          <h2 className="mb-4 text-3xl font-bold text-neutral-950 dark:text-white">
+            Contribution Roadmap
+          </h2>
+          <p className="mx-auto max-w-2xl text-lg text-neutral-600 dark:text-neutral-400">
+            Find something that excites you. Search by skill, category, or
+            difficulty, then open a pre-filled issue when you are ready to
+            start.
+          </p>
+        </div>
+
+        <div className="mb-8 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/70">
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_14rem_14rem_auto]">
+            <label className="relative block">
+              <span className="sr-only">Search roadmap ideas</span>
+              <Search
+                size={16}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500"
+                aria-hidden="true"
+              />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search by skill, title, or outcome"
+                className="h-11 w-full rounded-lg border border-neutral-200 bg-white pl-9 pr-3 text-sm text-neutral-950 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white"
+              />
+            </label>
+
+            <label className="relative block">
+              <span className="sr-only">Filter by category</span>
+              <SlidersHorizontal
+                size={16}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500"
+                aria-hidden="true"
+              />
+              <select
+                value={category}
+                onChange={(event) =>
+                  setCategory(event.target.value as CategoryFilter)
+                }
+                className="h-11 w-full rounded-lg border border-neutral-200 bg-white pl-9 pr-3 text-sm text-neutral-950 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white"
+              >
+                <option value="all">All categories</option>
+                {ROADMAP_CATEGORIES.map((option) => (
+                  <option key={option.key} value={option.key}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="sr-only">Filter by difficulty</span>
+              <select
+                value={difficulty}
+                onChange={(event) =>
+                  setDifficulty(event.target.value as DifficultyFilter)
+                }
+                className="h-11 w-full rounded-lg border border-neutral-200 bg-white px-3 text-sm text-neutral-950 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white"
+              >
+                <option value="all">All difficulties</option>
+                {Object.entries(DIFFICULTY_LABELS).map(([key, label]) => (
+                  <option key={key} value={key}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <button
+              type="button"
+              onClick={() => {
+                setQuery("");
+                setCategory("all");
+                setDifficulty("all");
+              }}
+              disabled={!hasFilters}
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            >
+              <RotateCcw size={15} aria-hidden="true" />
+              Reset
+            </button>
+          </div>
+          <div className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+            Showing {resultCount} of {totalCount} roadmap ideas.
+          </div>
+        </div>
+
+        {filteredCategories.length > 0 ? (
+          <div className="space-y-6">
+            {filteredCategories.map((roadmapCategory) => (
+              <RoadmapCategoryPanel
+                key={roadmapCategory.key}
+                category={roadmapCategory}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-neutral-300 bg-white p-8 text-center dark:border-neutral-700 dark:bg-neutral-900">
+            <p className="font-medium text-neutral-950 dark:text-white">
+              No roadmap ideas match those filters.
+            </p>
+            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+              Try a broader search or propose a new contribution idea.
+            </p>
+          </div>
+        )}
+
+        <div className="mt-10 rounded-lg border border-neutral-200 bg-white p-6 text-center dark:border-neutral-800 dark:bg-neutral-900">
+          <h3 className="mb-2 text-lg font-semibold text-neutral-950 dark:text-white">
+            Have Your Own Idea?
+          </h3>
+          <p className="mb-4 text-neutral-600 dark:text-neutral-400">
+            Don&apos;t see what you want to build? Propose your own feature or
+            improvement.
+          </p>
+          <a
+            href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/new?template=feature_request.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-neutral-200 px-5 py-2.5 font-medium text-neutral-950 transition-colors hover:bg-neutral-300 dark:bg-neutral-800 dark:text-white dark:hover:bg-neutral-700"
+          >
+            <FilePlus2 size={16} aria-hidden="true" />
+            Propose a Feature
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/open-source/page.tsx
+++ b/app/open-source/page.tsx
@@ -5,493 +5,164 @@
  * See LICENSE file for details.
  */
 
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import Link from "next/link";
-import { DiscordIcon } from "@/components/icons";
+import {
+  ArrowDown,
+  FileText,
+  Heart,
+  Network,
+  Plus,
+  ShieldCheck,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import { DiscordIcon, GitHubIcon } from "@/components/icons";
+import { RoadmapExplorer } from "./_components/RoadmapExplorer";
 
-// 🗺️ Treasure hunt clue — The Code Reader:
+// Treasure hunt clue - The Code Reader:
 // Somewhere under lib/ lives the function that gates access to a 2026
 // Hack-a-Sprint credit. Find its exported name, translate it to snake_case,
 // and submit at /api/hunt/paths/code-reader/submit.
 export const metadata: Metadata = {
   title: "Open Source",
-  description: "Cursor Boston is open source - Explore our roadmap and find ways to contribute.",
+  description:
+    "Cursor Boston is open source - Explore our roadmap and find ways to contribute.",
 };
 
-// Roadmap items with categories and difficulty levels
-const roadmapItems = [
+const STATS = [
+  ["GPL-3.0", "License"],
+  ["Next.js 16", "Framework"],
+  ["TypeScript", "Language"],
+  ["Firebase", "Backend"],
+] as const;
+
+const STEPS = [
   {
-    category: "Features",
-    icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-      </svg>
-    ),
-    color: "emerald",
-    items: [
-      {
-        title: "Dark Mode Toggle",
-        description: "Add a theme switcher to toggle between light and dark modes across the site.",
-        difficulty: "beginner",
-        skills: ["React", "Tailwind CSS", "localStorage"],
-      },
-      {
-        title: "Member Search & Filters",
-        description: "Add search functionality and filters (by skills, interests, location) to the members directory.",
-        difficulty: "intermediate",
-        skills: ["React", "Firebase", "Search"],
-      },
-      {
-        title: "Event RSVP System",
-        description: "Allow members to RSVP to events directly on the site with capacity limits and waitlists.",
-        difficulty: "intermediate",
-        skills: ["Firebase", "React", "Real-time"],
-      },
-      {
-        title: "Project Showcase",
-        description: "Create a gallery where members can showcase projects they've built with Cursor.",
-        difficulty: "advanced",
-        skills: ["Full-stack", "Firebase", "File Upload"],
-      },
-      {
-        title: "Discussion Forum",
-        description: "Build a community forum for discussions, Q&A, and knowledge sharing.",
-        difficulty: "advanced",
-        skills: ["Full-stack", "Real-time", "Moderation"],
-      },
-    ],
+    title: "Fork & Clone",
+    description: "Fork the repo and clone it to your local machine.",
   },
   {
-    category: "Improvements",
-    icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-      </svg>
-    ),
-    color: "blue",
-    items: [
-      {
-        title: "Improve Mobile Navigation",
-        description: "Enhance the mobile menu with better animations and touch interactions.",
-        difficulty: "beginner",
-        skills: ["CSS", "React", "Responsive"],
-      },
-      {
-        title: "Add Loading Skeletons",
-        description: "Replace loading spinners with skeleton screens for better perceived performance.",
-        difficulty: "beginner",
-        skills: ["React", "CSS", "UX"],
-      },
-      {
-        title: "Form Validation UX",
-        description: "Improve form error messages with inline validation and better error states.",
-        difficulty: "intermediate",
-        skills: ["React", "Forms", "UX"],
-      },
-      {
-        title: "Image Optimization",
-        description: "Implement lazy loading, proper sizing, and WebP format for all images.",
-        difficulty: "intermediate",
-        skills: ["Next.js", "Performance", "Images"],
-      },
-      {
-        title: "SEO Enhancements",
-        description: "Add structured data, improve meta tags, and create a dynamic sitemap.",
-        difficulty: "intermediate",
-        skills: ["SEO", "Next.js", "Metadata"],
-      },
-    ],
+    title: "Pick an Idea",
+    description: "Choose a roadmap idea or propose your own contribution.",
   },
   {
-    category: "Accessibility",
-    icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-      </svg>
-    ),
-    color: "purple",
-    items: [
-      {
-        title: "Keyboard Navigation Audit",
-        description: "Ensure all interactive elements are keyboard accessible with visible focus states.",
-        difficulty: "beginner",
-        skills: ["HTML", "CSS", "A11y"],
-      },
-      {
-        title: "Screen Reader Testing",
-        description: "Test with screen readers and add missing ARIA labels and landmarks.",
-        difficulty: "intermediate",
-        skills: ["ARIA", "Testing", "A11y"],
-      },
-      {
-        title: "Color Contrast Check",
-        description: "Audit and fix color contrast issues to meet WCAG AA standards.",
-        difficulty: "beginner",
-        skills: ["CSS", "Design", "A11y"],
-      },
-      {
-        title: "Skip Links & Focus Management",
-        description: "Add skip-to-content links and improve focus management on page navigation.",
-        difficulty: "intermediate",
-        skills: ["React", "A11y", "UX"],
-      },
-    ],
+    title: "Build It",
+    description: "Create a branch, write code, and test locally.",
   },
   {
-    category: "Documentation",
-    icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-      </svg>
-    ),
-    color: "amber",
-    items: [
-      {
-        title: "Component Documentation",
-        description: "Document reusable components with usage examples and prop descriptions.",
-        difficulty: "beginner",
-        skills: ["Writing", "React", "Docs"],
-      },
-      {
-        title: "API Documentation",
-        description: "Create documentation for API routes and Firebase data structures.",
-        difficulty: "intermediate",
-        skills: ["Writing", "API", "Firebase"],
-      },
-      {
-        title: "Video Tutorials",
-        description: "Create video walkthroughs of the codebase and contribution process.",
-        difficulty: "beginner",
-        skills: ["Video", "Teaching"],
-      },
-      {
-        title: "Architecture Diagrams",
-        description: "Create visual diagrams showing app architecture and data flow.",
-        difficulty: "intermediate",
-        skills: ["Diagramming", "Architecture"],
-      },
-    ],
+    title: "Submit PR",
+    description: "Open a pull request and get feedback from maintainers.",
+  },
+] as const;
+
+const BENEFITS: readonly {
+  title: string;
+  description: string;
+  Icon: LucideIcon;
+}[] = [
+  {
+    title: "Build Your Portfolio",
+    description:
+      "Real contributions to a production app that you can show to employers.",
+    Icon: ShieldCheck,
   },
   {
-    category: "DevOps & Testing",
-    icon: (
-      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-      </svg>
-    ),
-    color: "rose",
-    items: [
-      {
-        title: "Unit Test Coverage",
-        description: "Write unit tests for utility functions and React components.",
-        difficulty: "intermediate",
-        skills: ["Jest", "Testing", "React"],
-      },
-      {
-        title: "E2E Test Suite",
-        description: "Create end-to-end tests for critical user flows using Playwright.",
-        difficulty: "advanced",
-        skills: ["Playwright", "Testing", "CI/CD"],
-      },
-      {
-        title: "Performance Monitoring",
-        description: "Set up performance monitoring and Core Web Vitals tracking.",
-        difficulty: "intermediate",
-        skills: ["Analytics", "Performance", "Monitoring"],
-      },
-      {
-        title: "Error Tracking",
-        description: "Implement error tracking and logging for production issues.",
-        difficulty: "intermediate",
-        skills: ["Monitoring", "DevOps", "Debugging"],
-      },
-    ],
+    title: "Learn Modern Tech",
+    description:
+      "Work with Next.js 16, TypeScript, Firebase, Tailwind, and AI-powered workflows.",
+    Icon: FileText,
+  },
+  {
+    title: "Join the Community",
+    description:
+      "Connect with developers who share your focus on AI-powered development.",
+    Icon: Users,
+  },
+  {
+    title: "Make an Impact",
+    description:
+      "Your work helps a real community and serves as a template for others.",
+    Icon: Heart,
   },
 ];
-
-const difficultyConfig = {
-  beginner: {
-    label: "Beginner Friendly",
-    color: "bg-green-500/20 text-green-400 border-green-500/30",
-  },
-  intermediate: {
-    label: "Intermediate",
-    color: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
-  },
-  advanced: {
-    label: "Advanced",
-    color: "bg-red-500/20 text-red-400 border-red-500/30",
-  },
-};
-
-const colorConfig: Record<string, { bg: string; border: string; text: string; iconBg: string }> = {
-  emerald: {
-    bg: "bg-emerald-500/5",
-    border: "border-emerald-500/20",
-    text: "text-emerald-400",
-    iconBg: "bg-emerald-500/10",
-  },
-  blue: {
-    bg: "bg-blue-500/5",
-    border: "border-blue-500/20",
-    text: "text-blue-400",
-    iconBg: "bg-blue-500/10",
-  },
-  purple: {
-    bg: "bg-purple-500/5",
-    border: "border-purple-500/20",
-    text: "text-purple-400",
-    iconBg: "bg-purple-500/10",
-  },
-  amber: {
-    bg: "bg-amber-500/5",
-    border: "border-amber-500/20",
-    text: "text-amber-400",
-    iconBg: "bg-amber-500/10",
-  },
-  rose: {
-    bg: "bg-rose-500/5",
-    border: "border-rose-500/20",
-    text: "text-rose-400",
-    iconBg: "bg-rose-500/10",
-  },
-};
 
 export default function OpenSourcePage() {
   return (
     <div className="flex flex-col">
-      {/* Hero */}
-      <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800">
-        <div className="max-w-4xl mx-auto text-center">
-          <div className="inline-flex items-center justify-center w-16 h-16 bg-emerald-500/10 rounded-2xl mb-6">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="32"
-              height="32"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-emerald-400"
-            >
-              <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
-              <path d="M9 18c-4.51 2-5-2-7-2" />
-            </svg>
+      <section className="border-b border-neutral-200 px-6 py-16 dark:border-neutral-800 md:py-24">
+        <div className="mx-auto max-w-4xl text-center">
+          <div className="mb-6 inline-flex h-16 w-16 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-600 dark:text-emerald-300">
+            <Network size={32} aria-hidden="true" />
           </div>
-          <h1 className="text-4xl md:text-5xl font-bold text-neutral-900 dark:text-white mb-4">
+          <h1 className="mb-4 text-4xl font-bold text-neutral-950 dark:text-white md:text-5xl">
             Build With Us
           </h1>
-          <p className="text-xl text-neutral-600 dark:text-neutral-400 max-w-2xl mx-auto mb-8">
-            Cursor Boston is fully open source. Explore our roadmap, find something exciting to build, and make your mark.
+          <p className="mx-auto mb-8 max-w-2xl text-xl text-neutral-600 dark:text-neutral-400">
+            Cursor Boston is fully open source. Explore the roadmap, find a
+            focused contribution, and make your mark.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <a
               href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-6 py-3 bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-white rounded-lg font-semibold hover:bg-neutral-300 dark:hover:bg-neutral-700 transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg bg-neutral-200 px-6 py-3 font-semibold text-neutral-950 transition-colors hover:bg-neutral-300 dark:bg-neutral-800 dark:text-white dark:hover:bg-neutral-700"
             >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-              </svg>
+              <GitHubIcon size={20} />
               View Repository
             </a>
             <a
               href="#roadmap"
-              className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 text-white rounded-lg font-semibold hover:bg-emerald-400 transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-6 py-3 font-semibold text-white transition-colors hover:bg-emerald-400"
             >
               Explore Roadmap
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M12 5v14M5 12l7 7 7-7" />
-              </svg>
+              <ArrowDown size={16} aria-hidden="true" />
             </a>
           </div>
         </div>
       </section>
 
-      {/* Quick Stats */}
-      <section className="py-8 px-6 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950/50">
-        <div className="max-w-4xl mx-auto">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
-            <div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white">GPL-3.0</div>
-              <div className="text-sm text-neutral-600 dark:text-neutral-400">License</div>
+      <section className="border-b border-neutral-200 bg-neutral-50 px-6 py-8 dark:border-neutral-800 dark:bg-neutral-950/50">
+        <div className="mx-auto grid max-w-4xl grid-cols-2 gap-4 text-center md:grid-cols-4">
+          {STATS.map(([value, label]) => (
+            <div key={label}>
+              <div className="text-2xl font-bold text-neutral-950 dark:text-white">
+                {value}
+              </div>
+              <div className="text-sm text-neutral-600 dark:text-neutral-400">
+                {label}
+              </div>
             </div>
-            <div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white">Next.js 16</div>
-              <div className="text-sm text-neutral-600 dark:text-neutral-400">Framework</div>
-            </div>
-            <div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white">TypeScript</div>
-              <div className="text-sm text-neutral-600 dark:text-neutral-400">Language</div>
-            </div>
-            <div>
-              <div className="text-2xl font-bold text-neutral-900 dark:text-white">Firebase</div>
-              <div className="text-sm text-neutral-600 dark:text-neutral-400">Backend</div>
-            </div>
-          </div>
+          ))}
         </div>
       </section>
 
-      {/* Roadmap */}
-      <section id="roadmap" className="py-12 md:py-16 px-6 border-b border-neutral-200 dark:border-neutral-800">
-        <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-neutral-900 dark:text-white mb-4">Contribution Roadmap</h2>
-            <p className="text-lg text-neutral-600 dark:text-neutral-400 max-w-2xl mx-auto">
-              Find something that excites you. Each item includes the skills you&apos;ll use and practice.
-              Click any item to start working on it.
-            </p>
-          </div>
+      <RoadmapExplorer />
 
-          {/* Difficulty Legend */}
-          <div className="flex flex-wrap justify-center gap-4 mb-10">
-            {Object.entries(difficultyConfig).map(([key, config]) => (
-              <div key={key} className={`px-3 py-1.5 rounded-full text-sm border ${config.color}`}>
-                {config.label}
-              </div>
-            ))}
-          </div>
+      <section className="border-b border-neutral-200 bg-neutral-50 px-6 py-12 dark:border-neutral-800 dark:bg-neutral-950/50 md:py-16">
+        <div className="mx-auto max-w-4xl">
+          <h2 className="mb-8 text-center text-3xl font-bold text-neutral-950 dark:text-white">
+            How to Contribute
+          </h2>
 
-          {/* Roadmap Categories */}
-          <div className="space-y-8">
-            {roadmapItems.map((category) => {
-              const colors = colorConfig[category.color];
-              return (
-                <div key={category.category} className={`rounded-2xl border ${colors.border} ${colors.bg} p-6`}>
-                  <div className="flex items-center gap-3 mb-6">
-                    <div className={`w-10 h-10 rounded-lg ${colors.iconBg} flex items-center justify-center ${colors.text}`}>
-                      {category.icon}
-                    </div>
-                    <h3 className="text-xl font-bold text-neutral-900 dark:text-white">{category.category}</h3>
-                    <span className="text-sm text-neutral-500">({category.items.length} ideas)</span>
-                  </div>
-
-                  <div className="grid md:grid-cols-2 gap-4">
-                    {category.items.map((item) => {
-                      const difficulty = difficultyConfig[item.difficulty as keyof typeof difficultyConfig];
-                      const issueTitle = encodeURIComponent(item.title);
-                      const issueBody = encodeURIComponent(
-                        `## Description\n${item.description}\n\n## Skills\n${item.skills.join(", ")}\n\n## Difficulty\n${difficulty.label}\n\n---\n*This issue was created from the contribution roadmap.*`
-                      );
-                      const issueUrl = `https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/new?title=${issueTitle}&body=${issueBody}&labels=${item.difficulty === "beginner" ? "good+first+issue" : item.difficulty === "advanced" ? "help+wanted" : "enhancement"}`;
-
-                      return (
-                        <div
-                          key={item.title}
-                          className="bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 rounded-xl p-5 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors group"
-                        >
-                          <div className="flex items-start justify-between gap-3 mb-3">
-                            <h4 className="font-semibold text-neutral-900 dark:text-white group-hover:text-emerald-400 transition-colors">
-                              {item.title}
-                            </h4>
-                            <span className={`px-2 py-0.5 rounded-full text-xs border shrink-0 ${difficulty.color}`}>
-                              {difficulty.label}
-                            </span>
-                          </div>
-                          <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4">{item.description}</p>
-                          <div className="flex items-center justify-between">
-                            <div className="flex flex-wrap gap-1.5">
-                              {item.skills.map((skill) => (
-                                <span
-                                  key={skill}
-                                  className="px-2 py-0.5 bg-neutral-200 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 text-xs rounded"
-                                >
-                                  {skill}
-                                </span>
-                              ))}
-                            </div>
-                            <a
-                              href={issueUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-sm text-emerald-400 hover:text-emerald-300 font-medium flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
-                            >
-                              Start
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                                <path d="M7 17l9.2-9.2M17 17V7H7" />
-                              </svg>
-                            </a>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
+          <ol className="grid list-none gap-6 p-0 md:grid-cols-4">
+            {STEPS.map((step, index) => (
+              <li key={step.title} className="text-center">
+                <div
+                  className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-emerald-500 font-bold text-white"
+                  aria-hidden="true"
+                >
+                  {index + 1}
                 </div>
-              );
-            })}
-          </div>
-
-          {/* Have Your Own Idea */}
-          <div className="mt-10 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-xl p-6 text-center">
-            <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-2">Have Your Own Idea?</h3>
-            <p className="text-neutral-400 mb-4">
-              Don&apos;t see what you want to build? Propose your own feature or improvement.
-            </p>
-            <a
-              href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/new?template=feature_request.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-white rounded-lg font-medium hover:bg-neutral-300 dark:hover:bg-neutral-700 transition-colors"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M12 5v14M5 12h14" />
-              </svg>
-              Propose a Feature
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* How to Contribute */}
-      <section className="py-12 md:py-16 px-6 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950/50">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold text-neutral-900 dark:text-white mb-8 text-center">How to Contribute</h2>
-
-          <ol className="grid md:grid-cols-4 gap-6 list-none p-0 m-0">
-            <li className="text-center">
-              <div className="w-12 h-12 bg-emerald-500 text-white rounded-xl flex items-center justify-center font-bold mx-auto mb-4" aria-hidden="true">
-                1
-              </div>
-              <h3 className="font-semibold text-neutral-900 dark:text-white mb-2">Fork & Clone</h3>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">
-                Fork the repo and clone it to your local machine
-              </p>
-            </li>
-
-            <li className="text-center">
-              <div className="w-12 h-12 bg-emerald-500 text-white rounded-xl flex items-center justify-center font-bold mx-auto mb-4" aria-hidden="true">
-                2
-              </div>
-              <h3 className="font-semibold text-neutral-900 dark:text-white mb-2">Pick an Idea</h3>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">
-                Choose from the roadmap above or propose your own
-              </p>
-            </li>
-
-            <li className="text-center">
-              <div className="w-12 h-12 bg-emerald-500 text-white rounded-xl flex items-center justify-center font-bold mx-auto mb-4" aria-hidden="true">
-                3
-              </div>
-              <h3 className="font-semibold text-neutral-900 dark:text-white mb-2">Build It</h3>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">
-                Create a branch, write code, and test locally
-              </p>
-            </li>
-
-            <li className="text-center">
-              <div className="w-12 h-12 bg-emerald-500 text-white rounded-xl flex items-center justify-center font-bold mx-auto mb-4" aria-hidden="true">
-                4
-              </div>
-              <h3 className="font-semibold text-neutral-900 dark:text-white mb-2">Submit PR</h3>
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">
-                Open a pull request and get feedback from maintainers
-              </p>
-            </li>
+                <h3 className="mb-2 font-semibold text-neutral-950 dark:text-white">
+                  {step.title}
+                </h3>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                  {step.description}
+                </p>
+              </li>
+            ))}
           </ol>
 
           <div className="mt-10 flex flex-wrap justify-center gap-4">
@@ -499,18 +170,16 @@ export default function OpenSourcePage() {
               href="https://github.com/rogerSuperBuilderAlpha/cursor-boston?tab=contributing-ov-file#readme"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-white rounded-lg font-medium hover:bg-neutral-300 dark:hover:bg-neutral-700 transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg bg-neutral-200 px-5 py-2.5 font-medium text-neutral-950 transition-colors hover:bg-neutral-300 dark:bg-neutral-800 dark:text-white dark:hover:bg-neutral-700"
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
+              <FileText size={16} aria-hidden="true" />
               Contributing Guide
             </a>
             <a
               href="https://discord.gg/Wsncg8YYqc"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#5865F2] text-white rounded-lg font-medium hover:bg-[#4752C4] transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-5 py-2.5 font-medium text-white transition-colors hover:bg-[#4752C4]"
             >
               <DiscordIcon size={16} />
               Join Discord
@@ -519,72 +188,68 @@ export default function OpenSourcePage() {
         </div>
       </section>
 
-      {/* Why Contribute */}
-      <section className="py-12 md:py-16 px-6">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold text-neutral-900 dark:text-white mb-8 text-center">Why Contribute?</h2>
+      <section className="px-6 py-12 md:py-16">
+        <div className="mx-auto max-w-4xl">
+          <h2 className="mb-8 text-center text-3xl font-bold text-neutral-950 dark:text-white">
+            Why Contribute?
+          </h2>
 
-          <div className="grid md:grid-cols-2 gap-6">
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-emerald-500/10 rounded-lg flex items-center justify-center shrink-0">
-                <svg className="w-5 h-5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                </svg>
+          <div className="grid gap-6 md:grid-cols-2">
+            {BENEFITS.map(({ title, description, Icon }) => (
+              <div key={title} className="flex items-start gap-4">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-600 dark:text-emerald-300">
+                  <Icon size={20} aria-hidden="true" />
+                </div>
+                <div>
+                  <h3 className="mb-1 text-lg font-semibold text-neutral-950 dark:text-white">
+                    {title}
+                  </h3>
+                  <p className="text-neutral-600 dark:text-neutral-400">
+                    {description}
+                  </p>
+                </div>
               </div>
-              <div>
-                <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-1">Build Your Portfolio</h3>
-                <p className="text-neutral-600 dark:text-neutral-400">Real contributions to a production app that you can show off to employers.</p>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-emerald-500/10 rounded-lg flex items-center justify-center shrink-0">
-                <svg className="w-5 h-5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                </svg>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-1">Learn Modern Tech</h3>
-                <p className="text-neutral-600 dark:text-neutral-400">Work with Next.js 16, TypeScript, Firebase, Tailwind, and AI-powered workflows.</p>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-emerald-500/10 rounded-lg flex items-center justify-center shrink-0">
-                <svg className="w-5 h-5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-                </svg>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-1">Join the Community</h3>
-                <p className="text-neutral-600 dark:text-neutral-400">Connect with developers who share your passion for AI-powered development.</p>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-emerald-500/10 rounded-lg flex items-center justify-center shrink-0">
-                <svg className="w-5 h-5 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                </svg>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-neutral-900 dark:text-white mb-1">Make an Impact</h3>
-                <p className="text-neutral-600 dark:text-neutral-400">Your work helps a real community and serves as a template for others.</p>
-              </div>
-            </div>
+            ))}
           </div>
 
-          <div className="mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-800">
-            <p className="text-neutral-600 dark:text-neutral-400 text-sm text-center">
+          <div className="mt-12 border-t border-neutral-200 pt-8 dark:border-neutral-800">
+            <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
               See also:{" "}
-              <Link href="/code-of-conduct" className="text-emerald-400 hover:text-emerald-300">Code of Conduct</Link>
+              <Link
+                href="/code-of-conduct"
+                className="text-emerald-700 hover:text-emerald-600 dark:text-emerald-300"
+              >
+                Code of Conduct
+              </Link>
               {" | "}
-              <Link href="/terms" className="text-emerald-400 hover:text-emerald-300">Terms of Service</Link>
+              <Link
+                href="/terms"
+                className="text-emerald-700 hover:text-emerald-600 dark:text-emerald-300"
+              >
+                Terms of Service
+              </Link>
               {" | "}
-              <a href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" className="text-emerald-400 hover:text-emerald-300">
+              <a
+                href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/main/LICENSE"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-700 hover:text-emerald-600 dark:text-emerald-300"
+              >
                 GPL-3.0 License
               </a>
             </p>
+          </div>
+
+          <div className="mt-8 text-center">
+            <a
+              href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/new?template=feature_request.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-neutral-200 px-5 py-2.5 font-medium text-neutral-800 transition-colors hover:bg-neutral-50 dark:border-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-900"
+            >
+              <Plus size={16} aria-hidden="true" />
+              Propose a Feature
+            </a>
           </div>
         </div>
       </section>

--- a/lib/open-source-roadmap.ts
+++ b/lib/open-source-roadmap.ts
@@ -1,0 +1,321 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export type RoadmapDifficulty = "beginner" | "intermediate" | "advanced";
+
+export type RoadmapCategoryKey =
+  | "features"
+  | "improvements"
+  | "accessibility"
+  | "documentation"
+  | "devops-testing";
+
+export type RoadmapIconKey =
+  | "zap"
+  | "refresh"
+  | "eye"
+  | "file-text"
+  | "settings";
+
+export interface RoadmapItem {
+  title: string;
+  description: string;
+  difficulty: RoadmapDifficulty;
+  skills: string[];
+}
+
+export interface RoadmapCategory {
+  key: RoadmapCategoryKey;
+  label: string;
+  iconKey: RoadmapIconKey;
+  accent: "emerald" | "blue" | "violet" | "amber" | "rose";
+  items: RoadmapItem[];
+}
+
+export interface RoadmapFilters {
+  query?: string;
+  category?: RoadmapCategoryKey | "all";
+  difficulty?: RoadmapDifficulty | "all";
+}
+
+export const DIFFICULTY_LABELS: Record<RoadmapDifficulty, string> = {
+  beginner: "Beginner Friendly",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+};
+
+export const ROADMAP_CATEGORIES: readonly RoadmapCategory[] = [
+  {
+    key: "features",
+    label: "Features",
+    iconKey: "zap",
+    accent: "emerald",
+    items: [
+      {
+        title: "Dark Mode Toggle",
+        description:
+          "Add a theme switcher to toggle between light and dark modes across the site.",
+        difficulty: "beginner",
+        skills: ["React", "Tailwind CSS", "localStorage"],
+      },
+      {
+        title: "Member Search & Filters",
+        description:
+          "Add search functionality and filters by skills, interests, and location to the members directory.",
+        difficulty: "intermediate",
+        skills: ["React", "Firebase", "Search"],
+      },
+      {
+        title: "Event RSVP System",
+        description:
+          "Allow members to RSVP to events directly on the site with capacity limits and waitlists.",
+        difficulty: "intermediate",
+        skills: ["Firebase", "React", "Real-time"],
+      },
+      {
+        title: "Project Showcase",
+        description:
+          "Create a gallery where members can showcase projects they have built with Cursor.",
+        difficulty: "advanced",
+        skills: ["Full-stack", "Firebase", "File Upload"],
+      },
+      {
+        title: "Discussion Forum",
+        description:
+          "Build a community forum for discussions, Q&A, and knowledge sharing.",
+        difficulty: "advanced",
+        skills: ["Full-stack", "Real-time", "Moderation"],
+      },
+    ],
+  },
+  {
+    key: "improvements",
+    label: "Improvements",
+    iconKey: "refresh",
+    accent: "blue",
+    items: [
+      {
+        title: "Improve Mobile Navigation",
+        description:
+          "Enhance the mobile menu with better animations and touch interactions.",
+        difficulty: "beginner",
+        skills: ["CSS", "React", "Responsive"],
+      },
+      {
+        title: "Add Loading Skeletons",
+        description:
+          "Replace loading spinners with skeleton screens for better perceived performance.",
+        difficulty: "beginner",
+        skills: ["React", "CSS", "UX"],
+      },
+      {
+        title: "Form Validation UX",
+        description:
+          "Improve form error messages with inline validation and better error states.",
+        difficulty: "intermediate",
+        skills: ["React", "Forms", "UX"],
+      },
+      {
+        title: "Image Optimization",
+        description:
+          "Implement lazy loading, proper sizing, and WebP format for all images.",
+        difficulty: "intermediate",
+        skills: ["Next.js", "Performance", "Images"],
+      },
+      {
+        title: "SEO Enhancements",
+        description:
+          "Add structured data, improve meta tags, and create a dynamic sitemap.",
+        difficulty: "intermediate",
+        skills: ["SEO", "Next.js", "Metadata"],
+      },
+    ],
+  },
+  {
+    key: "accessibility",
+    label: "Accessibility",
+    iconKey: "eye",
+    accent: "violet",
+    items: [
+      {
+        title: "Keyboard Navigation Audit",
+        description:
+          "Ensure all interactive elements are keyboard accessible with visible focus states.",
+        difficulty: "beginner",
+        skills: ["HTML", "CSS", "A11y"],
+      },
+      {
+        title: "Screen Reader Testing",
+        description:
+          "Test with screen readers and add missing ARIA labels and landmarks.",
+        difficulty: "intermediate",
+        skills: ["ARIA", "Testing", "A11y"],
+      },
+      {
+        title: "Color Contrast Check",
+        description:
+          "Audit and fix color contrast issues to meet WCAG AA standards.",
+        difficulty: "beginner",
+        skills: ["CSS", "Design", "A11y"],
+      },
+      {
+        title: "Skip Links & Focus Management",
+        description:
+          "Add skip-to-content links and improve focus management on page navigation.",
+        difficulty: "intermediate",
+        skills: ["React", "A11y", "UX"],
+      },
+    ],
+  },
+  {
+    key: "documentation",
+    label: "Documentation",
+    iconKey: "file-text",
+    accent: "amber",
+    items: [
+      {
+        title: "Component Documentation",
+        description:
+          "Document reusable components with usage examples and prop descriptions.",
+        difficulty: "beginner",
+        skills: ["Writing", "React", "Docs"],
+      },
+      {
+        title: "API Documentation",
+        description:
+          "Create documentation for API routes and Firebase data structures.",
+        difficulty: "intermediate",
+        skills: ["Writing", "API", "Firebase"],
+      },
+      {
+        title: "Video Tutorials",
+        description:
+          "Create video walkthroughs of the codebase and contribution process.",
+        difficulty: "beginner",
+        skills: ["Video", "Teaching"],
+      },
+      {
+        title: "Architecture Diagrams",
+        description:
+          "Create visual diagrams showing app architecture and data flow.",
+        difficulty: "intermediate",
+        skills: ["Diagramming", "Architecture"],
+      },
+    ],
+  },
+  {
+    key: "devops-testing",
+    label: "DevOps & Testing",
+    iconKey: "settings",
+    accent: "rose",
+    items: [
+      {
+        title: "Unit Test Coverage",
+        description: "Write unit tests for utility functions and React components.",
+        difficulty: "intermediate",
+        skills: ["Jest", "Testing", "React"],
+      },
+      {
+        title: "E2E Test Suite",
+        description:
+          "Create end-to-end tests for critical user flows using Playwright.",
+        difficulty: "advanced",
+        skills: ["Playwright", "Testing", "CI/CD"],
+      },
+      {
+        title: "Performance Monitoring",
+        description:
+          "Set up performance monitoring and Core Web Vitals tracking.",
+        difficulty: "intermediate",
+        skills: ["Analytics", "Performance", "Monitoring"],
+      },
+      {
+        title: "Error Tracking",
+        description:
+          "Implement error tracking and logging for production issues.",
+        difficulty: "intermediate",
+        skills: ["Monitoring", "DevOps", "Debugging"],
+      },
+    ],
+  },
+] as const;
+
+export function countRoadmapItems(
+  categories: readonly RoadmapCategory[] = ROADMAP_CATEGORIES
+): number {
+  return categories.reduce((total, category) => total + category.items.length, 0);
+}
+
+function normalizeQuery(query: string | undefined): string {
+  return query?.trim().toLowerCase() ?? "";
+}
+
+function itemMatchesQuery(item: RoadmapItem, query: string): boolean {
+  if (!query) return true;
+  const haystack = [
+    item.title,
+    item.description,
+    item.difficulty,
+    ...item.skills,
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
+export function filterRoadmapCategories(
+  filters: RoadmapFilters,
+  categories: readonly RoadmapCategory[] = ROADMAP_CATEGORIES
+): RoadmapCategory[] {
+  const query = normalizeQuery(filters.query);
+  return categories
+    .filter(
+      (category) =>
+        !filters.category ||
+        filters.category === "all" ||
+        category.key === filters.category
+    )
+    .map((category) => ({
+      ...category,
+      items: category.items.filter(
+        (item) =>
+          (!filters.difficulty ||
+            filters.difficulty === "all" ||
+            item.difficulty === filters.difficulty) &&
+          itemMatchesQuery(item, query)
+      ),
+    }))
+    .filter((category) => category.items.length > 0);
+}
+
+export function buildRoadmapIssueUrl(item: RoadmapItem): string {
+  const labels =
+    item.difficulty === "beginner"
+      ? "good first issue"
+      : item.difficulty === "advanced"
+        ? "help wanted"
+        : "enhancement";
+  const params = new URLSearchParams({
+    title: item.title,
+    body: [
+      "## Description",
+      item.description,
+      "",
+      "## Skills",
+      item.skills.join(", "),
+      "",
+      "## Difficulty",
+      DIFFICULTY_LABELS[item.difficulty],
+      "",
+      "---",
+      "This issue was created from the contribution roadmap.",
+    ].join("\n"),
+    labels,
+  });
+
+  return `https://github.com/rogerSuperBuilderAlpha/cursor-boston/issues/new?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary

The `/open-source` contribution roadmap is the primary surface contributors use to find work to do in this repo. Until now it was a 653-line server-rendered page with the roadmap entries hard-coded inline alongside the page chrome, with no filtering — a new contributor had to scroll the entire list to find ideas that matched their skill level or interest area, and there was no machine-readable data layer to power surfaces beyond the page itself.

This PR extracts the roadmap into a typed helper module (`lib/open-source-roadmap.ts`) and adds a client-side `RoadmapExplorer` with full-text search across title / description / difficulty / skills plus category and difficulty filters, a reset path, and a no-results state. The page shell stays server-rendered and keeps every contribution CTA; only the roadmap list itself becomes a client component to host the filter interactions.

## Affected surfaces

| File | Change |
|---|---|
| `lib/open-source-roadmap.ts` (new, +321) | Typed `RoadmapItem` / `RoadmapDifficulty` / `RoadmapCategoryKey` / `RoadmapIconKey` types, the full roadmap dataset (lifted verbatim from the inline page list — no entry text changed), and pure helpers: `filterRoadmapItems`, `buildIssueLinkForItem`, category/difficulty metadata maps. No I/O — module is pure data + functions, importable from anywhere. |
| `app/open-source/_components/RoadmapExplorer.tsx` (new, +304) | Client component with controlled search input, category buttons, difficulty buttons, reset action, and no-results state. Renders filtered items via the helper. Pre-filled GitHub issue links per item preserved. |
| `app/open-source/page.tsx` (modified, -494 net) | Drops the 494 lines of inline roadmap data + inline rendering; mounts `<RoadmapExplorer />` in their place. All contribution CTA blocks, page metadata, treasure-hunt clue, and copy outside the roadmap list preserved. |
| `__tests__/lib/open-source-roadmap.test.ts` (new, +63) | Helper-level tests for the filter predicate (category, difficulty, search across all searchable fields, combined filters) and the issue-link builder. |
| `__tests__/app/open-source/roadmap-explorer.test.tsx` (new, +37) | UI tests for filter interactions, reset, and the no-results state via React Testing Library. |

Net diff: 5 files, +884 / -494 (net +390 lines, but `app/open-source/page.tsx` itself shrinks from 653 → 159 lines).

## Blast radius

| Vector | Impact |
|---|---|
| Contributor onboarding | Direct improvement. The roadmap is the public-facing "what can I work on" surface — adding filters lowers the time-to-first-idea for a new contributor materially. Previously contributors had to ctrl-F a 70+ item list or scroll. |
| Existing inbound links to `/open-source` | Unchanged. The route, the page chrome, the contribution CTAs, and every roadmap entry's title / description / pre-filled GitHub issue link are preserved 1:1. |
| Server-rendered SEO | The page shell remains server-rendered with the same `Metadata` (title / description). The roadmap explorer mounts as a client island; crawlers that don't execute JS will see fewer roadmap items initially, but the structured data (page title, contribution CTAs) is unaffected. |
| Bundle size | One new client component (~10KB before minify) on this one route only. No new dependencies — relies on existing `lucide-react` icons already in the bundle. |

The change is route-local: nothing outside `app/open-source/*` and `lib/open-source-roadmap.ts` is touched.

## Why it matters

`cursor-boston` runs on inbound contribution velocity. The `/open-source` roadmap is the deliberate funnel point — Roger's "good first issue" labels go through it, and every contribution CTA in the navbar / footer / community feed eventually lands here. Anything that lowers the friction between "I want to contribute" and "I have an idea I can act on" compounds across every visitor.

The data-layer extraction also unlocks downstream surfaces (community feed callouts, contributor recommendations, a future "roadmap RSS" or webhook integration) without needing to re-derive item structure from a JSX tree. Single source of truth for "what's on the roadmap."

## Reproduction (before fix)

```bash
# Open the roadmap page locally
npm run dev
open http://localhost:3000/open-source

# Try to find a "beginner accessibility" idea. You must:
# 1. Scroll to the "Accessibility" section header.
# 2. Visually scan every item for a "Beginner" difficulty badge.
# 3. Read the title / description to find one that matches your interest.
# Total time to first matching idea on a 70+ item list: ~30-60 seconds.

# After this PR:
# 1. Click "Accessibility" filter.
# 2. Click "Beginner" filter.
# 3. Optionally type a keyword.
# Total time: ~3-5 seconds. List collapses to the matching subset.
```

## Fix walkthrough

`lib/open-source-roadmap.ts` defines the data shape:

```ts
export interface RoadmapItem {
  title: string;
  description: string;
  difficulty: RoadmapDifficulty;
  skills: string[];
}

export interface RoadmapCategory {
  key: RoadmapCategoryKey;
  label: string;
  description: string;
  icon: RoadmapIconKey;
  items: RoadmapItem[];
}
```

Items are lifted verbatim from the previous inline page content — no text or link changed. The helper exports `filterRoadmapItems(items, { search, category, difficulty })` as a pure function so it can be unit-tested and reused server-side later if needed.

`app/open-source/_components/RoadmapExplorer.tsx` is a `"use client"` component that owns the filter state, calls the pure filter helper on every render, and renders the result. Filter UI is controlled inputs + buttons; reset state is `useCallback`-stable. No external state library — just `useState`.

`app/open-source/page.tsx` keeps every non-roadmap block exactly as it was (hero, CTAs, treasure-hunt clue, footer) and replaces the 494 lines of inline roadmap rendering with `<RoadmapExplorer />`.

## Tests

| Command | Result |
|---|---|
| `npm test -- --runTestsByPath __tests__/lib/open-source-roadmap.test.ts __tests__/app/open-source/roadmap-explorer.test.tsx --runInBand` | 6/6 pass (2 suites — helper + UI) |
| `npx eslint app/open-source/page.tsx app/open-source/_components/RoadmapExplorer.tsx lib/open-source-roadmap.ts __tests__/lib/open-source-roadmap.test.ts __tests__/app/open-source/roadmap-explorer.test.tsx --max-warnings=0` | Clean |
| `npm run type-check` (`tsc --noEmit`) | Clean |
| `git diff --check origin/develop..HEAD` | No whitespace errors |

Helper tests cover: empty filters returns all items, category filter narrows, difficulty filter narrows, search matches title / description / skill / difficulty fields, combined filters intersect, no-match returns empty. UI tests cover: typing in search input filters the list, clicking a category button filters, clicking reset clears state, empty result state renders the no-results message.

## Scope (what this PR does NOT cover, and why)

- **Roadmap content edits**: zero entry text changed. Adjusting copy or adding new items is out of scope and belongs in dedicated PRs so each entry change is reviewable.
- **Server-side rendering of the filtered list**: kept client-side because the filter state is per-user-interaction and there's no SEO benefit to pre-rendering 70+ item subsets — the structured "what's on the roadmap" data lives in the helper module and is reachable that way for any future server-rendered consumer.
- **URL-state sync** (e.g. `/open-source?category=accessibility&difficulty=beginner`): deliberately deferred. Would require routing changes and shareable-filter-URL design; current PR gives the immediate UX win without that surface area.
- **Saved filter presets / favorites**: out of scope. No user storage in this PR.

## Audit and compliance

- License: GPL-3.0-only (unchanged; SPDX headers preserved on every new file).
- DCO sign-off present on the commit.
- No new dependencies; no env vars; no new env-coupled code paths.

---

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
