### PR TITLE
fix(github-oauth): wire sports-hack signup + reveal real error codes

### DIFF
--- a/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
@@ -378,10 +378,12 @@ describe("Sports Hack 2026 signup page", () => {
       .default;
     render(<Page />);
 
-    expect(await screen.findByRole("link", { name: /Connect GitHub/i })).toHaveAttribute(
-      "href",
-      "/api/github/authorize",
-    );
+    // Connect GitHub is now a button that delegates to useGithubConnection.connect()
+    // (sets window.location.href with the right returnTo). The Discord button
+    // is still a plain link until it gets the same treatment.
+    expect(
+      await screen.findByRole("button", { name: /Connect GitHub/i }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Connect Discord/i })).toHaveAttribute(
       "href",
       "/api/discord/authorize",

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -57,6 +57,14 @@ async function handleGitHubCallback(request: NextRequest) {
   );
 
   if (!code || !state) {
+    // Silent path before — log so we can tell when users land here without
+    // the expected OAuth params (interrupted flow, back-nav onto the callback
+    // URL, GitHub didn't return a code, etc.).
+    logger.warn("GitHub OAuth missing params", {
+      endpoint: "/api/github/callback",
+      hasCode: Boolean(code),
+      hasState: Boolean(state),
+    });
     return buildCallbackRedirect(request, returnTo, "github=error&message=missing_params");
   }
 
@@ -152,10 +160,19 @@ export const GET = withMiddleware(
   {
     distributed: true,
     failMode: "closed",
-    onRateLimitDenied: (request) => {
+    onRateLimitDenied: (request, result) => {
       const returnTo = sanitizeReturnTo(
         request.cookies.get("github_oauth_return_to")?.value
       );
+      // Silent path before — log so we can distinguish "ceiling hit" from
+      // "Upstash unavailable" without scraping 503/307 ratios from the edge.
+      logger.warn("GitHub OAuth rate-limit denied", {
+        endpoint: "/api/github/callback",
+        reason:
+          "reason" in result && result.reason
+            ? result.reason
+            : "rate_limited",
+      });
       return buildCallbackRedirect(
         request,
         returnTo,

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { Suspense, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
@@ -15,8 +15,6 @@ import { GitHubIcon, DiscordIcon } from "@/components/icons";
 import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
 import { trackEvent } from "@/lib/analytics";
 import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
-
-const SPORTS_HACK_RETURN_TO = "/hackathons/sports-hack-2026/signup";
 import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
@@ -26,6 +24,8 @@ import {
   getSportsHack2026RankTier,
   type SportsHack2026RankTone,
 } from "@/lib/sports-hack-2026";
+
+const SPORTS_HACK_RETURN_TO = "/hackathons/sports-hack-2026/signup";
 
 const TONE_PILL_CLASS: Record<SportsHack2026RankTone, string> = {
   hot: "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300",
@@ -142,7 +142,7 @@ function profileFromContext(
   };
 }
 
-export default function SportsHack2026SignupPage() {
+function SportsHack2026SignupPageInner() {
   const { user, userProfile, loading: authLoading, refreshUserProfile } = useAuth();
   const searchParams = useSearchParams();
   const github = useGithubConnection(
@@ -1315,5 +1315,19 @@ function ShowDiscordRow({
         />
       </button>
     </div>
+  );
+}
+
+export default function SportsHack2026SignupPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto w-full max-w-3xl px-4 py-10 text-sm text-neutral-500 md:px-6 md:py-14">
+          Loading…
+        </div>
+      }
+    >
+      <SportsHack2026SignupPageInner />
+    </Suspense>
   );
 }

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -9,10 +9,14 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
 import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
 import { trackEvent } from "@/lib/analytics";
+import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
+
+const SPORTS_HACK_RETURN_TO = "/hackathons/sports-hack-2026/signup";
 import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
@@ -139,7 +143,15 @@ function profileFromContext(
 }
 
 export default function SportsHack2026SignupPage() {
-  const { user, userProfile, loading: authLoading } = useAuth();
+  const { user, userProfile, loading: authLoading, refreshUserProfile } = useAuth();
+  const searchParams = useSearchParams();
+  const github = useGithubConnection(
+    user,
+    userProfile?.github,
+    userProfile?.provider,
+    refreshUserProfile,
+    SPORTS_HACK_RETURN_TO
+  );
   const [data, setData] = useState<LeaderboardResponse | null>(null);
   const [profile, setProfile] = useState<ProfileStatus | null>(
     profileFromContext(userProfile)
@@ -222,6 +234,31 @@ export default function SportsHack2026SignupPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
     if (user) void loadProfile();
   }, [user, loadProfile]);
+
+  // GitHub OAuth callback lands back here with ?github=success|error.
+  // Without this handler, users got bounced to /profile and never returned
+  // to the signup flow — which is why event attendees were re-clicking
+  // Connect and burning the per-IP rate-limit bucket.
+  useEffect(() => {
+    if (authLoading) return;
+    const githubStatus = searchParams.get("github");
+    if (!githubStatus) return;
+    if (githubStatus === "success") {
+      const data = searchParams.get("data");
+      if (data) {
+        try {
+          github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
+        } catch {
+          github.handleOAuthError(searchParams.get("message"));
+        }
+      } else {
+        github.handleOAuthError(searchParams.get("message"));
+      }
+    } else if (githubStatus === "error") {
+      github.handleOAuthError(searchParams.get("message"));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, authLoading]);
 
   const isProfileReady =
     profile?.visibility?.isPublic === true &&
@@ -897,13 +934,15 @@ export default function SportsHack2026SignupPage() {
                         <GitHubIcon size={16} />@{profile.githubUsername}
                       </span>
                     ) : (
-                      <a
-                        href="/api/github/authorize"
-                        className="inline-flex items-center gap-2 rounded-lg bg-neutral-800 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-700 transition-colors dark:bg-neutral-700 dark:hover:bg-neutral-600"
+                      <button
+                        type="button"
+                        onClick={github.connect}
+                        disabled={github.connecting}
+                        className="inline-flex items-center gap-2 rounded-lg bg-neutral-800 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-700 transition-colors disabled:opacity-60 dark:bg-neutral-700 dark:hover:bg-neutral-600"
                       >
                         <GitHubIcon size={16} />
-                        Connect GitHub
-                      </a>
+                        {github.connecting ? "Connecting…" : "Connect GitHub"}
+                      </button>
                     )}
                   </div>
 

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -673,10 +673,10 @@ function SummerCohortPageInner() {
         try {
           github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
         } catch {
-          github.handleOAuthError();
+          github.handleOAuthError(searchParams.get("message"));
         }
       } else if (githubStatus === "error") {
-        github.handleOAuthError();
+        github.handleOAuthError(searchParams.get("message"));
       }
     }
     const discordStatus = searchParams.get("discord");


### PR DESCRIPTION
## Summary

- **`/hackathons/sports-hack-2026/signup`** (the May 26 event page): replaced bare `<a href="/api/github/authorize">` with `useGithubConnection` hook + `useEffect` callback handler. Previously, attendees clicked Connect, got bounced to `/profile` after OAuth, never saw the signup page update, and re-clicked Connect — burning the per-IP rate-limit bucket on shared event Wi-Fi. Now flow stays on the signup page with `returnTo`.
- **`app/summer-cohort/page.tsx`**: both `github.handleOAuthError()` calls now pass `searchParams.get("message")`. Was always rendering the generic "We don't know exactly what failed" toast even when the real code was `rate_limited` / `invalid_state` / etc.
- **`app/api/github/callback/route.ts`**: added `logger.warn` to the two silent paths (`missing_params` early return + `onRateLimitDenied` handler). The recent rate-limit outage was hard to triage because both paths returned 307 redirects with zero log output.

## Why now

Multiple users reporting "Something went wrong connecting GitHub" on the May 26 event page today (event tomorrow). Investigation showed (a) the signup page wasn't wired to receive the OAuth callback at all, and (b) the underlying error code was being swallowed on the summer-cohort page where the bug was reproducible. The two new warn logs let us tell ceiling-hit from Upstash-unavailable next time without re-deriving it from edge status codes.

## Test plan

- [ ] On `/hackathons/sports-hack-2026/signup`, click Connect GitHub while signed in — round-trip should land back on the signup page with GitHub showing connected (not on `/profile`).
- [ ] On `/summer-cohort`, force a rate-limit error and verify the toast text now reads "Too many GitHub connect attempts" instead of "We don't know exactly what failed".
- [ ] Trigger a missing-params callback (visit `/api/github/callback` with no query) and confirm a `GitHub OAuth missing params` warn line appears in runtime logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)