### PR TITLE
ci: harden workflow token permissions

### DIFF
--- a/.github/workflows/ci-fork-notice.yml
+++ b/.github/workflows/ci-fork-notice.yml
@@ -8,13 +8,14 @@ on:
     branches: [develop]
     types: [opened]
 
-permissions:
-  pull-requests: write
+permissions: read-all
 
 jobs:
   welcome:
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Post contributor guidance
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/cut-signed-tag.yml
+++ b/.github/workflows/cut-signed-tag.yml
@@ -28,14 +28,15 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write          # push the tag
-  id-token: write          # mint OIDC token for gitsign
+permissions: read-all
 
 jobs:
   cut-signed-tag:
     name: Cut signed tag via gitsign
     runs-on: ubuntu-latest
+    permissions:
+      contents: write          # push the tag
+      id-token: write          # mint OIDC token for gitsign
     steps:
       - name: Validate version input
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,17 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: read
-  id-token: write       # Required for Sigstore keyless signing
-  attestations: write   # Required for actions/attest-build-provenance (SLSA L2)
+permissions: read-all
 
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write       # Required for Sigstore keyless signing
+      attestations: write   # Required for actions/attest-build-provenance (SLSA L2)
     
     steps:
       - name: Checkout code

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,13 +5,14 @@ on:
     - cron: '30 6 * * 1'  # Every Monday at 06:30 UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:


### PR DESCRIPTION
## Summary

The OpenSSF Scorecard `Token-Permissions` check scores this repo **0/10** — not because workflows lack a `permissions:` block (every workflow has one), but because four workflows declare **write scopes at the top level**, where they apply to every job in the file rather than only the job that needs them. Scorecard flags top-level write as a least-privilege violation: if any step in any job is compromised, the broad token is available to it.

This PR moves the write scopes down to the specific jobs that use them and sets each of the four workflows to `permissions: read-all` at the top level. No job loses a capability it actually uses — the change is purely about scoping the elevated token to the job boundary instead of the workflow boundary.

## Affected surfaces

| Workflow | Top-level before | Top-level after | Job that keeps write |
|---|---|---|---|
| `.github/workflows/release.yml` | `contents: write`, `pull-requests: read`, `id-token: write`, `attestations: write` | `read-all` | `release` job retains all four (release creation/upload, changelog PR read, Sigstore OIDC, SLSA provenance). The `notify` job runs only `echo` summary steps — read-only. |
| `.github/workflows/cut-signed-tag.yml` | `contents: write`, `id-token: write` | `read-all` | `cut-signed-tag` job retains both (tag push, gitsign OIDC). |
| `.github/workflows/stale.yml` | `issues: write`, `pull-requests: write` | `read-all` | `stale` job retains both (the stale action mutates issues/PRs). |
| `.github/workflows/ci-fork-notice.yml` | `pull-requests: write` | `read-all` | `welcome` job retains PR-comment scope. No checkout of untrusted code. |

Net diff: 4 files, +17 / -13.

## Blast radius

| Vector | Impact |
|---|---|
| Release / signing pipeline | None, if scoping is correct — the `release` job keeps `contents: write` (for `gh release upload` + `action-gh-release`), `id-token: write` (cosign keyless + provenance OIDC), and `attestations: write` (SLSA `attest-build-provenance`). Verified against every step in the job. |
| Tag-signing workflow | None — `cut-signed-tag` job keeps `contents: write` (tag push) + `id-token: write` (gitsign). |
| Stale bot | None — `stale` job keeps `issues: write` + `pull-requests: write`. |
| Fork-PR notice | None — `welcome` job keeps `pull-requests: write` for the comment. |
| Scorecard | `Token-Permissions` should move from 0 toward 10 once these are the only top-level declarations and all are read-only. |

The failure mode for this kind of change is stripping a scope a job silently needs and only discovering it when a release fails. Mitigated by mapping every job's steps to its required scopes before the change (see Fix walkthrough) and by the fact that `read-all` at top level still grants read to every job, so no read-dependent step breaks.

## Why it matters

GitHub Actions tokens are a real supply-chain attack surface: a compromised dependency or action step runs with whatever the workflow token grants. Top-level write means *every* job — including ones that only read, lint, or echo — carries a token that can push commits, create releases, or mutate issues. Least privilege says the elevated token should exist only in the job and step that needs it.

This is also a direct OpenSSF Scorecard signal. The repo is at gold on the CII Best Practices Badge but the automated Scorecard aggregate is held down by exactly these kinds of gaps; `Token-Permissions` at 0 is one of the larger single contributors. Scoping tokens to the job boundary is the canonical fix Scorecard documents.

## Fix walkthrough

For each workflow, every job's steps were mapped to the minimum scope it needs, then write was moved from top-level to that job:

- **`release.yml`** — the `release` job runs `gh release upload`, `softprops/action-gh-release` (both need `contents: write`), `cosign sign-blob --yes` keyless (`id-token: write`), and `actions/attest-build-provenance` (`id-token: write` + `attestations: write`); the changelog builder reads PRs (`pull-requests: read`). All four scopes move to `jobs.release.permissions`. The `notify` job (`needs: release`) runs only `echo` summary steps — no token scope needed, inherits top-level `read-all`.
- **`cut-signed-tag.yml`** — the single `cut-signed-tag` job pushes a signed tag (`contents: write`) and uses gitsign OIDC (`id-token: write`). Both move to the job.
- **`stale.yml`** — the single `stale` job runs `actions/stale`, which closes/labels issues and PRs (`issues: write`, `pull-requests: write`). Both move to the job.
- **`ci-fork-notice.yml`** — the single `welcome` job posts a PR comment (`pull-requests: write`). Moves to the job. This workflow does not check out untrusted PR head code, so the scope is safe.

Top level becomes `permissions: read-all` in all four. `read-all` (rather than `contents: read`) is used at top level so read-only jobs that read PRs, issues, or other scopes don't lose read access — the check only requires the *absence of write* at top level, which `read-all` satisfies.

## Tests

| Command | Result |
|---|---|
| `git diff --check origin/develop..HEAD` | Clean (no whitespace errors). |
| `rg "^permissions:" -A2` across the four workflows | Confirms top-level is `read-all` in all four; write scopes appear only under the intended `jobs.<name>.permissions`. |
| YAML well-formedness (workflow parse) | Valid — scopes relocated, no structural change to steps. |

No runtime test can fully exercise a release without cutting a tag, so the verification is by static scope-mapping: each job retains exactly the scopes its steps require, confirmed step-by-step above. The next real release (Roger-cut) will exercise the `release` job's retained scopes end-to-end.

## Scope (what this PR does NOT cover, and why)

- **Other Scorecard gaps** (SAST/CodeQL, Fuzzing, Signed-Releases asset format, Branch-Protection) are separate PRs / maintainer actions. This PR is the `Token-Permissions` slice only.
- **Workflows already at minimal scope** (the CI workflows that are read-only or already job-scoped) are untouched.
- **Changing `read-all` to per-scope `contents: read`** at top level is deliberately not done — `read-all` is the safe choice that satisfies the check without risking a read-dependent step in a non-write job. Tightening top-level reads further would be a separate, lower-value change with higher breakage risk.

## Audit and compliance

- License: GPL-3.0-only (unchanged; workflow YAML carries no SPDX header by project convention).
- DCO sign-off present on the commit.
- No app code, no dependencies, no env vars changed — CI configuration only.
- Addresses OpenSSF Scorecard `Token-Permissions` (0 → expected 10).

---

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
