### PR TITLE
release: add fuzzing for OpenSSF Scorecard

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,12 @@
+# Pinned by digest for supply-chain integrity (OpenSSF Scorecard
+# Pinned-Dependencies). The base-builder-javascript image carries the
+# fuzzing toolchain (libFuzzer wrappers + Node.js) — it's the official
+# ClusterFuzzLite base for JS projects and saves us from layering
+# Node.js ourselves.
+FROM gcr.io/oss-fuzz-base/base-builder-javascript@sha256:d7e4afe145a0898074facc5a44f2519e7c668dfb4a97f03615aa4a1126bf0979
+
+WORKDIR $SRC
+COPY . $SRC/cursor-boston
+WORKDIR $SRC/cursor-boston
+
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# ClusterFuzzLite build script for the cursor-boston fuzz harness suite.
+# Invoked by the ClusterFuzzLite base-builder image; environment variables
+# OUT and SRC are provided by the base image.
+set -euo pipefail
+
+cd "$SRC/cursor-boston"
+
+# Install only what the harnesses need. The full project's deps are
+# heavy (Next.js, Firebase Admin, etc.) and ClusterFuzzLite's wall-clock
+# budget is finite; the sanitize.fuzz.ts harness compiles standalone
+# against jazzer.js. Versions are pinned (Scorecard Pinned-Dependencies).
+npm install --no-audit --no-fund --no-save \
+  @jazzer.js/core@2.1.0 \
+  typescript@5.6.3
+
+# base-builder-javascript exposes `compile_javascript_fuzzer` which knows
+# how to wrap a jazzer.js harness into a libFuzzer-compatible binary at
+# $OUT/<name>. Use it per fuzz target so we get the standard
+# ClusterFuzzLite invocation contract.
+for target in fuzz/*.fuzz.ts; do
+  name="$(basename "$target" .fuzz.ts)"
+  # Transpile the harness + sanitize.ts to CJS so jazzer.js can require
+  # it at fuzz time (jazzer is a CJS-only runtime).
+  npx --no-install tsc \
+    --module commonjs --target es2022 --esModuleInterop \
+    --outDir "build_${name}" \
+    --rootDir . \
+    "$target" lib/sanitize.ts
+
+  compile_javascript_fuzzer cursor-boston \
+    "build_${name}/fuzz/${name}.fuzz" \
+    --sync
+done
+
+exit 0
+

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,10 @@
+# ClusterFuzzLite project descriptor.
+# See https://google.github.io/clusterfuzzlite/build-integration/javascript-lang/
+language: javascript
+primary_contact: rhunt@bentley.edu
+auto_ccs:
+  - rhunt@bentley.edu
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,57 @@
+name: ClusterFuzzLite
+
+# Coverage-guided fuzzing for the input-sanitization paths in
+# lib/sanitize.ts. Two modes:
+#  - PR builds run a short (10-minute) fuzz session on each target and
+#    fail the job if any crash is found.
+#  - The weekly batch run uses a longer budget and stores the corpus +
+#    coverage artifacts as build artifacts for follow-up review.
+#
+# The actual harnesses live under fuzz/ and the build glue under
+# .clusterfuzzlite/. See fuzz/README.md for the rationale.
+
+on:
+  pull_request:
+    paths:
+      - "lib/sanitize.ts"
+      - "fuzz/**"
+      - ".clusterfuzzlite/**"
+      - ".github/workflows/fuzz.yml"
+  schedule:
+    - cron: "27 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz (${{ matrix.sanitizer }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Build fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: javascript
+          sanitizer: ${{ matrix.sanitizer }}
+
+      - name: Run fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: javascript
+          sanitizer: ${{ matrix.sanitizer }}
+          # PR-mode: 600s of fuzzing on each target. Long enough to catch
+          # regressions, short enough to stay within the PR latency
+          # budget. The weekly batch run uses the same workflow with a
+          # longer mode.
+          fuzz-seconds: 600
+          mode: ${{ github.event_name == 'pull_request' && 'code-change' || 'batch' }}
+          output-sarif: true

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,23 @@
+# Fuzz harnesses
+
+Coverage-guided fuzz tests for input-handling code paths. Run by
+ClusterFuzzLite in CI (see `.github/workflows/fuzz.yml`) on every PR
+that touches a fuzz target or the code it covers.
+
+Why these specific targets:
+
+- **`sanitize.fuzz.ts`** — `lib/sanitize.ts` is the single point of
+  contact between untrusted user input (display names, URLs, free-text)
+  and Firestore writes / link rendering. Regression in any of its regex
+  paths could open XSS or ReDoS. Fuzzed for both crashes and the
+  documented invariants (no control chars in output, URLs always
+  resolve to a valid `http(s)`/null result, doc IDs always match the
+  Firestore charset).
+
+How to add a new target:
+
+1. Create `fuzz/<name>.fuzz.ts` that exports `fuzz(data: Buffer)`.
+2. Add the new target file to the corpus matrix in
+   `.github/workflows/fuzz.yml`.
+3. Add a one-line description here so future maintainers know what
+   each target proves.

--- a/fuzz/sanitize.fuzz.ts
+++ b/fuzz/sanitize.fuzz.ts
@@ -1,0 +1,98 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+// jazzer.js coverage-guided fuzzer for lib/sanitize.ts.
+//
+// Exercises every public sanitizer with byte-level random input and
+// asserts the documented invariants. A crash, ReDoS-style hang, or
+// invariant violation is what we want jazzer to find — those are
+// regressions worth catching before they reach prod.
+//
+// Run locally:
+//   npx jazzer fuzz/sanitize.fuzz.ts --sync
+// In CI: ClusterFuzzLite invokes this via .clusterfuzzlite/Dockerfile.
+
+import {
+  sanitizeText,
+  sanitizeName,
+  sanitizeUrl,
+  sanitizeDocId,
+  isValidHackathonId,
+} from "../lib/sanitize";
+
+// jazzer.js expects a `fuzz` export with signature (data: Buffer) => void.
+export function fuzz(data: Buffer): void {
+  // Decode the random bytes into a string the sanitizers can chew on.
+  // Cap length defensively so a single iteration can't dominate the
+  // fuzzing budget; real inputs aren't multi-MB anyway.
+  const input = data.subarray(0, 4096).toString("utf8");
+
+  // === sanitizeText: must never crash and must drop control chars ===
+  const text = sanitizeText(input);
+  if (typeof text !== "string") {
+    throw new Error("sanitizeText returned non-string");
+  }
+  // Invariant: no ASCII control chars in output (except newline 0x0A).
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    if (
+      (c >= 0x00 && c <= 0x08) ||
+      c === 0x0b ||
+      c === 0x0c ||
+      (c >= 0x0e && c <= 0x1f) ||
+      c === 0x7f
+    ) {
+      throw new Error(
+        `sanitizeText leaked control char 0x${c.toString(16)} in output`
+      );
+    }
+  }
+
+  // === sanitizeName: stricter — only [A-Za-z0-9 _\-.] allowed ===
+  const name = sanitizeName(input);
+  if (typeof name !== "string") {
+    throw new Error("sanitizeName returned non-string");
+  }
+  if (!/^[a-zA-Z0-9 _\-.]*$/.test(name)) {
+    throw new Error(`sanitizeName leaked disallowed char in: ${JSON.stringify(name)}`);
+  }
+
+  // === sanitizeUrl: returns string|null; if non-null, must be parseable
+  // and must use http(s) ===
+  const url = sanitizeUrl(input);
+  if (url !== null) {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error(`sanitizeUrl returned non-URL: ${url}`);
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(
+        `sanitizeUrl returned ${parsed.protocol} (must be http: or https:)`
+      );
+    }
+  }
+
+  // === sanitizeDocId: returns string|null; if non-null, must match the
+  // Firestore-safe alphabet and be ≤1500 chars ===
+  const docId = sanitizeDocId(input);
+  if (docId !== null) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(docId)) {
+      throw new Error(`sanitizeDocId returned invalid id: ${docId}`);
+    }
+    if (docId.length > 1500) {
+      throw new Error(`sanitizeDocId returned >1500 chars (${docId.length})`);
+    }
+  }
+
+  // === isValidHackathonId: pure boolean; just must not throw ===
+  const ok = isValidHackathonId(input);
+  if (typeof ok !== "boolean") {
+    throw new Error("isValidHackathonId returned non-boolean");
+  }
+}


### PR DESCRIPTION
## Summary

- **#1428** — chore(security): add jazzer.js fuzzing for sanitize.ts (@Ludwitt). Adds a real coverage-guided fuzz harness over `lib/sanitize.ts` + ClusterFuzzLite CI integration. Expected to move Scorecard's Fuzzing check from 0/10 to 10/10.

## Test plan

- [x] Fuzz CI job green on #1428 (no crashes against current sanitizers in the PR-mode 600s run)
- [ ] Post-promotion: `gh workflow run scorecards.yml` to confirm Fuzzing 0 → 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)