### PR TITLE
release: OAuth failure-toast UX

### DIFF
--- a/__tests__/app/(auth)/profile/_hooks/useDiscordConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useDiscordConnection.test.tsx
@@ -159,16 +159,25 @@ describe("useDiscordConnection", () => {
   });
 
   describe("handleOAuthError", () => {
+    // Copy lives in lib/oauth-errors.ts now; tests assert on stable
+    // sub-strings so wording tweaks don't churn the suite.
     it("sets specific message for not_member", () => {
       const { result } = renderHook(() => useDiscordConnection(USER));
       act(() => result.current.handleOAuthError("not_member"));
-      expect(result.current.error).toContain("Cursor Boston Discord");
+      expect(result.current.error).toContain("cursor-boston Discord");
     });
 
     it("falls back to generic message", () => {
       const { result } = renderHook(() => useDiscordConnection(USER));
       act(() => result.current.handleOAuthError("anything_else"));
-      expect(result.current.error).toContain("Failed to connect Discord");
+      // Unknown codes route through describeOAuthError's `unknown` entry.
+      expect(result.current.error).toMatch(/connecting Discord|the repo/i);
+    });
+
+    it("uses rate-limit copy when the callback redirected with rate_limited", () => {
+      const { result } = renderHook(() => useDiscordConnection(USER));
+      act(() => result.current.handleOAuthError("rate_limited"));
+      expect(result.current.error).toMatch(/rate limit|too many/i);
     });
   });
 });

--- a/__tests__/app/(auth)/profile/_hooks/useGithubConnection.test.tsx
+++ b/__tests__/app/(auth)/profile/_hooks/useGithubConnection.test.tsx
@@ -160,10 +160,17 @@ describe("useGithubConnection", () => {
   });
 
   describe("handleOAuthError", () => {
+    // Copy lives in lib/oauth-errors.ts now.
     it("falls back to generic message", () => {
       const { result } = renderHook(() => useGithubConnection(USER));
       act(() => result.current.handleOAuthError("anything"));
-      expect(result.current.error).toContain("Failed to connect GitHub");
+      expect(result.current.error).toMatch(/connecting GitHub|the repo/i);
+    });
+
+    it("uses rate-limit copy when the callback redirected with rate_limited", () => {
+      const { result } = renderHook(() => useGithubConnection(USER));
+      act(() => result.current.handleOAuthError("rate_limited"));
+      expect(result.current.error).toMatch(/rate limit|too many/i);
     });
   });
 

--- a/app/(auth)/profile/_hooks/useDiscordConnection.ts
+++ b/app/(auth)/profile/_hooks/useDiscordConnection.ts
@@ -10,6 +10,8 @@ import { useRouter } from "next/navigation";
 import { doc, updateDoc, serverTimestamp, deleteField } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { User } from "firebase/auth";
+import { useToast } from "@/components/Toast";
+import { describeOAuthError } from "@/lib/oauth-errors";
 
 const DISCORD_CLIENT_ID = process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID;
 
@@ -25,6 +27,7 @@ export function useDiscordConnection(
   returnTo?: string
 ) {
   const router = useRouter();
+  const toast = useToast();
   const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,12 +91,24 @@ export function useDiscordConnection(
     }
   };
 
+  // Surfaces the specific OAuth failure mode (rate-limited, state
+  // mismatch, not a guild member, etc.) via the global toast with
+  // auto-appended repo-fork CTA. See lib/oauth-errors.ts for the full
+  // code→copy table. setError stays as a fallback so the inline banner
+  // on the profile page keeps working.
   const handleOAuthError = (message: string | null) => {
-    if (message === "not_member") {
-      setError("You need to join the Cursor Boston Discord server first! Join at discord.gg/Wsncg8YYqc then try again.");
-    } else {
-      setError("Failed to connect Discord. Please try again.");
-    }
+    const describe = describeOAuthError("Discord", message);
+    toast.error({
+      title: describe.title,
+      description: describe.description,
+    });
+    // Inline banner gets the full title+description so SR users hear the
+    // same content the toast carries.
+    setError(
+      describe.description
+        ? `${describe.title}. ${describe.description}`
+        : describe.title
+    );
     router.replace(fallbackPath);
   };
 

--- a/app/(auth)/profile/_hooks/useGithubConnection.ts
+++ b/app/(auth)/profile/_hooks/useGithubConnection.ts
@@ -10,6 +10,8 @@ import { useRouter } from "next/navigation";
 import { doc, updateDoc, serverTimestamp, deleteField } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { User } from "firebase/auth";
+import { useToast } from "@/components/Toast";
+import { describeOAuthError } from "@/lib/oauth-errors";
 
 const GITHUB_CLIENT_ID = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID;
 
@@ -29,6 +31,7 @@ export function useGithubConnection(
   returnTo?: string
 ) {
   const router = useRouter();
+  const toast = useToast();
   const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -113,8 +116,26 @@ export function useGithubConnection(
     }
   };
 
-  const handleOAuthError = () => {
-    setError("Failed to connect GitHub. Please try again.");
+  // OAuth callback redirected us back with `?github=error&message=<code>`.
+  // Surface the exact code via a toast (with the auto-appended "fork the
+  // repo and send a fix" footer the ToastProvider adds for errors) so
+  // users know whether they were rate-limited, hit a state mismatch,
+  // etc. — and have a path to file the bug if it's something we don't
+  // know about yet. setError stays as a fallback so the existing inline
+  // banner on the profile page still works.
+  const handleOAuthError = (code?: string | null) => {
+    const describe = describeOAuthError("GitHub", code);
+    toast.error({
+      title: describe.title,
+      description: describe.description,
+    });
+    // Inline banner gets the full title+description so SR users hear the
+    // same content the toast carries.
+    setError(
+      describe.description
+        ? `${describe.title}. ${describe.description}`
+        : describe.title
+    );
     router.replace(fallbackPath);
   };
 

--- a/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
+++ b/app/(auth)/profile/_hooks/useOAuthCallbacks.ts
@@ -63,7 +63,11 @@ export function useOAuthCallbacks({
       if (githubStatus === "success" && data) {
         github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
       } else if (githubStatus === "error") {
-        github.handleOAuthError();
+        // Pass through the specific failure code (parity with the Discord
+        // branch). useGithubConnection.handleOAuthError maps it via
+        // describeOAuthError so users see the actual reason instead of
+        // a generic "failed to connect" line.
+        github.handleOAuthError(searchParams.get("message"));
       }
     }
 

--- a/app/api/discord/callback/route.ts
+++ b/app/api/discord/callback/route.ts
@@ -159,9 +159,25 @@ async function handleDiscordCallback(request: NextRequest) {
   }
 }
 
-// Apply rate limiting and logging middleware
+// Apply rate limiting and logging middleware. Rate-limit denials
+// redirect to the originating page with `?discord=error&message=rate_limited`
+// instead of returning JSON 429 — see lib/oauth-errors.ts for the
+// matching client-side copy.
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
   handleDiscordCallback,
-  { distributed: true, failMode: "closed" }
+  {
+    distributed: true,
+    failMode: "closed",
+    onRateLimitDenied: (request) => {
+      const returnTo = sanitizeReturnTo(
+        request.cookies.get("discord_oauth_return_to")?.value
+      );
+      return buildCallbackRedirect(
+        request,
+        returnTo,
+        "discord=error&message=rate_limited"
+      );
+    },
+  }
 );

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -142,9 +142,25 @@ async function handleGitHubCallback(request: NextRequest) {
   }
 }
 
-// Apply rate limiting and logging middleware
+// Apply rate limiting and logging middleware. Rate-limit denials
+// redirect to the originating page with `?github=error&message=rate_limited`
+// instead of returning JSON 429 — see lib/oauth-errors.ts for the
+// matching client-side copy.
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
   handleGitHubCallback,
-  { distributed: true, failMode: "closed" }
+  {
+    distributed: true,
+    failMode: "closed",
+    onRateLimitDenied: (request) => {
+      const returnTo = sanitizeReturnTo(
+        request.cookies.get("github_oauth_return_to")?.value
+      );
+      return buildCallbackRedirect(
+        request,
+        returnTo,
+        "github=error&message=rate_limited"
+      );
+    },
+  }
 );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import LumaCheckoutTracker from "@/components/LumaCheckoutTracker";
 import { KonamiListener } from "@/components/hunt/KonamiListener";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { ToastProvider } from "@/components/Toast";
 
 const ORGANIZATION_SOCIAL_LINKS = [
   "https://discord.gg/Wsncg8YYqc",
@@ -123,10 +124,12 @@ export default function RootLayout({
         </a>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <AuthProvider>
-            <AppShell>{children}</AppShell>
-            <SummerCohortModal />
-            <LumaCheckoutTracker />
-            <KonamiListener />
+            <ToastProvider>
+              <AppShell>{children}</AppShell>
+              <SummerCohortModal />
+              <LumaCheckoutTracker />
+              <KonamiListener />
+            </ToastProvider>
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,248 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+/**
+ * Minimal in-house toast system.
+ *
+ * Why not a library: the entire surface we need is "fire-and-forget
+ * notification with a tiny CTA inside". Adding sonner / react-hot-toast
+ * for that is a 5-15KB tax on every page load, and we want this to
+ * eventually live behind a feature flag for a11y testing — easier on a
+ * surface we own.
+ *
+ * Accessibility: the Toaster mounts inside an `aria-live` region so
+ * screen readers announce errors as they appear. Severity → role:
+ *  - error      → role="alert"      (announced assertively)
+ *  - success/info → role="status"   (announced politely)
+ *
+ * Failure-class toasts (`error`) automatically get a "If this looks
+ * broken, fork the repo and send a fix" footer link. That's a project
+ * policy decision (see CLAUDE.md) — every visible failure should give
+ * the user a concrete path to help fix it.
+ */
+
+import Link from "next/link";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+const REPO_FORK_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/fork";
+const DEFAULT_DURATION_MS = 8_000;
+const ERROR_DURATION_MS = 12_000; // errors get longer so users can read the fix-link
+
+export type ToastSeverity = "error" | "success" | "info";
+
+export interface ToastOptions {
+  /** Title line — short, action-oriented. */
+  title: string;
+  /** Optional explanatory body. Errors should always include this. */
+  description?: string;
+  /** Defaults to "info". */
+  severity?: ToastSeverity;
+  /** Auto-dismiss timeout (ms). null disables auto-dismiss. */
+  durationMs?: number | null;
+}
+
+interface ToastEntry extends ToastOptions {
+  id: string;
+}
+
+interface ToastContextValue {
+  toast: (options: ToastOptions) => void;
+  /** Shorthand for `toast({ severity: "error", ... })`. */
+  error: (options: Omit<ToastOptions, "severity">) => void;
+  /** Shorthand for `toast({ severity: "success", ... })`. */
+  success: (options: Omit<ToastOptions, "severity">) => void;
+  dismiss: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastEntry[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((current) => current.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = useCallback((options: ToastOptions) => {
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const entry: ToastEntry = { ...options, id };
+    setToasts((current) => [...current, entry]);
+  }, []);
+
+  const error = useCallback(
+    (options: Omit<ToastOptions, "severity">) =>
+      toast({ ...options, severity: "error" }),
+    [toast]
+  );
+  const success = useCallback(
+    (options: Omit<ToastOptions, "severity">) =>
+      toast({ ...options, severity: "success" }),
+    [toast]
+  );
+
+  const value = useMemo<ToastContextValue>(
+    () => ({ toast, error, success, dismiss }),
+    [toast, error, success, dismiss]
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <Toaster toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+// Noop fallback so consumers (and especially the renderHook-style unit
+// tests in __tests__/app/(auth)/profile/_hooks/) don't need to wrap
+// every renderHook call in <ToastProvider> just to satisfy a context
+// dependency. Production paths always render under the provider in
+// app/layout.tsx; the fallback only fires in tests + Storybook-like
+// shallow renders.
+const NOOP_TOAST: ToastContextValue = {
+  toast: () => undefined,
+  error: () => undefined,
+  success: () => undefined,
+  dismiss: () => undefined,
+};
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  return ctx ?? NOOP_TOAST;
+}
+
+interface ToasterProps {
+  toasts: ToastEntry[];
+  onDismiss: (id: string) => void;
+}
+
+function Toaster({ toasts, onDismiss }: ToasterProps) {
+  // Two stacked live regions so SR announcement priority matches severity
+  // (assertive for errors, polite for success/info). Both are visually
+  // identical and share the bottom-right column.
+  const errors = toasts.filter((t) => t.severity === "error");
+  const other = toasts.filter((t) => t.severity !== "error");
+  return (
+    <>
+      <div
+        className="pointer-events-none fixed bottom-4 right-4 z-[100] flex max-w-[min(420px,calc(100vw-2rem))] flex-col gap-2"
+        aria-live="assertive"
+        aria-atomic="false"
+        role="region"
+        aria-label="Error notifications"
+      >
+        {errors.map((t) => (
+          <ToastCard key={t.id} toast={t} onDismiss={onDismiss} />
+        ))}
+      </div>
+      <div
+        className="pointer-events-none fixed bottom-4 right-4 z-[99] mt-12 flex max-w-[min(420px,calc(100vw-2rem))] flex-col gap-2"
+        aria-live="polite"
+        aria-atomic="false"
+        role="region"
+        aria-label="Notifications"
+        style={{
+          // Stack below the error region without overlapping; height-driven.
+          transform: `translateY(${errors.length * 88}px)`,
+        }}
+      >
+        {other.map((t) => (
+          <ToastCard key={t.id} toast={t} onDismiss={onDismiss} />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function ToastCard({
+  toast,
+  onDismiss,
+}: {
+  toast: ToastEntry;
+  onDismiss: (id: string) => void;
+}) {
+  const severity: ToastSeverity = toast.severity ?? "info";
+  const durationMs =
+    toast.durationMs === null
+      ? null
+      : toast.durationMs ??
+        (severity === "error" ? ERROR_DURATION_MS : DEFAULT_DURATION_MS);
+
+  useEffect(() => {
+    if (durationMs === null) return;
+    const handle = setTimeout(() => onDismiss(toast.id), durationMs);
+    return () => clearTimeout(handle);
+  }, [durationMs, onDismiss, toast.id]);
+
+  const accent =
+    severity === "error"
+      ? "border-red-300 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950/60 dark:text-red-100"
+      : severity === "success"
+        ? "border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950/60 dark:text-emerald-100"
+        : "border-neutral-300 bg-neutral-50 text-neutral-900 dark:border-neutral-800 dark:bg-neutral-950/80 dark:text-neutral-100";
+
+  return (
+    <div
+      role={severity === "error" ? "alert" : "status"}
+      className={`pointer-events-auto rounded-lg border ${accent} shadow-lg backdrop-blur px-4 py-3`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold">{toast.title}</div>
+          {toast.description && (
+            <div className="mt-1 text-sm opacity-90">{toast.description}</div>
+          )}
+          {severity === "error" && (
+            <div className="mt-2 text-xs opacity-80">
+              If this looks broken,{" "}
+              <Link
+                href={REPO_FORK_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2 hover:opacity-100"
+              >
+                fork the repo
+              </Link>{" "}
+              and send a fix →{" "}
+              <Link
+                href={REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2"
+              >
+                cursor-boston
+              </Link>
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onDismiss(toast.id)}
+          aria-label="Dismiss notification"
+          className="-mr-1 -mt-1 px-1 text-current opacity-70 hover:opacity-100"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -38,6 +38,20 @@ type RateLimitResult = ReturnType<typeof checkRateLimit> | UpstashRateLimitResul
 interface RateLimitBackendOptions {
   distributed?: boolean;
   failMode?: "degrade" | "closed";
+  /**
+   * Custom response builder invoked when the rate limiter denies the
+   * request. Default behaviour is the JSON 429 in `rateLimitDeniedResponse`.
+   *
+   * OAuth callbacks override this to redirect to
+   * `?<provider>=error&message=rate_limited` so the user lands back on
+   * the originating page with a clear error instead of staring at a raw
+   * JSON 429 (which is what they saw at the May 26 immersion event
+   * before this hook existed).
+   */
+  onRateLimitDenied?: (
+    request: NextRequest,
+    result: RateLimitResult
+  ) => NextResponse;
 }
 
 function isDevelopmentEnvironment(): boolean {
@@ -193,6 +207,9 @@ export function withRateLimitMiddleware(
       : checkRateLimit(identifier, options);
 
     if (!result.success) {
+      if (backendOptions.onRateLimitDenied) {
+        return backendOptions.onRateLimitDenied(request, result);
+      }
       return rateLimitDeniedResponse(result, options);
     }
 

--- a/lib/oauth-errors.ts
+++ b/lib/oauth-errors.ts
@@ -1,0 +1,102 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Shared lookup from OAuth callback error codes (what each provider's
+ * callback handler shoves into the `?<provider>=error&message=<code>`
+ * query string) to user-facing copy.
+ *
+ * Why a shared file: both Discord and GitHub used to silently fall back
+ * to "Failed to connect, please try again" for any error. After the
+ * 2026-05-23 rate-limit incident at the May 26 immersion event, every
+ * code now maps to a specific sentence so users know what's wrong AND
+ * what they can do next.
+ */
+
+import type { ToastOptions } from "@/components/Toast";
+
+type Provider = "Discord" | "GitHub";
+
+interface OAuthErrorEntry {
+  title: string;
+  description: string;
+}
+
+const COMMON: Record<string, (provider: Provider) => OAuthErrorEntry> = {
+  rate_limited: (p) => ({
+    title: `Too many ${p} connect attempts`,
+    description:
+      "Lots of people on this network connected accounts in the last 15 minutes. Give it a few minutes and try again — your account is fine, the rate limit just resets.",
+  }),
+  missing_params: (p) => ({
+    title: `${p} sign-in was interrupted`,
+    description:
+      "We didn't get the OAuth response we expected back from " +
+      p +
+      ". Cancelling the popup or refreshing during sign-in usually does this. Try again from scratch.",
+  }),
+  invalid_state: (p) => ({
+    title: `${p} sign-in didn't match our session`,
+    description:
+      "The session token from " +
+      p +
+      " didn't match the one we issued — usually means you started the flow in one tab and finished it in another. Try the connect button again in this tab.",
+  }),
+  not_configured: (p) => ({
+    title: `${p} connect isn't set up on this deploy`,
+    description:
+      "The server is missing the " +
+      p +
+      " OAuth credentials. This is a config bug on our side, not yours.",
+  }),
+  token_failed: (p) => ({
+    title: `${p} rejected our token exchange`,
+    description:
+      "We sent " +
+      p +
+      " your auth code and it came back without a usable access token. Try again; if it keeps failing, your " +
+      p +
+      " account may have a security restriction.",
+  }),
+  user_fetch_failed: (p) => ({
+    title: `Couldn't read your ${p} profile`,
+    description: `${p} accepted the connection but the follow-up profile read failed. Try the connect button again.`,
+  }),
+  unknown: (p) => ({
+    title: `Something went wrong connecting ${p}`,
+    description:
+      "We don't know exactly what failed. Try again, or open a new tab and start over. If it keeps happening, the link below to the repo is the fastest way to file it.",
+  }),
+};
+
+const DISCORD_ONLY: Record<string, () => OAuthErrorEntry> = {
+  guilds_fetch_failed: () => ({
+    title: "Couldn't read your Discord servers",
+    description:
+      "Discord accepted the connection but we couldn't fetch your guild list to verify the cursor-boston server. Try again.",
+  }),
+  not_member: () => ({
+    title: "You're not in the cursor-boston Discord server",
+    description:
+      "Join the server first, then re-run the connect flow. The link is in the event page footer.",
+  }),
+};
+
+export function describeOAuthError(
+  provider: Provider,
+  code: string | null | undefined
+): ToastOptions {
+  const key = code ?? "unknown";
+  if (provider === "Discord" && DISCORD_ONLY[key]) {
+    return { ...DISCORD_ONLY[key](), severity: "error" };
+  }
+  const common = COMMON[key];
+  if (common) {
+    return { ...common(provider), severity: "error" };
+  }
+  return { ...COMMON.unknown(provider), severity: "error" };
+}


### PR DESCRIPTION
## Summary

- **#1431** — feat(ui): toast system + clear OAuth-error messages with repo-fork CTA (@Ludwitt). Adds the project-wide toast component, the shared OAuth error code → copy table, opt-in redirect-on-rate-limit for OAuth callbacks (so users see a clear message instead of raw JSON 429), and wires GitHub + Discord profile hooks to fire toasts. Every error toast auto-appends the "fork the repo and send a fix" CTA — new project-wide convention.

## Test plan

- [x] CI green on develop after #1431 merged
- [ ] After promotion: hit an OAuth rate limit (or any callback failure) on prod and confirm the toast shows the specific reason + fork-the-repo footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)