### PR TITLE
feat(sports-hack): submission detection + count switches (PR 2/4)

### DIFF
--- a/__tests__/app/hackathons/sports-hack-page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-page.test.tsx
@@ -86,8 +86,10 @@ describe("SportsHack2026LandingPage", () => {
     })) as never;
     setAuth();
     render(<SportsHack2026LandingPage />);
-    // Credit seats locked stat shows the rank-frozen confirmed count
-    await waitFor(() => expect(screen.getByText(/2\/50 \(Cursor credit link\)/)).toBeInTheDocument());
+    // Credit seats locked stat now counts entries with creditEligible (under the
+    // three-tier model = inCreditBand && hasSubmission). Label updated to
+    // "(in band + submission opened)" to reflect the new gate.
+    await waitFor(() => expect(screen.getByText(/2\/50 \(in band \+ submission opened\)/)).toBeInTheDocument());
     // Confirmed-attending stat shows the new opt-in count
     expect(screen.getByText(/0\/200 · 60 signed up/)).toBeInTheDocument();
   });
@@ -108,7 +110,7 @@ describe("SportsHack2026LandingPage", () => {
     })) as never;
     setAuth();
     render(<SportsHack2026LandingPage />);
-    await waitFor(() => expect(screen.getByText(/1\/50 \(Cursor credit link\)/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/1\/50 \(in band \+ submission opened\)/)).toBeInTheDocument());
   });
 
   it("renders signed-up CTA with rank when user is in leaderboard", async () => {

--- a/__tests__/lib/hackathon-leaderboard-snapshot.attendance.test.ts
+++ b/__tests__/lib/hackathon-leaderboard-snapshot.attendance.test.ts
@@ -29,6 +29,12 @@ jest.mock("@/lib/github-recent-merged-prs", () => ({
   getGithubRepoPair: jest.fn(() => ({ owner: "test", repo: "repo" })),
 }));
 
+jest.mock("@/lib/sports-hack-2026-submission-prs", () => ({
+  fetchSportsHack2026SubmissionAuthors: jest.fn(async () => new Set<string>()),
+  SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG:
+    "sports-hack-2026-submission-authors",
+}));
+
 jest.mock("@/lib/summer-cohort", () => ({
   SUMMER_COHORT_COLLECTION: "summer_cohort_applications",
 }));
@@ -377,6 +383,55 @@ describe("buildLeaderboardPayload — three-tier ranking (sports-hack-2026)", ()
     // set) for downstream consumers that want to know "did this person get
     // confirmed somehow" without caring about tier.
     expect(a.attendingConfirmed).toBe(true);
+  });
+
+  it("sets hasSubmission for github logins in the submission-authors set", async () => {
+    const subsMod = jest.requireMock("@/lib/sports-hack-2026-submission-prs");
+    subsMod.fetchSportsHack2026SubmissionAuthors = jest.fn(
+      async () => new Set<string>(["submitter"])
+    );
+    installDbMock({
+      signups: [
+        makeSignupDoc("submitter", {
+          attendingConfirmedAt: new Date("2026-05-20"),
+          attendingConfirmedBy: "user",
+        }),
+        makeSignupDoc("non-submitter", {
+          attendingConfirmedAt: new Date("2026-05-21"),
+          attendingConfirmedBy: "user",
+        }),
+      ],
+      users: [
+        {
+          exists: true,
+          id: "submitter",
+          data: () => ({
+            displayName: "submitter",
+            email: "submitter@test.com",
+            github: { login: "submitter" },
+          }),
+        },
+        {
+          exists: true,
+          id: "non-submitter",
+          data: () => ({
+            displayName: "non-submitter",
+            email: "non-submitter@test.com",
+            github: { login: "non-submitter" },
+          }),
+        },
+      ],
+    });
+
+    const payload = await buildLeaderboardPayload(SPORTS);
+    const s = payload.entries.find((e) => e.userId === "submitter")!;
+    const n = payload.entries.find((e) => e.userId === "non-submitter")!;
+    expect(s.hasSubmission).toBe(true);
+    expect(n.hasSubmission).toBe(false);
+    // Credit eligibility = inCreditBand && hasSubmission. Both are Tier A and
+    // inside the cap at small N, so only the submitter is credit-eligible.
+    expect(s.creditEligible).toBe(true);
+    expect(n.creditEligible).toBe(false);
   });
 
   it("freeze-model events ignore the three-tier fields", async () => {

--- a/app/api/hackathons/events/[eventId]/refresh-submissions/route.ts
+++ b/app/api/hackathons/events/[eventId]/refresh-submissions/route.ts
@@ -19,6 +19,10 @@ import {
   getClientIdentifier,
   rateLimitConfigs,
 } from "@/lib/rate-limit";
+// @contracts: hackathonsContract.eventRefreshSubmissions
+import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+
+void hackathonsContract;
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";

--- a/app/api/hackathons/events/[eventId]/refresh-submissions/route.ts
+++ b/app/api/hackathons/events/[eventId]/refresh-submissions/route.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
+import {
+  getRankingModelForEvent,
+  isHackathonEventSignupId,
+} from "@/lib/hackathon-event-signup";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
+import { SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG } from "@/lib/sports-hack-2026-submission-prs";
+import {
+  checkRateLimit,
+  getClientIdentifier,
+  rateLimitConfigs,
+} from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = { params: Promise<{ eventId: string }> };
+
+/**
+ * POST /api/hackathons/events/[eventId]/refresh-submissions
+ *
+ * Admin-only force-refresh for the three-tier ranking submission lookup.
+ * The submission-author set is cached for 60s by `unstable_cache`; during
+ * the event a maintainer may want to flip a just-opened PR through to the
+ * `hasSubmission` flag (and the credit-eligibility gate) immediately.
+ *
+ * Steps:
+ *   1. `revalidateTag` the cache so the next read goes back to GitHub.
+ *   2. `refreshSnapshot(eventId)` so the new state is durable in Firestore
+ *      and visible to all future GETs without another GitHub round-trip.
+ *
+ * Gated on `getRankingModelForEvent(eventId) === "three-tier"` — events on
+ * the historical freeze model have no submission detection to refresh and
+ * return 404 here.
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rate = checkRateLimit(
+      `hackathon-event-refresh-submissions:${clientId}`,
+      rateLimitConfigs.hackathonEventSignup,
+    );
+    if (!rate.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rate.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rate.retryAfter || 60) } },
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 },
+      );
+    }
+
+    const { eventId: raw } = await context.params;
+    const eventId = raw?.trim() ?? "";
+    if (!isHackathonEventSignupId(eventId)) {
+      return NextResponse.json({ error: "Unknown event" }, { status: 404 });
+    }
+    if (getRankingModelForEvent(eventId) !== "three-tier") {
+      return NextResponse.json(
+        {
+          error:
+            "This event does not use the three-tier ranking model — nothing to refresh.",
+        },
+        { status: 404 },
+      );
+    }
+
+    revalidateTag(SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG, { expire: 0 });
+    const snapshot = await refreshSnapshot(eventId);
+    const submissionCount = snapshot.entries.filter((e) => e.hasSubmission).length;
+
+    return NextResponse.json({
+      ok: true,
+      eventId,
+      submissionAuthorCount: submissionCount,
+      generatedAt: snapshot.generatedAt,
+    });
+  } catch (e) {
+    console.error("[hackathon event refresh-submissions]", e);
+    return NextResponse.json(
+      { error: "Failed to refresh submission cache" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/hackathons/sports-hack-2026/admin/page.tsx
+++ b/app/hackathons/sports-hack-2026/admin/page.tsx
@@ -30,6 +30,13 @@ type SignupEntry = {
   willBeLate?: boolean;
   queuingForSpot?: boolean;
   lumaRegistered?: boolean;
+  // Three-tier ranking model fields (sports-hack-2026). Optional for
+  // back-compat — populated by buildLeaderboardPayload when the event uses
+  // the three-tier model.
+  tier?: "A" | "B" | "C" | null;
+  inAttendanceBand?: boolean;
+  inCreditBand?: boolean;
+  hasSubmission?: boolean;
 };
 
 type SignupData = {

--- a/app/hackathons/sports-hack-2026/page.tsx
+++ b/app/hackathons/sports-hack-2026/page.tsx
@@ -26,6 +26,11 @@ type LeaderboardEntry = {
   rank: number;
   status?: "confirmed" | "waitlisted";
   creditEligible: boolean;
+  /** Three-tier ranking model fields (sports-hack-2026). Optional for back-compat. */
+  tier?: "A" | "B" | "C" | null;
+  inAttendanceBand?: boolean;
+  inCreditBand?: boolean;
+  hasSubmission?: boolean;
 };
 
 type LeaderboardResponse = {
@@ -67,8 +72,13 @@ export default function SportsHack2026LandingPage() {
     void load();
   }, [load]);
 
-  const confirmedCount = data
-    ? data.entries.filter((e) => (e.status ?? (e.creditEligible ? "confirmed" : "waitlisted")) === "confirmed").length
+  // "Credit seats locked" — under the three-tier model this is the count of
+  // entries inside the top-119 credit band that ALSO have an open submission PR.
+  // creditEligible already encodes `inCreditBand && hasSubmission` on the
+  // server side, so use it directly. Pre-event this is zero (nobody has
+  // opened a submission PR yet) and ramps as PRs land on event day.
+  const creditLockedCount = data
+    ? data.entries.filter((e) => e.creditEligible).length
     : null;
   const isAdmin = Boolean((userProfile as { isAdmin?: boolean } | null)?.isAdmin);
 
@@ -119,8 +129,8 @@ export default function SportsHack2026LandingPage() {
               <FactCard
                 label="Credit seats locked"
                 value={
-                  confirmedCount != null && data
-                    ? `${confirmedCount}/${SPORTS_HACK_2026_CAPACITY} (Cursor credit link)`
+                  creditLockedCount != null && data
+                    ? `${creditLockedCount}/${SPORTS_HACK_2026_CAPACITY} (in band + submission opened)`
                     : `Top ${SPORTS_HACK_2026_CAPACITY} get Cursor credit`
                 }
               />

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -86,6 +86,12 @@ type LeaderboardEntry = {
   attendingConfirmed?: boolean;
   attendingConfirmedAt?: string | null;
   attendanceRank?: number | null;
+  // Three-tier ranking model fields (sports-hack-2026). Optional for
+  // back-compat with old snapshots and freeze-model events.
+  tier?: "A" | "B" | "C" | null;
+  inAttendanceBand?: boolean;
+  inCreditBand?: boolean;
+  hasSubmission?: boolean;
 };
 
 type LeaderboardResponse = {
@@ -108,6 +114,10 @@ type LeaderboardResponse = {
     attendingConfirmed?: boolean;
     attendingConfirmedAt?: string | null;
     attendanceRank?: number | null;
+    tier?: "A" | "B" | "C" | null;
+    inAttendanceBand?: boolean;
+    inCreditBand?: boolean;
+    hasSubmission?: boolean;
   } | null;
 };
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**185 paths, 222 operations across 35 areas.**
+**186 paths, 223 operations across 35 areas.**
 
 ---
 
@@ -211,6 +211,7 @@ _Hackathon pool, teams, submissions, and Hack-a-Sprint showcase._
 | POST | `/api/hackathons/events/{eventId}/checkin` | Yes | Admin-only: check a user in to an event |
 | DELETE | `/api/hackathons/events/{eventId}/confirm-attendance` | Yes | Withdraw the user's attendance confirmation (keeps signup) |
 | POST | `/api/hackathons/events/{eventId}/confirm-attendance` | Yes | Confirm attendance for an event the user has signed up for |
+| POST | `/api/hackathons/events/{eventId}/refresh-submissions` | Yes | Admin-only — force-refresh the three-tier submission cache |
 | DELETE | `/api/hackathons/events/{eventId}/signup` | Yes | Withdraw the current user's signup |
 | GET | `/api/hackathons/events/{eventId}/signup` | Yes | Public event-signup leaderboard |
 | PATCH | `/api/hackathons/events/{eventId}/signup` | Yes | Update the current user's signup state |

--- a/lib/api-schemas/hackathons.ts
+++ b/lib/api-schemas/hackathons.ts
@@ -254,6 +254,34 @@ export const hackathonsContract = c.router(
         ] as const,
       },
     },
+    eventRefreshSubmissions: {
+      method: "POST",
+      path: "/api/hackathons/events/:eventId/refresh-submissions",
+      pathParams: EventIdParam,
+      summary: "Admin-only — force-refresh the three-tier submission cache",
+      description:
+        "Invalidates the 60s submission-author cache for three-tier events (sports-hack-2026) and rebuilds the leaderboard snapshot so a just-opened submission PR flips an attendee's hasSubmission / creditEligible flags immediately. Returns the post-refresh submission count and the snapshot generation timestamp. 404 for events that don't use the three-tier model.",
+      body: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          ok: z.literal(true),
+          eventId: z.string(),
+          submissionAuthorCount: z.number(),
+          generatedAt: z.string(),
+        }),
+        ...teamGuardedErrors,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "FORBIDDEN",
+          "NOT_FOUND",
+          "RATE_LIMITED",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+
     eventConfirmAttendanceDelete: {
       method: "DELETE",
       path: "/api/hackathons/events/:eventId/confirm-attendance",

--- a/lib/hackathon-leaderboard-snapshot.ts
+++ b/lib/hackathon-leaderboard-snapshot.ts
@@ -37,6 +37,7 @@ import {
 } from "@/lib/hackathon-event-signup";
 import { fetchMergedPrCountsForLogins } from "@/lib/github-merged-pr-count";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { fetchSportsHack2026SubmissionAuthors } from "@/lib/sports-hack-2026-submission-prs";
 import { SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
 
 export const HACKATHON_LEADERBOARD_SNAPSHOTS_COLLECTION =
@@ -298,12 +299,21 @@ export async function buildLeaderboardPayload(
     }
   }
 
-  const [githubMergedByLogin, firestoreMergedCounts] = await Promise.all([
-    fetchMergedPrCountsForLogins(githubLogins, preloadedBulkPrCounts),
-    userIdsWithoutGithub.length > 0
-      ? countMergedCommunityPrsByUserIds(db, userIdsWithoutGithub)
-      : Promise.resolve(new Map<string, number>()),
-  ]);
+  // For three-tier events, fetch the submission-PR author set in parallel
+  // with the PR-count fetches. Returns an empty set for any non-three-tier
+  // event so the rest of the pipeline stays uniform.
+  const wantsSubmissionLookup = getRankingModelForEvent(eventId) === "three-tier";
+
+  const [githubMergedByLogin, firestoreMergedCounts, submissionAuthors] =
+    await Promise.all([
+      fetchMergedPrCountsForLogins(githubLogins, preloadedBulkPrCounts),
+      userIdsWithoutGithub.length > 0
+        ? countMergedCommunityPrsByUserIds(db, userIdsWithoutGithub)
+        : Promise.resolve(new Map<string, number>()),
+      wantsSubmissionLookup
+        ? fetchSportsHack2026SubmissionAuthors()
+        : Promise.resolve(new Set<string>()),
+    ]);
 
   for (const doc of snap.docs) {
     const data = doc.data();
@@ -607,9 +617,9 @@ export async function buildLeaderboardPayload(
       const tier = u._tier;
       const inCreditBand = rank <= creditCap;
       const inAttendanceBand = rank <= attendanceLimit;
-      // hasSubmission is wired in PR 2; default false so the field is present
-      // on every entry from PR 1 onward.
-      const hasSubmission = false;
+      const hasSubmission =
+        u.githubLogin != null &&
+        submissionAuthors.has(u.githubLogin.toLowerCase());
       const attendingConfirmed = u.attendingConfirmedAt != null;
       return {
         rank,

--- a/lib/sports-hack-2026-submission-prs.ts
+++ b/lib/sports-hack-2026-submission-prs.ts
@@ -1,0 +1,126 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Live GitHub query for submission PRs into the sports-hack-2026 submissions
+ * branch. Modeled on `lib/github-merged-pr-count.ts`: one bulk Search call,
+ * cached via `unstable_cache` so the leaderboard snapshot doesn't pay a
+ * GitHub round-trip on every refresh.
+ *
+ * Cache TTL is short (60s) so newly-opened submission PRs propagate to the
+ * snapshot's `hasSubmission` flag — and to the credit-eligibility gate —
+ * within a minute. Maintainers can force-refresh via
+ * `POST /api/hackathons/events/sports-hack-2026/refresh-submissions` which
+ * revalidates the tag and rebuilds the snapshot.
+ *
+ * Returns lowercased author logins so callers can do a single
+ * `set.has(login.toLowerCase())` check per attendee.
+ */
+import { unstable_cache } from "next/cache";
+import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { fetchWithTimeout } from "@/lib/http-fetch";
+import { logger } from "@/lib/logger";
+import { SPORTS_HACK_2026_SUBMISSIONS_BRANCH } from "@/lib/sports-hack-2026-submissions";
+
+export const SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG =
+  "sports-hack-2026-submission-authors";
+
+const SEARCH_PER_PAGE = 100;
+/** GitHub search caps at 1000 results; 10 pages × 100. */
+const SEARCH_MAX_PAGES = 10;
+
+type SearchIssueItem = {
+  user?: { login?: string } | null;
+};
+
+function searchHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Uncached search for PRs (open + merged + closed) targeting the sports-hack
+ * submissions branch. Returns lowercased author logins as an array of strings
+ * so the result is JSON-serialisable for the next/cache layer.
+ *
+ * Returns `null` on hard failure so callers can leave `hasSubmission` false
+ * without crashing the snapshot build.
+ */
+export async function fetchSportsHack2026SubmissionAuthorsUncached(): Promise<
+  string[] | null
+> {
+  const { owner, repo } = getGithubRepoPair();
+  const q = `repo:${owner}/${repo} is:pr base:${SPORTS_HACK_2026_SUBMISSIONS_BRANCH}`;
+  const headers = searchHeaders();
+  const logins = new Set<string>();
+
+  try {
+    for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
+      const url = new URL("https://api.github.com/search/issues");
+      url.searchParams.set("q", q);
+      url.searchParams.set("per_page", String(SEARCH_PER_PAGE));
+      url.searchParams.set("page", String(page));
+
+      const res = await fetchWithTimeout(url.toString(), {
+        headers,
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        logger.warn("GitHub sports-hack submission PR search failed", {
+          status: res.status,
+          page,
+        });
+        return page === 1 ? null : Array.from(logins);
+      }
+
+      const data = (await res.json()) as { items?: SearchIssueItem[] };
+      const items = data.items ?? [];
+      if (items.length === 0) break;
+
+      for (const item of items) {
+        const login = item.user?.login;
+        if (typeof login === "string" && login.trim()) {
+          logins.add(login.trim().toLowerCase());
+        }
+      }
+
+      if (items.length < SEARCH_PER_PAGE) break;
+    }
+
+    return Array.from(logins);
+  } catch (error) {
+    logger.warn("GitHub sports-hack submission PR search error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+const cachedSubmissionAuthors = unstable_cache(
+  fetchSportsHack2026SubmissionAuthorsUncached,
+  ["fetchSportsHack2026SubmissionAuthors"],
+  { revalidate: 60, tags: [SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG] },
+);
+
+/**
+ * Cached set of lowercased GitHub logins that have at least one PR (open,
+ * merged, or closed) targeting the submissions branch.
+ *
+ * Returns an empty Set on hard fetch failure so the snapshot still renders —
+ * downstream consumers treat "not in set" as "no submission yet."
+ */
+export async function fetchSportsHack2026SubmissionAuthors(): Promise<
+  Set<string>
+> {
+  const arr = await cachedSubmissionAuthors();
+  return new Set(arr ?? []);
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -133,7 +133,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (222 endpoints)
+## API (223 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -277,6 +277,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     POST   /api/hackathons/events/{eventId}/checkin [Yes] — Admin-only: check a user in to an event
     DELETE /api/hackathons/events/{eventId}/confirm-attendance [Yes] — Withdraw the user's attendance confirmation (keeps signup)
     POST   /api/hackathons/events/{eventId}/confirm-attendance [Yes] — Confirm attendance for an event the user has signed up for
+    POST   /api/hackathons/events/{eventId}/refresh-submissions [Yes] — Admin-only — force-refresh the three-tier submission cache
     DELETE /api/hackathons/events/{eventId}/signup [Yes] — Withdraw the current user's signup
     GET    /api/hackathons/events/{eventId}/signup [Yes] — Public event-signup leaderboard
     PATCH  /api/hackathons/events/{eventId}/signup [Yes] — Update the current user's signup state


### PR DESCRIPTION
## Summary

PR 2 of 4 in the May 26 sports-hack-2026 ranking rework. Stacks on top of #1440 (now merged). Wires the `hasSubmission` flag from a placeholder `false` to a live GitHub query against the submissions branch, and flips the public "Credit seats locked" count to use the new tier semantics.

## What this PR ships

**Live submission-PR detection** — `lib/sports-hack-2026-submission-prs.ts`. Modeled on `lib/github-merged-pr-count.ts`. One paginated Search call:
```
repo:owner/repo is:pr base:sports-hack-2026-submissions
```
Result wrapped in `unstable_cache` (60-second TTL, tag `sports-hack-2026-submission-authors`). Returns lowercased Set of author logins; empty on hard fetch failure (safe-fail).

**buildLeaderboardPayload hookup** — submission authors fetched in parallel with the existing PR-count Promise.all. For three-tier entries, `hasSubmission = !!githubLogin && submissionAuthors.has(login.toLowerCase())`. `creditEligible` becomes `inCreditBand && hasSubmission` — gating credits on actually opening a submission PR, per the user's intent.

**New endpoint** — `POST /api/hackathons/events/[eventId]/refresh-submissions`. Admin-only. `revalidateTag` + `refreshSnapshot` so a freshly-opened submission PR can flip the credit gate without waiting 60s. Gated on `getRankingModelForEvent === "three-tier"` so freeze-model events 404 here.

**Page count switch** — `app/hackathons/sports-hack-2026/page.tsx`:
- "Confirmed attending X / 200" — **no client change** (server already counts Tier A only after PR 1).
- "Credit seats locked X / 119" — switched from `entries.filter(status === "confirmed")` (over-inclusive: that's the top-200 attendance band) to `entries.filter(creditEligible)`. Label updated to "in band + submission opened". Reads `0 / 119` pre-event; ramps as PRs land Tuesday.

**Type extensions** — public/signup/admin TSX `LeaderboardEntry` and signup `me` all get optional `tier / inAttendanceBand / inCreditBand / hasSubmission` so PR 3 can render per-user UI without re-deriving.

## Test plan

- [x] `npm test -- --testPathPatterns=hackathon-leaderboard` → 9/9 pass (new test asserts `hasSubmission` flows through and `creditEligible` follows)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] After merge: hit `POST /api/hackathons/events/sports-hack-2026/refresh-submissions` as admin → verify response shape + that `hasSubmission` is computed for entries with known GitHub logins
- [ ] Pre-event verification: confirm the "Credit seats locked" card reads `0/119` (no submissions yet)
- [ ] Event-day verification: open a throwaway PR into `sports-hack-2026-submissions`, wait 60s or call refresh-submissions, confirm `hasSubmission` and `creditEligible` flip

## Out of scope (PR 3-4)

- PR 3: Render-side migration nudges, tier dividers, cutoff dividers, per-tier badges on signup/admin pages
- PR 4: `scripts/distribute-sports-hack-2026-credits.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)