### PR TITLE
release: develop → main (2026-05-23) — 21 PRs, baseline CI fix + security/reliability hardening

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -171,7 +171,7 @@ Practical implications you should know up front:
 - **Network use is not distribution.** Running a private hosted instance does not trigger the copyleft. Only redistributing the code (or a binary) does. (This project uses GPL-3.0, not AGPL-3.0.)
 - **If you need a permissive license** (MIT / Apache) for proprietary use, this project is not the right starting point.
 
-Every TypeScript / TSX source file under `app/`, `lib/`, `components/`, `hooks/`, `contexts/`, and `types/` carries an `SPDX-License-Identifier: GPL-3.0-or-later` header. The CI gate refuses to land new files without one — run `node scripts/add-gpl-headers.js` if you add files in those directories. See [LICENSE](../LICENSE) for full terms and [NOTICE](../NOTICE) for third-party attributions.
+Every TypeScript / TSX source file under `app/`, `lib/`, `components/`, `hooks/`, `contexts/`, and `types/` carries a GPL-3.0-only SPDX license header. The CI gate refuses to land new files without one — run `node scripts/add-gpl-headers.js` if you add files in those directories. See [LICENSE](../LICENSE) for full terms and [NOTICE](../NOTICE) for third-party attributions.
 
 ## Getting Started
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+if [ "${HUSKY:-1}" = "0" ]; then
+  exit 0
+fi
 
-npx --no -- commitlint --edit ${1}
+husky_sh="$(dirname -- "$0")/_/husky.sh"
+if [ -f "$husky_sh" ]; then
+  . "$husky_sh"
+fi
+
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,12 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+if [ "${HUSKY:-1}" = "0" ]; then
+  exit 0
+fi
+
+husky_sh="$(dirname -- "$0")/_/husky.sh"
+if [ -f "$husky_sh" ]; then
+  . "$husky_sh"
+fi
 
 # Scan for secrets in staged files (if gitleaks is installed)
 if command -v gitleaks > /dev/null 2>&1; then

--- a/__tests__/_helpers/_helpers-smoke.test.ts
+++ b/__tests__/_helpers/_helpers-smoke.test.ts
@@ -174,6 +174,8 @@ describe("__tests__/_helpers (smoke)", () => {
     it("makeServerAuthSpies → getVerifiedUser returns null by default", async () => {
       const spies = makeServerAuthSpies();
       expect(await spies.getVerifiedUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedAdminUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedUserWithRevocation({} as never)).toBeNull();
     });
 
     it("mockVerifiedUser one-shots a user", async () => {
@@ -182,20 +184,34 @@ describe("__tests__/_helpers (smoke)", () => {
       const u = (await spies.getVerifiedUser({} as never)) as { uid: string; email: string };
       expect(u.uid).toBe("u1");
       expect(u.email).toBe("u@x.com");
+      const admin = (await spies.getVerifiedAdminUser({} as never)) as { uid: string };
+      expect(admin.uid).toBe("u1");
+      const revoked = (await spies.getVerifiedUserWithRevocation({} as never)) as {
+        uid: string;
+      };
+      expect(revoked.uid).toBe("u1");
       // Next call falls back to null again
       expect(await spies.getVerifiedUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedAdminUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedUserWithRevocation({} as never)).toBeNull();
     });
 
     it("mockUnauthenticated → null", async () => {
       const spies = makeServerAuthSpies();
       spies.mockUnauthenticated();
       expect(await spies.getVerifiedUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedAdminUser({} as never)).toBeNull();
+      expect(await spies.getVerifiedUserWithRevocation({} as never)).toBeNull();
     });
 
     it("mockAuthError → rejects", async () => {
       const spies = makeServerAuthSpies();
       spies.mockAuthError(new Error("expired"));
       await expect(spies.getVerifiedUser({} as never)).rejects.toThrow("expired");
+      await expect(spies.getVerifiedAdminUser({} as never)).rejects.toThrow("expired");
+      await expect(spies.getVerifiedUserWithRevocation({} as never)).rejects.toThrow(
+        "expired",
+      );
     });
 
     it("createServerAuthModule binds spies to module exports", async () => {
@@ -204,6 +220,25 @@ describe("__tests__/_helpers (smoke)", () => {
       spies.mockVerifiedUser({ uid: "u9" });
       const u = (await mod.getVerifiedUser({} as never)) as { uid: string };
       expect(u.uid).toBe("u9");
+      const admin = (await mod.getVerifiedAdminUser({} as never)) as { uid: string };
+      expect(admin.uid).toBe("u9");
+      const revoked = (await mod.getVerifiedUserWithRevocation({} as never)) as {
+        uid: string;
+      };
+      expect(revoked.uid).toBe("u9");
+      expect(mod.isRevokedIdTokenError(new Error("expired"))).toBe(false);
+    });
+
+    it("mockRevokedAuthError wires revoked-token classification", async () => {
+      const spies = makeServerAuthSpies();
+      const mod = createServerAuthModule(spies);
+      const err = new Error("The Firebase ID token has been revoked.");
+      spies.mockRevokedAuthError(err);
+
+      await expect(mod.getVerifiedAdminUser({} as never)).rejects.toThrow(
+        "revoked",
+      );
+      expect(mod.isRevokedIdTokenError(err)).toBe(true);
     });
 
     it("withCronSecret + clearCronSecret manage process.env", () => {

--- a/__tests__/_helpers/server-auth-mock.ts
+++ b/__tests__/_helpers/server-auth-mock.ts
@@ -24,45 +24,71 @@ import type { VerifiedUser } from "@/lib/server-auth";
 
 export interface ServerAuthSpies {
   getVerifiedUser: jest.Mock;
+  getVerifiedAdminUser: jest.Mock;
+  getVerifiedUserWithRevocation: jest.Mock;
   getOptionalVerifiedUser: jest.Mock;
+  isCurrentIdTokenRevoked: jest.Mock;
+  isRevokedIdTokenError: jest.Mock;
   /** Pre-seed `getVerifiedUser` to return the given user on the next call. */
   mockVerifiedUser: (user: Partial<VerifiedUser> & { uid: string }) => void;
   /** Pre-seed `getVerifiedUser` to return null (unauth) on the next call. */
   mockUnauthenticated: () => void;
   /** Pre-seed `getVerifiedUser` to throw on the next call (token verify fail). */
   mockAuthError: (err?: Error) => void;
+  /** Pre-seed all auth helpers to throw a revoked-token error. */
+  mockRevokedAuthError: (err?: Error) => void;
 }
 
 export function makeServerAuthSpies(): ServerAuthSpies {
   const getVerifiedUser = jest.fn().mockResolvedValue(null);
+  const getVerifiedAdminUser = jest.fn().mockResolvedValue(null);
+  const getVerifiedUserWithRevocation = jest.fn().mockResolvedValue(null);
   const getOptionalVerifiedUser = jest.fn().mockResolvedValue(null);
+  const isCurrentIdTokenRevoked = jest.fn().mockResolvedValue(false);
+  const isRevokedIdTokenError = jest.fn().mockReturnValue(false);
 
   return {
     getVerifiedUser,
+    getVerifiedAdminUser,
+    getVerifiedUserWithRevocation,
     getOptionalVerifiedUser,
+    isCurrentIdTokenRevoked,
+    isRevokedIdTokenError,
     mockVerifiedUser(user) {
-      getVerifiedUser.mockResolvedValueOnce({
+      const verified = {
         email: undefined,
         name: undefined,
         picture: undefined,
         isAdmin: false,
         ...user,
-      });
-      getOptionalVerifiedUser.mockResolvedValueOnce({
-        email: undefined,
-        name: undefined,
-        picture: undefined,
-        isAdmin: false,
-        ...user,
-      });
+      };
+      getVerifiedUser.mockResolvedValueOnce(verified);
+      getVerifiedAdminUser.mockResolvedValueOnce(verified);
+      getVerifiedUserWithRevocation.mockResolvedValueOnce(verified);
+      getOptionalVerifiedUser.mockResolvedValueOnce(verified);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(false);
     },
     mockUnauthenticated() {
       getVerifiedUser.mockResolvedValueOnce(null);
+      getVerifiedAdminUser.mockResolvedValueOnce(null);
+      getVerifiedUserWithRevocation.mockResolvedValueOnce(null);
       getOptionalVerifiedUser.mockResolvedValueOnce(null);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(false);
     },
     mockAuthError(err = new Error("token verify failed")) {
       getVerifiedUser.mockRejectedValueOnce(err);
+      getVerifiedAdminUser.mockRejectedValueOnce(err);
+      getVerifiedUserWithRevocation.mockRejectedValueOnce(err);
       getOptionalVerifiedUser.mockRejectedValueOnce(err);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(false);
+    },
+    mockRevokedAuthError(err = new Error("The Firebase ID token has been revoked.")) {
+      getVerifiedUser.mockRejectedValueOnce(err);
+      getVerifiedAdminUser.mockRejectedValueOnce(err);
+      getVerifiedUserWithRevocation.mockRejectedValueOnce(err);
+      getOptionalVerifiedUser.mockRejectedValueOnce(err);
+      isCurrentIdTokenRevoked.mockResolvedValueOnce(true);
+      isRevokedIdTokenError.mockReturnValueOnce(true);
     },
   };
 }
@@ -70,8 +96,15 @@ export function makeServerAuthSpies(): ServerAuthSpies {
 export function createServerAuthModule(spies: ServerAuthSpies) {
   return {
     getVerifiedUser: (...a: unknown[]) => spies.getVerifiedUser(...a),
+    getVerifiedAdminUser: (...a: unknown[]) =>
+      spies.getVerifiedAdminUser(...a),
+    getVerifiedUserWithRevocation: (...a: unknown[]) =>
+      spies.getVerifiedUserWithRevocation(...a),
     getOptionalVerifiedUser: (...a: unknown[]) =>
       spies.getOptionalVerifiedUser(...a),
+    isCurrentIdTokenRevoked: (...a: unknown[]) =>
+      spies.isCurrentIdTokenRevoked(...a),
+    isRevokedIdTokenError: spies.isRevokedIdTokenError,
   };
 }
 

--- a/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
@@ -56,7 +56,11 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(AUTH_USER),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(AUTH_USER),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(AUTH_USER),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(AUTH_USER),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(AUTH_USER),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke-authed.test.ts
@@ -5,7 +5,7 @@
  * past the 401 guard than the unauthenticated invoke in #74).
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { NextRequest } from "next/server";
 import { makeCronRequest } from "@/__tests__/_helpers/route-test-utils";
 
@@ -107,13 +107,14 @@ function walk(dir: string, out: string[] = []): string[] {
 const ROUTE_FILES = walk(APP_API);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
 function apiPathFromFile(absPath: string): string {
-  const rel = absPath.replace(join(process.cwd(), "app"), "").replace(/\\/g, "/");
-  return rel.replace(/\/route\.ts$/, "") || "/api";
+  const rel = relative(join(process.cwd(), "app"), absPath).replace(/\\/g, "/");
+  const withoutRoute = rel.replace(/\/route\.ts$/, "");
+  return `/${withoutRoute}` || "/api";
 }
 
 function buildRouteContext(apiPath: string) {

--- a/__tests__/app/api/all-routes-handler-invoke.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke.test.ts
@@ -7,7 +7,7 @@
  * the import-only sweep in all-routes-smoke.test.ts.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { NextRequest } from "next/server";
 import { makeCronRequest } from "@/__tests__/_helpers/route-test-utils";
 
@@ -100,15 +100,15 @@ function walk(dir: string, out: string[] = []): string[] {
 const ROUTE_FILES = walk(APP_API);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
 /** Build `/api/...` path from absolute route file path. */
 function apiPathFromFile(absPath: string): string {
-  const rel = absPath.replace(join(process.cwd(), "app"), "").replace(/\\/g, "/");
+  const rel = relative(join(process.cwd(), "app"), absPath).replace(/\\/g, "/");
   const withoutRoute = rel.replace(/\/route\.ts$/, "");
-  return withoutRoute || "/api";
+  return `/${withoutRoute}` || "/api";
 }
 
 /** Next.js 15+ dynamic route context from `[param]` and `[...slug]` segments. */

--- a/__tests__/app/api/all-routes-handler-invoke.test.ts
+++ b/__tests__/app/api/all-routes-handler-invoke.test.ts
@@ -49,7 +49,11 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/app/api/all-routes-smoke.test.ts
+++ b/__tests__/app/api/all-routes-smoke.test.ts
@@ -24,7 +24,11 @@ jest.mock("@/lib/firebase-admin", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/app/api/all-routes-smoke.test.ts
+++ b/__tests__/app/api/all-routes-smoke.test.ts
@@ -13,7 +13,7 @@
  * follow-up.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 // Heavyweight dependencies that many routes pull in. Mock them up-front
 // so a route's module init can succeed without real Firebase / cron / etc.
@@ -83,7 +83,7 @@ const ROUTE_FILES = walk(APP_API);
 
 // Convert an absolute path to the `@/...` module-id form Jest resolves.
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
@@ -106,7 +106,7 @@ describe("app/api smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/app/api/community/moderate.test.ts
+++ b/__tests__/app/api/community/moderate.test.ts
@@ -9,7 +9,10 @@
 import { NextRequest } from "next/server";
 import { POST, GET } from "@/app/api/community/moderate/route";
 import type { VerifiedUser } from "@/lib/server-auth";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 
 jest.mock("@/lib/logger", () => ({
   logger: { error: jest.fn(), logError: jest.fn() },
@@ -17,6 +20,7 @@ jest.mock("@/lib/logger", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 const mockBatchUpdate = jest.fn();
@@ -55,6 +59,9 @@ jest.mock("firebase-admin/firestore", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const adminUser: VerifiedUser = { uid: "admin1", name: "Admin", isAdmin: true };
 const regularUser: VerifiedUser = { uid: "u1", name: "Reg", isAdmin: false };
 
@@ -72,6 +79,7 @@ function makeGetRequest(query = "") {
 describe("POST /api/community/moderate (admin actions)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(adminUser);
     mockReportGet.mockResolvedValue({
       exists: true,
@@ -83,6 +91,20 @@ describe("POST /api/community/moderate (admin actions)", () => {
     mockGetVerifiedUser.mockResolvedValue(null);
     const res = await POST(makePostRequest({ reportId: "r1", action: "dismiss" }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 without moderation side effects when the admin token is revoked", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(adminUser);
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await POST(makePostRequest({ reportId: "r1", action: "dismiss" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: "Session revoked. Please sign in again.",
+    });
+    expect(mockBatchUpdate).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
   });
 
   it("returns 403 for non-admin", async () => {
@@ -145,6 +167,7 @@ describe("POST /api/community/moderate (admin actions)", () => {
 describe("GET /api/community/moderate (admin listing)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(adminUser);
     mockListSnap.docs = [
       {

--- a/__tests__/app/api/events/pydata-2026/admin/list.test.ts
+++ b/__tests__/app/api/events/pydata-2026/admin/list.test.ts
@@ -5,10 +5,16 @@
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/events/pydata-2026/admin/list/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
 jest.mock("@/lib/middleware", () => ({
   withMiddleware: (_cfg: unknown, handler: any) => handler,
   rateLimitConfigs: { standard: {} },
@@ -16,6 +22,9 @@ jest.mock("@/lib/middleware", () => ({
 
 const mockAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 
 function tsLike(ms: number) {
   return { toMillis: () => ms };
@@ -42,12 +51,25 @@ function req() {
 describe("GET /api/events/pydata-2026/admin/list", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
   });
 
   it("returns 401 when unauthenticated", async () => {
     mockUser.mockResolvedValue(null);
     const res = await GET(req());
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    mockUser.mockResolvedValueOnce({ uid: "admin", isAdmin: true } as any);
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await GET(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the user is not an admin", async () => {

--- a/__tests__/app/api/game/admin/grant/route.test.ts
+++ b/__tests__/app/api/game/admin/grant/route.test.ts
@@ -3,23 +3,61 @@
  */
 import { POST } from "@/app/api/game/admin/grant/route";
 import { adminGrantTurnsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 import { makeAuthedRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
 jest.mock("@/lib/game/data-server", () => ({
   adminGrantTurnsServer: jest.fn(),
 }));
 
 describe("POST /api/game/admin/grant", () => {
+  const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+    typeof isCurrentIdTokenRevoked
+  >;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
     (getVerifiedUser as jest.Mock).mockResolvedValue({
       uid: "admin",
       email: "a@test.com",
       name: "A",
       isAdmin: false,
     });
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    (getVerifiedUser as jest.Mock).mockResolvedValueOnce({
+      uid: "admin",
+      email: "a@test.com",
+      name: "A",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/admin/grant",
+          body: { weekStartIso: "2026-05-18T05:30:00.000Z" },
+        }),
+      ),
+    );
+
+    expect(status).toBe(401);
+    expect(body.error).toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Session revoked. Please sign in again.",
+    });
+    expect(adminGrantTurnsServer).not.toHaveBeenCalled();
   });
 
   it("returns 403 for non-admin", async () => {

--- a/__tests__/app/api/game/admin/units/route.test.ts
+++ b/__tests__/app/api/game/admin/units/route.test.ts
@@ -5,11 +5,15 @@
  */
 import { POST } from "@/app/api/game/admin/units/route";
 import { adminGrantUnitsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/game/data-server", () => ({
@@ -17,11 +21,15 @@ jest.mock("@/lib/game/data-server", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGrantUnits = adminGrantUnitsServer as jest.MockedFunction<typeof adminGrantUnitsServer>;
 
 describe("POST /api/game/admin/units", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue({
       uid: "u1",
       email: "u@test.com",
@@ -41,6 +49,33 @@ describe("POST /api/game/admin/units", () => {
       }),
     );
     expect(res.status).toBe(401);
+    expect(mockGrantUnits).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin",
+      email: "a@test.com",
+      name: "A",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const { status, body } = await readJson(
+      await POST(
+        makeAuthedRequest({
+          method: "POST",
+          path: "/api/game/admin/units",
+          body: { tileId: "t1", unitType: "ground", count: 5 },
+        }),
+      ),
+    );
+
+    expect(status).toBe(401);
+    expect(body.error).toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Session revoked. Please sign in again.",
+    });
     expect(mockGrantUnits).not.toHaveBeenCalled();
   });
 

--- a/__tests__/app/api/game/heroes/chapter.test.ts
+++ b/__tests__/app/api/game/heroes/chapter.test.ts
@@ -17,13 +17,16 @@ import {
   DELETE,
   PATCH,
 } from "@/app/api/game/heroes/[heroId]/chapter/[chapterId]/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HeroLoreForbiddenError,
   HeroLoreNotFoundError,
 } from "@/lib/game/hero-lore";
 
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
 
 jest.mock("@/lib/game/hero-lore", () => {
   const actual = jest.requireActual("@/lib/game/hero-lore");
@@ -35,6 +38,9 @@ jest.mock("@/lib/game/hero-lore", () => {
 });
 
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 
 function makeReq(method: "DELETE" | "PATCH") {
   return new NextRequest(
@@ -54,6 +60,7 @@ beforeEach(() => {
     email: "u@x",
     isAdmin: false,
   } as never);
+  mockIsRevoked.mockResolvedValue(false);
   const { deleteHeroChapterServer, approveHeroChapterServer } = jest.requireMock(
     "@/lib/game/hero-lore",
   ) as {

--- a/__tests__/app/api/github/webhook/route.test.ts
+++ b/__tests__/app/api/github/webhook/route.test.ts
@@ -20,6 +20,7 @@ import {
   notifyHackASprintSubmissionMerged,
 } from "@/lib/discord";
 import { getAdminDb } from "@/lib/firebase-admin";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
 import { makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 // Quiet the next/cache revalidate calls in jest while preserving the rest
@@ -54,6 +55,10 @@ jest.mock("@/lib/hackathon-showcase-admin", () => ({
   awardHackASprint2026ShowcaseBadge: jest.fn(),
 }));
 
+jest.mock("@/lib/hackathon-leaderboard-snapshot", () => ({
+  refreshSnapshot: jest.fn(),
+}));
+
 jest.mock("@/lib/summer-cohort-auto-admit", () => ({
   maybeAutoAdmitOnPRMerge: jest.fn(),
 }));
@@ -82,6 +87,7 @@ const mockProcessPullRequest = processPullRequest as jest.MockedFunction<
 const mockIsTargetRepository = isTargetRepository as jest.MockedFunction<
   typeof isTargetRepository
 >;
+const mockRefreshSnapshot = refreshSnapshot as jest.MockedFunction<typeof refreshSnapshot>;
 
 describe("GET /api/github/webhook", () => {
   it("returns ok status", async () => {
@@ -95,6 +101,13 @@ describe("GET /api/github/webhook", () => {
 describe("POST /api/github/webhook", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRefreshSnapshot.mockResolvedValue({
+      entries: [],
+      totalCount: 0,
+      websiteSignupCount: 0,
+      creditTopN: 0,
+      generatedAt: "2026-05-22T00:00:00.000Z",
+    });
   });
 
   it("returns 401 when signature is invalid", async () => {
@@ -399,6 +412,40 @@ describe("POST /api/github/webhook", () => {
       authorLogin: "octocat",
       prNumber: 6,
     });
+  });
+
+  it("refreshes persisted hackathon signup leaderboard snapshots on target repo merge", async () => {
+    mockVerify.mockReturnValue(true);
+    mockIsTargetRepository.mockReturnValue(true);
+    (fetchPullRequestChangedFilenames as jest.Mock).mockResolvedValue([]);
+    const req = makeRequest({
+      method: "POST",
+      path: "/api/github/webhook",
+      body: {
+        action: "closed",
+        pull_request: {
+          number: 66,
+          title: "Merged",
+          state: "closed",
+          merged: true,
+          merged_at: "2026-05-01",
+          user: { login: "octocat", avatar_url: "x" },
+          html_url: "u",
+          created_at: "2026-04-30",
+          updated_at: "2026-05-01",
+        },
+        repository: { owner: { login: "o" }, name: "r" },
+      },
+      headers: {
+        "x-hub-signature-256": "sha256=abc",
+        "x-github-event": "pull_request",
+      },
+    });
+
+    await POST(req);
+
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith("hack-a-sprint-2026");
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith("sports-hack-2026");
   });
 
   it("swallows processPullRequest errors and still returns 200", async () => {

--- a/__tests__/app/api/hackathons/events/checkin.route.test.ts
+++ b/__tests__/app/api/hackathons/events/checkin.route.test.ts
@@ -4,7 +4,7 @@
 
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/events/[eventId]/checkin/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkRateLimit } from "@/lib/rate-limit";
 
@@ -19,6 +19,7 @@ jest.mock("@/lib/rate-limit", () => {
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -31,6 +32,9 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
 const VALID_EVENT_ID = "hack-a-sprint-2026";
@@ -57,13 +61,16 @@ function makeMockDoc(data: Record<string, unknown> | null) {
 }
 
 describe("POST /api/hackathons/events/[eventId]/checkin", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
+  });
 
-  it("returns 403 when not authenticated", async () => {
+  it("returns 401 when not authenticated", async () => {
     mockGetVerifiedUser.mockResolvedValue(null);
     const req = makeRequest({ userId: "u1", checkedIn: true });
     const res = await POST(req, makeContext(VALID_EVENT_ID));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 
   it("returns 403 when user is not admin", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.test.ts
@@ -5,7 +5,7 @@
  */
 import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import {
@@ -21,6 +21,7 @@ import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/r
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -52,6 +53,9 @@ jest.mock("@/lib/hackathon-asprint-2026-state", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockCheckRateLimit = checkRateLimit as jest.MockedFunction<typeof checkRateLimit>;
 const mockFetchSubmissions = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
@@ -126,6 +130,7 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard", () =
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetVerifiedUser.mockResolvedValue(null);
+    mockIsRevoked.mockResolvedValue(false);
     mockCheckRateLimit.mockReturnValue({ success: true, retryAfter: 0 });
     mockGetPhase.mockReturnValue("judging");
     mockFetchSubmissions.mockResolvedValue([]);
@@ -269,14 +274,14 @@ describe("GET /api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard", () =
     expect(body.error).toBe("Failed to load dashboard");
   });
 
-  it("returns 401-like 403 when caller is unauthenticated (no user)", async () => {
+  it("returns 401 when caller is unauthenticated (no user)", async () => {
     mockGetVerifiedUser.mockResolvedValue(null);
     const res = await GET(
       makeAuthedRequest({
         path: "/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard",
       }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 
   it("handles submissions with no score docs (all null fields, rawScore null)", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score.route.test.ts
@@ -6,12 +6,15 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
 jest.mock("@/lib/hackathon-showcase", () => ({
   ...jest.requireActual("@/lib/hackathon-showcase"),
   fetchShowcaseSubmissionsFromGitHub: jest.fn(),
@@ -28,6 +31,9 @@ jest.mock("firebase-admin/firestore", () => ({
 }));
 
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
   typeof fetchShowcaseSubmissionsFromGitHub
@@ -57,6 +63,7 @@ function setupDb() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsRevoked.mockResolvedValue(false);
   mockRate.mockResolvedValue({ success: true } as never);
   mockUser.mockResolvedValue({ uid: "admin", isAdmin: true } as never);
   mockSubs.mockResolvedValue([
@@ -84,10 +91,10 @@ describe("POST /api/hackathons/showcase/hack-a-sprint-2026/ai-score", () => {
     expect(res.status).toBe(403);
   });
 
-  it("returns 403 when caller is not authenticated", async () => {
+  it("returns 401 when caller is not authenticated", async () => {
     mockUser.mockResolvedValue(null);
     const res = await POST(makeReq());
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
   });
 
   it("returns 400 for invalid JSON body", async () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code.route.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
+import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
+jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
+  resolveHackASprint2026CreditForUser: jest.fn(),
+}));
+
+const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
+const mockResolve = resolveHackASprint2026CreditForUser as jest.MockedFunction<
+  typeof resolveHackASprint2026CreditForUser
+>;
+
+function makeReq() {
+  return new NextRequest(
+    "https://example.com/api/hackathons/showcase/hack-a-sprint-2026/credit-code",
+    { method: "GET" },
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsRevoked.mockResolvedValue(false);
+});
+
+describe("GET /api/hackathons/showcase/hack-a-sprint-2026/credit-code", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+
+    const res = await GET(makeReq());
+
+    expect(res.status).toBe(401);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the sensitive credit token has been revoked", async () => {
+    const db = { collection: jest.fn() };
+    mockUser.mockResolvedValueOnce({ uid: "u1", email: "u@example.com" } as never);
+    mockDb.mockReturnValue(db as never);
+    mockResolve.mockResolvedValueOnce({
+      ok: true,
+      creditUrl: "https://cursor.com/credit/abc",
+      rank: 7,
+    } as never);
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockDb).toHaveBeenCalled();
+    expect(mockResolve).toHaveBeenCalledWith(db, "u1", "u@example.com");
+  });
+
+  it("returns the resolved credit URL for eligible users", async () => {
+    const db = { collection: jest.fn() };
+    mockUser.mockResolvedValue({ uid: "u1", email: "u@example.com" } as never);
+    mockDb.mockReturnValue(db as never);
+    mockResolve.mockResolvedValue({
+      ok: true,
+      creditUrl: "https://cursor.com/credit/abc",
+      rank: 7,
+    } as never);
+
+    const res = await GET(makeReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      eligible: true,
+      creditUrl: "https://cursor.com/credit/abc",
+      rank: 7,
+    });
+    expect(mockResolve).toHaveBeenCalledWith(db, "u1", "u@example.com");
+  });
+});

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email.route.test.ts
@@ -6,7 +6,10 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 import { sendEmail } from "@/lib/mailgun";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
@@ -15,7 +18,10 @@ jest.mock("@/lib/firebase-admin", () => ({
   getAdminDb: jest.fn(),
   getAdminAuth: jest.fn(),
 }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
 jest.mock("@/lib/hackathon-asprint-2026-credit-eligibility", () => ({
   resolveHackASprint2026CreditForUser: jest.fn(),
 }));
@@ -36,6 +42,9 @@ jest.mock("firebase-admin/firestore", () => ({
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockAuth = getAdminAuth as jest.MockedFunction<typeof getAdminAuth>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockResolve = resolveHackASprint2026CreditForUser as jest.MockedFunction<
   typeof resolveHackASprint2026CreditForUser
 >;
@@ -79,6 +88,7 @@ function setupAdmins(opts: DbOpts = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsRevoked.mockResolvedValue(false);
   mockRate.mockResolvedValue({ success: true } as never);
   mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
   mockResolve.mockResolvedValue({
@@ -86,6 +96,22 @@ beforeEach(() => {
     creditUrl: "https://cursor.com/credit/xyz",
   } as never);
   mockSendEmail.mockResolvedValue(undefined as never);
+});
+
+it("returns 401 when the sensitive credit token is revoked", async () => {
+  setupAdmins();
+  mockUser.mockResolvedValueOnce({ uid: "u1", email: "u@x" } as never);
+  mockIsRevoked.mockResolvedValueOnce(true);
+
+  const res = await POST(makeReq());
+
+  expect(res.status).toBe(401);
+  await expect(res.json()).resolves.toMatchObject({
+    error: "Session revoked. Please sign in again.",
+  });
+  expect(mockDb).toHaveBeenCalled();
+  expect(mockAuth).toHaveBeenCalled();
+  expect(mockSendEmail).not.toHaveBeenCalled();
 });
 
 describe("POST /api/hackathons/showcase/hack-a-sprint-2026/credit-email", () => {

--- a/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
+++ b/__tests__/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score.route.test.ts
@@ -6,14 +6,20 @@
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 import { fetchShowcaseSubmissionsFromGitHub } from "@/lib/hackathon-showcase";
 import { userIsHackASprint2026Judge } from "@/lib/hackathon-showcase-admin";
 import { getHackASprint2026Phase } from "@/lib/hackathon-asprint-2026-schedule";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
 jest.mock("@/lib/hackathon-showcase", () => ({
   ...jest.requireActual("@/lib/hackathon-showcase"),
   fetchShowcaseSubmissionsFromGitHub: jest.fn(),
@@ -38,6 +44,9 @@ jest.mock("firebase-admin/firestore", () => ({
 
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockSubs = fetchShowcaseSubmissionsFromGitHub as jest.MockedFunction<
   typeof fetchShowcaseSubmissionsFromGitHub
 >;
@@ -68,6 +77,7 @@ function setupDb() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsRevoked.mockResolvedValue(false);
   mockRate.mockResolvedValue({ success: true, remaining: 9 } as never);
   mockUser.mockResolvedValue({ uid: "u1", email: "u@x" } as never);
   mockPhase.mockReturnValue("peerVotingOpen");
@@ -96,6 +106,20 @@ describe("POST /api/hackathons/showcase/hack-a-sprint-2026/judge-score", () => {
     mockUser.mockResolvedValueOnce(null);
     const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the judge token has been revoked", async () => {
+    mockUser.mockResolvedValueOnce({ uid: "u1", email: "u@x" } as never);
+    setupDb();
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await POST(makeReq({ submissionId: "team-alpha", score: 8 }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockDb).toHaveBeenCalled();
+    expect(mockSubs).not.toHaveBeenCalled();
   });
 
   it("returns 403 when phase is not peerVotingOpen", async () => {

--- a/__tests__/app/api/hackathons/submissions/check-disqualified/route.test.ts
+++ b/__tests__/app/api/hackathons/submissions/check-disqualified/route.test.ts
@@ -120,6 +120,10 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
 
     const { status, body } = await readJson<{
       hackathonId: string;
+      scannedCount: number;
+      checkedCount: number;
+      skippedCount: number;
+      githubErrorCount: number;
       disqualifiedCount: number;
     }>(
       await GET(
@@ -132,7 +136,13 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
     );
 
     expect(status).toBe(200);
+    expect(body.scannedCount).toBe(1);
+    expect(body.checkedCount).toBe(1);
+    expect(body.skippedCount).toBe(0);
+    expect(body.githubErrorCount).toBe(0);
     expect(body.disqualifiedCount).toBe(1);
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
         disqualified: true,
@@ -171,7 +181,13 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
 
     (global.fetch as jest.Mock).mockRejectedValue(new Error("rate limit"));
 
-    const { status, body } = await readJson<{ disqualifiedCount: number }>(
+    const { status, body } = await readJson<{
+      scannedCount: number;
+      checkedCount: number;
+      skippedCount: number;
+      githubErrorCount: number;
+      disqualifiedCount: number;
+    }>(
       await GET(
         makeCronRequest({
           path: "/api/hackathons/submissions/check-disqualified",
@@ -182,6 +198,10 @@ describe("GET /api/hackathons/submissions/check-disqualified", () => {
     );
 
     expect(status).toBe(200);
+    expect(body.scannedCount).toBe(2);
+    expect(body.checkedCount).toBe(1);
+    expect(body.skippedCount).toBe(1);
+    expect(body.githubErrorCount).toBe(1);
     expect(body.disqualifiedCount).toBe(0);
     expect(update).not.toHaveBeenCalled();
   });

--- a/__tests__/app/api/hackathons/submissions/register.route.test.ts
+++ b/__tests__/app/api/hackathons/submissions/register.route.test.ts
@@ -219,6 +219,22 @@ describe("POST /api/hackathons/submissions/register", () => {
     expect(body.error).toMatch(/Could not verify repo/i);
   });
 
+  it("returns 502 when GitHub verification fetch throws or times out", async () => {
+    mockGetVerifiedUser.mockResolvedValue(testUser);
+    mockGet.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: "team-1" }],
+    });
+    mockFetch.mockRejectedValueOnce(new DOMException("aborted", "AbortError"));
+
+    const res = await POST(makeRequest({ repoUrl: "https://github.com/a/b" }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/Could not verify repo/i);
+    expect(mockSet).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when repo is private", async () => {
     mockGetVerifiedUser.mockResolvedValue(testUser);
     mockGet.mockResolvedValueOnce({
@@ -340,7 +356,7 @@ describe("POST /api/hackathons/submissions/register", () => {
     // The fetch call should use the parsed owner/repo (without .git)
     expect(mockFetch).toHaveBeenCalledWith(
       "https://api.github.com/repos/owner/repo",
-      expect.any(Object)
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 

--- a/__tests__/app/api/hunt/oracle/route.test.ts
+++ b/__tests__/app/api/hunt/oracle/route.test.ts
@@ -5,9 +5,8 @@
 import { createHash } from "crypto";
 import { GET as getOracle } from "@/app/api/hunt/oracle/route";
 import { GET as getKonami } from "@/app/api/hunt/oracle/konami/route";
+import { KONAMI_SEQUENCE_HEADER } from "@/lib/konami-handler";
 import { getKonamiToken, getOracleAnswer } from "@/lib/treasure-hunt-paths";
-
-const KONAMI_SEQUENCE = "UUDDLRLRBA";
 
 function konamiRequest(sequence?: string) {
   const headers: Record<string, string> = {};
@@ -69,7 +68,7 @@ describe("GET /api/hunt/oracle/konami", () => {
   });
 
   it("returns the daily token when sequence is correct", async () => {
-    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE));
+    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE_HEADER));
     const body = await res.json();
 
     expect(res.status).toBe(200);
@@ -78,7 +77,7 @@ describe("GET /api/hunt/oracle/konami", () => {
   });
 
   it("is case-sensitive for the Konami sequence header", async () => {
-    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE.toLowerCase()));
+    const res = await getKonami(konamiRequest(KONAMI_SEQUENCE_HEADER.toLowerCase()));
     expect(res.status).toBe(404);
   });
 });

--- a/__tests__/app/api/live/session/route.test.ts
+++ b/__tests__/app/api/live/session/route.test.ts
@@ -4,11 +4,15 @@
 
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/live/session/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/live-sessions/data-server", () => ({
@@ -16,6 +20,9 @@ jest.mock("@/lib/live-sessions/data-server", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockCreateLiveSessionServer =
   createLiveSessionServer as jest.MockedFunction<typeof createLiveSessionServer>;
 
@@ -38,6 +45,7 @@ function makeInvalidJsonRequest() {
 describe("POST /api/live/session", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
   });
 
   it("requires authentication", async () => {
@@ -46,6 +54,22 @@ describe("POST /api/live/session", () => {
     const res = await POST(makeRequest({ title: "Demo Night" }));
 
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin-1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await POST(makeRequest({ title: "Demo Night" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: "Session revoked. Please sign in again.",
+    });
   });
 
   it("requires admin privileges", async () => {

--- a/__tests__/app/api/showcase/submission/approve/route.test.ts
+++ b/__tests__/app/api/showcase/submission/approve/route.test.ts
@@ -4,7 +4,10 @@
 
 import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/showcase/submission/approve/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkServerRateLimit } from "@/lib/rate-limit-server";
 
@@ -23,6 +26,7 @@ jest.mock("@/lib/rate-limit-server", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -30,6 +34,9 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
 function makeGetRequest() {
@@ -47,8 +54,43 @@ function makePostRequest(body: Record<string, unknown>) {
 describe("/api/showcase/submission/approve", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
     process.env.ADMIN_EMAILS = "admin@example.com";
     process.env.ADMIN_EMAIL = "";
+  });
+
+  it("returns 401 when the GET admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await GET(makeGetRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(checkServerRateLimit).toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the POST admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce({
+      uid: "admin1",
+      email: "admin@example.com",
+      isAdmin: true,
+    });
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await POST(makePostRequest({ submissionId: "s1", action: "approve" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(checkServerRateLimit).toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("rejects non-admin moderation access", async () => {

--- a/__tests__/app/api/summer-cohort/admin/access.route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/access.route.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from "@/app/api/summer-cohort/admin/access/route";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
+import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
+import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
+jest.mock("@/lib/summer-cohort-admin-access", () => ({
+  isSummerCohortAdminEmail: jest.fn(),
+}));
+
+const mockUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
+const mockIsAdminEmail = isSummerCohortAdminEmail as jest.MockedFunction<
+  typeof isSummerCohortAdminEmail
+>;
+
+describe("GET /api/summer-cohort/admin/access", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
+    mockIsAdminEmail.mockReturnValue(false);
+  });
+
+  it("returns allowed false when unauthenticated", async () => {
+    mockUser.mockResolvedValue(null);
+
+    const { status, body } = await readJson(
+      await GET(makeRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(401);
+    expect(body).toEqual({ allowed: false });
+  });
+
+  it("treats malformed or expired tokens as an unauthenticated probe", async () => {
+    mockUser.mockRejectedValueOnce(new Error("token expired") as never);
+
+    const { status, body } = await readJson(
+      await GET(makeAuthedRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(401);
+    expect(body).toEqual({ allowed: false });
+    expect(mockIsAdminEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns an explicit revoked-session error for revoked tokens", async () => {
+    mockUser.mockResolvedValueOnce({ uid: "u1", email: "admin@example.com" } as never);
+    mockIsAdminEmail.mockReturnValueOnce(true);
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const { status, body } = await readJson(
+      await GET(makeAuthedRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(401);
+    expect(body).toEqual({
+      allowed: false,
+      error: "Session revoked. Please sign in again.",
+    });
+    expect(mockIsAdminEmail).toHaveBeenCalledWith("admin@example.com");
+  });
+
+  it("returns the admin-email gate result for authenticated users", async () => {
+    mockUser.mockResolvedValue({ uid: "u1", email: "admin@example.com" } as never);
+    mockIsAdminEmail.mockReturnValue(true);
+
+    const { status, body } = await readJson(
+      await GET(makeAuthedRequest({ path: "/api/summer-cohort/admin/access" })),
+    );
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ allowed: true });
+    expect(mockIsAdminEmail).toHaveBeenCalledWith("admin@example.com");
+  });
+});

--- a/__tests__/app/api/summer-cohort/admin/applications.route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/applications.route.test.ts
@@ -4,18 +4,24 @@
  * OpenSSF Gold coverage push #17 — summer-cohort admin applications route.
  */
 import { GET } from "@/app/api/summer-cohort/admin/applications/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
-jest.mock("@/lib/server-auth", () => ({ getVerifiedUser: jest.fn() }));
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
+}));
 jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: jest.fn() }));
 jest.mock("@/lib/summer-cohort-admin-access", () => ({
   isSummerCohortAdminEmail: jest.fn(),
 }));
 
 const mockUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockIsAdmin = isSummerCohortAdminEmail as jest.MockedFunction<typeof isSummerCohortAdminEmail>;
 
@@ -40,6 +46,7 @@ function setupDb(docs: Array<{ id: string; data: Record<string, unknown> }>) {
 beforeEach(() => {
   jest.clearAllMocks();
   mockIsAdmin.mockReturnValue(true);
+  mockIsRevoked.mockResolvedValue(false);
 });
 
 describe("GET /api/summer-cohort/admin/applications", () => {

--- a/__tests__/app/api/summer-cohort/admin/intake-aggregates/route.test.ts
+++ b/__tests__/app/api/summer-cohort/admin/intake-aggregates/route.test.ts
@@ -6,12 +6,13 @@
 import { GET } from "@/app/api/summer-cohort/admin/intake-aggregates/route";
 import { SUMMER_COHORT_INTAKE_COLLECTION } from "@/lib/summer-cohort-intake";
 import { SUMMER_COHORT_ADMIN_EMAILS_ENV } from "@/lib/summer-cohort-admin-access";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { makeAuthedRequest, makeRequest, readJson } from "@/__tests__/_helpers/route-test-utils";
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -19,6 +20,9 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 
 const adminUser = {
@@ -63,6 +67,7 @@ describe("GET /api/summer-cohort/admin/intake-aggregates", () => {
     jest.clearAllMocks();
     process.env[SUMMER_COHORT_ADMIN_EMAILS_ENV] = "cohort-admin@example.com";
     mockGetVerifiedUser.mockResolvedValue(null);
+    mockIsRevoked.mockResolvedValue(false);
   });
 
   afterEach(() => {

--- a/__tests__/app/api/summer-cohort/my-score-by-week.route.test.ts
+++ b/__tests__/app/api/summer-cohort/my-score-by-week.route.test.ts
@@ -332,5 +332,6 @@ describe("GET /api/summer-cohort/my-score/[weekId]", () => {
     await GET(makeRequest({ method: "GET" }), withParams("week-1"));
     const [, init] = (global.fetch as jest.Mock).mock.calls[0];
     expect(init.headers.Authorization).toBe("Bearer ghp_secret");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/__tests__/app/api/talks/submission/moderate/route.test.ts
+++ b/__tests__/app/api/talks/submission/moderate/route.test.ts
@@ -4,7 +4,10 @@
  * OpenSSF Silver coverage — talk submission moderation route GET/POST guards.
  */
 import { GET, POST } from "@/app/api/talks/submission/moderate/route";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { checkServerRateLimit } from "@/lib/rate-limit-server";
 import { paginateFirestoreQuery } from "@/lib/firestore-pagination";
@@ -30,6 +33,7 @@ jest.mock("@/lib/firestore-pagination", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn(),
+  isCurrentIdTokenRevoked: jest.fn(async () => false),
 }));
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -37,6 +41,9 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 
 const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockIsRevoked = isCurrentIdTokenRevoked as jest.MockedFunction<
+  typeof isCurrentIdTokenRevoked
+>;
 const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
 const mockCheckServerRateLimit = checkServerRateLimit as jest.MockedFunction<
   typeof checkServerRateLimit
@@ -79,8 +86,22 @@ function makeStatusDocs(status: string, count = 1) {
 describe("GET /api/talks/submission/moderate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(null);
     mockCheckServerRateLimit.mockResolvedValue({ success: true, retryAfter: 0 });
+  });
+
+  it("returns 401 when the GET admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(adminUser);
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await GET(makeAuthedRequest({ path: "/api/talks/submission/moderate" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockCheckServerRateLimit).toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -247,6 +268,7 @@ describe("GET /api/talks/submission/moderate", () => {
 describe("POST /api/talks/submission/moderate", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsRevoked.mockResolvedValue(false);
     mockGetVerifiedUser.mockResolvedValue(null);
     mockCheckServerRateLimit.mockResolvedValue({ success: true, retryAfter: 0 });
   });
@@ -260,6 +282,25 @@ describe("POST /api/talks/submission/moderate", () => {
       }),
     );
     expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the POST admin token has been revoked", async () => {
+    mockGetVerifiedUser.mockResolvedValueOnce(adminUser);
+    mockIsRevoked.mockResolvedValueOnce(true);
+
+    const res = await POST(
+      makeAuthedRequest({
+        method: "POST",
+        path: "/api/talks/submission/moderate",
+        body: { submissionId: "t1", action: "approve" },
+      }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe("Session revoked. Please sign in again.");
+    expect(mockCheckServerRateLimit).toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
   });
 
   it("returns 403 when the caller is not an admin", async () => {

--- a/__tests__/app/components-smoke.test.tsx
+++ b/__tests__/app/components-smoke.test.tsx
@@ -11,7 +11,7 @@
  * otherwise has no dedicated tests.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 // Mock all of Firebase + client SDK calls so nothing dies at import time.
 jest.mock("firebase/auth", () => ({
@@ -95,13 +95,14 @@ function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const s = statSync(full);
+    const normalized = full.replace(/\\/g, "/");
     if (s.isDirectory()) walk(full, out);
     else if (
       (entry.endsWith(".tsx") || entry.endsWith(".ts")) &&
       // Only target _components / _hooks / _lib helper directories
-      (full.includes("/_components/") ||
-        full.includes("/_hooks/") ||
-        full.includes("/_lib/"))
+      (normalized.includes("/_components/") ||
+        normalized.includes("/_hooks/") ||
+        normalized.includes("/_lib/"))
     ) {
       out.push(full);
     }
@@ -112,7 +113,7 @@ function walk(dir: string, out: string[] = []): string[] {
 const FILES = walk(APP_DIR);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return (
     "@/" +
     rel
@@ -137,7 +138,7 @@ describe("app/**/_components smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/app/cookbook/[slug]/page.test.tsx
+++ b/__tests__/app/cookbook/[slug]/page.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { notFound } from "next/navigation";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/components/cookbook/PromptMarkdown", () => ({
+  PromptMarkdown: ({ content }: { content: string }) => (
+    <pre data-testid="prompt-markdown">{content}</pre>
+  ),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockNotFound = notFound as jest.MockedFunction<typeof notFound>;
+
+function makeDoc(data: Record<string, unknown> | undefined) {
+  return {
+    id: "entry-1",
+    exists: data !== undefined,
+    data: () => data,
+  };
+}
+
+function installEntry(data: Record<string, unknown> | undefined) {
+  mockGetAdminDb.mockReturnValue({
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue(makeDoc(data)),
+      })),
+    })),
+  } as never);
+}
+
+const entryData = {
+  title: "Review React render paths",
+  description: "A prompt for finding expensive React render work.",
+  promptContent: "Find avoidable rerenders and suggest measured fixes.",
+  category: "performance",
+  tags: ["react", "profiling"],
+  worksWith: ["React", "TypeScript"],
+  authorId: "user-1",
+  authorDisplayName: "Ada",
+  createdAt: { toMillis: () => Date.parse("2026-05-01T00:00:00.000Z") },
+  upCount: 7,
+  downCount: 2,
+  seo: {
+    title: "React Render Review Prompt",
+    description: "Find expensive render paths with this Cursor prompt.",
+    image: "/showcase/react-review.png",
+  },
+};
+
+describe("cookbook entry page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installEntry(entryData);
+  });
+
+  it("generateMetadata returns title, canonical, and social preview data", async () => {
+    const { generateMetadata } = await import("@/app/cookbook/[slug]/page");
+
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: "entry-1" }),
+    });
+
+    expect(meta.title).toBe("React Render Review Prompt");
+    expect(meta.description).toBe(
+      "Find expensive render paths with this Cursor prompt.",
+    );
+    expect(meta.alternates?.canonical).toBe(
+      "https://cursorboston.com/cookbook/entry-1",
+    );
+    expect(meta.openGraph?.images).toEqual([
+      {
+        url: "https://cursorboston.com/showcase/react-review.png",
+        width: 1200,
+        height: 630,
+        alt: "Review React render paths",
+      },
+    ]);
+  });
+
+  it("renders the entry page with CreativeWork JSON-LD", async () => {
+    const Page = (await import("@/app/cookbook/[slug]/page")).default;
+
+    const ui = await Page({ params: Promise.resolve({ slug: "entry-1" }) });
+    const { container } = render(ui);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Review React render paths",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Performance")).toBeInTheDocument();
+    expect(screen.getByTestId("prompt-markdown")).toHaveTextContent(
+      "Find avoidable rerenders",
+    );
+    expect(screen.getByRole("link", { name: "#react" })).toHaveAttribute(
+      "href",
+      "/cookbook?search=react",
+    );
+
+    const jsonLd = container.querySelector('script[type="application/ld+json"]');
+    expect(jsonLd?.textContent).toContain('"@type":"CreativeWork"');
+    expect(jsonLd?.textContent).toContain('"keywords":"react, profiling, React, TypeScript"');
+  });
+
+  it("returns not-found metadata and calls notFound for missing entries", async () => {
+    installEntry(undefined);
+    mockNotFound.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    });
+
+    const pageModule = await import("@/app/cookbook/[slug]/page");
+    await expect(
+      pageModule.generateMetadata({
+        params: Promise.resolve({ slug: "missing" }),
+      }),
+    ).resolves.toEqual({ title: "Cookbook Entry Not Found" });
+
+    await expect(
+      pageModule.default({ params: Promise.resolve({ slug: "missing" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/pages-and-shared-smoke.test.tsx
+++ b/__tests__/app/pages-and-shared-smoke.test.tsx
@@ -11,7 +11,7 @@
  * lift coverage without exercising the React render.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 jest.mock("firebase/auth", () => ({
   onAuthStateChanged: jest.fn(() => jest.fn()),
@@ -135,11 +135,11 @@ const COMPONENT_FILES = walk(COMPONENTS_DIR, (f) =>
   f.endsWith(".tsx") || f.endsWith(".ts")
 );
 const PAGE_FILES = walk(APP_DIR, (f) =>
-  /\/(page|layout)\.tsx$/.test(f)
+  /\/(page|layout)\.tsx$/.test(f.replace(/\\/g, "/"))
 );
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.tsx$/, "").replace(/\.ts$/, "");
 }
 
@@ -160,7 +160,7 @@ function runSweep(label: string, files: string[]) {
           });
         } catch (e) {
           failures.push({
-            path: file.replace(process.cwd() + "/", ""),
+            path: relative(process.cwd(), file).replace(/\\/g, "/"),
             err: e instanceof Error ? e.message.split("\n")[0] : String(e),
           });
         }

--- a/__tests__/app/pages-and-shared-smoke.test.tsx
+++ b/__tests__/app/pages-and-shared-smoke.test.tsx
@@ -73,7 +73,11 @@ jest.mock("@/lib/firebase-admin", () => ({
 }));
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 jest.mock("next/navigation", () => ({
   useRouter: () => ({

--- a/__tests__/app/pages-gap-fill-wave-4.test.tsx
+++ b/__tests__/app/pages-gap-fill-wave-4.test.tsx
@@ -8,20 +8,24 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { doc, getDoc } from "firebase/firestore";
 
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({
+jest.mock("next/navigation", () => {
+  const mockRouter = {
     push: jest.fn(),
     replace: jest.fn(),
     back: jest.fn(),
     refresh: jest.fn(),
     prefetch: jest.fn(),
-  }),
-  useSearchParams: () => new URLSearchParams(),
-  usePathname: () => "/",
-  useParams: () => ({ sessionId: "sess-pair-wave4" }),
-  redirect: jest.fn(),
-  notFound: jest.fn(),
-}));
+  };
+
+  return {
+    useRouter: () => mockRouter,
+    useSearchParams: () => new URLSearchParams(),
+    usePathname: () => "/",
+    useParams: () => ({ sessionId: "sess-pair-wave4" }),
+    redirect: jest.fn(),
+    notFound: jest.fn(),
+  };
+});
 
 jest.mock("@/lib/firebase", () => ({
   auth: {},

--- a/__tests__/app/pages-shallow-render.test.tsx
+++ b/__tests__/app/pages-shallow-render.test.tsx
@@ -6,7 +6,7 @@
  * (async RSC defaults cannot be rendered in jsdom).
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import React from "react";
 import { render } from "@testing-library/react";
 
@@ -139,7 +139,7 @@ function isUseClientPage(absPath: string): boolean {
 }
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.tsx$/, "");
 }
 
@@ -167,7 +167,7 @@ describe("app/**/page.tsx shallow render (use client only)", () => {
         rendered++;
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/app/summer-cohort/page-coverage.test.tsx
+++ b/__tests__/app/summer-cohort/page-coverage.test.tsx
@@ -804,11 +804,11 @@ describe("summer-cohort page (extra coverage)", () => {
     void user; // keep linter happy
   });
 
-  it("renders the Mon May 18 zoom banner when Date.now() is before cutoff", async () => {
+  it("renders the Fri May 22 zoom banner when Date.now() is before cutoff", async () => {
     const realNow = Date.now;
-    // Mon May 18 2026 21:00:00 UTC ≈ 5pm EST — before the May 19 04:00Z cutoff.
+    // Fri May 22 2026 21:00:00 UTC is before the May 23 04:00Z cutoff.
     jest.spyOn(Date, "now").mockReturnValue(
-      new Date("2026-05-18T21:00:00Z").getTime(),
+      new Date("2026-05-22T21:00:00Z").getTime(),
     );
     setupFetch(admittedReady());
     const Page = (await import("@/app/summer-cohort/page")).default;
@@ -817,7 +817,7 @@ describe("summer-cohort page (extra coverage)", () => {
 
     await screen.findByText(/Status: Admitted/i);
     expect(
-      await screen.findByText(/Tonight · Mon May 18 · 6 pm EST/i),
+      await screen.findByText(/Tonight · Fri May 22 · 6 pm EST/i),
     ).toBeInTheDocument();
     // Clicking "Open Week 2 →" switches to the Week 2 tab.
     await user.click(screen.getByRole("button", { name: /Open Week 2/i }));

--- a/__tests__/components-and-contexts-smoke.test.tsx
+++ b/__tests__/components-and-contexts-smoke.test.tsx
@@ -19,7 +19,7 @@
  * this alone moves statement and line coverage off zero.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 jest.mock("firebase/auth", () => ({
   onAuthStateChanged: jest.fn(() => jest.fn()),
@@ -196,7 +196,7 @@ function findAppMetaFiles(): string[] {
 const APP_META_FILES = findAppMetaFiles();
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(ROOT + "/", "");
+  const rel = relative(ROOT, absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.tsx$/, "").replace(/\.ts$/, "");
 }
 
@@ -215,7 +215,7 @@ describe("components/** + contexts/** smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(ROOT + "/", ""),
+          path: relative(ROOT, file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }
@@ -254,7 +254,7 @@ describe("app-router meta files smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(ROOT + "/", ""),
+          path: relative(ROOT, file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/components/feed/MessageCard.test.tsx
+++ b/__tests__/components/feed/MessageCard.test.tsx
@@ -7,7 +7,7 @@ jest.mock("next/image", () => ({
   __esModule: true,
   default: (props: Record<string, unknown>) => {
     const { fill, ...rest } = props;
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    // eslint-disable-next-line @next/next/no-img-element
     return <img data-fill={fill ? "true" : undefined} {...rest} />;
   },
 }));
@@ -106,7 +106,7 @@ describe("MessageCard", () => {
 
   it("shows repost button for non-repost messages", () => {
     render(<MessageCard {...defaultProps()} />);
-    expect(screen.getByLabelText("Repost")).toBeInTheDocument();
+    expect(screen.getByLabelText("Repost Alice's message")).toBeInTheDocument();
   });
 
   it("hides repost button for repost messages", () => {
@@ -119,7 +119,7 @@ describe("MessageCard", () => {
       },
     });
     render(<MessageCard {...defaultProps({ message: msg })} />);
-    expect(screen.queryByLabelText("Repost")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Repost Alice's message")).not.toBeInTheDocument();
   });
 
   it("shows repost header for reposted messages", () => {
@@ -180,18 +180,31 @@ describe("MessageCard", () => {
     const onDislike = jest.fn();
     render(<MessageCard {...defaultProps({ onLike, onDislike })} />);
 
-    await user.click(screen.getByLabelText("Like"));
+    await user.click(screen.getByLabelText("Like Alice's message"));
     expect(onLike).toHaveBeenCalledTimes(1);
 
-    await user.click(screen.getByLabelText("Dislike"));
+    await user.click(screen.getByLabelText("Dislike Alice's message"));
     expect(onDislike).toHaveBeenCalledTimes(1);
   });
 
   it("disables reaction buttons when not logged in", () => {
     render(<MessageCard {...defaultProps({ isLoggedIn: false })} />);
-    expect(screen.getByLabelText("Like")).toBeDisabled();
-    expect(screen.getByLabelText("Dislike")).toBeDisabled();
-    expect(screen.getByLabelText("Reply")).toBeDisabled();
+    expect(screen.getByLabelText("Like Alice's message")).toBeDisabled();
+    expect(screen.getByLabelText("Dislike Alice's message")).toBeDisabled();
+    expect(screen.getByLabelText("Reply to Alice's message")).toBeDisabled();
+  });
+
+  it("exposes context-specific action labels", () => {
+    render(<MessageCard {...defaultProps()} />);
+    expect(
+      screen.getByRole("button", { name: "Like Alice's message" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Dislike Alice's message" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reply to Alice's message" }),
+    ).toBeInTheDocument();
   });
 
   it("calls onAuthorClick when author name clicked", async () => {
@@ -262,11 +275,11 @@ describe("MessageCard", () => {
 
   it("shows active like state", () => {
     render(<MessageCard {...defaultProps({ userReaction: "like" as const })} />);
-    expect(screen.getByLabelText("Remove like")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove like from Alice's message")).toBeInTheDocument();
   });
 
   it("shows active dislike state", () => {
     render(<MessageCard {...defaultProps({ userReaction: "dislike" as const })} />);
-    expect(screen.getByLabelText("Remove dislike")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove dislike from Alice's message")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/feed/ReplyCard.test.tsx
+++ b/__tests__/components/feed/ReplyCard.test.tsx
@@ -9,6 +9,7 @@ jest.mock("next/image", () => ({
   __esModule: true,
   default: (props: Record<string, unknown>) => {
     const { fill, priority, ...rest } = props;
+    // eslint-disable-next-line @next/next/no-img-element
     return <img data-fill={fill ? "true" : undefined} {...rest} />;
   },
 }));
@@ -69,7 +70,7 @@ describe("ReplyCard", () => {
     const user = userEvent.setup();
     const props = defaultProps();
     render(<ReplyCard {...props} />);
-    await user.click(screen.getByRole("button", { name: "Like" }));
+    await user.click(screen.getByRole("button", { name: "Like Bob's reply" }));
     expect(props.onLike).toHaveBeenCalledTimes(1);
   });
 
@@ -77,16 +78,22 @@ describe("ReplyCard", () => {
     const user = userEvent.setup();
     const props = defaultProps();
     render(<ReplyCard {...props} />);
-    await user.click(screen.getByRole("button", { name: "Dislike" }));
+    await user.click(screen.getByRole("button", { name: "Dislike Bob's reply" }));
     expect(props.onDislike).toHaveBeenCalledTimes(1);
   });
 
   it("disables reaction buttons when not logged in", () => {
     render(<ReplyCard {...defaultProps({ isLoggedIn: false })} />);
-    const likeBtn = screen.getByRole("button", { name: "Like" });
-    const dislikeBtn = screen.getByRole("button", { name: "Dislike" });
+    const likeBtn = screen.getByRole("button", { name: "Like Bob's reply" });
+    const dislikeBtn = screen.getByRole("button", { name: "Dislike Bob's reply" });
     expect(likeBtn).toBeDisabled();
     expect(dislikeBtn).toBeDisabled();
+  });
+
+  it("exposes context-specific action labels", () => {
+    render(<ReplyCard {...defaultProps()} />);
+    expect(screen.getByRole("button", { name: "Like Bob's reply" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dislike Bob's reply" })).toBeInTheDocument();
   });
 
   it("shows delete confirm flow for owner", async () => {
@@ -116,5 +123,19 @@ describe("ReplyCard", () => {
   it("does not show delete button for non-owners", () => {
     render(<ReplyCard {...defaultProps({ isOwner: false })} />);
     expect(screen.queryByRole("button", { name: /delete reply/i })).not.toBeInTheDocument();
+  });
+
+  it("labels active reaction removal with reply context", () => {
+    const { rerender } = render(
+      <ReplyCard {...defaultProps({ userReaction: "like" as const })} />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Remove like from Bob's reply" }),
+    ).toBeInTheDocument();
+
+    rerender(<ReplyCard {...defaultProps({ userReaction: "dislike" as const })} />);
+    expect(
+      screen.getByRole("button", { name: "Remove dislike from Bob's reply" }),
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/hunt/KonamiListener.test.tsx
+++ b/__tests__/components/hunt/KonamiListener.test.tsx
@@ -10,21 +10,12 @@ jest.mock("@/contexts/AuthContext", () => ({
 
 import { useAuth } from "@/contexts/AuthContext";
 import { KonamiListener } from "@/components/hunt/KonamiListener";
+import {
+  KONAMI_SEQUENCE,
+  KONAMI_SEQUENCE_HEADER,
+} from "@/lib/konami-handler";
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
-
-const KONAMI_SEQUENCE = [
-  "ArrowUp",
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowLeft",
-  "ArrowRight",
-  "b",
-  "a",
-];
 
 function mockAuthUser(user: typeof mockUser | null) {
   mockedUseAuth.mockReturnValue({
@@ -77,7 +68,7 @@ describe("KonamiListener", () => {
     expect(screen.getByText("🎮 You found a path.")).toBeInTheDocument();
     expect(screen.getByText(/token: konami-secret-token/)).toBeInTheDocument();
     expect(mockFetchFn).toHaveBeenCalledWith("/api/hunt/oracle/konami", {
-      headers: { "X-Konami-Sequence": "UUDDLRLRBA" },
+      headers: { "X-Konami-Sequence": KONAMI_SEQUENCE_HEADER },
     });
   });
 

--- a/__tests__/config/next-config-skip-typecheck.test.ts
+++ b/__tests__/config/next-config-skip-typecheck.test.ts
@@ -1,0 +1,78 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+jest.mock("@next/bundle-analyzer", () => () => (config: unknown) => config);
+jest.mock("child_process", () => ({
+  execSync: jest.fn(() => "test-build-id\n"),
+}));
+
+const ORIGINAL_ENV = process.env;
+const TOGGLED_ENV_KEYS = [
+  "ANALYZE",
+  "CI",
+  "DOCKER_BUILD",
+  "GITHUB_ACTIONS",
+  "NEXT_BUILD_ID",
+  "SKIP_TYPECHECK",
+] as const;
+
+function loadNextConfig(env: Record<string, string | undefined> = {}) {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+  for (const key of TOGGLED_ENV_KEYS) {
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  let config: {
+    typescript?: { ignoreBuildErrors?: boolean };
+    eslint?: { ignoreDuringBuilds?: boolean };
+  };
+  jest.isolateModules(() => {
+    config = require("../../next.config.js");
+  });
+  return config!;
+}
+
+describe("next.config.js SKIP_TYPECHECK guard", () => {
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.resetModules();
+  });
+
+  it("leaves build checks enabled by default", () => {
+    const config = loadNextConfig();
+
+    expect(config.typescript?.ignoreBuildErrors).not.toBe(true);
+    expect(config.eslint?.ignoreDuringBuilds).not.toBe(true);
+  });
+
+  it("allows SKIP_TYPECHECK only for local builds", () => {
+    const config = loadNextConfig({ SKIP_TYPECHECK: "1" });
+
+    expect(config.typescript).toEqual({ ignoreBuildErrors: true });
+    expect(config.eslint).toEqual({ ignoreDuringBuilds: true });
+  });
+
+  it("rejects SKIP_TYPECHECK in generic CI", () => {
+    expect(() =>
+      loadNextConfig({ CI: "true", SKIP_TYPECHECK: "1" })
+    ).toThrow("SKIP_TYPECHECK=1 is local-only and must not be set in CI");
+  });
+
+  it("rejects SKIP_TYPECHECK in GitHub Actions", () => {
+    expect(() =>
+      loadNextConfig({ GITHUB_ACTIONS: "true", SKIP_TYPECHECK: "1" })
+    ).toThrow("SKIP_TYPECHECK=1 is local-only and must not be set in CI");
+  });
+});

--- a/__tests__/lib/all-lib-smoke.test.ts
+++ b/__tests__/lib/all-lib-smoke.test.ts
@@ -23,7 +23,11 @@ jest.mock("@/lib/firebase", () => ({
 
 jest.mock("@/lib/server-auth", () => ({
   getVerifiedUser: jest.fn().mockResolvedValue(null),
-  verifyIdTokenAdmin: jest.fn().mockResolvedValue(null),
+  getVerifiedAdminUser: jest.fn().mockResolvedValue(null),
+  getVerifiedUserWithRevocation: jest.fn().mockResolvedValue(null),
+  getOptionalVerifiedUser: jest.fn().mockResolvedValue(null),
+  isCurrentIdTokenRevoked: jest.fn().mockResolvedValue(false),
+  isRevokedIdTokenError: jest.fn(() => false),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({

--- a/__tests__/lib/all-lib-smoke.test.ts
+++ b/__tests__/lib/all-lib-smoke.test.ts
@@ -6,7 +6,7 @@
  * lifts coverage on modules that have no dedicated unit tests yet.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 jest.mock("@/lib/firebase-admin", () => ({
   getAdminDb: () => null,
@@ -70,7 +70,7 @@ function walkTs(dir: string, out: string[] = []): string[] {
 const LIB_FILES = walkTs(LIB_DIR);
 
 function moduleIdFor(absPath: string): string {
-  const rel = absPath.replace(process.cwd() + "/", "");
+  const rel = relative(process.cwd(), absPath).replace(/\\/g, "/");
   return "@/" + rel.replace(/\.ts$/, "");
 }
 
@@ -89,7 +89,7 @@ describe("lib/* smoke imports", () => {
         });
       } catch (e) {
         failures.push({
-          path: file.replace(process.cwd() + "/", ""),
+          path: relative(process.cwd(), file).replace(/\\/g, "/"),
           err: e instanceof Error ? e.message.split("\n")[0] : String(e),
         });
       }

--- a/__tests__/lib/hackathon-event-signup-ranking.test.ts
+++ b/__tests__/lib/hackathon-event-signup-ranking.test.ts
@@ -17,11 +17,14 @@ import {
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
 } from "@/lib/sports-hack-2026";
+import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
 
 describe("hackathon-event-signup ranking + capacity", () => {
   describe("hackathonEventSignupDocId", () => {
     it("composes eventId__userId", () => {
-      expect(hackathonEventSignupDocId("ev", "u")).toBe("ev__u");
+      expect(hackathonEventSignupDocId(HACK_A_SPRINT_2026_EVENT_ID, "u")).toBe(
+        "hack-a-sprint-2026__u"
+      );
     });
   });
 

--- a/__tests__/lib/konami-handler.test.tsx
+++ b/__tests__/lib/konami-handler.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * @jest-environment jsdom
+ */
+
+import { useCallback, useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  KONAMI_SEQUENCE,
+  KONAMI_SEQUENCE_HEADER,
+  nextSequenceIndex,
+  sequenceToHeaderProof,
+  type KonamiSequence,
+} from "@/lib/konami-handler";
+import { useKonamiListener } from "@/hooks/use-konami-listener";
+
+function CustomSequenceProbe({ sequence }: { sequence: KonamiSequence }) {
+  const [completions, setCompletions] = useState(0);
+  const onComplete = useCallback(() => {
+    setCompletions((value) => value + 1);
+  }, []);
+
+  useKonamiListener(sequence, onComplete);
+
+  return <output aria-label="Completions">{completions}</output>;
+}
+
+function pressKeys(sequence: KonamiSequence) {
+  for (const key of sequence) {
+    fireEvent.keyDown(window, { key });
+  }
+}
+
+describe("konami handler", () => {
+  it("serializes the current sequence proof for the oracle header", () => {
+    expect(sequenceToHeaderProof(KONAMI_SEQUENCE)).toBe("UUDDLRLRBA");
+    expect(KONAMI_SEQUENCE_HEADER).toBe("UUDDLRLRBA");
+  });
+
+  it("advances and resets progress for partial key sequences", () => {
+    let index = nextSequenceIndex(KONAMI_SEQUENCE, 0, "ArrowUp");
+    expect(index).toBe(1);
+
+    index = nextSequenceIndex(KONAMI_SEQUENCE, index, "ArrowUp");
+    expect(index).toBe(2);
+
+    index = nextSequenceIndex(KONAMI_SEQUENCE, index, "Escape");
+    expect(index).toBe(0);
+  });
+
+  it("restarts progress when the wrong key is also the sequence prefix", () => {
+    const sequence = ["a", "b", "a"] as const;
+    let index = nextSequenceIndex(sequence, 0, "a");
+    index = nextSequenceIndex(sequence, index, "a");
+
+    expect(index).toBe(1);
+  });
+
+  it("calls onComplete for a custom sequence", () => {
+    render(<CustomSequenceProbe sequence={["x", "y", "z"]} />);
+
+    pressKeys(["x", "y", "z"]);
+
+    expect(screen.getByLabelText("Completions")).toHaveTextContent("1");
+  });
+
+  it("does not complete on an incomplete custom sequence", () => {
+    render(<CustomSequenceProbe sequence={["q", "w"]} />);
+
+    pressKeys(["q"]);
+
+    expect(screen.getByLabelText("Completions")).toHaveTextContent("0");
+  });
+});

--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -63,8 +63,16 @@ describe("isOriginAllowed", () => {
   const originalEnv = process.env.NODE_ENV;
   const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
 
+  function setNodeEnv(value: string | undefined) {
+    if (value === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = value;
+    }
+  }
+
   afterEach(() => {
-    Object.defineProperty(process.env, "NODE_ENV", { value: originalEnv, configurable: true });
+    setNodeEnv(originalEnv);
     if (originalAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
     else process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
   });
@@ -129,12 +137,12 @@ describe("isOriginAllowed", () => {
   });
 
   it("returns false for POST with no origin/referer in production", () => {
-    Object.defineProperty(process.env, "NODE_ENV", { value: "production", configurable: true });
+    setNodeEnv("production");
     expect(isOriginAllowed(makeRequest({ method: "POST" }))).toBe(false);
   });
 
   it("returns true for POST with no origin/referer in development", () => {
-    Object.defineProperty(process.env, "NODE_ENV", { value: "development", configurable: true });
+    setNodeEnv("development");
     expect(isOriginAllowed(makeRequest({ method: "POST" }))).toBe(true);
   });
 

--- a/__tests__/lib/middleware.test.ts
+++ b/__tests__/lib/middleware.test.ts
@@ -97,6 +97,32 @@ describe("isOriginAllowed", () => {
     ).toBe(true);
   });
 
+  it("returns false for production POST from localhost to a production URL", () => {
+    Object.defineProperty(process.env, "NODE_ENV", { value: "production", configurable: true });
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          origin: "http://localhost:3000",
+          url: "https://cursorboston.com/api/x",
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("returns false for production POST with only a localhost referer", () => {
+    Object.defineProperty(process.env, "NODE_ENV", { value: "production", configurable: true });
+    expect(
+      isOriginAllowed(
+        makeRequest({
+          method: "POST",
+          referer: "http://localhost:3000/form",
+          url: "https://cursorboston.com/api/x",
+        })
+      )
+    ).toBe(false);
+  });
+
   it("returns true when origin matches NEXT_PUBLIC_APP_URL", () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
     expect(

--- a/__tests__/lib/pair-programming/matching.test.ts
+++ b/__tests__/lib/pair-programming/matching.test.ts
@@ -202,6 +202,73 @@ describe("getTopMatches", () => {
     expect(matches.length).toBe(5);
   });
 
+  it("returns every viable match in an odd-sized candidate pool", async () => {
+    const me = makeProfile({
+      userId: "me",
+      skillsCanTeach: ["React"],
+      skillsWantToLearn: ["Go"],
+      preferredLanguages: ["TypeScript"],
+    });
+    const profiles = [
+      makeProfile({ userId: "learn-react", skillsWantToLearn: ["React"] }),
+      makeProfile({ userId: "teach-go", skillsCanTeach: ["Go"] }),
+      makeProfile({
+        userId: "shared-typescript",
+        skillsCanTeach: ["Testing"],
+        preferredLanguages: ["TypeScript"],
+      }),
+    ];
+
+    const matches = await getTopMatches(me, profiles);
+
+    expect(matches).toHaveLength(3);
+    expect(matches.map((match) => match.userId)).toEqual(
+      expect.arrayContaining(["learn-react", "teach-go", "shared-typescript"])
+    );
+  });
+
+  it("does not mutate candidate eligibility between match requests", async () => {
+    const me = makeProfile({
+      userId: "me",
+      skillsCanTeach: ["React"],
+      skillsWantToLearn: ["Go"],
+    });
+    const profiles = [
+      makeProfile({ userId: "learn-react", skillsWantToLearn: ["React"] }),
+      makeProfile({ userId: "teach-go", skillsCanTeach: ["Go"] }),
+      makeProfile({
+        userId: "shared-session",
+        skillsWantToLearn: ["React"],
+        sessionTypes: ["build-together"],
+      }),
+    ];
+
+    const firstPass = await getTopMatches(me, profiles, 3);
+    const secondPass = await getTopMatches(me, profiles, 3);
+
+    expect(secondPass.map((match) => match.userId)).toEqual(
+      firstPass.map((match) => match.userId)
+    );
+    expect(secondPass).toHaveLength(3);
+  });
+
+  it("returns no matches when no candidate is eligible or scoreable", async () => {
+    const me = makeProfile({ userId: "me", timezone: "America/New_York" });
+    const profiles = [
+      me,
+      makeProfile({
+        userId: "inactive",
+        isActive: false,
+        skillsWantToLearn: ["React"],
+      }),
+      makeProfile({ userId: "zero-score", timezone: "Asia/Tokyo" }),
+    ];
+
+    const matches = await getTopMatches(me, profiles);
+
+    expect(matches).toHaveLength(0);
+  });
+
   it("excludes zero-score matches", async () => {
     const me = makeProfile({ userId: "me", timezone: "America/New_York" });
     const other = makeProfile({ userId: "other", timezone: "Asia/Tokyo" });

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -156,7 +156,7 @@ describe('Rate Limiting', () => {
       });
     });
 
-    it('should keep distinct showcase presets where the behavior differs', () => {
+    it('should keep distinct live showcase presets where the behavior differs', () => {
       expect(rateLimitConfigs.hackathonShowcaseAiScore).toEqual({
         windowMs: 60 * 1000,
         maxRequests: 30,
@@ -164,14 +164,6 @@ describe('Rate Limiting', () => {
       expect(rateLimitConfigs.hackathonShowcaseJudgeScore).toEqual({
         windowMs: 60 * 1000,
         maxRequests: 40,
-      });
-      expect(rateLimitConfigs.hackathonShowcaseUnlock).toEqual({
-        windowMs: 60 * 1000,
-        maxRequests: 20,
-      });
-      expect(rateLimitConfigs.hackathonShowcaseUnlockAttempts).toEqual({
-        windowMs: 5 * 60 * 1000,
-        maxRequests: 15,
       });
       expect(rateLimitConfigs.hackathonShowcaseVote).toEqual({
         windowMs: 60 * 1000,

--- a/__tests__/lib/server-auth.test.ts
+++ b/__tests__/lib/server-auth.test.ts
@@ -3,7 +3,14 @@
  */
 
 import { NextRequest } from "next/server";
-import { getVerifiedUser, getOptionalVerifiedUser } from "@/lib/server-auth";
+import {
+  getOptionalVerifiedUser,
+  getVerifiedAdminUser,
+  getVerifiedUser,
+  getVerifiedUserWithRevocation,
+  isCurrentIdTokenRevoked,
+  isRevokedIdTokenError,
+} from "@/lib/server-auth";
 import { getAdminAuth } from "@/lib/firebase-admin";
 
 jest.mock("@/lib/firebase-admin", () => ({
@@ -17,9 +24,9 @@ function makeRequest(headers: Record<string, string> = { Authorization: "Bearer 
 }
 
 function mockVerify(returnValue: Record<string, unknown>) {
-  mockGetAdminAuth.mockReturnValue({
-    verifyIdToken: jest.fn(async () => returnValue),
-  } as never);
+  const verifyIdToken = jest.fn(async () => returnValue);
+  mockGetAdminAuth.mockReturnValue({ verifyIdToken } as never);
+  return verifyIdToken;
 }
 
 describe("getVerifiedUser admin authorization bridge", () => {
@@ -80,6 +87,26 @@ describe("getVerifiedUser admin authorization bridge", () => {
       }),
     );
     expect(verifyFn).toHaveBeenCalledWith("primary-token", false);
+  });
+
+  it("uses non-revocation checks on the default verified-user path", async () => {
+    const verifyFn = mockVerify({ uid: "u-default", email: "x@y" });
+    await getVerifiedUser(makeRequest());
+    expect(verifyFn).toHaveBeenCalledWith("test-token", false);
+  });
+
+  it("keeps the admin helper on the non-revocation default path", async () => {
+    const verifyFn = mockVerify({ uid: "admin", email: "admin@example.com", admin: true });
+    const user = await getVerifiedAdminUser(makeRequest());
+    expect(user?.isAdmin).toBe(true);
+    expect(verifyFn).toHaveBeenCalledWith("test-token", false);
+  });
+
+  it("uses revocation checks on the sensitive user helper path", async () => {
+    const verifyFn = mockVerify({ uid: "credit-user", email: "u@example.com" });
+    const user = await getVerifiedUserWithRevocation(makeRequest());
+    expect(user?.uid).toBe("credit-user");
+    expect(verifyFn).toHaveBeenCalledWith("test-token", true);
   });
 
   it("throws when Firebase Admin Auth is not configured", async () => {
@@ -168,6 +195,68 @@ describe("getVerifiedUser admin authorization bridge", () => {
   });
 });
 
+describe("isCurrentIdTokenRevoked", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns false when no token is present", async () => {
+    const req = new NextRequest("http://localhost/api/test");
+    await expect(isCurrentIdTokenRevoked(req)).resolves.toBe(false);
+    expect(mockGetAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns false when Firebase Admin Auth is not configured", async () => {
+    mockGetAdminAuth.mockReturnValue(null as never);
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(false);
+  });
+
+  it("uses revocation checks and returns false for a valid current token", async () => {
+    const verifyFn = mockVerify({ uid: "u-current", email: "x@y" });
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(false);
+    expect(verifyFn).toHaveBeenCalledWith("test-token", true);
+  });
+
+  it("returns true for Firebase revoked-token errors", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => {
+        throw { code: "auth/id-token-revoked" };
+      }),
+    } as never);
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(true);
+  });
+
+  it("returns false for unrelated verification errors", async () => {
+    mockGetAdminAuth.mockReturnValue({
+      verifyIdToken: jest.fn(async () => {
+        throw { code: "auth/id-token-expired" };
+      }),
+    } as never);
+    await expect(isCurrentIdTokenRevoked(makeRequest())).resolves.toBe(false);
+  });
+});
+
+describe("isRevokedIdTokenError", () => {
+  it("matches Firebase revoked-token error codes", () => {
+    expect(isRevokedIdTokenError({ code: "auth/id-token-revoked" })).toBe(true);
+    expect(
+      isRevokedIdTokenError({ errorInfo: { code: "auth/id-token-revoked" } }),
+    ).toBe(true);
+  });
+
+  it("matches Firebase revoked-token messages", () => {
+    expect(
+      isRevokedIdTokenError(new Error("The Firebase ID token has been revoked.")),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated auth errors", () => {
+    expect(isRevokedIdTokenError({ code: "auth/id-token-expired" })).toBe(false);
+    expect(isRevokedIdTokenError(new Error("token expired"))).toBe(false);
+    expect(isRevokedIdTokenError(null)).toBe(false);
+  });
+});
+
 describe("getOptionalVerifiedUser", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -228,4 +317,3 @@ describe("getOptionalVerifiedUser", () => {
     expect(user?.uid).toBe("opt-4");
   });
 });
-

--- a/__tests__/lib/summer-cohort-submissions.test.ts
+++ b/__tests__/lib/summer-cohort-submissions.test.ts
@@ -94,6 +94,7 @@ describe("fetchSummerCohortSubmissions", () => {
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
     expect(out.tryingToWin).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(0);
     expect(out.submissions).toEqual([]);
   });
 
@@ -101,12 +102,14 @@ describe("fetchSummerCohortSubmissions", () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(mkRes({}, false, 500));
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("returns the empty payload when the fetch throws", async () => {
     (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("network down"));
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("returns the empty payload when listJson.json() throws (malformed body)", async () => {
@@ -120,12 +123,14 @@ describe("fetchSummerCohortSubmissions", () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(malformed);
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("returns the empty payload when listJson is not an array", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(mkRes({ message: "rate limit" }));
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(0);
+    expect(out.githubFetchErrorCount).toBe(1);
   });
 
   it("happy path: walks two submissions, normalizes, sorts, returns counts", async () => {
@@ -161,6 +166,10 @@ describe("fetchSummerCohortSubmissions", () => {
     mockGetAdminDb.mockReturnValueOnce(null); // skip user enrichment
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
     expect(out.merged).toBe(2);
+    expect(out.githubFetchErrorCount).toBe(0);
+    for (const [, init] of (global.fetch as jest.Mock).mock.calls) {
+      expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    }
     // Sorted alphabetically by handle → alice, bob
     expect(out.submissions[0]?.githubHandle).toBe("alice");
     expect(out.submissions[1]?.githubHandle).toBe("bob");
@@ -211,6 +220,7 @@ describe("fetchSummerCohortSubmissions", () => {
     );
     mockGetAdminDb.mockReturnValueOnce(null);
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
+    expect(out.githubFetchErrorCount).toBe(0);
     expect(out.submissions).toEqual([]);
   });
 
@@ -224,6 +234,7 @@ describe("fetchSummerCohortSubmissions", () => {
       });
     mockGetAdminDb.mockReturnValueOnce(null);
     const out = await fetchSummerCohortSubmissions(VOTE_WEEK, "week-1");
+    expect(out.githubFetchErrorCount).toBe(2);
     expect(out.submissions).toEqual([]);
   });
 
@@ -235,6 +246,7 @@ describe("fetchSummerCohortSubmissions", () => {
     const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
     const headers = init.headers as Record<string, string>;
     expect(headers["Authorization"]).toBe("Bearer gho_test");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("enriches submissions with Firebase user identity (displayName + photoURL)", async () => {

--- a/__tests__/types/hackathon-events.test.ts
+++ b/__tests__/types/hackathon-events.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * @jest-environment node
+ */
+
+import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
+import { SPORTS_HACK_2026_EVENT_ID } from "@/lib/sports-hack-2026";
+import {
+  HACKATHON_EVENT_ID_LIST,
+  HACKATHON_EVENT_IDS,
+  type HackathonEventId,
+} from "@/types/hackathon-events";
+
+function acceptsHackathonEventId(eventId: HackathonEventId): HackathonEventId {
+  return eventId;
+}
+
+describe("hackathon event ids", () => {
+  it("centralizes supported hackathon event ids", () => {
+    expect(HACKATHON_EVENT_IDS).toEqual({
+      HACK_A_SPRINT_2026: "hack-a-sprint-2026",
+      SPORTS_HACK_2026: "sports-hack-2026",
+    });
+    expect(HACKATHON_EVENT_ID_LIST).toEqual([
+      "hack-a-sprint-2026",
+      "sports-hack-2026",
+    ]);
+  });
+
+  it("keeps legacy event exports sourced from the typed registry", () => {
+    expect(acceptsHackathonEventId(HACK_A_SPRINT_2026_EVENT_ID)).toBe(
+      HACKATHON_EVENT_IDS.HACK_A_SPRINT_2026
+    );
+    expect(acceptsHackathonEventId(SPORTS_HACK_2026_EVENT_ID)).toBe(
+      HACKATHON_EVENT_IDS.SPORTS_HACK_2026
+    );
+  });
+});

--- a/app/api/community/moderate/route.ts
+++ b/app/api/community/moderate/route.ts
@@ -21,7 +21,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
 import {
   clampLimit,
@@ -46,6 +46,12 @@ export async function GET(request: NextRequest) {
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();
@@ -112,6 +118,12 @@ export async function POST(request: NextRequest) {
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     let body: unknown;

--- a/app/api/community/reply/route.ts
+++ b/app/api/community/reply/route.ts
@@ -15,6 +15,7 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { communityContract } from "@/lib/api-schemas/community";
+import { COMMUNITY_CONTENT_LENGTH_ERROR } from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
     const sanitizedContent = sanitizeText(content);
     if (sanitizedContent.length < 100 || sanitizedContent.length > 500) {
       return NextResponse.json(
-        { error: "Content must be between 100 and 500 characters" },
+        { error: COMMUNITY_CONTENT_LENGTH_ERROR },
         { status: 400 }
       );
     }

--- a/app/api/community/repost/route.ts
+++ b/app/api/community/repost/route.ts
@@ -15,6 +15,7 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { communityContract } from "@/lib/api-schemas/community";
+import { COMMUNITY_CONTENT_LENGTH_ERROR } from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
     const sanitizedContent = sanitizeText(content);
     if (sanitizedContent.length < 100 || sanitizedContent.length > 500) {
       return NextResponse.json(
-        { error: "Content must be between 100 and 500 characters" },
+        { error: COMMUNITY_CONTENT_LENGTH_ERROR },
         { status: 400 }
       );
     }

--- a/app/api/cookbook/entries/route.ts
+++ b/app/api/cookbook/entries/route.ts
@@ -10,7 +10,6 @@ import type {
   DocumentSnapshot,
   Firestore,
   Query,
-  QueryDocumentSnapshot,
 } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
@@ -20,12 +19,16 @@ import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import { matchesCookbookSearchTerms } from "@/lib/cookbook-search";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import {
-  COOKBOOK_CATEGORIES,
-  WORKS_WITH_LANGUAGES,
   type CookbookCategory,
+  type CookbookEntry,
   type WorksWithTag,
 } from "@/types/cookbook";
 import { cookbookContract } from "@/lib/api-schemas/cookbook";
+import {
+  isValidCookbookCategory,
+  isValidWorksWithTag,
+  mapCookbookDocToEntry,
+} from "@/lib/cookbook-entries";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -33,11 +36,11 @@ export const dynamic = "force-dynamic";
 const COOKBOOK_SUBMIT_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 10 };
 
 function isValidCategory(v: string): v is CookbookCategory {
-  return COOKBOOK_CATEGORIES.includes(v as CookbookCategory);
+  return isValidCookbookCategory(v);
 }
 
 function isValidWorksWith(v: string): v is WorksWithTag {
-  return WORKS_WITH_LANGUAGES.includes(v as WorksWithTag);
+  return isValidWorksWithTag(v);
 }
 
 const PAGE_SIZE = 12;
@@ -74,43 +77,6 @@ function isFirestoreIndexError(err: unknown): boolean {
     code === 9 ||
     (message.includes("FAILED_PRECONDITION") && message.includes("index"))
   );
-}
-
-interface CookbookEntryRow {
-  id: string;
-  title: string;
-  description: string;
-  promptContent: string;
-  category: string;
-  tags: string[];
-  worksWith: string[];
-  authorId: string;
-  authorDisplayName: string;
-  createdAt: string;
-  upCount: number;
-  downCount: number;
-}
-
-function mapDocToEntry(doc: QueryDocumentSnapshot): CookbookEntryRow {
-  const d = doc.data();
-  const upCount = Number(d.upCount ?? 0);
-  const downCount = Number(d.downCount ?? 0);
-  return {
-    id: doc.id,
-    title: d.title || "",
-    description: d.description || "",
-    promptContent: d.promptContent || "",
-    category: d.category || "other",
-    tags: Array.isArray(d.tags) ? d.tags : [],
-    worksWith: Array.isArray(d.worksWith) ? d.worksWith : [],
-    authorId: d.authorId || "",
-    authorDisplayName: d.authorDisplayName || "",
-    createdAt: d.createdAt?.toMillis?.()
-      ? new Date(d.createdAt.toMillis()).toISOString()
-      : "",
-    upCount,
-    downCount,
-  };
 }
 
 function buildFilteredQuery(
@@ -170,7 +136,7 @@ export async function GET(request: NextRequest) {
     const searchTerms = hasSearch ? searchRaw.split(/\s+/).filter(Boolean) : [];
 
     if (hasSearch) {
-      const results: CookbookEntryRow[] = [];
+      const results: CookbookEntry[] = [];
       let resumeAfter: DocumentSnapshot | null = null;
       if (cursor) {
         const cdoc = await db.collection("cookbook_entries").doc(cursor).get();
@@ -200,7 +166,7 @@ export async function GET(request: NextRequest) {
 
         for (const doc of snap.docs) {
           resumeAfter = doc;
-          const entry = mapDocToEntry(doc);
+          const entry = mapCookbookDocToEntry(doc);
           if (
             !matchesCookbookSearchTerms(
               entry.title,
@@ -276,7 +242,7 @@ export async function GET(request: NextRequest) {
     }
 
     const docs = snap.docs.slice(0, limit);
-    const entries = docs.map(mapDocToEntry);
+    const entries = docs.map(mapCookbookDocToEntry);
     const hasMore = snap.docs.length > limit;
     const nextCursor =
       hasMore && entries.length > 0 ? entries[entries.length - 1].id : null;

--- a/app/api/events/pydata-2026/admin/list/route.ts
+++ b/app/api/events/pydata-2026/admin/list/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { withMiddleware, rateLimitConfigs } from "@/lib/middleware";
 import {
   PYDATA_2026_CAPACITY,
@@ -36,13 +36,25 @@ const VALID_STATUSES: ReadonlyArray<PydataRegistrationStatus> = [
 ];
 
 async function handleGet(request: NextRequest) {
-  const user = await getVerifiedUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  let user;
+  try {
+    user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
+  } catch (error) {
+    throw error;
   }
-  if (!user.isAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+
   const db = getAdminDb();
   if (!db) {
     return NextResponse.json({ error: "Server not configured" }, { status: 500 });

--- a/app/api/game/admin/grant/route.ts
+++ b/app/api/game/admin/grant/route.ts
@@ -12,7 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
 import { adminGrantTurnsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { gameContract } from "@/lib/api-schemas/game";
 
 export async function POST(request: NextRequest) {
@@ -20,6 +20,9 @@ export async function POST(request: NextRequest) {
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
+    if (await isCurrentIdTokenRevoked(request)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
 
     const bodyOrError = await parseRequestBody(request);
     if (bodyOrError instanceof NextResponse) return bodyOrError;

--- a/app/api/game/admin/units/route.ts
+++ b/app/api/game/admin/units/route.ts
@@ -12,7 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiSuccess, parseRequestBody } from "@/lib/api-response";
 import { mapGameError } from "@/lib/game/api-error-map";
 import { adminGrantUnitsServer } from "@/lib/game/data-server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { gameContract } from "@/lib/api-schemas/game";
 
 export async function POST(request: NextRequest) {
@@ -20,6 +20,9 @@ export async function POST(request: NextRequest) {
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
+    if (await isCurrentIdTokenRevoked(request)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
 
     const bodyOrError = await parseRequestBody(request);
     if (bodyOrError instanceof NextResponse) return bodyOrError;

--- a/app/api/game/heroes/[heroId]/chapter/[chapterId]/route.ts
+++ b/app/api/game/heroes/[heroId]/chapter/[chapterId]/route.ts
@@ -13,7 +13,10 @@ import {
   approveHeroChapterServer,
   deleteHeroChapterServer,
 } from "@/lib/game/hero-lore";
-import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  getVerifiedUser,
+  isCurrentIdTokenRevoked,
+} from "@/lib/server-auth";
 
 // DELETE /api/game/heroes/[heroId]/chapter/[chapterId]
 //
@@ -57,6 +60,9 @@ export async function PATCH(
     const user = await getVerifiedUser(request);
     if (!user) return apiError("Authentication required", 401);
     if (!user.isAdmin) return apiError("Admin only", 403);
+    if (await isCurrentIdTokenRevoked(request)) {
+      return apiError("Session revoked. Please sign in again.", 401);
+    }
     const { heroId, chapterId } = await params;
     if (!heroId || !chapterId) return apiError("Missing path params", 400);
     const chapter = await approveHeroChapterServer({

--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -18,6 +18,8 @@ import {
   SHOWCASE_SUBMISSIONS_CACHE_TAG,
 } from "@/lib/hackathon-showcase";
 import { MERGED_PR_COUNTS_CACHE_TAG } from "@/lib/github-merged-pr-count";
+import { HACKATHON_EVENT_SIGNUP_IDS } from "@/lib/hackathon-event-signup";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
 import { ensureHackASprint2026ScoreDoc } from "@/lib/hackathon-asprint-2026-scores";
 import { awardHackASprint2026ShowcaseBadge } from "@/lib/hackathon-showcase-admin";
 import { maybeAutoAdmitOnPRMerge } from "@/lib/summer-cohort-auto-admit";
@@ -206,6 +208,24 @@ async function handleWebhook(request: NextRequest) {
         // Merged PR counts caches go stale on every merge — refresh.
         try {
           revalidateTag(MERGED_PR_COUNTS_CACHE_TAG, { expire: 0 });
+        } catch {
+          // non-fatal
+        }
+
+        // GET /api/hackathons/events/:eventId/signup serves a persisted
+        // Firestore snapshot. Refresh it after PR merges so the public
+        // leaderboard reflects newly earned merged-PR credit.
+        try {
+          const refreshResults = await Promise.allSettled(
+            HACKATHON_EVENT_SIGNUP_IDS.map((eventId) => refreshSnapshot(eventId))
+          );
+          const failed = refreshResults.filter((r) => r.status === "rejected").length;
+          if (failed > 0) {
+            logger.warn("Hackathon signup leaderboard snapshot refresh failed", {
+              failed,
+              total: refreshResults.length,
+            });
+          }
         } catch {
           // non-fatal
         }

--- a/app/api/hackathons/events/[eventId]/checkin/route.ts
+++ b/app/api/hackathons/events/[eventId]/checkin/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   hackathonEventSignupDocId,
   isHackathonEventSignupId,
@@ -45,8 +45,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
 
     const user = await getVerifiedUser(request);
-    if (!user?.isAdmin) {
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const { eventId: raw } = await context.params;

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/admin-dashboard/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { DocumentData } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -55,8 +55,17 @@ export async function GET(request: NextRequest) {
     }
 
     const user = await getVerifiedUser(request);
-    if (!user?.isAdmin) {
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/ai-score/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -35,8 +35,17 @@ export async function POST(request: NextRequest) {
     }
 
     const user = await getVerifiedUser(request);
-    if (!user?.isAdmin) {
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     let body: unknown;

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/credit-code/route.ts
@@ -7,7 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 
 // @contracts: hackathonsContract.hackASprintCreditCode (lib/api-schemas/hackathons.ts)
@@ -47,6 +47,12 @@ export async function GET(request: NextRequest) {
         eligible: false,
         reason: resolved.reason,
       });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     return NextResponse.json({

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/credit-email/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminAuth, getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { resolveHackASprint2026CreditForUser } from "@/lib/hackathon-asprint-2026-credit-eligibility";
 import { sendEmail } from "@/lib/mailgun";
 import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
@@ -79,6 +79,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { ok: false, reason: resolved.reason },
         { status: 400 }
+      );
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
       );
     }
 

--- a/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
+++ b/app/api/hackathons/showcase/hack-a-sprint-2026/judge-score/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import {
   HACK_A_SPRINT_2026_EVENT_ID,
   fetchShowcaseSubmissionsFromGitHub,
@@ -57,6 +57,12 @@ export async function POST(request: NextRequest) {
     const okJudge = await userIsHackASprint2026Judge(db, user.uid, user.email);
     if (!okJudge) {
       return NextResponse.json({ error: "Not a judge" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     let body: unknown;

--- a/app/api/hackathons/submissions/check-disqualified/route.ts
+++ b/app/api/hackathons/submissions/check-disqualified/route.ts
@@ -10,12 +10,14 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getCurrentVirtualHackathonId, isVirtualHackathonId } from "@/lib/hackathons";
 import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+import { fetchWithTimeout } from "@/lib/http-fetch";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const CRON_SECRET = process.env.CRON_SECRET;
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 function parseRepoUrl(repoUrl: string): { owner: string; repo: string } | null {
   try {
@@ -91,25 +93,40 @@ export async function GET(request: NextRequest) {
       headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
     }
 
+    const scannedCount = submissionsSnap.docs.length;
+    let checkedCount = 0;
+    let skippedCount = 0;
+    let githubErrorCount = 0;
     let disqualifiedCount = 0;
 
     for (const docSnap of submissionsSnap.docs) {
       const data = docSnap.data();
-      if (data.disqualified || !data.submittedAt || !data.repoUrl || !data.cutoffAt) continue;
+      if (data.disqualified || !data.submittedAt || !data.repoUrl || !data.cutoffAt) {
+        skippedCount++;
+        continue;
+      }
 
       const cutoffAt = data.cutoffAt?.toDate ? data.cutoffAt.toDate() : new Date(data.cutoffAt);
       const since = cutoffAt.toISOString();
 
       const parsed = parseRepoUrl(data.repoUrl);
-      if (!parsed) continue;
+      if (!parsed) {
+        skippedCount++;
+        continue;
+      }
 
       try {
-        const commitsRes = await fetch(
+        checkedCount++;
+        const commitsRes = await fetchWithTimeout(
           `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/commits?since=${encodeURIComponent(since)}`,
-          { headers }
+          { headers },
+          GITHUB_FETCH_TIMEOUT_MS
         );
 
-        if (!commitsRes.ok) continue;
+        if (!commitsRes.ok) {
+          githubErrorCount++;
+          continue;
+        }
 
         const commits = (await commitsRes.json()) as unknown[];
         const hasCommitAfterCutoff = Array.isArray(commits) && commits.length > 0;
@@ -123,12 +140,17 @@ export async function GET(request: NextRequest) {
           disqualifiedCount++;
         }
       } catch {
-        // Skip on error (rate limit, repo gone, etc.)
+        githubErrorCount++;
+        // Skip on error (timeout, rate limit, repo gone, etc.)
       }
     }
 
     return NextResponse.json({
       hackathonId,
+      scannedCount,
+      checkedCount,
+      skippedCount,
+      githubErrorCount,
       disqualifiedCount,
       message: `Checked submissions for ${hackathonId}; disqualified ${disqualifiedCount}.`,
     });

--- a/app/api/hackathons/submissions/register/route.ts
+++ b/app/api/hackathons/submissions/register/route.ts
@@ -13,12 +13,14 @@ import { getCurrentVirtualHackathonId, getVirtualMonthStartEndUtc, isVirtualHack
 import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+import { fetchWithTimeout } from "@/lib/http-fetch";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const HACKATHON_RATE_LIMIT = rateLimitConfigs.hackathonMutation;
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 /**
  * Parse repo URL to owner/repo (e.g. https://github.com/owner/repo -> owner/repo).
@@ -118,10 +120,19 @@ export async function POST(request: NextRequest) {
       headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
     }
 
-    const ghRes = await fetch(
-      `https://api.github.com/repos/${parsed.owner}/${parsed.repo}`,
-      { headers }
-    );
+    let ghRes: Response;
+    try {
+      ghRes = await fetchWithTimeout(
+        `https://api.github.com/repos/${parsed.owner}/${parsed.repo}`,
+        { headers },
+        GITHUB_FETCH_TIMEOUT_MS
+      );
+    } catch {
+      return NextResponse.json(
+        { error: "Could not verify repo with GitHub" },
+        { status: 502 }
+      );
+    }
 
     if (ghRes.status === 404) {
       return NextResponse.json(

--- a/app/api/hunt/oracle/konami/route.ts
+++ b/app/api/hunt/oracle/konami/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { KONAMI_SEQUENCE_HEADER } from "@/lib/konami-handler";
 import { getKonamiToken } from "@/lib/treasure-hunt-paths";
 
 // @contracts: huntContract.oracleKonami (lib/api-schemas/hunt.ts)
@@ -20,7 +21,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET(request: Request) {
   const sequence = request.headers.get("x-konami-sequence") || "";
-  if (sequence !== "UUDDLRLRBA") {
+  if (sequence !== KONAMI_SEQUENCE_HEADER) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   return NextResponse.json({ token: getKonamiToken() });

--- a/app/api/live/session/route.ts
+++ b/app/api/live/session/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { sanitizeText } from "@/lib/sanitize";
 import { createLiveSessionServer } from "@/lib/live-sessions/data-server";
 import { liveContract } from "@/lib/api-schemas/live";
@@ -47,6 +47,12 @@ export async function POST(request: NextRequest) {
 
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const rawBody = await request.json().catch(() => null);

--- a/app/api/profile/update/route.ts
+++ b/app/api/profile/update/route.ts
@@ -13,6 +13,14 @@ import { getClientIdentifier } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeName, sanitizeText, sanitizeUrl } from "@/lib/sanitize";
 import { profileContract } from "@/lib/api-schemas/profile";
+import {
+  PROFILE_BIO_MAX_LENGTH_ERROR,
+  PROFILE_COMPANY_MAX_LENGTH_ERROR,
+  PROFILE_DISPLAY_NAME_MAX_LENGTH_ERROR,
+  PROFILE_DISPLAY_NAME_MIN_LENGTH_ERROR,
+  PROFILE_JOB_TITLE_MAX_LENGTH_ERROR,
+  PROFILE_LOCATION_MAX_LENGTH_ERROR,
+} from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -66,13 +74,13 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeName(body.displayName);
       if (sanitized.length < 2) {
         return NextResponse.json(
-          { error: "Display name must be at least 2 characters" },
+          { error: PROFILE_DISPLAY_NAME_MIN_LENGTH_ERROR },
           { status: 400 }
         );
       }
       if (sanitized.length > 50) {
         return NextResponse.json(
-          { error: "Display name must be 50 characters or less" },
+          { error: PROFILE_DISPLAY_NAME_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -84,7 +92,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.bio);
       if (sanitized.length > 500) {
         return NextResponse.json(
-          { error: "Bio must be 500 characters or less" },
+          { error: PROFILE_BIO_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -96,7 +104,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.location);
       if (sanitized.length > 100) {
         return NextResponse.json(
-          { error: "Location must be 100 characters or less" },
+          { error: PROFILE_LOCATION_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -108,7 +116,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.company);
       if (sanitized.length > 100) {
         return NextResponse.json(
-          { error: "Company must be 100 characters or less" },
+          { error: PROFILE_COMPANY_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }
@@ -120,7 +128,7 @@ export async function PATCH(request: NextRequest) {
       const sanitized = sanitizeText(body.jobTitle);
       if (sanitized.length > 100) {
         return NextResponse.json(
-          { error: "Job title must be 100 characters or less" },
+          { error: PROFILE_JOB_TITLE_MAX_LENGTH_ERROR },
           { status: 400 }
         );
       }

--- a/app/api/questions/answer/route.ts
+++ b/app/api/questions/answer/route.ts
@@ -17,6 +17,7 @@ import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText, sanitizeDocId } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { questionsContract } from "@/lib/api-schemas/questions";
+import { QUESTION_ANSWER_RANGE_ERROR } from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -62,7 +63,7 @@ export async function POST(request: NextRequest) {
     const sanitizedBody = sanitizeText(parsed.data.body);
     if (sanitizedBody.length < 20 || sanitizedBody.length > 5000) {
       return NextResponse.json(
-        { error: "Answer must be between 20 and 5000 characters" },
+        { error: QUESTION_ANSWER_RANGE_ERROR },
         { status: 400 }
       );
     }

--- a/app/api/questions/post/route.ts
+++ b/app/api/questions/post/route.ts
@@ -15,6 +15,10 @@ import { sanitizeText } from "@/lib/sanitize";
 import { getDisplayName } from "@/lib/utils";
 import { QUESTION_TAGS, type QuestionTag } from "@/types/questions";
 import { questionsContract } from "@/lib/api-schemas/questions";
+import {
+  QUESTION_BODY_RANGE_ERROR,
+  QUESTION_TITLE_RANGE_ERROR,
+} from "@/lib/error-messages";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -57,14 +61,14 @@ export async function POST(request: NextRequest) {
 
     if (sanitizedTitle.length < 10 || sanitizedTitle.length > 200) {
       return NextResponse.json(
-        { error: "Title must be between 10 and 200 characters" },
+        { error: QUESTION_TITLE_RANGE_ERROR },
         { status: 400 }
       );
     }
 
     if (sanitizedBody.length < 20 || sanitizedBody.length > 5000) {
       return NextResponse.json(
-        { error: "Body must be between 20 and 5000 characters" },
+        { error: QUESTION_BODY_RANGE_ERROR },
         { status: 400 }
       );
     }

--- a/app/api/showcase/submission/approve/route.ts
+++ b/app/api/showcase/submission/approve/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
 import { sanitizeDocId } from "@/lib/sanitize";
@@ -152,6 +152,12 @@ export async function GET(request: NextRequest) {
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
 
     const db = getAdminDb();
     if (!db) {
@@ -227,6 +233,12 @@ export async function POST(request: NextRequest) {
 
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();

--- a/app/api/summer-cohort/admin/access/route.ts
+++ b/app/api/summer-cohort/admin/access/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { type NextRequest, NextResponse } from "next/server";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 
@@ -26,11 +26,29 @@ export const dynamic = "force-dynamic";
  * permissions error.
  */
 export async function GET(request: NextRequest) {
-  const user = await getVerifiedUser(request).catch(() => null);
+  let user;
+  try {
+    user = await getVerifiedUser(request);
+  } catch (error) {
+    return NextResponse.json({ allowed: false }, { status: 401 });
+  }
+
   if (!user) {
     return NextResponse.json({ allowed: false }, { status: 401 });
   }
+  if (!isSummerCohortAdminEmail(user.email)) {
+    return NextResponse.json({ allowed: false });
+  }
+  if (await isCurrentIdTokenRevoked(request)) {
+    return NextResponse.json(
+      {
+        allowed: false,
+        error: "Session revoked. Please sign in again.",
+      },
+      { status: 401 }
+    );
+  }
   return NextResponse.json({
-    allowed: isSummerCohortAdminEmail(user.email),
+    allowed: true,
   });
 }

--- a/app/api/summer-cohort/admin/applications/route.ts
+++ b/app/api/summer-cohort/admin/applications/route.ts
@@ -7,7 +7,7 @@
 
 import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
@@ -58,12 +58,23 @@ interface AdminApplicationRow {
  * triage in one place.
  */
 export async function GET(request: NextRequest) {
-  const user = await getVerifiedUser(request);
+  let user;
+  try {
+    user = await getVerifiedUser(request);
+  } catch (error) {
+    throw error;
+  }
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   if (!isSummerCohortAdminEmail(user.email)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (await isCurrentIdTokenRevoked(request)) {
+    return NextResponse.json(
+      { error: "Session revoked. Please sign in again." },
+      { status: 401 }
+    );
   }
 
   const db = getAdminDb();

--- a/app/api/summer-cohort/admin/intake-aggregates/route.ts
+++ b/app/api/summer-cohort/admin/intake-aggregates/route.ts
@@ -7,7 +7,7 @@
 
 import { type NextRequest, NextResponse } from "next/server";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { isSummerCohortAdminEmail } from "@/lib/summer-cohort-admin-access";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
 import {
@@ -119,12 +119,23 @@ function yesNoCounts(values: unknown[]): { yes: number; no: number; blank: numbe
  * who need those should pull from Firestore directly.
  */
 export async function GET(request: NextRequest) {
-  const user = await getVerifiedUser(request);
+  let user;
+  try {
+    user = await getVerifiedUser(request);
+  } catch (error) {
+    throw error;
+  }
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   if (!isSummerCohortAdminEmail(user.email)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (await isCurrentIdTokenRevoked(request)) {
+    return NextResponse.json(
+      { error: "Session revoked. Please sign in again." },
+      { status: 401 }
+    );
   }
 
   const db = getAdminDb();

--- a/app/api/summer-cohort/my-score/[weekId]/route.ts
+++ b/app/api/summer-cohort/my-score/[weekId]/route.ts
@@ -15,6 +15,7 @@ import { isValidCohortId, type SummerCohortId } from "@/lib/summer-cohort";
 import { getOptionalVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
 import { summerCohortContract } from "@/lib/api-schemas/summer-cohort";
+import { fetchWithTimeout } from "@/lib/http-fetch";
 
 interface ScoreFile {
   score: number;
@@ -23,6 +24,8 @@ interface ScoreFile {
   scoredAt?: string;
   scorerVersion?: number;
 }
+
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 function scoresDirFromSubmissionPath(submissionPath: string): string | null {
   // submissionPath looks like:
@@ -134,12 +137,16 @@ export async function GET(
 
   let res: Response;
   try {
-    res = await fetch(url, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-      // Match the submissions feed's revalidate window — scores update rarely
-      // and the same content addresses cache nicely.
-      next: { revalidate: 60 },
-    });
+    res = await fetchWithTimeout(
+      url,
+      {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        // Match the submissions feed's revalidate window — scores update rarely
+        // and the same content addresses cache nicely.
+        next: { revalidate: 60 },
+      },
+      GITHUB_FETCH_TIMEOUT_MS
+    );
   } catch (error) {
     logger.warn("my-score: raw fetch failed", {
       weekId,

--- a/app/api/talks/submission/moderate/route.ts
+++ b/app/api/talks/submission/moderate/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue, type QuerySnapshot } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
-import { getVerifiedUser } from "@/lib/server-auth";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { buildRateLimitHeaders, checkServerRateLimit } from "@/lib/rate-limit-server";
 import { sanitizeDocId } from "@/lib/sanitize";
@@ -162,6 +162,12 @@ export async function GET(request: NextRequest) {
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
+    }
 
     const db = getAdminDb();
     if (!db) {
@@ -267,6 +273,12 @@ export async function POST(request: NextRequest) {
 
     if (!user.isAdmin) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 }
+      );
     }
 
     const db = getAdminDb();

--- a/app/cookbook/[slug]/page.tsx
+++ b/app/cookbook/[slug]/page.tsx
@@ -1,0 +1,252 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { PromptMarkdown } from "@/components/cookbook/PromptMarkdown";
+import { CATEGORY_LABELS } from "@/lib/cookbook-labels";
+import { getCookbookEntryById } from "@/lib/cookbook-entries";
+import { formatCookbookDate } from "@/lib/format-cookbook-date";
+import type { CookbookEntry } from "@/types/cookbook";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SITE_URL = "https://cursorboston.com";
+const DEFAULT_IMAGE = "/cursor-boston-logo.png";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function absoluteUrl(pathOrUrl: string): string {
+  if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://")) {
+    return pathOrUrl;
+  }
+  return `${SITE_URL}${pathOrUrl.startsWith("/") ? "" : "/"}${pathOrUrl}`;
+}
+
+function cookbookEntryUrl(entry: CookbookEntry): string {
+  return absoluteUrl(entry.seo?.canonicalUrl ?? `/cookbook/${entry.id}`);
+}
+
+function metadataTitle(entry: CookbookEntry): string {
+  return entry.seo?.title ?? `${entry.title} | Cursor Boston Cookbook`;
+}
+
+function metadataDescription(entry: CookbookEntry): string {
+  return entry.seo?.description ?? entry.description;
+}
+
+function metadataImage(entry: CookbookEntry): string {
+  return absoluteUrl(entry.seo?.image ?? DEFAULT_IMAGE);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getCookbookEntryById(slug);
+
+  if (!entry) {
+    return {
+      title: "Cookbook Entry Not Found",
+    };
+  }
+
+  const title = metadataTitle(entry);
+  const description = metadataDescription(entry);
+  const image = metadataImage(entry);
+  const canonical = cookbookEntryUrl(entry);
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: entry.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+    alternates: {
+      canonical,
+    },
+  };
+}
+
+function buildJsonLd(entry: CookbookEntry) {
+  const url = cookbookEntryUrl(entry);
+  const keywords = [...entry.tags, ...entry.worksWith].filter(Boolean);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: entry.title,
+    description: entry.description,
+    text: entry.promptContent,
+    url,
+    image: metadataImage(entry),
+    dateCreated: entry.createdAt || undefined,
+    keywords: keywords.length > 0 ? keywords.join(", ") : undefined,
+    creator: {
+      "@type": "Person",
+      name: entry.authorDisplayName || "Cursor Boston member",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Cursor Boston",
+      url: SITE_URL,
+      logo: {
+        "@type": "ImageObject",
+        url: absoluteUrl(DEFAULT_IMAGE),
+      },
+    },
+    isPartOf: {
+      "@type": "CreativeWorkSeries",
+      name: "Cursor Boston Prompt & Rules Cookbook",
+      url: `${SITE_URL}/cookbook`,
+    },
+    about: CATEGORY_LABELS[entry.category],
+    interactionStatistic: [
+      {
+        "@type": "InteractionCounter",
+        interactionType: "https://schema.org/LikeAction",
+        userInteractionCount: entry.upCount,
+      },
+      {
+        "@type": "InteractionCounter",
+        interactionType: "https://schema.org/DislikeAction",
+        userInteractionCount: entry.downCount,
+      },
+    ],
+  };
+}
+
+export default async function CookbookEntryPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = await getCookbookEntryById(slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  const jsonLd = buildJsonLd(entry);
+  const netScore = entry.upCount - entry.downCount;
+
+  return (
+    <main className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <nav
+        className="border-b border-neutral-200 dark:border-neutral-800 px-6 py-4"
+        aria-label="Breadcrumb"
+      >
+        <ol className="mx-auto flex max-w-4xl items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
+          <li>
+            <Link href="/cookbook" className="hover:text-foreground">
+              Cookbook
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="truncate text-foreground">{entry.title}</li>
+        </ol>
+      </nav>
+
+      <article className="mx-auto max-w-4xl px-6 py-12">
+        <header className="mb-8">
+          <div className="mb-4 flex flex-wrap items-center gap-2 text-sm">
+            <span className="rounded-full bg-emerald-500/10 px-3 py-1 font-medium text-emerald-700 dark:text-emerald-300">
+              {CATEGORY_LABELS[entry.category]}
+            </span>
+            {entry.worksWith.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-neutral-200 px-3 py-1 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+
+          <h1 className="text-3xl font-bold tracking-normal text-neutral-950 dark:text-white md:text-5xl">
+            {entry.title}
+          </h1>
+          <p className="mt-4 text-lg leading-8 text-neutral-700 dark:text-neutral-300">
+            {entry.description}
+          </p>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-neutral-500 dark:text-neutral-400">
+            <Link
+              href={`/members?search=${encodeURIComponent(entry.authorDisplayName)}`}
+              className="hover:text-foreground"
+            >
+              by {entry.authorDisplayName || "Cursor Boston member"}
+            </Link>
+            {entry.createdAt ? (
+              <>
+                <span aria-hidden="true">/</span>
+                <time dateTime={entry.createdAt}>
+                  {formatCookbookDate(entry.createdAt)}
+                </time>
+              </>
+            ) : null}
+            <span aria-hidden="true">/</span>
+            <span>{netScore >= 0 ? `+${netScore}` : netScore} net score</span>
+          </div>
+        </header>
+
+        <section
+          aria-labelledby="cookbook-entry-prompt"
+          className="overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
+        >
+          <div className="border-b border-neutral-200 bg-neutral-100 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-800/70">
+            <h2
+              id="cookbook-entry-prompt"
+              className="text-sm font-semibold uppercase text-neutral-500 dark:text-neutral-400"
+            >
+              Full prompt
+            </h2>
+          </div>
+          <PromptMarkdown
+            content={entry.promptContent}
+            className="px-4 py-4 text-sm md:px-6 md:py-5"
+          />
+        </section>
+
+        {entry.tags.length > 0 ? (
+          <section aria-label="Tags" className="mt-8 flex flex-wrap gap-2">
+            {entry.tags.map((tag) => (
+              <Link
+                key={tag}
+                href={`/cookbook?search=${encodeURIComponent(tag)}`}
+                className="rounded-full bg-neutral-200 px-3 py-1 text-sm text-neutral-700 hover:bg-neutral-300 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+              >
+                #{tag}
+              </Link>
+            ))}
+          </section>
+        ) : null}
+      </article>
+    </main>
+  );
+}

--- a/components/feed/MessageCard.tsx
+++ b/components/feed/MessageCard.tsx
@@ -196,7 +196,11 @@ export function MessageCard({
                   ? "text-emerald-400 bg-emerald-500/10"
                   : "text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
-              aria-label={userReaction === "like" ? "Remove like" : "Like"}
+              aria-label={
+                userReaction === "like"
+                  ? `Remove like from ${message.authorName}'s message`
+                  : `Like ${message.authorName}'s message`
+              }
             >
               <svg
                 width="18"
@@ -221,7 +225,11 @@ export function MessageCard({
                   ? "text-red-400 bg-red-500/10"
                   : "text-neutral-500 hover:text-red-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
-              aria-label={userReaction === "dislike" ? "Remove dislike" : "Dislike"}
+              aria-label={
+                userReaction === "dislike"
+                  ? `Remove dislike from ${message.authorName}'s message`
+                  : `Dislike ${message.authorName}'s message`
+              }
             >
               <svg
                 width="18"
@@ -246,7 +254,7 @@ export function MessageCard({
                   ? "text-emerald-400 bg-emerald-500/10"
                   : "text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800"
               } ${!isLoggedIn ? "opacity-50 cursor-not-allowed" : ""}`}
-              aria-label="Reply"
+              aria-label={`Reply to ${message.authorName}'s message`}
             >
               <svg
                 width="18"
@@ -270,7 +278,7 @@ export function MessageCard({
                 className={`flex items-center gap-1.5 px-3 py-2 rounded-lg transition-colors min-h-[44px] text-neutral-500 hover:text-emerald-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 ${
                   !isLoggedIn ? "opacity-50 cursor-not-allowed" : ""
                 }`}
-                aria-label="Repost"
+                aria-label={`Repost ${message.authorName}'s message`}
               >
                 <svg
                   width="18"

--- a/components/feed/ReplyCard.tsx
+++ b/components/feed/ReplyCard.tsx
@@ -88,7 +88,11 @@ export function ReplyCard({
             <button
               onClick={onLike}
               disabled={!isLoggedIn}
-              aria-label={userReaction === "like" ? "Remove like" : "Like"}
+              aria-label={
+                userReaction === "like"
+                  ? `Remove like from ${reply.authorName}'s reply`
+                  : `Like ${reply.authorName}'s reply`
+              }
               className={`flex items-center gap-1 px-2 py-1 rounded transition-colors text-xs ${
                 userReaction === "like"
                   ? "text-emerald-400"
@@ -111,7 +115,11 @@ export function ReplyCard({
             <button
               onClick={onDislike}
               disabled={!isLoggedIn}
-              aria-label={userReaction === "dislike" ? "Remove dislike" : "Dislike"}
+              aria-label={
+                userReaction === "dislike"
+                  ? `Remove dislike from ${reply.authorName}'s reply`
+                  : `Dislike ${reply.authorName}'s reply`
+              }
               className={`flex items-center gap-1 px-2 py-1 rounded transition-colors text-xs ${
                 userReaction === "dislike"
                   ? "text-red-400"

--- a/components/hunt/KonamiListener.tsx
+++ b/components/hunt/KonamiListener.tsx
@@ -7,21 +7,13 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-
-const SEQUENCE = [
-  "ArrowUp",
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowLeft",
-  "ArrowRight",
-  "b",
-  "a",
-];
+import {
+  KONAMI_SEQUENCE,
+  KONAMI_SEQUENCE_HEADER,
+} from "@/lib/konami-handler";
+import { useKonamiListener } from "@/hooks/use-konami-listener";
 
 export function KonamiListener() {
   const { user } = useAuth();
@@ -29,34 +21,22 @@ export function KonamiListener() {
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<null | string>(null);
 
-  useEffect(() => {
-    let index = 0;
-    function onKey(e: KeyboardEvent) {
-      const expected = SEQUENCE[index];
-      if (e.key.toLowerCase() === expected?.toLowerCase()) {
-        index += 1;
-        if (index === SEQUENCE.length) {
-          index = 0;
-          void fetch("/api/hunt/oracle/konami", {
-            headers: { "X-Konami-Sequence": "UUDDLRLRBA" },
-          })
-            .then(async (r) => {
-              if (!r.ok) {
-                setRevealed({ error: "Not today." });
-                return;
-              }
-              const j = (await r.json()) as { token?: string };
-              if (j.token) setRevealed({ token: j.token });
-            })
-            .catch(() => setRevealed({ error: "Network error." }));
+  const revealToken = useCallback(() => {
+    void fetch("/api/hunt/oracle/konami", {
+      headers: { "X-Konami-Sequence": KONAMI_SEQUENCE_HEADER },
+    })
+      .then(async (r) => {
+        if (!r.ok) {
+          setRevealed({ error: "Not today." });
+          return;
         }
-      } else {
-        index = 0;
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+        const j = (await r.json()) as { token?: string };
+        if (j.token) setRevealed({ token: j.token });
+      })
+      .catch(() => setRevealed({ error: "Network error." }));
   }, []);
+
+  useKonamiListener(KONAMI_SEQUENCE, revealToken);
 
   async function submit() {
     if (!user || !revealed?.token) return;

--- a/docs/API_CACHING.md
+++ b/docs/API_CACHING.md
@@ -1,0 +1,80 @@
+# API Caching Strategy
+
+This project uses three cache layers for API responses:
+
+- HTTP `Cache-Control` headers on route responses.
+- Next.js data cache APIs such as `fetch(..., { next: { revalidate } })`,
+  `unstable_cache`, `revalidateTag`, and `revalidatePath`.
+- Persisted Firestore snapshots for expensive aggregate reads.
+
+Use the current Next.js caching guide as the framework reference:
+<https://nextjs.org/docs/app/getting-started/caching-and-revalidating>.
+
+## Defaults
+
+- Authenticated or user-specific routes should use `private` or `no-store`.
+- Public list and aggregate routes can use short public or CDN caches.
+- Mutation routes should stay dynamic and should invalidate any public read cache
+  they make stale.
+- GitHub API fan-out should be cached or snapshotted unless the caller is a
+  one-off script that explicitly opts into uncached reads.
+
+## Route Inventory
+
+| Route or helper                                                            | Cache policy                                                                 | TTL                                                                                                                                                | Revalidation / invalidation                                                                                                             |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/analytics/summary`                                               | Public response cache plus `analytics_snapshots/latest` Firestore snapshot.  | Browser `max-age=300`, CDN `s-maxage=3600`, stale for `86400`. Snapshot has its own `expiresAt`.                                                   | Snapshot producer owns refresh; stale snapshot is surfaced with `X-Data-Stale: true`.                                                   |
+| `GET /api/members/public`                                                  | Public response cache over the public member snapshot.                       | Browser `max-age=60`, CDN `s-maxage=300`, stale for `600`.                                                                                         | Snapshot freshness is checked against `MEMBERS_SNAPSHOT_CACHE_TTL_MS`.                                                                  |
+| `GET /api/badges/definitions`                                              | Public response cache for static badge definitions.                          | CDN `s-maxage=3600`, stale for `300`.                                                                                                              | Code deploy changes the definitions; no runtime invalidation.                                                                           |
+| `GET /api/docs`                                                            | Public response cache for generated OpenAPI docs UI assets.                  | CDN `s-maxage=300`, stale for `600`.                                                                                                               | Regenerated OpenAPI artifacts ship with deploys.                                                                                        |
+| `GET /api/cookbook/entries` without search                                 | Public response cache on non-search paginated reads.                         | CDN `s-maxage=60`, stale for `30`.                                                                                                                 | Search or personalized reads should not reuse this cache path.                                                                          |
+| `GET /api/game/community/feed`                                             | Public response cache for the latest community events.                       | Browser `max-age=15`, CDN `s-maxage=30`, stale for `60`.                                                                                           | Short TTL absorbs bursts; moderation follow-up may add explicit invalidation.                                                           |
+| `GET /api/game/world`                                                      | Public response cache backed by the persisted world snapshot when available. | Snapshot path: browser `max-age=60`, CDN `s-maxage=300`, stale for `600`. Live fallback: browser `max-age=30`, CDN `s-maxage=60`, stale for `120`. | Snapshot cron / rebuild updates the persisted world data. Responses expose `X-World-Snapshot-Stale` and `X-World-Snapshot-GeneratedAt`. |
+| `GET /api/game/map/me`                                                     | Private browser cache for the caller's derived map view.                     | Snapshot path: `private, max-age=60, must-revalidate`. Live fallback: `private, max-age=30, must-revalidate`.                                      | Client action handlers patch the local map cache after mutations.                                                                       |
+| `GET /api/game/players/[playerId]`                                         | Private browser cache for player detail reads.                               | `private, max-age=30, must-revalidate`.                                                                                                            | Mutations should update the client view or rely on the short TTL.                                                                       |
+| `GET /api/game/prophecies` and `GET /api/game/pacts`                       | Private browser cache for current-player game state.                         | `private, max-age=30, must-revalidate`.                                                                                                            | Game actions mutate state and should update local UI state.                                                                             |
+| `GET /api/game/world-meta`                                                 | Private short cache for world meta and resolving-state checks.               | `private, max-age=15, stale-while-revalidate=30`.                                                                                                  | Short TTL keeps armageddon / resolving-state transitions fresh.                                                                         |
+| `GET /api/summer-cohort/submissions/[weekId]`                              | Public response cache mirroring the GitHub Contents API cache window.        | Browser `max-age=0`, CDN `s-maxage=60`, stale for `300`.                                                                                           | GitHub content changes become visible after the one-minute CDN window.                                                                  |
+| `GET /api/summer-cohort/my-score/[weekId]`                                 | Server-side upstream fetch cache, private route response.                    | Upstream fetch `next.revalidate=60`; response `private, no-store`.                                                                                 | Per-user response must not enter shared caches.                                                                                         |
+| `GET /api/cursor/github-issues`                                            | Server-side GitHub fetch cache.                                              | Upstream fetch `next.revalidate=60`.                                                                                                               | Good-first-issue listings update within one minute.                                                                                     |
+| `GET /api/hackathons/teams-board` and `GET /api/hackathons/pool-dashboard` | Private short cache for hackathon dashboards.                                | `private, max-age=30`.                                                                                                                             | Fresh enough for dashboards while avoiding repeated Firestore reads.                                                                    |
+| `GET /api/hackathons/team-dashboard` and profile/data routes               | Private no-store responses.                                                  | `private, no-store`.                                                                                                                               | Authenticated user/team state must not be shared.                                                                                       |
+| `GET /api/hackathons/events/[eventId]/signup`                              | Dynamic route backed by `getCachedHackathonLeaderboardSnapshot`.             | The snapshot helper uses a 30-second in-process Next cache and persisted Firestore snapshots.                                                      | Check-in and signup mutations invalidate with tag `hackathon-event-signup`.                                                             |
+
+## Shared Cached Helpers
+
+| Helper                                                                             | Cache key / tag          | TTL                                                    | Invalidation                                                                                                                                                               |
+| ---------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fetchShowcaseSubmissionsFromGitHub` in `lib/hackathon-showcase.ts`                | `showcase-submissions`   | `unstable_cache` revalidates every `60` seconds.       | GitHub webhook calls `revalidateTag(SHOWCASE_SUBMISSIONS_CACHE_TAG)` and `revalidatePath("/hackathons/hack-a-sprint-2026")` when a merged PR touches showcase submissions. |
+| `fetchMergedPrCountByAuthorForRepo` in `lib/github-merged-pr-count.ts`             | `merged-pr-counts`       | `unstable_cache` revalidates every `600` seconds.      | GitHub webhook calls `revalidateTag(MERGED_PR_COUNTS_CACHE_TAG)` on every target-repo merge.                                                                               |
+| `getCachedHackathonLeaderboardSnapshot` in `lib/hackathon-leaderboard-snapshot.ts` | `hackathon-event-signup` | 30-second in-process cache around persisted snapshots. | Check-in and signup mutations call `revalidateTag("hackathon-event-signup")`; GitHub merge handling should refresh snapshots when PR counts change.                        |
+
+## Mutation Pattern
+
+When adding a mutation that changes public cached data:
+
+1. Keep the mutation route dynamic with `export const dynamic = "force-dynamic"`.
+2. Perform the write first.
+3. Call the narrowest `revalidateTag` or `revalidatePath` needed for affected
+   public reads.
+4. Treat invalidation as best-effort only when the write already succeeded and a
+   stale cache is acceptable for the documented TTL.
+
+Example:
+
+```ts
+await writeCheckin();
+revalidateTag("hackathon-event-signup", { expire: 0 });
+```
+
+## No-Store Pattern
+
+Use `private, no-store` for responses containing:
+
+- User profile data.
+- Team dashboard data.
+- Certificates owned by the caller.
+- Admin lists, moderation state, live controls, or other privileged data.
+
+Short private caches are acceptable for per-user game reads when the UI also
+patches local state after actions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,11 @@ Read docs in this order depending on your goal:
 | 2 | [DEVELOPMENT.md](DEVELOPMENT.md) | Developers — setup, scripts, hooks, architecture |
 | 3 | [FIRST_CONTRIBUTION.md](FIRST_CONTRIBUTION.md) | Step-by-step first pull request |
 | 4 | [API.md](API.md) | API route reference |
-| 5 | [RELEASING.md](RELEASING.md) | Maintainers — versioning and GitHub Releases |
-| 6 | [SUPPLY_CHAIN.md](SUPPLY_CHAIN.md) | Security automation, dependencies, and trust signals |
-| 7 | [VERCEL.md](VERCEL.md) | Why PRs do not deploy to Vercel; production-only settings |
-| 8 | [Architecture Decision Records](adr/README.md) | Why the project is built the way it is |
+| 5 | [API_CACHING.md](API_CACHING.md) | API cache TTLs, tags, and invalidation rules |
+| 6 | [RELEASING.md](RELEASING.md) | Maintainers — versioning and GitHub Releases |
+| 7 | [SUPPLY_CHAIN.md](SUPPLY_CHAIN.md) | Security automation, dependencies, and trust signals |
+| 8 | [VERCEL.md](VERCEL.md) | Why PRs do not deploy to Vercel; production-only settings |
+| 9 | [Architecture Decision Records](adr/README.md) | Why the project is built the way it is |
 
 **Site visitor map:** [USER_GUIDE.md](USER_GUIDE.md) lists every public section on cursorboston.com with one-line descriptions — start here when you're trying to find where something lives.
 

--- a/hooks/use-konami-listener.ts
+++ b/hooks/use-konami-listener.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect } from "react";
+import {
+  nextSequenceIndex,
+  type KonamiSequence,
+} from "@/lib/konami-handler";
+
+export function useKonamiListener(
+  sequence: KonamiSequence,
+  onComplete: () => void
+) {
+  useEffect(() => {
+    let index = 0;
+
+    function onKey(event: KeyboardEvent) {
+      index = nextSequenceIndex(sequence, index, event.key);
+      if (index === sequence.length) {
+        index = 0;
+        onComplete();
+      }
+    }
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onComplete, sequence]);
+}

--- a/lib/api-schemas/community.ts
+++ b/lib/api-schemas/community.ts
@@ -14,6 +14,7 @@ import {
   PaginationQuerySchema,
   RateLimitedErrorSchema,
 } from "./common";
+import { COMMUNITY_CONTENT_LENGTH_ERROR } from "@/lib/error-messages";
 
 const c = initContract();
 
@@ -40,8 +41,8 @@ const PostBody = z
   .object({
     content: z
       .string()
-      .min(100, "Content must be between 100 and 500 characters")
-      .max(500, "Content must be between 100 and 500 characters"),
+      .min(100, COMMUNITY_CONTENT_LENGTH_ERROR)
+      .max(500, COMMUNITY_CONTENT_LENGTH_ERROR),
   })
   .openapi("CommunityPostBody", {
     example: {

--- a/lib/api-schemas/questions.ts
+++ b/lib/api-schemas/questions.ts
@@ -14,6 +14,14 @@ import {
   PaginationQuerySchema,
   RateLimitedErrorSchema,
 } from "./common";
+import {
+  QUESTION_ANSWER_MAX_LENGTH_ERROR,
+  QUESTION_ANSWER_MIN_LENGTH_ERROR,
+  QUESTION_BODY_MAX_LENGTH_ERROR,
+  QUESTION_BODY_MIN_LENGTH_ERROR,
+  QUESTION_TITLE_MAX_LENGTH_ERROR,
+  QUESTION_TITLE_MIN_LENGTH_ERROR,
+} from "@/lib/error-messages";
 
 const c = initContract();
 
@@ -45,12 +53,12 @@ const PostBody = z
   .object({
     title: z
       .string()
-      .min(10, "Title must be at least 10 characters")
-      .max(200, "Title must be at most 200 characters"),
+      .min(10, QUESTION_TITLE_MIN_LENGTH_ERROR)
+      .max(200, QUESTION_TITLE_MAX_LENGTH_ERROR),
     body: z
       .string()
-      .min(20, "Body must be at least 20 characters")
-      .max(5000, "Body must be at most 5000 characters"),
+      .min(20, QUESTION_BODY_MIN_LENGTH_ERROR)
+      .max(5000, QUESTION_BODY_MAX_LENGTH_ERROR),
     tags: z.array(z.string()).max(10).optional(),
   })
   .openapi("QuestionsPostBody");
@@ -60,8 +68,8 @@ const AnswerBody = z
     questionId: z.string().min(1),
     body: z
       .string()
-      .min(20, "Answer must be at least 20 characters")
-      .max(5000, "Answer must be at most 5000 characters"),
+      .min(20, QUESTION_ANSWER_MIN_LENGTH_ERROR)
+      .max(5000, QUESTION_ANSWER_MAX_LENGTH_ERROR),
   })
   .openapi("QuestionsAnswerBody");
 

--- a/lib/cookbook-entries.ts
+++ b/lib/cookbook-entries.ts
@@ -1,0 +1,101 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { DocumentSnapshot, QueryDocumentSnapshot } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { sanitizeDocId } from "@/lib/sanitize";
+import {
+  COOKBOOK_CATEGORIES,
+  WORKS_WITH_LANGUAGES,
+  type CookbookCategory,
+  type CookbookEntry,
+  type CookbookEntrySeo,
+  type WorksWithTag,
+} from "@/types/cookbook";
+
+type CookbookDoc = DocumentSnapshot | QueryDocumentSnapshot;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+export function isValidCookbookCategory(value: string): value is CookbookCategory {
+  return COOKBOOK_CATEGORIES.includes(value as CookbookCategory);
+}
+
+export function isValidWorksWithTag(value: string): value is WorksWithTag {
+  return WORKS_WITH_LANGUAGES.includes(value as WorksWithTag);
+}
+
+function timestampToIso(value: unknown): string {
+  if (!isRecord(value) || typeof value.toMillis !== "function") return "";
+  return new Date(value.toMillis()).toISOString();
+}
+
+function normalizeSeo(data: Record<string, unknown>): CookbookEntrySeo | undefined {
+  const seoSource = isRecord(data.seo) ? data.seo : {};
+  const seo: CookbookEntrySeo = {
+    title: readString(seoSource.title) ?? readString(data.seoTitle),
+    description:
+      readString(seoSource.description) ?? readString(data.seoDescription),
+    image:
+      readString(seoSource.image) ??
+      readString(seoSource.ogImage) ??
+      readString(data.ogImageUrl),
+    canonicalUrl:
+      readString(seoSource.canonicalUrl) ?? readString(data.canonicalUrl),
+  };
+
+  return Object.values(seo).some(Boolean) ? seo : undefined;
+}
+
+export function mapCookbookDocToEntry(doc: CookbookDoc): CookbookEntry {
+  const rawData = doc.data();
+  const data = isRecord(rawData) ? rawData : {};
+  const category = readString(data.category) ?? "other";
+  const upCount = Number(data.upCount ?? 0);
+  const downCount = Number(data.downCount ?? 0);
+
+  return {
+    id: doc.id,
+    title: readString(data.title) ?? "",
+    description: readString(data.description) ?? "",
+    promptContent: readString(data.promptContent) ?? "",
+    category: isValidCookbookCategory(category) ? category : "other",
+    tags: readStringArray(data.tags),
+    worksWith: readStringArray(data.worksWith).filter(isValidWorksWithTag),
+    authorId: readString(data.authorId) ?? "",
+    authorDisplayName: readString(data.authorDisplayName) ?? "",
+    createdAt: timestampToIso(data.createdAt),
+    upCount,
+    downCount,
+    seo: normalizeSeo(data),
+  };
+}
+
+export async function getCookbookEntryById(id: string): Promise<CookbookEntry | null> {
+  const sanitizedId = sanitizeDocId(id);
+  if (!sanitizedId) return null;
+
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const doc = await db.collection("cookbook_entries").doc(sanitizedId).get();
+  if (!doc.exists) return null;
+
+  return mapCookbookDocToEntry(doc);
+}

--- a/lib/error-messages.ts
+++ b/lib/error-messages.ts
@@ -1,0 +1,90 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Build the standard API validation message for fields with inclusive
+ * character-count bounds.
+ */
+export function lengthBetweenError(
+  label: string,
+  min: number,
+  max: number
+): string {
+  return `${label} must be between ${min} and ${max} characters`;
+}
+
+/**
+ * Build the standard API validation message for minimum character counts.
+ */
+export function minLengthError(label: string, min: number): string {
+  return `${label} must be at least ${min} characters`;
+}
+
+/**
+ * Build the standard schema validation message for maximum character counts.
+ */
+export function maxLengthError(label: string, max: number): string {
+  return `${label} must be at most ${max} characters`;
+}
+
+/**
+ * Build the route-level validation message used by legacy profile endpoints.
+ */
+export function lengthOrLessError(label: string, max: number): string {
+  return `${label} must be ${max} characters or less`;
+}
+
+export const COMMUNITY_CONTENT_LENGTH_ERROR = lengthBetweenError(
+  "Content",
+  100,
+  500
+);
+
+export const QUESTION_TITLE_MIN_LENGTH_ERROR = minLengthError("Title", 10);
+export const QUESTION_TITLE_MAX_LENGTH_ERROR = maxLengthError("Title", 200);
+export const QUESTION_TITLE_RANGE_ERROR = lengthBetweenError(
+  "Title",
+  10,
+  200
+);
+
+export const QUESTION_BODY_MIN_LENGTH_ERROR = minLengthError("Body", 20);
+export const QUESTION_BODY_MAX_LENGTH_ERROR = maxLengthError("Body", 5000);
+export const QUESTION_BODY_RANGE_ERROR = lengthBetweenError("Body", 20, 5000);
+
+export const QUESTION_ANSWER_MIN_LENGTH_ERROR = minLengthError("Answer", 20);
+export const QUESTION_ANSWER_MAX_LENGTH_ERROR = maxLengthError(
+  "Answer",
+  5000
+);
+export const QUESTION_ANSWER_RANGE_ERROR = lengthBetweenError(
+  "Answer",
+  20,
+  5000
+);
+
+export const PROFILE_DISPLAY_NAME_MIN_LENGTH_ERROR = minLengthError(
+  "Display name",
+  2
+);
+export const PROFILE_DISPLAY_NAME_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Display name",
+  50
+);
+export const PROFILE_BIO_MAX_LENGTH_ERROR = lengthOrLessError("Bio", 500);
+export const PROFILE_LOCATION_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Location",
+  100
+);
+export const PROFILE_COMPANY_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Company",
+  100
+);
+export const PROFILE_JOB_TITLE_MAX_LENGTH_ERROR = lengthOrLessError(
+  "Job title",
+  100
+);

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -58,9 +58,15 @@ function getAdminApp(): App | null {
 }
 
 /**
- * Get the Firebase Admin Firestore instance.
+ * Get the server-only Firebase Admin Firestore instance.
+ *
+ * Use this helper from Route Handlers, server actions, scripts, and other
+ * trusted Node.js code that needs elevated Firebase Admin privileges. Never
+ * import or expose this helper from client components because Admin SDK
+ * credentials can bypass Firestore security rules.
+ *
  * Initializes the instance on first call and reuses it on subsequent calls.
- * @returns The Firestore instance, or null if Firebase Admin could not be initialized
+ * @returns The Firestore instance, or null when no supported Admin SDK credentials are configured.
  */
 export function getAdminDb(): Firestore | null {
   if (adminDb) {
@@ -87,9 +93,14 @@ export function getAdminDb(): Firestore | null {
 }
 
 /**
- * Get the Firebase Admin Auth instance.
+ * Get the server-only Firebase Admin Auth instance.
+ *
+ * Use this helper only from trusted server-side code that verifies or manages
+ * Firebase Auth users with Admin SDK privileges. Client code should use the
+ * browser SDK `auth` export from `lib/firebase` instead.
+ *
  * Initializes the instance on first call and reuses it on subsequent calls.
- * @returns The Auth instance, or null if Firebase Admin could not be initialized
+ * @returns The Auth instance, or null when no supported Admin SDK credentials are configured.
  */
 export function getAdminAuth(): Auth | null {
   if (adminAuth) {
@@ -106,9 +117,14 @@ export function getAdminAuth(): Auth | null {
 }
 
 /**
- * Get the Firebase Admin Realtime Database instance.
+ * Get the server-only Firebase Admin Realtime Database instance.
+ *
+ * Use this helper from trusted Node.js code that needs Admin SDK access to
+ * Realtime Database. Never import it from client components; browser code
+ * should use the client `rtdb` export from `lib/firebase`.
+ *
  * Initializes the instance on first call and reuses it on subsequent calls.
- * @returns The Database instance, or null if Firebase Admin could not be initialized
+ * @returns The Database instance, or null when no supported Admin SDK credentials are configured.
  */
 export function getAdminRtdb(): Database | null {
   if (adminRtdb) {

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -35,14 +35,63 @@ const isPlaceholderKey =
   (firebaseConfig.projectId?.startsWith("your-") ?? false) ||
   (firebaseConfig.projectId?.startsWith("demo-") ?? false);
 
+/**
+ * Client-side Firebase app singleton.
+ *
+ * Available only in the browser when public Firebase config is present.
+ * Remains `undefined` during server rendering, tests, and local runs that use
+ * placeholder env values. Server-side code that needs privileged Firebase
+ * access should use `lib/firebase-admin` instead.
+ */
 let app: FirebaseApp | undefined;
+
+/**
+ * Client-side Firebase Auth singleton.
+ *
+ * Use from browser components and hooks after checking it is defined. This is
+ * not an Admin SDK auth instance and cannot verify or manage users on the
+ * server.
+ */
 let auth: Auth | undefined;
+
+/**
+ * Client-side Firestore singleton.
+ *
+ * Use from browser code that should obey Firestore security rules. It is
+ * `undefined` outside the browser or when public Firebase env is missing.
+ */
 let db: Firestore | undefined;
+
+/**
+ * Client-side Realtime Database singleton.
+ *
+ * Use from browser code that should obey database security rules. It is
+ * `undefined` outside the browser or when public Firebase env is missing.
+ */
 let rtdb: Database | undefined;
+
+/**
+ * Client-side Firebase Storage singleton.
+ *
+ * Use from browser code that should obey Storage security rules. It is
+ * `undefined` outside the browser or when public Firebase env is missing.
+ */
 let storage: FirebaseStorage | undefined;
+
+/**
+ * Client-side Firebase Analytics singleton.
+ *
+ * Analytics is loaded only in supported browsers with non-placeholder public
+ * Firebase config, so callers must handle `undefined`.
+ */
 let analytics: Analytics | undefined;
 
-// Promise that resolves when analytics is ready (or resolves to undefined if not supported)
+/**
+ * Promise that resolves to Analytics when browser support and config allow it.
+ *
+ * Resolves to `undefined` on the server, in unsupported browsers, or when local
+ * placeholder Firebase env values are configured.
+ */
 const analyticsReady: Promise<Analytics | undefined> = (async () => {
   if (!isConfigured || typeof window === "undefined" || isPlaceholderKey) {
     return undefined;

--- a/lib/game/content/hero-backstories/_index.ts
+++ b/lib/game/content/hero-backstories/_index.ts
@@ -1,4 +1,5 @@
 /**
+ * SPDX-License-Identifier: GPL-3.0-only
  * Copyright (C) 2026 Cursor Boston
  * This file is part of Cursor Boston, licensed under GPL-3.0.
  * See LICENSE file for details.

--- a/lib/hackathon-event-signup.ts
+++ b/lib/hackathon-event-signup.ts
@@ -5,21 +5,21 @@
  * See LICENSE file for details.
  */
 
-import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
 import {
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_DECLINED_EMAILS,
   SPORTS_HACK_2026_EVENT_ID,
   SPORTS_HACK_2026_JUDGE_EMAILS,
 } from "@/lib/sports-hack-2026";
+import {
+  HACKATHON_EVENT_ID_LIST,
+  type HackathonEventId,
+} from "@/types/hackathon-events";
 
 /** In-person / special events with website signup (separate from Luma). */
-export const HACKATHON_EVENT_SIGNUP_IDS = [
-  HACK_A_SPRINT_2026_EVENT_ID,
-  SPORTS_HACK_2026_EVENT_ID,
-] as const;
+export const HACKATHON_EVENT_SIGNUP_IDS = HACKATHON_EVENT_ID_LIST;
 
-export type HackathonEventSignupId = (typeof HACKATHON_EVENT_SIGNUP_IDS)[number];
+export type HackathonEventSignupId = HackathonEventId;
 
 export function isHackathonEventSignupId(
   eventId: string
@@ -28,7 +28,7 @@ export function isHackathonEventSignupId(
 }
 
 export function hackathonEventSignupDocId(
-  eventId: string,
+  eventId: HackathonEventSignupId,
   userId: string
 ): string {
   return `${eventId}__${userId}`;
@@ -144,7 +144,9 @@ export function getJudgeEmailsForEvent(eventId: string): ReadonlySet<string> {
   return JUDGE_EMAILS;
 }
 
-export function getDeclinedEmailsForEvent(eventId: string): ReadonlySet<string> {
+export function getDeclinedEmailsForEvent(
+  eventId: string
+): ReadonlySet<string> {
   if (eventId === SPORTS_HACK_2026_EVENT_ID) return SPORTS_HACK_2026_DECLINED_EMAILS;
   return DECLINED_EMAILS;
 }

--- a/lib/hackathon-showcase.ts
+++ b/lib/hackathon-showcase.ts
@@ -8,12 +8,14 @@
 import { unstable_cache } from "next/cache";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
 import { fetchWithTimeout } from "@/lib/http-fetch";
+import { HACKATHON_EVENT_IDS } from "@/types/hackathon-events";
 
-export const HACK_A_SPRINT_2026_EVENT_ID = "hack-a-sprint-2026";
+export const HACK_A_SPRINT_2026_EVENT_ID =
+  HACKATHON_EVENT_IDS.HACK_A_SPRINT_2026;
 export const SHOWCASE_SUBMISSIONS_CACHE_TAG = "showcase-submissions";
-export const HACK_A_SPRINT_2026_LABEL = "hack-a-sprint-2026";
+export const HACK_A_SPRINT_2026_LABEL = HACK_A_SPRINT_2026_EVENT_ID;
 export const HACK_A_SPRINT_2026_SUBMISSIONS_PATH =
-  "content/hackathons/hack-a-sprint-2026/submissions";
+  `content/hackathons/${HACK_A_SPRINT_2026_EVENT_ID}/submissions`;
 
 export type ShowcaseSubmissionPayload = {
   /** May be empty if omitted in JSON; hide repo link in UI when missing. */

--- a/lib/konami-handler.ts
+++ b/lib/konami-handler.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export type KonamiSequence = readonly string[];
+
+export const KONAMI_SEQUENCE = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+] as const satisfies KonamiSequence;
+
+const SEQUENCE_PROOF_KEYS: Record<string, string> = {
+  ArrowUp: "U",
+  ArrowDown: "D",
+  ArrowLeft: "L",
+  ArrowRight: "R",
+  b: "B",
+  a: "A",
+};
+
+export function sequenceToHeaderProof(sequence: KonamiSequence): string {
+  return sequence
+    .map((key) => SEQUENCE_PROOF_KEYS[key] ?? key.slice(0, 1).toUpperCase())
+    .join("");
+}
+
+export const KONAMI_SEQUENCE_HEADER = sequenceToHeaderProof(KONAMI_SEQUENCE);
+
+export function keyMatchesSequenceValue(key: string, expected: string): boolean {
+  return key.toLowerCase() === expected.toLowerCase();
+}
+
+export function nextSequenceIndex(
+  sequence: KonamiSequence,
+  currentIndex: number,
+  key: string
+): number {
+  const expected = sequence[currentIndex];
+  if (expected && keyMatchesSequenceValue(key, expected)) {
+    return currentIndex + 1;
+  }
+
+  const first = sequence[0];
+  return first && keyMatchesSequenceValue(key, first) ? 1 : 0;
+}

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -21,10 +21,14 @@ import type { UpstashRateLimitResult } from "./upstash-rate-limit";
 // Re-export rateLimitConfigs for convenience
 export { rateLimitConfigs } from "./rate-limit";
 
-// Allowed origins for CSRF protection
+// Allowed production origins for CSRF protection.
 const ALLOWED_ORIGINS = [
   "https://cursorboston.com",
   "https://www.cursorboston.com",
+];
+
+// Local development origins are never accepted in production.
+const DEVELOPMENT_ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:3001",
 ];
@@ -34,6 +38,17 @@ type RateLimitResult = ReturnType<typeof checkRateLimit> | UpstashRateLimitResul
 interface RateLimitBackendOptions {
   distributed?: boolean;
   failMode?: "degrade" | "closed";
+}
+
+function isDevelopmentEnvironment(): boolean {
+  return process.env["NODE_ENV"] === "development";
+}
+
+function isListedOriginAllowed(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) {
+    return true;
+  }
+  return isDevelopmentEnvironment() && DEVELOPMENT_ALLOWED_ORIGINS.includes(origin);
 }
 
 function rateLimitDeniedResponse(
@@ -87,7 +102,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
   // If no origin header, check referer (some browsers don't send origin)
   if (!origin && !referer) {
     // Allow requests without origin/referer in development only
-    return process.env.NODE_ENV === "development";
+    return isDevelopmentEnvironment();
   }
 
   // Check if origin matches allowed list
@@ -95,7 +110,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
     if (origin === new URL(request.url).origin) {
       return true;
     }
-    if (ALLOWED_ORIGINS.includes(origin)) {
+    if (isListedOriginAllowed(origin)) {
       return true;
     }
     // Allow if origin matches the app URL from environment
@@ -113,7 +128,7 @@ export function isOriginAllowed(request: NextRequest): boolean {
       if (refererOrigin === new URL(request.url).origin) {
         return true;
       }
-      if (ALLOWED_ORIGINS.includes(refererOrigin)) {
+      if (isListedOriginAllowed(refererOrigin)) {
         return true;
       }
       const appUrl = process.env.NEXT_PUBLIC_APP_URL;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -314,20 +314,6 @@ export const rateLimitConfigs = {
     maxRequests: 40, // 40 requests per minute
   },
   /**
-   * Rate limiting for unlocking Hackathon Showcase voting functionality.
-   */
-  hackathonShowcaseUnlock: {
-    windowMs: 60 * 1000, // 1 minute
-    maxRequests: 20, // 20 requests per minute
-  },
-  /**
-   * Strict rate limiting for brute-force prevention on Showcase unlock attempts.
-   */
-  hackathonShowcaseUnlockAttempts: {
-    windowMs: 5 * 60 * 1000, // 5 minutes
-    maxRequests: 15, // 15 attempts per 5 minutes
-  },
-  /**
    * Rate limiting for casting votes in the Hackathon Showcase.
    */
   hackathonShowcaseVote: {

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -61,20 +61,19 @@ function isLegacyAdminEmail(email?: string): boolean {
   return getLegacyAdminEmailSet().has(email.trim().toLowerCase());
 }
 
-/**
- * Verify the Firebase ID token from the request and return the authenticated user.
- * Checks both Authorization Bearer header and x-firebase-id-token header.
- * @param request - The incoming Next.js request
- * @returns The verified user object, or null if no token is provided
- * @throws Error if Firebase Admin Auth is not configured
- */
-export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUser | null> {
+function extractFirebaseIdToken(request: NextRequest): string {
   const authHeader = request.headers.get("authorization") || "";
   const match = authHeader.match(/^Bearer\s+(.+)$/);
   const tokenFromAuth = match ? match[1].trim() : "";
   const tokenFromHeader = request.headers.get("x-firebase-id-token")?.trim() || "";
-  const token = tokenFromAuth || tokenFromHeader;
+  return tokenFromAuth || tokenFromHeader;
+}
 
+async function verifyRequestUser(
+  request: NextRequest,
+  checkRevoked: boolean
+): Promise<VerifiedUser | null> {
+  const token = extractFirebaseIdToken(request);
   if (!token) {
     return null;
   }
@@ -85,7 +84,7 @@ export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUse
   }
 
   // checkRevoked=false: revocation check can fail (tenant/API issues).
-  const decoded = await adminAuth.verifyIdToken(token, false);
+  const decoded = await adminAuth.verifyIdToken(token, checkRevoked);
   const role = typeof decoded.role === "string" ? decoded.role : undefined;
   const roles = toStringArray(decoded.roles);
   const hasExplicitAdminClaims = hasExplicitAdminClaimFields(decoded);
@@ -106,6 +105,77 @@ export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUse
 }
 
 /**
+ * Verify the Firebase ID token from the request and return the authenticated user.
+ * Checks both Authorization Bearer header and x-firebase-id-token header.
+ * @param request - The incoming Next.js request
+ * @returns The verified user object, or null if no token is provided
+ * @throws Error if Firebase Admin Auth is not configured
+ */
+export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUser | null> {
+  // Keep the default path non-revocation checked for ordinary user reads.
+  return verifyRequestUser(request, false);
+}
+
+/**
+ * Verify the Firebase ID token with revocation checks for sensitive non-admin
+ * flows such as financial benefit delivery.
+ */
+export async function getVerifiedUserWithRevocation(
+  request: NextRequest
+): Promise<VerifiedUser | null> {
+  return verifyRequestUser(request, true);
+}
+
+export async function isCurrentIdTokenRevoked(request: NextRequest): Promise<boolean> {
+  const token = extractFirebaseIdToken(request);
+  if (!token) {
+    return false;
+  }
+
+  const adminAuth = getAdminAuth();
+  if (!adminAuth) {
+    return false;
+  }
+
+  try {
+    await adminAuth.verifyIdToken(token, true);
+    return false;
+  } catch (error) {
+    return isRevokedIdTokenError(error);
+  }
+}
+
+export async function getVerifiedAdminUser(
+  request: NextRequest
+): Promise<VerifiedUser | null> {
+  return verifyRequestUser(request, false);
+}
+
+export function isRevokedIdTokenError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const err = error as {
+    code?: unknown;
+    message?: unknown;
+    errorInfo?: { code?: unknown };
+  };
+  const code =
+    typeof err.code === "string"
+      ? err.code
+      : typeof err.errorInfo?.code === "string"
+      ? err.errorInfo.code
+      : "";
+  if (code === "auth/id-token-revoked") {
+    return true;
+  }
+
+  const message = typeof err.message === "string" ? err.message : "";
+  return message.toLowerCase().includes("id token has been revoked");
+}
+
+/**
  * Like getVerifiedUser, but returns null if the token is missing or invalid.
  * For public API handlers that optionally personalize the response.
  * @param request - The incoming Next.js request
@@ -114,39 +184,8 @@ export async function getVerifiedUser(request: NextRequest): Promise<VerifiedUse
 export async function getOptionalVerifiedUser(
   request: NextRequest
 ): Promise<VerifiedUser | null> {
-  const authHeader = request.headers.get("authorization") || "";
-  const match = authHeader.match(/^Bearer\s+(.+)$/);
-  const tokenFromAuth = match ? match[1].trim() : "";
-  const tokenFromHeader = request.headers.get("x-firebase-id-token")?.trim() || "";
-  const token = tokenFromAuth || tokenFromHeader;
-
-  if (!token) {
-    return null;
-  }
-
-  const adminAuth = getAdminAuth();
-  if (!adminAuth) {
-    return null;
-  }
-
   try {
-    const decoded = await adminAuth.verifyIdToken(token, false);
-    const role = typeof decoded.role === "string" ? decoded.role : undefined;
-    const roles = toStringArray(decoded.roles);
-    const hasExplicitAdminClaims = hasExplicitAdminClaimFields(decoded);
-    const claimAdmin = hasAdminClaim(decoded);
-    const isAdmin =
-      claimAdmin || (!hasExplicitAdminClaims && isLegacyAdminEmail(decoded.email));
-
-    return {
-      uid: decoded.uid,
-      name: decoded.name,
-      email: decoded.email,
-      picture: decoded.picture,
-      isAdmin,
-      role,
-      roles,
-    };
+    return await verifyRequestUser(request, false);
   } catch {
     return null;
   }

--- a/lib/sports-hack-2026.ts
+++ b/lib/sports-hack-2026.ts
@@ -5,7 +5,10 @@
  * See LICENSE file for details.
  */
 
-export const SPORTS_HACK_2026_EVENT_ID = "sports-hack-2026";
+import { HACKATHON_EVENT_IDS } from "@/types/hackathon-events";
+
+export const SPORTS_HACK_2026_EVENT_ID =
+  HACKATHON_EVENT_IDS.SPORTS_HACK_2026;
 
 export const SPORTS_HACK_2026_NAME = "Boston Tech Week Sports Hack";
 export const SPORTS_HACK_2026_SHORT_NAME = "Sports Hack 2026";

--- a/lib/summer-cohort-submissions.ts
+++ b/lib/summer-cohort-submissions.ts
@@ -7,6 +7,7 @@
 
 import { getAdminDb } from "./firebase-admin";
 import { getGithubRepoPair } from "./github-recent-merged-prs";
+import { fetchWithTimeout } from "./http-fetch";
 import { logger } from "./logger";
 import {
   SUMMER_COHORT_C1_VOTE_WEEKS,
@@ -30,6 +31,8 @@ export interface SummerCohortSubmissionsSummary {
   path: string;
   merged: number;
   tryingToWin: number;
+  /** GitHub list/file fetch failures skipped while building this feed. */
+  githubFetchErrorCount: number;
   /** Sorted by githubHandle for stable ordering. */
   submissions: ReadonlyArray<{
     githubHandle: string;
@@ -44,6 +47,8 @@ export interface SummerCohortSubmissionsSummary {
     photoUrl: string | null;
   }>;
 }
+
+const GITHUB_FETCH_TIMEOUT_MS = 8_000;
 
 /** Strip leading slashes / `<github-handle>.json` placeholder so we can use the
  *  path as a directory listing target on the GitHub Contents API. */
@@ -183,6 +188,7 @@ export async function fetchSummerCohortSubmissions(
     path: dirPath,
     merged: 0,
     tryingToWin: 0,
+    githubFetchErrorCount: 0,
     submissions: [],
   };
 
@@ -192,21 +198,25 @@ export async function fetchSummerCohortSubmissions(
 
   let listRes: Response;
   try {
-    listRes = await fetch(listUrl, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    listRes = await fetchWithTimeout(
+      listUrl,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        next: { revalidate: 60 },
       },
-      next: { revalidate: 60 },
-    });
+      GITHUB_FETCH_TIMEOUT_MS
+    );
   } catch (error) {
     logger.warn("fetchSummerCohortSubmissions: contents-list fetch failed", {
       weekId,
       branch: week.submissionBranch,
       error: error instanceof Error ? error.message : String(error),
     });
-    return empty;
+    return { ...empty, githubFetchErrorCount: 1 };
   }
 
   // 404 = branch or directory doesn't exist yet (program hasn't started, or
@@ -218,41 +228,68 @@ export async function fetchSummerCohortSubmissions(
       branch: week.submissionBranch,
       status: listRes.status,
     });
-    return empty;
+    return { ...empty, githubFetchErrorCount: 1 };
   }
 
   let listJson: unknown;
   try {
     listJson = await listRes.json();
   } catch {
-    return empty;
+    return { ...empty, githubFetchErrorCount: 1 };
   }
-  if (!Array.isArray(listJson)) return empty;
+  if (!Array.isArray(listJson)) return { ...empty, githubFetchErrorCount: 1 };
 
   const fileItems = (listJson as ContentsApiItem[]).filter(isJsonFileItem);
 
-  const submissions = await Promise.all(
+  const submissionResults = await Promise.all(
     fileItems.map(async (item) => {
       const downloadUrl =
         typeof item.download_url === "string" ? item.download_url : null;
       const name = typeof item.name === "string" ? item.name : "";
       const fallbackHandle = name.replace(/\.json$/, "");
-      if (!downloadUrl) return null;
+      if (!downloadUrl) return { submission: null, githubFetchErrorCount: 0 };
       try {
-        const fileRes = await fetch(downloadUrl, {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-          next: { revalidate: 60 },
-        });
-        if (!fileRes.ok) return null;
-        const fileJson = await fileRes.json();
-        return normalizeSubmission(fileJson, fallbackHandle);
+        const fileRes = await fetchWithTimeout(
+          downloadUrl,
+          {
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
+            next: { revalidate: 60 },
+          },
+          GITHUB_FETCH_TIMEOUT_MS
+        );
+        if (!fileRes.ok) {
+          return { submission: null, githubFetchErrorCount: 1 };
+        }
+        let fileJson: unknown;
+        try {
+          fileJson = await fileRes.json();
+        } catch {
+          return { submission: null, githubFetchErrorCount: 1 };
+        }
+        return {
+          submission: normalizeSubmission(fileJson, fallbackHandle),
+          githubFetchErrorCount: 0,
+        };
       } catch {
-        return null;
+        return { submission: null, githubFetchErrorCount: 1 };
       }
     })
   );
 
-  const cleaned = submissions
+  const githubFetchErrorCount = submissionResults.reduce(
+    (sum, result) => sum + result.githubFetchErrorCount,
+    0
+  );
+  if (githubFetchErrorCount > 0) {
+    logger.warn("fetchSummerCohortSubmissions: file fetches failed", {
+      weekId,
+      branch: week.submissionBranch,
+      githubFetchErrorCount,
+    });
+  }
+
+  const cleaned = submissionResults
+    .map((result) => result.submission)
     .filter((s): s is RawSubmission => s !== null)
     .sort((a, b) => a.githubHandle.localeCompare(b.githubHandle));
 
@@ -289,6 +326,7 @@ export async function fetchSummerCohortSubmissions(
     path: dirPath,
     merged,
     tryingToWin,
+    githubFetchErrorCount,
     submissions: finalized,
   };
 }

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,18 @@ function reproducibleBuildId() {
   }
 }
 
+function isCiEnvironment() {
+  return process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true'
+}
+
+function shouldSkipTypecheck() {
+  if (process.env.SKIP_TYPECHECK !== '1') return false
+  if (isCiEnvironment()) {
+    throw new Error('SKIP_TYPECHECK=1 is local-only and must not be set in CI')
+  }
+  return true
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // If a package-lock.json exists above this repo (e.g. in $HOME), Next.js would pick that
@@ -39,7 +51,7 @@ const nextConfig = {
   // unrelated type/lint errors. NEVER set this in CI; CI is the boundary
   // that catches real type errors. See CLAUDE.md "Local production
   // verification — emergency typecheck bypass".
-  ...(process.env.SKIP_TYPECHECK === '1'
+  ...(shouldSkipTypecheck()
     ? {
         typescript: { ignoreBuildErrors: true },
         eslint: { ignoreDuringBuilds: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11779,15 +11779,15 @@
       "optional": true
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -11806,7 +11806,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -11860,22 +11860,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -20767,9 +20751,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/scripts/build-hero-backstory-index.ts
+++ b/scripts/build-hero-backstory-index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /**
+ * SPDX-License-Identifier: GPL-3.0-only
  * Copyright (C) 2026 Cursor Boston
  * This file is part of Cursor Boston, licensed under GPL-3.0.
  * See LICENSE file for details.
@@ -35,6 +36,7 @@ function main(): void {
   const heroIds = entries.map((f) => f.replace(/\.md$/, "")).sort();
   const lines = heroIds.map((id) => `  ${JSON.stringify(id)},`).join("\n");
   const next = `/**
+ * SPDX-License-Identifier: GPL-3.0-only
  * Copyright (C) 2026 Cursor Boston
  * This file is part of Cursor Boston, licensed under GPL-3.0.
  * See LICENSE file for details.

--- a/scripts/check-route-contracts.js
+++ b/scripts/check-route-contracts.js
@@ -57,6 +57,7 @@ let withContract = 0;
 for (const file of walk(API_DIR)) {
   const rel = path
     .relative(API_DIR, file)
+    .replace(/\\/g, "/")
     .replace(/[\\/]route\.tsx?$/, "");
   const src = fs.readFileSync(file, "utf8");
   const hasContract =

--- a/types/cookbook.ts
+++ b/types/cookbook.ts
@@ -37,6 +37,13 @@ export const WORKS_WITH_LANGUAGES = [
 
 export type WorksWithTag = (typeof WORKS_WITH_LANGUAGES)[number];
 
+export interface CookbookEntrySeo {
+  title?: string;
+  description?: string;
+  image?: string;
+  canonicalUrl?: string;
+}
+
 export interface CookbookEntry {
   id: string;
   title: string;
@@ -50,4 +57,5 @@ export interface CookbookEntry {
   createdAt: string;
   upCount: number;
   downCount: number;
+  seo?: CookbookEntrySeo;
 }

--- a/types/hackathon-events.ts
+++ b/types/hackathon-events.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export const HACKATHON_EVENT_IDS = {
+  HACK_A_SPRINT_2026: "hack-a-sprint-2026",
+  SPORTS_HACK_2026: "sports-hack-2026",
+} as const;
+
+export type HackathonEventId =
+  (typeof HACKATHON_EVENT_IDS)[keyof typeof HACKATHON_EVENT_IDS];
+
+export const HACKATHON_EVENT_ID_LIST = [
+  HACKATHON_EVENT_IDS.HACK_A_SPRINT_2026,
+  HACKATHON_EVENT_IDS.SPORTS_HACK_2026,
+] as const satisfies readonly HackathonEventId[];


### PR DESCRIPTION
## Summary

Promotes today's develop work to `main`. 21 commits — one CI baseline unblock (#1345) followed by a batch of security/reliability hardening, refactors, tests, and docs from Carter Theogene plus a Dependabot patch bump.

## Highlights

- **Security hardening:** revoked-token rejection on 13 admin/sensitive routes (#1347), CSRF localhost origins gated to dev only (#1360), CI typecheck bypass guarded (#1364), fail-closed semantics elsewhere reinforced.
- **Reliability:** 8-second timeouts on all GitHub API fetches (#1341) — particularly load-bearing for the Sports Hack 2026-05-26T20:00:00Z disqualifier cron. Hackathon signup leaderboard refresh wired into the GitHub webhook (#1351).
- **New feature:** cookbook entry SEO pages at `/cookbook/[slug]` with CreativeWork JSON-LD (#1365).
- **Foundation:** centralized hackathon event ID registry (#1368), reusable Konami listener (#1367), shared API validation messages (#1362).
- **Dev experience:** Windows path compat across smoke tests and route-contract scripts (#1352, #1366), husky hooks hardened for `HUSKY=0` + spaced paths (#1355), portable NODE_ENV in middleware tests (#1353).

## Included PRs and contributors

All 21 PRs reviewed (with diff-level backdoor audit) before merge. Listed by merge order on develop:

| PR | Title | Contributor |
|---|---|---|
| #1345 | chore: unblock base CI hygiene checks | Carter Theogene (@mrrCarter) |
| #1358 | test(pairing): cover matching edge cases | Carter Theogene |
| #1354 | test(pair-page): stable Next router mock identity | Carter Theogene |
| #1353 | test(middleware): portable NODE_ENV assignment | Carter Theogene |
| #1357 | chore: remove dead showcase unlock rate-limit presets | Carter Theogene |
| #1356 | docs: document API caching strategy | Carter Theogene |
| #1363 | fix: label community feed action buttons | Carter Theogene |
| #1366 | fix: normalize route contract paths on windows | Carter Theogene |
| #1368 | refactor: centralize hackathon event ids | Carter Theogene |
| #1367 | refactor: extract reusable konami listener | Carter Theogene |
| #1365 | feat: add cookbook entry SEO pages | Carter Theogene |
| #1364 | test: guard typecheck bypass from CI | Carter Theogene |
| #1360 | fix: gate localhost csrf origins to development | Carter Theogene |
| #1351 | fix(hackathons): refresh signup leaderboard after merges | Carter Theogene |
| #1347 | fix: reject revoked tokens on sensitive routes | Carter Theogene |
| #1355 | fix: harden husky hooks for spaced paths | Carter Theogene |
| #1341 | fix: time out GitHub submission fetches | Carter Theogene |
| #1342 | chore(deps): Bump qs to 6.15.2 | @dependabot |
| #1352 | test: normalize Windows module-ID paths in smoke harness | Carter Theogene |
| #1359 | docs(firebase): clarify client and admin helper usage | Carter Theogene |
| #1362 | refactor: centralize API validation messages | Carter Theogene |

## Verification

- All 21 PRs passed `Lint and Type Check`, `Test`, `E2E Tests`, `Firestore rules tests`, `REUSE lint`, `Signed-off-by (DCO)`, and `Security Scanning` on their post-rebase SHAs.
- Per-PR review comments posted in advance; security-focused backdoor audit covered all 21 diffs (one footgun flagged for follow-up on `getVerifiedAdminUser` naming in `lib/server-auth.ts` — not exploited by any current route).
- Local `npm run build` succeeded against develop tip (typecheck bypassed via `SKIP_TYPECHECK=1` for an unrelated untracked script per CLAUDE.md emergency procedure).

## Post-merge

- Fast-forward the cohort/event submission branches per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)