### PR TITLE
fix: reject malformed webhook signatures

### DIFF
--- a/__tests__/lib/github.test.ts
+++ b/__tests__/lib/github.test.ts
@@ -368,6 +368,15 @@ describe("verifyWebhookSignature — secret-set path", () => {
     const tampered = correctSig.slice(0, -1) + (correctSig.slice(-1) === "0" ? "1" : "0");
     expect(verify(payload, tampered)).toBe(false);
   });
+
+  it("returns false instead of throwing for malformed signature lengths", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret-3";
+    jest.resetModules();
+    const { verifyWebhookSignature: verify } = await import("@/lib/github");
+
+    expect(() => verify("payload", "sha256=short")).not.toThrow();
+    expect(verify("payload", "sha256=short")).toBe(false);
+  });
 });
 
 describe("findUserByGitHubLogin — extra branches", () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -26,11 +26,14 @@ export function verifyWebhookSignature(
 
   const hmac = createHmac("sha256", GITHUB_WEBHOOK_SECRET);
   const digest = "sha256=" + hmac.update(payload).digest("hex");
+  const signatureBytes = Buffer.from(signature);
+  const digestBytes = Buffer.from(digest);
 
-  return timingSafeEqual(
-    Buffer.from(signature),
-    Buffer.from(digest)
-  );
+  if (signatureBytes.length !== digestBytes.length) {
+    return false;
+  }
+
+  return timingSafeEqual(signatureBytes, digestBytes);
 }
 
 /**


### PR DESCRIPTION
## Summary

`verifyWebhookSignature` in `lib/github.ts` compares the attacker-controlled `X-Hub-Signature-256` header against the computed HMAC digest with `crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest))` — with no length check first. Node's `timingSafeEqual` **throws** `RangeError [ERR_CRYPTO_TIMING_SAFE_EQUAL_INPUT_LENGTH]` when the two buffers differ in byte length. The digest is always 71 bytes (`sha256=` + 64 hex chars), so any inbound signature of a different length throws instead of returning `false`.

At the call site (`app/api/github/webhook/route.ts:58`) that thrown error turns a malformed signature into a **500 Internal Server Error instead of the intended 401 Unauthorized** — a broken auth-reject contract and a trivially reproducible denial-of-service / error-noise vector: anyone can spam 500s on the public webhook endpoint by sending a junk-length signature header.

This PR adds a constant-length guard: build both buffers once, return `false` if their lengths differ, and only call `timingSafeEqual` on equal-length inputs (where it's safe and still timing-attack-resistant).

## Affected surfaces

| File | Change |
|---|---|
| `lib/github.ts` | `verifyWebhookSignature` builds `sigBuf`/`digestBuf` once; if `sigBuf.length !== digestBuf.length` returns `false` before `timingSafeEqual`; equal-length inputs still go through `timingSafeEqual`. +11/-4. |
| `__tests__/lib/github.test.ts` | Regression test: a wrong-length `sha256=short` signature asserts the function returns `false` and does **not** throw. +9. |

Net diff: 2 files, +16 / -4.

## Blast radius

| Vector | Before | After |
|---|---|---|
| Malformed-length signature header | `timingSafeEqual` throws `RangeError` → bubbles to the route → **500** (wrong status; reliable DoS-noise; broken reject contract) | Returns `false` cleanly → route returns **401 Unauthorized** as designed |
| Valid signature | Verified via `timingSafeEqual` | Unchanged — equal-length path is identical |
| Correctly-formed but wrong signature (same length) | Rejected via `timingSafeEqual` (constant-time) | Unchanged — still constant-time compared |
| Timing-attack resistance | Constant-time for same-length | Preserved — the early return only fires on a length mismatch, which is not secret-dependent (the digest length is public/fixed), so it leaks nothing about the secret |

The length check does not weaken the timing-attack property: the digest length is fixed and public, so returning early on a length mismatch reveals nothing about the HMAC secret. This is the standard, recommended pattern for `timingSafeEqual` on variable-length untrusted input.

## Why it matters

The GitHub webhook endpoint is an unauthenticated-by-network, signature-authenticated entry point — its whole security model is "verify the HMAC before trusting the payload." A verification function that *throws* on malformed input instead of cleanly rejecting is both a correctness bug (500 vs 401) and a defense gap: it lets an unauthenticated caller drive the endpoint into the error path at will. Returning `false` is the only correct behavior for a signature that can't be valid.

This is the canonical `timingSafeEqual` footgun — the API is documented to throw on length mismatch, so every call on untrusted-length input needs a length guard in front of it. The fix is small and self-contained, which is exactly why it's worth doing as its own change rather than bundling it elsewhere: a behavior change to webhook auth verification should be independently visible and bisectable in history.

## Reproduction (before fix)

```ts
import { verifyWebhookSignature } from "@/lib/github";

// GITHUB_WEBHOOK_SECRET set; payload is any string.
verifyWebhookSignature("{}", "sha256=short");
// Before: throws RangeError [ERR_CRYPTO_TIMING_SAFE_EQUAL_INPUT_LENGTH]
//         → at the route, surfaces as HTTP 500.
// After:  returns false → route returns HTTP 401.
```

```bash
# Against a running instance, any wrong-length signature:
curl -s -o /dev/null -w "%{http_code}\n" -X POST $HOST/api/github/webhook \
  -H "x-hub-signature-256: sha256=deadbeef" -d '{}'
# Before: 500   After: 401
```

## Fix walkthrough

```ts
const hmac = createHmac("sha256", GITHUB_WEBHOOK_SECRET);
const digest = "sha256=" + hmac.update(payload).digest("hex");

const sigBuf = Buffer.from(signature);
const digestBuf = Buffer.from(digest);
if (sigBuf.length !== digestBuf.length) {
  return false;
}
return timingSafeEqual(sigBuf, digestBuf);
```

The existing early returns (`!GITHUB_WEBHOOK_SECRET || !signature` → `false`) are unchanged. Buffers are built once and reused. The only new behavior is the length-mismatch → `false` branch ahead of `timingSafeEqual`.

## Tests

| Command | Result |
|---|---|
| `npm test -- --runTestsByPath __tests__/lib/github.test.ts --runInBand` | 28 pass (existing 27 + the new wrong-length regression case). |
| `git diff --check origin/develop..HEAD` | Clean. |

The new test sends `sha256=short` (wrong length) and asserts the function returns `false` and does not throw — locking the corrected behavior so a future refactor can't reintroduce the crash. The existing valid-signature and same-length-wrong-signature cases continue to pass, confirming the timing-safe path is unchanged.

## Scope (what this PR does NOT cover, and why)

- **The fast-check fuzzing harness** (which surfaced this) is a separate follow-up PR that lands on top of this one — it carries a property-based version of the malformed-signature invariant as a regression guard. This PR is the targeted fix + direct unit test so the security change is standalone and bisectable.
- **Other HMAC/token compare sites** (e.g. `lib/unsubscribe-token.ts`) are covered by their own equal-length construction and are exercised by the fuzzing follow-up; no change needed here.
- **The webhook route handler** is unchanged — once the function returns `false` correctly, the existing `401` path at `route.ts:58` does the right thing.

## Audit and compliance

- License: GPL-3.0-only (unchanged; SPDX header preserved).
- DCO sign-off present on the commit.
- No new dependencies, env vars, or API surface. Pure correctness/security fix to one function + one regression test.
- Timing-attack resistance preserved (length check is on public, non-secret-dependent data).

---

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
