### PR TITLE
release: develop → main (GitHub OAuth event-page hotfix + broadcast archive)

### DIFF
--- a/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
@@ -378,10 +378,12 @@ describe("Sports Hack 2026 signup page", () => {
       .default;
     render(<Page />);
 
-    expect(await screen.findByRole("link", { name: /Connect GitHub/i })).toHaveAttribute(
-      "href",
-      "/api/github/authorize",
-    );
+    // Connect GitHub is now a button that delegates to useGithubConnection.connect()
+    // (sets window.location.href with the right returnTo). The Discord button
+    // is still a plain link until it gets the same treatment.
+    expect(
+      await screen.findByRole("button", { name: /Connect GitHub/i }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Connect Discord/i })).toHaveAttribute(
       "href",
       "/api/discord/authorize",

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -57,6 +57,14 @@ async function handleGitHubCallback(request: NextRequest) {
   );
 
   if (!code || !state) {
+    // Silent path before — log so we can tell when users land here without
+    // the expected OAuth params (interrupted flow, back-nav onto the callback
+    // URL, GitHub didn't return a code, etc.).
+    logger.warn("GitHub OAuth missing params", {
+      endpoint: "/api/github/callback",
+      hasCode: Boolean(code),
+      hasState: Boolean(state),
+    });
     return buildCallbackRedirect(request, returnTo, "github=error&message=missing_params");
   }
 
@@ -152,10 +160,19 @@ export const GET = withMiddleware(
   {
     distributed: true,
     failMode: "closed",
-    onRateLimitDenied: (request) => {
+    onRateLimitDenied: (request, result) => {
       const returnTo = sanitizeReturnTo(
         request.cookies.get("github_oauth_return_to")?.value
       );
+      // Silent path before — log so we can distinguish "ceiling hit" from
+      // "Upstash unavailable" without scraping 503/307 ratios from the edge.
+      logger.warn("GitHub OAuth rate-limit denied", {
+        endpoint: "/api/github/callback",
+        reason:
+          "reason" in result && result.reason
+            ? result.reason
+            : "rate_limited",
+      });
       return buildCallbackRedirect(
         request,
         returnTo,

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -7,12 +7,14 @@
 
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { Suspense, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
 import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
 import { trackEvent } from "@/lib/analytics";
+import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
 import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
@@ -22,6 +24,8 @@ import {
   getSportsHack2026RankTier,
   type SportsHack2026RankTone,
 } from "@/lib/sports-hack-2026";
+
+const SPORTS_HACK_RETURN_TO = "/hackathons/sports-hack-2026/signup";
 
 const TONE_PILL_CLASS: Record<SportsHack2026RankTone, string> = {
   hot: "bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300",
@@ -138,8 +142,16 @@ function profileFromContext(
   };
 }
 
-export default function SportsHack2026SignupPage() {
-  const { user, userProfile, loading: authLoading } = useAuth();
+function SportsHack2026SignupPageInner() {
+  const { user, userProfile, loading: authLoading, refreshUserProfile } = useAuth();
+  const searchParams = useSearchParams();
+  const github = useGithubConnection(
+    user,
+    userProfile?.github,
+    userProfile?.provider,
+    refreshUserProfile,
+    SPORTS_HACK_RETURN_TO
+  );
   const [data, setData] = useState<LeaderboardResponse | null>(null);
   const [profile, setProfile] = useState<ProfileStatus | null>(
     profileFromContext(userProfile)
@@ -222,6 +234,31 @@ export default function SportsHack2026SignupPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
     if (user) void loadProfile();
   }, [user, loadProfile]);
+
+  // GitHub OAuth callback lands back here with ?github=success|error.
+  // Without this handler, users got bounced to /profile and never returned
+  // to the signup flow — which is why event attendees were re-clicking
+  // Connect and burning the per-IP rate-limit bucket.
+  useEffect(() => {
+    if (authLoading) return;
+    const githubStatus = searchParams.get("github");
+    if (!githubStatus) return;
+    if (githubStatus === "success") {
+      const data = searchParams.get("data");
+      if (data) {
+        try {
+          github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
+        } catch {
+          github.handleOAuthError(searchParams.get("message"));
+        }
+      } else {
+        github.handleOAuthError(searchParams.get("message"));
+      }
+    } else if (githubStatus === "error") {
+      github.handleOAuthError(searchParams.get("message"));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, authLoading]);
 
   const isProfileReady =
     profile?.visibility?.isPublic === true &&
@@ -897,13 +934,15 @@ export default function SportsHack2026SignupPage() {
                         <GitHubIcon size={16} />@{profile.githubUsername}
                       </span>
                     ) : (
-                      <a
-                        href="/api/github/authorize"
-                        className="inline-flex items-center gap-2 rounded-lg bg-neutral-800 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-700 transition-colors dark:bg-neutral-700 dark:hover:bg-neutral-600"
+                      <button
+                        type="button"
+                        onClick={github.connect}
+                        disabled={github.connecting}
+                        className="inline-flex items-center gap-2 rounded-lg bg-neutral-800 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-700 transition-colors disabled:opacity-60 dark:bg-neutral-700 dark:hover:bg-neutral-600"
                       >
                         <GitHubIcon size={16} />
-                        Connect GitHub
-                      </a>
+                        {github.connecting ? "Connecting…" : "Connect GitHub"}
+                      </button>
                     )}
                   </div>
 
@@ -1276,5 +1315,19 @@ function ShowDiscordRow({
         />
       </button>
     </div>
+  );
+}
+
+export default function SportsHack2026SignupPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto w-full max-w-3xl px-4 py-10 text-sm text-neutral-500 md:px-6 md:py-14">
+          Loading…
+        </div>
+      }
+    >
+      <SportsHack2026SignupPageInner />
+    </Suspense>
   );
 }

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -673,10 +673,10 @@ function SummerCohortPageInner() {
         try {
           github.handleOAuthSuccess(JSON.parse(decodeURIComponent(data)));
         } catch {
-          github.handleOAuthError();
+          github.handleOAuthError(searchParams.get("message"));
         }
       } else if (githubStatus === "error") {
-        github.handleOAuthError();
+        github.handleOAuthError(searchParams.get("message"));
       }
     }
     const discordStatus = searchParams.get("discord");

--- a/scripts/send-cohort1-week2-comms-final.ts
+++ b/scripts/send-cohort1-week2-comms-final.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Final-call nudge on deadline day (Fri May 22, 2026) to every admitted
+ * Cohort 1 applicant: Week 2 comms submission PR closes at 5pm EST,
+ * and the voting / show-and-tell Zoom kicks off at 6pm. Emphasizes both
+ * the last-chance draft PR and showing up at 6pm regardless of submission
+ * status.
+ *
+ * Idempotent via `cohort1Week2CommsFinalEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week2-comms-final.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week2-comms-final.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week2-comms-final.ts --send
+ *   npx tsx scripts/send-cohort1-week2-comms-final.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week2CommsFinalEmailedAt";
+
+const SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/c1w2comms-submission";
+const DEADLINE_LABEL = "5:00 pm EST — right now";
+const VOTING_CALL_LABEL = "Tonight · 6:00 pm EST";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93113089218";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/93113089218";
+const ZOOM_MEETING_ID = "931 1308 9218";
+const ZOOM_ONE_TAP_1 = "+13017158592,,93113089218# US (Washington DC)";
+const ZOOM_ONE_TAP_2 = "+13052241968,,93113089218# US";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Final call — deadline now, Zoom at 6pm";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>This is it — the Week 2 deadline is at ${escapeHtml(DEADLINE_LABEL)}.</strong> If you have anything to submit, open a draft PR against <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> in the next few minutes. Placeholder JSON is fine — getting on the branch is what counts. You can keep pushing commits up to 5:00 pm sharp.</p>
+
+<p><strong>Whether you submitted or not — see you at 6pm.</strong> That&apos;s the whole point. We walk through every build, hear the pitches live, and vote on Week 2. The room is way better when everyone shows up, including folks who didn&apos;t ship this week.</p>
+
+<div style="border:2px solid #0284c7;border-radius:8px;padding:16px;margin:20px 0;background:#f0f9ff;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;font-size:16px;"><strong>Zoom — tonight, 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<p>
+  <a href="${ZOOM_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Join the 6pm Zoom →
+  </a>
+</p>
+
+<p>See you in a bit.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+This is it — the Week 2 deadline is at ${DEADLINE_LABEL}. If you have anything to submit, open a draft PR against c1w2comms-submission in the next few minutes. Placeholder JSON is fine — getting on the branch is what counts. You can keep pushing commits up to 5:00 pm sharp.
+
+(${SUBMISSION_BRANCH_URL})
+
+WHETHER YOU SUBMITTED OR NOT — SEE YOU AT 6PM. That's the whole point. We walk through every build, hear the pitches live, and vote on Week 2. The room is way better when everyone shows up, including folks who didn't ship this week.
+
+ZOOM — TONIGHT, ${VOTING_CALL_LABEL}
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+Open the cohort page: ${COHORT_URL}
+
+See you in a bit.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week2-comms-reminder.ts
+++ b/scripts/send-cohort1-week2-comms-reminder.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Thursday-before-deadline nudge to every admitted Cohort 1 applicant:
+ * the Week 2 comms build PR is due Fri May 22 at 5pm EST. Encourage
+ * folks to open a draft PR *now* to claim a slot on the
+ * `c1w2comms-submission` branch, then push updates tomorrow when
+ * they're done.
+ *
+ * Idempotent via `cohort1Week2CommsReminderEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week2-comms-reminder.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week2-comms-reminder.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week2-comms-reminder.ts --send
+ *   npx tsx scripts/send-cohort1-week2-comms-reminder.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week2CommsReminderEmailedAt";
+
+const SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/c1w2comms-submission";
+const SUBMISSION_PATH =
+  "content/summer-cohort/c1/w2-comms/submissions/<github-handle>.json";
+const DEADLINE_LABEL = "Fri, May 22 · 5pm EST";
+const VOTING_CALL_LABEL = "Fri, May 22 · 6pm EST";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Reminder: Week 2 comms build PR due tomorrow 5pm EST";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick reminder — the <strong>Week 2 comms build</strong> submission PR is due <strong>${escapeHtml(DEADLINE_LABEL)}</strong>. Voting call is right after at <strong>${escapeHtml(VOTING_CALL_LABEL)}</strong>.</p>
+
+<p><strong>Pro move: open a draft PR <em>right now</em>.</strong> You don&apos;t need a finished submission to get on the branch — just open a PR into <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> today with whatever you have (even a placeholder JSON), then push updates tomorrow as you finish. That way you&apos;re queued up, the branch knows you&apos;re shipping, and you don&apos;t have to race the deadline tomorrow afternoon.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>How to submit</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Open a PR into <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> with your submission JSON at:
+  </p>
+  <p style="margin:0 0 10px 0;">
+    <code>${escapeHtml(SUBMISSION_PATH)}</code>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Deadline: <strong>${escapeHtml(DEADLINE_LABEL)}</strong>
+  </p>
+  <p style="margin:0;">
+    Voting call: <strong>${escapeHtml(VOTING_CALL_LABEL)}</strong>
+  </p>
+</div>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<p style="margin-top:8px;font-size:13px;color:#555;">
+  Week 2 prompt, inspiration list, and submission form all live on the <strong>&quot;Week 2: Comms&quot;</strong> tab.
+</p>
+
+<p>Stuck? Reply to this email or ping in Discord — happy to look at what you&apos;ve got before you push.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick reminder — the Week 2 comms build submission PR is due ${DEADLINE_LABEL}. Voting call is right after at ${VOTING_CALL_LABEL}.
+
+PRO MOVE: OPEN A DRAFT PR RIGHT NOW.
+You don't need a finished submission to get on the branch — just open a PR into c1w2comms-submission today with whatever you have (even a placeholder JSON), then push updates tomorrow as you finish. That way you're queued up, the branch knows you're shipping, and you don't have to race the deadline tomorrow afternoon.
+
+HOW TO SUBMIT
+  Open a PR into the c1w2comms-submission branch
+  (${SUBMISSION_BRANCH_URL})
+  with your submission JSON at:
+    ${SUBMISSION_PATH}
+  Deadline:     ${DEADLINE_LABEL}
+  Voting call:  ${VOTING_CALL_LABEL}
+
+Open the cohort page: ${COHORT_URL}
+Week 2 prompt, inspiration list, and submission form all live on the "Week 2: Comms" tab.
+
+Stuck? Reply to this email or ping in Discord — happy to look at what you've got before you push.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week2-comms-t15m.ts
+++ b/scripts/send-cohort1-week2-comms-t15m.ts
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * T-15m nudge on deadline day (Fri May 22, 2026) to every admitted
+ * Cohort 1 applicant: Week 2 comms submission PR closes at 5pm EST,
+ * roughly 15 minutes from when this fires (intended to run at 4:45 pm ET).
+ *
+ * Idempotent via `cohort1Week2CommsT15mEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week2-comms-t15m.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week2-comms-t15m.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week2-comms-t15m.ts --send
+ *   npx tsx scripts/send-cohort1-week2-comms-t15m.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week2CommsT15mEmailedAt";
+
+const SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/c1w2comms-submission";
+const SUBMISSION_PATH =
+  "content/summer-cohort/c1/w2-comms/submissions/<github-handle>.json";
+const DEADLINE_LABEL = "5:00 pm EST (≈15 minutes)";
+const VOTING_CALL_LABEL = "Tonight · 6:00 pm EST";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93113089218";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/93113089218";
+const ZOOM_MEETING_ID = "931 1308 9218";
+const ZOOM_ONE_TAP_1 = "+13017158592,,93113089218# US (Washington DC)";
+const ZOOM_ONE_TAP_2 = "+13052241968,,93113089218# US";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "15 minutes left — Week 2 PR closes at 5pm EST";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>15 minutes.</strong> Week 2 comms submissions close at <strong>${escapeHtml(DEADLINE_LABEL)}</strong>. After that, the branch is locked and your work isn&apos;t on tonight&apos;s ballot.</p>
+
+<p><strong>Open a draft PR now</strong> — even with a placeholder JSON. That claims your slot on <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a>. You can keep pushing commits to it right up to 5:00 pm sharp. A scrappy draft on the branch beats a polished idea that never lands.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>How to submit</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Open a PR into <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> with your submission JSON at:
+  </p>
+  <p style="margin:0 0 10px 0;">
+    <code>${escapeHtml(SUBMISSION_PATH)}</code>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Deadline: <strong>${escapeHtml(DEADLINE_LABEL)}</strong>
+  </p>
+  <p style="margin:0;">
+    Voting call: <strong>${escapeHtml(VOTING_CALL_LABEL)}</strong>
+  </p>
+</div>
+
+<p>Submitted or not, <strong>come to the 6pm Zoom</strong>. We walk through every build, hear the pitches live, and vote on Week 2. Show up curious — half the value of this cohort is seeing what other folks shipped.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>Zoom — tonight, 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<p>Stuck? Reply to this email or ping in Discord right now — I&apos;ll look at whatever you&apos;ve got.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+15 minutes. Week 2 comms submissions close at ${DEADLINE_LABEL}. After that, the branch is locked and your work isn't on tonight's ballot.
+
+OPEN A DRAFT PR NOW — even with a placeholder JSON. That claims your slot on c1w2comms-submission. You can keep pushing commits to it right up to 5:00 pm sharp. A scrappy draft on the branch beats a polished idea that never lands.
+
+HOW TO SUBMIT
+  Open a PR into the c1w2comms-submission branch
+  (${SUBMISSION_BRANCH_URL})
+  with your submission JSON at:
+    ${SUBMISSION_PATH}
+  Deadline:     ${DEADLINE_LABEL}
+  Voting call:  ${VOTING_CALL_LABEL}
+
+Submitted or not, come to the 6pm Zoom. We walk through every build, hear the pitches live, and vote on Week 2. Show up curious — half the value of this cohort is seeing what other folks shipped.
+
+ZOOM — TONIGHT, 6:00 PM EST
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+Open the cohort page: ${COHORT_URL}
+
+Stuck? Reply to this email or ping in Discord right now — I'll look at whatever you've got.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week2-comms-t1h.ts
+++ b/scripts/send-cohort1-week2-comms-t1h.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * T-1h nudge on deadline day (Fri May 22, 2026) to every admitted
+ * Cohort 1 applicant: Week 2 comms submission PR closes at 5pm EST,
+ * roughly 1 hour from when this fires. Drops the 6pm Zoom for the
+ * voting / show-and-tell call right after.
+ *
+ * Idempotent via `cohort1Week2CommsT1hEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week2-comms-t1h.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week2-comms-t1h.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week2-comms-t1h.ts --send
+ *   npx tsx scripts/send-cohort1-week2-comms-t1h.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week2CommsT1hEmailedAt";
+
+const SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/c1w2comms-submission";
+const SUBMISSION_PATH =
+  "content/summer-cohort/c1/w2-comms/submissions/<github-handle>.json";
+const DEADLINE_LABEL = "5:00 pm EST (≈1 hour)";
+const VOTING_CALL_LABEL = "Tonight · 6:00 pm EST";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93113089218";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/93113089218";
+const ZOOM_MEETING_ID = "931 1308 9218";
+const ZOOM_ONE_TAP_1 = "+13017158592,,93113089218# US (Washington DC)";
+const ZOOM_ONE_TAP_2 = "+13052241968,,93113089218# US";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "1 hour left — Week 2 PR closes at 5pm EST";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>~1 hour left.</strong> Week 2 comms submissions close at <strong>${escapeHtml(DEADLINE_LABEL)}</strong>. If your PR isn&apos;t open against <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> by then, it won&apos;t be on tonight&apos;s ballot.</p>
+
+<p>Not done? <strong>Open a draft PR right now</strong> with a placeholder JSON — that claims your slot. You can keep pushing commits to it until 5:00 pm sharp. A scrappy draft on the branch beats a polished idea that never lands.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>How to submit</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Open a PR into <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> with your submission JSON at:
+  </p>
+  <p style="margin:0 0 10px 0;">
+    <code>${escapeHtml(SUBMISSION_PATH)}</code>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Deadline: <strong>${escapeHtml(DEADLINE_LABEL)}</strong>
+  </p>
+  <p style="margin:0;">
+    Voting call: <strong>${escapeHtml(VOTING_CALL_LABEL)}</strong>
+  </p>
+</div>
+
+<p>Submitted or not, <strong>please come to the 6pm Zoom</strong>. We walk through every build, hear the pitches live, and vote on Week 2. Half the value of this cohort is seeing what other folks shipped — show up curious.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>Zoom — tonight, 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<p>Stuck in the last stretch? Reply to this email or ping in Discord — I&apos;ll look at whatever you&apos;ve got, fast.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+~1 hour left. Week 2 comms submissions close at ${DEADLINE_LABEL}. If your PR isn't open against c1w2comms-submission by then, it won't be on tonight's ballot.
+
+Not done? OPEN A DRAFT PR RIGHT NOW with a placeholder JSON — that claims your slot. You can keep pushing commits to it until 5:00 pm sharp. A scrappy draft on the branch beats a polished idea that never lands.
+
+HOW TO SUBMIT
+  Open a PR into the c1w2comms-submission branch
+  (${SUBMISSION_BRANCH_URL})
+  with your submission JSON at:
+    ${SUBMISSION_PATH}
+  Deadline:     ${DEADLINE_LABEL}
+  Voting call:  ${VOTING_CALL_LABEL}
+
+Submitted or not, please come to the 6pm Zoom. We walk through every build, hear the pitches live, and vote on Week 2. Half the value of this cohort is seeing what other folks shipped — show up curious.
+
+ZOOM — TONIGHT, 6:00 PM EST
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+Open the cohort page: ${COHORT_URL}
+
+Stuck in the last stretch? Reply to this email or ping in Discord — I'll look at whatever you've got, fast.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week2-comms-t2h.ts
+++ b/scripts/send-cohort1-week2-comms-t2h.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * T-2h nudge on deadline day (Fri May 22, 2026) to every admitted
+ * Cohort 1 applicant: Week 2 comms submission PR closes at 5pm EST,
+ * roughly 2 hours from when this fires. Drops the 6pm Zoom for the
+ * voting / show-and-tell call right after.
+ *
+ * Idempotent via `cohort1Week2CommsT2hEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week2-comms-t2h.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week2-comms-t2h.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week2-comms-t2h.ts --send
+ *   npx tsx scripts/send-cohort1-week2-comms-t2h.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week2CommsT2hEmailedAt";
+
+const SUBMISSION_BRANCH_URL =
+  "https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/c1w2comms-submission";
+const SUBMISSION_PATH =
+  "content/summer-cohort/c1/w2-comms/submissions/<github-handle>.json";
+const DEADLINE_LABEL = "5:00 pm EST (≈2 hours)";
+const VOTING_CALL_LABEL = "Tonight · 6:00 pm EST";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93113089218";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/93113089218";
+const ZOOM_MEETING_ID = "931 1308 9218";
+const ZOOM_ONE_TAP_1 = "+13017158592,,93113089218# US (Washington DC)";
+const ZOOM_ONE_TAP_2 = "+13052241968,,93113089218# US";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "2 hours left — Week 2 PR closes at 5pm EST";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>~2 hours left.</strong> Week 2 comms submissions close at <strong>${escapeHtml(DEADLINE_LABEL)}</strong>. If your PR isn&apos;t open against <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> by then, it won&apos;t be on tonight&apos;s ballot.</p>
+
+<p>If you&apos;re close but not done — <strong>open a draft PR right now</strong> with a placeholder JSON. That claims your slot on the branch. You can keep pushing commits to it until 5:00 pm sharp.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>How to submit</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Open a PR into <a href="${escapeHtml(SUBMISSION_BRANCH_URL)}"><code>c1w2comms-submission</code></a> with your submission JSON at:
+  </p>
+  <p style="margin:0 0 10px 0;">
+    <code>${escapeHtml(SUBMISSION_PATH)}</code>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Deadline: <strong>${escapeHtml(DEADLINE_LABEL)}</strong>
+  </p>
+  <p style="margin:0;">
+    Voting call: <strong>${escapeHtml(VOTING_CALL_LABEL)}</strong>
+  </p>
+</div>
+
+<p>Submitted or not, <strong>please come to the 6pm Zoom</strong>. We walk through every build, hear the pitches live, and vote on Week 2. Half the value of this cohort is seeing what other folks shipped — show up curious.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>Zoom — tonight, 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<p>Stuck in the last stretch? Reply to this email or ping in Discord — I&apos;ll look at whatever you&apos;ve got, fast.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+~2 hours left. Week 2 comms submissions close at ${DEADLINE_LABEL}. If your PR isn't open against c1w2comms-submission by then, it won't be on tonight's ballot.
+
+If you're close but not done — OPEN A DRAFT PR RIGHT NOW with a placeholder JSON. That claims your slot on the branch. You can keep pushing commits to it until 5:00 pm sharp.
+
+HOW TO SUBMIT
+  Open a PR into the c1w2comms-submission branch
+  (${SUBMISSION_BRANCH_URL})
+  with your submission JSON at:
+    ${SUBMISSION_PATH}
+  Deadline:     ${DEADLINE_LABEL}
+  Voting call:  ${VOTING_CALL_LABEL}
+
+Submitted or not, please come to the 6pm Zoom. We walk through every build, hear the pitches live, and vote on Week 2. Half the value of this cohort is seeing what other folks shipped — show up curious.
+
+ZOOM — TONIGHT, 6:00 PM EST
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+Open the cohort page: ${COHORT_URL}
+
+Stuck in the last stretch? Reply to this email or ping in Discord — I'll look at whatever you've got, fast.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week2-zoom-starting.ts
+++ b/scripts/send-cohort1-week2-zoom-starting.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * "We're live" Zoom nudge — fires when the 6pm voting / show-and-tell call
+ * for Cohort 1 Week 2 comms is starting (Fri May 22, 2026). Short, just the
+ * join info.
+ *
+ * Idempotent via `cohort1Week2ZoomStartingEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week2-zoom-starting.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week2-zoom-starting.ts --send --only-email=roger@cursorboston.com
+ *   npx tsx scripts/send-cohort1-week2-zoom-starting.ts --send
+ *   npx tsx scripts/send-cohort1-week2-zoom-starting.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const STAMP_FIELD = "cohort1Week2ZoomStartingEmailedAt";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93113089218";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/93113089218";
+const ZOOM_MEETING_ID = "931 1308 9218";
+const ZOOM_ONE_TAP_1 = "+13017158592,,93113089218# US (Washington DC)";
+const ZOOM_ONE_TAP_2 = "+13052241968,,93113089218# US";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "We're live — Week 2 Zoom starting now";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>We&apos;re starting now.</strong> Hop into the Week 2 voting + show-and-tell call.</p>
+
+<p>
+  <a href="${ZOOM_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:14px 28px;border-radius:8px;text-decoration:none;font-weight:700;font-size:16px;">
+    Join the Zoom →
+  </a>
+</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<p>Submitted or not — come hang. We&apos;re walking through every build and voting on Week 2 live.</p>
+
+<p>See you in there.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+We're starting now. Hop into the Week 2 voting + show-and-tell call.
+
+JOIN THE ZOOM
+  ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+Submitted or not — come hang. We're walking through every build and voting on Week 2 live.
+
+See you in there.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && d.email.trim().toLowerCase() !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible recipients (admitted cohort-1${onlyEmail ? `, --only-email=${onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-may26-confirm-attendance.ts
+++ b/scripts/send-may26-confirm-attendance.ts
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * T-2 closing push for the May 26 Sports Hack: make it explicit that the
+ * Luma RSVP + Partiful RSVP are *interest signals* and do NOT reserve a
+ * seat — the canonical attendance list is the website signup list, and the
+ * top-{capacity} cut requires both a claim *and* a confirm-attendance click
+ * on cursorboston.com.
+ *
+ * Recipient set mirrors send-sports-hack-2026-participation-rules.ts:
+ * union of website signups + Luma-only, minus judges/declined/unsubscribed,
+ * deduped by email + matching GitHub login. Carries its own stamp
+ * (`sportsHack2026ConfirmAttendanceEmailedAt`) so it does NOT inherit the
+ * participation-rules send suppression — this is a different message,
+ * intentionally going to everyone (the user explicitly asked for full
+ * blast, not just newcomers).
+ *
+ * Idempotent via `sportsHack2026ConfirmAttendanceEmailedAt` stamped on:
+ *   - hackathonEventSignups/{id} for website signups
+ *   - hackathonLumaRegistrants/{id} for Luma-only attendees
+ *
+ * Usage:
+ *   npx tsx scripts/send-may26-confirm-attendance.ts --dry-run
+ *   npx tsx scripts/send-may26-confirm-attendance.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-may26-confirm-attendance.ts --send
+ *   npx tsx scripts/send-may26-confirm-attendance.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import {
+  getDeclinedEmailsForEvent,
+  getJudgeEmailsForEvent,
+} from "../lib/hackathon-event-signup";
+import {
+  SPORTS_HACK_2026_CAPACITY,
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_NAME,
+} from "../lib/sports-hack-2026";
+
+const EVENT_ID = SPORTS_HACK_2026_EVENT_ID;
+const STAMP_FIELD = "sportsHack2026ConfirmAttendanceEmailedAt";
+
+const SIGNUP_URL = `https://cursorboston.com/hackathons/${EVENT_ID}/signup`;
+const EVENT_TIME_HUMAN =
+  "Tuesday, May 26 · 10 AM – 4 PM ET · Hult International, Cambridge";
+
+interface Recipient {
+  email: string;
+  firstName: string;
+  source: "website" | "luma";
+  sourceDocId: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function getOnlyEmailFlag(): string | null {
+  const arg = process.argv.find((a) => a.startsWith("--only-email="));
+  if (!arg) return null;
+  return arg.slice("--only-email=".length).trim().toLowerCase();
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject =
+    "Action needed — confirm your seat for Tuesday's Sports Hack (Luma/Partiful RSVPs don't reserve a spot)";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick, important one for <strong>${escapeHtml(SPORTS_HACK_2026_NAME)}</strong> — <strong>${escapeHtml(EVENT_TIME_HUMAN)}</strong>.</p>
+
+<div style="border:1px solid #f59e0b;border-radius:8px;padding:16px;margin:16px 0;background:#fffbeb;color:#78350f;">
+  <p style="margin:0 0 8px 0;"><strong>Your Luma or Partiful RSVP is an interest signal — it does not reserve a seat.</strong></p>
+  <p style="margin:0;">The canonical attendance list — the one we use for door check-in and for the ${SPORTS_HACK_2026_CAPACITY}-credit Cursor cap — lives on the website. To be on it, you have to take two actions on cursorboston.com.</p>
+</div>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Do both of these before Tuesday:</h3>
+<ol>
+  <li style="margin-bottom:10px;"><strong>Claim your spot on the website.</strong> Sign in (or create an account) and click claim on the signup page. Required even if you&apos;re already on Luma or Partiful.</li>
+  <li style="margin-bottom:10px;"><strong>Confirm attendance.</strong> Once you&apos;ve claimed, the same page shows a second button to confirm you&apos;re actually coming. Only confirmed attendees count toward the Cursor-credit cap and the door list.</li>
+</ol>
+
+<p><a href="${SIGNUP_URL}" style="display:inline-block;padding:12px 22px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">Claim &amp; confirm on cursorboston.com →</a></p>
+
+<p style="margin-top:20px;font-size:14px;color:#555;">Already claimed and confirmed? Thank you — nothing more to do. The same page shows your current rank and whether you&apos;re inside the ${SPORTS_HACK_2026_CAPACITY}-credit band.</p>
+
+<p>See you Tuesday —</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you registered for the Cursor Boston May 26 event on Luma, Partiful, or the website.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick, important one for ${SPORTS_HACK_2026_NAME} — ${EVENT_TIME_HUMAN}.
+
+YOUR LUMA OR PARTIFUL RSVP IS AN INTEREST SIGNAL — IT DOES NOT RESERVE A SEAT.
+
+The canonical attendance list — the one we use for door check-in and for the ${SPORTS_HACK_2026_CAPACITY}-credit Cursor cap — lives on the website. To be on it, you have to take two actions on cursorboston.com:
+
+DO BOTH OF THESE BEFORE TUESDAY:
+
+  1) CLAIM YOUR SPOT ON THE WEBSITE.
+     Sign in (or create an account) and click claim on the signup page.
+     Required even if you're already on Luma or Partiful.
+
+  2) CONFIRM ATTENDANCE.
+     Once you've claimed, the same page shows a second button to confirm
+     you're actually coming. Only confirmed attendees count toward the
+     Cursor-credit cap and the door list.
+
+Claim & confirm on cursorboston.com:
+${SIGNUP_URL}
+
+Already claimed and confirmed? Thank you — nothing more to do. The same page shows your current rank and whether you're inside the ${SPORTS_HACK_2026_CAPACITY}-credit band.
+
+See you Tuesday —
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you registered for the Cursor Boston May 26 event on Luma, Partiful, or the website.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function firstNameFrom(s: string | null | undefined): string {
+  if (!s) return "";
+  return s.trim().split(/\s+/)[0] ?? "";
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  const onlyEmail = getOnlyEmailFlag();
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  if (send) await syncMailgunSuppressions(db);
+
+  const signupSnap = await db
+    .collection("hackathonEventSignups")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  const websiteUserIds = signupSnap.docs
+    .map((d) => d.data().userId as string | undefined)
+    .filter((u): u is string => Boolean(u));
+  const userMap = new Map<string, FirebaseFirestore.DocumentData>();
+  for (let i = 0; i < websiteUserIds.length; i += 10) {
+    const chunk = websiteUserIds.slice(i, i + 10);
+    const refs = chunk.map((id) => db.collection("users").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const s of snaps) if (s.exists) userMap.set(s.id, s.data() ?? {});
+  }
+  console.log(`Website signups (${EVENT_ID}): ${signupSnap.size}`);
+
+  const lumaSnap = await db
+    .collection("hackathonLumaRegistrants")
+    .where("eventId", "==", EVENT_ID)
+    .get();
+  console.log(`Luma registrants (${EVENT_ID}): ${lumaSnap.size}`);
+
+  const ecSnap = await db.collection("eventContacts").get();
+  const unsubscribedEmails = new Set<string>();
+  for (const doc of ecSnap.docs) {
+    if (doc.data().unsubscribed === true) {
+      const e = (doc.data().email || doc.id).toString().trim().toLowerCase();
+      if (e) unsubscribedEmails.add(e);
+    }
+  }
+  console.log(`Unsubscribed emails (global): ${unsubscribedEmails.size}`);
+
+  const judgeEmails = getJudgeEmailsForEvent(EVENT_ID);
+  const declinedEmails = getDeclinedEmailsForEvent(EVENT_ID);
+
+  const recipients: Recipient[] = [];
+  const seenEmails = new Set<string>();
+  const websiteGithubLogins = new Set<string>();
+
+  let skippedAlreadyEmailed = 0;
+  let skippedOnlyEmailFilter = 0;
+  let skippedJudgeOrDeclined = 0;
+  let skippedUnsubscribed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of signupSnap.docs) {
+    const data = doc.data();
+    const userId = data.userId as string | undefined;
+    if (!userId) {
+      skippedNoEmail++;
+      continue;
+    }
+    const profile = userMap.get(userId) ?? {};
+    const email =
+      typeof profile.email === "string"
+        ? profile.email.trim().toLowerCase()
+        : null;
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (judgeEmails.has(email) || declinedEmails.has(email)) {
+      skippedJudgeOrDeclined++;
+      continue;
+    }
+    if (unsubscribedEmails.has(email)) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    if (!force && data[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && email !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    seenEmails.add(email);
+    const ghLogin =
+      profile.github && typeof profile.github === "object"
+        ? (profile.github as { login?: string }).login ?? null
+        : null;
+    if (ghLogin) websiteGithubLogins.add(ghLogin.toLowerCase());
+    recipients.push({
+      email,
+      firstName: firstNameFrom(
+        typeof profile.displayName === "string" ? profile.displayName : ""
+      ),
+      source: "website",
+      sourceDocId: doc.id,
+    });
+  }
+
+  for (const doc of lumaSnap.docs) {
+    const d = doc.data();
+    const email = (d.email as string | undefined)?.trim().toLowerCase() ?? "";
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (judgeEmails.has(email) || declinedEmails.has(email)) {
+      skippedJudgeOrDeclined++;
+      continue;
+    }
+    if (unsubscribedEmails.has(email)) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    if (seenEmails.has(email)) continue;
+    const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+    if (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase())) continue;
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (onlyEmail && email !== onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    seenEmails.add(email);
+    recipients.push({
+      email,
+      firstName: firstNameFrom(typeof d.name === "string" ? d.name : ""),
+      source: "luma",
+      sourceDocId: doc.id,
+    });
+  }
+
+  console.log(
+    `\nRecipients: ${recipients.length}${onlyEmail ? ` (--only-email=${onlyEmail})` : ""}`
+  );
+  console.log(`Skipped — judge/declined:           ${skippedJudgeOrDeclined}`);
+  console.log(`Skipped — unsubscribed:             ${skippedUnsubscribed}`);
+  console.log(`Skipped — no email:                 ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (stamp):  ${skippedAlreadyEmailed}`);
+  if (onlyEmail) {
+    console.log(`Skipped — --only-email filter:      ${skippedOnlyEmailFilter}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email} (${sample.source})`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} recipients.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      const collection =
+        r.source === "website" ? "hackathonEventSignups" : "hackathonLumaRegistrants";
+      await db
+        .collection(collection)
+        .doc(r.sourceDocId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() })
+        .catch((e) => {
+          console.warn(`  [stamp-fail] ${r.email}`, e);
+        });
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-may26-partiful-last-chance.ts
+++ b/scripts/send-may26-partiful-last-chance.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Last-chance push to RSVP on Partiful for the May 26 Hult event.
+ *
+ * Context: today is 2026-05-19. The Hult attendee list is submitted on
+ * 2026-05-20, so this is the final ask before the door closes.
+ *
+ * Recipients: every `eventContacts` doc that isn't unsubscribed. After the
+ * sync-auth-to-eventcontacts.ts run, this also covers Firebase Auth users
+ * who had no prior Luma registration.
+ *
+ * Usage:
+ *   npx tsx scripts/send-may26-partiful-last-chance.ts --dry-run
+ *   npx tsx scripts/send-may26-partiful-last-chance.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ *
+ * Sender: this script sends as roger@cursorboston.com explicitly (passed
+ * as `from` on every sendEmail call), independent of MAILGUN_FROM.
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+}
+
+const PARTIFUL_URL = "https://partiful.com/e/tuwaHOMgiJHvTfOFUJzA?c=EIywhmXE";
+const HULT_CUTOFF_HUMAN = "tomorrow (Wednesday, May 20)";
+const FROM_ADDRESS = "Roger <roger@cursorboston.com>";
+
+function buildEmail(contact: ContactData): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const firstHtml = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
+  );
+  const firstText =
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  const subject = `Last chance: RSVP on Partiful for May 26 — Hult list closes ${HULT_CUTOFF_HUMAN}`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${firstHtml},</p>
+
+<p>Quick one: we submit the final attendee list to Hult <strong>${escapeHtml(HULT_CUTOFF_HUMAN)}</strong> for our May 26 event. If you want to be on it, please <strong>RSVP on Partiful now</strong>.</p>
+
+<p style="margin-top:0;color:#555;">Tuesday <strong>May 26</strong> · Hult International, Cambridge · kicks off Boston Tech Week</p>
+
+<p><a href="${PARTIFUL_URL}" style="display:inline-block;padding:12px 22px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">RSVP on Partiful →</a></p>
+
+<p>Even if you already RSVP&apos;d on Luma or signed up on the website, please <strong>also RSVP on Partiful</strong> — Boston Tech Week only counts events that are on Partiful, and our Hult headcount is being pulled from the Partiful list.</p>
+
+<p>And — please share the link. The bigger the RSVP count, the more visible Cursor Boston is during Tech Week:</p>
+
+<p style="margin:8px 0;padding:8px 12px;background:#f5f5f5;border-radius:6px;font-family:ui-monospace,Menlo,monospace;font-size:13px;word-break:break-all;"><a href="${PARTIFUL_URL}">${PARTIFUL_URL}</a></p>
+
+<p>Thanks — see you at Hult on the 26th.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a> · <a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you signed up at cursorboston.com or registered for a Cursor Boston event.<br/>
+Don&apos;t want to hear from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick one: we submit the final attendee list to Hult ${HULT_CUTOFF_HUMAN} for our May 26 event. If you want to be on it, please RSVP on Partiful now.
+
+Tuesday May 26 · Hult International, Cambridge · kicks off Boston Tech Week
+
+RSVP on Partiful:
+→ ${PARTIFUL_URL}
+
+Even if you already RSVP'd on Luma or signed up on the website, please also RSVP on Partiful — Boston Tech Week only counts events that are on Partiful, and our Hult headcount is being pulled from the Partiful list.
+
+And — please share the link. The bigger the RSVP count, the more visible Cursor Boston is during Tech Week:
+
+   ${PARTIFUL_URL}
+
+Thanks — see you at Hult on the 26th.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+---
+You're receiving this because you signed up at cursorboston.com or registered for a Cursor Boston event.
+Unsubscribe: ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  if (send) await syncMailgunSuppressions(db);
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    const email = (data.email || doc.id || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+
+    contacts.push({
+      email,
+      name: data.name || "",
+      firstName: data.firstName || "",
+    });
+  }
+
+  console.log(
+    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed} | Skipped no-email: ${skippedNoEmail}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = contacts[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample);
+      console.log(`Sample email to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- TEXT preview ----\n${text}\n---- end TEXT ----\n`);
+    }
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ from: FROM_ADDRESS, to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(
+    `\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed + skippedNoEmail}.`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/sync-auth-to-eventcontacts.ts
+++ b/scripts/sync-auth-to-eventcontacts.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Sync Firebase Auth users into the `eventContacts` mailing list.
+ *
+ * For every Firebase Auth user with an email address, ensure a doc exists at
+ * eventContacts/<lowercased-email>. Auth users who have no eventContacts doc
+ * yet get a minimal placeholder created with `sources: ["firebase-auth"]` and
+ * their `authUid` recorded, so future audits can tell auth-sourced rows from
+ * Luma-sourced rows.
+ *
+ * Existing eventContacts docs are NEVER mutated. We only add what's missing.
+ *
+ * The user's prior unsubscribe choice (from the in-app `/users/<uid>.unsubscribed`
+ * mirror) is honored — if the auth user already opted out, the new
+ * eventContacts doc is created with `unsubscribed: true` so they stay out.
+ *
+ * Usage:
+ *   npx tsx scripts/sync-auth-to-eventcontacts.ts --dry-run
+ *   npx tsx scripts/sync-auth-to-eventcontacts.ts --commit
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { Timestamp } from "firebase-admin/firestore";
+import { getAdminAuth, getAdminDb } from "../lib/firebase-admin";
+
+interface AuthUser {
+  uid: string;
+  email: string; // already lowercased + trimmed
+  displayName: string | null;
+}
+
+function parseArgs(argv: string[]) {
+  const dryRun = argv.includes("--dry-run");
+  const commit = argv.includes("--commit");
+  if ((dryRun && commit) || (!dryRun && !commit)) {
+    console.error("Specify exactly one of: --dry-run | --commit");
+    process.exit(1);
+  }
+  return { dryRun, commit };
+}
+
+async function listAllAuthUsers(): Promise<AuthUser[]> {
+  const auth = getAdminAuth();
+  if (!auth) {
+    throw new Error("Firebase Admin Auth not configured");
+  }
+  const out: AuthUser[] = [];
+  let pageToken: string | undefined;
+  let page = 0;
+  do {
+    page++;
+    const res = await auth.listUsers(1000, pageToken);
+    for (const u of res.users) {
+      const rawEmail = u.email ?? "";
+      const email = rawEmail.trim().toLowerCase();
+      if (!email || !email.includes("@")) continue;
+      out.push({
+        uid: u.uid,
+        email,
+        displayName: u.displayName ?? null,
+      });
+    }
+    pageToken = res.pageToken;
+    console.log(`  auth page ${page}: cumulative=${out.length}`);
+  } while (pageToken);
+  return out;
+}
+
+async function main() {
+  const { dryRun } = parseArgs(process.argv.slice(2));
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log("Listing Firebase Auth users…");
+  const authUsers = await listAllAuthUsers();
+  console.log(`Auth users with email: ${authUsers.length}`);
+
+  console.log("Loading eventContacts emails…");
+  const ecSnap = await db.collection("eventContacts").get();
+  const ecEmails = new Set<string>();
+  for (const doc of ecSnap.docs) {
+    const data = doc.data();
+    const email = (data.email || doc.id || "").toString().trim().toLowerCase();
+    if (email) ecEmails.add(email);
+  }
+  console.log(`Existing eventContacts: ${ecEmails.size}`);
+
+  console.log("Loading /users docs for unsubscribe-flag lookup…");
+  const usersSnap = await db.collection("users").get();
+  const unsubByEmail = new Map<string, boolean>();
+  for (const doc of usersSnap.docs) {
+    const d = doc.data();
+    const email = typeof d.email === "string" ? d.email.trim().toLowerCase() : "";
+    if (!email) continue;
+    if (d.unsubscribed === true) unsubByEmail.set(email, true);
+  }
+  console.log(`/users docs flagged unsubscribed: ${unsubByEmail.size}`);
+
+  // Dedupe auth list by email (multiple auth records sharing one email is rare
+  // but possible across providers). Keep the first uid seen; record duplicates.
+  const seenAuthEmail = new Map<string, AuthUser>();
+  let authDupes = 0;
+  for (const u of authUsers) {
+    if (seenAuthEmail.has(u.email)) {
+      authDupes++;
+      continue;
+    }
+    seenAuthEmail.set(u.email, u);
+  }
+  if (authDupes > 0) {
+    console.log(`Auth duplicates by email (dropped): ${authDupes}`);
+  }
+
+  // Figure out who's missing from eventContacts.
+  const toAdd: AuthUser[] = [];
+  for (const u of seenAuthEmail.values()) {
+    if (!ecEmails.has(u.email)) toAdd.push(u);
+  }
+
+  let wouldAddSubscribed = 0;
+  let wouldAddUnsubscribed = 0;
+  for (const u of toAdd) {
+    if (unsubByEmail.get(u.email)) wouldAddUnsubscribed++;
+    else wouldAddSubscribed++;
+  }
+
+  console.log("");
+  console.log("=== Sync plan ===");
+  console.log(`Auth users (unique by email):     ${seenAuthEmail.size}`);
+  console.log(`Already in eventContacts:         ${seenAuthEmail.size - toAdd.length}`);
+  console.log(`Would add (subscribed):           ${wouldAddSubscribed}`);
+  console.log(`Would add (unsubscribed honored): ${wouldAddUnsubscribed}`);
+  console.log(`Total would-add:                  ${toAdd.length}`);
+
+  if (dryRun) {
+    const sample = toAdd[0];
+    if (sample) {
+      console.log("");
+      console.log("Sample doc that would be created:");
+      console.log(JSON.stringify(buildContactDoc(sample, unsubByEmail.get(sample.email) === true), null, 2));
+    }
+    console.log("\n--dry-run: no writes made.");
+    return;
+  }
+
+  if (toAdd.length === 0) {
+    console.log("\nNothing to add. Done.");
+    return;
+  }
+
+  console.log(`\nWriting ${toAdd.length} new eventContacts docs in batches of 400…`);
+  let written = 0;
+  for (let i = 0; i < toAdd.length; i += 400) {
+    const slice = toAdd.slice(i, i + 400);
+    const batch = db.batch();
+    for (const u of slice) {
+      const ref = db.collection("eventContacts").doc(u.email);
+      const doc = buildContactDoc(u, unsubByEmail.get(u.email) === true);
+      batch.set(ref, doc, { merge: false });
+    }
+    await batch.commit();
+    written += slice.length;
+    console.log(`  wrote ${written}/${toAdd.length}`);
+  }
+  console.log(`\nDone. Added ${written} eventContacts docs from Firebase Auth.`);
+}
+
+function buildContactDoc(u: AuthUser, unsubscribed: boolean) {
+  const now = Timestamp.now();
+  const nowIso = new Date().toISOString();
+  const name = (u.displayName ?? "").trim();
+  const firstName = name.split(/\s+/)[0] ?? "";
+  const lastName = name.includes(" ")
+    ? name.split(/\s+/).slice(1).join(" ")
+    : "";
+  return {
+    email: u.email,
+    name,
+    firstName,
+    lastName,
+    events: [],
+    eventNames: [],
+    totalEvents: 0,
+    firstSeenAt: nowIso,
+    lastSeenAt: nowIso,
+    updatedAt: now,
+    sources: ["firebase-auth"],
+    authUid: u.uid,
+    ...(unsubscribed ? { unsubscribed: true } : {}),
+  };
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/sync-may26-partiful-and-luma.ts
+++ b/scripts/sync-may26-partiful-and-luma.ts
@@ -1,0 +1,655 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Merge a Partiful CSV + a Luma CSV for the May 26 Boston Tech Week Sports
+ * Hack into one canonical attendee list, then:
+ *
+ *   1. Write a deduped merged CSV (status normalized to
+ *      approved | invited/maybe | not going). Dedupe key: lowercased email.
+ *      Rows without an email (most Partiful rows) are emitted but cannot
+ *      participate in any of the downstream Firestore writes.
+ *
+ *   2. Upsert every emailed contact into `eventContacts` under the shared
+ *      event name "Boston Tech Week Sports Hack — May 26 2026". New emails
+ *      get a fresh doc; existing emails get the May 26 event appended to
+ *      their `events` array (idempotent re-runs).
+ *
+ *   3. Refresh `hackathonLumaRegistrants` for `sports-hack-2026` so the
+ *      event page leaderboard reflects both Luma `approved` and Partiful
+ *      `Going` attendees. Run with --prune to drop rows that fell out of
+ *      both lists.
+ *
+ * Usage:
+ *   npx tsx scripts/sync-may26-partiful-and-luma.ts \
+ *     --partiful <partiful.csv> --luma <luma.csv> \
+ *     --out <merged.csv> --dry-run
+ *
+ *   npx tsx scripts/sync-may26-partiful-and-luma.ts \
+ *     --partiful <partiful.csv> --luma <luma.csv> \
+ *     --out <merged.csv> --write [--prune]
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS.
+ */
+import { readFileSync, writeFileSync } from "fs";
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { parseGithubLogin } from "./_lib/parse-github-login";
+
+const SHARED_EVENT_NAME = "Boston Tech Week Sports Hack — May 26 2026";
+const SPORTS_HACK_EVENT_ID = "sports-hack-2026";
+const EVENT_CONTACTS_COLLECTION = "eventContacts";
+const LUMA_REGISTRANTS_COLLECTION = "hackathonLumaRegistrants";
+
+// ---------------------------------------------------------------------------
+// CSV parsing (same shape as scripts/sync-event-contacts.ts)
+// ---------------------------------------------------------------------------
+
+type CsvRow = Record<string, string>;
+
+function parseCsv(content: string): CsvRow[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      /* ignore */
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((cell) => cell.length > 0)) rows.push(row);
+
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  const out: CsvRow[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const line = rows[r]!;
+    const obj: CsvRow = {};
+    for (let j = 0; j < header.length; j++) obj[header[j]!] = (line[j] ?? "").trim();
+    out.push(obj);
+  }
+  return out;
+}
+
+function loadCsv(path: string): CsvRow[] {
+  let raw = readFileSync(path, "utf8");
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  return parseCsv(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Status normalization
+// ---------------------------------------------------------------------------
+
+type NormalizedStatus = "approved" | "invited/maybe" | "not going";
+
+function rankStatus(s: NormalizedStatus): number {
+  // Higher wins when consolidating duplicate emails across sources.
+  if (s === "approved") return 2;
+  if (s === "invited/maybe") return 1;
+  return 0;
+}
+
+function partifulStatus(raw: string): NormalizedStatus | null {
+  const v = raw.replace(/ /g, " ").trim().toLowerCase();
+  if (v === "going") return "approved";
+  if (v === "invited" || v === "maybe" || v === "interested") return "invited/maybe";
+  if (v === "can't go" || v === "cant go" || v === "can’t go") return "not going";
+  if (v === "error") return "not going";
+  return null;
+}
+
+function lumaStatus(raw: string): NormalizedStatus | null {
+  const v = raw.trim().toLowerCase();
+  if (v === "approved") return "approved";
+  if (v === "invited") return "invited/maybe";
+  if (v === "declined") return "not going";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+interface MergedRow {
+  email: string | null;            // null when neither source had one
+  name: string;
+  firstName: string;
+  lastName: string;
+  status: NormalizedStatus;
+  sources: ("partiful" | "luma")[];
+  partifulRawStatus: string | null;
+  lumaRawStatus: string | null;
+  githubLogin: string | null;
+  linkedinUrl: string | null;
+  company: string | null;
+  jobTitle: string | null;
+  lumaCreatedAt: string | null;
+  partifulRsvpDate: string | null;
+  partifulName: string | null;     // kept for emailless rows
+}
+
+function splitName(full: string): { first: string; last: string } {
+  const t = full.trim();
+  if (!t) return { first: "", last: "" };
+  const parts = t.split(/\s+/);
+  return { first: parts[0]!, last: parts.slice(1).join(" ") };
+}
+
+function mergeRows(
+  partifulRows: CsvRow[],
+  lumaRows: CsvRow[]
+): { byEmail: Map<string, MergedRow>; emaillessPartiful: MergedRow[] } {
+  const byEmail = new Map<string, MergedRow>();
+  const emaillessPartiful: MergedRow[] = [];
+
+  for (const r of partifulRows) {
+    const rawStatus = r["Status"] || "";
+    const status = partifulStatus(rawStatus);
+    if (!status) continue; // skip "AKA", parsing junk
+    const emailRaw = (r["What is your email?"] || "").trim();
+    const name = (r["Name"] || "").trim();
+    const { first, last } = splitName(name);
+    const linkedin = (r["What's your LinkedIn URL?"] || "").trim() || null;
+    const company =
+      (r["What's is the name of your company?"] || r["What's the name of your company?"] || "").trim() ||
+      null;
+    const jobTitle = (r["What is your job title?"] || "").trim() || null;
+    const githubRaw = (r["What is your GitHub?"] || "").trim();
+    const githubLogin = parseGithubLogin(githubRaw);
+
+    const base: MergedRow = {
+      email: emailRaw ? emailRaw.toLowerCase() : null,
+      name,
+      firstName: first,
+      lastName: last,
+      status,
+      sources: ["partiful"],
+      partifulRawStatus: rawStatus,
+      lumaRawStatus: null,
+      githubLogin,
+      linkedinUrl: linkedin,
+      company,
+      jobTitle,
+      lumaCreatedAt: null,
+      partifulRsvpDate: (r["RSVP date"] || "").trim() || null,
+      partifulName: name,
+    };
+
+    if (!base.email) {
+      emaillessPartiful.push(base);
+      continue;
+    }
+    const existing = byEmail.get(base.email);
+    if (existing) {
+      // Same email already from Partiful (shouldn't happen, but just in case).
+      if (rankStatus(base.status) > rankStatus(existing.status)) {
+        existing.status = base.status;
+      }
+      existing.partifulRawStatus = existing.partifulRawStatus || base.partifulRawStatus;
+      existing.linkedinUrl = existing.linkedinUrl || base.linkedinUrl;
+      existing.company = existing.company || base.company;
+      existing.jobTitle = existing.jobTitle || base.jobTitle;
+      existing.githubLogin = existing.githubLogin || base.githubLogin;
+      existing.partifulRsvpDate = existing.partifulRsvpDate || base.partifulRsvpDate;
+      if (!existing.sources.includes("partiful")) existing.sources.push("partiful");
+    } else {
+      byEmail.set(base.email, base);
+    }
+  }
+
+  for (const r of lumaRows) {
+    const rawStatus = r["approval_status"] || "";
+    const status = lumaStatus(rawStatus);
+    if (!status) continue;
+    const emailRaw = (r["email"] || "").trim();
+    if (!emailRaw) continue;
+    const email = emailRaw.toLowerCase();
+    const firstName = (r["first_name"] || "").trim();
+    const lastName = (r["last_name"] || "").trim();
+    const name = (r["name"] || `${firstName} ${lastName}`.trim()).trim();
+    const githubRaw = (r["What is your GitHub username?"] || "").trim();
+    const githubLogin = parseGithubLogin(githubRaw);
+
+    const existing = byEmail.get(email);
+    if (existing) {
+      if (rankStatus(status) > rankStatus(existing.status)) {
+        existing.status = status;
+      }
+      existing.lumaRawStatus = rawStatus;
+      if (!existing.sources.includes("luma")) existing.sources.push("luma");
+      existing.githubLogin = existing.githubLogin || githubLogin;
+      existing.lumaCreatedAt = existing.lumaCreatedAt || (r["created_at"] || "").trim() || null;
+      // Prefer Luma's structured first/last when ours was a single-token guess.
+      if (!existing.firstName && firstName) existing.firstName = firstName;
+      if (!existing.lastName && lastName) existing.lastName = lastName;
+      if (!existing.name) existing.name = name;
+    } else {
+      byEmail.set(email, {
+        email,
+        name,
+        firstName,
+        lastName,
+        status,
+        sources: ["luma"],
+        partifulRawStatus: null,
+        lumaRawStatus: rawStatus,
+        githubLogin,
+        linkedinUrl: null,
+        company: null,
+        jobTitle: null,
+        lumaCreatedAt: (r["created_at"] || "").trim() || null,
+        partifulRsvpDate: null,
+        partifulName: null,
+      });
+    }
+  }
+
+  return { byEmail, emaillessPartiful };
+}
+
+// ---------------------------------------------------------------------------
+// Merged CSV writer
+// ---------------------------------------------------------------------------
+
+function csvEscape(s: string | null | undefined): string {
+  if (s === null || s === undefined) return "";
+  const needs = /[",\n\r]/.test(s);
+  const out = s.replace(/"/g, '""');
+  return needs ? `"${out}"` : out;
+}
+
+function writeMergedCsv(
+  outPath: string,
+  byEmail: Map<string, MergedRow>,
+  emailless: MergedRow[]
+): void {
+  const header = [
+    "email",
+    "name",
+    "status",
+    "sources",
+    "partiful_raw_status",
+    "luma_raw_status",
+    "github_login",
+    "linkedin_url",
+    "company",
+    "job_title",
+    "luma_created_at",
+    "partiful_rsvp_date",
+  ];
+
+  // Sort: approved → invited/maybe → not going, then by email.
+  const statusOrder = (s: NormalizedStatus) => -rankStatus(s);
+  const rows = [...byEmail.values()].sort(
+    (a, b) =>
+      statusOrder(a.status) - statusOrder(b.status) ||
+      (a.email ?? "").localeCompare(b.email ?? "")
+  );
+
+  const lines: string[] = [header.join(",")];
+  for (const r of rows) {
+    lines.push(
+      [
+        r.email,
+        r.name,
+        r.status,
+        r.sources.join("+"),
+        r.partifulRawStatus,
+        r.lumaRawStatus,
+        r.githubLogin,
+        r.linkedinUrl,
+        r.company,
+        r.jobTitle,
+        r.lumaCreatedAt,
+        r.partifulRsvpDate,
+      ]
+        .map(csvEscape)
+        .join(",")
+    );
+  }
+
+  // Emailless block — kept separate so downstream pipelines can ignore it.
+  if (emailless.length > 0) {
+    lines.push("");
+    lines.push("# Partiful guests without email (cannot dedupe or sync — name only)");
+    lines.push(["email", "name", "status", "sources", "partiful_raw_status"].join(","));
+    const sorted = emailless.sort((a, b) =>
+      statusOrder(a.status) - statusOrder(b.status) || a.name.localeCompare(b.name)
+    );
+    for (const r of sorted) {
+      lines.push(
+        ["", r.name, r.status, r.sources.join("+"), r.partifulRawStatus]
+          .map(csvEscape)
+          .join(",")
+      );
+    }
+  }
+
+  writeFileSync(outPath, lines.join("\n") + "\n", "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Firestore: eventContacts
+// ---------------------------------------------------------------------------
+
+interface EventAttendance {
+  eventName: string;
+  csvFile: string;
+  registeredAt: string;
+  approvalStatus: string;
+  checkedIn: boolean;
+  checkedInAt: string | null;
+  ticketType: string | null;
+}
+
+async function upsertEventContacts(
+  db: FirebaseFirestore.Firestore,
+  byEmail: Map<string, MergedRow>,
+  dryRun: boolean
+): Promise<{ created: number; updated: number; alreadyHasEvent: number }> {
+  let created = 0;
+  let updated = 0;
+  let alreadyHasEvent = 0;
+
+  for (const [email, r] of byEmail) {
+    const docRef = db.collection(EVENT_CONTACTS_COLLECTION).doc(email);
+    const existing = await docRef.get();
+
+    const registeredAt =
+      r.lumaCreatedAt ||
+      r.partifulRsvpDate ||
+      "";
+    const approvalStatus = r.status; // approved | invited/maybe | not going
+    const attendance: EventAttendance = {
+      eventName: SHARED_EVENT_NAME,
+      csvFile: r.sources.join("+"),
+      registeredAt,
+      approvalStatus,
+      checkedIn: false,
+      checkedInAt: null,
+      ticketType: null,
+    };
+
+    if (existing.exists) {
+      const data = existing.data()!;
+      const existingEvents: EventAttendance[] = Array.isArray(data.events) ? data.events : [];
+      const idx = existingEvents.findIndex((e) => e.eventName === SHARED_EVENT_NAME);
+
+      let mergedEvents: EventAttendance[];
+      if (idx >= 0) {
+        // Update the existing entry in place (status may have changed)
+        mergedEvents = existingEvents.slice();
+        mergedEvents[idx] = { ...mergedEvents[idx]!, ...attendance };
+        alreadyHasEvent++;
+      } else {
+        mergedEvents = [...existingEvents, attendance];
+        updated++;
+      }
+
+      const mergedEventNames = [...new Set(mergedEvents.map((e) => e.eventName))];
+      const mergedDates = mergedEvents.map((e) => e.registeredAt).filter(Boolean).sort();
+
+      if (!dryRun) {
+        await docRef.update({
+          name: r.name || data.name || "",
+          firstName: r.firstName || data.firstName || "",
+          lastName: r.lastName || data.lastName || "",
+          events: mergedEvents,
+          eventNames: mergedEventNames,
+          totalEvents: mergedEventNames.length,
+          firstSeenAt: mergedDates[0] || data.firstSeenAt || "",
+          lastSeenAt: mergedDates[mergedDates.length - 1] || data.lastSeenAt || "",
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+      }
+    } else {
+      created++;
+      if (!dryRun) {
+        await docRef.set({
+          email,
+          name: r.name,
+          firstName: r.firstName,
+          lastName: r.lastName,
+          events: [attendance],
+          eventNames: [SHARED_EVENT_NAME],
+          totalEvents: 1,
+          firstSeenAt: registeredAt,
+          lastSeenAt: registeredAt,
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+      }
+    }
+  }
+
+  return { created, updated, alreadyHasEvent };
+}
+
+// ---------------------------------------------------------------------------
+// Firestore: hackathonLumaRegistrants (page leaderboard)
+// ---------------------------------------------------------------------------
+
+interface PageRegistrant {
+  email: string;
+  name: string;
+  githubLogin: string | null;
+  lumaCreatedAt: string;
+  lumaApprovalStatus: string;
+  sourceTag: string;
+}
+
+async function seedHackathonLumaRegistrants(
+  db: FirebaseFirestore.Firestore,
+  byEmail: Map<string, MergedRow>,
+  dryRun: boolean,
+  prune: boolean
+): Promise<{ seeded: number; pruned: number }> {
+  // Only rows that should appear on the leaderboard:
+  //  - approved (Luma) OR Going (Partiful) → status === "approved"
+  //  - must have email (no leaderboard slot otherwise)
+  const eligible: PageRegistrant[] = [];
+  for (const [email, r] of byEmail) {
+    if (r.status !== "approved") continue;
+    eligible.push({
+      email,
+      name: r.name || `${r.firstName} ${r.lastName}`.trim(),
+      githubLogin: r.githubLogin,
+      // Sort key for the leaderboard prefers the Luma timestamp when present.
+      lumaCreatedAt: r.lumaCreatedAt || r.partifulRsvpDate || "",
+      lumaApprovalStatus: r.sources.includes("luma") ? "approved" : "partiful-going",
+      sourceTag: r.sources.join("+"),
+    });
+  }
+
+  const approvedEmails = new Set(eligible.map((r) => r.email));
+
+  let seeded = 0;
+  if (!dryRun) {
+    for (const r of eligible) {
+      const docId = `${SPORTS_HACK_EVENT_ID}__${r.email}`;
+      await db
+        .collection(LUMA_REGISTRANTS_COLLECTION)
+        .doc(docId)
+        .set(
+          {
+            eventId: SPORTS_HACK_EVENT_ID,
+            email: r.email,
+            name: r.name,
+            githubLogin: r.githubLogin,
+            lumaCreatedAt: r.lumaCreatedAt,
+            lumaApprovalStatus: r.lumaApprovalStatus,
+            rsvpSource: r.sourceTag,
+            updatedAt: FieldValue.serverTimestamp(),
+          },
+          { merge: true }
+        );
+      seeded++;
+    }
+  } else {
+    seeded = eligible.length;
+  }
+
+  let pruned = 0;
+  if (prune && !dryRun) {
+    const existing = await db
+      .collection(LUMA_REGISTRANTS_COLLECTION)
+      .where("eventId", "==", SPORTS_HACK_EVENT_ID)
+      .get();
+    for (const doc of existing.docs) {
+      const em = String(doc.data().email ?? "").toLowerCase();
+      if (!approvedEmails.has(em)) {
+        await doc.ref.delete();
+        pruned++;
+      }
+    }
+  }
+
+  return { seeded, pruned };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function getFlag(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  if (idx < 0) return undefined;
+  return process.argv[idx + 1];
+}
+
+async function main(): Promise<void> {
+  const partifulPath = getFlag("--partiful");
+  const lumaPath = getFlag("--luma");
+  const outPath = getFlag("--out");
+  const dryRun = process.argv.includes("--dry-run");
+  const write = process.argv.includes("--write");
+  const prune = process.argv.includes("--prune");
+
+  if (!partifulPath || !lumaPath || !outPath) {
+    console.error("Usage: --partiful <csv> --luma <csv> --out <merged.csv> --dry-run | --write [--prune]");
+    process.exit(1);
+  }
+  if ((dryRun && write) || (!dryRun && !write)) {
+    console.error("Specify exactly one of --dry-run | --write.");
+    process.exit(1);
+  }
+  if (prune && !write) {
+    console.error("--prune requires --write.");
+    process.exit(1);
+  }
+
+  console.log(`Partiful CSV: ${partifulPath}`);
+  console.log(`Luma CSV:     ${lumaPath}`);
+  const partifulRows = loadCsv(partifulPath);
+  const lumaRows = loadCsv(lumaPath);
+  console.log(`  Partiful rows: ${partifulRows.length}`);
+  console.log(`  Luma rows:     ${lumaRows.length}`);
+
+  const { byEmail, emaillessPartiful } = mergeRows(partifulRows, lumaRows);
+
+  const statusCounts: Record<NormalizedStatus, number> = {
+    approved: 0,
+    "invited/maybe": 0,
+    "not going": 0,
+  };
+  const sourceCounts = { "partiful": 0, "luma": 0, "partiful+luma": 0 };
+  for (const r of byEmail.values()) {
+    statusCounts[r.status]++;
+    const tag = r.sources.length === 2 ? "partiful+luma" : (r.sources[0] as "partiful" | "luma");
+    sourceCounts[tag]++;
+  }
+
+  console.log("\n=== Merged (deduped by email) ===");
+  console.log(`  unique emails:  ${byEmail.size}`);
+  console.log(`  approved:       ${statusCounts.approved}`);
+  console.log(`  invited/maybe:  ${statusCounts["invited/maybe"]}`);
+  console.log(`  not going:      ${statusCounts["not going"]}`);
+  console.log(`  source breakdown — partiful only: ${sourceCounts.partiful}, luma only: ${sourceCounts.luma}, both: ${sourceCounts["partiful+luma"]}`);
+  console.log(`  Partiful guests w/o email:        ${emaillessPartiful.length} (in CSV, not synced)`);
+
+  writeMergedCsv(outPath, byEmail, emaillessPartiful);
+  console.log(`\nMerged CSV written: ${outPath}`);
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // --- eventContacts ---
+  console.log(`\n=== eventContacts (collection: ${EVENT_CONTACTS_COLLECTION}) ===`);
+  console.log(`Looking up which of the ${byEmail.size} emails are already on file…`);
+  const existingEmails = new Set<string>();
+  const ecSnap = await db.collection(EVENT_CONTACTS_COLLECTION).select().get();
+  for (const doc of ecSnap.docs) existingEmails.add(doc.id);
+  let newEmails = 0;
+  let dbHits = 0;
+  for (const email of byEmail.keys()) {
+    if (existingEmails.has(email)) dbHits++;
+    else newEmails++;
+  }
+  console.log(`  Already in eventContacts: ${dbHits}`);
+  console.log(`  New to eventContacts:     ${newEmails}`);
+
+  if (dryRun) {
+    console.log(`  [dry-run] would create ${newEmails} new contacts and append "${SHARED_EVENT_NAME}" to ${dbHits} existing contacts.`);
+  } else {
+    const r = await upsertEventContacts(db, byEmail, false);
+    console.log(`  Created: ${r.created}, Updated (event appended): ${r.updated}, Already had this event: ${r.alreadyHasEvent}`);
+  }
+
+  // --- hackathonLumaRegistrants (May 26 page leaderboard) ---
+  console.log(`\n=== hackathonLumaRegistrants (eventId=${SPORTS_HACK_EVENT_ID}) ===`);
+  if (dryRun) {
+    const approvedCount = [...byEmail.values()].filter((r) => r.status === "approved").length;
+    console.log(`  [dry-run] would seed ${approvedCount} approved/going rows.`);
+    if (prune) console.log(`  [dry-run] --prune skipped (requires --write).`);
+  } else {
+    const r = await seedHackathonLumaRegistrants(db, byEmail, false, prune);
+    console.log(`  Seeded: ${r.seeded}${prune ? `, Pruned stale rows: ${r.pruned}` : ""}`);
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run complete. Re-run with --write [--prune] to apply.");
+  } else {
+    console.log("\nAll writes complete.");
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Included PRs

- **#1441** `fix(github-oauth): wire sports-hack signup + reveal real error codes` — @Ludwitt
- **97eedcb1** `chore(broadcast): archive May 21–24 broadcast/sync scripts` (direct-to-develop) — @Ludwitt

## Why now

Event-day hotfix for the May 26 Sports Hack signup page. Without this, attendees clicking Connect GitHub got bounced to `/profile` (no `returnTo`), then re-clicked Connect on the stale signup page, and the per-IP rate-limit ceiling collapsed for everyone behind the same NAT.

Local production verification step was **skipped** at user request — this needs to land before the event tomorrow.

## What changes user-visibly

- `/hackathons/sports-hack-2026/signup` now keeps users on the signup page through the OAuth round-trip.
- `/summer-cohort` error toast surfaces the actual reason instead of "We don't know exactly what failed".
- New `logger.warn` lines fire on the previously silent `missing_params` and `rate_limited` callback paths so the next outage is triageable from Vercel runtime logs alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)