### PR TITLE
fix(auth): enforce isAdmin in getVerifiedAdminUser

### DIFF
--- a/__tests__/lib/server-auth.test.ts
+++ b/__tests__/lib/server-auth.test.ts
@@ -102,6 +102,17 @@ describe("getVerifiedUser admin authorization bridge", () => {
     expect(verifyFn).toHaveBeenCalledWith("test-token", false);
   });
 
+  it("returns null from the admin helper when the verified user lacks admin claims", async () => {
+    mockVerify({ uid: "u-non-admin", email: "regular@example.com" });
+    const user = await getVerifiedAdminUser(makeRequest());
+    expect(user).toBeNull();
+  });
+
+  it("returns null from the admin helper when no token is presented", async () => {
+    const user = await getVerifiedAdminUser(makeRequest({}));
+    expect(user).toBeNull();
+  });
+
   it("uses revocation checks on the sensitive user helper path", async () => {
     const verifyFn = mockVerify({ uid: "credit-user", email: "u@example.com" });
     const user = await getVerifiedUserWithRevocation(makeRequest());

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -145,10 +145,24 @@ export async function isCurrentIdTokenRevoked(request: NextRequest): Promise<boo
   }
 }
 
+/**
+ * Verify the Firebase ID token AND require admin status. Combines the auth
+ * + role gate that admin routes used to spell out in two steps.
+ *
+ * Returns null when the request has no token, the token is missing the admin
+ * claim, OR the resolved user is not in the admin role set. Callers should
+ * treat null as 401/403 (route returns 401 to avoid leaking admin status).
+ *
+ * Throws when Firebase Admin Auth is not configured.
+ */
 export async function getVerifiedAdminUser(
   request: NextRequest
 ): Promise<VerifiedUser | null> {
-  return verifyRequestUser(request, false);
+  const user = await verifyRequestUser(request, false);
+  if (!user || !user.isAdmin) {
+    return null;
+  }
+  return user;
 }
 
 export function isRevokedIdTokenError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

Tighten the `getVerifiedAdminUser` helper introduced in #1347 so it actually enforces admin status, matching its name.

## Background

PR #1347 (\"fix: reject revoked tokens on sensitive routes\") introduced \`getVerifiedAdminUser\` as an exported helper alongside the revocation-check work. Its body was:

```ts
export async function getVerifiedAdminUser(
  request: NextRequest
): Promise<VerifiedUser | null> {
  return verifyRequestUser(request, false);
}
```

i.e. **identical to \`getVerifiedUser\`** — no \`isAdmin\` check. The security audit on #1347 flagged this as a footgun: a future caller adopting the helper based on its name would silently authorize any logged-in user as an admin. No live route relies on the helper today, so this is preventative not reactive.

## Fix

The helper now requires the admin claim and returns null otherwise:

```ts
export async function getVerifiedAdminUser(
  request: NextRequest
): Promise<VerifiedUser | null> {
  const user = await verifyRequestUser(request, false);
  if (!user || !user.isAdmin) {
    return null;
  }
  return user;
}
```

Returns null when:
- No token / token missing
- Token invalid (via the existing \`verifyRequestUser\` path)
- Verified user lacks the admin claim

Throws when Firebase Admin Auth is not configured (unchanged).

## Tests

Added two cases to \`__tests__/lib/server-auth.test.ts\`:

- \"returns null from the admin helper when the verified user lacks admin claims\" — a token resolved to a non-admin user yields null.
- \"returns null from the admin helper when no token is presented\" — empty-headers request yields null.

The existing positive-case test (\"keeps the admin helper on the non-revocation default path\") continues to pass because it mocks a token with \`admin: true\`.

Full test suite: \`npx jest --config config/jest.config.js __tests__/lib/server-auth.test.ts __tests__/_helpers/_helpers-smoke.test.ts __tests__/app/api/all-routes-handler-invoke-authed.test.ts __tests__/app/api/all-routes-handler-invoke.test.ts __tests__/app/api/all-routes-smoke.test.ts --runInBand\` — all 71 passing.

## Test plan
- [x] Existing positive-case test still passes (admin token → user with isAdmin: true)
- [x] New negative-case test: non-admin token → null
- [x] New no-token test: empty headers → null
- [x] Downstream auth-mock tests in \`__tests__/_helpers/\` and \`__tests__/app/api/all-routes-*\` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)