### PR TITLE
docs(adr): add ADR-0007 and ADR-0008 to index table

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,8 @@ What becomes easier or more difficult because of this decision?
 | [0004](0004-webpack-bundler.md) | Webpack over Turbopack | Accepted | 2026-04-13 |
 | [0005](0005-in-memory-rate-limiting.md) | In-memory rate limiting with Firestore fallback | Accepted | 2026-04-13 |
 | [0006](0006-develop-main-branching.md) | develop/main branching strategy | Accepted | 2026-04-13 |
+| [0007](0007-account-deletion-model.md) | Account deletion — hard-delete with 30-day soft-delete grace | Accepted | 2026-05-18 |
+| [0008](0008-community-maintainer-track.md) | Community Maintainer track + multi-maintainer onboarding model | Accepted | 2026-05-18 |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
## Description
Add ADR-0007 and ADR-0008 to index table
Updates docs/adr/README.md to include the two ADRs that were written in the 2026-05-18 OSS master-class lift but never added to the index table.

ADR-0007: Account deletion — hard-delete with 30-day soft-delete grace
ADR-0008: Community Maintainer track + multi-maintainer onboarding model

Closes the discoverability gap where the files existed but weren't reachable from the index.

**Base branch:** Open PRs against **`develop`** (default). Only release PRs use **`develop` → `main`**.

Fixes # Added two ADRs

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Accessibility improvement

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally
- [x] Tested on mobile devices
- [ ] Tested accessibility (keyboard navigation, screen readers)
- [x] Tested authentication flows
- [ ] Tested form submissions

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes