### PR TITLE
fix(oauth): callbacks degrade-instead-of-deny on Upstash unavailability (hotfix #2)

### DIFF
--- a/app/api/discord/callback/route.ts
+++ b/app/api/discord/callback/route.ts
@@ -163,12 +163,20 @@ async function handleDiscordCallback(request: NextRequest) {
 // redirect to the originating page with `?discord=error&message=rate_limited`
 // instead of returning JSON 429 — see lib/oauth-errors.ts for the
 // matching client-side copy.
+//
+// `failMode: "degrade"` (was "closed" through 2026-05-24): if Upstash is
+// unreachable we fall back to the per-instance in-memory rate limiter
+// instead of denying every callback. Production tripped fail-closed all
+// afternoon when Upstash flapped — every OAuth user got
+// `?discord=error&message=rate_limited` even though no real rate limit had
+// been hit. Brute-force protection on the callback is the cookie-bound
+// `state` token; the rate limit is purely defense-in-depth.
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
   handleDiscordCallback,
   {
     distributed: true,
-    failMode: "closed",
+    failMode: "degrade",
     onRateLimitDenied: (request) => {
       const returnTo = sanitizeReturnTo(
         request.cookies.get("discord_oauth_return_to")?.value

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -154,12 +154,20 @@ async function handleGitHubCallback(request: NextRequest) {
 // redirect to the originating page with `?github=error&message=rate_limited`
 // instead of returning JSON 429 — see lib/oauth-errors.ts for the
 // matching client-side copy.
+//
+// `failMode: "degrade"` (was "closed" through 2026-05-24): if Upstash is
+// unreachable we fall back to the per-instance in-memory rate limiter
+// instead of denying every callback. Production tripped fail-closed all
+// afternoon when Upstash flapped — every OAuth user got
+// `?github=error&message=rate_limited` even though no real rate limit had
+// been hit. Brute-force protection on the callback is the cookie-bound
+// `state` token; the rate limit is purely defense-in-depth.
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
   handleGitHubCallback,
   {
     distributed: true,
-    failMode: "closed",
+    failMode: "degrade",
     onRateLimitDenied: (request, result) => {
       const returnTo = sanitizeReturnTo(
         request.cookies.get("github_oauth_return_to")?.value


### PR DESCRIPTION
## TL;DR

**Real cause of \"no one can connect Discord/GitHub\" is NOT the ceiling.** It's Upstash Redis returning `rate_limit_unavailable` on every callback, combined with `failMode: \"closed\"` denying everything in that case.

The earlier hotfix #1449 (100 → 1000) was the wrong knob. Even one request gets denied when the limiter is broken, regardless of ceiling.

This PR switches both OAuth callbacks to `failMode: \"degrade\"` so a broken Upstash falls back to the per-instance in-memory limiter instead of denying. DoS protection preserved; the real brute-force protection on these callbacks is the cookie-bound `state` token, not the IP rate limit.

## Evidence

`vercel logs --environment production --query github` shows the same pattern over the last 2h:

```
[WARN] GitHub OAuth rate-limit denied {"endpoint":"/api/github/callback","reason":"rate_limit_unavailable"}
[INFO] API Request {"method":"GET","path":"/api/github/callback","statusCode":307,"ip":"73.143.70.159", ...}
[WARN] GitHub OAuth rate-limit denied {"endpoint":"/api/github/callback","reason":"rate_limit_unavailable"}
[INFO] API Request {... "ip":"108.26.179.159", ...}
[WARN] GitHub OAuth rate-limit denied {"endpoint":"/api/github/callback","reason":"rate_limit_unavailable"}
[INFO] API Request {... "ip":"76.23.243.97", ...}
```

Different IPs, same denial reason — not shared-NAT saturation, **Upstash side**.

## Change

```diff
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
   handleDiscordCallback,
   {
     distributed: true,
-    failMode: \"closed\",
+    failMode: \"degrade\",
     ...
```

Same in `app/api/github/callback/route.ts`.

`failMode: \"degrade\"` (lib/upstash-rate-limit.ts:111-117) falls through to the per-instance `checkRateLimit` (in-memory). Single-instance bursts are still bounded; cross-instance bursts pass — but the actual security on these routes is the cookie-bound `state` token, not the IP ceiling.

## Out of scope (next item to investigate)
- WHY is Upstash failing. Could be: UPSTASH_REDIS_REST_URL / _TOKEN env vars missing or wrong in prod, billing/quota issue on the Upstash account, or transient outage. Need to follow up after the user-facing fix lands.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --testPathPatterns='discord/callback|github/callback|rate-limit|middleware|upstash'` → 116/116 pass
- [ ] After merge + release to main: click Connect Discord on production with a fresh browser session → expect Discord auth flow to complete, redirect back with the connection saved (no more `?discord=error&message=rate_limited`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)