### PR TITLE
release: OAuth rate-limit hotfix + community contributor batch

### DIFF
--- a/__tests__/app/open-source/roadmap-explorer.test.tsx
+++ b/__tests__/app/open-source/roadmap-explorer.test.tsx
@@ -9,7 +9,10 @@ describe("RoadmapExplorer", () => {
   it("filters contribution ideas by category, difficulty, and search", () => {
     render(<RoadmapExplorer />);
 
-    expect(screen.getByText("Showing 22 of 22 roadmap ideas.")).toBeInTheDocument();
+    const status = screen.getByRole("status");
+    const searchInput = screen.getByLabelText("Search roadmap ideas");
+
+    expect(status).toHaveTextContent("Showing 22 of 22 roadmap ideas.");
 
     fireEvent.change(screen.getByLabelText("Filter by category"), {
       target: { value: "accessibility" },
@@ -21,17 +24,19 @@ describe("RoadmapExplorer", () => {
     expect(screen.getByText("Keyboard Navigation Audit")).toBeInTheDocument();
     expect(screen.getByText("Color Contrast Check")).toBeInTheDocument();
     expect(screen.queryByText("Dark Mode Toggle")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing 2 of 22 roadmap ideas.")).toBeInTheDocument();
+    expect(status).toHaveTextContent("Showing 2 of 22 roadmap ideas.");
 
-    fireEvent.change(screen.getByLabelText("Search roadmap ideas"), {
+    fireEvent.change(searchInput, {
       target: { value: "screen reader" },
     });
 
+    expect(status).toHaveTextContent("No roadmap ideas match those filters.");
     expect(screen.getByText("No roadmap ideas match those filters.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Reset" }));
 
     expect(screen.getByText("Dark Mode Toggle")).toBeInTheDocument();
-    expect(screen.getByText("Showing 22 of 22 roadmap ideas.")).toBeInTheDocument();
+    expect(status).toHaveTextContent("Showing 22 of 22 roadmap ideas.");
+    expect(searchInput).toHaveFocus();
   });
 });

--- a/__tests__/app/opportunities/opportunity-listings.test.tsx
+++ b/__tests__/app/opportunities/opportunity-listings.test.tsx
@@ -48,7 +48,10 @@ describe("OpportunityListings", () => {
   it("filters listings and resets back to the full list", () => {
     render(<OpportunityListings opportunities={opportunities} />);
 
-    expect(screen.getByText("Showing 2 of 2 listings.")).toBeInTheDocument();
+    const status = screen.getByRole("status");
+    const searchInput = screen.getByLabelText("Search opportunities");
+
+    expect(status).toHaveTextContent("Showing 2 of 2 listings.");
     expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
     expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
     expect(screen.getByText("A sports community startup building in Boston.")).toBeInTheDocument();
@@ -64,18 +67,20 @@ describe("OpportunityListings", () => {
 
     expect(screen.queryByText("CTO / Co-Founder")).not.toBeInTheDocument();
     expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
-    expect(screen.getByText("Showing 1 of 2 listings.")).toBeInTheDocument();
+    expect(status).toHaveTextContent("Showing 1 of 2 listings.");
 
-    fireEvent.change(screen.getByLabelText("Search opportunities"), {
+    fireEvent.change(searchInput, {
       target: { value: "does-not-exist" },
     });
 
+    expect(status).toHaveTextContent("No opportunities match those filters.");
     expect(screen.getByText("No opportunities match those filters.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Reset" }));
 
     expect(screen.getByText("CTO / Co-Founder")).toBeInTheDocument();
-    expect(screen.getByText("Showing 2 of 2 listings.")).toBeInTheDocument();
+    expect(status).toHaveTextContent("Showing 2 of 2 listings.");
+    expect(searchInput).toHaveFocus();
   });
 
   it("filters listings by work mode", () => {

--- a/__tests__/app/skills/page.test.tsx
+++ b/__tests__/app/skills/page.test.tsx
@@ -3,7 +3,7 @@
  */
 import "@/__tests__/app/_shared/page-test-setup";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ensureUserBadgesForEligibleWithStatus } from "@/lib/badges/data";
 import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
@@ -85,6 +85,21 @@ describe("SkillsPage", () => {
     }) as typeof fetch;
   });
 
+  it("announces the initial skills passport loading state", async () => {
+    mockUseAuth.mockReturnValue({
+      loading: true,
+      user: null,
+      userProfile: null,
+    });
+
+    const Page = (await import("@/app/skills/page")).default;
+    render(<Page />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Loading your skills passport..."
+    );
+  });
+
   it("renders badge-backed skill tracks for signed-in users", async () => {
     const Page = (await import("@/app/skills/page")).default;
     render(<Page />);
@@ -97,6 +112,20 @@ describe("SkillsPage", () => {
     expect(await screen.findByText("3/9")).toBeInTheDocument();
     expect(screen.getByText("33%")).toBeInTheDocument();
     expect(screen.getAllByText("Conversation Starter").length).toBeGreaterThan(0);
+    const earnedBadge = await screen.findByLabelText("Badge: First Steps - Earned");
+    const inProgressBadge = screen.getByLabelText(
+      "Badge: Conversation Starter - In progress"
+    );
+    const buildProgress = screen.getByRole("progressbar", {
+      name: "Build and Ship progress",
+    });
+
+    expect(within(earnedBadge).getByText("Earned")).toBeInTheDocument();
+    expect(within(inProgressBadge).getByText("In progress")).toBeInTheDocument();
+    expect(buildProgress).toHaveAttribute(
+      "aria-valuetext",
+      "1 of 3 badges earned - 33%"
+    );
 
     await waitFor(() => {
       expect(mockEnsureBadges).toHaveBeenCalled();

--- a/__tests__/lib/github.test.ts
+++ b/__tests__/lib/github.test.ts
@@ -368,6 +368,15 @@ describe("verifyWebhookSignature — secret-set path", () => {
     const tampered = correctSig.slice(0, -1) + (correctSig.slice(-1) === "0" ? "1" : "0");
     expect(verify(payload, tampered)).toBe(false);
   });
+
+  it("returns false instead of throwing for malformed signature lengths", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret-3";
+    jest.resetModules();
+    const { verifyWebhookSignature: verify } = await import("@/lib/github");
+
+    expect(() => verify("payload", "sha256=short")).not.toThrow();
+    expect(verify("payload", "sha256=short")).toBe(false);
+  });
 });
 
 describe("findUserByGitHubLogin — extra branches", () => {

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -122,7 +122,7 @@ describe('Rate Limiting', () => {
     it('should have oauthCallback configuration', () => {
       expect(rateLimitConfigs.oauthCallback).toBeDefined();
       expect(rateLimitConfigs.oauthCallback.windowMs).toBe(15 * 60 * 1000);
-      expect(rateLimitConfigs.oauthCallback.maxRequests).toBe(10);
+      expect(rateLimitConfigs.oauthCallback.maxRequests).toBe(100);
     });
 
     it('should have webhook configuration', () => {

--- a/app/open-source/_components/RoadmapExplorer.tsx
+++ b/app/open-source/_components/RoadmapExplorer.tsx
@@ -20,7 +20,7 @@ import {
   Zap,
   type LucideIcon,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   buildRoadmapIssueUrl,
   countRoadmapItems,
@@ -157,6 +157,7 @@ export function RoadmapExplorer() {
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<CategoryFilter>("all");
   const [difficulty, setDifficulty] = useState<DifficultyFilter>("all");
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const filteredCategories = useMemo(
     () => filterRoadmapCategories({ query, category, difficulty }),
@@ -165,6 +166,13 @@ export function RoadmapExplorer() {
   const resultCount = countRoadmapItems(filteredCategories);
   const totalCount = countRoadmapItems();
   const hasFilters = query.trim() !== "" || category !== "all" || difficulty !== "all";
+
+  function handleReset() {
+    setQuery("");
+    setCategory("all");
+    setDifficulty("all");
+    searchInputRef.current?.focus();
+  }
 
   return (
     <section
@@ -193,6 +201,7 @@ export function RoadmapExplorer() {
                 aria-hidden="true"
               />
               <input
+                ref={searchInputRef}
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="Search by skill, title, or outcome"
@@ -243,11 +252,7 @@ export function RoadmapExplorer() {
 
             <button
               type="button"
-              onClick={() => {
-                setQuery("");
-                setCategory("all");
-                setDifficulty("all");
-              }}
+              onClick={handleReset}
               disabled={!hasFilters}
               className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
             >
@@ -255,8 +260,21 @@ export function RoadmapExplorer() {
               Reset
             </button>
           </div>
-          <div className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
-            Showing {resultCount} of {totalCount} roadmap ideas.
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="mt-3 text-sm text-neutral-600 dark:text-neutral-400"
+          >
+            <span aria-hidden={resultCount === 0 ? "true" : undefined}>
+              Showing {resultCount} of {totalCount} roadmap ideas.
+            </span>
+            {resultCount === 0 ? (
+              <span className="sr-only">
+                No roadmap ideas match those filters. Try a broader search or
+                propose a new contribution idea.
+              </span>
+            ) : null}
           </div>
         </div>
 

--- a/app/opportunities/_components/OpportunityListings.tsx
+++ b/app/opportunities/_components/OpportunityListings.tsx
@@ -17,7 +17,7 @@ import {
   Search,
   SlidersHorizontal,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   filterOpportunityListings,
   formatOpportunityType,
@@ -174,6 +174,7 @@ export function OpportunityListings({
   const [query, setQuery] = useState("");
   const [type, setType] = useState("all");
   const [workMode, setWorkMode] = useState<OpportunityWorkModeFilter>("all");
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const typeOptions = useMemo(
     () => getOpportunityTypeOptions(opportunities),
@@ -184,6 +185,15 @@ export function OpportunityListings({
     [opportunities, query, type, workMode]
   );
   const hasFilters = query.trim() !== "" || type !== "all" || workMode !== "all";
+  const hasFilteredOutAllListings =
+    opportunities.length > 0 && filteredOpportunities.length === 0;
+
+  function handleReset() {
+    setQuery("");
+    setType("all");
+    setWorkMode("all");
+    searchInputRef.current?.focus();
+  }
 
   return (
     <section className="px-6 py-16">
@@ -193,8 +203,22 @@ export function OpportunityListings({
             <h2 className="text-2xl font-bold text-foreground md:text-3xl">
               Open Opportunities
             </h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-              Showing {filteredOpportunities.length} of {opportunities.length} listings.
+            <p
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="mt-2 text-sm text-neutral-600 dark:text-neutral-400"
+            >
+              <span aria-hidden={hasFilteredOutAllListings ? "true" : undefined}>
+                Showing {filteredOpportunities.length} of {opportunities.length}{" "}
+                listings.
+              </span>
+              {hasFilteredOutAllListings ? (
+                <span className="sr-only">
+                  No opportunities match those filters. Try a broader search or
+                  reset the filters.
+                </span>
+              ) : null}
             </p>
           </div>
 
@@ -208,6 +232,7 @@ export function OpportunityListings({
                   aria-hidden="true"
                 />
                 <input
+                  ref={searchInputRef}
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder="Search roles, companies, tags"
@@ -253,11 +278,7 @@ export function OpportunityListings({
 
               <button
                 type="button"
-                onClick={() => {
-                  setQuery("");
-                  setType("all");
-                  setWorkMode("all");
-                }}
+                onClick={handleReset}
                 disabled={!hasFilters}
                 className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-neutral-200 bg-white px-4 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
               >

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -179,7 +179,13 @@ export default function SkillsPage() {
   if (loading || !user) {
     return (
       <div className="min-h-[80vh] flex items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-neutral-900 dark:border-white" />
+        <div role="status" aria-live="polite">
+          <div
+            className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-neutral-900 dark:border-white"
+            aria-hidden="true"
+          />
+          <span className="sr-only">Loading your skills passport...</span>
+        </div>
       </div>
     );
   }
@@ -258,7 +264,11 @@ export default function SkillsPage() {
               Skill Tracks
             </h2>
             {loadingPassport && (
-              <span className="text-xs text-neutral-500 dark:text-neutral-400">
+              <span
+                role="status"
+                aria-live="polite"
+                className="text-xs text-neutral-500 dark:text-neutral-400"
+              >
                 Updating...
               </span>
             )}
@@ -282,13 +292,21 @@ export default function SkillsPage() {
                     {track.earnedCount}/{track.totalCount}
                   </span>
                 </div>
-                <ProgressBar value={track.percent} label={track.name} />
+                <ProgressBar
+                  value={track.percent}
+                  label={track.name}
+                  valueText={`${track.earnedCount} of ${track.totalCount} badges earned - ${track.percent}%`}
+                />
                 <div className="mt-4 flex flex-wrap gap-2">
                   {track.badges.map((badge) => {
                     const earned = passport.earnedBadgeIds.includes(badge.id);
+                    const badgeState = earned ? "Earned" : "In progress";
+                    const BadgeStateIcon = earned ? CheckCircle2 : CircleDashed;
+
                     return (
                       <span
                         key={badge.id}
+                        aria-label={`Badge: ${badge.name} - ${badgeState}`}
                         className={cn(
                           "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs",
                           earned
@@ -296,11 +314,8 @@ export default function SkillsPage() {
                             : "border-neutral-200 bg-neutral-50 text-neutral-600 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-400"
                         )}
                       >
-                        {earned ? (
-                          <CheckCircle2 className="h-3.5 w-3.5" />
-                        ) : (
-                          <CircleDashed className="h-3.5 w-3.5" />
-                        )}
+                        <BadgeStateIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                        <span className="font-semibold">{badgeState}</span>
                         {badge.name}
                       </span>
                     );
@@ -358,6 +373,7 @@ export default function SkillsPage() {
                     <ProgressBar
                       value={milestone.percent}
                       label={milestone.badge.name}
+                      valueText={`${milestone.current} of ${milestone.target} ${milestone.unit} completed - ${milestone.percent}%`}
                     />
                   </div>
                 ))
@@ -394,13 +410,22 @@ function SummaryStat({
   );
 }
 
-function ProgressBar({ value, label }: { value: number; label: string }) {
+function ProgressBar({
+  value,
+  label,
+  valueText,
+}: {
+  value: number;
+  label: string;
+  valueText: string;
+}) {
   return (
     <div
       aria-label={`${label} progress`}
       aria-valuemax={100}
       aria-valuemin={0}
       aria-valuenow={value}
+      aria-valuetext={valueText}
       className="h-2 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800"
       role="progressbar"
     >

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -26,11 +26,14 @@ export function verifyWebhookSignature(
 
   const hmac = createHmac("sha256", GITHUB_WEBHOOK_SECRET);
   const digest = "sha256=" + hmac.update(payload).digest("hex");
+  const signatureBytes = Buffer.from(signature);
+  const digestBytes = Buffer.from(digest);
 
-  return timingSafeEqual(
-    Buffer.from(signature),
-    Buffer.from(digest)
-  );
+  if (signatureBytes.length !== digestBytes.length) {
+    return false;
+  }
+
+  return timingSafeEqual(signatureBytes, digestBytes);
 }
 
 /**

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -244,11 +244,22 @@ export function withRateLimit(
  */
 export const rateLimitConfigs = {
   /**
-   * Strict rate limit for OAuth callbacks to prevent abuse and brute-forcing.
+   * Rate limit for OAuth callbacks. Per-IP, used as defense-in-depth —
+   * the actual brute-force protection lives in the cookie-bound
+   * `state` token validated inside each callback handler (see
+   * app/api/discord/callback/route.ts and app/api/github/callback/route.ts).
+   *
+   * Sized for shared-NAT venues. At in-person events (Hult campus on
+   * 2026-05-26 was the trigger for the current value), every attendee
+   * connecting Discord + GitHub hits this from the same egress IP.
+   * The old 10/15min ceiling blew up after ~5 attendees and produced
+   * a wave of "I can't connect my account" reports. 100/15min absorbs
+   * a ~50-person venue with each person connecting both providers
+   * without losing the DoS guardrail.
    */
   oauthCallback: {
     windowMs: 15 * 60 * 1000, // 15 minutes
-    maxRequests: 10, // 10 requests per 15 minutes
+    maxRequests: 100, // 100 requests per 15 minutes
   },
   /**
    * Moderate rate limit for incoming webhooks.


### PR DESCRIPTION
## Summary

Hotfix release for the **2026-05-23** OAuth rate-limit incident affecting the May 26 immersion event, bundled with four community-contributor PRs already merged to develop.

- **#1430** — fix(rate-limit): raise oauthCallback ceiling 10 → 100 per 15min (@Ludwitt). **EVENT HOTFIX.** In-person events on shared NAT blew through the prior 10/15min limit after ~5 attendees connected Discord + GitHub. OAuth `state` validation remains the brute-force protection.
- **#1427** — fix: announce skills passport progress (@mrrCarter). a11y: loading state + badge state + progress bar `aria-valuetext`.
- **#1425** — fix: announce opportunity filter updates (@mrrCarter). a11y: ARIA live region + focus restore on Reset.
- **#1424** — fix: announce roadmap filter updates (@mrrCarter). Same pattern for `/open-source`.
- **#1423** — fix: reject malformed webhook signatures (@mrrCarter). Adds length check before `crypto.timingSafeEqual` to prevent the `RangeError` throw on malformed `X-Hub-Signature-256`.

## Test plan

- [x] CI green on develop for each constituent PR
- [ ] After promotion: confirm Discord + GitHub connect flows complete from the venue Wi-Fi at the May 26 event
- [ ] After promotion: confirm GitHub webhook delivery still works (signature path unchanged on the happy case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)