### PR TITLE
fix(rate-limit): raise oauthCallback ceiling 100 → 1000 (hotfix)

### DIFF
--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -122,7 +122,11 @@ describe('Rate Limiting', () => {
     it('should have oauthCallback configuration', () => {
       expect(rateLimitConfigs.oauthCallback).toBeDefined();
       expect(rateLimitConfigs.oauthCallback.windowMs).toBe(15 * 60 * 1000);
-      expect(rateLimitConfigs.oauthCallback.maxRequests).toBe(100);
+      // Sized for shared-NAT venues. Raised to 1000 on 2026-05-24 after the
+      // previous 100 ceiling saturated at the May 26 event prep (218+
+      // confirmed attendees connecting Discord/GitHub from the same egress).
+      // See lib/rate-limit.ts oauthCallback comment for the full history.
+      expect(rateLimitConfigs.oauthCallback.maxRequests).toBe(1000);
     });
 
     it('should have webhook configuration', () => {

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -250,16 +250,22 @@ export const rateLimitConfigs = {
    * app/api/discord/callback/route.ts and app/api/github/callback/route.ts).
    *
    * Sized for shared-NAT venues. At in-person events (Hult campus on
-   * 2026-05-26 was the trigger for the current value), every attendee
-   * connecting Discord + GitHub hits this from the same egress IP.
-   * The old 10/15min ceiling blew up after ~5 attendees and produced
-   * a wave of "I can't connect my account" reports. 100/15min absorbs
-   * a ~50-person venue with each person connecting both providers
-   * without losing the DoS guardrail.
+   * 2026-05-26 was the trigger), every attendee connecting Discord +
+   * GitHub hits this from the same egress IP.
+   *
+   * History:
+   *   - 10/15min  (original)        — blew up after ~5 attendees, #1430
+   *   - 100/15min (#1430)           — absorbed a ~50-person venue
+   *   - 1000/15min (this commit)    — re-hit on 2026-05-24 with 218+
+   *     confirmed attendees prepping connections two days before the
+   *     event; the previous ceiling saturated again. 1000/15min absorbs
+   *     a ~250-person venue with each user connecting both providers
+   *     AND a couple of retries each, without giving up the DoS
+   *     guardrail. Brute-force protection is unchanged (state cookie).
    */
   oauthCallback: {
     windowMs: 15 * 60 * 1000, // 15 minutes
-    maxRequests: 100, // 100 requests per 15 minutes
+    maxRequests: 1000, // 1000 requests per 15 minutes
   },
   /**
    * Moderate rate limit for incoming webhooks.


### PR DESCRIPTION
## Symptom (right now, T-2 days to May 26)

Discord + GitHub Connect buttons fail with:

> **Too many Discord connect attempts**
> Lots of people on this network connected accounts in the last 15 minutes.

User repro: visit `cursorboston.com/hackathons/sports-hack-2026/signup`, click \"Connect Discord\" or \"Connect GitHub\" — even on a fresh attempt, the callback returns rate-limited.

## Cause

`rateLimitConfigs.oauthCallback` is **100/15min keyed by client IP**. PR #1430 raised this from 10 → 100 thinking it'd handle a ~50-person venue. Today 218+ confirmed attendees are prepping their profiles over the weekend from shared networks — 50 people connecting both Discord + GitHub saturates the bucket, then everyone else lands on \"too many connect attempts\".

Tuesday's event-day load is strictly worse: same network + simultaneous connect-at-the-door spikes.

## Fix

Raise to **1000/15min**. Absorbs a ~250-person venue with both providers + a couple retries each. Brute-force protection is **unchanged** — the actual security on callbacks is the cookie-bound `state` token validated inside `app/api/{discord,github}/callback/route.ts`. The IP rate limit is defense-in-depth.

History block in the code comment now records all three values (10 → 100 → 1000) so the next person has the context.

## Test plan

- [x] `npm test -- --testPathPatterns='rate-limit|oauth|discord/callback|github/callback'` → 89/89 pass
- [x] Test that pinned `maxRequests === 100` updated to assert 1000 with the rationale inline
- [ ] After merge: try Connect Discord on cursorboston.com from a fresh browser session — should redirect to Discord, authorize, return successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)