### PR TITLE
feat(game): show Open game world map FAB on every page

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -7,28 +7,11 @@
 
 "use client";
 
-import Link from "next/link";
 import { CreatePlayerGate } from "./_components/dashboard/CreatePlayerGate";
 import { DashboardView } from "./_components/dashboard/DashboardView";
 import { NameYourGeneralGate } from "./_components/dashboard/NameYourGeneralGate";
 import { SignedOutLanding } from "./_components/dashboard/SignedOutLanding";
 import { useDashboardData } from "./_lib/use-dashboard-data";
-
-// Fixed bottom-right FAB linking into the 3D fly-around at /game/world.
-// Always rendered (signed-out landing, create-player gate, full
-// dashboard) so the world map is discoverable from every entrypoint.
-function WorldMapFab() {
-  return (
-    <Link
-      href="/game/world"
-      className="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-neutral-900/80 backdrop-blur border border-neutral-700/60 px-4 py-2.5 text-sm font-medium text-neutral-100 shadow-lg hover:bg-neutral-800 dark:bg-neutral-900/80 dark:hover:bg-neutral-800 transition-colors"
-      aria-label="Open game world map"
-    >
-      <span aria-hidden>🗺️</span>
-      <span>Open game world map</span>
-    </Link>
-  );
-}
 
 /**
  * /game — the dashboard. Composition only: every meaningful piece lives
@@ -78,12 +61,7 @@ export default function GameDashboardPage() {
     content = <DashboardView player={player} data={data} />;
   }
 
-  // The FAB rides on top of every state — even pre-auth — so the 3D
-  // fly-around is one click away from anywhere in /game.
-  return (
-    <>
-      {content}
-      {!authLoading && <WorldMapFab />}
-    </>
-  );
+  // The "Open game world map" FAB lives in AppShell now so it's on
+  // every page, not just /game.
+  return <>{content}</>;
 }

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -528,6 +528,23 @@ export default function AppShell({ children }: { children: ReactNode }) {
         <Footer />
       </div>
       <SportsHackConfirmAttendanceModal />
+      <WorldMapFab />
     </div>
+  );
+}
+
+// Floating "Open game world map" launcher. Lives at z-40, so the
+// /game/world page's own fixed inset-0 z-50 overlay covers it — no
+// path check needed.
+function WorldMapFab() {
+  return (
+    <Link
+      href="/game/world"
+      className="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-neutral-900/80 backdrop-blur border border-neutral-700/60 px-4 py-2.5 text-sm font-medium text-neutral-100 shadow-lg hover:bg-neutral-800 transition-colors"
+      aria-label="Open game world map"
+    >
+      <span aria-hidden>🗺️</span>
+      <span>Open game world map</span>
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary

- Hoists the "🗺️ Open game world map" floating launcher from `app/game/page.tsx` into `components/AppShell.tsx` so it's visible on every page in the app, not just under `/game`.
- The FAB sits at `z-40`; `/game/world`'s own `fixed inset-0 z-50` overlay covers it without needing any path-based hide logic.

## Test plan

- [x] Local `npm run build` clean
- [ ] After deploy: confirm the FAB shows on `/`, `/cookbook`, `/blog`, etc.
- [ ] After deploy: confirm `/game/world` does NOT show two launchers stacked (the AppShell FAB should be covered by the world overlay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)