### PR TITLE
chore(coverage): ArmyPanel / SpellPicker / SourceTileCard tests

### DIFF
--- a/__tests__/app/game/threats/_components/ArmyPanel.test.tsx
+++ b/__tests__/app/game/threats/_components/ArmyPanel.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ArmyPanel } from "@/app/game/threats/_components/ArmyPanel";
+import type { GamePlayer } from "@/lib/game/types";
+
+jest.mock("@/app/game/_components/CatalogImage", () => ({
+  CatalogImage: () => <div data-testid="catalog-image" />,
+}));
+
+function makePlayer(overrides: Partial<GamePlayer> = {}): GamePlayer {
+  return {
+    userId: "u1",
+    displayName: "Test General",
+    caste: "red",
+    turnsRemaining: 100,
+    turnsSpentTotal: 0,
+    phase: "play",
+    tilesExplored: 0,
+    shieldUntil: { toMillis: () => 0 } as never,
+    shieldDropAtTurn: 0,
+    stats: { attacksWon: 0, attacksLost: 0, tilesHeld: 0, unitsAlive: 0 },
+    productionSpellsActive: [],
+    activeUpgrades: {},
+    ...overrides,
+  } as GamePlayer;
+}
+
+describe("ArmyPanel", () => {
+  it("returns null when the player has no caste", () => {
+    const { container } = render(<ArmyPanel player={makePlayer({ caste: null })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the header with the player's caste label", () => {
+    render(<ArmyPanel player={makePlayer({ caste: "blue" })} />);
+    expect(screen.getByText(/🪖 Your army/)).toBeInTheDocument();
+    expect(screen.getByText(/blue caste/)).toBeInTheDocument();
+  });
+
+  it("renders both Units and Buildings sections by default", () => {
+    render(<ArmyPanel player={makePlayer({ caste: "red" })} />);
+    expect(screen.getByText("Units")).toBeInTheDocument();
+    expect(screen.getByText("Tiles & buildings")).toBeInTheDocument();
+  });
+
+  it("toggles open/closed when the header button is clicked", () => {
+    render(<ArmyPanel player={makePlayer({ caste: "red" })} />);
+    const toggle = screen.getByRole("button", { expanded: true });
+    expect(screen.getByText("Units")).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.queryByText("Units")).not.toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.getByText("Units")).toBeInTheDocument();
+  });
+
+  it("shows 'no upgrade picked' when the active-upgrades map is empty", () => {
+    render(<ArmyPanel player={makePlayer({ caste: "red", activeUpgrades: {} })} />);
+    expect(screen.getAllByText("no upgrade picked").length).toBeGreaterThan(0);
+  });
+
+  it("renders one image per unit and building card", () => {
+    render(<ArmyPanel player={makePlayer({ caste: "red" })} />);
+    // Each caste ships 3 units + 3 buildings = 6 cards minimum.
+    expect(screen.getAllByTestId("catalog-image").length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/__tests__/app/game/threats/_components/SourceTileCard.test.tsx
+++ b/__tests__/app/game/threats/_components/SourceTileCard.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SourceTileCard } from "@/app/game/threats/_components/SourceTileCard";
+import type { MapTile } from "@/lib/game/types";
+
+jest.mock("@/app/game/_components/CatalogImage", () => ({
+  CatalogImage: () => <div data-testid="catalog-image" />,
+}));
+
+function makeTile(overrides: Partial<MapTile> = {}): MapTile {
+  return {
+    tileId: "0_0",
+    q: 0,
+    r: 0,
+    type: "military",
+    ownerId: "u1",
+    units: { ground: 5, siege: 2, air: 1 },
+    baseUnits: { ground: 3, siege: 1, air: 0 },
+    armedDefenseSpellId: null,
+    ...overrides,
+  };
+}
+
+describe("SourceTileCard", () => {
+  const noop = () => undefined;
+
+  it("renders the tile id, building name, and combined unit counts", () => {
+    render(
+      <SourceTileCard
+        source={makeTile()}
+        myCaste="red"
+        candidateCount={1}
+        isBest={false}
+        onOpenPicker={noop}
+      />
+    );
+    expect(screen.getByText("0_0")).toBeInTheDocument();
+    // BASE+SUPER: ground=5+3, siege=2+1, air=1+0
+    expect(screen.getByText(/G8 · S3 · A1/)).toBeInTheDocument();
+    expect(screen.getByText("(12)")).toBeInTheDocument();
+  });
+
+  it("falls back to the tile.type label when no caste building matches", () => {
+    render(
+      <SourceTileCard
+        source={makeTile({ type: "unassigned" })}
+        myCaste="red"
+        candidateCount={1}
+        isBest={false}
+        onOpenPicker={noop}
+      />
+    );
+    expect(screen.getByText("unassigned")).toBeInTheDocument();
+  });
+
+  it("shows the ✨ best badge when isBest=true", () => {
+    render(
+      <SourceTileCard
+        source={makeTile()}
+        myCaste="red"
+        candidateCount={2}
+        isBest={true}
+        onOpenPicker={noop}
+      />
+    );
+    expect(screen.getByText(/best/)).toBeInTheDocument();
+  });
+
+  it("disables the Change button when only one candidate borders the enemy", () => {
+    render(
+      <SourceTileCard
+        source={makeTile()}
+        myCaste="red"
+        candidateCount={1}
+        isBest={false}
+        onOpenPicker={noop}
+      />
+    );
+    const change = screen.getByRole("button", { name: /Change/ });
+    expect(change).toBeDisabled();
+    expect(change).toHaveAttribute(
+      "title",
+      "Only one of your tiles borders this enemy."
+    );
+  });
+
+  it("enables Change and shows the candidate count when there are alternatives", () => {
+    render(
+      <SourceTileCard
+        source={makeTile()}
+        myCaste="red"
+        candidateCount={3}
+        isBest={false}
+        onOpenPicker={noop}
+      />
+    );
+    const change = screen.getByRole("button", { name: /Change/ });
+    expect(change).not.toBeDisabled();
+    expect(screen.getByText("(3)")).toBeInTheDocument();
+  });
+
+  it("invokes onOpenPicker when Change is clicked", () => {
+    const onOpenPicker = jest.fn();
+    render(
+      <SourceTileCard
+        source={makeTile()}
+        myCaste="red"
+        candidateCount={3}
+        isBest={false}
+        onOpenPicker={onOpenPicker}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Change/ }));
+    expect(onOpenPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats missing baseUnits as zeros", () => {
+    render(
+      <SourceTileCard
+        source={makeTile({ baseUnits: undefined })}
+        myCaste="red"
+        candidateCount={1}
+        isBest={false}
+        onOpenPicker={noop}
+      />
+    );
+    // units only: ground=5, siege=2, air=1
+    expect(screen.getByText(/G5 · S2 · A1/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/game/threats/_components/SpellPicker.test.tsx
+++ b/__tests__/app/game/threats/_components/SpellPicker.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SpellPicker } from "@/app/game/threats/_components/SpellPicker";
+import { ALL_SPELLS } from "@/lib/game/content";
+import type { SpellDefinition } from "@/lib/game/types";
+
+jest.mock("@/app/game/_components/CatalogImage", () => ({
+  CatalogImage: () => <div data-testid="catalog-image" />,
+}));
+
+const offensiveSpells: ReadonlyArray<SpellDefinition> = ALL_SPELLS.filter(
+  (s) => s.type === "offense"
+).slice(0, 2);
+
+describe("SpellPicker", () => {
+  it("renders the header + optional-spell hint", () => {
+    render(
+      <SpellPicker
+        spells={offensiveSpells}
+        expectedById={new Map()}
+        selectedSpellId=""
+        onSelect={() => undefined}
+      />
+    );
+    expect(screen.getByText(/Offensive spell/)).toBeInTheDocument();
+    expect(screen.getByText(/optional · \+5t when cast/)).toBeInTheDocument();
+  });
+
+  it("renders the empty-state message when no spells are unlocked", () => {
+    render(
+      <SpellPicker
+        spells={[]}
+        expectedById={new Map()}
+        selectedSpellId=""
+        onSelect={() => undefined}
+      />
+    );
+    expect(
+      screen.getByText(/No offensive spells unlocked yet/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a 'No spell' card alongside each spell", () => {
+    render(
+      <SpellPicker
+        spells={offensiveSpells}
+        expectedById={new Map()}
+        selectedSpellId=""
+        onSelect={() => undefined}
+      />
+    );
+    expect(screen.getByText("No spell")).toBeInTheDocument();
+    // Each spell title is prefixed with the tier (e.g. "T1 Smite").
+    for (const s of offensiveSpells) {
+      expect(screen.getByText(new RegExp(s.name))).toBeInTheDocument();
+    }
+  });
+
+  it("calls onSelect with empty string when the No-spell card is clicked", () => {
+    const onSelect = jest.fn();
+    render(
+      <SpellPicker
+        spells={offensiveSpells}
+        expectedById={new Map()}
+        selectedSpellId={offensiveSpells[0]!.id}
+        onSelect={onSelect}
+      />
+    );
+    fireEvent.click(screen.getByText("No spell").closest("button")!);
+    expect(onSelect).toHaveBeenCalledWith("");
+  });
+
+  it("calls onSelect with the spell id when a spell card is clicked", () => {
+    const onSelect = jest.fn();
+    render(
+      <SpellPicker
+        spells={offensiveSpells}
+        expectedById={new Map()}
+        selectedSpellId=""
+        onSelect={onSelect}
+      />
+    );
+    const spell = offensiveSpells[0]!;
+    fireEvent.click(screen.getByText(new RegExp(spell.name)).closest("button")!);
+    expect(onSelect).toHaveBeenCalledWith(spell.id);
+  });
+
+  it("toggles selection off when the currently-selected spell is clicked again", () => {
+    const onSelect = jest.fn();
+    const spell = offensiveSpells[0]!;
+    render(
+      <SpellPicker
+        spells={offensiveSpells}
+        expectedById={new Map()}
+        selectedSpellId={spell.id}
+        onSelect={onSelect}
+      />
+    );
+    fireEvent.click(screen.getByText(new RegExp(spell.name)).closest("button")!);
+    expect(onSelect).toHaveBeenCalledWith("");
+  });
+
+  it("shows the expected-attack-power chip when expectedById has the spell", () => {
+    const spell = offensiveSpells[0]!;
+    render(
+      <SpellPicker
+        spells={offensiveSpells}
+        expectedById={new Map([[spell.id, 12.4]])}
+        selectedSpellId=""
+        onSelect={() => undefined}
+      />
+    );
+    // Rounded to the nearest int.
+    expect(screen.getByText("~+12 atk")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why

Third coverage PR in the series. `app/game/threats/` is the second-biggest single subtree on the leverage map (75.0% on 652 lines). BattleSimPanel and ThreatRow already had tests; this PR covers three of the still-naked components.

## What's covered

| File | Before | Tests added |
|---|---|---|
| `ArmyPanel.tsx` (35 lines, 68.6%) | no tests | null-caste no-op, header label, units + buildings sections, toggle, 'no upgrade picked' fallback, image count |
| `SpellPicker.tsx` (12 src lines, 58.3%) | no tests | header, empty state, No-spell card, select/toggle-off, expected-atk chip rounding |
| `SourceTileCard.tsx` (16 src lines, 75.0%) | no tests | BASE+SUPER unit-count math, unassigned fallback, ✨best badge, Change-button disabled at 1 candidate, candidate-count badge, missing-baseUnits-as-zeros |

## Expected impact

- `app/game/threats/_components/` subtree: 73.8% → ~85%
- Overall Codecov: ~+0.1pp

## Test plan

- [ ] CI green
- [ ] Codecov PR comment shows the three files at ≥95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)