### PR TITLE
release: develop → main batch 3 (2026-05-23) — Sports Hack confirm-attendance + auth helper hardening

### DIFF
--- a/__tests__/app/api/hackathons/events/confirm-attendance.route.test.ts
+++ b/__tests__/app/api/hackathons/events/confirm-attendance.route.test.ts
@@ -1,0 +1,297 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import {
+  POST,
+  DELETE,
+} from "@/app/api/hackathons/events/[eventId]/confirm-attendance/route";
+import { getVerifiedUser } from "@/lib/server-auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
+
+jest.mock("@/lib/rate-limit", () => {
+  const actual = jest.requireActual("@/lib/rate-limit");
+  return {
+    ...actual,
+    getClientIdentifier: jest.fn(() => "test-ip"),
+    checkRateLimit: jest.fn(() => ({ success: true, retryAfter: 0 })),
+  };
+});
+
+jest.mock("@/lib/upstash-rate-limit", () => ({
+  checkUpstashRateLimit: jest.fn(async () => ({
+    success: true,
+    remaining: 9,
+    resetTime: Date.now() + 60000,
+  })),
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/hackathon-leaderboard-snapshot", () => ({
+  refreshSnapshot: jest.fn(async () => ({
+    entries: [],
+    totalCount: 0,
+    websiteSignupCount: 0,
+    creditTopN: 119,
+    confirmedAttendeeCount: 0,
+    attendanceLimit: 200,
+    generatedAt: new Date().toISOString(),
+  })),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<
+  typeof getVerifiedUser
+>;
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+const mockRefreshSnapshot = refreshSnapshot as jest.MockedFunction<
+  typeof refreshSnapshot
+>;
+const { checkUpstashRateLimit } = jest.requireMock(
+  "@/lib/upstash-rate-limit"
+) as { checkUpstashRateLimit: jest.Mock };
+
+const VALID_EVENT_ID = "sports-hack-2026";
+
+function makeContext(eventId: string) {
+  return { params: Promise.resolve({ eventId }) };
+}
+
+function makeRequest(method: "POST" | "DELETE") {
+  return new NextRequest(
+    `http://localhost/api/hackathons/events/${VALID_EVENT_ID}/confirm-attendance`,
+    { method }
+  );
+}
+
+function makeMockSignupDoc(data: Record<string, unknown> | null) {
+  const update = jest.fn(async () => undefined);
+  return {
+    update,
+    snap: {
+      exists: data !== null,
+      data: () => data,
+    },
+  };
+}
+
+describe("POST /api/hackathons/events/[eventId]/confirm-attendance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRefreshSnapshot.mockResolvedValue({
+      entries: [
+        {
+          rank: 1,
+          userId: "user-1",
+          displayName: "User One",
+          githubLogin: null,
+          mergedPrCount: 0,
+          signedUpAt: "2026-01-01T00:00:00.000Z",
+          creditEligible: false,
+          status: "waitlisted",
+          checkedIn: false,
+          willBeLate: false,
+          queuingForSpot: false,
+          lumaRegistered: false,
+          isCohort1: false,
+          attendingConfirmed: true,
+          attendingConfirmedAt: "2026-05-23T00:00:00.000Z",
+          attendanceRank: 1,
+        },
+      ],
+      totalCount: 1,
+      websiteSignupCount: 1,
+      creditTopN: 119,
+      confirmedAttendeeCount: 1,
+      attendanceLimit: 200,
+      generatedAt: new Date().toISOString(),
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest("POST"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    checkUpstashRateLimit.mockResolvedValueOnce({
+      success: false,
+      retryAfter: 30,
+    });
+    const res = await POST(makeRequest("POST"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("returns 404 for unknown event ID", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    const res = await POST(makeRequest("POST"), makeContext("bogus-event"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when db is not configured", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    mockGetAdminDb.mockReturnValue(null as never);
+    const res = await POST(makeRequest("POST"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 404 when the user has not signed up", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    const mock = makeMockSignupDoc(null);
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => mock.snap),
+          update: mock.update,
+        })),
+      })),
+    } as never);
+    const res = await POST(makeRequest("POST"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(404);
+    expect(mock.update).not.toHaveBeenCalled();
+  });
+
+  it("sets attendingConfirmedAt and returns 200", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    const mock = makeMockSignupDoc({
+      userId: "user-1",
+      signedUpAt: new Date("2026-05-20"),
+    });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => mock.snap),
+          update: mock.update,
+        })),
+      })),
+    } as never);
+    const res = await POST(makeRequest("POST"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    expect(mock.update).toHaveBeenCalledTimes(1);
+    const callArg = mock.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(callArg)).toEqual(["attendingConfirmedAt"]);
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith(VALID_EVENT_ID);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      ok: true,
+      attendingConfirmed: true,
+      confirmedAttendeeCount: 1,
+      attendanceLimit: 200,
+    });
+  });
+
+  it("is idempotent: skips the update when already confirmed", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    const mock = makeMockSignupDoc({
+      userId: "user-1",
+      signedUpAt: new Date("2026-05-20"),
+      attendingConfirmedAt: new Date("2026-05-21"),
+    });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => mock.snap),
+          update: mock.update,
+        })),
+      })),
+    } as never);
+    const res = await POST(makeRequest("POST"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    expect(mock.update).not.toHaveBeenCalled();
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith(VALID_EVENT_ID);
+  });
+});
+
+describe("DELETE /api/hackathons/events/[eventId]/confirm-attendance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRefreshSnapshot.mockResolvedValue({
+      entries: [],
+      totalCount: 0,
+      websiteSignupCount: 0,
+      creditTopN: 119,
+      confirmedAttendeeCount: 0,
+      attendanceLimit: 200,
+      generatedAt: new Date().toISOString(),
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await DELETE(makeRequest("DELETE"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when not signed up", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    const mock = makeMockSignupDoc(null);
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => mock.snap),
+          update: mock.update,
+        })),
+      })),
+    } as never);
+    const res = await DELETE(makeRequest("DELETE"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(404);
+    expect(mock.update).not.toHaveBeenCalled();
+  });
+
+  it("clears attendingConfirmedAt and returns 200", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    const mock = makeMockSignupDoc({
+      userId: "user-1",
+      signedUpAt: new Date("2026-05-20"),
+      attendingConfirmedAt: new Date("2026-05-21"),
+    });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => mock.snap),
+          update: mock.update,
+        })),
+      })),
+    } as never);
+    const res = await DELETE(makeRequest("DELETE"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    expect(mock.update).toHaveBeenCalledTimes(1);
+    const callArg = mock.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(callArg)).toEqual(["attendingConfirmedAt"]);
+    expect(mockRefreshSnapshot).toHaveBeenCalledWith(VALID_EVENT_ID);
+  });
+
+  it("is idempotent: skips the update when not currently confirmed", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "user-1", email: "u@test.com" });
+    const mock = makeMockSignupDoc({
+      userId: "user-1",
+      signedUpAt: new Date("2026-05-20"),
+    });
+    mockGetAdminDb.mockReturnValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn(async () => mock.snap),
+          update: mock.update,
+        })),
+      })),
+    } as never);
+    const res = await DELETE(makeRequest("DELETE"), makeContext(VALID_EVENT_ID));
+    expect(res.status).toBe(200);
+    expect(mock.update).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/hackathons/sports-hack-page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-page.test.tsx
@@ -33,6 +33,7 @@ jest.mock("@/lib/sports-hack-2026", () => ({
   SPORTS_HACK_2026_LUMA_URL: "https://lu.ma/sports",
   SPORTS_HACK_2026_LUMA_EMBED_ID: "embed",
   SPORTS_HACK_2026_CAPACITY: 50,
+  SPORTS_HACK_2026_ATTENDANCE_LIMIT: 200,
 }));
 
 import SportsHack2026LandingPage from "@/app/hackathons/sports-hack-2026/page";
@@ -61,7 +62,8 @@ describe("SportsHack2026LandingPage", () => {
     setAuth();
     render(<SportsHack2026LandingPage />);
     expect(screen.getAllByText(/Sports Hack/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/50 confirmed seats/)).toBeInTheDocument();
+    expect(screen.getByText(/Top 50 get Cursor credit/)).toBeInTheDocument();
+    expect(screen.getByText(/guaranteed-entry cap/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Register on the website/i })).toBeInTheDocument();
   });
 
@@ -77,12 +79,17 @@ describe("SportsHack2026LandingPage", () => {
           { rank: 3, status: "waitlisted", creditEligible: false },
         ],
         creditTopN: 50,
+        confirmedAttendeeCount: 0,
+        attendanceLimit: 200,
         me: null,
       }),
     })) as never;
     setAuth();
     render(<SportsHack2026LandingPage />);
-    await waitFor(() => expect(screen.getByText(/2\/50 confirmed · 60 registered/)).toBeInTheDocument());
+    // Credit seats locked stat shows the rank-frozen confirmed count
+    await waitFor(() => expect(screen.getByText(/2\/50 \(Cursor credit link\)/)).toBeInTheDocument());
+    // Confirmed-attending stat shows the new opt-in count
+    expect(screen.getByText(/0\/200 · 60 signed up/)).toBeInTheDocument();
   });
 
   it("falls back to creditEligible when entry.status is undefined", async () => {
@@ -95,11 +102,13 @@ describe("SportsHack2026LandingPage", () => {
           { rank: 2, creditEligible: false }, // → waitlisted via fallback
         ],
         creditTopN: 50,
+        confirmedAttendeeCount: 0,
+        attendanceLimit: 200,
       }),
     })) as never;
     setAuth();
     render(<SportsHack2026LandingPage />);
-    await waitFor(() => expect(screen.getByText(/1\/50 confirmed · 10 registered/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/1\/50 \(Cursor credit link\)/)).toBeInTheDocument());
   });
 
   it("renders signed-up CTA with rank when user is in leaderboard", async () => {

--- a/__tests__/components/hackathons/SportsHackConfirmAttendanceModal.test.tsx
+++ b/__tests__/components/hackathons/SportsHackConfirmAttendanceModal.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SportsHackConfirmAttendanceModal } from "@/components/hackathons/SportsHackConfirmAttendanceModal";
+import { useAuth } from "@/contexts/AuthContext";
+import { usePathname } from "next/navigation";
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/"),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    onClick,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    onClick?: () => void;
+    className?: string;
+  }) => (
+    <a href={href} onClick={onClick} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+
+function setAuth(
+  signedIn: boolean,
+  opts: { loading?: boolean } = {}
+) {
+  mockUseAuth.mockReturnValue({
+    user: signedIn
+      ? ({ uid: "u1", getIdToken: async () => "fake-token" } as never)
+      : null,
+    loading: opts.loading ?? false,
+  } as never);
+}
+
+function setSignupResponse(
+  fetchMock: jest.Mock,
+  body: { signedUp: boolean; attendingConfirmed?: boolean }
+) {
+  fetchMock.mockImplementationOnce(async () => ({
+    ok: true,
+    json: async () => ({ me: body }),
+  }));
+}
+
+describe("SportsHackConfirmAttendanceModal", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-24T12:00:00Z"));
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    window.sessionStorage.clear();
+    mockUsePathname.mockReturnValue("/");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders nothing when the user is not signed in", () => {
+    setAuth(false);
+    render(<SportsHackConfirmAttendanceModal />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing while auth is still loading", () => {
+    setAuth(true, { loading: true });
+    render(<SportsHackConfirmAttendanceModal />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when pathname starts with /hackathons/sports-hack-2026", async () => {
+    setAuth(true);
+    mockUsePathname.mockReturnValue("/hackathons/sports-hack-2026/signup");
+    render(<SportsHackConfirmAttendanceModal />);
+    await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing if sessionStorage flag is set", async () => {
+    window.sessionStorage.setItem("sports-hack-2026-confirm-dismissed", "1");
+    setAuth(true);
+    render(<SportsHackConfirmAttendanceModal />);
+    await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when event date has passed", async () => {
+    jest.setSystemTime(new Date("2026-05-28T00:00:00Z"));
+    setAuth(true);
+    render(<SportsHackConfirmAttendanceModal />);
+    await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when me.signedUp is false", async () => {
+    setAuth(true);
+    setSignupResponse(fetchMock, { signedUp: false });
+    render(<SportsHackConfirmAttendanceModal />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when already attendingConfirmed", async () => {
+    setAuth(true);
+    setSignupResponse(fetchMock, { signedUp: true, attendingConfirmed: true });
+    render(<SportsHackConfirmAttendanceModal />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders modal when signed up but not confirmed", async () => {
+    setAuth(true);
+    setSignupResponse(fetchMock, { signedUp: true, attendingConfirmed: false });
+    render(<SportsHackConfirmAttendanceModal />);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Confirm I'll attend/i })).toBeInTheDocument();
+  });
+
+  it("calls POST /confirm-attendance on Confirm click and hides modal on success", async () => {
+    jest.useRealTimers();
+    setAuth(true);
+    setSignupResponse(fetchMock, { signedUp: true, attendingConfirmed: false });
+    fetchMock.mockImplementationOnce(async () => ({ ok: true, json: async () => ({ ok: true }) }));
+
+    render(<SportsHackConfirmAttendanceModal />);
+    const confirmButton = await screen.findByRole("button", {
+      name: /Confirm I'll attend/i,
+    });
+
+    const user = userEvent.setup();
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+    expect(fetchMock.mock.calls[1][0]).toContain("/confirm-attendance");
+    expect(fetchMock.mock.calls[1][1]?.method).toBe("POST");
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("dismisses + writes sessionStorage flag on X click", async () => {
+    jest.useRealTimers();
+    setAuth(true);
+    setSignupResponse(fetchMock, { signedUp: true, attendingConfirmed: false });
+
+    render(<SportsHackConfirmAttendanceModal />);
+    const dismissButton = await screen.findByRole("button", { name: /Dismiss/i });
+
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.click(dismissButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(window.sessionStorage.getItem("sports-hack-2026-confirm-dismissed")).toBe("1");
+  });
+});

--- a/__tests__/lib/hackathon-event-signup-ranking.test.ts
+++ b/__tests__/lib/hackathon-event-signup-ranking.test.ts
@@ -9,11 +9,13 @@
 import {
   CURSOR_CREDIT_TOP_N,
   compareUnifiedHackathonRanking,
+  getAttendanceLimitForEvent,
   getConfirmedCapacityForEvent,
   getHackathonEventSignupBlockReason,
   hackathonEventSignupDocId,
 } from "@/lib/hackathon-event-signup";
 import {
+  SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
 } from "@/lib/sports-hack-2026";
@@ -37,6 +39,19 @@ describe("hackathon-event-signup ranking + capacity", () => {
 
     it("falls back to CURSOR_CREDIT_TOP_N for any other event", () => {
       expect(getConfirmedCapacityForEvent("any-other")).toBe(CURSOR_CREDIT_TOP_N);
+    });
+  });
+
+  describe("getAttendanceLimitForEvent", () => {
+    it("returns SPORTS_HACK_2026_ATTENDANCE_LIMIT for sports-hack-2026", () => {
+      expect(getAttendanceLimitForEvent(SPORTS_HACK_2026_EVENT_ID)).toBe(
+        SPORTS_HACK_2026_ATTENDANCE_LIMIT
+      );
+    });
+
+    it("returns 0 (feature off) for any other event", () => {
+      expect(getAttendanceLimitForEvent("hack-a-sprint-2026")).toBe(0);
+      expect(getAttendanceLimitForEvent("any-other")).toBe(0);
     });
   });
 

--- a/__tests__/lib/hackathon-leaderboard-snapshot.attendance.test.ts
+++ b/__tests__/lib/hackathon-leaderboard-snapshot.attendance.test.ts
@@ -1,0 +1,244 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment node
+ *
+ * Coverage for the second-step "Confirm attendance" fields on the leaderboard
+ * snapshot: attendingConfirmed / attendingConfirmedAt / attendanceRank per
+ * entry plus confirmedAttendeeCount / attendanceLimit at the payload level.
+ *
+ * The legacy confirmedAt / status / creditEligible paths are untouched — see
+ * hackathon-leaderboard-snapshot.test.ts for the regression suite.
+ */
+
+import { buildLeaderboardPayload } from "@/lib/hackathon-leaderboard-snapshot";
+import { getAdminDb } from "@/lib/firebase-admin";
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/github-merged-pr-count", () => ({
+  fetchMergedPrCountsForLogins: jest.fn(async () => new Map()),
+}));
+
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: jest.fn(() => ({ owner: "test", repo: "repo" })),
+}));
+
+jest.mock("@/lib/summer-cohort", () => ({
+  SUMMER_COHORT_COLLECTION: "summer_cohort_applications",
+}));
+
+const mockGetAdminDb = getAdminDb as jest.MockedFunction<typeof getAdminDb>;
+
+const SPORTS = "sports-hack-2026";
+const OTHER = "hack-a-sprint-2026";
+
+function makeSignupDoc(
+  userId: string,
+  data: Record<string, unknown> = {}
+): { id: string; data: () => Record<string, unknown> } {
+  return {
+    id: `${SPORTS}__${userId}`,
+    data: () => ({
+      userId,
+      eventId: SPORTS,
+      signedUpAt: new Date("2026-05-15"),
+      ...data,
+    }),
+  };
+}
+
+function makeUserDoc(
+  userId: string,
+  data: Record<string, unknown> = {}
+): { exists: true; id: string; data: () => Record<string, unknown> } {
+  return {
+    exists: true,
+    id: userId,
+    data: () => ({
+      displayName: `User ${userId}`,
+      email: `${userId}@test.com`,
+      ...data,
+    }),
+  };
+}
+
+function installDbMock(opts: {
+  signups: Array<{ id: string; data: () => Record<string, unknown> }>;
+  users: Array<{ exists: true; id: string; data: () => Record<string, unknown> }>;
+}) {
+  const signupsCol = {
+    where: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => ({ docs: opts.signups })),
+  };
+  const lumaCol = {
+    where: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => ({ docs: [] })),
+  };
+  const prCol = {
+    where: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => ({ docs: [] })),
+  };
+  const cohortAppsCol = {
+    get: jest.fn(async () => ({ docs: [] })),
+  };
+  const usersCol = {
+    doc: jest.fn((id: string) =>
+      opts.users.find((u) => u.id === id) ?? { exists: false, id, data: () => ({}) }
+    ),
+  };
+  mockGetAdminDb.mockReturnValue({
+    collection: jest.fn((name: string) => {
+      if (name === "hackathonEventSignups") return signupsCol;
+      if (name === "hackathonLumaRegistrants") return lumaCol;
+      if (name === "pullRequests") return prCol;
+      if (name === "users") return usersCol;
+      if (name === "summer_cohort_applications") return cohortAppsCol;
+      return { where: jest.fn().mockReturnThis(), get: jest.fn(async () => ({ docs: [] })) };
+    }),
+    getAll: jest.fn(async (...refs: { id: string }[]) =>
+      refs.map((r) => opts.users.find((u) => u.id === r.id) ?? { exists: false, id: r.id, data: () => ({}) })
+    ),
+  } as never);
+}
+
+describe("buildLeaderboardPayload — attendance-confirmation fields", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("emits attendanceLimit = 200 for sports-hack-2026, 0 for other events", async () => {
+    installDbMock({ signups: [], users: [] });
+    const sports = await buildLeaderboardPayload(SPORTS);
+    expect(sports.attendanceLimit).toBe(200);
+    expect(sports.confirmedAttendeeCount).toBe(0);
+
+    installDbMock({ signups: [], users: [] });
+    const hackASprint = await buildLeaderboardPayload(OTHER);
+    expect(hackASprint.attendanceLimit).toBe(0);
+    expect(hackASprint.confirmedAttendeeCount).toBe(0);
+  });
+
+  it("counts only entries with attendingConfirmedAt toward confirmedAttendeeCount", async () => {
+    installDbMock({
+      signups: [
+        makeSignupDoc("u1", { attendingConfirmedAt: new Date("2026-05-20") }),
+        makeSignupDoc("u2"), // claimed, not confirmed
+        makeSignupDoc("u3", { attendingConfirmedAt: new Date("2026-05-21") }),
+      ],
+      users: [makeUserDoc("u1"), makeUserDoc("u2"), makeUserDoc("u3")],
+    });
+    const payload = await buildLeaderboardPayload(SPORTS);
+
+    expect(payload.confirmedAttendeeCount).toBe(2);
+    const u1 = payload.entries.find((e) => e.userId === "u1")!;
+    const u2 = payload.entries.find((e) => e.userId === "u2")!;
+    const u3 = payload.entries.find((e) => e.userId === "u3")!;
+    expect(u1.attendingConfirmed).toBe(true);
+    expect(u1.attendingConfirmedAt).not.toBeNull();
+    expect(u2.attendingConfirmed).toBe(false);
+    expect(u2.attendingConfirmedAt).toBeNull();
+    expect(u3.attendingConfirmed).toBe(true);
+  });
+
+  it("preserves existing rank order in attendanceRank (does NOT re-sort by confirm time)", async () => {
+    // Signed up in this order, with confirm times in REVERSE order. The
+    // existing leaderboard sorts by mergedPrCount desc, then signedUpAt asc.
+    // Without PRs, ordering is by signedUpAt. We test that attendanceRank
+    // tracks rank order, NOT the order users clicked Confirm.
+    installDbMock({
+      signups: [
+        makeSignupDoc("first", {
+          signedUpAt: new Date("2026-05-10"),
+          attendingConfirmedAt: new Date("2026-05-22"), // confirmed LAST
+        }),
+        makeSignupDoc("second", {
+          signedUpAt: new Date("2026-05-11"),
+          attendingConfirmedAt: new Date("2026-05-20"), // confirmed FIRST
+        }),
+        makeSignupDoc("third", {
+          signedUpAt: new Date("2026-05-12"),
+          attendingConfirmedAt: new Date("2026-05-21"), // confirmed MIDDLE
+        }),
+      ],
+      users: [
+        makeUserDoc("first"),
+        makeUserDoc("second"),
+        makeUserDoc("third"),
+      ],
+    });
+    const payload = await buildLeaderboardPayload(SPORTS);
+
+    const first = payload.entries.find((e) => e.userId === "first")!;
+    const second = payload.entries.find((e) => e.userId === "second")!;
+    const third = payload.entries.find((e) => e.userId === "third")!;
+    // Rank by existing leaderboard order (earliest signup wins, no PRs):
+    expect(first.rank).toBe(1);
+    expect(second.rank).toBe(2);
+    expect(third.rank).toBe(3);
+    // attendanceRank should mirror that — NOT the confirm-time order:
+    expect(first.attendanceRank).toBe(1);
+    expect(second.attendanceRank).toBe(2);
+    expect(third.attendanceRank).toBe(3);
+  });
+
+  it("skips attendanceRank for entries that have not confirmed", async () => {
+    installDbMock({
+      signups: [
+        makeSignupDoc("confirmed-1", {
+          attendingConfirmedAt: new Date("2026-05-20"),
+        }),
+        makeSignupDoc("not-confirmed"),
+        makeSignupDoc("confirmed-2", {
+          attendingConfirmedAt: new Date("2026-05-21"),
+          signedUpAt: new Date("2026-05-16"),
+        }),
+      ],
+      users: [
+        makeUserDoc("confirmed-1"),
+        makeUserDoc("not-confirmed"),
+        makeUserDoc("confirmed-2"),
+      ],
+    });
+    const payload = await buildLeaderboardPayload(SPORTS);
+
+    const c1 = payload.entries.find((e) => e.userId === "confirmed-1")!;
+    const nc = payload.entries.find((e) => e.userId === "not-confirmed")!;
+    const c2 = payload.entries.find((e) => e.userId === "confirmed-2")!;
+
+    expect(c1.attendanceRank).toBe(1); // first confirmed entry in rank order
+    expect(nc.attendanceRank).toBeNull();
+    expect(c2.attendanceRank).toBe(2); // second confirmed entry
+    expect(payload.confirmedAttendeeCount).toBe(2);
+  });
+
+  it("emits inert attendance fields for events without the flow (attendanceLimit=0)", async () => {
+    installDbMock({
+      signups: [
+        // Even with attendingConfirmedAt set, an event with attendanceLimit=0
+        // should not surface it on entries — the field is gated by feature.
+        {
+          id: `${OTHER}__u1`,
+          data: () => ({
+            userId: "u1",
+            eventId: OTHER,
+            signedUpAt: new Date("2026-05-10"),
+            attendingConfirmedAt: new Date("2026-05-20"),
+          }),
+        },
+      ],
+      users: [makeUserDoc("u1")],
+    });
+    const payload = await buildLeaderboardPayload(OTHER);
+
+    const u1 = payload.entries.find((e) => e.userId === "u1")!;
+    expect(payload.attendanceLimit).toBe(0);
+    expect(payload.confirmedAttendeeCount).toBe(0);
+    expect(u1.attendingConfirmed).toBe(false);
+    expect(u1.attendingConfirmedAt).toBeNull();
+    expect(u1.attendanceRank).toBeNull();
+  });
+});

--- a/__tests__/lib/server-auth.test.ts
+++ b/__tests__/lib/server-auth.test.ts
@@ -102,6 +102,17 @@ describe("getVerifiedUser admin authorization bridge", () => {
     expect(verifyFn).toHaveBeenCalledWith("test-token", false);
   });
 
+  it("returns null from the admin helper when the verified user lacks admin claims", async () => {
+    mockVerify({ uid: "u-non-admin", email: "regular@example.com" });
+    const user = await getVerifiedAdminUser(makeRequest());
+    expect(user).toBeNull();
+  });
+
+  it("returns null from the admin helper when no token is presented", async () => {
+    const user = await getVerifiedAdminUser(makeRequest({}));
+    expect(user).toBeNull();
+  });
+
   it("uses revocation checks on the sensitive user helper path", async () => {
     const verifyFn = mockVerify({ uid: "credit-user", email: "u@example.com" });
     const user = await getVerifiedUserWithRevocation(makeRequest());

--- a/app/api/hackathons/events/[eventId]/checkin/route.ts
+++ b/app/api/hackathons/events/[eventId]/checkin/route.ts
@@ -104,11 +104,15 @@ export async function POST(request: NextRequest, context: RouteContext) {
           { status: 404 },
         );
       }
+      // Door check-in also marks the user as attending-confirmed. This catches
+      // walk-ins / late-RSVPs who never clicked Confirm on the site so they
+      // show up in the public confirmed-attendee count and attendanceRank.
       await ref.set({
         eventId,
         userId: targetUserId,
         signedUpAt: FieldValue.serverTimestamp(),
         checkedInAt: FieldValue.serverTimestamp(),
+        attendingConfirmedAt: FieldValue.serverTimestamp(),
       });
       revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
       return NextResponse.json({ ok: true, checkedIn: true, created: true });
@@ -122,7 +126,19 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
 
     if (checkedIn) {
-      await ref.update({ checkedInAt: FieldValue.serverTimestamp() });
+      // Preserve any existing attendingConfirmedAt (don't overwrite the user's
+      // earlier confirm time). Only set it when currently unset, so walk-ins
+      // who never clicked Confirm still get counted as attending. Un-check-in
+      // does NOT clear attendingConfirmedAt — un-check-in is an admin
+      // correction, not an attendance revocation.
+      const data = snap.data() ?? {};
+      const update: Record<string, unknown> = {
+        checkedInAt: FieldValue.serverTimestamp(),
+      };
+      if (!data.attendingConfirmedAt) {
+        update.attendingConfirmedAt = FieldValue.serverTimestamp();
+      }
+      await ref.update(update);
     } else {
       await ref.update({ checkedInAt: FieldValue.delete() });
     }

--- a/app/api/hackathons/events/[eventId]/confirm-attendance/route.ts
+++ b/app/api/hackathons/events/[eventId]/confirm-attendance/route.ts
@@ -1,0 +1,170 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { getVerifiedUser } from "@/lib/server-auth";
+import {
+  hackathonEventSignupDocId,
+  isHackathonEventSignupId,
+} from "@/lib/hackathon-event-signup";
+import { getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
+import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
+// @contracts: hackathonsContract.eventConfirmAttendancePost, hackathonsContract.eventConfirmAttendanceDelete
+import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+
+void hackathonsContract;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE = rateLimitConfigs.hackathonEventSignup;
+
+type RouteContext = { params: Promise<{ eventId: string }> };
+
+interface ConfirmAttendanceResponse {
+  ok: true;
+  attendingConfirmed: boolean;
+  attendingConfirmedAt: string | null;
+  confirmedAttendeeCount: number;
+  attendanceLimit: number;
+}
+
+async function handleRateLimit(request: NextRequest, scope: string) {
+  const clientId = getClientIdentifier(request as unknown as Request);
+  const rate = await checkUpstashRateLimit(
+    `hackathon-event-confirm-attendance-${scope}:${clientId}`,
+    RATE
+  );
+  if (!rate.success) {
+    return NextResponse.json(
+      { error: "Too many requests", retryAfterSeconds: rate.retryAfter },
+      { status: 429, headers: { "Retry-After": String(rate.retryAfter || 60) } }
+    );
+  }
+  return null;
+}
+
+async function buildResponse(eventId: string, userId: string): Promise<ConfirmAttendanceResponse> {
+  const snapshot = await refreshSnapshot(eventId);
+  const entry = snapshot.entries.find((e) => e.userId === userId);
+  return {
+    ok: true,
+    attendingConfirmed: entry?.attendingConfirmed ?? false,
+    attendingConfirmedAt: entry?.attendingConfirmedAt ?? null,
+    confirmedAttendeeCount: snapshot.confirmedAttendeeCount,
+    attendanceLimit: snapshot.attendanceLimit,
+  };
+}
+
+/**
+ * POST — confirm attendance. Idempotent: setting attendingConfirmedAt twice
+ * preserves the original timestamp. Returns the snapshot's confirmed-attendee
+ * count and the per-event attendance limit so the client can refresh its UI
+ * without a separate GET.
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const limited = await handleRateLimit(request, "post");
+    if (limited) return limited;
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { eventId: raw } = await context.params;
+    const eventId = raw?.trim() ?? "";
+    if (!isHackathonEventSignupId(eventId)) {
+      return NextResponse.json({ error: "Unknown event" }, { status: 404 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const docId = hackathonEventSignupDocId(eventId, user.uid);
+    const ref = db.collection("hackathonEventSignups").doc(docId);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      return NextResponse.json(
+        { error: "Claim your spot before confirming attendance" },
+        { status: 404 }
+      );
+    }
+
+    const data = snap.data() ?? {};
+    if (!data.attendingConfirmedAt) {
+      await ref.update({ attendingConfirmedAt: FieldValue.serverTimestamp() });
+    }
+
+    const response = await buildResponse(eventId, user.uid);
+    return NextResponse.json(response, { status: 200 });
+  } catch (e) {
+    console.error("[hackathon event confirm-attendance POST]", e);
+    return NextResponse.json(
+      { error: "Failed to confirm attendance" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE — clear the attending-confirmation. Idempotent: clearing twice is a
+ * no-op. The user keeps their signup; this only releases the second-step
+ * confirmation, which removes them from the public confirmed-attendee count
+ * until they re-confirm.
+ */
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  try {
+    const limited = await handleRateLimit(request, "delete");
+    if (limited) return limited;
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { eventId: raw } = await context.params;
+    const eventId = raw?.trim() ?? "";
+    if (!isHackathonEventSignupId(eventId)) {
+      return NextResponse.json({ error: "Unknown event" }, { status: 404 });
+    }
+
+    const db = getAdminDb();
+    if (!db) {
+      return NextResponse.json({ error: "Server not configured" }, { status: 500 });
+    }
+
+    const docId = hackathonEventSignupDocId(eventId, user.uid);
+    const ref = db.collection("hackathonEventSignups").doc(docId);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      return NextResponse.json(
+        { error: "Not signed up for this event" },
+        { status: 404 }
+      );
+    }
+
+    const data = snap.data() ?? {};
+    if (data.attendingConfirmedAt) {
+      await ref.update({ attendingConfirmedAt: FieldValue.delete() });
+    }
+
+    const response = await buildResponse(eventId, user.uid);
+    return NextResponse.json(response, { status: 200 });
+  } catch (e) {
+    console.error("[hackathon event confirm-attendance DELETE]", e);
+    return NextResponse.json(
+      { error: "Failed to un-confirm attendance" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -64,6 +64,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
       willBeLate: boolean;
       queuingForSpot: boolean;
       lumaRegistered: boolean;
+      attendingConfirmed: boolean;
+      attendingConfirmedAt: string | null;
+      attendanceRank: number | null;
     } | null = null;
 
     if (meUser) {
@@ -78,6 +81,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
             willBeLate: entry.willBeLate,
             queuingForSpot: entry.queuingForSpot,
             lumaRegistered: entry.lumaRegistered,
+            attendingConfirmed: entry.attendingConfirmed,
+            attendingConfirmedAt: entry.attendingConfirmedAt,
+            attendanceRank: entry.attendanceRank,
           }
         : {
             signedUp: false,
@@ -88,6 +94,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
             willBeLate: false,
             queuingForSpot: false,
             lumaRegistered: false,
+            attendingConfirmed: false,
+            attendingConfirmedAt: null,
+            attendanceRank: null,
           };
     }
 
@@ -97,6 +106,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       websiteSignupCount: payload.websiteSignupCount,
       entries: payload.entries,
       creditTopN: payload.creditTopN,
+      confirmedAttendeeCount: payload.confirmedAttendeeCount,
+      attendanceLimit: payload.attendanceLimit,
       me,
     });
   } catch (e) {

--- a/app/hackathons/sports-hack-2026/page.tsx
+++ b/app/hackathons/sports-hack-2026/page.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
 import { LumaEmbed } from "@/components/hackathons/LumaEmbed";
 import {
+  SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
   SPORTS_HACK_2026_LOCATION,
@@ -31,7 +32,13 @@ type LeaderboardResponse = {
   websiteSignupCount?: number;
   entries: LeaderboardEntry[];
   creditTopN: number;
-  me?: { signedUp: boolean; rank: number | null } | null;
+  confirmedAttendeeCount?: number;
+  attendanceLimit?: number;
+  me?: {
+    signedUp: boolean;
+    rank: number | null;
+    attendingConfirmed?: boolean;
+  } | null;
 };
 
 export default function SportsHack2026LandingPage() {
@@ -99,11 +106,19 @@ export default function SportsHack2026LandingPage() {
               <FactCard label="When" value="Tue May 26 · 10 AM – 4 PM ET" />
               <FactCard label="Where" value={SPORTS_HACK_2026_LOCATION} />
               <FactCard
-                label="Capacity"
+                label="Confirmed attending"
+                value={
+                  data
+                    ? `${data.confirmedAttendeeCount ?? 0}/${data.attendanceLimit ?? SPORTS_HACK_2026_ATTENDANCE_LIMIT} · ${data.totalCount} signed up`
+                    : `${SPORTS_HACK_2026_ATTENDANCE_LIMIT} guaranteed-entry cap`
+                }
+              />
+              <FactCard
+                label="Credit seats locked"
                 value={
                   confirmedCount != null && data
-                    ? `${confirmedCount}/${SPORTS_HACK_2026_CAPACITY} confirmed · ${data.totalCount} registered`
-                    : `${SPORTS_HACK_2026_CAPACITY} confirmed seats`
+                    ? `${confirmedCount}/${SPORTS_HACK_2026_CAPACITY} (Cursor credit link)`
+                    : `Top ${SPORTS_HACK_2026_CAPACITY} get Cursor credit`
                 }
               />
               <FactCard

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
 import { trackEvent } from "@/lib/analytics";
 import {
+  SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
   SPORTS_HACK_2026_LUMA_URL,
@@ -77,6 +78,9 @@ type LeaderboardEntry = {
   queuingForSpot?: boolean;
   lumaRegistered?: boolean;
   isCohort1?: boolean;
+  attendingConfirmed?: boolean;
+  attendingConfirmedAt?: string | null;
+  attendanceRank?: number | null;
 };
 
 type LeaderboardResponse = {
@@ -85,6 +89,8 @@ type LeaderboardResponse = {
   websiteSignupCount?: number;
   entries: LeaderboardEntry[];
   creditTopN: number;
+  confirmedAttendeeCount?: number;
+  attendanceLimit?: number;
   me: {
     signedUp: boolean;
     rank: number | null;
@@ -94,6 +100,9 @@ type LeaderboardResponse = {
     willBeLate: boolean;
     queuingForSpot: boolean;
     lumaRegistered: boolean;
+    attendingConfirmed?: boolean;
+    attendingConfirmedAt?: string | null;
+    attendanceRank?: number | null;
   } | null;
 };
 
@@ -301,6 +310,42 @@ export default function SportsHack2026SignupPage() {
       await load();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not update RSVP");
+    } finally {
+      setRsvpBusy(false);
+    }
+  };
+
+  const toggleAttendingConfirmation = async (confirming: boolean) => {
+    if (!user) return;
+    setRsvpBusy(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(
+        `/api/hackathons/events/${eventId}/confirm-attendance`,
+        {
+          method: confirming ? "POST" : "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          json.error ||
+            (confirming
+              ? "Could not confirm attendance"
+              : "Could not un-confirm")
+        );
+      }
+      await load();
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message
+          : confirming
+            ? "Could not confirm attendance"
+            : "Could not un-confirm"
+      );
     } finally {
       setRsvpBusy(false);
     }
@@ -530,6 +575,74 @@ export default function SportsHack2026SignupPage() {
                         >
                           Leave list
                         </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })()}
+
+              {/* Attendance confirmation card — second step beyond claim. */}
+              {(() => {
+                const meConfirmed = data.me?.attendingConfirmed === true;
+                const attendingCount = data.confirmedAttendeeCount ?? 0;
+                const attendanceLimit =
+                  data.attendanceLimit ?? SPORTS_HACK_2026_ATTENDANCE_LIMIT;
+                const myAttendanceRank = data.me?.attendanceRank ?? null;
+                const onWaitlist =
+                  meConfirmed &&
+                  attendanceLimit > 0 &&
+                  myAttendanceRank != null &&
+                  myAttendanceRank > attendanceLimit;
+                return (
+                  <div
+                    className={`mt-6 rounded-2xl border p-6 ${
+                      meConfirmed
+                        ? "border-emerald-500/30 bg-emerald-500/5 dark:bg-emerald-500/10"
+                        : "border-amber-500/40 bg-amber-500/5 dark:bg-amber-500/10"
+                    }`}
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="text-sm">
+                        <h2 className="font-semibold text-foreground">
+                          {meConfirmed
+                            ? onWaitlist
+                              ? "Confirmed — currently on the waitlist"
+                              : "Confirmed — you're attending"
+                            : "Step 2: Confirm you'll attend"}
+                        </h2>
+                        <p className="mt-1 text-neutral-700 dark:text-neutral-300">
+                          {meConfirmed
+                            ? onWaitlist
+                              ? `Confirmed attendees beyond #${attendanceLimit} (you're #${myAttendanceRank}) can still show up but are not guaranteed entry. Climbing the leaderboard moves you above the cutoff.`
+                              : myAttendanceRank != null
+                                ? `You're confirmed attendee #${myAttendanceRank} of ${attendanceLimit} guaranteed seats.`
+                                : "Your attendance is confirmed."
+                            : "Claiming a spot reserves your rank. Click below to also confirm you'll be there May 26 — first 200 confirmed by leaderboard rank are guaranteed entry."}
+                        </p>
+                        <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                          {attendingCount} of {attendanceLimit} confirmed attending site-wide.
+                        </p>
+                      </div>
+                      <div className="shrink-0">
+                        {meConfirmed ? (
+                          <button
+                            type="button"
+                            disabled={rsvpBusy}
+                            onClick={() => void toggleAttendingConfirmation(false)}
+                            className="rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium hover:bg-neutral-100 disabled:opacity-50 dark:border-neutral-600 dark:hover:bg-neutral-800"
+                          >
+                            I can&apos;t make it
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            disabled={rsvpBusy}
+                            onClick={() => void toggleAttendingConfirmation(true)}
+                            className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-400 disabled:opacity-50"
+                          >
+                            Confirm attendance
+                          </button>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -53,6 +53,7 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import Avatar from "@/components/Avatar";
 import Footer from "@/components/Footer";
+import { SportsHackConfirmAttendanceModal } from "@/components/hackathons/SportsHackConfirmAttendanceModal";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { SUMMER_COHORT_OPEN_EVENT } from "@/lib/summer-cohort";
 
@@ -526,6 +527,7 @@ export default function AppShell({ children }: { children: ReactNode }) {
         </main>
         <Footer />
       </div>
+      <SportsHackConfirmAttendanceModal />
     </div>
   );
 }

--- a/components/hackathons/SportsHackConfirmAttendanceModal.tsx
+++ b/components/hackathons/SportsHackConfirmAttendanceModal.tsx
@@ -1,0 +1,218 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  SPORTS_HACK_2026_ATTENDANCE_LIMIT,
+  SPORTS_HACK_2026_EVENT_DATE,
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_SHORT_NAME,
+} from "@/lib/sports-hack-2026";
+
+/**
+ * Bottom-right nudge for users who have claimed a Sports Hack spot but
+ * haven't completed the second-step attendance confirmation. Mounted
+ * site-wide in AppShell. Suppression rules (any failure hides the modal):
+ *
+ *   1. user is signed in and auth context is resolved
+ *   2. pathname is not under /hackathons/sports-hack-2026
+ *      (the event pages have their own inline confirm UI)
+ *   3. event date has not passed
+ *   4. sessionStorage 'sports-hack-2026-confirm-dismissed' is unset
+ *   5. me.signedUp === true && me.attendingConfirmed === false
+ */
+
+const DISMISS_STORAGE_KEY = "sports-hack-2026-confirm-dismissed";
+
+type SignupMeResponse = {
+  me: {
+    signedUp: boolean;
+    attendingConfirmed?: boolean;
+  } | null;
+};
+
+function isPastEventDate(): boolean {
+  // SPORTS_HACK_2026_EVENT_DATE is "2026-05-26" in ET. Compare to UTC midnight
+  // of the day after — gives the modal one full day of grace before hiding.
+  const cutoff = new Date(`${SPORTS_HACK_2026_EVENT_DATE}T23:59:59-04:00`);
+  return Date.now() > cutoff.getTime();
+}
+
+export function SportsHackConfirmAttendanceModal() {
+  const { user, loading } = useAuth();
+  const pathname = usePathname();
+  const [eligibleToShow, setEligibleToShow] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  // Initialize the dismissed flag from sessionStorage. Done in effect (not
+  // useState init) because sessionStorage is not available in SSR.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      setDismissed(
+        window.sessionStorage.getItem(DISMISS_STORAGE_KEY) === "1"
+      );
+    } catch {
+      // sessionStorage can throw in some private-browsing modes — treat as
+      // not-dismissed.
+    }
+  }, []);
+
+  const onPath = pathname?.startsWith("/hackathons/sports-hack-2026") ?? false;
+  const suppressedByContext =
+    loading || !user || dismissed || onPath || isPastEventDate();
+
+  const fetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (suppressedByContext) {
+      setEligibleToShow(false);
+      return;
+    }
+    if (!user || fetchedRef.current) return;
+    fetchedRef.current = true;
+    let aborted = false;
+    void (async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(
+          `/api/hackathons/events/${SPORTS_HACK_2026_EVENT_ID}/signup`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        if (!res.ok) return;
+        const json = (await res.json()) as SignupMeResponse;
+        if (aborted) return;
+        const me = json.me;
+        if (
+          me &&
+          me.signedUp === true &&
+          me.attendingConfirmed !== true
+        ) {
+          setEligibleToShow(true);
+        }
+      } catch {
+        // Non-critical — silently skip the nudge if the lookup fails.
+      }
+    })();
+    return () => {
+      aborted = true;
+    };
+  }, [user, suppressedByContext]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!user) return;
+    setConfirming(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(
+        `/api/hackathons/events/${SPORTS_HACK_2026_EVENT_ID}/confirm-attendance`,
+        { method: "POST", headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}) as { error?: string });
+        throw new Error(json.error || "Could not confirm attendance");
+      }
+      // No sessionStorage flag set — me.attendingConfirmed will now be true,
+      // which naturally suppresses the modal on next mount.
+      setEligibleToShow(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not confirm attendance");
+    } finally {
+      setConfirming(false);
+    }
+  }, [user]);
+
+  const handleDismiss = useCallback(() => {
+    if (typeof window !== "undefined") {
+      try {
+        window.sessionStorage.setItem(DISMISS_STORAGE_KEY, "1");
+      } catch {
+        // Best-effort — if storage fails, the modal still hides for this mount.
+      }
+    }
+    setDismissed(true);
+    setEligibleToShow(false);
+  }, []);
+
+  if (suppressedByContext || !eligibleToShow) {
+    return null;
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Confirm Sports Hack attendance"
+      className="fixed bottom-4 right-4 z-50 w-[min(92vw,360px)] rounded-2xl border border-emerald-500/30 bg-white p-4 shadow-2xl dark:border-emerald-500/40 dark:bg-neutral-900"
+    >
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={handleDismiss}
+        className="absolute top-2 right-2 rounded-md p-1 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+      <div className="pr-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
+          {SPORTS_HACK_2026_SHORT_NAME} · May 26
+        </p>
+        <h2 className="mt-1 text-base font-semibold text-foreground">
+          Lock in your spot
+        </h2>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+          You&apos;ve claimed a Sports Hack spot. Confirm you&apos;ll attend so
+          you&apos;re counted in the {SPORTS_HACK_2026_ATTENDANCE_LIMIT}-seat
+          guaranteed-entry cap.
+        </p>
+        {error ? (
+          <p className="mt-2 rounded-md bg-rose-500/10 px-2 py-1 text-xs text-rose-700 dark:text-rose-300">
+            {error}
+          </p>
+        ) : null}
+        <div className="mt-3 flex items-center gap-2">
+          <button
+            type="button"
+            disabled={confirming}
+            onClick={() => void handleConfirm()}
+            className="flex-1 rounded-lg bg-emerald-500 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-400 disabled:opacity-50"
+          >
+            {confirming ? "Confirming…" : "Confirm I'll attend"}
+          </button>
+          <Link
+            href={`/hackathons/${SPORTS_HACK_2026_EVENT_ID}/signup`}
+            onClick={handleDismiss}
+            className="rounded-lg border border-neutral-300 px-3 py-2 text-sm hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
+          >
+            Details
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**180 paths, 216 operations across 33 areas.**
+**184 paths, 221 operations across 35 areas.**
 
 ---
 
@@ -208,6 +208,8 @@ _Hackathon pool, teams, submissions, and Hack-a-Sprint showcase._
 |--------|----------|------|-------------|
 | GET | `/api/hackathons/eligibility` | Yes | Get current user's hackathon eligibility |
 | POST | `/api/hackathons/events/{eventId}/checkin` | Yes | Admin-only: check a user in to an event |
+| DELETE | `/api/hackathons/events/{eventId}/confirm-attendance` | Yes | Withdraw the user's attendance confirmation (keeps signup) |
+| POST | `/api/hackathons/events/{eventId}/confirm-attendance` | Yes | Confirm attendance for an event the user has signed up for |
 | DELETE | `/api/hackathons/events/{eventId}/signup` | Yes | Withdraw the current user's signup |
 | GET | `/api/hackathons/events/{eventId}/signup` | Yes | Public event-signup leaderboard |
 | PATCH | `/api/hackathons/events/{eventId}/signup` | Yes | Update the current user's signup state |
@@ -449,7 +451,7 @@ _Talk-submission moderation queue._
 
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
-| GET | `/api/skills/progress` | Yes | Get the current user'"'"'s Skills Passport progress |
+| GET | `/api/skills/progress` | Yes | Get the current user's Skills Passport progress |
 
 ## SummerCohort
 

--- a/lib/api-schemas/hackathons.ts
+++ b/lib/api-schemas/hackathons.ts
@@ -226,6 +226,63 @@ export const hackathonsContract = c.router(
       },
     },
 
+    eventConfirmAttendancePost: {
+      method: "POST",
+      path: "/api/hackathons/events/:eventId/confirm-attendance",
+      pathParams: EventIdParam,
+      summary: "Confirm attendance for an event the user has signed up for",
+      description:
+        "Idempotent second-step confirmation distinct from the rank-freeze 'confirmed seat' flow. Sets attendingConfirmedAt on the user's signup doc; preserved if already set. Returns the updated confirmed-attendee count and the per-event attendance limit.",
+      body: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          ok: z.literal(true),
+          attendingConfirmed: z.boolean(),
+          attendingConfirmedAt: z.string().nullable(),
+          confirmedAttendeeCount: z.number(),
+          attendanceLimit: z.number(),
+        }),
+        ...writeErrors,
+        404: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "NOT_FOUND",
+          "RATE_LIMITED",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+    eventConfirmAttendanceDelete: {
+      method: "DELETE",
+      path: "/api/hackathons/events/:eventId/confirm-attendance",
+      pathParams: EventIdParam,
+      summary: "Withdraw the user's attendance confirmation (keeps signup)",
+      description:
+        "Idempotent. Clears attendingConfirmedAt while preserving the underlying signup. The user remains signed up but is no longer counted in the public confirmed-attendee count.",
+      body: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          ok: z.literal(true),
+          attendingConfirmed: z.boolean(),
+          attendingConfirmedAt: z.string().nullable(),
+          confirmedAttendeeCount: z.number(),
+          attendanceLimit: z.number(),
+        }),
+        ...writeErrors,
+        404: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "NOT_FOUND",
+          "RATE_LIMITED",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+
     inviteAccept: {
       method: "POST",
       path: "/api/hackathons/invites/accept",

--- a/lib/hackathon-event-signup.ts
+++ b/lib/hackathon-event-signup.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_DECLINED_EMAILS,
   SPORTS_HACK_2026_EVENT_ID,
@@ -69,6 +70,20 @@ export const CURSOR_CREDIT_TOP_N = 50;
 export function getConfirmedCapacityForEvent(eventId: string): number {
   if (eventId === SPORTS_HACK_2026_EVENT_ID) return SPORTS_HACK_2026_CAPACITY;
   return CURSOR_CREDIT_TOP_N;
+}
+
+/**
+ * Per-event guaranteed-attendance cap. Distinct from the credit cap above:
+ * the top SPORTS_HACK_2026_ATTENDANCE_LIMIT confirmed-attending users by
+ * leaderboard rank are guaranteed entry; the top SPORTS_HACK_2026_CAPACITY
+ * of those also get a credit link.
+ *
+ * Returns 0 for events that don't use the second-step "Confirm attendance"
+ * flow. Snapshot emits the new attendance fields only when this is > 0.
+ */
+export function getAttendanceLimitForEvent(eventId: string): number {
+  if (eventId === SPORTS_HACK_2026_EVENT_ID) return SPORTS_HACK_2026_ATTENDANCE_LIMIT;
+  return 0;
 }
 
 /**

--- a/lib/hackathon-leaderboard-snapshot.ts
+++ b/lib/hackathon-leaderboard-snapshot.ts
@@ -29,6 +29,7 @@ import type { DocumentData, Firestore } from "firebase-admin/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import {
+  getAttendanceLimitForEvent,
   getConfirmedCapacityForEvent,
   getDeclinedEmailsForEvent,
   getJudgeEmailsForEvent,
@@ -57,6 +58,20 @@ export interface LeaderboardEntry {
   lumaRegistered: boolean;
   /** True when the email matches a Cohort-1 application (status pending/admitted). */
   isCohort1: boolean;
+  /**
+   * True when the user has clicked "Confirm attending" (or has been checked
+   * in at the door). Distinct from `creditEligible` / `status` which reflect
+   * the offline rank-freeze. Only meaningful when payload.attendanceLimit > 0.
+   */
+  attendingConfirmed: boolean;
+  /** ISO timestamp when the user confirmed attendance, or null. */
+  attendingConfirmedAt: string | null;
+  /**
+   * Rank within the confirmed-attending subset (1-based), preserving the
+   * entry's existing `rank` order — NOT re-sorted by confirm time. Null
+   * when this entry has not confirmed or the event doesn't use this flow.
+   */
+  attendanceRank: number | null;
 }
 
 export interface LeaderboardPayload {
@@ -64,6 +79,17 @@ export interface LeaderboardPayload {
   totalCount: number;
   websiteSignupCount: number;
   creditTopN: number;
+  /**
+   * Count of entries with attendingConfirmedAt set. 0 when the event
+   * doesn't use the second-step attendance-confirmation flow.
+   */
+  confirmedAttendeeCount: number;
+  /**
+   * Per-event guaranteed-attendance cap. 0 when the event doesn't use the
+   * second-step flow (in which case the new attendance fields on entries
+   * are inert: attendingConfirmed=false, attendanceRank=null).
+   */
+  attendanceLimit: number;
 }
 
 export interface LeaderboardSnapshot extends LeaderboardPayload {
@@ -223,6 +249,7 @@ export async function buildLeaderboardPayload(
     willBeLate: boolean;
     queuingForSpot: boolean;
     lumaRegistered: boolean;
+    attendingConfirmedAt: number | null;
   }[] = [];
 
   const userIds = snap.docs.map((d) => d.data().userId as string).filter(Boolean);
@@ -285,6 +312,9 @@ export async function buildLeaderboardPayload(
       willBeLate: data.willBeLate === true,
       queuingForSpot: data.queuingForSpot === true,
       lumaRegistered: false, // flipped true below when the Luma loop finds a match
+      attendingConfirmedAt: data.attendingConfirmedAt
+        ? signedUpAtToMs(data.attendingConfirmedAt)
+        : null,
     });
   }
 
@@ -406,6 +436,7 @@ export async function buildLeaderboardPayload(
     queuingForSpot: boolean;
     lumaRegistered: boolean;
     isCohort1: boolean;
+    attendingConfirmedAt: number | null;
   };
   const unified: UnifiedRow[] = [];
 
@@ -428,6 +459,7 @@ export async function buildLeaderboardPayload(
       queuingForSpot: r.queuingForSpot,
       lumaRegistered: r.lumaRegistered,
       isCohort1: email ? cohort1Emails.has(email) : false,
+      attendingConfirmedAt: r.attendingConfirmedAt,
     });
   }
   for (const lr of lumaRows) {
@@ -447,6 +479,11 @@ export async function buildLeaderboardPayload(
       queuingForSpot: false,
       lumaRegistered: true,
       isCohort1: email ? cohort1Emails.has(email) : false,
+      // Luma-only rows have no website user account, so they cannot click
+      // "Confirm attending" on the site. They acquire attendingConfirmedAt
+      // only via admin door check-in (which writes through the website-signup
+      // path when matched by email/github).
+      attendingConfirmedAt: null,
     });
   }
 
@@ -471,11 +508,15 @@ export async function buildLeaderboardPayload(
   const sorted = [...confirmed, ...waitlisted];
 
   const websiteCount = rows.length;
-  const entries: LeaderboardEntry[] = sorted.map((u, i) => {
+  const attendanceLimit = getAttendanceLimitForEvent(eventId);
+  // First pass: build entries with attendance flags but without attendanceRank.
+  const partialEntries: LeaderboardEntry[] = sorted.map((u, i) => {
     const rank = i + 1;
     const isConfirmed = u.confirmedAt != null;
     const displayPrs =
       isConfirmed && u.frozenPrCount != null ? u.frozenPrCount : u.mergedPrCount;
+    const hasAttendanceFlow = attendanceLimit > 0;
+    const attendingConfirmed = hasAttendanceFlow && u.attendingConfirmedAt != null;
     return {
       rank,
       userId: u.userId,
@@ -490,14 +531,38 @@ export async function buildLeaderboardPayload(
       queuingForSpot: u.queuingForSpot,
       lumaRegistered: u.lumaRegistered,
       isCohort1: u.isCohort1,
+      attendingConfirmed,
+      attendingConfirmedAt:
+        hasAttendanceFlow && u.attendingConfirmedAt != null
+          ? new Date(u.attendingConfirmedAt).toISOString()
+          : null,
+      attendanceRank: null, // filled in below
     };
   });
 
+  // Second pass: re-number confirmed-attending entries 1..N in existing rank
+  // order. This deliberately does NOT re-sort by attendingConfirmedAt time —
+  // a slow-to-RSVP top contributor cannot be pushed out by a fast-clicking
+  // lower-ranked user.
+  let confirmedAttendeeCount = 0;
+  if (attendanceLimit > 0) {
+    let attendanceRank = 0;
+    for (const entry of partialEntries) {
+      if (entry.attendingConfirmed) {
+        attendanceRank += 1;
+        entry.attendanceRank = attendanceRank;
+        confirmedAttendeeCount += 1;
+      }
+    }
+  }
+
   return {
-    entries,
-    totalCount: entries.length,
+    entries: partialEntries,
+    totalCount: partialEntries.length,
     websiteSignupCount: websiteCount,
     creditTopN: getConfirmedCapacityForEvent(eventId),
+    confirmedAttendeeCount,
+    attendanceLimit,
   };
 }
 
@@ -524,18 +589,49 @@ export async function readSnapshot(
           typeof (data.generatedAt as { toDate?: () => Date }).toDate === "function"
         ? (data.generatedAt as { toDate: () => Date }).toDate().toISOString()
         : new Date(0).toISOString();
+  // Hydrate the new attendance fields for snapshots written before this
+  // feature shipped. attendingConfirmed defaults to false, attendingConfirmedAt
+  // to null, attendanceRank to null. Recomputation on the next mutation will
+  // backfill the real values.
+  const rawEntries = data.entries as Array<Record<string, unknown>>;
+  const entries: LeaderboardEntry[] = rawEntries.map((e) => ({
+    rank: typeof e.rank === "number" ? e.rank : 0,
+    userId: (e.userId as string | null) ?? null,
+    displayName: (e.displayName as string | null) ?? null,
+    githubLogin: (e.githubLogin as string | null) ?? null,
+    mergedPrCount: typeof e.mergedPrCount === "number" ? e.mergedPrCount : 0,
+    signedUpAt: typeof e.signedUpAt === "string" ? e.signedUpAt : "",
+    creditEligible: e.creditEligible === true,
+    status: e.status === "confirmed" ? "confirmed" : "waitlisted",
+    checkedIn: e.checkedIn === true,
+    willBeLate: e.willBeLate === true,
+    queuingForSpot: e.queuingForSpot === true,
+    lumaRegistered: e.lumaRegistered === true,
+    isCohort1: e.isCohort1 === true,
+    attendingConfirmed: e.attendingConfirmed === true,
+    attendingConfirmedAt:
+      typeof e.attendingConfirmedAt === "string" ? e.attendingConfirmedAt : null,
+    attendanceRank:
+      typeof e.attendanceRank === "number" ? e.attendanceRank : null,
+  }));
   return {
-    entries: data.entries as LeaderboardEntry[],
+    entries,
     totalCount:
-      typeof data.totalCount === "number"
-        ? data.totalCount
-        : (data.entries as unknown[]).length,
+      typeof data.totalCount === "number" ? data.totalCount : entries.length,
     websiteSignupCount:
       typeof data.websiteSignupCount === "number" ? data.websiteSignupCount : 0,
     creditTopN:
       typeof data.creditTopN === "number"
         ? data.creditTopN
         : getConfirmedCapacityForEvent(eventId),
+    confirmedAttendeeCount:
+      typeof data.confirmedAttendeeCount === "number"
+        ? data.confirmedAttendeeCount
+        : entries.filter((e) => e.attendingConfirmed).length,
+    attendanceLimit:
+      typeof data.attendanceLimit === "number"
+        ? data.attendanceLimit
+        : getAttendanceLimitForEvent(eventId),
     generatedAt,
   };
 }

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -145,10 +145,24 @@ export async function isCurrentIdTokenRevoked(request: NextRequest): Promise<boo
   }
 }
 
+/**
+ * Verify the Firebase ID token AND require admin status. Combines the auth
+ * + role gate that admin routes used to spell out in two steps.
+ *
+ * Returns null when the request has no token, the token is missing the admin
+ * claim, OR the resolved user is not in the admin role set. Callers should
+ * treat null as 401/403 (route returns 401 to avoid leaking admin status).
+ *
+ * Throws when Firebase Admin Auth is not configured.
+ */
 export async function getVerifiedAdminUser(
   request: NextRequest
 ): Promise<VerifiedUser | null> {
-  return verifyRequestUser(request, false);
+  const user = await verifyRequestUser(request, false);
+  if (!user || !user.isAdmin) {
+    return null;
+  }
+  return user;
 }
 
 export function isRevokedIdTokenError(error: unknown): boolean {

--- a/lib/sports-hack-2026.ts
+++ b/lib/sports-hack-2026.ts
@@ -20,8 +20,20 @@ export const SPORTS_HACK_2026_LUMA_URL = `https://luma.com/${SPORTS_HACK_2026_LU
 /**
  * Confirmed-seat cap for the May 26 event. Bumped from 80 → 119 on 2026-05-22
  * when an additional batch of Cursor credit codes brought the total to 119.
+ *
+ * This is the *credit-link* cap (only the top 119 confirmed attendees by
+ * leaderboard rank receive a Cursor credit link).
  */
 export const SPORTS_HACK_2026_CAPACITY = 119;
+
+/**
+ * Guaranteed-entry cap distinct from the credit-link cap above. The first
+ * 200 confirmed-attending users (ranked by the existing leaderboard order —
+ * PR count + signedUpAt) are guaranteed entry on May 26; ranks 201+ are
+ * waitlisted (may still show up but not guaranteed). Of the guaranteed 200,
+ * the top SPORTS_HACK_2026_CAPACITY also receive a Cursor credit link.
+ */
+export const SPORTS_HACK_2026_ATTENDANCE_LIMIT = 200;
 export const SPORTS_HACK_2026_TIMEZONE = "America/New_York";
 export const SPORTS_HACK_2026_EVENT_DATE = "2026-05-26";
 export const SPORTS_HACK_2026_START_HOUR_ET = 10;

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -30,11 +30,14 @@ Licensed GPL-3.0-only.
     /certificate
     /certificate/verify/[certId]
     /cfp
+    /challenges
+    /challenges/[month]
     /code-of-conduct
     /cohort-ai
     /cohort-withdraw
     /contribute/game-art
     /cookbook
+    /cookbook/[slug]
     /cookies
     /disclaimer
     /ecosystem
@@ -100,13 +103,18 @@ Licensed GPL-3.0-only.
     /questions
     /questions/[questionId]
     /questions/ask
+    /recordings
+    /recordings/[sessionId]
     /research
     /research/[slug]
     /showcase
     /signup
+    /skills
     /summer-cohort
     /talks
     /talks/submit
+    /templates
+    /templates/[templateId]
     /terms
     /unsubscribe
 
@@ -124,7 +132,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (215 endpoints)
+## API (221 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -170,6 +178,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     DELETE /api/community/block [Yes] — Unblock another user
     POST   /api/community/block [Yes] — Block another user
     POST   /api/community/delete [Yes] — Delete the current user's own community message
+    GET    /api/community/feed — List visible community feed messages
     GET    /api/community/moderate [Yes] — Admin: list community reports (paginated)
     POST   /api/community/moderate [Yes] — Admin: act on a community report (dismiss / hide / suspend)
     GET    /api/community/my-reactions [Yes] — Get the current user's reactions for a batch of messages
@@ -264,6 +273,8 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
 
     GET    /api/hackathons/eligibility [Yes] — Get current user's hackathon eligibility
     POST   /api/hackathons/events/{eventId}/checkin [Yes] — Admin-only: check a user in to an event
+    DELETE /api/hackathons/events/{eventId}/confirm-attendance [Yes] — Withdraw the user's attendance confirmation (keeps signup)
+    POST   /api/hackathons/events/{eventId}/confirm-attendance [Yes] — Confirm attendance for an event the user has signed up for
     DELETE /api/hackathons/events/{eventId}/signup [Yes] — Withdraw the current user's signup
     GET    /api/hackathons/events/{eventId}/signup [Yes] — Public event-signup leaderboard
     PATCH  /api/hackathons/events/{eventId}/signup [Yes] — Update the current user's signup state
@@ -417,11 +428,23 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     GET    /api/hiring-partners/apply [Yes] — Get the current user's hiring-partner application
     POST   /api/hiring-partners/apply [Yes] — Create or update the current user's hiring-partner application
 
+### MonthlyChallenges
+
+    POST   /api/challenges/{challengeId}/submissions [Yes] — Create a monthly challenge submission draft or submitted entry
+
 ### NotifyAdmin
 
     POST   /api/notify-admin/cfp — Email admin about a new CFP submission
     POST   /api/notify-admin/event — Email admin about a new event request
     POST   /api/notify-admin/talk — Email admin about a new talk submission
+
+### PromptTemplates
+
+    POST   /api/templates [Yes] — Create a private prompt template draft or pending-review template
+
+### Skills
+
+    GET    /api/skills/progress [Yes] — Get the current user's Skills Passport progress
 
 ### SummerCohort
 


### PR DESCRIPTION
## Summary

Third develop → main release of the day. Two PRs:

1. **#1407** — Sports Hack 2026 second-step "Confirm attendance" flow. After someone claims a spot, they now must click Confirm to count toward the 200-seat guaranteed-entry cap. Public count starts at 0 on launch; 119 Cursor credit links continue to allocate to the top 119 confirmed by leaderboard rank. Includes a site-wide bottom-right modal nudge.
2. **#1406** — Auth helper hardening. \`getVerifiedAdminUser\` was added by #1347 but its body did not actually check \`isAdmin\`. Tightened so the helper returns null unless the user has the admin claim — closes a future-footgun. No live route was relying on the misnaming.

## Included PRs and contributors

| PR | Title | Contributor |
|---|---|---|
| #1407 | feat(sports-hack-2026): second-step 'Confirm attendance' flow + site-wide modal | Ludwitt |
| #1406 | fix(auth): enforce isAdmin in getVerifiedAdminUser | Ludwitt |

## What's in #1407

**Data + API**
- New Firestore field \`attendingConfirmedAt\` on \`hackathonEventSignups\`. Absent = unconfirmed.
- New endpoint \`POST/DELETE /api/hackathons/events/[eventId]/confirm-attendance\` (auth + rate-limited, idempotent set/clear). Returns \`{ ok, attendingConfirmed, attendingConfirmedAt, confirmedAttendeeCount, attendanceLimit }\`.
- Admin checkin endpoint now also sets \`attendingConfirmedAt\` when missing on \`checkedIn === true\` so walk-ins count. Un-check-in does not clear it.

**Snapshot**
- New per-entry: \`attendingConfirmed\`, \`attendingConfirmedAt\`, \`attendanceRank\`.
- New payload fields: \`confirmedAttendeeCount\`, \`attendanceLimit\` (200 for sports-hack-2026, 0 = feature off).
- \`attendanceRank\` preserves the entry's **existing** leaderboard rank order — a slow-to-RSVP top contributor cannot be pushed out by a fast-clicking lower-ranked user.

**UI**
- Landing page: new "Confirmed attending" primary stat (X/200) alongside the renamed "Credit seats locked" stat.
- Signup detail: inline Confirm / "I can't make it" toggle + waitlist label when rank > 200.
- Site-wide bottom-right modal, suppressed on \`/hackathons/sports-hack-2026*\` paths and when sessionStorage dismiss is set.

**Constants**
- \`SPORTS_HACK_2026_ATTENDANCE_LIMIT = 200\` (distinct from \`SPORTS_HACK_2026_CAPACITY = 119\` which is the credit cap).

## What's in #1406

\`getVerifiedAdminUser\` in \`lib/server-auth.ts\` is now:

\`\`\`ts
const user = await verifyRequestUser(request, false);
if (!user || !user.isAdmin) return null;
return user;
\`\`\`

Previously it was just \`return verifyRequestUser(request, false)\` — name suggested admin gating, body didn't check it. Adds two negative-case tests (non-admin token, no token).

## Verification

- Both PRs passed Lint and Type Check, Test, E2E Tests, Firestore rules tests, REUSE lint, DCO, Security Scanning on their post-rebase SHAs.
- Local \`SKIP_TYPECHECK=1 npm run build\` succeeded against the develop tip on the feature branch; OpenAPI + docs/API.md regenerated. New routes prerendered (/skills, /templates, /challenges, /recordings + the new /confirm-attendance API).
- \`npx jest\` on the new test files: 87/87 passing locally (route + snapshot + modal + the regression page test that I updated for the new copy).
- Manual smoke checklist included in #1407's body for the four-state matrix (logged out / signed-in not-signed-up / signed-up not-confirmed / signed-up confirmed).

## Post-merge

- Fast-forward cohort/event submission branches per CLAUDE.md.
- \`c1w2comms-submission\` continues to be skipped (jonathanlittel submission still 1 commit ahead, not yet promoted to develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)