### PR TITLE
release: develop→main — sports-hack three-tier ranking + OAuth rate-limit hotfix

### DIFF
--- a/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
@@ -634,7 +634,10 @@ describe("Sports Hack 2026 signup page", () => {
     render(<Page />);
 
     expect(await screen.findByText(/Day-of RSVP/i)).toBeInTheDocument();
-    expect(screen.getByText(/Waitlist starts here/i)).toBeInTheDocument();
+    // PR 3 renamed the post-freeze waitlist-start divider to a credit-cutoff
+    // banner with the explicit "Top N credit cutoff" wording. Mock has
+    // creditTopN: 80 so the divider reads "Top 80 credit cutoff".
+    expect(screen.getByText(/Top 80 credit cutoff/i)).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("button", { name: /I'll be late but I'm coming/i }),

--- a/__tests__/app/hackathons/sports-hack-page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-page.test.tsx
@@ -86,8 +86,10 @@ describe("SportsHack2026LandingPage", () => {
     })) as never;
     setAuth();
     render(<SportsHack2026LandingPage />);
-    // Credit seats locked stat shows the rank-frozen confirmed count
-    await waitFor(() => expect(screen.getByText(/2\/50 \(Cursor credit link\)/)).toBeInTheDocument());
+    // Credit seats locked stat now counts entries with creditEligible (under the
+    // three-tier model = inCreditBand && hasSubmission). Label updated to
+    // "(in band + submission opened)" to reflect the new gate.
+    await waitFor(() => expect(screen.getByText(/2\/50 \(in band \+ submission opened\)/)).toBeInTheDocument());
     // Confirmed-attending stat shows the new opt-in count
     expect(screen.getByText(/0\/200 · 60 signed up/)).toBeInTheDocument();
   });
@@ -108,7 +110,7 @@ describe("SportsHack2026LandingPage", () => {
     })) as never;
     setAuth();
     render(<SportsHack2026LandingPage />);
-    await waitFor(() => expect(screen.getByText(/1\/50 \(Cursor credit link\)/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/1\/50 \(in band \+ submission opened\)/)).toBeInTheDocument());
   });
 
   it("renders signed-up CTA with rank when user is in leaderboard", async () => {

--- a/__tests__/lib/hackathon-leaderboard-snapshot.attendance.test.ts
+++ b/__tests__/lib/hackathon-leaderboard-snapshot.attendance.test.ts
@@ -29,6 +29,12 @@ jest.mock("@/lib/github-recent-merged-prs", () => ({
   getGithubRepoPair: jest.fn(() => ({ owner: "test", repo: "repo" })),
 }));
 
+jest.mock("@/lib/sports-hack-2026-submission-prs", () => ({
+  fetchSportsHack2026SubmissionAuthors: jest.fn(async () => new Set<string>()),
+  SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG:
+    "sports-hack-2026-submission-authors",
+}));
+
 jest.mock("@/lib/summer-cohort", () => ({
   SUMMER_COHORT_COLLECTION: "summer_cohort_applications",
 }));
@@ -377,6 +383,55 @@ describe("buildLeaderboardPayload — three-tier ranking (sports-hack-2026)", ()
     // set) for downstream consumers that want to know "did this person get
     // confirmed somehow" without caring about tier.
     expect(a.attendingConfirmed).toBe(true);
+  });
+
+  it("sets hasSubmission for github logins in the submission-authors set", async () => {
+    const subsMod = jest.requireMock("@/lib/sports-hack-2026-submission-prs");
+    subsMod.fetchSportsHack2026SubmissionAuthors = jest.fn(
+      async () => new Set<string>(["submitter"])
+    );
+    installDbMock({
+      signups: [
+        makeSignupDoc("submitter", {
+          attendingConfirmedAt: new Date("2026-05-20"),
+          attendingConfirmedBy: "user",
+        }),
+        makeSignupDoc("non-submitter", {
+          attendingConfirmedAt: new Date("2026-05-21"),
+          attendingConfirmedBy: "user",
+        }),
+      ],
+      users: [
+        {
+          exists: true,
+          id: "submitter",
+          data: () => ({
+            displayName: "submitter",
+            email: "submitter@test.com",
+            github: { login: "submitter" },
+          }),
+        },
+        {
+          exists: true,
+          id: "non-submitter",
+          data: () => ({
+            displayName: "non-submitter",
+            email: "non-submitter@test.com",
+            github: { login: "non-submitter" },
+          }),
+        },
+      ],
+    });
+
+    const payload = await buildLeaderboardPayload(SPORTS);
+    const s = payload.entries.find((e) => e.userId === "submitter")!;
+    const n = payload.entries.find((e) => e.userId === "non-submitter")!;
+    expect(s.hasSubmission).toBe(true);
+    expect(n.hasSubmission).toBe(false);
+    // Credit eligibility = inCreditBand && hasSubmission. Both are Tier A and
+    // inside the cap at small N, so only the submitter is credit-eligible.
+    expect(s.creditEligible).toBe(true);
+    expect(n.creditEligible).toBe(false);
   });
 
   it("freeze-model events ignore the three-tier fields", async () => {

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -122,7 +122,11 @@ describe('Rate Limiting', () => {
     it('should have oauthCallback configuration', () => {
       expect(rateLimitConfigs.oauthCallback).toBeDefined();
       expect(rateLimitConfigs.oauthCallback.windowMs).toBe(15 * 60 * 1000);
-      expect(rateLimitConfigs.oauthCallback.maxRequests).toBe(100);
+      // Sized for shared-NAT venues. Raised to 1000 on 2026-05-24 after the
+      // previous 100 ceiling saturated at the May 26 event prep (218+
+      // confirmed attendees connecting Discord/GitHub from the same egress).
+      // See lib/rate-limit.ts oauthCallback comment for the full history.
+      expect(rateLimitConfigs.oauthCallback.maxRequests).toBe(1000);
     });
 
     it('should have webhook configuration', () => {

--- a/app/api/hackathons/events/[eventId]/refresh-submissions/route.ts
+++ b/app/api/hackathons/events/[eventId]/refresh-submissions/route.ts
@@ -1,0 +1,109 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
+import {
+  getRankingModelForEvent,
+  isHackathonEventSignupId,
+} from "@/lib/hackathon-event-signup";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
+import { SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG } from "@/lib/sports-hack-2026-submission-prs";
+import {
+  checkRateLimit,
+  getClientIdentifier,
+  rateLimitConfigs,
+} from "@/lib/rate-limit";
+// @contracts: hackathonsContract.eventRefreshSubmissions
+import { hackathonsContract } from "@/lib/api-schemas/hackathons";
+
+void hackathonsContract;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = { params: Promise<{ eventId: string }> };
+
+/**
+ * POST /api/hackathons/events/[eventId]/refresh-submissions
+ *
+ * Admin-only force-refresh for the three-tier ranking submission lookup.
+ * The submission-author set is cached for 60s by `unstable_cache`; during
+ * the event a maintainer may want to flip a just-opened PR through to the
+ * `hasSubmission` flag (and the credit-eligibility gate) immediately.
+ *
+ * Steps:
+ *   1. `revalidateTag` the cache so the next read goes back to GitHub.
+ *   2. `refreshSnapshot(eventId)` so the new state is durable in Firestore
+ *      and visible to all future GETs without another GitHub round-trip.
+ *
+ * Gated on `getRankingModelForEvent(eventId) === "three-tier"` — events on
+ * the historical freeze model have no submission detection to refresh and
+ * return 404 here.
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rate = checkRateLimit(
+      `hackathon-event-refresh-submissions:${clientId}`,
+      rateLimitConfigs.hackathonEventSignup,
+    );
+    if (!rate.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rate.retryAfter },
+        { status: 429, headers: { "Retry-After": String(rate.retryAfter || 60) } },
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (await isCurrentIdTokenRevoked(request)) {
+      return NextResponse.json(
+        { error: "Session revoked. Please sign in again." },
+        { status: 401 },
+      );
+    }
+
+    const { eventId: raw } = await context.params;
+    const eventId = raw?.trim() ?? "";
+    if (!isHackathonEventSignupId(eventId)) {
+      return NextResponse.json({ error: "Unknown event" }, { status: 404 });
+    }
+    if (getRankingModelForEvent(eventId) !== "three-tier") {
+      return NextResponse.json(
+        {
+          error:
+            "This event does not use the three-tier ranking model — nothing to refresh.",
+        },
+        { status: 404 },
+      );
+    }
+
+    revalidateTag(SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG, { expire: 0 });
+    const snapshot = await refreshSnapshot(eventId);
+    const submissionCount = snapshot.entries.filter((e) => e.hasSubmission).length;
+
+    return NextResponse.json({
+      ok: true,
+      eventId,
+      submissionAuthorCount: submissionCount,
+      generatedAt: snapshot.generatedAt,
+    });
+  } catch (e) {
+    console.error("[hackathon event refresh-submissions]", e);
+    return NextResponse.json(
+      { error: "Failed to refresh submission cache" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/hackathons/sports-hack-2026/admin/page.tsx
+++ b/app/hackathons/sports-hack-2026/admin/page.tsx
@@ -30,6 +30,13 @@ type SignupEntry = {
   willBeLate?: boolean;
   queuingForSpot?: boolean;
   lumaRegistered?: boolean;
+  // Three-tier ranking model fields (sports-hack-2026). Optional for
+  // back-compat — populated by buildLeaderboardPayload when the event uses
+  // the three-tier model.
+  tier?: "A" | "B" | "C" | null;
+  inAttendanceBand?: boolean;
+  inCreditBand?: boolean;
+  hasSubmission?: boolean;
 };
 
 type SignupData = {

--- a/app/hackathons/sports-hack-2026/page.tsx
+++ b/app/hackathons/sports-hack-2026/page.tsx
@@ -26,6 +26,11 @@ type LeaderboardEntry = {
   rank: number;
   status?: "confirmed" | "waitlisted";
   creditEligible: boolean;
+  /** Three-tier ranking model fields (sports-hack-2026). Optional for back-compat. */
+  tier?: "A" | "B" | "C" | null;
+  inAttendanceBand?: boolean;
+  inCreditBand?: boolean;
+  hasSubmission?: boolean;
 };
 
 type LeaderboardResponse = {
@@ -67,8 +72,13 @@ export default function SportsHack2026LandingPage() {
     void load();
   }, [load]);
 
-  const confirmedCount = data
-    ? data.entries.filter((e) => (e.status ?? (e.creditEligible ? "confirmed" : "waitlisted")) === "confirmed").length
+  // "Credit seats locked" — under the three-tier model this is the count of
+  // entries inside the top-119 credit band that ALSO have an open submission PR.
+  // creditEligible already encodes `inCreditBand && hasSubmission` on the
+  // server side, so use it directly. Pre-event this is zero (nobody has
+  // opened a submission PR yet) and ramps as PRs land on event day.
+  const creditLockedCount = data
+    ? data.entries.filter((e) => e.creditEligible).length
     : null;
   const isAdmin = Boolean((userProfile as { isAdmin?: boolean } | null)?.isAdmin);
 
@@ -119,8 +129,8 @@ export default function SportsHack2026LandingPage() {
               <FactCard
                 label="Credit seats locked"
                 value={
-                  confirmedCount != null && data
-                    ? `${confirmedCount}/${SPORTS_HACK_2026_CAPACITY} (Cursor credit link)`
+                  creditLockedCount != null && data
+                    ? `${creditLockedCount}/${SPORTS_HACK_2026_CAPACITY} (in band + submission opened)`
                     : `Top ${SPORTS_HACK_2026_CAPACITY} get Cursor credit`
                 }
               />

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -657,8 +657,8 @@ function SportsHack2026SignupPageInner() {
                           {meConfirmed
                             ? onWaitlist
                               ? "Confirmed — currently on the waitlist"
-                              : "Confirmed — you're attending"
-                            : "Step 2: Confirm you'll attend"}
+                              : "Confirmed — you're attending (Tier A)"
+                            : "Step 2: Confirm you'll attend — locks in Tier A"}
                         </h2>
                         <p className="mt-1 text-neutral-700 dark:text-neutral-300">
                           {meConfirmed
@@ -667,7 +667,7 @@ function SportsHack2026SignupPageInner() {
                               : myAttendanceRank != null
                                 ? `You're confirmed attendee #${myAttendanceRank} of ${attendanceLimit} guaranteed seats.`
                                 : "Your attendance is confirmed."
-                            : "Claiming a spot reserves your rank. Click below to also confirm you'll be there May 26 — first 200 confirmed by leaderboard rank are guaranteed entry."}
+                            : "Claiming reserves a rank slot. Confirming attendance is the second step — it moves you into Tier A (above everyone who only claimed) and counts toward the pre-event headcount we share with the venue. Top 200 confirmed by rank are guaranteed entry; top 119 are credit-eligible after opening a submission PR."}
                         </p>
                         <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
                           {attendingCount} of {attendanceLimit} confirmed attending site-wide.
@@ -698,6 +698,59 @@ function SportsHack2026SignupPageInner() {
                   </div>
                 );
               })()}
+
+              {/* Tier-A + credit band + no submission = the final UX nudge.
+                  Tells the user they're in the 119-credit band but the credit
+                  itself only unlocks once they open a submission PR. Renders
+                  pre-event with "on event day" framing; same card stays useful
+                  post-event for last-minute submitters. */}
+              {data.me?.tier === "A" &&
+              data.me?.inCreditBand === true &&
+              data.me?.hasSubmission === false ? (
+                <div className="mt-6 rounded-2xl border border-emerald-500/40 bg-emerald-500/5 p-6 dark:bg-emerald-500/10">
+                  <h2 className="font-semibold text-foreground">
+                    You&apos;re in the credit band — finish your submission to unlock it
+                  </h2>
+                  <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">
+                    Your Tier-A rank puts you inside the top {capacity} credit
+                    slots, but a Cursor credit only goes out if you also open a
+                    submission PR. On event day, push a folder named after your
+                    GitHub handle into the{" "}
+                    <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs dark:bg-neutral-800">
+                      sports-hack-2026-submissions
+                    </code>{" "}
+                    branch with a <code className="rounded bg-neutral-200 px-1 py-0.5 text-xs dark:bg-neutral-800">meta.json</code>{" "}
+                    (title, description, videoUrl, repoUrl, deployedUrl).
+                  </p>
+                  <p className="mt-3 text-sm">
+                    <a
+                      href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/main/sports-hack-2026-submissions/README.md"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-emerald-700 underline hover:text-emerald-600 dark:text-emerald-400"
+                    >
+                      Submission template + field reference →
+                    </a>
+                  </p>
+                </div>
+              ) : null}
+
+              {/* Tier-A + credit band + submission opened — confirmation card. */}
+              {data.me?.tier === "A" &&
+              data.me?.inCreditBand === true &&
+              data.me?.hasSubmission === true ? (
+                <div className="mt-6 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-6 dark:bg-emerald-500/15">
+                  <h2 className="font-semibold text-foreground">
+                    Credit-eligible ✓ Submission detected
+                  </h2>
+                  <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">
+                    Tier A · in the top-{capacity} credit band · submission PR
+                    detected. You&apos;re locked in for a Cursor credit code,
+                    assuming your submission stays open through the 4 PM ET
+                    deadline.
+                  </p>
+                </div>
+              ) : null}
 
               {/* Pre-freeze info card (replaces the day-of RSVP controls until a real confirmed/waitlist split exists) */}
               {preFreeze ? (
@@ -1123,9 +1176,17 @@ function SportsHack2026SignupPageInner() {
                       // Post-freeze: divide between confirmed/waitlisted as the API reports.
                       const inTopN = row.rank <= data.creditTopN;
                       const prevInTopN = prev ? prev.rank <= data.creditTopN : false;
-                      const showWaitlistDivider = preFreeze
+                      const showCreditCutoffDivider = preFreeze
                         ? !inTopN && prevInTopN
                         : status === "waitlisted" && prevStatus === "confirmed";
+
+                      // Three-tier model dividers (sports-hack-2026). Render at
+                      // the first row of each tier transition so the visual
+                      // ladder A → B → C is unmistakable.
+                      const showTierAtoBDivider = row.tier === "B" && prev?.tier === "A";
+                      const showTierBtoCDivider = row.tier === "C" && prev?.tier === "B";
+                      const showTierAtoCDivider =
+                        row.tier === "C" && prev?.tier === "A"; // no Tier B people at all
 
                       const rowHighlight = preFreeze
                         ? inTopN
@@ -1135,22 +1196,57 @@ function SportsHack2026SignupPageInner() {
                           ? "bg-emerald-500/5 dark:bg-emerald-500/10"
                           : "";
 
-                      const tier = preFreeze ? getSportsHack2026RankTier(row.rank) : null;
+                      const rankTier = preFreeze ? getSportsHack2026RankTier(row.rank) : null;
+                      const engagementTier = row.tier ?? null;
 
                       return (
                         <React.Fragment key={row.userId ?? `luma-${row.rank}`}>
-                          {showWaitlistDivider && (
+                          {showTierAtoBDivider && (
                             <tr>
                               <td
                                 colSpan={5}
                                 className="px-4 py-3 bg-amber-500/10 dark:bg-amber-500/20 border-t-2 border-amber-500/30"
                               >
-                                <div className="flex items-center gap-2">
+                                <div className="flex flex-wrap items-center gap-2">
                                   <span className="text-sm font-bold text-amber-700 dark:text-amber-400">
-                                    {preFreeze ? `Below the top-${data.creditTopN} cut` : "Waitlist starts here"}
+                                    Tier B starts here
                                   </span>
                                   <span className="text-xs text-amber-600 dark:text-amber-500">
-                                    — merge PRs to the community repo to climb into the top {data.creditTopN}
+                                    — claimed but haven&apos;t confirmed attendance. Click &ldquo;Confirm attendance&rdquo; on your signup card to move into Tier A.
+                                  </span>
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                          {(showTierBtoCDivider || showTierAtoCDivider) && (
+                            <tr>
+                              <td
+                                colSpan={5}
+                                className="px-4 py-3 bg-neutral-200/60 dark:bg-neutral-800/60 border-t-2 border-neutral-300 dark:border-neutral-700"
+                              >
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span className="text-sm font-bold text-neutral-700 dark:text-neutral-300">
+                                    Tier C starts here
+                                  </span>
+                                  <span className="text-xs text-neutral-600 dark:text-neutral-400">
+                                    — Luma/Partiful RSVP only, no website claim. Sign in and claim a spot to enter the active ranking.
+                                  </span>
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                          {showCreditCutoffDivider && (
+                            <tr>
+                              <td
+                                colSpan={5}
+                                className="px-4 py-3 bg-rose-500/10 dark:bg-rose-500/20 border-t-2 border-rose-500/30"
+                              >
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span className="text-sm font-bold text-rose-700 dark:text-rose-400">
+                                    Top {data.creditTopN} credit cutoff
+                                  </span>
+                                  <span className="text-xs text-rose-600 dark:text-rose-500">
+                                    — only the top {data.creditTopN} ranked attendees are eligible for a Cursor credit (after opening a submission PR).
                                   </span>
                                 </div>
                               </td>
@@ -1189,12 +1285,33 @@ function SportsHack2026SignupPageInner() {
                             </td>
                             <td className="px-4 py-3">
                               <div className="flex flex-col gap-1 items-start">
-                                {tier ? (
+                                {engagementTier === "A" ? (
                                   <span
-                                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${TONE_PILL_CLASS[tier.tone]}`}
-                                    title={tier.detail}
+                                    className="inline-flex items-center rounded-full bg-emerald-500/15 border border-emerald-500/40 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-300"
+                                    title="Tier A — claimed and user-confirmed attendance"
                                   >
-                                    {tier.label}
+                                    Tier A · confirmed
+                                  </span>
+                                ) : engagementTier === "B" ? (
+                                  <span
+                                    className="inline-flex items-center rounded-full bg-amber-500/15 border border-amber-500/40 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-300"
+                                    title="Tier B — claimed a spot but hasn't clicked Confirm Attendance"
+                                  >
+                                    Tier B · claimed
+                                  </span>
+                                ) : engagementTier === "C" ? (
+                                  <span
+                                    className="inline-flex items-center rounded-full bg-neutral-300/40 border border-neutral-400/40 px-2 py-0.5 text-xs font-semibold text-neutral-700 dark:bg-neutral-700/40 dark:text-neutral-300"
+                                    title="Tier C — external Luma/Partiful RSVP only, no website signup"
+                                  >
+                                    Tier C · RSVP only
+                                  </span>
+                                ) : rankTier ? (
+                                  <span
+                                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${TONE_PILL_CLASS[rankTier.tone]}`}
+                                    title={rankTier.detail}
+                                  >
+                                    {rankTier.label}
                                   </span>
                                 ) : status === "confirmed" ? (
                                   <span className="inline-flex items-center rounded-full bg-emerald-500/10 border border-emerald-500/30 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
@@ -1205,10 +1322,18 @@ function SportsHack2026SignupPageInner() {
                                     Waitlist
                                   </span>
                                 )}
+                                {row.hasSubmission ? (
+                                  <span
+                                    className="inline-flex items-center rounded-full bg-emerald-500/15 border border-emerald-500/40 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-300"
+                                    title="A submission PR has been opened on this attendee's GitHub login"
+                                  >
+                                    ✓ Submitted
+                                  </span>
+                                ) : null}
                                 {row.isCohort1 ? (
                                   <span
                                     className="inline-flex items-center rounded-full border border-violet-500/30 bg-violet-500/10 px-2 py-0.5 text-xs font-semibold text-violet-700 dark:text-violet-400"
-                                    title="Summer Cohort 1 applicant — prioritized in the May 26 immersion ranking"
+                                    title="Summer Cohort 1 applicant (informational — cohort-1 boost was removed from the May 26 ranking)"
                                   >
                                     Cohort 1
                                   </span>

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -86,6 +86,12 @@ type LeaderboardEntry = {
   attendingConfirmed?: boolean;
   attendingConfirmedAt?: string | null;
   attendanceRank?: number | null;
+  // Three-tier ranking model fields (sports-hack-2026). Optional for
+  // back-compat with old snapshots and freeze-model events.
+  tier?: "A" | "B" | "C" | null;
+  inAttendanceBand?: boolean;
+  inCreditBand?: boolean;
+  hasSubmission?: boolean;
 };
 
 type LeaderboardResponse = {
@@ -108,6 +114,10 @@ type LeaderboardResponse = {
     attendingConfirmed?: boolean;
     attendingConfirmedAt?: string | null;
     attendanceRank?: number | null;
+    tier?: "A" | "B" | "C" | null;
+    inAttendanceBand?: boolean;
+    inCreditBand?: boolean;
+    hasSubmission?: boolean;
   } | null;
 };
 

--- a/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/jonathanlittel.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "jonathanlittel",
+  "name": "Jon Littel",
+  "photoUrl": "https://avatars.githubusercontent.com/jonathanlittel",
+  "repoUrl": "https://github.com/jonathanlittel/cursor-boston/tree/c1w2-comms/projects/c1w2-comms",
+  "liveUrl": "https://cursochat.vercel.app",
+  "loomUrl": "https://www.loom.com/share/placeholder-update-before-submit",
+  "pitch": "Three channels. The electronic version of sticky notes on a fridge.",
+  "competeForWin": false
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**185 paths, 222 operations across 35 areas.**
+**186 paths, 223 operations across 35 areas.**
 
 ---
 
@@ -211,6 +211,7 @@ _Hackathon pool, teams, submissions, and Hack-a-Sprint showcase._
 | POST | `/api/hackathons/events/{eventId}/checkin` | Yes | Admin-only: check a user in to an event |
 | DELETE | `/api/hackathons/events/{eventId}/confirm-attendance` | Yes | Withdraw the user's attendance confirmation (keeps signup) |
 | POST | `/api/hackathons/events/{eventId}/confirm-attendance` | Yes | Confirm attendance for an event the user has signed up for |
+| POST | `/api/hackathons/events/{eventId}/refresh-submissions` | Yes | Admin-only — force-refresh the three-tier submission cache |
 | DELETE | `/api/hackathons/events/{eventId}/signup` | Yes | Withdraw the current user's signup |
 | GET | `/api/hackathons/events/{eventId}/signup` | Yes | Public event-signup leaderboard |
 | PATCH | `/api/hackathons/events/{eventId}/signup` | Yes | Update the current user's signup state |

--- a/lib/api-schemas/hackathons.ts
+++ b/lib/api-schemas/hackathons.ts
@@ -254,6 +254,34 @@ export const hackathonsContract = c.router(
         ] as const,
       },
     },
+    eventRefreshSubmissions: {
+      method: "POST",
+      path: "/api/hackathons/events/:eventId/refresh-submissions",
+      pathParams: EventIdParam,
+      summary: "Admin-only — force-refresh the three-tier submission cache",
+      description:
+        "Invalidates the 60s submission-author cache for three-tier events (sports-hack-2026) and rebuilds the leaderboard snapshot so a just-opened submission PR flips an attendee's hasSubmission / creditEligible flags immediately. Returns the post-refresh submission count and the snapshot generation timestamp. 404 for events that don't use the three-tier model.",
+      body: z.object({}).optional(),
+      responses: {
+        200: z.object({
+          ok: z.literal(true),
+          eventId: z.string(),
+          submissionAuthorCount: z.number(),
+          generatedAt: z.string(),
+        }),
+        ...teamGuardedErrors,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "FORBIDDEN",
+          "NOT_FOUND",
+          "RATE_LIMITED",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+
     eventConfirmAttendanceDelete: {
       method: "DELETE",
       path: "/api/hackathons/events/:eventId/confirm-attendance",

--- a/lib/hackathon-leaderboard-snapshot.ts
+++ b/lib/hackathon-leaderboard-snapshot.ts
@@ -37,6 +37,7 @@ import {
 } from "@/lib/hackathon-event-signup";
 import { fetchMergedPrCountsForLogins } from "@/lib/github-merged-pr-count";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { fetchSportsHack2026SubmissionAuthors } from "@/lib/sports-hack-2026-submission-prs";
 import { SUMMER_COHORT_COLLECTION } from "@/lib/summer-cohort";
 
 export const HACKATHON_LEADERBOARD_SNAPSHOTS_COLLECTION =
@@ -298,12 +299,21 @@ export async function buildLeaderboardPayload(
     }
   }
 
-  const [githubMergedByLogin, firestoreMergedCounts] = await Promise.all([
-    fetchMergedPrCountsForLogins(githubLogins, preloadedBulkPrCounts),
-    userIdsWithoutGithub.length > 0
-      ? countMergedCommunityPrsByUserIds(db, userIdsWithoutGithub)
-      : Promise.resolve(new Map<string, number>()),
-  ]);
+  // For three-tier events, fetch the submission-PR author set in parallel
+  // with the PR-count fetches. Returns an empty set for any non-three-tier
+  // event so the rest of the pipeline stays uniform.
+  const wantsSubmissionLookup = getRankingModelForEvent(eventId) === "three-tier";
+
+  const [githubMergedByLogin, firestoreMergedCounts, submissionAuthors] =
+    await Promise.all([
+      fetchMergedPrCountsForLogins(githubLogins, preloadedBulkPrCounts),
+      userIdsWithoutGithub.length > 0
+        ? countMergedCommunityPrsByUserIds(db, userIdsWithoutGithub)
+        : Promise.resolve(new Map<string, number>()),
+      wantsSubmissionLookup
+        ? fetchSportsHack2026SubmissionAuthors()
+        : Promise.resolve(new Set<string>()),
+    ]);
 
   for (const doc of snap.docs) {
     const data = doc.data();
@@ -607,9 +617,9 @@ export async function buildLeaderboardPayload(
       const tier = u._tier;
       const inCreditBand = rank <= creditCap;
       const inAttendanceBand = rank <= attendanceLimit;
-      // hasSubmission is wired in PR 2; default false so the field is present
-      // on every entry from PR 1 onward.
-      const hasSubmission = false;
+      const hasSubmission =
+        u.githubLogin != null &&
+        submissionAuthors.has(u.githubLogin.toLowerCase());
       const attendingConfirmed = u.attendingConfirmedAt != null;
       return {
         rank,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -250,16 +250,22 @@ export const rateLimitConfigs = {
    * app/api/discord/callback/route.ts and app/api/github/callback/route.ts).
    *
    * Sized for shared-NAT venues. At in-person events (Hult campus on
-   * 2026-05-26 was the trigger for the current value), every attendee
-   * connecting Discord + GitHub hits this from the same egress IP.
-   * The old 10/15min ceiling blew up after ~5 attendees and produced
-   * a wave of "I can't connect my account" reports. 100/15min absorbs
-   * a ~50-person venue with each person connecting both providers
-   * without losing the DoS guardrail.
+   * 2026-05-26 was the trigger), every attendee connecting Discord +
+   * GitHub hits this from the same egress IP.
+   *
+   * History:
+   *   - 10/15min  (original)        — blew up after ~5 attendees, #1430
+   *   - 100/15min (#1430)           — absorbed a ~50-person venue
+   *   - 1000/15min (this commit)    — re-hit on 2026-05-24 with 218+
+   *     confirmed attendees prepping connections two days before the
+   *     event; the previous ceiling saturated again. 1000/15min absorbs
+   *     a ~250-person venue with each user connecting both providers
+   *     AND a couple of retries each, without giving up the DoS
+   *     guardrail. Brute-force protection is unchanged (state cookie).
    */
   oauthCallback: {
     windowMs: 15 * 60 * 1000, // 15 minutes
-    maxRequests: 100, // 100 requests per 15 minutes
+    maxRequests: 1000, // 1000 requests per 15 minutes
   },
   /**
    * Moderate rate limit for incoming webhooks.

--- a/lib/sports-hack-2026-submission-prs.ts
+++ b/lib/sports-hack-2026-submission-prs.ts
@@ -1,0 +1,126 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Live GitHub query for submission PRs into the sports-hack-2026 submissions
+ * branch. Modeled on `lib/github-merged-pr-count.ts`: one bulk Search call,
+ * cached via `unstable_cache` so the leaderboard snapshot doesn't pay a
+ * GitHub round-trip on every refresh.
+ *
+ * Cache TTL is short (60s) so newly-opened submission PRs propagate to the
+ * snapshot's `hasSubmission` flag — and to the credit-eligibility gate —
+ * within a minute. Maintainers can force-refresh via
+ * `POST /api/hackathons/events/sports-hack-2026/refresh-submissions` which
+ * revalidates the tag and rebuilds the snapshot.
+ *
+ * Returns lowercased author logins so callers can do a single
+ * `set.has(login.toLowerCase())` check per attendee.
+ */
+import { unstable_cache } from "next/cache";
+import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { fetchWithTimeout } from "@/lib/http-fetch";
+import { logger } from "@/lib/logger";
+import { SPORTS_HACK_2026_SUBMISSIONS_BRANCH } from "@/lib/sports-hack-2026-submissions";
+
+export const SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG =
+  "sports-hack-2026-submission-authors";
+
+const SEARCH_PER_PAGE = 100;
+/** GitHub search caps at 1000 results; 10 pages × 100. */
+const SEARCH_MAX_PAGES = 10;
+
+type SearchIssueItem = {
+  user?: { login?: string } | null;
+};
+
+function searchHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Uncached search for PRs (open + merged + closed) targeting the sports-hack
+ * submissions branch. Returns lowercased author logins as an array of strings
+ * so the result is JSON-serialisable for the next/cache layer.
+ *
+ * Returns `null` on hard failure so callers can leave `hasSubmission` false
+ * without crashing the snapshot build.
+ */
+export async function fetchSportsHack2026SubmissionAuthorsUncached(): Promise<
+  string[] | null
+> {
+  const { owner, repo } = getGithubRepoPair();
+  const q = `repo:${owner}/${repo} is:pr base:${SPORTS_HACK_2026_SUBMISSIONS_BRANCH}`;
+  const headers = searchHeaders();
+  const logins = new Set<string>();
+
+  try {
+    for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
+      const url = new URL("https://api.github.com/search/issues");
+      url.searchParams.set("q", q);
+      url.searchParams.set("per_page", String(SEARCH_PER_PAGE));
+      url.searchParams.set("page", String(page));
+
+      const res = await fetchWithTimeout(url.toString(), {
+        headers,
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        logger.warn("GitHub sports-hack submission PR search failed", {
+          status: res.status,
+          page,
+        });
+        return page === 1 ? null : Array.from(logins);
+      }
+
+      const data = (await res.json()) as { items?: SearchIssueItem[] };
+      const items = data.items ?? [];
+      if (items.length === 0) break;
+
+      for (const item of items) {
+        const login = item.user?.login;
+        if (typeof login === "string" && login.trim()) {
+          logins.add(login.trim().toLowerCase());
+        }
+      }
+
+      if (items.length < SEARCH_PER_PAGE) break;
+    }
+
+    return Array.from(logins);
+  } catch (error) {
+    logger.warn("GitHub sports-hack submission PR search error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+const cachedSubmissionAuthors = unstable_cache(
+  fetchSportsHack2026SubmissionAuthorsUncached,
+  ["fetchSportsHack2026SubmissionAuthors"],
+  { revalidate: 60, tags: [SPORTS_HACK_2026_SUBMISSION_AUTHORS_CACHE_TAG] },
+);
+
+/**
+ * Cached set of lowercased GitHub logins that have at least one PR (open,
+ * merged, or closed) targeting the submissions branch.
+ *
+ * Returns an empty Set on hard fetch failure so the snapshot still renders —
+ * downstream consumers treat "not in set" as "no submission yet."
+ */
+export async function fetchSportsHack2026SubmissionAuthors(): Promise<
+  Set<string>
+> {
+  const arr = await cachedSubmissionAuthors();
+  return new Set(arr ?? []);
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -133,7 +133,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (222 endpoints)
+## API (223 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -277,6 +277,7 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     POST   /api/hackathons/events/{eventId}/checkin [Yes] — Admin-only: check a user in to an event
     DELETE /api/hackathons/events/{eventId}/confirm-attendance [Yes] — Withdraw the user's attendance confirmation (keeps signup)
     POST   /api/hackathons/events/{eventId}/confirm-attendance [Yes] — Confirm attendance for an event the user has signed up for
+    POST   /api/hackathons/events/{eventId}/refresh-submissions [Yes] — Admin-only — force-refresh the three-tier submission cache
     DELETE /api/hackathons/events/{eventId}/signup [Yes] — Withdraw the current user's signup
     GET    /api/hackathons/events/{eventId}/signup [Yes] — Public event-signup leaderboard
     PATCH  /api/hackathons/events/{eventId}/signup [Yes] — Update the current user's signup state

--- a/scripts/distribute-sports-hack-2026-credits.ts
+++ b/scripts/distribute-sports-hack-2026-credits.ts
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Sports Hack 2026 — distribute Cursor credit links to credit-eligible
+ * attendees.
+ *
+ * Eligibility is computed by the three-tier ranking model
+ * (lib/hackathon-leaderboard-snapshot.ts): top SPORTS_HACK_2026_CAPACITY
+ * (119) by rank, gated on `hasSubmission` (a PR was opened against the
+ * sports-hack-2026-submissions branch). The snapshot is already in tier
+ * order (Tier A > B > C, PR count desc within each), so this script just
+ * filters by the precomputed flags — no re-sort, no second source of truth.
+ *
+ * Usage:
+ *   # Print ranked credit-eligible list (no emails, no credit assignment)
+ *   npx tsx scripts/distribute-sports-hack-2026-credits.ts --dry-run
+ *
+ *   # Preview emails with credit links (no send)
+ *   npx tsx scripts/distribute-sports-hack-2026-credits.ts --dry-run --credits credits.json
+ *
+ *   # Send credit emails
+ *   npx tsx scripts/distribute-sports-hack-2026-credits.ts --send --credits credits.json
+ *
+ * `credits.json` format: flat array of redemption URL strings, assigned by
+ * rank order to credit-eligible entries:
+ *   ["https://cursor.com/redeem/abc", "https://cursor.com/redeem/def", ...]
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON; for --send: MAILGUN_API_KEY,
+ * MAILGUN_DOMAIN. UNSUBSCRIBE_SECRET required since 2026-05-22 to mint
+ * unsubscribe tokens.
+ */
+import { readFileSync } from "fs";
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import {
+  SPORTS_HACK_2026_CAPACITY,
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_NAME,
+} from "../lib/sports-hack-2026";
+import {
+  getSnapshotOrRefresh,
+  type LeaderboardEntry,
+} from "../lib/hackathon-leaderboard-snapshot";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const SITE_ORIGIN = process.env.NEXT_PUBLIC_APP_URL || "https://cursorboston.com";
+const CREDIT_AMOUNT = "$50";
+const FROM_ADDRESS = "Roger <roger@cursorboston.com>";
+const SUBMISSIONS_PAGE_URL = `${SITE_ORIGIN.replace(/\/$/, "")}/events/cursor-boston-sports-hack-2026`;
+
+interface RankedEntry {
+  rank: number;
+  userId: string | null;
+  githubLogin: string | null;
+  displayName: string | null;
+  email: string | null;
+  mergedPrCount: number;
+  tier: "A" | "B" | "C" | null;
+  hasSubmission: boolean;
+  inCreditBand: boolean;
+  creditUrl: string | null;
+}
+
+function parseArgs(argv: string[]) {
+  const dryRun = argv.includes("--dry-run");
+  const send = argv.includes("--send");
+  const creditsIdx = argv.indexOf("--credits");
+  const creditsPath = creditsIdx >= 0 ? argv[creditsIdx + 1] ?? null : null;
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  return { dryRun, send, creditsPath };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function resolveEmailsForEntries(
+  db: FirebaseFirestore.Firestore,
+  entries: LeaderboardEntry[],
+): Promise<Map<string, { email: string | null; displayName: string | null }>> {
+  // Two lookup paths:
+  //   1. userId !== null → users/{userId}.email (Tier A and Tier B)
+  //   2. userId === null + githubLogin → reverse-lookup users by github.login
+  //      (covers Tier C registrants who have a Cursor Boston account but
+  //      never claimed a website spot — rare but possible)
+  // The returned map is keyed by a row identifier so we can attach the
+  // result to the right RankedEntry without re-doing the lookup.
+  const out = new Map<string, { email: string | null; displayName: string | null }>();
+
+  const userIds = entries.map((e) => e.userId).filter((u): u is string => Boolean(u));
+  if (userIds.length > 0) {
+    // getAll batches in groups of 500; userIds < 119 always so one call.
+    const refs = userIds.map((id) => db.collection("users").doc(id));
+    const snaps = await db.getAll(...refs);
+    for (const snap of snaps) {
+      if (!snap.exists) continue;
+      const d = snap.data() ?? {};
+      out.set(`uid:${snap.id}`, {
+        email: typeof d.email === "string" ? d.email : null,
+        displayName: typeof d.displayName === "string" ? d.displayName : null,
+      });
+    }
+  }
+
+  const orphanLogins = entries
+    .filter((e) => !e.userId && e.githubLogin)
+    .map((e) => e.githubLogin!.toLowerCase());
+  if (orphanLogins.length > 0) {
+    // One full pass over users to build a login → uid map. This is the only
+    // path that scans the whole collection — kept off the hot path above.
+    const userSnap = await db.collection("users").get();
+    for (const doc of userSnap.docs) {
+      const d = doc.data();
+      const gh =
+        d.github && typeof d.github === "object"
+          ? (d.github as { login?: string }).login
+          : undefined;
+      if (typeof gh === "string" && orphanLogins.includes(gh.toLowerCase())) {
+        out.set(`login:${gh.toLowerCase()}`, {
+          email: typeof d.email === "string" ? d.email : null,
+          displayName: typeof d.displayName === "string" ? d.displayName : null,
+        });
+      }
+    }
+  }
+
+  return out;
+}
+
+function buildCreditEmail(entry: RankedEntry): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const name = escapeHtml(entry.displayName || entry.githubLogin || "there");
+  const firstNameText =
+    (entry.displayName || entry.githubLogin || "there").split(/\s+/)[0] ?? "there";
+  const creditLink = escapeHtml(entry.creditUrl!);
+  const unsubUrl = entry.email ? buildUnsubscribeUrl(entry.email) : "";
+
+  const subject = `Your Cursor credit — ${SPORTS_HACK_2026_NAME} (rank #${entry.rank})`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${name},</p>
+
+<p>Thanks for building with us at the <strong>${escapeHtml(SPORTS_HACK_2026_NAME)}</strong>! You landed at <strong>rank #${entry.rank}</strong> in the credit band${entry.mergedPrCount > 0 ? ` (${entry.mergedPrCount} merged PR${entry.mergedPrCount !== 1 ? "s" : ""} to cursor-boston)` : ""}, and your submission PR was open at the deadline, so you've earned a <strong>${CREDIT_AMOUNT} Cursor credit</strong>.</p>
+
+<p><strong>Redeem your credit here:</strong></p>
+<p><a href="${creditLink}" style="display:inline-block;margin:8px 0;padding:12px 22px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">${creditLink}</a></p>
+
+<p>Public submission board: <a href="${escapeHtml(SUBMISSIONS_PAGE_URL)}">${escapeHtml(SUBMISSIONS_PAGE_URL)}</a></p>
+
+<p>Reply if anything's off, or to share what you built.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+${
+  unsubUrl
+    ? `<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you participated in the Cursor Boston Sports Hack on May 26.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a>
+</p>`
+    : ""
+}
+</body></html>`;
+
+  const text = `Hi ${firstNameText},
+
+Thanks for building with us at the ${SPORTS_HACK_2026_NAME}! You landed at rank #${entry.rank} in the credit band${entry.mergedPrCount > 0 ? ` (${entry.mergedPrCount} merged PR${entry.mergedPrCount !== 1 ? "s" : ""} to cursor-boston)` : ""}, and your submission PR was open at the deadline, so you've earned a ${CREDIT_AMOUNT} Cursor credit.
+
+Redeem your credit here:
+${entry.creditUrl}
+
+Public submission board: ${SUBMISSIONS_PAGE_URL}
+
+Reply if anything's off, or to share what you built.
+
+— Roger
+roger@cursorboston.com
+${unsubUrl ? `\n---\nYou're receiving this because you participated in the Cursor Boston Sports Hack on May 26.\nUnsubscribe: ${unsubUrl}\n` : ""}`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const { dryRun, send, creditsPath } = parseArgs(process.argv.slice(2));
+
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS).",
+    );
+    process.exit(1);
+  }
+
+  let creditUrls: string[] = [];
+  if (creditsPath) {
+    try {
+      const raw = readFileSync(creditsPath, "utf8");
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed) || parsed.some((x) => typeof x !== "string")) {
+        console.error("Credits file must be a JSON array of URL strings.");
+        process.exit(1);
+      }
+      creditUrls = parsed as string[];
+      console.log(`Loaded ${creditUrls.length} credit link(s) from ${creditsPath}`);
+    } catch (e) {
+      console.error(`Cannot read credits file: ${creditsPath}`, e);
+      process.exit(1);
+    }
+  }
+
+  console.log(`Refreshing ${SPORTS_HACK_2026_EVENT_ID} snapshot…`);
+  const snapshot = await getSnapshotOrRefresh(SPORTS_HACK_2026_EVENT_ID);
+  console.log(`Snapshot has ${snapshot.entries.length} entries (generated ${snapshot.generatedAt}).`);
+
+  // Take the credit band (top SPORTS_HACK_2026_CAPACITY by rank), then filter
+  // to entries that have an open submission PR. This is the same filter the
+  // public page renders for "Credit seats locked X/119".
+  const creditBand = snapshot.entries
+    .filter((e) => e.inCreditBand)
+    .slice(0, SPORTS_HACK_2026_CAPACITY);
+  const eligible = creditBand.filter((e) => e.hasSubmission);
+  const missingSubmission = creditBand.filter((e) => !e.hasSubmission);
+
+  console.log(`In credit band (top ${SPORTS_HACK_2026_CAPACITY}): ${creditBand.length}`);
+  console.log(`  Credit-eligible (in band + submission opened): ${eligible.length}`);
+  console.log(`  In band, no submission opened:                ${missingSubmission.length}`);
+
+  // Resolve emails for the eligible set. Two paths (uid lookup primary,
+  // login lookup fallback for Tier C orphans).
+  const emailMap = await resolveEmailsForEntries(db, eligible);
+
+  let creditIdx = 0;
+  const ranked: RankedEntry[] = eligible.map((e) => {
+    const profile =
+      e.userId != null
+        ? emailMap.get(`uid:${e.userId}`)
+        : e.githubLogin
+          ? emailMap.get(`login:${e.githubLogin.toLowerCase()}`)
+          : undefined;
+    const creditUrl = creditIdx < creditUrls.length ? creditUrls[creditIdx]! : null;
+    if (creditUrl) creditIdx++;
+    return {
+      rank: e.rank,
+      userId: e.userId,
+      githubLogin: e.githubLogin,
+      displayName: profile?.displayName ?? e.displayName,
+      email: profile?.email ?? null,
+      mergedPrCount: e.mergedPrCount,
+      tier: e.tier ?? null,
+      hasSubmission: e.hasSubmission,
+      inCreditBand: e.inCreditBand,
+      creditUrl,
+    };
+  });
+
+  // Print the assignment table.
+  const pad = (s: string, n: number) => s.slice(0, n).padEnd(n);
+  console.log(
+    `\n${pad("Rank", 6)} ${pad("Tier", 5)} ${pad("Login", 22)} ${pad("PRs", 4)} ${pad("Email", 32)} ${pad("Credit", 12)}`,
+  );
+  console.log("-".repeat(90));
+  for (const r of ranked) {
+    console.log(
+      `${pad(`#${r.rank}`, 6)} ${pad(r.tier ?? "—", 5)} ${pad(r.githubLogin ?? "—", 22)} ${pad(String(r.mergedPrCount), 4)} ${pad(r.email ?? "—", 32)} ${pad(r.creditUrl ? "ASSIGNED" : "—", 12)}`,
+    );
+  }
+
+  if (missingSubmission.length > 0) {
+    console.log(
+      `\n[info] ${missingSubmission.length} attendee(s) in the credit band did NOT open a submission PR — they forfeit the credit slot:`,
+    );
+    for (const e of missingSubmission) {
+      console.log(`  #${e.rank} ${e.tier ?? "—"} @${e.githubLogin ?? "(no github)"} — ${e.displayName ?? "(no display name)"}`);
+    }
+  }
+
+  if (!creditsPath) {
+    console.log(
+      `\nRanked credit-eligible list exported. Run with --credits <file.json> to pair with redemption URLs.`,
+    );
+    return;
+  }
+
+  if (creditUrls.length < ranked.length) {
+    console.warn(
+      `\n[warn] Only ${creditUrls.length} credit link(s) for ${ranked.length} credit-eligible attendee(s). The last ${ranked.length - creditUrls.length} won't get one.`,
+    );
+  }
+
+  const toSend = ranked.filter((r) => r.email && r.creditUrl);
+  const noEmail = ranked.filter((r) => !r.email && r.creditUrl);
+
+  if (noEmail.length > 0) {
+    console.warn(`\n[warn] ${noEmail.length} ranked credit-eligible attendee(s) have no resolvable email:`);
+    for (const r of noEmail) {
+      console.warn(`  #${r.rank} @${r.githubLogin ?? "(no github)"} — no matching users/{uid}.email or github-login match`);
+    }
+  }
+
+  console.log(`\nWill send ${toSend.length} email(s).`);
+
+  if (dryRun) {
+    const sample = toSend[0];
+    if (sample) {
+      const { subject, html, text } = buildCreditEmail(sample);
+      console.log(`\nSample email to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML (first 800 chars) ---");
+      console.log(html.slice(0, 800));
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log("\n--dry-run: no emails sent.");
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of toSend) {
+    const { subject, html, text } = buildCreditEmail(r);
+    try {
+      await sendEmail({
+        from: FROM_ADDRESS,
+        to: r.email!,
+        subject,
+        html,
+        text,
+      });
+      sent++;
+      console.log(`  [ok] #${r.rank} @${r.githubLogin ?? "—"} → ${r.email}`);
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] #${r.rank} ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Release contents

Fast hotfix release ahead of the May 26 Sports Hack. **Priority: the OAuth rate-limit hotfix** — Discord + GitHub Connect buttons are currently failing in production with "Too many connect attempts" because the previous 100/15min ceiling saturated. This release pushes it to 1000/15min.

### Commits

| Commit | PR | Title | Contributors |
|---|---|---|---|
| `759216db` | #1447 | feat(sports-hack): credit distribution script (PR 4/4) | @Ludwitt |
| `b8e775d0` | #1448 | feat(sports-hack): three-tier signup-page UX (PR 3/4) | @Ludwitt |
| `da1dc35a` | #1449 | **fix(rate-limit): raise oauthCallback ceiling 100 → 1000 (hotfix)** | @Ludwitt |
| `0ff1e937` | #1445 | feat(sports-hack): submission detection + count switches (PR 2/4) | @Ludwitt |
| `ce090dd6` | #1444 | chore(summer-cohort): promote c1w2comms jonathanlittel submission to develop | @jonathanlittel (submission), @Ludwitt (promotion) |

### What this unlocks in production

1. **OAuth Connect works again.** Users hitting "Too many Discord/GitHub connect attempts" at shared-network venues will succeed. Brute-force protection is unchanged (state-token cookie).
2. **Sports Hack 2026 ranking is now the three-tier engagement model** end-to-end:
   - Tier A (claimed + user-confirmed) → Tier B (claimed only) → Tier C (Luma/Partiful RSVP only)
   - Within each tier: PR-count desc, signup-time asc. No cohort-1 boost.
   - Credit gate: top 119 AND has-open-submission-PR (live GitHub query, 60s cache).
   - Door list: top 200 by tier order.
3. **Live signup page UX:** tier dividers, credit-cutoff divider, Tier-A migration cards ("you claimed but haven't confirmed", "finish your submission to unlock the credit"), per-row Tier A/B/C + ✓ Submitted badges.
4. **Public landing page:** "Confirmed attending X/200" counts Tier A only (proactive confirms, pre-event headcount); "Credit seats locked X/119" counts entries that are both inCreditBand and hasSubmission.
5. **`scripts/distribute-sports-hack-2026-credits.ts`** ready for Tuesday afternoon — reads the snapshot, filters to credit-eligible, pairs with a maintainer-supplied `credits.json`, sends Mailgun emails.

### Already-applied prod data step
`scripts/backfill-attending-confirmed-by.ts --write --event=sports-hack-2026` was run at 14:55Z today, tagging the 13 existing confirms with `attendingConfirmedBy: "user"` so they correctly land in Tier A under the new model.

### Risk
- OAuth rate-limit raise: low (defense-in-depth ceiling, security unchanged)
- Three-tier ranking: medium (large surface area, but all four PRs hit CI green on develop and the snapshot lib branches per-event so hack-a-sprint-2026 stays on the freeze model byte-identical)
- Submission detection: low (live GitHub query with 60s cache; safe-fails to empty set)
- Credit distribution script: zero in this release (no entry points wired; intentional manual run Tuesday)

### Test plan
- [x] CI green on each individual PR (#1445, #1448, #1449 all merged with full green CI; #1447 merged after tests + E2E green, Build was in progress at admin-merge time)
- [ ] Post-deploy: verify the OAuth Connect button on cursorboston.com/hackathons/sports-hack-2026/signup goes through end-to-end
- [ ] Post-deploy: verify the public page reads "Credit seats locked: 0/119" (currently 200/119)
- [ ] Post-deploy: verify hack-a-sprint-2026 leaderboard renders unchanged (freeze-model regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)