### PR TITLE
release: develop→main — hotfix #2 (OAuth failMode degrade)

### DIFF
--- a/app/api/discord/callback/route.ts
+++ b/app/api/discord/callback/route.ts
@@ -163,12 +163,20 @@ async function handleDiscordCallback(request: NextRequest) {
 // redirect to the originating page with `?discord=error&message=rate_limited`
 // instead of returning JSON 429 — see lib/oauth-errors.ts for the
 // matching client-side copy.
+//
+// `failMode: "degrade"` (was "closed" through 2026-05-24): if Upstash is
+// unreachable we fall back to the per-instance in-memory rate limiter
+// instead of denying every callback. Production tripped fail-closed all
+// afternoon when Upstash flapped — every OAuth user got
+// `?discord=error&message=rate_limited` even though no real rate limit had
+// been hit. Brute-force protection on the callback is the cookie-bound
+// `state` token; the rate limit is purely defense-in-depth.
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
   handleDiscordCallback,
   {
     distributed: true,
-    failMode: "closed",
+    failMode: "degrade",
     onRateLimitDenied: (request) => {
       const returnTo = sanitizeReturnTo(
         request.cookies.get("discord_oauth_return_to")?.value

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -154,12 +154,20 @@ async function handleGitHubCallback(request: NextRequest) {
 // redirect to the originating page with `?github=error&message=rate_limited`
 // instead of returning JSON 429 — see lib/oauth-errors.ts for the
 // matching client-side copy.
+//
+// `failMode: "degrade"` (was "closed" through 2026-05-24): if Upstash is
+// unreachable we fall back to the per-instance in-memory rate limiter
+// instead of denying every callback. Production tripped fail-closed all
+// afternoon when Upstash flapped — every OAuth user got
+// `?github=error&message=rate_limited` even though no real rate limit had
+// been hit. Brute-force protection on the callback is the cookie-bound
+// `state` token; the rate limit is purely defense-in-depth.
 export const GET = withMiddleware(
   rateLimitConfigs.oauthCallback,
   handleGitHubCallback,
   {
     distributed: true,
-    failMode: "closed",
+    failMode: "degrade",
     onRateLimitDenied: (request, result) => {
       const returnTo = sanitizeReturnTo(
         request.cookies.get("github_oauth_return_to")?.value


### PR DESCRIPTION
## Release contents

Single-PR followup to release #1450. **Critical:** the OAuth callbacks were still failing for every user even after #1450 deployed because the real cause was Upstash returning `rate_limit_unavailable`, not the rate-limit ceiling. This release switches the callbacks to `failMode: "degrade"` so the OAuth flow continues working when Upstash is broken.

### Commits

| Commit | PR | Title | Contributor |
|---|---|---|---|
| `2159d525` | #1451 | **fix(oauth): callbacks degrade-instead-of-deny on Upstash unavailability** | @Ludwitt |

### Evidence

Vercel production logs over the past 2h show every OAuth callback failing with `rate_limit_unavailable` (Upstash side) from multiple distinct user IPs. The earlier ceiling raise (100→1000) was the wrong knob.

### Risk
Low. The change strictly reduces the chance of false denials; brute-force protection on the callbacks is the cookie-bound `state` token, which is unchanged.

### Followup (not in this release)
- Diagnose **why** Upstash is failing — env vars / account / quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)