### PR TITLE
chore(coverage): codecov.yml baseline + ResearchCard tests (7.7% → ~95%)

### DIFF
--- a/__tests__/components/research/ResearchCard.test.tsx
+++ b/__tests__/components/research/ResearchCard.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Coverage push: components/research/ResearchCard.tsx was at 7.7% on
+ * 2026-05-23 (52 source lines). Every entry-type and edge-case branch
+ * gets hit exactly once below.
+ */
+import { render, screen, within } from "@testing-library/react";
+import { ResearchCard } from "@/components/research/ResearchCard";
+import type { ActiveResearchEntry, WorkingPaperEntry, DatasetEntry, CollaborationEntry, CfpEntry } from "@/lib/research";
+
+// Stable now() so date-based branches (expired / closed) deterministic.
+const NOW = new Date("2026-05-23T12:00:00Z");
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(NOW);
+});
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+const baseFields = {
+  slug: "test-entry",
+  authors: [
+    { name: "Ada Lovelace", affiliation: "Analytical Engine Co" },
+    { name: "Charles Babbage" },
+  ],
+  postedAt: "2026-05-01T00:00:00Z",
+  disciplines: ["computer-science", "history"],
+  summary: "A reasonably long summary that exceeds the 20-character minimum.",
+  sourceRepoUrl: "https://example.com/repo",
+};
+
+function makeActive(overrides: Partial<ActiveResearchEntry> = {}): ActiveResearchEntry {
+  return {
+    ...baseFields,
+    type: "active-research",
+    title: "Recruiting study participants",
+    deadline: "2026-06-01T00:00:00Z",
+    compensation: "$50",
+    timeCommitment: "1 hour",
+    location: "remote",
+    eligibility: "18+",
+    status: "open",
+    ...overrides,
+  } as ActiveResearchEntry;
+}
+
+function makeWorkingPaper(overrides: Partial<WorkingPaperEntry> = {}): WorkingPaperEntry {
+  return {
+    ...baseFields,
+    type: "working-paper",
+    title: "Draft paper on test coverage",
+    version: "v0.1",
+    license: "CC-BY-4.0",
+    pdfUrl: "https://example.com/paper.pdf",
+    peerReviewStatus: "approved-with-reservations",
+    ...overrides,
+  } as WorkingPaperEntry;
+}
+
+function makeDataset(overrides: Partial<DatasetEntry> = {}): DatasetEntry {
+  return {
+    ...baseFields,
+    type: "dataset",
+    title: "Open commit corpus",
+    license: "ODbL",
+    size: "1.2 GB",
+    format: ["jsonl", "parquet"],
+    ...overrides,
+  } as DatasetEntry;
+}
+
+function makeCollaboration(overrides: Partial<CollaborationEntry> = {}): CollaborationEntry {
+  return {
+    ...baseFields,
+    type: "collaboration",
+    title: "Looking for a co-author",
+    collaborationType: "co-author",
+    projectStage: "writing",
+    seeking: "Anyone with stats experience",
+    timeCommitment: "4 hours/week",
+    status: "open",
+    ...overrides,
+  } as CollaborationEntry;
+}
+
+function makeCfp(overrides: Partial<CfpEntry> = {}): CfpEntry {
+  return {
+    ...baseFields,
+    type: "cfp",
+    title: "Call for papers: AI in Practice",
+    conferenceDates: "Oct 1-3, 2026",
+    location: "Boston, USA",
+    submissionDeadline: "2026-06-15T00:00:00Z",
+    conferenceUrl: "https://example.com/conf",
+    organizingBody: "ACM",
+    submissionTypes: ["full paper", "poster"],
+    status: "open",
+    ...overrides,
+  } as CfpEntry;
+}
+
+describe("ResearchCard", () => {
+  describe("active-research", () => {
+    it("renders title, authors, deadline + slot count", () => {
+      render(
+        <ResearchCard
+          entry={makeActive({ slotsRemaining: 3 })}
+        />
+      );
+      expect(
+        screen.getByRole("heading", { name: "Recruiting study participants" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Ada Lovelace \(Analytical Engine Co\) · Charles Babbage/)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Deadline /)).toBeInTheDocument();
+      expect(screen.getByText(/3 slots left/)).toBeInTheDocument();
+    });
+
+    it("shows 'Closed' for past deadline", () => {
+      render(
+        <ResearchCard
+          entry={makeActive({ deadline: "2026-05-01T00:00:00Z" })}
+        />
+      );
+      expect(screen.getByText(/Closed /)).toBeInTheDocument();
+    });
+  });
+
+  describe("working-paper", () => {
+    it("renders version + license + PDF link", () => {
+      render(<ResearchCard entry={makeWorkingPaper()} />);
+      expect(screen.getByText(/v0.1 · CC-BY-4.0/)).toBeInTheDocument();
+      const pdf = screen.getByRole("link", { name: /PDF/ });
+      expect(pdf).toHaveAttribute("href", "https://example.com/paper.pdf");
+      // approved-with-reservations gets humanized
+      expect(screen.getByText(/approved with reservations/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("dataset", () => {
+    it("renders license, size, and format chips", () => {
+      render(<ResearchCard entry={makeDataset()} />);
+      expect(screen.getByText("ODbL")).toBeInTheDocument();
+      expect(screen.getByText("1.2 GB")).toBeInTheDocument();
+      expect(screen.getByText("jsonl")).toBeInTheDocument();
+      expect(screen.getByText("parquet")).toBeInTheDocument();
+    });
+
+    it("renders without optional fields", () => {
+      render(<ResearchCard entry={makeDataset({ size: undefined, format: undefined })} />);
+      // License still shows even with everything else missing
+      expect(screen.getByText("ODbL")).toBeInTheDocument();
+      expect(screen.queryByText("1.2 GB")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("collaboration", () => {
+    it("renders type, stage, time commitment, and deadline", () => {
+      render(
+        <ResearchCard
+          entry={makeCollaboration({ deadline: "2026-06-01T00:00:00Z" })}
+        />
+      );
+      expect(screen.getByText(/co author/i)).toBeInTheDocument();
+      expect(screen.getByText(/stage: writing/)).toBeInTheDocument();
+      expect(screen.getByText("4 hours/week")).toBeInTheDocument();
+      expect(screen.getByText(/Need by /)).toBeInTheDocument();
+    });
+
+    it("omits the Need-by row when no deadline", () => {
+      render(<ResearchCard entry={makeCollaboration()} />);
+      expect(screen.queryByText(/Need by /)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("cfp", () => {
+    it("renders submission deadline, conference dates, and external link", () => {
+      render(<ResearchCard entry={makeCfp()} />);
+      expect(screen.getByText(/Submit by /)).toBeInTheDocument();
+      expect(screen.getByText("Oct 1-3, 2026")).toBeInTheDocument();
+      const conf = screen.getByRole("link", { name: /Conference site/ });
+      expect(conf).toHaveAttribute("href", "https://example.com/conf");
+    });
+
+    it("shows 'Submission closed' once submissionDeadline passes", () => {
+      render(
+        <ResearchCard
+          entry={makeCfp({ submissionDeadline: "2026-05-01T00:00:00Z" })}
+        />
+      );
+      expect(screen.getByText(/Submission closed/)).toBeInTheDocument();
+    });
+  });
+
+  describe("sample entries", () => {
+    it("renders the Sample banner and disables external CTAs", () => {
+      const entry = makeCfp({ isSample: true });
+      render(<ResearchCard entry={entry} />);
+      expect(screen.getByText(/Sample · placeholder entry/)).toBeInTheDocument();
+      // Conference site link replaced with disabled span
+      expect(
+        screen.queryByRole("link", { name: /Conference site/ })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/Conference site \(sample\)/)).toBeInTheDocument();
+      // Source repo link also replaced with disabled span
+      expect(
+        screen.queryByRole("link", { name: /Source repo/ })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/Source repo \(sample\)/)).toBeInTheDocument();
+    });
+
+    it("greys out the working-paper PDF link on sample entries", () => {
+      render(<ResearchCard entry={makeWorkingPaper({ isSample: true })} />);
+      expect(screen.queryByRole("link", { name: /PDF/ })).not.toBeInTheDocument();
+      expect(screen.getByText(/PDF/)).toBeInTheDocument();
+    });
+  });
+
+  describe("metadata header", () => {
+    it("shows 'updated' suffix when updatedAt is set", () => {
+      render(
+        <ResearchCard
+          entry={makeActive({ updatedAt: "2026-05-10T00:00:00Z" })}
+        />
+      );
+      expect(screen.getByText(/· updated/)).toBeInTheDocument();
+    });
+
+    it("only shows postedAt when no updatedAt", () => {
+      render(<ResearchCard entry={makeActive()} />);
+      expect(screen.queryByText(/· updated/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("discipline chips", () => {
+    it("caps visible discipline chips at four", () => {
+      const entry = makeActive({
+        disciplines: ["a", "b", "c", "d", "e", "f"],
+      });
+      const { container } = render(<ResearchCard entry={entry} />);
+      // The chips share a class; just count their rendered text.
+      for (const d of ["a", "b", "c", "d"]) {
+        expect(within(container).getByText(d)).toBeInTheDocument();
+      }
+      expect(within(container).queryByText("e")).not.toBeInTheDocument();
+      expect(within(container).queryByText("f")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,82 @@
+# Codecov configuration for cursor-boston.
+#
+# Two things this file does:
+#
+# 1. Sets explicit project + patch coverage targets so every PR gets
+#    a meaningful Codecov status check. Without this file Codecov
+#    runs with the defaults ("auto" target, 1% threshold), which
+#    silently allows large regressions.
+#
+# 2. Tells Codecov where the report lives + what to ignore so the
+#    PR comment is clean (no test files, no generated artifacts).
+#
+# Reference numbers (2026-05-23 develop tip):
+#   - Project coverage: ~83% (Codecov strict hits/lines)
+#   - Jest internal:    ~90% stmts / ~81% branches (counts partials as hits)
+
+coverage:
+  status:
+    project:
+      default:
+        # Target is "auto" — we ratchet against the parent commit
+        # rather than a hard number so the floor moves with us.
+        target: auto
+        # Allow tiny regressions (0.2%) so noise from rounding /
+        # smoke-import order doesn't fail every PR.
+        threshold: 0.2%
+        # Don't fail before Codecov has processed both the PR and
+        # base commit; flaky uploads otherwise red-X the check.
+        if_ci_failed: error
+        only_pulls: false
+    patch:
+      default:
+        # New / changed lines must be at least 80% covered.
+        # Matches the spirit of the OpenSSF Gold attestation (90/80
+        # statements/branches) while staying achievable for small
+        # config-only PRs.
+        target: 80%
+        threshold: 0%
+        if_ci_failed: error
+
+# PR comment: only attach if coverage changed or a check failed.
+# Keeps the noise down on docs-only / .md PRs.
+comment:
+  layout: "header, diff, flags, components, files"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+# Files Codecov shouldn't blame coverage on.
+ignore:
+  - "**/__tests__/**"
+  - "**/__mocks__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.d.ts"
+  - "**/node_modules/**"
+  - "coverage/**"
+  - ".next/**"
+  - "scripts/**"      # one-off operational scripts; not product code
+  - "e2e/**"          # Playwright tests; not unit-tested code paths
+  - "fuzz/**"         # jazzer.js harnesses; coverage is reported separately
+
+# Component groupings show up in the PR comment so big regressions in
+# one area are obvious.
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 0.5%
+  individual_components:
+    - component_id: app
+      paths: [app/**]
+    - component_id: api
+      paths: [app/api/**]
+    - component_id: components
+      paths: [components/**]
+    - component_id: lib
+      paths: [lib/**]
+    - component_id: game
+      paths: [app/game/**, lib/game/**]


### PR DESCRIPTION
## Why

User asked to "work on Codecov scores." Pulling the current state:

| Metric | Value |
|---|---|
| Codecov overall (strict line cov) | **82.99%** |
| Jest internal (counts partials) | ~90% stmts / ~81% branches |
| `lib/` | 88.51% |
| `app/api/` | 87.4% |
| `app/` | 80.81% |
| `app/game/` | **75.0%** (5,125 lines — biggest single lever) |
| `components/` | 75.41% |
| `contexts/` | 75.47% |
| `components/research` | **7.7%** (52 lines — lowest-coverage component) |
| `app/research` | **9.3%** (108 lines) |
| `app/recordings` | 24.4% (41 lines) |

This PR delivers the first two wins.

## What changes

**`codecov.yml`** — the repo had no Codecov config, so PR status checks ran with defaults (auto target, 1% wobble, no component breakdown). The new file sets:

- **Project status check**: `auto` target with a 0.2% wobble (catches regressions without thrashing on rounding noise).
- **Patch status check**: 80% on net-new lines, matching the OpenSSF Gold attestation spirit.
- **Component statuses**: separate per-area checks for `app/`, `app/api/`, `components/`, `lib/`, `game/` so a regression in one area is obvious in the PR comment.
- **Ignore**: tests, mocks, scripts, e2e harnesses, fuzz harnesses, build artifacts.

**`__tests__/components/research/ResearchCard.test.tsx`** — covers every entry type (`active-research`, `working-paper`, `dataset`, `collaboration`, `cfp`) plus the sample-mode CTA downgrades and the past-deadline / closed branches. Should lift the file from **7.7% → ~95%** based on a manual branch count of the source.

## What's next (separate PRs)

Highest leverage to drive the overall Codecov number up:

1. **`app/game/` (75% on 5,125 lines)** — biggest single lever, ~+2.8pp if lifted to 95%. Complex game logic; needs targeted dashboard + action-handler tests.
2. **`app/api/` (87.4% on 9,002 lines)** — ~+1.85pp possible. Many routes already covered; remaining gaps are the new heroes / armageddon / pact endpoints.
3. **`app/research` + `app/recordings`** — small files, very low coverage; quick wins for ~+0.5pp combined.
4. **`components/questions`** (62.4% on 287 lines) — medium-size component, decent leverage.

## Test plan

- [ ] CI green (local jest is broken on my machine; relying on CI's fresh install to validate)
- [ ] Codecov shows the new file at ≥90%
- [ ] Codecov PR comment displays the new component breakdown
- [ ] codecov.yml validated by Codecov (look for the "config validation" check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)