### PR TITLE
release: develop → main batch 4 (2026-05-23) — Sports Hack event nav + self-serve agent prompt

### DIFF
--- a/__tests__/components/events/SportsHackSubmitPromptButton.test.tsx
+++ b/__tests__/components/events/SportsHackSubmitPromptButton.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SportsHackSubmitPromptButton } from "@/components/events/SportsHackSubmitPromptButton";
+
+describe("SportsHackSubmitPromptButton", () => {
+  let writeText: jest.Mock;
+
+  beforeEach(() => {
+    writeText = jest.fn().mockResolvedValue(undefined);
+    // Override clipboard via defineProperty (Object.assign won't work — slot is read-only in jsdom).
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("renders the headline + copy + preview buttons", () => {
+    render(<SportsHackSubmitPromptButton />);
+    expect(screen.getByText(/Let your agent submit for you/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Copy agent prompt/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Preview prompt/ })).toBeInTheDocument();
+  });
+
+  it("toggles the inline preview block on Preview prompt", async () => {
+    const user = userEvent.setup();
+    render(<SportsHackSubmitPromptButton />);
+    expect(screen.queryByText(/Hard deadline/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Preview prompt/ }));
+    expect(screen.getByText(/Hard deadline/)).toBeInTheDocument();
+  });
+
+  it("copies the prompt to the clipboard with the event branch + deadline + handle detection", async () => {
+    render(<SportsHackSubmitPromptButton />);
+    // fireEvent rather than userEvent — user-event v14 ships its own clipboard
+    // simulation that would intercept navigator.clipboard.writeText.
+    fireEvent.click(screen.getByRole("button", { name: /Copy agent prompt/ }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0][0];
+    expect(typeof copied).toBe("string");
+    expect(copied).toMatch(/sports-hack-2026-submissions/);
+    expect(copied).toMatch(/2026-05-26T20:00:00Z/);
+    expect(copied).toMatch(/meta\.json/);
+    expect(copied).toMatch(/gh api user --jq \.login/);
+    expect(copied).toMatch(/rogerSuperBuilderAlpha\/cursor-boston/);
+    expect(await screen.findByRole("button", { name: /Copied/ })).toBeInTheDocument();
+  });
+
+  it("falls back to the inline preview + error message when clipboard fails", async () => {
+    writeText.mockRejectedValue(new Error("Clipboard blocked"));
+    render(<SportsHackSubmitPromptButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Copy agent prompt/ }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Couldn't write to clipboard/i,
+      ),
+    );
+    // Inline preview auto-opens so the user can copy manually.
+    expect(screen.getByText(/Hard deadline/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/hackathons/SportsHack2026EventNav.test.tsx
+++ b/__tests__/components/hackathons/SportsHack2026EventNav.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
+import { useAuth } from "@/contexts/AuthContext";
+import { usePathname } from "next/navigation";
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/hackathons/sports-hack-2026"),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+    "aria-current": ariaCurrent,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+    "aria-current"?: string;
+  }) => (
+    <a href={href} className={className} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+
+function setAuth(isAdmin: boolean | null) {
+  mockUseAuth.mockReturnValue({
+    user: isAdmin === null ? null : ({ uid: "u1" } as never),
+    userProfile: isAdmin === null ? null : ({ isAdmin } as never),
+    loading: false,
+  } as never);
+}
+
+describe("SportsHack2026EventNav", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePathname.mockReturnValue("/hackathons/sports-hack-2026");
+  });
+
+  it("renders Overview, Sign up, and Submissions links for all users", () => {
+    setAuth(null);
+    render(<SportsHack2026EventNav />);
+    expect(screen.getByRole("link", { name: /Overview/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Sign up & rank/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Submissions/ })).toBeInTheDocument();
+  });
+
+  it("hides Admin link from logged-out users", () => {
+    setAuth(null);
+    render(<SportsHack2026EventNav />);
+    expect(screen.queryByRole("link", { name: /^Admin$/ })).not.toBeInTheDocument();
+  });
+
+  it("hides Admin link from non-admin signed-in users", () => {
+    setAuth(false);
+    render(<SportsHack2026EventNav />);
+    expect(screen.queryByRole("link", { name: /^Admin$/ })).not.toBeInTheDocument();
+  });
+
+  it("shows Admin link for admin users", () => {
+    setAuth(true);
+    render(<SportsHack2026EventNav />);
+    expect(screen.getByRole("link", { name: /^Admin$/ })).toBeInTheDocument();
+  });
+
+  it("marks the Overview link active on the overview path", () => {
+    setAuth(null);
+    mockUsePathname.mockReturnValue("/hackathons/sports-hack-2026");
+    render(<SportsHack2026EventNav />);
+    const overview = screen.getByRole("link", { name: /Overview/ });
+    expect(overview).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: /Sign up & rank/ })).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks the Sign up link active on the signup path", () => {
+    setAuth(null);
+    mockUsePathname.mockReturnValue("/hackathons/sports-hack-2026/signup");
+    render(<SportsHack2026EventNav />);
+    expect(screen.getByRole("link", { name: /Sign up & rank/ })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: /Overview/ })).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks the Submissions link active on the submissions path", () => {
+    setAuth(null);
+    mockUsePathname.mockReturnValue("/events/cursor-boston-sports-hack-2026");
+    render(<SportsHack2026EventNav />);
+    expect(screen.getByRole("link", { name: /Submissions/ })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("marks the Admin link active on the admin path for admins", () => {
+    setAuth(true);
+    mockUsePathname.mockReturnValue("/hackathons/sports-hack-2026/admin");
+    render(<SportsHack2026EventNav />);
+    expect(screen.getByRole("link", { name: /^Admin$/ })).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/app/events/cursor-boston-sports-hack-2026/page.tsx
+++ b/app/events/cursor-boston-sports-hack-2026/page.tsx
@@ -9,6 +9,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import eventsData from "@/content/events.json";
 import type { EventsData } from "@/types/events";
+import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
+import { SportsHackSubmitPromptButton } from "@/components/events/SportsHackSubmitPromptButton";
 import {
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
@@ -88,6 +90,10 @@ export default function SportsHack2026HubPage() {
           </ol>
         </div>
       </nav>
+
+      <div className="px-6 pt-6 max-w-6xl mx-auto w-full">
+        <SportsHack2026EventNav />
+      </div>
 
       <Hero event={event} />
       <HowToWinCredits />
@@ -253,7 +259,7 @@ function HowToSubmit() {
         <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-2">
           How to submit your project
         </h2>
-        <p className="text-neutral-600 dark:text-neutral-400 mb-8 max-w-3xl">
+        <p className="text-neutral-600 dark:text-neutral-400 mb-6 max-w-3xl">
           On event day you submit by opening a PR into the{" "}
           <code className="rounded bg-neutral-200 px-1.5 py-0.5 text-xs font-mono dark:bg-neutral-800">
             {SPORTS_HACK_2026_SUBMISSIONS_BRANCH}
@@ -263,6 +269,12 @@ function HowToSubmit() {
           project. Once a maintainer merges through to{" "}
           <code className="font-mono">main</code>, your card appears in the grid
           below.
+        </p>
+
+        <SportsHackSubmitPromptButton />
+
+        <p className="text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-3">
+          Or do it by hand
         </p>
 
         <ol className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">

--- a/app/hackathons/sports-hack-2026/admin/page.tsx
+++ b/app/hackathons/sports-hack-2026/admin/page.tsx
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
+import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
 import {
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
@@ -247,6 +248,7 @@ export default function SportsHack2026AdminPage() {
     <div className="flex flex-col min-h-screen">
       <section className="py-8 px-6 border-b border-neutral-200 dark:border-neutral-800">
         <div className="max-w-7xl mx-auto">
+          <SportsHack2026EventNav />
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <p className="text-sm text-neutral-500 mb-1">

--- a/app/hackathons/sports-hack-2026/page.tsx
+++ b/app/hackathons/sports-hack-2026/page.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
 import { LumaEmbed } from "@/components/hackathons/LumaEmbed";
+import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
 import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
@@ -74,7 +75,7 @@ export default function SportsHack2026LandingPage() {
   return (
     <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
       <div className="mx-auto max-w-5xl px-6 py-12 md:py-16">
-        <nav className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+        <nav className="mb-4 text-sm text-neutral-500 dark:text-neutral-400">
           <Link
             href="/hackathons"
             className="hover:text-emerald-600 dark:hover:text-emerald-400"
@@ -86,6 +87,8 @@ export default function SportsHack2026LandingPage() {
             {SPORTS_HACK_2026_NAME}
           </span>
         </nav>
+
+        <SportsHack2026EventNav />
 
         <div className="grid gap-10 md:grid-cols-[1fr_minmax(320px,420px)]">
           <div>

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
+import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
 import { trackEvent } from "@/lib/analytics";
 import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
@@ -413,7 +414,7 @@ export default function SportsHack2026SignupPage() {
   return (
     <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
       <div className="mx-auto max-w-4xl px-6 py-12 md:py-16">
-        <nav className="mb-8 text-sm text-neutral-500 dark:text-neutral-400">
+        <nav className="mb-4 text-sm text-neutral-500 dark:text-neutral-400">
           <Link
             href="/hackathons"
             className="hover:text-emerald-600 dark:hover:text-emerald-400"
@@ -430,6 +431,8 @@ export default function SportsHack2026SignupPage() {
           <span className="mx-2">/</span>
           <span className="text-neutral-700 dark:text-neutral-300">Signup</span>
         </nav>
+
+        <SportsHack2026EventNav />
 
         <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
           {SPORTS_HACK_2026_SHORT_NAME} — website signup

--- a/components/events/SportsHackSubmitPromptButton.tsx
+++ b/components/events/SportsHackSubmitPromptButton.tsx
@@ -1,0 +1,228 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Self-contained prompt an attendee can paste into a fresh Cursor (or
+ * Claude Code) chat to have the agent open their Sports Hack 2026 PR
+ * end-to-end. Modeled on `CursorSubmitPromptButton` (the PyData
+ * equivalent), but the submission shape is different: meta.json only
+ * (no notebook file), additional video / repo / deploy URL fields, and
+ * the 4 PM ET cutoff is what gates AI-track eligibility.
+ *
+ * Keep in sync with `sports-hack-2026-submissions/README.md` (the
+ * source of truth that the maintainer reviews each PR against).
+ */
+const SPORTS_HACK_PROMPT = `I just attended the Cursor Boston × Hult Boston Tech Week Sports Hack (May 26, 2026) at Hult International. Open a pull request submitting my project to https://github.com/rogerSuperBuilderAlpha/cursor-boston targeting the \`sports-hack-2026-submissions\` branch (NOT main or develop).
+
+## Hard deadline
+4:00 PM ET on Tuesday May 26, 2026 (\`2026-05-26T20:00:00Z\`). The PR must be **opened before** that moment to be eligible for the AI-judged track. After the deadline the PR is still mergeable for the human-judges track, but AI scoring is closed and the public page will flag the card as after-deadline.
+
+## Ask me for these — do not guess
+- Project **title** (≤120 chars).
+- A **1–3 sentence description** of what I built and what problem it solves (≤500 chars, plain text — markdown is not rendered).
+- My **GitHub handle**, lowercased exactly as it appears in \`github.com/<handle>\`. Auto-detect with \`gh api user --jq .login\` and confirm with me.
+- The **display name** I want on the public card (defaults to my GitHub handle if I don't have one).
+- **Video URL** — Loom, YouTube, or Vimeo. Keep it ≤3 minutes.
+- **Public repo URL** for the code (must be a \`https://github.com/...\` URL on a PUBLIC repo).
+- **Deployed URL** — a live URL we can open in the browser. If you didn't deploy, pass an empty string \`""\` and explain in the description.
+- Optional **tags** (up to 6 short strings, lowercase preferred).
+- Optional **collaborators** (up to 10 entries, each with \`displayName\` and optional \`githubHandle\`).
+
+If \`gh\` isn't authenticated (\`gh auth status\` fails), tell me to run \`gh auth login\` and stop until I confirm.
+
+## Before you commit — sanity checks
+1. \`title\` non-empty and ≤120 chars; \`description\` ≤500 chars.
+2. \`videoUrl\` and \`repoUrl\` start with \`https://\`. \`deployedUrl\` either starts with \`https://\` or is \`""\`.
+3. Confirm \`repoUrl\` returns 200 on \`gh api repos/<owner>/<repo>\` (i.e. it's public).
+4. Grep the repo for accidentally-committed secrets: \`AKIA\`, \`AIza\`, \`sk-\`, \`BEGIN PRIVATE KEY\`, \`api_key=\`. If any match, STOP and tell me.
+5. Run \`python3 -c "import json; json.load(open('meta.json'))"\` after writing meta.json to confirm it parses.
+
+## File to add
+Exactly one file, where \`<handle>\` is my lowercased GitHub handle:
+
+\`sports-hack-2026-submissions/<handle>/meta.json\`:
+
+\`\`\`json
+{
+  "title": "Short, specific project title",
+  "description": "1–3 sentences. What did you build? What problem does it solve?",
+  "displayName": "Your name as you want it on the page",
+  "videoUrl": "https://www.loom.com/share/...",
+  "repoUrl": "https://github.com/your-handle/your-project",
+  "deployedUrl": "https://your-project.vercel.app",
+  "tags": ["nba", "live-stats", "next.js"],
+  "collaborators": [
+    { "displayName": "Pat Collaborator", "githubHandle": "pat-collab" }
+  ]
+}
+\`\`\`
+
+Omit \`tags\` or \`collaborators\` entirely if I don't have them — don't include empty arrays unless I tell you to.
+
+## How to open the PR (use \`gh\`)
+1. Fork upstream if I don't already have one: \`gh repo fork rogerSuperBuilderAlpha/cursor-boston --clone=false\`.
+2. Clone my fork into a scratch dir (e.g. \`/tmp/cb-sports-hack-<handle>\`), \`cd\` into it, add upstream: \`git remote add upstream https://github.com/rogerSuperBuilderAlpha/cursor-boston && git fetch upstream\`.
+3. Branch off the upstream submission branch: \`git checkout -b submit/<handle> upstream/sports-hack-2026-submissions\`.
+4. Add my meta.json under \`sports-hack-2026-submissions/<handle>/\`. Commit (with sign-off): \`git add sports-hack-2026-submissions/<handle>/ && git commit -s -m "sports-hack-2026: <handle> submission"\`. Push: \`git push -u origin submit/<handle>\`.
+5. Open the PR: \`gh pr create --repo rogerSuperBuilderAlpha/cursor-boston --base sports-hack-2026-submissions --head <handle>:submit/<handle> --title "sports-hack-2026: <displayName> — <title>" --body "Project submission for the May 26 Cursor Boston × Hult Sports Hack at Hult International."\`
+6. Print the PR URL, the current time in ET, and how much time is left before the 4 PM ET cutoff. Stop.
+
+## Rules (the maintainer will reject the PR if any of these are wrong)
+- Folder name **must** be my GitHub handle, lowercased exactly.
+- The only file in the folder is \`meta.json\`. Do not add screenshots, code, or anything else — submissions are pointers to my own repo + video.
+- Required fields (\`title\`, \`description\`, \`videoUrl\`, \`repoUrl\`, \`deployedUrl\`) are all present. \`deployedUrl\` may be an empty string if I didn't deploy, but the field must exist.
+- No Moderna, Cursor, Red Bull, or Hult branding misuse in the description or anything reachable from the URLs.
+- No secrets or API keys in my project repo (the maintainer will spot-check).
+
+If anything fails — auth, fork already exists, branch already taken, push rejected, validation fails — tell me what happened and what to do. Do not silently bypass.
+`;
+
+const COPY_RESET_MS = 2500;
+
+export function SportsHackSubmitPromptButton() {
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const handleCopy = async () => {
+    setCopyError(null);
+    try {
+      await navigator.clipboard.writeText(SPORTS_HACK_PROMPT);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), COPY_RESET_MS);
+    } catch {
+      setCopyError(
+        "Couldn't write to clipboard — open the preview below and copy manually."
+      );
+      setPreviewOpen(true);
+    }
+  };
+
+  return (
+    <div className="mb-8 rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-5 dark:bg-emerald-500/10">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 max-w-2xl">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-700 dark:text-emerald-300">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+              </svg>
+            </span>
+            <h3 className="text-base font-semibold text-foreground">
+              Let your agent submit for you
+            </h3>
+          </div>
+          <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+            Copy this self-contained prompt and paste it into Cursor, Claude
+            Code, or any agent with shell access. It asks you for the title,
+            description, video, repo, and deploy URLs, validates them, forks
+            this repo, writes <code>meta.json</code> in the right place, and
+            opens the PR against <code>sports-hack-2026-submissions</code>{" "}
+            before the 4 PM ET cutoff.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2"
+            aria-live="polite"
+          >
+            {copied ? (
+              <>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                Copied
+              </>
+            ) : (
+              <>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+                Copy agent prompt
+              </>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setPreviewOpen((p) => !p)}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 px-3 py-2 text-xs font-medium text-emerald-700 hover:bg-emerald-500/10 dark:text-emerald-300 dark:hover:bg-emerald-500/15"
+            aria-expanded={previewOpen}
+          >
+            {previewOpen ? "Hide preview" : "Preview prompt"}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={previewOpen ? "rotate-180 transition-transform" : "transition-transform"}
+              aria-hidden="true"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {copyError ? (
+        <p className="mt-3 text-xs text-rose-700 dark:text-rose-300" role="alert">
+          {copyError}
+        </p>
+      ) : null}
+
+      {previewOpen ? (
+        <pre className="mt-4 max-h-96 overflow-auto rounded-xl border border-emerald-500/20 bg-white p-4 text-xs leading-relaxed text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+          <code>{SPORTS_HACK_PROMPT}</code>
+        </pre>
+      ) : null}
+    </div>
+  );
+}

--- a/components/hackathons/SportsHack2026EventNav.tsx
+++ b/components/hackathons/SportsHack2026EventNav.tsx
@@ -1,0 +1,92 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_SHORT_NAME,
+} from "@/lib/sports-hack-2026";
+
+/**
+ * Shared cross-page navigation for the May 26 Sports Hack 2026 event.
+ *
+ * The event spans four distinct routes (overview, signup leaderboard,
+ * admin door check-in, and the public submissions list under `/events/`).
+ * Before this component the only way to move between them was the back
+ * button or breadcrumbs. This nav surfaces all four with active-state
+ * highlighting on the current page.
+ *
+ * Admin link is hidden unless `userProfile.isAdmin === true`.
+ */
+
+const SUBMISSIONS_HREF = "/events/cursor-boston-sports-hack-2026";
+const OVERVIEW_HREF = `/hackathons/${SPORTS_HACK_2026_EVENT_ID}`;
+const SIGNUP_HREF = `/hackathons/${SPORTS_HACK_2026_EVENT_ID}/signup`;
+const ADMIN_HREF = `/hackathons/${SPORTS_HACK_2026_EVENT_ID}/admin`;
+
+type NavLink = {
+  href: string;
+  label: string;
+  requiresAdmin?: boolean;
+};
+
+const NAV_LINKS: readonly NavLink[] = [
+  { href: OVERVIEW_HREF, label: "Overview" },
+  { href: SIGNUP_HREF, label: "Sign up & rank" },
+  { href: SUBMISSIONS_HREF, label: "Submissions" },
+  { href: ADMIN_HREF, label: "Admin", requiresAdmin: true },
+] as const;
+
+export function SportsHack2026EventNav() {
+  const pathname = usePathname() ?? "";
+  const { userProfile } = useAuth();
+  const isAdmin = Boolean(
+    (userProfile as { isAdmin?: boolean } | null)?.isAdmin
+  );
+
+  const links = NAV_LINKS.filter(
+    (link) => !link.requiresAdmin || isAdmin
+  );
+
+  return (
+    <nav
+      aria-label="Sports Hack 2026 event"
+      className="mb-6 flex flex-wrap items-center gap-x-6 gap-y-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-4 py-3 text-sm dark:bg-emerald-500/10"
+    >
+      <Link
+        href={OVERVIEW_HREF}
+        className="font-semibold text-foreground hover:text-emerald-700 dark:hover:text-emerald-300"
+      >
+        {SPORTS_HACK_2026_SHORT_NAME} · May 26
+      </Link>
+      <ul className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        {links.map((link) => {
+          const isActive = pathname === link.href;
+          return (
+            <li key={link.href}>
+              <Link
+                href={link.href}
+                aria-current={isActive ? "page" : undefined}
+                className={
+                  isActive
+                    ? "border-b-2 border-emerald-500 pb-0.5 font-semibold text-emerald-700 dark:text-emerald-300"
+                    : "text-neutral-600 hover:text-foreground dark:text-neutral-400"
+                }
+              >
+                {link.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

Fourth develop → main release of the day. Single PR (#1409) bundling two related Sports Hack 2026 attendee-experience improvements:

1. **Shared event-nav header** across the four event pages (Overview / Sign up / Submissions / Admin) with active-state highlighting. Admin tab hidden for non-admins.
2. **Self-serve agent prompt** on the submissions page. Attendees copy a self-contained prompt and paste it into Cursor / Claude Code / any shell-capable agent — the agent collects + validates their submission fields, forks the repo, writes \`meta.json\`, and opens the PR against \`sports-hack-2026-submissions\` before the 4 PM ET cutoff.

## Included PRs and contributors

| PR | Title | Contributor |
|---|---|---|
| #1409 | feat(sports-hack-2026): event-nav header + self-serve agent prompt for PR submission | Ludwitt |

## Verification

- #1409 passed Lint and Type Check, Test, Build, E2E Tests, Firestore rules tests, REUSE lint, DCO, and Security Scanning.
- Local \`SKIP_TYPECHECK=1 npm run build\` succeeded; OpenAPI + docs/API.md regenerated. No new routes added (purely client-side UI).
- \`npx jest\` on the three relevant test files: 22/22 passing locally.

## Post-merge

- Fast-forward cohort/event submission branches per CLAUDE.md.
- \`c1w2comms-submission\` continues to be skipped (jonathanlittel submission still 1 commit ahead of develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)