### PR TITLE
fix: announce opportunity filter updates

### DIFF
--- a/__tests__/app/opportunities/opportunity-listings.test.tsx
+++ b/__tests__/app/opportunities/opportunity-listings.test.tsx
@@ -48,7 +48,10 @@ describe("OpportunityListings", () => {
   it("filters listings and resets back to the full list", () => {
     render(<OpportunityListings opportunities={opportunities} />);
 
-    expect(screen.getByText("Showing 2 of 2 listings.")).toBeInTheDocument();
+    const status = screen.getByRole("status");
+    const searchInput = screen.getByLabelText("Search opportunities");
+
+    expect(status).toHaveTextContent("Showing 2 of 2 listings.");
     expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
     expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
     expect(screen.getByText("A sports community startup building in Boston.")).toBeInTheDocument();
@@ -64,18 +67,20 @@ describe("OpportunityListings", () => {
 
     expect(screen.queryByText("CTO / Co-Founder")).not.toBeInTheDocument();
     expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
-    expect(screen.getByText("Showing 1 of 2 listings.")).toBeInTheDocument();
+    expect(status).toHaveTextContent("Showing 1 of 2 listings.");
 
-    fireEvent.change(screen.getByLabelText("Search opportunities"), {
+    fireEvent.change(searchInput, {
       target: { value: "does-not-exist" },
     });
 
+    expect(status).toHaveTextContent("No opportunities match those filters.");
     expect(screen.getByText("No opportunities match those filters.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Reset" }));
 
     expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
-    expect(screen.getByText("Showing 2 of 2 listings.")).toBeInTheDocument();
+    expect(status).toHaveTextContent("Showing 2 of 2 listings.");
+    expect(searchInput).toHaveFocus();
   });
 
   it("filters listings by work mode", () => {

--- a/app/opportunities/_components/OpportunityListings.tsx
+++ b/app/opportunities/_components/OpportunityListings.tsx
@@ -17,7 +17,7 @@ import {
   Search,
   SlidersHorizontal,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   filterOpportunityListings,
   formatOpportunityType,
@@ -174,6 +174,7 @@ export function OpportunityListings({
   const [query, setQuery] = useState("");
   const [type, setType] = useState("all");
   const [workMode, setWorkMode] = useState<OpportunityWorkModeFilter>("all");
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const typeOptions = useMemo(
     () => getOpportunityTypeOptions(opportunities),
@@ -184,6 +185,15 @@ export function OpportunityListings({
     [opportunities, query, type, workMode]
   );
   const hasFilters = query.trim() !== "" || type !== "all" || workMode !== "all";
+  const hasFilteredOutAllListings =
+    opportunities.length > 0 && filteredOpportunities.length === 0;
+
+  function handleReset() {
+    setQuery("");
+    setType("all");
+    setWorkMode("all");
+    searchInputRef.current?.focus();
+  }
 
   return (
     <section className="px-6 py-16">
@@ -193,8 +203,22 @@ export function OpportunityListings({
             <h2 className="text-2xl font-bold text-foreground md:text-3xl">
               Open Opportunities
             </h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-              Showing {filteredOpportunities.length} of {opportunities.length} listings.
+            <p
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="mt-2 text-sm text-neutral-600 dark:text-neutral-400"
+            >
+              <span aria-hidden={hasFilteredOutAllListings ? "true" : undefined}>
+                Showing {filteredOpportunities.length} of {opportunities.length}{" "}
+                listings.
+              </span>
+              {hasFilteredOutAllListings ? (
+                <span className="sr-only">
+                  No opportunities match those filters. Try a broader search or
+                  reset the filters.
+                </span>
+              ) : null}
             </p>
           </div>
 
@@ -208,6 +232,7 @@ export function OpportunityListings({
                   aria-hidden="true"
                 />
                 <input
+                  ref={searchInputRef}
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder="Search roles, companies, tags"
@@ -253,11 +278,7 @@ export function OpportunityListings({
 
               <button
                 type="button"
-                onClick={() => {
-                  setQuery("");
-                  setType("all");
-                  setWorkMode("all");
-                }}
+                onClick={handleReset}
                 disabled={!hasFilters}
                 className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
               >


### PR DESCRIPTION
## Summary

`OpportunityListings` (the `/opportunities` filter island) changes its visible listing set on every keystroke / type-filter / work-mode-filter, but doesn't announce those changes to assistive tech, and its Reset action strands keyboard focus. Screen-reader users get silent transitions (the list narrows from 20+ to 4 with no announcement), and after Reset focus is left on a control that no longer reflects the cleared state.

This PR adds two targeted WCAG 2.1 fixes to the existing component: the listing-count line becomes a single polite, atomic live region that announces the current count, the narrowed count, and a no-results + recovery message; and Reset returns focus to the search input. No visible-UI change, no styling change, no new dependencies.

## Affected surfaces

| File | Change |
|---|---|
| `app/opportunities/_components/OpportunityListings.tsx` | Add `useRef<HTMLInputElement>` on the search input; Reset clears query/type/workMode and refocuses search. Convert the listing-count line into one `role="status"` `aria-live="polite"` `aria-atomic="true"` region. Visible count renders as before; when filtering narrows existing listings to zero, the count text is `aria-hidden` and the same region carries an `sr-only` no-results + reset-guidance message. The no-results announcement is **guarded by `opportunities.length > 0`**, so the genuine "no listings posted yet" empty state keeps announcing just `Showing 0 of 0 listings.` (plus its existing visible empty state) rather than a filter-recovery hint that wouldn't apply. |
| `__tests__/app/opportunities/opportunity-listings.test.tsx` | Extend the existing filter/reset test: assert `getByRole("status")` announces full count, narrowed count, and no-results text; assert the search input has focus after Reset. |

Net diff: 2 files, +38 / -12.

## Blast radius

| Vector | Impact |
|---|---|
| Sighted users | Zero visible change. Count renders as before; live-region semantics + `sr-only` text are invisible. |
| Screen-reader users | Direct win. Count transitions and the no-results state are announced politely. The empty-listings-vs-no-filter-match distinction means the announcement always matches the actual state. |
| Keyboard-only users | Direct win. Reset returns focus deterministically to search. |
| Bundle | No new deps. |
| Existing tests | Filter/reset test extended, not replaced. |

Component-local: no API/prop change, no data-layer change (`content/opportunities.json` untouched).

## Why it matters

`/opportunities` is the recruiting funnel — silent filter updates and lost focus exclude SR and keyboard-only candidates from confidently narrowing the list. The fixes are short, standard WCAG 2.1 patterns (SC 4.1.3 status messages, SC 2.4.3 focus order), consistent with the sibling RoadmapExplorer a11y PR.

`aria-live="polite"` (not `assertive`) queues announcements without interrupting. The `opportunities.length > 0` guard is the careful part: "no listings exist" and "your filters matched nothing" are different states; only the latter should suggest resetting filters. Announcing a reset hint when there's simply nothing posted yet would be misleading.

## Reproduction (before fix)

```bash
npm run dev
open http://localhost:3000/opportunities

# With a screen reader on:
# 1. Tab to search, type "remote". The list narrows; SR announces nothing.
# 2. Click Reset. Focus is left on Reset; SR has no cue the filters cleared.

# With the fix:
# 1. SR announces "4 listings" → "20 listings" politely; a no-filter-match state
#    announces a reset hint, while a genuinely empty board just says "0 of 0".
# 2. After Reset, focus returns to the search input.
```

## Fix walkthrough

```tsx
const searchRef = useRef<HTMLInputElement>(null);

const handleReset = () => {
  setQuery("");
  setType("all");
  setWorkMode("all");
  searchRef.current?.focus();
};
// search input gets ref={searchRef}; Reset button calls handleReset

<div role="status" aria-live="polite" aria-atomic="true">
  <span aria-hidden={resultCount === 0 ? "true" : undefined}>
    Showing {resultCount} of {totalCount} listings.
  </span>
  {resultCount === 0 && opportunities.length > 0 && (
    <span className="sr-only">No opportunities match those filters. Reset to see all listings.</span>
  )}
</div>
```

No filter logic changed; the live region replaces the plain count line in the same DOM position. The existing visible empty-state card is untouched.

## Tests

| Command | Result |
|---|---|
| `npm test -- --runTestsByPath __tests__/app/opportunities/opportunity-listings.test.tsx --runInBand` | 3 pass — extended filter/reset test asserts the live-region announcements (full / narrowed / no-results) and search-input focus after Reset. |
| `npx eslint app/opportunities/_components/OpportunityListings.tsx __tests__/app/opportunities/opportunity-listings.test.tsx --max-warnings=0` | Clean |
| `npm run type-check` (`tsc --noEmit`) | Clean |
| `git diff --check origin/develop..HEAD` | No whitespace errors |

## Scope (what this PR does NOT cover, and why)

- **Other a11y dimensions** (type-badge contrast, focus-ring polish, skip links) are out of scope. This PR is the live-region + reset-focus slice. Tracked under #1401.
- **Sibling islands** (`RoadmapExplorer` shipped already; Skills Passport next) get the same treatment in their own PRs.
- **Native filter controls** (`<select>`) already inherit browser keyboard nav + label association — unchanged.
- **The listing data layer** (`lib/opportunity-listings.ts`, `content/opportunities.json`) is unaffected — presentation-only.

## Audit and compliance

- License: GPL-3.0-only (unchanged; SPDX header preserved).
- DCO sign-off present on the commit.
- No new dependencies; no env vars; no Firestore / API / network calls.
- Refs umbrella issue #1401 (A11y pass on Q2 2026 filter islands and Skills Passport states).

---

Carther Theogene · [https://linkedin.com/in/carther](https://linkedin.com/in/carther)
