### PR TITLE
release: Scorecard quick wins (Token-Perms, Pinned-Deps, Vulns, Signed-Releases, CodeQL, ADR docs)

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,6 +1,9 @@
 # Cloud Agent base image: Ubuntu (required for Cursor Computer Use with Dockerfiles).
 # Do not COPY the project — Cursor checks out the workspace separately.
-FROM ubuntu:24.04
+# Pinned by digest for supply-chain integrity (OpenSSF Scorecard
+# Pinned-Dependencies). Refresh the digest in lockstep with the human-
+# readable tag when bumping ubuntu versions.
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -63,7 +66,9 @@ RUN set -eux; \
 ########################################################
 # Firebase CLI (global)
 ########################################################
-RUN npm install -g firebase-tools
+# Pinned to match the devDependency in package.json (and the Scorecard
+# Pinned-Dependencies check). Bump in lockstep.
+RUN npm install -g firebase-tools@15.18.0
 
 ########################################################
 # ubuntu user (matches Cursor Cloud Agent Docker docs)

--- a/.github/workflows/ci-fork-notice.yml
+++ b/.github/workflows/ci-fork-notice.yml
@@ -8,13 +8,14 @@ on:
     branches: [develop]
     types: [opened]
 
-permissions:
-  pull-requests: write
+permissions: read-all
 
 jobs:
   welcome:
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Post contributor guidance
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: '37 4 * * 2'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+          - actions
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/cut-signed-tag.yml
+++ b/.github/workflows/cut-signed-tag.yml
@@ -28,14 +28,15 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write          # push the tag
-  id-token: write          # mint OIDC token for gitsign
+permissions: read-all
 
 jobs:
   cut-signed-tag:
     name: Cut signed tag via gitsign
     runs-on: ubuntu-latest
+    permissions:
+      contents: write          # push the tag
+      id-token: write          # mint OIDC token for gitsign
     steps:
       - name: Validate version input
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,17 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: read
-  id-token: write       # Required for Sigstore keyless signing
-  attestations: write   # Required for actions/attest-build-provenance (SLSA L2)
+permissions: read-all
 
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write       # Required for Sigstore keyless signing
+      attestations: write   # Required for actions/attest-build-provenance (SLSA L2)
     
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,31 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      # Generate a reproducible source archive of the tag and sign it so
+      # downstream consumers (and OpenSSF Scorecard's Signed-Releases
+      # check) have a cryptographically verifiable artifact to attach
+      # trust to. GitHub's auto-generated source-code zip/tar is not
+      # signed and Scorecard correctly flags releases that lack a
+      # signature file.
+      - name: Build signed source archive
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.version || github.ref_name }}"
+          ARCHIVE="cursor-boston-${TAG}.tar.gz"
+          # --prefix matches GitHub's default archive layout so consumers
+          # can swap our signed archive in without changing their unpack
+          # flow. Built from HEAD (= tagged commit) for byte-equivalence.
+          git archive --format=tar.gz --prefix="cursor-boston-${TAG}/" \
+            -o "$ARCHIVE" HEAD
+          cosign sign-blob --yes \
+            --bundle "${ARCHIVE}.cosign.bundle" \
+            "$ARCHIVE"
+          gh release upload "$TAG" \
+            "$ARCHIVE" \
+            "${ARCHIVE}.cosign.bundle" \
+            --repo "${{ github.repository }}"
+
       - name: Sign release SBOMs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -206,12 +231,33 @@ jobs:
             sbom.spdx.json.cosign.bundle \
             --repo "${{ github.repository }}"
 
-      - name: Attest SLSA build provenance for SBOMs
+      - name: Attest SLSA build provenance for release artifacts
+        id: attest
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: |
+            cursor-boston-${{ github.event.inputs.version || github.ref_name }}.tar.gz
             sbom.json
             sbom.spdx.json
+
+      # Attach the SLSA provenance bundle to the GitHub release so it's
+      # discoverable from the release page (and by OpenSSF Scorecard's
+      # Signed-Releases check, which scans release assets for
+      # provenance-shaped files).
+      - name: Upload SLSA provenance bundle to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.version || github.ref_name }}"
+          BUNDLE="${{ steps.attest.outputs.bundle-path }}"
+          if [ -n "$BUNDLE" ] && [ -f "$BUNDLE" ]; then
+            cp "$BUNDLE" "cursor-boston-${TAG}.intoto.jsonl"
+            gh release upload "$TAG" \
+              "cursor-boston-${TAG}.intoto.jsonl" \
+              --repo "${{ github.repository }}"
+          else
+            echo "::warning::attest-build-provenance produced no bundle file; skipping upload"
+          fi
 
   notify:
     name: Notify Release

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,13 +5,14 @@ on:
     - cron: '30 6 * * 1'  # Every Monday at 06:30 UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 # ==========================================
 
 # Stage 1: Dependencies
-FROM node:22.20.0-alpine3.21 AS deps
+FROM node:22.20.0-alpine3.21@sha256:f40aebdd0c1959821ab6d72daecafb2cd1d4c9a958e9952c1d71b84d4458f875 AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -21,7 +21,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --only=production --ignore-scripts && npm cache clean --force
 
 # Stage 2: Builder
-FROM node:22.20.0-alpine3.21 AS builder
+FROM node:22.20.0-alpine3.21@sha256:f40aebdd0c1959821ab6d72daecafb2cd1d4c9a958e9952c1d71b84d4458f875 AS builder
 WORKDIR /app
 
 # Copy dependencies from deps stage
@@ -58,7 +58,7 @@ ENV DOCKER_BUILD=1
 RUN npm run build
 
 # Stage 3: Runner (Production)
-FROM node:22.20.0-alpine3.21 AS runner
+FROM node:22.20.0-alpine3.21@sha256:f40aebdd0c1959821ab6d72daecafb2cd1d4c9a958e9952c1d71b84d4458f875 AS runner
 WORKDIR /app
 
 # Set production environment

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,8 @@ What becomes easier or more difficult because of this decision?
 | [0004](0004-webpack-bundler.md) | Webpack over Turbopack | Accepted | 2026-04-13 |
 | [0005](0005-in-memory-rate-limiting.md) | In-memory rate limiting with Firestore fallback | Accepted | 2026-04-13 |
 | [0006](0006-develop-main-branching.md) | develop/main branching strategy | Accepted | 2026-04-13 |
+| [0007](0007-account-deletion-model.md) | Account deletion — hard-delete with 30-day soft-delete grace | Accepted | 2026-05-18 |
+| [0008](0008-community-maintainer-track.md) | Community Maintainer track + multi-maintainer onboarding model | Accepted | 2026-05-18 |
 
 ## Adding a new ADR
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1960,9 +1960,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7051,9 +7051,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11651,9 +11651,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16420,9 +16420,9 @@
       }
     },
     "node_modules/jsdom/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Scorecard hardening pass. Brings overall score from 6.9 → ~8.5–9 once re-scanned.

- **#1422** — chore(security): Scorecard quick wins — Pinned-Deps, Vulns, Signed-Releases (@Ludwitt)
- **#1419** — ci: add CodeQL analysis (@codex bot)
- **#1417** — ci: harden workflow token permissions
- **#1411** — docs(adr): add ADR-0007 and ADR-0008 to index table

## Score deltas expected after re-scan

| Check | Before | After |
|---|---|---|
| Token-Permissions | 0 | 10 (via #1417) |
| SAST | 2 | 7–9 (via #1419; rises further as PRs accumulate) |
| Pinned-Dependencies | 8 | 10 (Docker SHA pins + firebase-tools, via #1422) |
| Vulnerabilities | 8 | 10 (npm audit fix, via #1422) |
| Branch-Protection | 4 | ~9 (ruleset flags flipped out-of-band) |
| Signed-Releases | 0 | 8–10 once a new release cuts (release.yml updated in #1422) |

## Test plan

- [x] CI green on develop after each constituent PR merged
- [ ] Post-promotion: cut v0.3.1 to exercise the new signed-source-archive flow
- [ ] Post-promotion: `gh workflow run scorecards.yml` to re-trigger Scorecard

🤖 Generated with [Claude Code](https://claude.com/claude-code)