### PR TITLE
release: 3D world flyover + send-may26 archive

### DIFF
--- a/app/api/game/world-3d/route.ts
+++ b/app/api/game/world-3d/route.ts
@@ -1,0 +1,60 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// Public read endpoint for the daily 3D world snapshot. Serves the doc
+// at `game_world_snapshots/daily-3d`, written once per day by the
+// `only=game-world-3d` cron branch in /api/internal/snapshots/rebuild.
+//
+// Anonymous access. ISR caches the response for 24h; combined with the
+// daily writer, steady-state cost is effectively zero Firestore reads
+// per visitor.
+
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { readWorld3DSnapshotServer } from "@/lib/game/world-snapshot-3d";
+
+// @contracts: gameContract.getWorld3d (lib/api-schemas/game.ts)
+// Validates the response shape returned to anonymous visitors.
+import "@/lib/api-schemas/game";
+
+export const runtime = "nodejs";
+export const revalidate = 86400; // 24h
+
+const CACHE_HEADER =
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=86400";
+
+export async function GET() {
+  try {
+    const snapshot = await readWorld3DSnapshotServer();
+    if (!snapshot) {
+      // Pre-first-cron-run: respond with an empty world rather than 404
+      // so the client renders an empty board (and the "no snapshot yet"
+      // state is visible in the UI rather than a broken page).
+      const res = NextResponse.json(
+        { tiles: [], generatedAt: null, tileCount: 0 },
+        { status: 200 }
+      );
+      // Short cache while the snapshot is missing — first cron run will
+      // populate it within 24h.
+      res.headers.set(
+        "Cache-Control",
+        "public, max-age=60, s-maxage=300, stale-while-revalidate=600"
+      );
+      return res;
+    }
+
+    const res = NextResponse.json(snapshot, { status: 200 });
+    res.headers.set("Cache-Control", CACHE_HEADER);
+    return res;
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/game/world-3d" });
+    return NextResponse.json(
+      { error: "Failed to read 3D world snapshot" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/internal/snapshots/rebuild/route.ts
+++ b/app/api/internal/snapshots/rebuild/route.ts
@@ -9,6 +9,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { logger } from "@/lib/logger";
 import {
@@ -20,6 +21,7 @@ import {
   MEMBERS_SNAPSHOT_CACHE_TTL_MS,
 } from "@/lib/members-public-snapshot";
 import { rebuildWorldSnapshotServer } from "@/lib/game/world-snapshot";
+import { rebuildWorld3DSnapshotServer } from "@/lib/game/world-snapshot-3d";
 
 // @contracts: internalContract.snapshotsRebuildGet, internalContract.snapshotsRebuildPost (lib/api-schemas/internal.ts)
 
@@ -80,6 +82,10 @@ async function handleRebuild(request: NextRequest): Promise<NextResponse> {
   // freshness budget than the other snapshots; its dedicated cron entry
   // in vercel.json fires every 5 minutes vs analytics/members at 6h.
   let runGameWorld = only === "game-world" || only === "all";
+  // Public 3D flyover snapshot — opt-in via `only=game-world-3d` (or
+  // `all`). Daily-rebuild cadence; the page reads it through an ISR
+  // route cached 24h.
+  let runGameWorld3D = only === "game-world-3d" || only === "all";
 
   try {
     const result: {
@@ -89,6 +95,12 @@ async function handleRebuild(request: NextRequest): Promise<NextResponse> {
         ok: boolean;
         tileCount?: number;
         ownerCount?: number;
+        error?: string;
+      };
+      gameWorld3D?: {
+        ok: boolean;
+        tileCount?: number;
+        bytes?: number;
         error?: string;
       };
     } = {};
@@ -192,10 +204,35 @@ async function handleRebuild(request: NextRequest): Promise<NextResponse> {
       }
     }
 
+    if (runGameWorld3D) {
+      try {
+        const out = await rebuildWorld3DSnapshotServer();
+        // Bust the ISR caches so the next visitor gets the fresh
+        // snapshot instead of waiting for revalidate=86400 to expire.
+        // Without this, the public route/page keeps serving the stale
+        // build-time prerender for up to 24h after each daily write.
+        revalidatePath("/api/game/world-3d");
+        revalidatePath("/game/world");
+        result.gameWorld3D = {
+          ok: true,
+          tileCount: out.tileCount,
+          bytes: out.bytes,
+        };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.logError(e, {
+          endpoint: "/api/internal/snapshots/rebuild",
+          phase: "game-world-3d",
+        });
+        result.gameWorld3D = { ok: false, error: msg };
+      }
+    }
+
     const ok =
       (!runAnalytics || result.analytics?.ok) &&
       (!runMembers || result.members?.ok) &&
-      (!runGameWorld || result.gameWorld?.ok);
+      (!runGameWorld || result.gameWorld?.ok) &&
+      (!runGameWorld3D || result.gameWorld3D?.ok);
     return NextResponse.json({ ok, invocationId, ...result }, { status: ok ? 200 : 500 });
   } catch (error) {
     logger.logError(error, { endpoint: "/api/internal/snapshots/rebuild", invocationId });

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -7,11 +7,28 @@
 
 "use client";
 
+import Link from "next/link";
 import { CreatePlayerGate } from "./_components/dashboard/CreatePlayerGate";
 import { DashboardView } from "./_components/dashboard/DashboardView";
 import { NameYourGeneralGate } from "./_components/dashboard/NameYourGeneralGate";
 import { SignedOutLanding } from "./_components/dashboard/SignedOutLanding";
 import { useDashboardData } from "./_lib/use-dashboard-data";
+
+// Fixed bottom-right FAB linking into the 3D fly-around at /game/world.
+// Always rendered (signed-out landing, create-player gate, full
+// dashboard) so the world map is discoverable from every entrypoint.
+function WorldMapFab() {
+  return (
+    <Link
+      href="/game/world"
+      className="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-neutral-900/80 backdrop-blur border border-neutral-700/60 px-4 py-2.5 text-sm font-medium text-neutral-100 shadow-lg hover:bg-neutral-800 dark:bg-neutral-900/80 dark:hover:bg-neutral-800 transition-colors"
+      aria-label="Open game world map"
+    >
+      <span aria-hidden>🗺️</span>
+      <span>Open game world map</span>
+    </Link>
+  );
+}
 
 /**
  * /game — the dashboard. Composition only: every meaningful piece lives
@@ -37,30 +54,36 @@ export default function GameDashboardPage() {
     handleSetName,
   } = data;
 
+  let content: React.ReactNode;
   if (authLoading || loading) {
-    return (
+    content = (
       <div className="min-h-screen flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-emerald-500" />
       </div>
     );
-  }
-
-  if (!user) return <SignedOutLanding />;
-
-  if (!player) {
-    return (
+  } else if (!user) {
+    content = <SignedOutLanding />;
+  } else if (!player) {
+    content = (
       <CreatePlayerGate
         creating={creating}
         error={error}
         onCreate={handleCreatePlayer}
       />
     );
+  } else if (!player.displayName) {
+    // Legacy gate: players who spawned before names were required.
+    content = <NameYourGeneralGate error={error} onSave={handleSetName} />;
+  } else {
+    content = <DashboardView player={player} data={data} />;
   }
 
-  // Legacy gate: players who spawned before names were required.
-  if (!player.displayName) {
-    return <NameYourGeneralGate error={error} onSave={handleSetName} />;
-  }
-
-  return <DashboardView player={player} data={data} />;
+  // The FAB rides on top of every state — even pre-auth — so the 3D
+  // fly-around is one click away from anywhere in /game.
+  return (
+    <>
+      {content}
+      {!authLoading && <WorldMapFab />}
+    </>
+  );
 }

--- a/app/game/world/_components/HowToPlayDrawer.tsx
+++ b/app/game/world/_components/HowToPlayDrawer.tsx
@@ -1,0 +1,143 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { CASTE_COLOR_HEX, CASTE_LABEL } from "./world-constants";
+
+interface HowToPlayDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function hexToCss(hex: number): string {
+  return `#${hex.toString(16).padStart(6, "0")}`;
+}
+
+export function HowToPlayDrawer({ open, onClose }: HowToPlayDrawerProps) {
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`absolute inset-0 bg-black/50 transition-opacity z-20 ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={onClose}
+        aria-hidden
+      />
+
+      {/* Drawer */}
+      <aside
+        className={`absolute top-0 left-0 h-full w-[min(380px,calc(100vw-3rem))] bg-neutral-900/95 backdrop-blur border-r border-neutral-700/60 transform transition-transform duration-300 z-30 ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
+        aria-hidden={!open}
+      >
+        <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-800">
+          <h2 className="font-semibold">How to read this map</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close drawer"
+            className="text-neutral-400 hover:text-neutral-100 px-2 text-xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-5 py-4 space-y-5 overflow-y-auto h-[calc(100%-3.5rem)]">
+          <section>
+            <h3 className="text-xs uppercase tracking-wide text-neutral-400 mb-2">
+              Tile types
+            </h3>
+            <ul className="space-y-2 text-sm">
+              <li className="flex items-center gap-3">
+                <span className="inline-block w-3 h-5 rounded-sm bg-amber-700" />
+                <span>
+                  <strong>Barracks</strong> — military tile, recruits units
+                </span>
+              </li>
+              <li className="flex items-center gap-3">
+                <span className="inline-block w-4 h-4 rounded-full bg-green-600" />
+                <span>
+                  <strong>Farm / Silo</strong> — food tile, feeds armies
+                </span>
+              </li>
+              <li className="flex items-center gap-3">
+                <span className="inline-block w-3 h-5 rounded-t-full bg-purple-500" />
+                <span>
+                  <strong>Spire</strong> — magic tile, fuels spells
+                </span>
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-xs uppercase tracking-wide text-neutral-400 mb-2">
+              Castes
+            </h3>
+            <ul className="grid grid-cols-2 gap-y-2 text-sm">
+              {(
+                Object.keys(CASTE_COLOR_HEX) as Array<
+                  keyof typeof CASTE_COLOR_HEX
+                >
+              ).map((c) => (
+                <li key={c} className="flex items-center gap-2">
+                  <span
+                    className="inline-block w-3.5 h-3.5 rounded-sm border border-neutral-700"
+                    style={{ backgroundColor: hexToCss(CASTE_COLOR_HEX[c]) }}
+                  />
+                  <span>{CASTE_LABEL[c]}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-xs uppercase tracking-wide text-neutral-400 mb-2">
+              Markers
+            </h3>
+            <ul className="space-y-2 text-sm">
+              <li>
+                <strong>Banner</strong> — a hero is stationed on this tile.
+              </li>
+              <li>
+                <strong>Skull pennant</strong> — held by an NPC. Conquer it for
+                land + glory.
+              </li>
+              <li>
+                <strong>Glow</strong> — the tile has recruited units beyond its
+                base garrison. Heavier defense ahead.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-xs uppercase tracking-wide text-neutral-400 mb-2">
+              How turns work
+            </h3>
+            <p className="text-sm text-neutral-300">
+              Merge a PR into the cursor-boston repo any time during a week and
+              you&apos;ll receive 100 turns the following Sunday at midnight
+              EST. No PR, no turns.
+            </p>
+          </section>
+
+          <section className="pt-2">
+            <Link
+              href="/game/help"
+              className="inline-block text-sm text-emerald-400 hover:text-emerald-300"
+            >
+              Full game rules →
+            </Link>
+          </section>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/app/game/world/_components/TileInfoCard.tsx
+++ b/app/game/world/_components/TileInfoCard.tsx
@@ -1,0 +1,107 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import type { Caste } from "@/lib/game/types";
+import type { World3DTile } from "@/lib/game/world-snapshot-3d";
+import { LAND_TYPE_LABEL } from "./world-constants";
+
+interface TileInfoCardProps {
+  tile: World3DTile;
+  signedIn: boolean;
+  onClose: () => void;
+  casteColorHex: Record<Caste, number>;
+  casteLabel: Record<Caste, string>;
+}
+
+function hexToCss(hex: number): string {
+  return `#${hex.toString(16).padStart(6, "0")}`;
+}
+
+export function TileInfoCard({
+  tile,
+  signedIn,
+  onClose,
+  casteColorHex,
+  casteLabel,
+}: TileInfoCardProps) {
+  const ownerLabel = tile.ownerName
+    ? tile.isNpc
+      ? `${tile.ownerName} (NPC)`
+      : tile.ownerName
+    : "Unclaimed";
+
+  const swatchColor = tile.caste
+    ? hexToCss(casteColorHex[tile.caste])
+    : "#6b6b6b";
+
+  return (
+    <div className="absolute left-1/2 -translate-x-1/2 bottom-24 sm:bottom-28 z-10 w-[min(420px,calc(100vw-2rem))] rounded-xl bg-neutral-900/90 backdrop-blur border border-neutral-700/60 shadow-2xl">
+      <div className="flex items-start justify-between p-4 pb-2">
+        <div className="flex items-center gap-3">
+          <span
+            className="inline-block h-4 w-4 rounded-sm border border-neutral-700"
+            style={{ backgroundColor: swatchColor }}
+            aria-hidden
+          />
+          <div>
+            <div className="text-xs uppercase tracking-wide text-neutral-400">
+              Tile {tile.tileId}
+            </div>
+            <div className="text-sm font-medium">{ownerLabel}</div>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="text-neutral-400 hover:text-neutral-100 px-2"
+        >
+          ×
+        </button>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 px-4 pb-4 text-sm">
+        <dt className="text-neutral-400">Caste</dt>
+        <dd>{tile.caste ? casteLabel[tile.caste] : "—"}</dd>
+
+        <dt className="text-neutral-400">Land</dt>
+        <dd>{LAND_TYPE_LABEL[tile.type]}</dd>
+
+        <dt className="text-neutral-400">Level</dt>
+        <dd>{tile.level}</dd>
+
+        <dt className="text-neutral-400">Reinforcements</dt>
+        <dd>{tile.hasExtraForces ? "Yes" : "Base garrison only"}</dd>
+
+        <dt className="text-neutral-400">Hero</dt>
+        <dd>{tile.hasHero ? "Stationed" : "—"}</dd>
+
+        {tile.ownerShielded && (
+          <>
+            <dt className="text-neutral-400">Shield</dt>
+            <dd>Active</dd>
+          </>
+        )}
+      </dl>
+
+      {!signedIn && (
+        <div className="border-t border-neutral-800 px-4 py-3 text-xs text-neutral-300">
+          <Link
+            href="/login"
+            className="text-emerald-400 hover:text-emerald-300"
+          >
+            Sign in
+          </Link>{" "}
+          to attack, recruit, and claim land of your own.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/game/world/_components/World3DClient.tsx
+++ b/app/game/world/_components/World3DClient.tsx
@@ -1,0 +1,212 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { World3DTile } from "@/lib/game/world-snapshot-3d";
+import { CASTE_LABEL, CASTE_COLOR_HEX } from "./world-constants";
+import { TileInfoCard } from "./TileInfoCard";
+import { HowToPlayDrawer } from "./HowToPlayDrawer";
+
+// `three` and `@react-three/fiber` touch `window` on import; load the
+// scene only on the client.
+const World3DScene = dynamic(
+  () =>
+    import("./World3DScene").then((m) => ({ default: m.World3DScene })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="absolute inset-0 flex items-center justify-center bg-neutral-950 text-neutral-400">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-emerald-500 mx-auto mb-3" />
+          <p className="text-sm">Loading world…</p>
+        </div>
+      </div>
+    ),
+  }
+);
+
+interface World3DClientProps {
+  initialTiles: World3DTile[];
+  generatedAt: string | null;
+}
+
+export function World3DClient({
+  initialTiles,
+  generatedAt,
+}: World3DClientProps) {
+  const { user, loading: authLoading } = useAuth();
+  const [selected, setSelected] = useState<World3DTile | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  // Player probe is keyed by uid so a sign-out (user → null) or a
+  // sign-in-as-different-account naturally invalidates the stored
+  // hasPlayer without an in-effect setState reset.
+  const [playerProbe, setPlayerProbe] = useState<{
+    uid: string;
+    hasPlayer: boolean;
+  } | null>(null);
+  const hasPlayer: boolean | null =
+    user && playerProbe?.uid === user.uid ? playerProbe.hasPlayer : null;
+
+  const tileIndex = useMemo(() => {
+    const m = new Map<string, World3DTile>();
+    for (const t of initialTiles) m.set(t.tileId, t);
+    return m;
+  }, [initialTiles]);
+
+  // Lazy probe for kingdom existence. Only fires once auth has settled
+  // AND we have a user — anonymous visitors never hit /api/game/player
+  // (it 401s without a token), keeping the public flyover truly public.
+  // No setState on the failure / signed-out paths: hasPlayer is derived
+  // from playerProbe.uid above, so a stale probe is invalidated
+  // automatically when the user changes.
+  useEffect(() => {
+    if (authLoading || !user) return;
+    const uid = user.uid;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch("/api/game/player", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const data = (await res.json()) as { player?: unknown | null };
+        if (cancelled) return;
+        setPlayerProbe({ uid, hasPlayer: Boolean(data.player) });
+      } catch {
+        // Network/parse failure — leave hasPlayer as null so the CTA
+        // shows the neutral "Access game" copy until the user retries.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  // CTA copy ladder, from most-engaged to least:
+  //   has kingdom     → "Manage kingdom"   (existing player, returning)
+  //   signed-in, no   → "Create my kingdom" (recruit them into the game)
+  //   signed-out      → "Sign in to play"   (the funnel entry)
+  // The destination is /game in every case except signed-out (→ /login).
+  // /game itself routes them to the right gate, so we don't need to
+  // branch on hasPlayer here.
+  const ctaHref = user ? "/game" : "/login";
+  let ctaLabel: string;
+  if (!user) {
+    ctaLabel = "Sign in to play";
+  } else if (hasPlayer === true) {
+    ctaLabel = "Manage kingdom";
+  } else if (hasPlayer === false) {
+    ctaLabel = "Create my kingdom";
+  } else {
+    // Still loading kingdom state — show a neutral label rather than
+    // flicker between Manage/Create.
+    ctaLabel = "Access game";
+  }
+  const ctaShowSpinner = authLoading;
+
+  const generatedLabel = generatedAt
+    ? new Date(generatedAt).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      })
+    : null;
+
+  const isEmpty = initialTiles.length === 0;
+
+  // fixed + inset-0 + z-50 deliberately escapes the AppShell wrapper.
+  // Without this, the AppShell footer extends the document below the
+  // viewport, so any drag on the canvas gets interpreted as a page
+  // scroll instead of an orbit/pan gesture — making the world feel
+  // "stuck, only zoom works".
+  return (
+    <div className="fixed inset-0 z-50 overflow-hidden bg-neutral-950 text-neutral-100">
+      <World3DScene
+        tiles={initialTiles}
+        onSelectTile={(tileId) => {
+          const t = tileId ? tileIndex.get(tileId) ?? null : null;
+          setSelected(t);
+        }}
+        selectedTileId={selected?.tileId ?? null}
+      />
+
+      {/* Top-left HUD */}
+      <div className="pointer-events-none absolute top-0 left-0 p-5 sm:p-6 max-w-md">
+        <div className="pointer-events-auto inline-block rounded-lg bg-neutral-900/70 backdrop-blur px-4 py-3 border border-neutral-700/50">
+          <h1 className="text-xl sm:text-2xl font-bold tracking-tight">
+            Generals
+          </h1>
+          <p className="text-xs sm:text-sm text-neutral-300 mt-1 max-w-sm">
+            A turn-based realm where every PR you merge buys you 100 turns.
+            Drag to fly across the map, scroll to zoom, right-drag to rotate.
+          </p>
+          {generatedLabel && (
+            <p className="text-[10px] text-neutral-500 mt-2 uppercase tracking-wide">
+              Snapshot: {generatedLabel}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Bottom-left: How to play */}
+      <div className="absolute bottom-0 left-0 p-5 sm:p-6">
+        <button
+          type="button"
+          onClick={() => setDrawerOpen(true)}
+          className="rounded-lg bg-neutral-900/70 backdrop-blur hover:bg-neutral-800/80 border border-neutral-700/50 px-4 py-2 text-sm text-neutral-100 transition-colors"
+        >
+          How to read this map
+        </button>
+      </div>
+
+      {/* Bottom-right: primary CTA */}
+      <div className="absolute bottom-0 right-0 p-5 sm:p-6">
+        <Link
+          href={ctaHref}
+          className="inline-block rounded-lg bg-emerald-500 hover:bg-emerald-400 px-5 sm:px-6 py-2.5 sm:py-3 text-sm sm:text-base font-medium text-white shadow-lg shadow-emerald-500/20 transition-colors"
+        >
+          {ctaShowSpinner ? "…" : ctaLabel}
+        </Link>
+      </div>
+
+      {/* Tile info card (slides in when a tile is clicked) */}
+      {selected && (
+        <TileInfoCard
+          tile={selected}
+          onClose={() => setSelected(null)}
+          signedIn={!!user}
+          casteColorHex={CASTE_COLOR_HEX}
+          casteLabel={CASTE_LABEL}
+        />
+      )}
+
+      {/* How-to-play slide-in drawer */}
+      <HowToPlayDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+      />
+
+      {/* Empty-state banner: rendered behind the scene since the scene
+          will be empty too. Keeps the page graceful pre-first-cron. */}
+      {isEmpty && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="rounded-lg bg-neutral-900/80 backdrop-blur border border-neutral-700/50 px-6 py-5 max-w-sm text-center">
+            <p className="text-sm text-neutral-300">
+              The world hasn&apos;t been snapshotted yet — check back tomorrow
+              once the daily build runs.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/game/world/_components/World3DScene.tsx
+++ b/app/game/world/_components/World3DScene.tsx
@@ -1,0 +1,505 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+// The actual three.js scene. Loaded only on the client (see
+// World3DClient → next/dynamic with ssr:false).
+//
+// Performance contract: every visible thing is an InstancedMesh so the
+// renderer ships one draw call per "layer" (hex prisms, military
+// buildings, food buildings, magic spires, hero banners, NPC pennants,
+// extra-forces glow rings) regardless of tile count. Empirically this
+// keeps a ~5K-tile world well above 60fps on a recent laptop.
+
+import { Canvas, extend, useFrame, useThree } from "@react-three/fiber";
+import { MapControls } from "@react-three/drei";
+import { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+
+// r3f v9 ships an empty catalogue — JSX primitives like <instancedMesh>,
+// <cylinderGeometry>, etc. resolve only after the THREE namespace has
+// been extended into it. Without this, the elements render as no-ops
+// (no error, just an empty scene) which is exactly what happened
+// during initial verification.
+//
+// The cast is because extend() expects a Catalogue (record of
+// constructables) but `import * as THREE` also exposes non-constructable
+// namespaces like THREE.AnimationUtils. r3f tolerates these at runtime;
+// it's the types that are too strict.
+extend(THREE as unknown as Parameters<typeof extend>[0]);
+import type { Caste, LandType } from "@/lib/game/types";
+import type { World3DTile } from "@/lib/game/world-snapshot-3d";
+import {
+  CASTE_COLOR_HEX,
+  HEX_RADIUS,
+  HEX_SPACING,
+  UNOWNED_COLOR_HEX,
+} from "./world-constants";
+
+const SQRT3 = Math.sqrt(3);
+
+interface World3DSceneProps {
+  tiles: World3DTile[];
+  onSelectTile: (tileId: string | null) => void;
+  selectedTileId: string | null;
+}
+
+interface ComputedTile {
+  tile: World3DTile;
+  x: number;
+  z: number;
+  height: number;
+  colorHex: number;
+}
+
+function axialToWorld(q: number, r: number): { x: number; z: number } {
+  return {
+    x: HEX_SPACING * HEX_RADIUS * SQRT3 * (q + r / 2),
+    z: HEX_SPACING * HEX_RADIUS * 1.5 * r,
+  };
+}
+
+function casteHex(caste: Caste | null): number {
+  return caste ? CASTE_COLOR_HEX[caste] : UNOWNED_COLOR_HEX;
+}
+
+function heightForLevel(level: number): number {
+  // Floor at 0.35 so even level-1 tiles read as a deliberate hex prism
+  // rather than a near-flat sliver; tops out around 1.55 for level 10.
+  return 0.35 + Math.min(10, Math.max(1, level)) * 0.12;
+}
+
+export function World3DScene({
+  tiles,
+  onSelectTile,
+  selectedTileId,
+}: World3DSceneProps) {
+  const computed = useMemo<ComputedTile[]>(
+    () =>
+      tiles.map((tile) => {
+        const { x, z } = axialToWorld(tile.q, tile.r);
+        return {
+          tile,
+          x,
+          z,
+          height: heightForLevel(tile.level),
+          colorHex: casteHex(tile.caste),
+        };
+      }),
+    [tiles]
+  );
+
+  const framing = useMemo(() => {
+    if (computed.length === 0) {
+      return { centerX: 0, centerZ: 0, worldRadius: 30, viewRadius: 30 };
+    }
+    let sx = 0;
+    let sz = 0;
+    for (const c of computed) {
+      sx += c.x;
+      sz += c.z;
+    }
+    const centerX = sx / computed.length;
+    const centerZ = sz / computed.length;
+    let maxDist = 0;
+    for (const c of computed) {
+      const d = Math.hypot(c.x - centerX, c.z - centerZ);
+      if (d > maxDist) maxDist = d;
+    }
+    // worldRadius is the true extent (for fog & far-plane sizing);
+    // viewRadius is the initial camera framing distance — capped so a
+    // 6K-tile world doesn't park the camera 200 units away where every
+    // hex is a sub-pixel speck. Users can wheel out to see the rest.
+    return {
+      centerX,
+      centerZ,
+      worldRadius: Math.max(20, maxDist),
+      viewRadius: Math.min(40, Math.max(20, maxDist)),
+    };
+  }, [computed]);
+
+  return (
+    <Canvas
+      dpr={[1, 2]}
+      camera={{
+        position: [
+          framing.centerX,
+          framing.viewRadius * 0.9,
+          framing.centerZ + framing.viewRadius * 1.1,
+        ],
+        fov: 55,
+        near: 0.1,
+        far: Math.max(500, framing.worldRadius * 8),
+      }}
+    >
+      <color attach="background" args={["#0a0d12"]} />
+      <fog
+        attach="fog"
+        args={["#0a0d12", framing.viewRadius * 1.5, framing.worldRadius * 4]}
+      />
+      <ambientLight intensity={0.55} />
+      <directionalLight
+        position={[
+          framing.centerX + framing.viewRadius,
+          framing.viewRadius * 2,
+          framing.centerZ + framing.viewRadius * 0.5,
+        ]}
+        intensity={0.85}
+      />
+      <SceneContent
+        computed={computed}
+        framing={framing}
+        onSelectTile={onSelectTile}
+        selectedTileId={selectedTileId}
+      />
+    </Canvas>
+  );
+}
+
+interface SceneContentProps {
+  computed: ComputedTile[];
+  framing: {
+    centerX: number;
+    centerZ: number;
+    worldRadius: number;
+    viewRadius: number;
+  };
+  onSelectTile: (tileId: string | null) => void;
+  selectedTileId: string | null;
+}
+
+function SceneContent({
+  computed,
+  framing,
+  onSelectTile,
+  selectedTileId,
+}: SceneContentProps) {
+  const baseHexRef = useRef<THREE.InstancedMesh>(null);
+  const militaryRef = useRef<THREE.InstancedMesh>(null);
+  const foodRef = useRef<THREE.InstancedMesh>(null);
+  const magicRef = useRef<THREE.InstancedMesh>(null);
+  const heroBannerRef = useRef<THREE.InstancedMesh>(null);
+  const npcPennantRef = useRef<THREE.InstancedMesh>(null);
+  const glowRingRef = useRef<THREE.InstancedMesh>(null);
+
+  // Subsets — each Instanced layer renders only the tiles that belong
+  // in it, so e.g. the food-silo mesh allocates exactly N_food instances.
+  const subsets = useMemo(() => {
+    const byType: Record<LandType, ComputedTile[]> = {
+      unrevealed: [],
+      unassigned: [],
+      military: [],
+      food: [],
+      magic: [],
+    };
+    const heroes: ComputedTile[] = [];
+    const npcs: ComputedTile[] = [];
+    const extras: ComputedTile[] = [];
+    for (const c of computed) {
+      byType[c.tile.type].push(c);
+      if (c.tile.hasHero) heroes.push(c);
+      if (c.tile.isNpc && c.tile.ownerId) npcs.push(c);
+      if (c.tile.hasExtraForces) extras.push(c);
+    }
+    return { byType, heroes, npcs, extras };
+  }, [computed]);
+
+  // === Base hex prisms — one InstancedMesh for ALL tiles. ===
+  useEffect(() => {
+    const mesh = baseHexRef.current;
+    if (!mesh) return;
+    const dummy = new THREE.Object3D();
+    const color = new THREE.Color();
+    for (let i = 0; i < computed.length; i++) {
+      const c = computed[i];
+      dummy.position.set(c.x, c.height / 2, c.z);
+      dummy.scale.set(1, c.height, 1);
+      // Pointy-top hex orientation: rotate the cylinder 30° around y so
+      // its flat sides face neighbors (default cylinder has points at 0°
+      // and 180°, which would put gaps between adjacent hexes).
+      dummy.rotation.set(0, Math.PI / 6, 0);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+      color.setHex(c.colorHex);
+      mesh.setColorAt(i, color);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [computed]);
+
+  // === Buildings per land type ===
+  useEffect(() => {
+    setBuildingInstances(
+      militaryRef.current,
+      subsets.byType.military,
+      "military"
+    );
+  }, [subsets.byType.military]);
+
+  useEffect(() => {
+    setBuildingInstances(foodRef.current, subsets.byType.food, "food");
+  }, [subsets.byType.food]);
+
+  useEffect(() => {
+    setBuildingInstances(magicRef.current, subsets.byType.magic, "magic");
+  }, [subsets.byType.magic]);
+
+  // === Hero banners (tall thin pole + flag) ===
+  useEffect(() => {
+    const mesh = heroBannerRef.current;
+    if (!mesh) return;
+    const dummy = new THREE.Object3D();
+    for (let i = 0; i < subsets.heroes.length; i++) {
+      const c = subsets.heroes[i];
+      dummy.position.set(c.x + 0.35, c.height + 0.8, c.z);
+      dummy.scale.set(1, 1, 1);
+      dummy.rotation.set(0, 0, 0);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+    }
+    mesh.count = subsets.heroes.length;
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [subsets.heroes]);
+
+  // === NPC pennants (small skull-tone marker) ===
+  useEffect(() => {
+    const mesh = npcPennantRef.current;
+    if (!mesh) return;
+    const dummy = new THREE.Object3D();
+    for (let i = 0; i < subsets.npcs.length; i++) {
+      const c = subsets.npcs[i];
+      dummy.position.set(c.x - 0.35, c.height + 0.55, c.z);
+      dummy.scale.set(1, 1, 1);
+      dummy.rotation.set(0, 0, 0);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+    }
+    mesh.count = subsets.npcs.length;
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [subsets.npcs]);
+
+  // === Glow rings (extra forces) ===
+  useEffect(() => {
+    const mesh = glowRingRef.current;
+    if (!mesh) return;
+    const dummy = new THREE.Object3D();
+    const color = new THREE.Color();
+    for (let i = 0; i < subsets.extras.length; i++) {
+      const c = subsets.extras[i];
+      dummy.position.set(c.x, 0.02, c.z);
+      dummy.scale.set(1, 1, 1);
+      dummy.rotation.set(-Math.PI / 2, 0, Math.PI / 6);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+      color.setHex(c.colorHex);
+      mesh.setColorAt(i, color);
+    }
+    mesh.count = subsets.extras.length;
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [subsets.extras]);
+
+  // === Camera fly-to on selected tile ===
+  const { camera } = useThree();
+  const controlsRef = useRef<React.ComponentRef<typeof MapControls> | null>(
+    null
+  );
+  const targetPos = useRef<THREE.Vector3 | null>(null);
+  const targetLook = useRef<THREE.Vector3 | null>(null);
+
+  useEffect(() => {
+    if (!selectedTileId) return;
+    const c = computed.find((x) => x.tile.tileId === selectedTileId);
+    if (!c) return;
+    // Stand about 6 units away and 4 above the target hex top, so the
+    // tile is centered with a slight downward angle.
+    targetLook.current = new THREE.Vector3(c.x, c.height, c.z);
+    targetPos.current = new THREE.Vector3(c.x + 5, c.height + 4, c.z + 5);
+  }, [selectedTileId, computed]);
+
+  useFrame(() => {
+    const controls = controlsRef.current;
+    if (!targetPos.current || !targetLook.current || !controls) return;
+    camera.position.lerp(targetPos.current, 0.08);
+    // MapControls/OrbitControls expose a `.target` Vector3; type via
+    // cast since drei's typing of the ref is the underlying class.
+    const ctrl = controls as unknown as { target: THREE.Vector3; update(): void };
+    ctrl.target.lerp(targetLook.current, 0.08);
+    ctrl.update();
+    if (
+      camera.position.distanceTo(targetPos.current) < 0.1 &&
+      ctrl.target.distanceTo(targetLook.current) < 0.1
+    ) {
+      targetPos.current = null;
+      targetLook.current = null;
+    }
+  });
+
+  // Tile pick — InstancedMesh exposes `instanceId` on the event.
+  const handleClick = (e: { instanceId?: number; stopPropagation: () => void }) => {
+    e.stopPropagation();
+    const id = e.instanceId;
+    if (typeof id === "number" && computed[id]) {
+      onSelectTile(computed[id].tile.tileId);
+    }
+  };
+
+  // Geometry singletons. Defined inline below via JSX <…Geometry args=… />
+  // refs and lookups; React/three will reuse them across renders.
+
+  // Ground plane sized to comfortably cover the world plus the fog
+  // distance, so the camera never sees the plane's edge from a low angle.
+  const groundSize = framing.worldRadius * 8;
+
+  return (
+    <>
+      {/* Ground */}
+      <mesh
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[framing.centerX, -0.01, framing.centerZ]}
+      >
+        <planeGeometry args={[groundSize, groundSize]} />
+        <meshStandardMaterial color="#0e1219" roughness={0.95} />
+      </mesh>
+
+      {/* Hex prisms — one instance per tile, click-pickable. */}
+      <instancedMesh
+        ref={baseHexRef}
+        args={[undefined, undefined, computed.length]}
+        onClick={handleClick}
+        frustumCulled={false}
+      >
+        <cylinderGeometry args={[HEX_RADIUS, HEX_RADIUS, 1, 6]} />
+        <meshStandardMaterial roughness={0.85} metalness={0.05} />
+      </instancedMesh>
+
+      {/* Buildings per type */}
+      <instancedMesh
+        ref={militaryRef}
+        args={[undefined, undefined, Math.max(1, subsets.byType.military.length)]}
+        frustumCulled={false}
+      >
+        <boxGeometry args={[0.55, 0.5, 0.55]} />
+        <meshStandardMaterial color="#7a4a26" roughness={0.9} />
+      </instancedMesh>
+
+      <instancedMesh
+        ref={foodRef}
+        args={[undefined, undefined, Math.max(1, subsets.byType.food.length)]}
+        frustumCulled={false}
+      >
+        <cylinderGeometry args={[0.3, 0.3, 0.6, 12]} />
+        <meshStandardMaterial color="#3f8a3a" roughness={0.8} />
+      </instancedMesh>
+
+      <instancedMesh
+        ref={magicRef}
+        args={[undefined, undefined, Math.max(1, subsets.byType.magic.length)]}
+        frustumCulled={false}
+      >
+        <coneGeometry args={[0.3, 0.95, 8]} />
+        <meshStandardMaterial
+          color="#9b5cd6"
+          emissive="#3a1860"
+          emissiveIntensity={0.35}
+          roughness={0.55}
+        />
+      </instancedMesh>
+
+      {/* Hero banner — slim post + flag */}
+      <instancedMesh
+        ref={heroBannerRef}
+        args={[undefined, undefined, Math.max(1, subsets.heroes.length)]}
+        frustumCulled={false}
+      >
+        <boxGeometry args={[0.07, 0.8, 0.5]} />
+        <meshStandardMaterial color="#f5d36a" roughness={0.6} />
+      </instancedMesh>
+
+      {/* NPC pennant — darker, smaller */}
+      <instancedMesh
+        ref={npcPennantRef}
+        args={[undefined, undefined, Math.max(1, subsets.npcs.length)]}
+        frustumCulled={false}
+      >
+        <boxGeometry args={[0.06, 0.45, 0.32]} />
+        <meshStandardMaterial color="#2a2a2a" roughness={0.8} />
+      </instancedMesh>
+
+      {/* Extra forces — emissive ring at ground level under the tile. */}
+      <instancedMesh
+        ref={glowRingRef}
+        args={[undefined, undefined, Math.max(1, subsets.extras.length)]}
+        frustumCulled={false}
+      >
+        <ringGeometry args={[HEX_RADIUS * 0.95, HEX_RADIUS * 1.25, 6]} />
+        <meshStandardMaterial
+          emissiveIntensity={0.9}
+          // emissive color is set per-instance from caste; base color
+          // stays bright so unlit faces still register.
+          toneMapped={false}
+          side={THREE.DoubleSide}
+        />
+      </instancedMesh>
+
+      <MapControls
+        ref={controlsRef}
+        target={[framing.centerX, 0, framing.centerZ]}
+        enableDamping
+        dampingFactor={0.08}
+        // MapControls is the same controller as OrbitControls but with
+        // the mouse bindings swapped: LEFT-drag pans (travel around the
+        // world, Google-Earth-style), RIGHT-drag rotates, scroll zooms.
+        // That matches the "fly the realm" mental model — users expect
+        // to move ACROSS the map, not orbit a fixed point.
+        screenSpacePanning={false}
+        // Keep the camera above the horizon — looking up from under the
+        // ground breaks the illusion fast.
+        maxPolarAngle={Math.PI / 2 - 0.05}
+        minDistance={3}
+        maxDistance={framing.worldRadius * 4}
+      />
+    </>
+  );
+}
+
+// Shared writer for the simple per-tile-type building meshes. Each
+// instance is positioned on top of its tile's hex prism with a small
+// vertical lift so the building doesn't z-fight the prism's top face.
+function setBuildingInstances(
+  mesh: THREE.InstancedMesh | null,
+  subset: ComputedTile[],
+  type: LandType
+): void {
+  if (!mesh) return;
+  const dummy = new THREE.Object3D();
+  for (let i = 0; i < subset.length; i++) {
+    const c = subset[i];
+    const top = c.height + buildingLift(type);
+    dummy.position.set(c.x, top, c.z);
+    dummy.scale.set(1, 1, 1);
+    dummy.rotation.set(0, 0, 0);
+    dummy.updateMatrix();
+    mesh.setMatrixAt(i, dummy.matrix);
+  }
+  mesh.count = subset.length;
+  mesh.instanceMatrix.needsUpdate = true;
+}
+
+function buildingLift(type: LandType): number {
+  switch (type) {
+    case "military":
+      return 0.25; // half the box height
+    case "food":
+      return 0.3; // half the cylinder height
+    case "magic":
+      return 0.475; // half the cone height
+    default:
+      return 0;
+  }
+}

--- a/app/game/world/_components/world-constants.ts
+++ b/app/game/world/_components/world-constants.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Caste, LandType } from "@/lib/game/types";
+
+// Caste colors picked to read clearly on a dark scene and match the
+// existing 2D map's caste palette (loosely — the 2D map uses muted
+// fills via Tailwind classes; here we use hex values direct from
+// three.js material setters).
+export const CASTE_COLOR_HEX: Record<Caste, number> = {
+  black: 0x4b3f5c,
+  red: 0xd0463a,
+  white: 0xe6e6e6,
+  green: 0x4caf50,
+  blue: 0x4f8cf6,
+};
+
+export const CASTE_LABEL: Record<Caste, string> = {
+  black: "Black",
+  red: "Red",
+  white: "White",
+  green: "Green",
+  blue: "Blue",
+};
+
+// Color for tiles with no caste / no owner. Slightly desaturated so they
+// recede behind the caste-held land.
+export const UNOWNED_COLOR_HEX = 0x6b6b6b;
+
+export const LAND_TYPE_LABEL: Record<LandType, string> = {
+  unrevealed: "Unrevealed",
+  unassigned: "Unassigned",
+  military: "Military",
+  food: "Food",
+  magic: "Magic",
+};
+
+// Sizes the renderer uses. Keeping a single source of truth here means
+// the scene and the legend stay in lock-step.
+export const HEX_RADIUS = 1.0;
+// Visual gap between hex centers — slightly larger than the radius so
+// neighbors don't overlap their roof prisms.
+export const HEX_SPACING = 1.05;

--- a/app/game/world/page.tsx
+++ b/app/game/world/page.tsx
@@ -1,0 +1,48 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// Public 3D flyover view of the Generals world. Lives under /game/ but
+// intentionally bypasses the sign-in gate that /game/page.tsx applies —
+// anonymous visitors are the primary audience (this page doubles as the
+// game's marketing surface).
+//
+// Data comes from `game_world_snapshots/daily-3d`, written once per day
+// by the `only=game-world-3d` cron. We read it server-side so the
+// initial HTML ships with the world data baked in; the client never
+// hits Firestore.
+
+import type { Metadata } from "next";
+import { readWorld3DSnapshotServer } from "@/lib/game/world-snapshot-3d";
+import { World3DClient } from "./_components/World3DClient";
+
+export const metadata: Metadata = {
+  title: "Fly the Realm — Generals",
+  description:
+    "A live 3D fly-over of the Generals world. Orbit, zoom, and explore the kingdoms that contributors are building one PR at a time.",
+  openGraph: {
+    title: "Fly the Realm — Generals",
+    description:
+      "A live 3D fly-over of the Generals world. Built by the cursor-boston community.",
+    type: "website",
+  },
+};
+
+// 24h ISR — matches the daily-snapshot writer's cadence. The page
+// itself is mostly static; the only server work is the one Firestore
+// read inside readWorld3DSnapshotServer, which Next caches for 24h.
+export const revalidate = 86400;
+
+export default async function GameWorldPage() {
+  const snapshot = await readWorld3DSnapshotServer();
+
+  return (
+    <World3DClient
+      initialTiles={snapshot?.tiles ?? []}
+      generatedAt={snapshot?.generatedAt ?? null}
+    />
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -131,7 +131,6 @@ const NAV_GROUPS: NavGroup[] = [
       },
       { href: "/blog", label: "Blog", icon: BookOpen },
       { href: "/certificate", label: "Certificate", icon: Award },
-      { href: "/skills", label: "Skills Passport", icon: BrainCircuit },
     ],
   },
   {
@@ -144,6 +143,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/pair", label: "Pair Programming", icon: UsersRound },
       { href: "/recordings", label: "Recordings", icon: Video },
       { href: "/mentorship", label: "Mentorship", icon: GraduationCap },
+      { href: "/skills", label: "Skills Passport", icon: BrainCircuit },
       { href: "/talks", label: "Talks", icon: MessageSquare },
       { href: "/analytics", label: "Analytics", icon: BarChart2 },
     ],

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**184 paths, 221 operations across 35 areas.**
+**185 paths, 222 operations across 35 areas.**
 
 ---
 
@@ -188,6 +188,7 @@ _Strategy game endpoints (leaderboard, attacks, artifacts, turns)._
 | POST | `/api/game/upgrades/apply` | Yes | Apply an upgrade to a target |
 | POST | `/api/game/upgrades/remove` | Yes | Remove an upgrade from a target |
 | GET | `/api/game/world` | Yes | Fetch tiles for the world map (full or bbox) |
+| GET | `/api/game/world-3d` | No | Public 3D flyover world snapshot (daily, anonymous-accessible) |
 
 ## Github
 

--- a/lib/api-schemas/game.ts
+++ b/lib/api-schemas/game.ts
@@ -641,6 +641,32 @@ const WorldOk = z.object({
     .describe("Legacy mode only — present when the request omits a bbox"),
 });
 
+// Public daily 3D snapshot. Anonymous-accessible; powers the /game/world
+// flyover page. Shape is deliberately denormalized so the renderer can
+// consume it without joining against player docs.
+const World3DTileSchema = z
+  .object({
+    tileId: z.string(),
+    q: z.number(),
+    r: z.number(),
+    type: z.enum(["unrevealed", "unassigned", "military", "food", "magic"]),
+    ownerId: z.string().nullable(),
+    ownerName: z.string().nullable(),
+    caste: z.enum(["black", "red", "white", "green", "blue"]).nullable(),
+    isNpc: z.boolean(),
+    level: z.number(),
+    hasExtraForces: z.boolean(),
+    hasHero: z.boolean(),
+    ownerShielded: z.boolean(),
+  })
+  .openapi("GameWorld3DTile");
+
+const World3DOk = z.object({
+  tiles: z.array(World3DTileSchema),
+  generatedAt: z.string().nullable(),
+  tileCount: z.number(),
+});
+
 // ──────────────────── Contract router ────────────────────
 
 const baseErrorResponses = {
@@ -744,6 +770,20 @@ export const gameContract = c.router(
       metadata: {
         errorCodes: ["UNAUTHORIZED", "VALIDATION_ERROR", "SERVER_ERROR"] as const,
       },
+    },
+
+    // Public 3D flyover snapshot — anonymous-accessible, ISR-cached 24h.
+    getWorld3d: {
+      method: "GET",
+      path: "/api/game/world-3d",
+      summary: "Public 3D flyover world snapshot (daily, anonymous-accessible)",
+      description:
+        "Returns the once-per-day denormalized world snapshot used by /game/world. No auth required. Responds with `{ tiles: [], generatedAt: null, tileCount: 0 }` until the first cron writes the underlying doc.",
+      responses: {
+        200: World3DOk,
+        500: ApiErrorSchema,
+      },
+      metadata: { errorCodes: ["SERVER_ERROR"] as const },
     },
 
     // World / tile

--- a/lib/api-schemas/internal.ts
+++ b/lib/api-schemas/internal.ts
@@ -27,7 +27,9 @@ const CleanupQuery = z.object({
 });
 
 const SnapshotsRebuildQuery = z.object({
-  only: z.enum(["analytics", "members", "all"]).optional(),
+  only: z
+    .enum(["analytics", "members", "game-world", "game-world-3d", "all"])
+    .optional(),
   force: z.enum(["true", "false"]).optional(),
 });
 

--- a/lib/game/world-snapshot-3d.ts
+++ b/lib/game/world-snapshot-3d.ts
@@ -1,0 +1,314 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// Daily, view-optimized snapshot of the world for the public 3D flyover
+// page (`/game/world`). Lives at `game_world_snapshots/daily-3d` and is
+// rebuilt once per day by a Vercel cron (see vercel.json). Stable, cheap,
+// and shaped for direct WebGL rendering.
+//
+// Why a separate doc from the 5-min `latest` snapshot:
+//  - The 3D page is a public marketing surface; serving from a frozen
+//    daily artifact (via 24h ISR) gives zero Firestore reads in steady
+//    state and immune to mid-rebuild blips on `latest`.
+//  - The shape here is denormalized for the renderer: tile × owner joined
+//    inline, units flattened to a single `hasExtraForces` boolean. No
+//    decoder, no second fetch.
+//
+// Unrevealed tiles are excluded — they have nothing to render and shipping
+// them just inflates the payload.
+
+import type { Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { logger } from "@/lib/logger";
+import { isShieldActive } from "./turns";
+import type { Caste, GamePlayer, LandType, UnitStack } from "./types";
+
+export const WORLD_3D_SNAPSHOT_COLLECTION = "game_world_snapshots";
+export const WORLD_3D_SNAPSHOT_DOC = "daily-3d";
+// v2: owner-deduped storage. v1 inlined owner fields on every tile and
+// blew past Firestore's 1MB doc ceiling at ~4.5K tiles. The reader still
+// returns the denormalized public shape — only the on-disk layout
+// changed.
+export const WORLD_3D_SNAPSHOT_SCHEMA_VERSION = 2;
+
+// Bit flags packed into World3DTile.flags for on-disk storage.
+const FLAG_HAS_EXTRA_FORCES = 1 << 0;
+const FLAG_HAS_HERO = 1 << 1;
+
+export interface World3DTile {
+  tileId: string;
+  q: number;
+  r: number;
+  type: LandType;
+  ownerId: string | null;
+  ownerName: string | null;
+  caste: Caste | null;
+  /** True for seeded NPC owners; false for humans and for unowned tiles. */
+  isNpc: boolean;
+  /** Fortification level (1..10). */
+  level: number;
+  /** True when the tile carries any recruited unit beyond its base garrison. */
+  hasExtraForces: boolean;
+  /** True when a hero is stationed on this tile. */
+  hasHero: boolean;
+  /** True when the owner currently has an active shield. Drives a defensive
+   *  visual treatment on the tile so the camera flythrough reads honestly. */
+  ownerShielded: boolean;
+}
+
+export interface World3DSnapshot {
+  tiles: World3DTile[];
+  generatedAt: string; // ISO
+  tileCount: number;
+}
+
+// Owner row in the deduped lookup table. Indexed by position in the
+// `owners` array; tiles reference by `ownerIdx` (-1 = unclaimed).
+interface StoredOwner {
+  ownerId: string;
+  ownerName: string | null;
+  caste: Caste | null;
+  isNpc: boolean;
+  shielded: boolean;
+}
+
+// Compact on-disk tile. Owner attributes are looked up via ownerIdx
+// (saves ~60 bytes/tile vs. inlining them — the difference between
+// fitting in Firestore's 1MB doc ceiling and not).
+interface StoredCompactTile {
+  tileId: string;
+  q: number;
+  r: number;
+  type: LandType;
+  ownerIdx: number; // -1 means unclaimed
+  level: number;
+  flags: number; // bitfield: see FLAG_* constants
+}
+
+interface StoredWorld3DSnapshot {
+  schemaVersion: number;
+  owners: StoredOwner[];
+  tiles: StoredCompactTile[];
+  generatedAt: FirebaseFirestore.Timestamp | Date;
+  expiresAt: FirebaseFirestore.Timestamp | Date;
+  tileCount: number;
+}
+
+interface OwnerJoin {
+  displayName: string | null;
+  caste: Caste | null;
+  isNpc: boolean;
+  shielded: boolean;
+}
+
+function unitsSum(u: UnitStack | undefined): number {
+  if (!u) return 0;
+  return (u.ground ?? 0) + (u.siege ?? 0) + (u.air ?? 0);
+}
+
+// Same single-collection-read pattern as computeWorldSnapshot(), but with
+// `level` and `hero` projected in and units collapsed to a single boolean.
+// Cost is one read per tile + one read per player, same as the live
+// snapshot — the cron runs once per day, so steady-state read budget is
+// ~5K reads/day from this writer.
+export async function computeWorld3DSnapshot(
+  db: Firestore,
+  now: Date = new Date()
+): Promise<World3DSnapshot> {
+  const [tilesSnap, playersSnap] = await Promise.all([
+    db
+      .collection("game_tiles")
+      .select("tileId", "q", "r", "type", "ownerId", "level", "units", "hero")
+      .get(),
+    db
+      .collection("game_players")
+      .select(
+        "userId",
+        "displayName",
+        "caste",
+        "shieldUntil",
+        "shieldDropAtTurn",
+        "turnsSpentTotal",
+        "isNpc"
+      )
+      .get(),
+  ]);
+
+  const owners = new Map<string, OwnerJoin>();
+  for (const d of playersSnap.docs) {
+    const p = d.data() as GamePlayer & { isNpc?: boolean };
+    owners.set(p.userId, {
+      displayName: p.displayName ?? null,
+      caste: p.caste ?? null,
+      isNpc: p.isNpc === true,
+      shielded: isShieldActive(p, now),
+    });
+  }
+
+  const tiles: World3DTile[] = [];
+  for (const d of tilesSnap.docs) {
+    const data = d.data() as Partial<{
+      tileId: string;
+      q: number;
+      r: number;
+      type: LandType;
+      ownerId: string | null;
+      level: number;
+      units: UnitStack;
+      hero: unknown;
+    }>;
+    if (data.type === "unrevealed") continue;
+
+    const ownerId = data.ownerId ?? null;
+    const join = ownerId ? owners.get(ownerId) : undefined;
+
+    tiles.push({
+      tileId: data.tileId ?? d.id,
+      q: data.q ?? 0,
+      r: data.r ?? 0,
+      type: (data.type ?? "unassigned") as LandType,
+      ownerId,
+      ownerName: join?.displayName ?? null,
+      caste: join?.caste ?? null,
+      isNpc: join?.isNpc ?? false,
+      level: data.level ?? 1,
+      hasExtraForces: unitsSum(data.units) > 0,
+      hasHero: data.hero != null,
+      ownerShielded: join?.shielded ?? false,
+    });
+  }
+
+  return {
+    tiles,
+    generatedAt: now.toISOString(),
+    tileCount: tiles.length,
+  };
+}
+
+// Idempotent writer. Mirrors rebuildWorldSnapshotServer in world-snapshot.ts
+// but without the "changed since" gate — this only runs once per day, so a
+// no-op skip isn't worth the extra metadata complexity.
+export async function rebuildWorld3DSnapshotServer(
+  now: Date = new Date()
+): Promise<{ tileCount: number; bytes: number }> {
+  const db = getAdminDb();
+  if (!db) throw new Error("Firebase Admin not initialized");
+
+  const snapshot = await computeWorld3DSnapshot(db, now);
+
+  // 24h soft expiry. The reader serves a stale doc rather than 500ing if
+  // the cron skips a day.
+  const expiresAt = new Date(now.getTime() + 25 * 60 * 60 * 1000);
+
+  // Build the owner lookup table, then compact each tile to reference
+  // the owner by index. Saves ~60 bytes/tile vs. inlining owner fields.
+  const ownerIdxById = new Map<string, number>();
+  const owners: StoredOwner[] = [];
+  const compactTiles: StoredCompactTile[] = snapshot.tiles.map((t) => {
+    let ownerIdx = -1;
+    if (t.ownerId) {
+      const existing = ownerIdxById.get(t.ownerId);
+      if (existing !== undefined) {
+        ownerIdx = existing;
+      } else {
+        ownerIdx = owners.length;
+        ownerIdxById.set(t.ownerId, ownerIdx);
+        owners.push({
+          ownerId: t.ownerId,
+          ownerName: t.ownerName,
+          caste: t.caste,
+          isNpc: t.isNpc,
+          shielded: t.ownerShielded,
+        });
+      }
+    }
+    let flags = 0;
+    if (t.hasExtraForces) flags |= FLAG_HAS_EXTRA_FORCES;
+    if (t.hasHero) flags |= FLAG_HAS_HERO;
+    return {
+      tileId: t.tileId,
+      q: t.q,
+      r: t.r,
+      type: t.type,
+      ownerIdx,
+      level: t.level,
+      flags,
+    };
+  });
+
+  const stored: StoredWorld3DSnapshot = {
+    schemaVersion: WORLD_3D_SNAPSHOT_SCHEMA_VERSION,
+    owners,
+    tiles: compactTiles,
+    generatedAt: now,
+    expiresAt,
+    tileCount: snapshot.tileCount,
+  };
+
+  const ref = db
+    .collection(WORLD_3D_SNAPSHOT_COLLECTION)
+    .doc(WORLD_3D_SNAPSHOT_DOC);
+  await ref.set(stored);
+
+  const bytes = JSON.stringify(stored).length;
+
+  logger.info("Game world 3D snapshot rebuilt", {
+    schemaVersion: WORLD_3D_SNAPSHOT_SCHEMA_VERSION,
+    tileCount: snapshot.tileCount,
+    approxBytes: bytes,
+    capacityPctOf1MB: Math.round((bytes / (1024 * 1024)) * 100),
+  });
+
+  return { tileCount: snapshot.tileCount, bytes };
+}
+
+export async function readWorld3DSnapshotServer(): Promise<World3DSnapshot | null> {
+  const db = getAdminDb();
+  if (!db) return null;
+
+  const ref = db
+    .collection(WORLD_3D_SNAPSHOT_COLLECTION)
+    .doc(WORLD_3D_SNAPSHOT_DOC);
+  const doc = await ref.get();
+  if (!doc.exists) return null;
+
+  const data = doc.data() as StoredWorld3DSnapshot | undefined;
+  if (!data || !Array.isArray(data.tiles)) return null;
+
+  const generatedAt =
+    data.generatedAt instanceof Date
+      ? data.generatedAt
+      : data.generatedAt?.toDate?.() ?? new Date(0);
+
+  // Expand the compact on-disk format back to the public denormalized
+  // shape. v1 legacy docs (no `owners` array) are no longer expected in
+  // production but the writer always emits v2 now.
+  const owners: StoredOwner[] = Array.isArray(data.owners) ? data.owners : [];
+  const tiles: World3DTile[] = data.tiles.map((t) => {
+    const o = t.ownerIdx >= 0 ? owners[t.ownerIdx] : undefined;
+    return {
+      tileId: t.tileId,
+      q: t.q,
+      r: t.r,
+      type: t.type,
+      ownerId: o?.ownerId ?? null,
+      ownerName: o?.ownerName ?? null,
+      caste: o?.caste ?? null,
+      isNpc: o?.isNpc ?? false,
+      level: t.level,
+      hasExtraForces: (t.flags & FLAG_HAS_EXTRA_FORCES) !== 0,
+      hasHero: (t.flags & FLAG_HAS_HERO) !== 0,
+      ownerShielded: o?.shielded ?? false,
+    };
+  });
+
+  return {
+    tiles,
+    generatedAt: generatedAt.toISOString(),
+    tileCount: data.tileCount ?? tiles.length,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.0",
         "@cursor/sdk": "^1.0.13",
+        "@react-three/drei": "^10.7.6",
+        "@react-three/fiber": "^9.4.2",
         "@tailwindcss/postcss": "^4.3.0",
         "@ts-rest/core": "^3.51.0",
         "@ts-rest/open-api": "^3.51.0",
@@ -27,8 +29,9 @@
         "next": "^16.2.4",
         "next-themes": "^0.4.6",
         "qrcode": "^1.5.4",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-is": "^18.3.1",
         "react-leaflet": "^5.0.0",
         "react-leaflet-cluster": "^4.1.3",
         "react-markdown": "^10.1.0",
@@ -36,6 +39,7 @@
         "recharts": "^3.8.1",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "three": "^0.165.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -58,6 +62,7 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@types/three": "^0.165.0",
         "cross-env": "^10.1.0",
         "eslint": "^10.4.0",
         "eslint-config-next": "^16.2.4",
@@ -4736,6 +4741,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -5036,6 +5047,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5405,7 +5428,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0"
@@ -5542,6 +5565,142 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/drei/node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -6192,6 +6351,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -6333,6 +6498,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -6516,6 +6687,12 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prismjs": {
       "version": "1.26.6",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
@@ -6526,12 +6703,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6546,6 +6725,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -6596,6 +6784,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.165.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.165.0.tgz",
+      "integrity": "sha512-AJK8JZAFNBF0kBXiAIl5pggYlzAGGA8geVYQXAcPCEDRbyA+oEjkpUBcJJrtNz6IiALwzGexFJGZG2yV3WsYBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.1",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -6620,6 +6827,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -7214,6 +7427,24 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/abbrev": {
@@ -8186,6 +8417,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -8699,6 +8939,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -9858,7 +10111,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -9904,6 +10156,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/csv-parse": {
@@ -10394,6 +10647,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -10471,6 +10733,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -12082,6 +12350,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -13174,6 +13448,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/google-auth-library": {
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -13722,6 +14002,12 @@
       "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
       "license": "CC0-1.0"
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/hono": {
       "version": "4.12.18",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
@@ -13928,6 +14214,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "10.2.0",
@@ -14857,7 +15149,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-fetch": {
@@ -14974,6 +15265,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jackspeak": {
@@ -16492,6 +16795,15 @@
         "libsodium": "^0.7.16"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -17220,6 +17532,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -17796,6 +18118,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -19466,6 +19803,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
       "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.2.1"
@@ -19855,7 +20193,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20123,7 +20460,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -20142,7 +20479,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -20155,6 +20492,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -20268,6 +20606,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -20424,6 +20768,22 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
+    "node_modules/promise-worker-transferable/node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -20882,9 +21242,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -20894,24 +21254,23 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "license": "MIT",
-      "peer": true
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -21027,6 +21386,21 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/readable-stream": {
@@ -21327,7 +21701,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21907,7 +22280,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -21920,7 +22292,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -22443,6 +22814,32 @@
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
       }
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -23090,6 +23487,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -23401,6 +23807,44 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.165.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
+      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -23591,6 +24035,36 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -23711,6 +24185,43 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -24225,6 +24736,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -24378,6 +24898,17 @@
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -24511,7 +25042,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -25032,6 +25562,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.0",
     "@cursor/sdk": "^1.0.13",
+    "@react-three/drei": "^10.7.6",
+    "@react-three/fiber": "^9.4.2",
     "@tailwindcss/postcss": "^4.3.0",
     "@ts-rest/core": "^3.51.0",
     "@ts-rest/open-api": "^3.51.0",
@@ -92,8 +94,9 @@
     "next": "^16.2.4",
     "next-themes": "^0.4.6",
     "qrcode": "^1.5.4",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-is": "^18.3.1",
     "react-leaflet": "^5.0.0",
     "react-leaflet-cluster": "^4.1.3",
     "react-markdown": "^10.1.0",
@@ -101,6 +104,7 @@
     "recharts": "^3.8.1",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "three": "^0.165.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -123,6 +127,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/three": "^0.165.0",
     "cross-env": "^10.1.0",
     "eslint": "^10.4.0",
     "eslint-config-next": "^16.2.4",
@@ -178,6 +183,14 @@
       "react-dom": "$react-dom"
     },
     "react-leaflet-cluster": {
+      "react": "$react",
+      "react-dom": "$react-dom"
+    },
+    "@react-three/fiber": {
+      "react": "$react",
+      "react-dom": "$react-dom"
+    },
+    "@react-three/drei": {
       "react": "$react",
       "react-dom": "$react-dom"
     },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -66,6 +66,7 @@ Licensed GPL-3.0-only.
     /game/tiles
     /game/tiles/[tileId]
     /game/upgrades
+    /game/world
     /game/zero-turn
     /hackathons
     /hackathons/hack-a-sprint-2026
@@ -132,7 +133,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (221 endpoints)
+## API (222 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -261,6 +262,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     POST   /api/game/upgrades/apply [Yes] — Apply an upgrade to a target
     POST   /api/game/upgrades/remove [Yes] — Remove an upgrade from a target
     GET    /api/game/world [Yes] — Fetch tiles for the world map (full or bbox)
+    GET    /api/game/world-3d — Public 3D flyover world snapshot (daily, anonymous-accessible)
 
 ### Github
 

--- a/scripts/send-may26-confirm-and-pitches.ts
+++ b/scripts/send-may26-confirm-and-pitches.ts
@@ -64,8 +64,6 @@ const SIGNUP_URL =
   "https://www.cursorboston.com/hackathons/sports-hack-2026/signup";
 const EVENT_URL =
   "https://www.cursorboston.com/hackathons/sports-hack-2026";
-const SUBMISSIONS_URL =
-  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
 const GAME_URL = "https://www.cursorboston.com/game";
 const RESEARCH_URL = "https://www.cursorboston.com/research";
 const ALGORITHMACY_URL =

--- a/scripts/send-may26-confirm-and-pitches.ts
+++ b/scripts/send-may26-confirm-and-pitches.ts
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+/**
+ * May-26 broadcast — confirm-attendance push + capacity context + /game + Research/CFP.
+ *
+ * Source of recipients: the union of two CSV exports landed on 2026-05-23.
+ *   1. Partiful-style guest list ("CursorBostonBostonTechWeek_5-23_guests.csv")
+ *   2. Luma export ("Cursor Boston - AIC - Hult International - Boston Tech Week
+ *      Speakers & Workshop - Guests - 2026-05-23-13-51-37.csv")
+ *
+ * For each CSV email (lowercased + trimmed, deduped):
+ *   - Look up `eventContacts/{email}`.
+ *   - If existing → use eventContacts firstName/name for personalization;
+ *     skip if `unsubscribed === true`.
+ *   - If new → batch-write a fresh eventContacts doc tagged with the May 26
+ *     event name and source = "csv-may26-broadcast" so future suppression /
+ *     unsubscribe handling covers them.
+ *
+ * Subject + body cover:
+ *   - The 4 PM ET May 26 event at Hult International (10 AM doors).
+ *   - The new "Confirm attendance" second step (200 guaranteed-entry cap,
+ *     119 Cursor credit links to top 119 confirmed).
+ *   - Full agenda from `content/events.json:cursor-boston-sports-hack-2026`.
+ *   - Short pitch for /game.
+ *   - Short pitch for /research + the First Global Algorithmacy Conference CFP
+ *     (Trinidad, late October / early November 2026).
+ *
+ * Usage:
+ *   npx tsx scripts/send-may26-confirm-and-pitches.ts --dry-run
+ *   npx tsx scripts/send-may26-confirm-and-pitches.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN, UNSUBSCRIBE_SECRET
+ */
+
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import fs from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { Timestamp } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+// ──────────────────── Constants ────────────────────
+
+const FROM = "Cursor Boston <hello@cursorboston.com>";
+
+const EVENT_NAME_MAY26 =
+  "Cursor Boston - AIC - Hult International - Boston Tech Week Speakers & Workshop";
+
+const SIGNUP_URL =
+  "https://www.cursorboston.com/hackathons/sports-hack-2026/signup";
+const EVENT_URL =
+  "https://www.cursorboston.com/hackathons/sports-hack-2026";
+const SUBMISSIONS_URL =
+  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
+const GAME_URL = "https://www.cursorboston.com/game";
+const RESEARCH_URL = "https://www.cursorboston.com/research";
+const ALGORITHMACY_URL =
+  "https://www.cursorboston.com/research/algorithmacy-scale-coauthor-search";
+
+const CSV_PARTIFUL = join(
+  homedir(),
+  "Downloads",
+  "CursorBostonBostonTechWeek_5-23_guests.csv"
+);
+const CSV_LUMA = join(
+  homedir(),
+  "Downloads",
+  "Cursor Boston - AIC - Hult International - Boston Tech Week Speakers & Workshop - Guests - 2026-05-23-13-51-37.csv"
+);
+
+// ──────────────────── CSV parser (RFC4180-compliant, inline-copy idiom) ────────────────────
+
+type CsvRow = Record<string, string>;
+
+function parseCsv(content: string): CsvRow[] {
+  // Strip UTF-8 BOM if present (Luma export ships with one).
+  if (content.charCodeAt(0) === 0xfeff) content = content.slice(1);
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      // skip — handled with the following \n
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((cell) => cell.length > 0)) rows.push(row);
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  const out: CsvRow[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const line = rows[r]!;
+    const obj: CsvRow = {};
+    for (let j = 0; j < header.length; j++) obj[header[j]!] = (line[j] ?? "").trim();
+    out.push(obj);
+  }
+  return out;
+}
+
+// ──────────────────── Contact ingest ────────────────────
+
+interface CombinedContact {
+  email: string;        // canonical lowercased
+  name: string;
+  firstName: string;
+  lastName: string;
+  sources: ("partiful" | "luma")[];
+}
+
+function splitName(full: string): { firstName: string; lastName: string } {
+  const trimmed = full.trim();
+  if (!trimmed) return { firstName: "", lastName: "" };
+  const parts = trimmed.split(/\s+/);
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+function ingestPartiful(path: string): CombinedContact[] {
+  const text = fs.readFileSync(path, "utf8");
+  const rows = parseCsv(text);
+  const out: CombinedContact[] = [];
+  for (const r of rows) {
+    const rawEmail = (r["What is your email?"] ?? "").trim();
+    if (!rawEmail || !rawEmail.includes("@")) continue;
+    const email = rawEmail.toLowerCase();
+    const name = (r["Name"] ?? "").trim();
+    const { firstName, lastName } = splitName(name);
+    out.push({ email, name, firstName, lastName, sources: ["partiful"] });
+  }
+  return out;
+}
+
+function ingestLuma(path: string): CombinedContact[] {
+  const text = fs.readFileSync(path, "utf8");
+  const rows = parseCsv(text);
+  const out: CombinedContact[] = [];
+  for (const r of rows) {
+    const rawEmail = (r["email"] ?? "").trim();
+    if (!rawEmail || !rawEmail.includes("@")) continue;
+    const email = rawEmail.toLowerCase();
+    const name = (r["name"] ?? "").trim();
+    const firstName = (r["first_name"] ?? "").trim() || splitName(name).firstName;
+    const lastName = (r["last_name"] ?? "").trim() || splitName(name).lastName;
+    out.push({ email, name, firstName, lastName, sources: ["luma"] });
+  }
+  return out;
+}
+
+function dedupe(all: CombinedContact[]): Map<string, CombinedContact> {
+  const map = new Map<string, CombinedContact>();
+  for (const c of all) {
+    const existing = map.get(c.email);
+    if (!existing) {
+      map.set(c.email, { ...c, sources: [...c.sources] });
+      continue;
+    }
+    // Merge: prefer non-empty fields, union sources.
+    map.set(c.email, {
+      email: existing.email,
+      name: existing.name || c.name,
+      firstName: existing.firstName || c.firstName,
+      lastName: existing.lastName || c.lastName,
+      sources: Array.from(new Set([...existing.sources, ...c.sources])) as (
+        | "partiful"
+        | "luma"
+      )[],
+    });
+  }
+  return map;
+}
+
+// ──────────────────── Email body ────────────────────
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface BuildEmailInput {
+  email: string;
+  firstName: string;
+  name: string;
+}
+
+function buildEmail(c: BuildEmailInput): { subject: string; html: string; text: string } {
+  const first = escapeHtml(
+    (c.firstName?.trim() || c.name?.split(" ")[0]?.trim() || "there")
+  );
+  const unsubUrl = buildUnsubscribeUrl(c.email);
+
+  const subject = "Confirm your seat — Tue May 26 at Hult";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;margin:0 auto;padding:16px;">
+
+<p>Hi ${first},</p>
+
+<p>We're nine days out from the <strong>Boston Tech Week Sports Hack</strong> at <strong>Hult International</strong> in Cambridge — <strong>Tuesday May 26, 10 AM – 4 PM ET</strong>. Please take 10 seconds to confirm whether you'll be there.</p>
+
+<p style="background:#ecfdf5;border-left:4px solid #10b981;padding:12px 16px;margin:16px 0;">
+  <strong>Why we're asking:</strong> we just shipped a second step on top of the existing claim. Hult's room caps at <strong>200 guaranteed seats</strong> (rank 201+ is the day-of waitlist — you can still show up, just not guaranteed), and we have <strong>119 Cursor credit links</strong> to allocate to the top 119 confirmed by leaderboard rank. So your confirmation drives both the seating headcount and credit eligibility.
+</p>
+
+<p style="text-align:center;margin:24px 0;">
+  <a href="${SIGNUP_URL}" style="background:#10b981;color:white;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;display:inline-block;">Confirm or decline →</a>
+</p>
+
+<p style="font-size:13px;color:#555;text-align:center;margin-top:-12px;">
+  (If you've already confirmed, you're set — nothing else to do.)
+</p>
+
+<h3 style="margin-top:32px;margin-bottom:8px;">Agenda — Tuesday May 26 at Hult</h3>
+<ul style="margin:0;padding-left:20px;">
+  <li><strong>10:00 AM</strong> — Doors, coffee, networking</li>
+  <li><strong>10:30 AM – 12:00 PM</strong> — Guest lecture: <strong>Antonio Mele</strong> (London School of Economics)</li>
+  <li><strong>12:00 – 12:30 PM</strong> — Lunch</li>
+  <li><strong>12:30 – 2:30 PM</strong> — 2-hour hackathon sprint</li>
+  <li><strong>2:30 – 3:00 PM</strong> — AI-powered scoring</li>
+  <li><strong>3:00 – 3:30 PM</strong> — Top-10 live pitches</li>
+  <li><strong>3:30 – 4:00 PM</strong> — Judges' analysis + winners</li>
+</ul>
+<p style="font-size:13px;color:#555;margin-top:8px;">
+  Full details + the public submissions page: <a href="${EVENT_URL}">cursorboston.com/hackathons/sports-hack-2026</a>.
+</p>
+
+<hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0;">
+
+<h3 style="margin-top:0;margin-bottom:8px;">While you're on the site — two new things</h3>
+
+<p style="margin-bottom:16px;">
+  <strong>1. <a href="${GAME_URL}">/game</a> is live.</strong> Cursor Boston's turn-based strategy game built by the community. Enlist a player, claim tiles, attack neighbors, earn artifacts. Designed to be picked up in 2 minutes a day. If you're into game design or game dev, the contribution surface is wide open — units, lore, spells, balance, UI.
+</p>
+
+<p style="margin-bottom:16px;">
+  <strong>2. <a href="${RESEARCH_URL}">/research</a> just opened</strong> — a community space for pre-prints, datasets, and study recruitment. Headlining the launch is the <strong><a href="${ALGORITHMACY_URL}">First Global Algorithmacy Conference</a></strong> at La Brea Pitch Lake, Trinidad &amp; Tobago, late October / early November 2026. The CFP is open right now: propose a talk by opening a PR with a Markdown abstract + outline + APA references. Algorithmacy is the worker-level communication competency for coordinating through algorithmic third parties — distinct from oracy and literacy. If you have a stake in platform work, HCI, or AI-mediated communication, this is the room.
+</p>
+
+<hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0;">
+
+<p>See you Tuesday.</p>
+
+<p>— Roger Hunt, Cursor Boston</p>
+
+<p style="font-size:11px;color:#888;margin-top:32px;">
+  <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+
+</body></html>`;
+
+  const text = `Hi ${c.firstName?.trim() || c.name?.split(" ")[0]?.trim() || "there"},
+
+We're nine days out from the Boston Tech Week Sports Hack at Hult International in Cambridge — Tuesday May 26, 10 AM – 4 PM ET. Please take 10 seconds to confirm whether you'll be there.
+
+Why we're asking: we just shipped a second step on top of the existing claim. Hult's room caps at 200 guaranteed seats (rank 201+ is the day-of waitlist — you can still show up, just not guaranteed), and we have 119 Cursor credit links to allocate to the top 119 confirmed by leaderboard rank. Your confirmation drives both the seating headcount and credit eligibility.
+
+Confirm or decline: ${SIGNUP_URL}
+
+(If you've already confirmed, you're set — nothing else to do.)
+
+Agenda — Tuesday May 26 at Hult
+  10:00 AM         Doors, coffee, networking
+  10:30 – 12:00    Guest lecture: Antonio Mele (London School of Economics)
+  12:00 – 12:30    Lunch
+  12:30 – 2:30     2-hour hackathon sprint
+  2:30 – 3:00      AI-powered scoring
+  3:00 – 3:30      Top-10 live pitches
+  3:30 – 4:00      Judges' analysis + winners
+
+Full details + public submissions: ${EVENT_URL}
+
+While you're on the site — two new things
+
+1. /game is live. Cursor Boston's turn-based strategy game built by the community.
+   Enlist a player, claim tiles, attack neighbors, earn artifacts. Designed to be
+   picked up in 2 minutes a day. Contribution surface is wide open.
+   ${GAME_URL}
+
+2. /research just opened — community space for pre-prints, datasets, and study
+   recruitment. Headlining: the First Global Algorithmacy Conference at La Brea
+   Pitch Lake, Trinidad & Tobago, late Oct / early Nov 2026. CFP open: propose a
+   talk via PR (abstract + outline + APA refs). Algorithmacy is the worker-level
+   competency for coordinating through algorithmic third parties — distinct from
+   oracy and literacy. If platform work, HCI, or AI-mediated communication are
+   your beat, this is the room.
+   ${RESEARCH_URL}
+   ${ALGORITHMACY_URL}
+
+See you Tuesday.
+
+— Roger Hunt, Cursor Boston
+
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+// ──────────────────── Main ────────────────────
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function buildEventContactsDoc(c: CombinedContact) {
+  const now = Timestamp.now();
+  const nowIso = new Date().toISOString();
+  return {
+    email: c.email,
+    name: c.name,
+    firstName: c.firstName,
+    lastName: c.lastName,
+    events: [
+      {
+        eventName: EVENT_NAME_MAY26,
+        checkedIn: false,
+        approvalStatus: "invited",
+      },
+    ],
+    eventNames: [EVENT_NAME_MAY26],
+    totalEvents: 1,
+    firstSeenAt: nowIso,
+    lastSeenAt: nowIso,
+    updatedAt: now,
+    sources: ["csv-may26-broadcast"],
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+    if (!process.env.UNSUBSCRIBE_SECRET) {
+      console.error("For --send, set UNSUBSCRIBE_SECRET (≥32 bytes).");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  // 1. Ingest CSVs
+  console.log("Ingesting CSVs…");
+  const partiful = ingestPartiful(CSV_PARTIFUL);
+  const luma = ingestLuma(CSV_LUMA);
+  const combined = dedupe([...partiful, ...luma]);
+  console.log(
+    `  Partiful rows with email: ${partiful.length}, Luma rows with email: ${luma.length}`
+  );
+  console.log(`  Combined unique emails: ${combined.size}`);
+
+  // 2. Suppression sync (mirrors Mailgun bounces/complaints onto eventContacts.unsubscribed)
+  console.log("\nSyncing Mailgun suppressions onto eventContacts…");
+  try {
+    await syncMailgunSuppressions(db);
+  } catch (e) {
+    // Non-fatal in dry-run; warn and continue. send mode still has db-level unsubscribed checks.
+    console.warn("  Suppression sync failed (continuing):", (e as Error).message);
+  }
+
+  // 3. Cross-reference vs eventContacts. We read the full collection once and
+  //    look up by doc id (email-lowercased).
+  console.log("\nLoading eventContacts…");
+  const ecSnap = await db.collection("eventContacts").get();
+  console.log(`  eventContacts total: ${ecSnap.size}`);
+
+  const existingByEmail = new Map<
+    string,
+    { name?: string; firstName?: string; unsubscribed?: boolean }
+  >();
+  for (const doc of ecSnap.docs) {
+    const data = doc.data();
+    existingByEmail.set(doc.id, {
+      name: typeof data.name === "string" ? data.name : undefined,
+      firstName: typeof data.firstName === "string" ? data.firstName : undefined,
+      unsubscribed: data.unsubscribed === true,
+    });
+  }
+
+  // 4. Build new-contact set (CSV emails not in eventContacts).
+  const newContacts: CombinedContact[] = [];
+  let existing = 0;
+  let unsubscribedCount = 0;
+  for (const c of combined.values()) {
+    const ec = existingByEmail.get(c.email);
+    if (ec) {
+      existing++;
+      if (ec.unsubscribed) unsubscribedCount++;
+    } else {
+      newContacts.push(c);
+    }
+  }
+  console.log(
+    `  Existing in eventContacts: ${existing} (of which unsubscribed: ${unsubscribedCount})`
+  );
+  console.log(`  New (to be added): ${newContacts.length}`);
+
+  // 5. Write new contacts to eventContacts in batches of 400.
+  if (newContacts.length > 0) {
+    console.log(
+      `\n${dryRun ? "[dry-run] WOULD write" : "Writing"} ${newContacts.length} new eventContacts docs in batches of 400…`
+    );
+    if (!dryRun) {
+      let written = 0;
+      for (let i = 0; i < newContacts.length; i += 400) {
+        const slice = newContacts.slice(i, i + 400);
+        const batch = db.batch();
+        for (const c of slice) {
+          const ref = db.collection("eventContacts").doc(c.email);
+          batch.set(ref, buildEventContactsDoc(c), { merge: false });
+        }
+        await batch.commit();
+        written += slice.length;
+        console.log(`    wrote ${written}/${newContacts.length}`);
+      }
+    }
+  }
+
+  // 6. Build final recipient list (non-unsubscribed only).
+  type Recipient = { email: string; firstName: string; name: string };
+  const recipients: Recipient[] = [];
+  for (const c of combined.values()) {
+    const ec = existingByEmail.get(c.email);
+    if (ec?.unsubscribed) continue;
+    recipients.push({
+      email: c.email,
+      // Prefer eventContacts-stored name (likely more polished) over CSV-derived.
+      firstName: (ec?.firstName?.trim() || c.firstName).trim(),
+      name: (ec?.name?.trim() || c.name).trim(),
+    });
+  }
+
+  console.log(
+    `\nFinal recipients (post-unsubscribe filter): ${recipients.length}`
+  );
+  console.log(`  Skipped unsubscribed: ${unsubscribedCount}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.");
+    const sample = recipients.find((r) => r.firstName) ?? recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`\nSample to: ${sample.email}  (firstName: "${sample.firstName}")`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview (first 1800 chars) ---");
+      console.log(html.slice(0, 1800));
+      console.log("\n--- Text preview ---");
+      console.log(text);
+    }
+    console.log(
+      `\nDry-run summary: would send to ${recipients.length} unique recipients.`
+    );
+    return;
+  }
+
+  // 7. Send loop.
+  console.log(`\nSending to ${recipients.length} recipients…`);
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text, from: FROM });
+      sent++;
+      if (sent % 50 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  FAILED: ${r.email}`, (e as Error).message);
+    }
+    await sleep(450);
+  }
+
+  console.log(
+    `\nDone. Sent ${sent}, failed ${failed}, skipped-unsubscribed ${unsubscribedCount}, added-to-eventContacts ${newContacts.length}.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
       "schedule": "*/5 * * * *"
     },
     {
+      "path": "/api/internal/snapshots/rebuild?only=game-world-3d",
+      "schedule": "0 9 * * *"
+    },
+    {
       "path": "/api/internal/hunt/email-retry",
       "schedule": "*/15 * * * *"
     },


### PR DESCRIPTION
## Summary

- **#1412** — feat(game): 3D fly-around world map at `/game/world` (@Ludwitt). Public WebGL flyover, daily Firestore snapshot, auth-aware CTA, Skills Passport sidebar move.
- **195bad9** — chore(broadcast): archive send-may26-confirm-and-pitches.ts (@Ludwitt). One-off broadcast script retired now that the May 26 send is done.

## Test plan

- [x] All CI checks green on develop after #1412 merged
- [x] Local `npm run build && npm start` walked through `/game/world` (pan/zoom/rotate, click-to-fly, info card, How-to-play drawer, auth-aware CTA) before the develop merge
- [ ] After promotion: hit `/game/world` on prod and verify the scene renders + the CTA flips correctly while signed-in
- [ ] After promotion: trigger `/api/internal/snapshots/rebuild?only=game-world-3d` via the cron secret to seed `game_world_snapshots/daily-3d` (the daily cron will keep it fresh thereafter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)