### PR TITLE
chore(summer-cohort): promote c1w2comms jonathanlittel submission to develop

### DIFF
--- a/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "jonathanlittel",
+  "name": "Jon Littel",
+  "photoUrl": "https://avatars.githubusercontent.com/jonathanlittel",
+  "repoUrl": "https://github.com/jonathanlittel/cursor-boston/tree/c1w2-comms/projects/c1w2-comms",
+  "liveUrl": "https://cursochat.vercel.app",
+  "loomUrl": "https://www.loom.com/share/placeholder-update-before-submit",
+  "pitch": "Three channels. The electronic version of sticky notes on a fridge.",
+  "competeForWin": false
+}


### PR DESCRIPTION
## Summary

Promotes @jonathanlittel's C1 Week 2 comms submission (originally landed on \`c1w2comms-submission\` via #1350 on 2026-05-22) onto \`develop\` so it shows up on the cohort dashboard.

## Why a fresh cherry-pick instead of merging the cohort branch

\`c1w2comms-submission\` has drifted ~25k lines behind \`develop\` since the original PR (lots of intervening cleanup on develop). A direct merge would silently revert all of it. The only actual contribution on that branch is this single 10-line JSON file, so promoting it directly is the safe move.

After this lands, \`c1w2comms-submission\` can be fast-forwarded to develop's tip cleanly.

## Test plan

- [ ] File appears in \`content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json\`
- [ ] Summer-cohort C1 Week 2 dashboard renders @jonathanlittel as a submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)