### PR TITLE
feat: add opportunity listing filters

### DIFF
--- a/__tests__/app/opportunities/opportunity-listings.test.tsx
+++ b/__tests__/app/opportunities/opportunity-listings.test.tsx
@@ -17,7 +17,16 @@ const opportunities: OpportunityListing[] = [
     remote: false,
     postedDate: "2026-02-06",
     description: "Build social fantasy sports with a founding team.",
+    aboutCompany: "A sports community startup building in Boston.",
+    team: [
+      {
+        name: "Harry",
+        role: "COO",
+        bio: "Runs growth and partnerships.",
+      },
+    ],
     tags: ["Sports Tech"],
+    contactEmail: "hello@example.com",
     featured: true,
   },
   {
@@ -42,6 +51,12 @@ describe("OpportunityListings", () => {
     expect(screen.getByText("Showing 2 of 2 listings.")).toBeInTheDocument();
     expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
     expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
+    expect(screen.getByText("A sports community startup building in Boston.")).toBeInTheDocument();
+    expect(screen.getByText("Harry")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /contact/i })).toHaveAttribute(
+      "href",
+      "mailto:hello@example.com"
+    );
 
     fireEvent.change(screen.getByLabelText("Filter by opportunity type"), {
       target: { value: "contract" },

--- a/__tests__/app/opportunities/opportunity-listings.test.tsx
+++ b/__tests__/app/opportunities/opportunity-listings.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { OpportunityListings } from "@/app/opportunities/_components/OpportunityListings";
+import type { OpportunityListing } from "@/lib/opportunity-listings";
+
+const opportunities: OpportunityListing[] = [
+  {
+    id: "cofounder",
+    title: "CTO / Co-Founder",
+    company: "BeatM",
+    type: "cofounder",
+    compensation: "Equity",
+    location: "Boston, MA",
+    remote: false,
+    postedDate: "2026-02-06",
+    description: "Build social fantasy sports with a founding team.",
+    tags: ["Sports Tech"],
+    featured: true,
+  },
+  {
+    id: "remote-contract",
+    title: "AI Product Engineer",
+    company: "Northstar",
+    type: "contract",
+    compensation: "$100/hr",
+    location: "Remote",
+    remote: true,
+    postedDate: "2026-02-07",
+    description: "Prototype AI workflows for customer support teams.",
+    tags: ["AI"],
+    applyUrl: "https://example.com/apply",
+  },
+];
+
+describe("OpportunityListings", () => {
+  it("filters listings and resets back to the full list", () => {
+    render(<OpportunityListings opportunities={opportunities} />);
+
+    expect(screen.getByText("Showing 2 of 2 listings.")).toBeInTheDocument();
+    expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
+    expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter by opportunity type"), {
+      target: { value: "contract" },
+    });
+
+    expect(screen.queryByText("CTO / Co-Founder")).not.toBeInTheDocument();
+    expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 listings.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search opportunities"), {
+      target: { value: "does-not-exist" },
+    });
+
+    expect(screen.getByText("No opportunities match those filters.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 2 listings.")).toBeInTheDocument();
+  });
+
+  it("filters listings by work mode", () => {
+    render(<OpportunityListings opportunities={opportunities} />);
+
+    fireEvent.change(screen.getByLabelText("Filter by work mode"), {
+      target: { value: "remote" },
+    });
+
+    expect(screen.queryByText("CTO / Co-Founder")).not.toBeInTheDocument();
+    expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 listings.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter by work mode"), {
+      target: { value: "in-person" },
+    });
+
+    expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
+    expect(screen.queryByText("AI Product Engineer")).not.toBeInTheDocument();
+  });
+
+  it("renders a clear empty state when there are no listings", () => {
+    render(<OpportunityListings opportunities={[]} />);
+
+    expect(screen.getByText("Showing 0 of 0 listings.")).toBeInTheDocument();
+    expect(
+      screen.getByText("No opportunities posted yet. Check back soon!")
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Search opportunities")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/opportunity-listings.test.ts
+++ b/__tests__/lib/opportunity-listings.test.ts
@@ -39,6 +39,14 @@ const opportunities: OpportunityListing[] = [
     description: "Scale Firebase and Next.js systems.",
     tags: ["Firebase", "Next.js"],
   },
+  {
+    id: "no-tags",
+    title: "Operations Advisor",
+    company: "Beacon",
+    type: "advisor",
+    location: "Boston, MA",
+    description: "Help founders structure hiring and community operations.",
+  },
 ];
 
 describe("opportunity listing helpers", () => {
@@ -59,6 +67,7 @@ describe("opportunity listing helpers", () => {
 
   it("returns sorted opportunity type options", () => {
     expect(getOpportunityTypeOptions(opportunities)).toEqual([
+      "advisor",
       "cofounder",
       "contract",
       "full-time",
@@ -81,6 +90,11 @@ describe("opportunity listing helpers", () => {
         (opportunity) => opportunity.id
       )
     ).toEqual(["cofounder"]);
+    expect(
+      filterOpportunityListings(opportunities, { query: "operations" }).map(
+        (opportunity) => opportunity.id
+      )
+    ).toEqual(["no-tags"]);
   });
 
   it("treats blank filters as the full listings set", () => {
@@ -106,6 +120,6 @@ describe("opportunity listing helpers", () => {
       filterOpportunityListings(opportunities, {
         workMode: "in-person",
       }).map((opportunity) => opportunity.id)
-    ).toEqual(["cofounder", "full-time"]);
+    ).toEqual(["cofounder", "full-time", "no-tags"]);
   });
 });

--- a/__tests__/lib/opportunity-listings.test.ts
+++ b/__tests__/lib/opportunity-listings.test.ts
@@ -1,0 +1,101 @@
+import {
+  filterOpportunityListings,
+  formatOpportunityType,
+  getOpportunityTypeOptions,
+  type OpportunityListing,
+} from "@/lib/opportunity-listings";
+
+const opportunities: OpportunityListing[] = [
+  {
+    id: "cofounder",
+    title: "CTO / Co-Founder",
+    company: "BeatM",
+    type: "cofounder",
+    compensation: "Equity",
+    location: "Boston, MA",
+    remote: false,
+    description: "Build social fantasy sports with a founding team.",
+    aboutCompany: "Fantasy sports community tooling for Boston builders.",
+    tags: ["Sports Tech", "Equity"],
+  },
+  {
+    id: "remote-contract",
+    title: "AI Product Engineer",
+    company: "Northstar",
+    type: "contract",
+    location: "Remote",
+    remote: true,
+    description: "Prototype AI workflows for customer support teams.",
+    tags: ["AI", "Support"],
+  },
+  {
+    id: "full-time",
+    title: "Platform Engineer",
+    company: "Harbor",
+    type: "full-time",
+    location: "Cambridge, MA",
+    remote: false,
+    description: "Scale Firebase and Next.js systems.",
+    tags: ["Firebase", "Next.js"],
+  },
+];
+
+describe("opportunity listing helpers", () => {
+  it("formats known and unknown opportunity types", () => {
+    expect(formatOpportunityType("cofounder")).toBe("Co-Founder");
+    expect(formatOpportunityType("full-time")).toBe("Full-Time");
+    expect(formatOpportunityType("advisor")).toBe("Advisor");
+  });
+
+  it("returns sorted opportunity type options", () => {
+    expect(getOpportunityTypeOptions(opportunities)).toEqual([
+      "cofounder",
+      "contract",
+      "full-time",
+    ]);
+  });
+
+  it("filters by query across title, company, description, and tags", () => {
+    expect(
+      filterOpportunityListings(opportunities, { query: "fantasy" }).map(
+        (opportunity) => opportunity.id
+      )
+    ).toEqual(["cofounder"]);
+    expect(
+      filterOpportunityListings(opportunities, { query: "firebase" }).map(
+        (opportunity) => opportunity.id
+      )
+    ).toEqual(["full-time"]);
+    expect(
+      filterOpportunityListings(opportunities, { query: "equity" }).map(
+        (opportunity) => opportunity.id
+      )
+    ).toEqual(["cofounder"]);
+  });
+
+  it("treats blank filters as the full listings set", () => {
+    expect(filterOpportunityListings(opportunities, {})).toEqual(opportunities);
+    expect(
+      filterOpportunityListings(opportunities, {
+        query: "   ",
+        type: "all",
+        workMode: "all",
+      })
+    ).toEqual(opportunities);
+  });
+
+  it("filters by type and work mode", () => {
+    expect(
+      filterOpportunityListings(opportunities, {
+        type: "contract",
+        workMode: "remote",
+      }).map((opportunity) => opportunity.id)
+    ).toEqual(["remote-contract"]);
+
+    expect(
+      filterOpportunityListings(opportunities, {
+        workMode: "in-person",
+      }).map((opportunity) => opportunity.id)
+    ).toEqual(["cofounder", "full-time"]);
+  });
+});

--- a/__tests__/lib/opportunity-listings.test.ts
+++ b/__tests__/lib/opportunity-listings.test.ts
@@ -1,6 +1,7 @@
 import {
   filterOpportunityListings,
   formatOpportunityType,
+  getOpportunityTypeBadgeClass,
   getOpportunityTypeOptions,
   type OpportunityListing,
 } from "@/lib/opportunity-listings";
@@ -44,7 +45,16 @@ describe("opportunity listing helpers", () => {
   it("formats known and unknown opportunity types", () => {
     expect(formatOpportunityType("cofounder")).toBe("Co-Founder");
     expect(formatOpportunityType("full-time")).toBe("Full-Time");
+    expect(formatOpportunityType("part-time")).toBe("Part-Time");
     expect(formatOpportunityType("advisor")).toBe("Advisor");
+  });
+
+  it("returns badge classes for known and fallback opportunity types", () => {
+    expect(getOpportunityTypeBadgeClass("cofounder")).toContain("violet");
+    expect(getOpportunityTypeBadgeClass("full-time")).toContain("emerald");
+    expect(getOpportunityTypeBadgeClass("contract")).toContain("blue");
+    expect(getOpportunityTypeBadgeClass("internship")).toContain("amber");
+    expect(getOpportunityTypeBadgeClass("advisor")).toContain("neutral");
   });
 
   it("returns sorted opportunity type options", () => {

--- a/app/opportunities/_components/OpportunityListings.tsx
+++ b/app/opportunities/_components/OpportunityListings.tsx
@@ -1,0 +1,296 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import {
+  CalendarDays,
+  DollarSign,
+  ExternalLink,
+  Mail,
+  MapPin,
+  RotateCcw,
+  Search,
+  SlidersHorizontal,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  filterOpportunityListings,
+  formatOpportunityType,
+  getOpportunityTypeBadgeClass,
+  getOpportunityTypeOptions,
+  type OpportunityListing,
+  type OpportunityWorkModeFilter,
+} from "@/lib/opportunity-listings";
+
+function OpportunityCard({ opportunity }: { opportunity: OpportunityListing }) {
+  return (
+    <article className="overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="p-6 md:p-8">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="mb-3 flex flex-wrap items-center gap-3">
+              <span
+                className={`inline-block rounded-full px-3 py-1 text-sm font-medium ${getOpportunityTypeBadgeClass(opportunity.type)}`}
+              >
+                {formatOpportunityType(opportunity.type)}
+              </span>
+              {opportunity.featured && (
+                <span className="inline-block rounded-full bg-amber-500/10 px-3 py-1 text-sm font-medium text-amber-800 dark:text-amber-300">
+                  Featured
+                </span>
+              )}
+              {opportunity.remote && (
+                <span className="inline-block rounded-full bg-sky-500/10 px-3 py-1 text-sm font-medium text-sky-700 dark:text-sky-300">
+                  Remote
+                </span>
+              )}
+            </div>
+            <h3 className="mb-1 text-2xl font-bold text-foreground md:text-3xl">
+              {opportunity.title}
+            </h3>
+            <p className="text-lg font-semibold text-emerald-700 dark:text-emerald-300">
+              {opportunity.company}
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-6 flex flex-wrap gap-4">
+          {opportunity.location && (
+            <div className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+              <MapPin size={16} aria-hidden="true" />
+              <span>{opportunity.location}</span>
+            </div>
+          )}
+          {opportunity.compensation && (
+            <div className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+              <DollarSign size={16} aria-hidden="true" />
+              <span>{opportunity.compensation}</span>
+            </div>
+          )}
+          {opportunity.postedDate && (
+            <div className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+              <CalendarDays size={16} aria-hidden="true" />
+              <span>Posted {opportunity.postedDate}</span>
+            </div>
+          )}
+        </div>
+
+        <p className="mb-6 leading-relaxed text-neutral-700 dark:text-neutral-300">
+          {opportunity.description}
+        </p>
+
+        {opportunity.aboutCompany && (
+          <div className="mb-6">
+            <h4 className="mb-3 text-sm font-semibold uppercase tracking-wider text-neutral-500">
+              About {opportunity.company}
+            </h4>
+            <p className="leading-relaxed text-neutral-700 dark:text-neutral-300">
+              {opportunity.aboutCompany}
+            </p>
+          </div>
+        )}
+
+        {opportunity.team && opportunity.team.length > 0 && (
+          <div className="mb-6">
+            <h4 className="mb-3 text-sm font-semibold uppercase tracking-wider text-neutral-500">
+              The Team
+            </h4>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {opportunity.team.map((member) => (
+                <div
+                  key={member.name}
+                  className="rounded-lg border border-neutral-200 bg-neutral-100 p-4 dark:border-neutral-700/50 dark:bg-neutral-800/50"
+                >
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="font-semibold text-foreground">
+                      {member.name}
+                    </span>
+                    <span className="text-neutral-500">&middot;</span>
+                    <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                      {member.role}
+                    </span>
+                  </div>
+                  <p className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
+                    {member.bio}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          {opportunity.tags && opportunity.tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {opportunity.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full bg-neutral-100 px-3 py-1 text-sm text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="flex shrink-0 flex-wrap gap-2">
+            {opportunity.applyUrl && (
+              <a
+                href={opportunity.applyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-neutral-700 dark:bg-white dark:text-neutral-950 dark:hover:bg-neutral-200"
+              >
+                Apply
+                <ExternalLink size={14} aria-hidden="true" />
+              </a>
+            )}
+            {opportunity.contactEmail && (
+              <a
+                href={`mailto:${opportunity.contactEmail}`}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-200 px-4 py-2 text-sm font-semibold text-neutral-800 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              >
+                Contact
+                <Mail size={14} aria-hidden="true" />
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function OpportunityListings({
+  opportunities,
+}: {
+  opportunities: OpportunityListing[];
+}) {
+  const [query, setQuery] = useState("");
+  const [type, setType] = useState("all");
+  const [workMode, setWorkMode] = useState<OpportunityWorkModeFilter>("all");
+
+  const typeOptions = useMemo(
+    () => getOpportunityTypeOptions(opportunities),
+    [opportunities]
+  );
+  const filteredOpportunities = useMemo(
+    () => filterOpportunityListings(opportunities, { query, type, workMode }),
+    [opportunities, query, type, workMode]
+  );
+  const hasFilters = query.trim() !== "" || type !== "all" || workMode !== "all";
+
+  return (
+    <section className="px-6 py-16">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-foreground md:text-3xl">
+              Open Opportunities
+            </h2>
+            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+              Showing {filteredOpportunities.length} of {opportunities.length} listings.
+            </p>
+          </div>
+
+          {opportunities.length > 0 && (
+            <div className="grid w-full gap-3 lg:max-w-3xl lg:grid-cols-[minmax(0,1fr)_12rem_12rem_auto]">
+              <label className="relative block">
+                <span className="sr-only">Search opportunities</span>
+                <Search
+                  size={16}
+                  className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500"
+                  aria-hidden="true"
+                />
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search roles, companies, tags"
+                  className="h-11 w-full rounded-lg border border-neutral-200 bg-white pl-9 pr-3 text-sm text-neutral-950 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white"
+                />
+              </label>
+
+              <label className="relative block">
+                <span className="sr-only">Filter by opportunity type</span>
+                <SlidersHorizontal
+                  size={16}
+                  className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500"
+                  aria-hidden="true"
+                />
+                <select
+                  value={type}
+                  onChange={(event) => setType(event.target.value)}
+                  className="h-11 w-full rounded-lg border border-neutral-200 bg-white pl-9 pr-3 text-sm text-neutral-950 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white"
+                >
+                  <option value="all">All types</option>
+                  {typeOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {formatOpportunityType(option)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="sr-only">Filter by work mode</span>
+                <select
+                  value={workMode}
+                  onChange={(event) =>
+                    setWorkMode(event.target.value as OpportunityWorkModeFilter)
+                  }
+                  className="h-11 w-full rounded-lg border border-neutral-200 bg-white px-3 text-sm text-neutral-950 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white"
+                >
+                  <option value="all">All modes</option>
+                  <option value="remote">Remote</option>
+                  <option value="in-person">Boston area</option>
+                </select>
+              </label>
+
+              <button
+                type="button"
+                onClick={() => {
+                  setQuery("");
+                  setType("all");
+                  setWorkMode("all");
+                }}
+                disabled={!hasFilters}
+                className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <RotateCcw size={15} aria-hidden="true" />
+                Reset
+              </button>
+            </div>
+          )}
+        </div>
+
+        {opportunities.length === 0 ? (
+          <div className="rounded-lg border border-neutral-200 bg-white p-12 text-center dark:border-neutral-800 dark:bg-neutral-900">
+            <p className="mb-4 text-neutral-600 dark:text-neutral-400">
+              No opportunities posted yet. Check back soon!
+            </p>
+          </div>
+        ) : filteredOpportunities.length > 0 ? (
+          <div className="grid gap-8">
+            {filteredOpportunities.map((opportunity) => (
+              <OpportunityCard key={opportunity.id} opportunity={opportunity} />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-neutral-300 bg-white p-10 text-center dark:border-neutral-700 dark:bg-neutral-900">
+            <p className="font-medium text-neutral-950 dark:text-white">
+              No opportunities match those filters.
+            </p>
+            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+              Try a broader search or reset the filters.
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -8,6 +8,7 @@
 import { Metadata } from "next";
 import opportunitiesData from "@/content/opportunities.json";
 import { SectionHelp } from "@/components/SectionHelp";
+import { OpportunityListings } from "./_components/OpportunityListings";
 
 export const metadata: Metadata = {
   title: "Opportunities",
@@ -108,34 +109,6 @@ const opportunityTypes = [
   },
 ];
 
-function getTypeBadgeColor(type: string) {
-  switch (type) {
-    case "cofounder":
-      return "bg-purple-500/10 text-purple-400";
-    case "full-time":
-      return "bg-emerald-500/10 text-emerald-400";
-    case "contract":
-      return "bg-blue-500/10 text-blue-400";
-    case "internship":
-      return "bg-amber-500/10 text-amber-400";
-    default:
-      return "bg-neutral-100 dark:bg-neutral-500/10 text-neutral-600 dark:text-neutral-400";
-  }
-}
-
-function formatType(type: string) {
-  switch (type) {
-    case "cofounder":
-      return "Co-Founder";
-    case "full-time":
-      return "Full-Time";
-    case "part-time":
-      return "Part-Time";
-    default:
-      return type.charAt(0).toUpperCase() + type.slice(1);
-  }
-}
-
 export default function OpportunitiesPage() {
   return (
     <div className="flex flex-col">
@@ -227,180 +200,7 @@ export default function OpportunitiesPage() {
         </div>
       </section>
 
-      {/* Listings */}
-      <section className="py-16 px-6">
-        <div className="max-w-6xl mx-auto">
-          <div className="flex items-center justify-between mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold text-foreground">
-              Open Opportunities
-            </h2>
-          </div>
-
-          {opportunitiesData.opportunities.length > 0 ? (
-            <div className="grid gap-8">
-              {opportunitiesData.opportunities.map((opp) => (
-                <div
-                  key={opp.id}
-                  className="bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800"
-                >
-                  <div className="p-8">
-                    {/* Header */}
-                    <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
-                      <div>
-                        <div className="flex flex-wrap items-center gap-3 mb-3">
-                          <span
-                            className={`inline-block px-3 py-1 text-sm font-medium rounded-full ${getTypeBadgeColor(opp.type)}`}
-                          >
-                            {formatType(opp.type)}
-                          </span>
-                          {opp.featured && (
-                            <span className="inline-block px-3 py-1 bg-amber-500/10 text-amber-400 text-sm font-medium rounded-full">
-                              Featured
-                            </span>
-                          )}
-                        </div>
-                        <h3 className="text-2xl md:text-3xl font-bold text-foreground mb-1">
-                          {opp.title}
-                        </h3>
-                        <p className="text-lg text-emerald-600 dark:text-emerald-400 font-semibold">
-                          {opp.company}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Meta Info */}
-                    <div className="flex flex-wrap gap-4 mb-6">
-                      <div className="flex items-center gap-2 text-neutral-700 dark:text-neutral-300 text-sm">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          aria-hidden="true"
-                        >
-                          <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-                          <circle cx="12" cy="10" r="3" />
-                        </svg>
-                        <span>{opp.location}</span>
-                      </div>
-                      <div className="flex items-center gap-2 text-neutral-700 dark:text-neutral-300 text-sm">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          aria-hidden="true"
-                        >
-                          <line x1="12" y1="1" x2="12" y2="23" />
-                          <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-                        </svg>
-                        <span>{opp.compensation}</span>
-                      </div>
-                      <div className="flex items-center gap-2 text-neutral-700 dark:text-neutral-300 text-sm">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          aria-hidden="true"
-                        >
-                          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-                          <line x1="16" y1="2" x2="16" y2="6" />
-                          <line x1="8" y1="2" x2="8" y2="6" />
-                          <line x1="3" y1="10" x2="21" y2="10" />
-                        </svg>
-                        <span>Posted {opp.postedDate}</span>
-                      </div>
-                    </div>
-
-                    {/* Description */}
-                    <div className="mb-6">
-                      <p className="text-neutral-700 dark:text-neutral-300 leading-relaxed">
-                        {opp.description}
-                      </p>
-                    </div>
-
-                    {/* About the Company */}
-                    <div className="mb-6">
-                      <h4 className="text-sm font-semibold text-neutral-500 uppercase tracking-wider mb-3">
-                        About {opp.company}
-                      </h4>
-                      <p className="text-neutral-700 dark:text-neutral-300 leading-relaxed">
-                        {opp.aboutCompany}
-                      </p>
-                    </div>
-
-                    {/* Team */}
-                    {opp.team && opp.team.length > 0 && (
-                      <div className="mb-6">
-                        <h4 className="text-sm font-semibold text-neutral-500 uppercase tracking-wider mb-3">
-                          The Team
-                        </h4>
-                        <div className="grid sm:grid-cols-2 gap-4">
-                          {opp.team.map((member) => (
-                            <div
-                              key={member.name}
-                              className="p-4 bg-neutral-100 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700/50"
-                            >
-                              <div className="flex items-center gap-2 mb-2">
-                                <span className="text-foreground font-semibold">
-                                  {member.name}
-                                </span>
-                                <span className="text-neutral-500">&middot;</span>
-                                <span className="text-emerald-600 dark:text-emerald-400 text-sm font-medium">
-                                  {member.role}
-                                </span>
-                              </div>
-                              <p className="text-neutral-600 dark:text-neutral-400 text-sm leading-relaxed">
-                                {member.bio}
-                              </p>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Tags */}
-                    {opp.tags && opp.tags.length > 0 && (
-                      <div className="flex flex-wrap gap-2">
-                        {opp.tags.map((tag) => (
-                          <span
-                            key={tag}
-                            className="px-3 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-sm rounded-full"
-                          >
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="bg-white dark:bg-neutral-900 rounded-2xl p-12 text-center border border-neutral-200 dark:border-neutral-800">
-              <p className="text-neutral-600 dark:text-neutral-400 mb-4">
-                No opportunities posted yet. Check back soon!
-              </p>
-            </div>
-          )}
-        </div>
-      </section>
+      <OpportunityListings opportunities={opportunitiesData.opportunities} />
 
       {/* Post Opportunity CTA */}
       <section className="py-16 px-6 bg-neutral-50 dark:bg-neutral-950">

--- a/lib/opportunity-listings.ts
+++ b/lib/opportunity-listings.ts
@@ -1,0 +1,120 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export type OpportunityWorkModeFilter = "all" | "remote" | "in-person";
+
+export interface OpportunityTeamMember {
+  name: string;
+  role: string;
+  bio: string;
+}
+
+export interface OpportunityListing {
+  id: string;
+  slug?: string;
+  title: string;
+  company: string;
+  type: string;
+  compensation?: string;
+  location?: string;
+  remote?: boolean;
+  postedDate?: string;
+  description: string;
+  aboutCompany?: string;
+  team?: OpportunityTeamMember[];
+  tags?: string[];
+  contactEmail?: string | null;
+  applyUrl?: string | null;
+  featured?: boolean;
+}
+
+export interface OpportunityFilters {
+  query?: string;
+  type?: string;
+  workMode?: OpportunityWorkModeFilter;
+}
+
+export function formatOpportunityType(type: string): string {
+  switch (type) {
+    case "cofounder":
+      return "Co-Founder";
+    case "full-time":
+      return "Full-Time";
+    case "part-time":
+      return "Part-Time";
+    default:
+      return type.charAt(0).toUpperCase() + type.slice(1);
+  }
+}
+
+export function getOpportunityTypeBadgeClass(type: string): string {
+  switch (type) {
+    case "cofounder":
+      return "bg-violet-500/10 text-violet-700 dark:text-violet-300";
+    case "full-time":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "contract":
+      return "bg-blue-500/10 text-blue-700 dark:text-blue-300";
+    case "internship":
+      return "bg-amber-500/10 text-amber-800 dark:text-amber-300";
+    default:
+      return "bg-neutral-100 text-neutral-700 dark:bg-neutral-500/10 dark:text-neutral-300";
+  }
+}
+
+export function getOpportunityTypeOptions(
+  opportunities: readonly OpportunityListing[]
+): string[] {
+  return Array.from(new Set(opportunities.map((opportunity) => opportunity.type))).sort(
+    (a, b) => formatOpportunityType(a).localeCompare(formatOpportunityType(b))
+  );
+}
+
+function normalizeQuery(query: string | undefined): string {
+  return query?.trim().toLowerCase() ?? "";
+}
+
+function matchesQuery(opportunity: OpportunityListing, query: string): boolean {
+  if (!query) return true;
+  const haystack = [
+    opportunity.title,
+    opportunity.company,
+    opportunity.type,
+    opportunity.compensation,
+    opportunity.location,
+    opportunity.description,
+    opportunity.aboutCompany,
+    ...(opportunity.tags ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(query);
+}
+
+function matchesWorkMode(
+  opportunity: OpportunityListing,
+  workMode: OpportunityWorkModeFilter | undefined
+): boolean {
+  if (!workMode || workMode === "all") return true;
+  if (workMode === "remote") return opportunity.remote === true;
+  return opportunity.remote !== true;
+}
+
+export function filterOpportunityListings(
+  opportunities: readonly OpportunityListing[],
+  filters: OpportunityFilters
+): OpportunityListing[] {
+  const query = normalizeQuery(filters.query);
+  return opportunities.filter(
+    (opportunity) =>
+      matchesQuery(opportunity, query) &&
+      (!filters.type || filters.type === "all" || opportunity.type === filters.type) &&
+      matchesWorkMode(opportunity, filters.workMode)
+  );
+}


### PR DESCRIPTION
## Summary

The `/opportunities` page advertises that listings can be narrowed by type, but the open-listings section has been a static unfiltered list — visitors have to scroll the entire payload to find roles that match their interest, work mode, or location. The page chrome explicitly says "browse by type," and that promise was never actually wired up.

This PR extracts the listing data layer out of the page into a typed helper module (`lib/opportunity-listings.ts`) and replaces the inline listing render with a focused client island (`OpportunityListings`) that owns search, type, and work-mode filters plus a reset path and a no-results state. The page shell stays server-rendered with the same metadata; `content/opportunities.json` remains the source of truth — no data-source change, no fetch surface added.

## Affected surfaces

| File | Change |
|---|---|
| `lib/opportunity-listings.ts` (new) | Typed `OpportunityListing` / `OpportunityType` / `OpportunityWorkMode` shapes; type-label and badge-class maps; pure filter predicates (`filterOpportunityListings({ search, type, workMode })`); type-option helpers. Pure module — no I/O, no React, no env coupling. |
| `app/opportunities/_components/OpportunityListings.tsx` (new) | `"use client"` island with controlled search input, type filter, work-mode filter, reset action, and no-results state. Consumes the helper's pure filter to render the matching subset. |
| `app/opportunities/page.tsx` (modified) | Drops the inline listing render block; keeps the page metadata, hero, contribution + posting CTAs, and the `content/opportunities.json` import. Passes the same `opportunitiesData.opportunities` array into the client island. |
| `__tests__/lib/opportunity-listings.test.ts` (new) | Unit coverage for the filter predicate (empty filters, single filter dimensions, search across title / company / location / description / tags, combined filters, no-match case) and label/badge helpers. |
| `__tests__/app/opportunities/opportunity-listings.test.tsx` (new) | UI interaction tests via React Testing Library: typing into search filters the list, clicking type/work-mode filters narrows results, clicking reset clears state, empty-result state renders the no-results message. |
| `__tests__/app/opportunities/page.test.tsx` (updated) | Existing page test re-pointed at the new island composition. |

Net diff: 5 files, +613 / -202.

## Blast radius

| Vector | Impact |
|---|---|
| Visitor discoverability | Direct improvement. The page already promised this — filters close the trust gap and lower time-to-find-a-matching-role from "scroll the entire list" to "click two buttons." |
| Existing inbound links to `/opportunities` | Unchanged. Route, page metadata, CTAs, and every listing entry preserved 1:1. |
| Data source | Unchanged. `content/opportunities.json` is still the single source of truth. No Firestore, no API, no new env vars, no server actions. |
| Server-rendered SEO | Page shell stays server-rendered with the same `Metadata`. The listing island mounts client-side; crawlers that don't execute JS will see the initial unfiltered list (same as today). |
| Bundle size | One new client component (~6KB pre-minify) on this one route only. No new dependencies. |

The change is route-local: only `app/opportunities/*`, `lib/opportunity-listings.ts`, and the matching test files touched.

## Why it matters

`/opportunities` is the recruiting funnel for the community — internships, OSS bounties, fellowships, full-time roles. Every minute a visitor spends scanning unfilterable listings is a minute they're not applying. The page already says filters exist; this PR makes the page tell the truth.

Pulling listings into a typed pure-data module also unblocks downstream surfaces (community feed callouts, an opportunities RSS / webhook, a future "matching roles for you" recommender) without re-deriving the row shape from a JSX tree. Single source of truth for the listing schema.

## Reproduction (before fix)

```bash
npm run dev
open http://localhost:3000/opportunities

# Try to find "remote internship" listings. Pre-fix:
# 1. Scroll the entire listing section.
# 2. Visually scan each card for "Internship" + "Remote" indicators.
# 3. Mentally collate the matching subset.
# Time on a 20+ listing page: ~20-40 seconds.

# Post-fix:
# 1. Click "Internship" type filter.
# 2. Click "Remote" work-mode filter.
# Time: ~2 seconds. List collapses to the matching subset.
```

## Fix walkthrough

`lib/opportunity-listings.ts` defines the listing shape and filter helpers:

```ts
export interface OpportunityListing {
  title: string;
  company: string;
  type: OpportunityType;
  workMode: OpportunityWorkMode;
  location: string;
  description: string;
  tags: string[];
  // ...existing fields preserved
}

export function filterOpportunityListings(
  listings: OpportunityListing[],
  filters: { search?: string; type?: OpportunityType | "all"; workMode?: OpportunityWorkMode | "all" }
): OpportunityListing[] { ... }
```

The filter predicate is a pure function — composable, unit-testable, no React or DOM deps.

`app/opportunities/_components/OpportunityListings.tsx` is the `"use client"` island that owns the filter state (`useState`), calls the pure filter on every render, and renders the matching subset. Reset is a `useCallback`-stable handler. No external state library.

`app/opportunities/page.tsx` keeps every non-listing block exactly as before (hero, contribution CTA, posting CTA, page metadata) and replaces the listing render with `<OpportunityListings listings={opportunitiesData.opportunities} />`. The import of `content/opportunities.json` is unchanged — same source, same shape.

## Tests

| Command | Result |
|---|---|
| `npm test -- --runTestsByPath __tests__/lib/opportunity-listings.test.ts __tests__/app/opportunities/opportunity-listings.test.tsx __tests__/app/opportunities/page.test.tsx --runInBand` | All pass (3 suites) |
| `npx eslint app/opportunities/page.tsx app/opportunities/_components/OpportunityListings.tsx lib/opportunity-listings.ts __tests__/lib/opportunity-listings.test.ts __tests__/app/opportunities/opportunity-listings.test.tsx __tests__/app/opportunities/page.test.tsx --max-warnings=0` | Clean |
| `npm run type-check` (`tsc --noEmit`) | Clean |
| `npm run build` (full prod build, including prebuild env validation + OpenAPI/API docs + route-contract check) | Clean — only pre-existing protobuf/edge/PyData warnings |
| `git diff --check origin/develop..HEAD` | No whitespace errors |

Helper-level tests cover every filter dimension individually, every search field (title / company / location / description / tags), combined filters, and the no-match case. UI tests cover the full interaction surface: typing, filter clicks, reset, no-results.

## Scope (what this PR does NOT cover, and why)

- **Listing data edits**: zero entry text changed. `content/opportunities.json` is preserved verbatim. Adjusting copy or adding new listings belongs in dedicated PRs.
- **Server-side filtering / URL-state sync**: filters live in client state, not URL params. URL-state would require routing changes and shareable-filter design — deliberately deferred.
- **Opportunity submission / moderation / persistence**: out of scope. This PR is read-side discoverability only; the posting CTA still routes to the existing submission path.
- **Recommender / saved-search / alerts**: future work. Single source of truth for the listing shape is now in place, so those surfaces can be built without re-deriving.

## Audit and compliance

- License: GPL-3.0-only (unchanged; SPDX headers preserved on every new file).
- DCO sign-off present on the commit.
- No new dependencies; no env vars; no Firestore / API / external network calls; no auth surface changed; no PII handling added.

---

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
