### PR TITLE
release: develop→main — Upstash env-var name fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ docs/*referral*/
 # Event-registration exports — contain attendee PII (email, phone). Live
 # in scripts/data/ as a working dir for one-shot exports; never commit.
 scripts/data/*-registrations-*.csv
+.env*

--- a/lib/upstash-rate-limit.ts
+++ b/lib/upstash-rate-limit.ts
@@ -37,8 +37,16 @@ const DEFAULT_UNAVAILABLE_RETRY_AFTER_SECONDS = 60;
 function getRedis(): Redis | null {
   if (redis) return redis;
 
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  // The Vercel Marketplace Upstash for Redis integration injects
+  // KV_REST_API_URL / KV_REST_API_TOKEN (Vercel's KV convention).
+  // Hand-set Upstash credentials (e.g. local dev where someone created
+  // an Upstash project outside the Vercel integration) use the
+  // UPSTASH_REDIS_REST_* names. Accept both so the same code works
+  // regardless of how the Redis backend was provisioned.
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
 
   if (!url || !token) return null;
 


### PR DESCRIPTION
## Release contents

| Commit | PR | Title | Contributor |
|---|---|---|---|
| `db967a6a` | #1453 | **fix(upstash): also read KV_REST_API_* env vars (Vercel integration naming)** | @Ludwitt |

## Why

The Upstash for Redis Vercel Marketplace integration was installed today and injects credentials as `KV_REST_API_URL`/`KV_REST_API_TOKEN`, but our code was looking for `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN`. This release wires the code to accept both names so the integration's auto-injected vars are picked up.

After deploy, sensitive routes (OAuth callbacks, hackathon mutations, webhooks) will use the distributed Upstash limiter instead of the per-instance in-memory degrade fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)