### PR TITLE
feat(sports-hack): website is source of truth — Luma & Partiful as side-by-side indicators

### DIFF
--- a/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
@@ -1098,7 +1098,7 @@ describe("Sports Hack 2026 signup page", () => {
     });
   });
 
-  it("shows lumaRegistered warning when the user is signed up but not on Luma", async () => {
+  it("does NOT show a Luma warning when the user is signed up but not on Luma (website-first as of 2026-05-24)", async () => {
     const noLumaPayload = {
       ...leaderboardPayload,
       me: { ...leaderboardPayload.me, lumaRegistered: false },
@@ -1117,10 +1117,15 @@ describe("Sports Hack 2026 signup page", () => {
       .default;
     render(<Page />);
 
+    // Wait for the signup card to render so the assertion runs after the page settled.
+    await screen.findByText(/You are signed up/i);
+    // The previous rose "You're not on the Luma list yet / RSVP on Luma now"
+    // warning was removed when the website became the source of truth.
+    // Luma/Partiful presence is now informational only.
+    expect(screen.queryByText(/You're not on the Luma list yet/i)).toBeNull();
     expect(
-      await screen.findByText(/You're not on the Luma list yet/i),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /RSVP on Luma now/i })).toBeInTheDocument();
+      screen.queryByRole("link", { name: /RSVP on Luma now/i }),
+    ).toBeNull();
   });
 
   it("renders the rank tier label for a top-10 user (pre-freeze)", async () => {

--- a/app/api/hackathons/events/[eventId]/signup/route.ts
+++ b/app/api/hackathons/events/[eventId]/signup/route.ts
@@ -64,6 +64,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       willBeLate: boolean;
       queuingForSpot: boolean;
       lumaRegistered: boolean;
+      partifulRegistered: boolean;
       attendingConfirmed: boolean;
       attendingConfirmedAt: string | null;
       attendanceRank: number | null;
@@ -85,6 +86,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             willBeLate: entry.willBeLate,
             queuingForSpot: entry.queuingForSpot,
             lumaRegistered: entry.lumaRegistered,
+            partifulRegistered: entry.partifulRegistered,
             attendingConfirmed: entry.attendingConfirmed,
             attendingConfirmedAt: entry.attendingConfirmedAt,
             attendanceRank: entry.attendanceRank,
@@ -102,6 +104,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             willBeLate: false,
             queuingForSpot: false,
             lumaRegistered: false,
+            partifulRegistered: false,
             attendingConfirmed: false,
             attendingConfirmedAt: null,
             attendanceRank: null,

--- a/app/hackathons/sports-hack-2026/page.tsx
+++ b/app/hackathons/sports-hack-2026/page.tsx
@@ -10,14 +10,12 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
-import { LumaEmbed } from "@/components/hackathons/LumaEmbed";
 import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026EventNav";
 import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
   SPORTS_HACK_2026_LOCATION,
-  SPORTS_HACK_2026_LUMA_EMBED_ID,
   SPORTS_HACK_2026_LUMA_URL,
   SPORTS_HACK_2026_NAME,
 } from "@/lib/sports-hack-2026";
@@ -149,14 +147,6 @@ export default function SportsHack2026LandingPage() {
                   ? `You're signed up${data.me.rank != null ? ` — rank #${data.me.rank}` : ""} · Manage`
                   : "Register on the website"}
               </Link>
-              <a
-                href={SPORTS_HACK_2026_LUMA_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-6 py-3 text-sm font-semibold hover:bg-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-800"
-              >
-                RSVP on Luma →
-              </a>
               {isAdmin ? (
                 <Link
                   href={`/hackathons/${SPORTS_HACK_2026_EVENT_ID}/admin`}
@@ -166,16 +156,23 @@ export default function SportsHack2026LandingPage() {
                 </Link>
               ) : null}
             </div>
-            <p className="mt-3 text-sm text-amber-600 dark:text-amber-400 font-medium">
-              You must register on <strong>both</strong>: Luma (for door entry) <strong>and</strong> the website (for hackathon ranking &amp; prizes). One without the other won&apos;t get you in.
+            <p className="mt-3 text-sm text-emerald-700 dark:text-emerald-400 font-medium">
+              The website is the source of truth — sign up, claim a spot, and confirm
+              attendance here to be on the door list and in the credit-band ranking.
+              {" "}
+              <span className="text-neutral-600 dark:text-neutral-400 font-normal">
+                A Luma or Partiful RSVP shows up next to your name as an interest
+                signal, but only the website list decides who gets in.
+              </span>
             </p>
 
             <div className="mt-10 rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
               <h2 className="text-lg font-semibold">How to win a Cursor credit</h2>
               <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
                 We have <strong>{SPORTS_HACK_2026_CAPACITY} Cursor credit codes</strong>{" "}
-                for participants. Luma approves your registration. Cursor Boston then
-                ranks registrants by merged PRs to the{" "}
+                for participants. The ranking is computed off the website signup list:
+                claim a spot, confirm attendance, and the top{" "}
+                {SPORTS_HACK_2026_CAPACITY} by merged PRs to the{" "}
                 <a
                   href="https://github.com/rogerSuperBuilderAlpha/cursor-boston"
                   target="_blank"
@@ -184,9 +181,9 @@ export default function SportsHack2026LandingPage() {
                 >
                   cursor-boston
                 </a>{" "}
-                community repo, with signup time as the tiebreaker. Top{" "}
-                {SPORTS_HACK_2026_CAPACITY} get a confirmed seat plus a Cursor credit
-                code; the rest join the waitlist. Merge a PR to move up.
+                community repo (signup time as the tiebreaker) land in the credit
+                band. Merge a PR to move up; open a submission PR on event day to
+                unlock the code itself.
               </p>
             </div>
 
@@ -224,22 +221,42 @@ export default function SportsHack2026LandingPage() {
           </div>
 
           <aside className="md:sticky md:top-24 md:self-start">
-            <LumaEmbed
-              embedId={SPORTS_HACK_2026_LUMA_EMBED_ID}
-              title={`${SPORTS_HACK_2026_NAME} — Luma registration`}
-              aspect="square"
-            />
-            <p className="mt-3 text-center text-xs text-neutral-500 dark:text-neutral-400">
-              Powered by{" "}
-              <a
-                href={SPORTS_HACK_2026_LUMA_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline hover:text-emerald-600 dark:hover:text-emerald-400"
+            <div className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                Get on the list
+              </h3>
+              <p className="mt-3 text-sm text-neutral-700 dark:text-neutral-300">
+                <strong>Sign up on the website.</strong> That&apos;s the only thing
+                that puts you on the door list and inside the credit-band ranking.
+              </p>
+              <Link
+                href={`/hackathons/${SPORTS_HACK_2026_EVENT_ID}/signup`}
+                className="mt-4 inline-flex w-full items-center justify-center rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
               >
-                Luma
-              </a>
-            </p>
+                {data?.me?.signedUp ? "Manage your signup" : "Sign up on the website"}
+              </Link>
+
+              <div className="mt-5 border-t border-neutral-200 pt-4 dark:border-neutral-800">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                  External RSVPs (optional)
+                </h4>
+                <p className="mt-2 text-xs text-neutral-600 dark:text-neutral-400">
+                  Already RSVP&apos;d on Luma or Partiful? It shows up next to your
+                  name as an interest indicator — but it does not reserve a spot.
+                  Still need to sign up here.
+                </p>
+                <p className="mt-3 text-xs">
+                  <a
+                    href={SPORTS_HACK_2026_LUMA_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-neutral-500 underline hover:text-emerald-600 dark:text-neutral-400 dark:hover:text-emerald-400"
+                  >
+                    Luma event page →
+                  </a>
+                </p>
+              </div>
+            </div>
           </aside>
         </div>
       </div>

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -47,23 +47,31 @@ const TONE_BANNER_CLASS: Record<SportsHack2026RankTone, string> = {
   far: "border-rose-500/40 bg-rose-500/5 dark:bg-rose-500/10",
 };
 
+// External-RSVP indicators. As of 2026-05-24 the website signup is the
+// source of truth — Luma + Partiful RSVPs are informational only. So both
+// pills are rendered only when present; the absence of a pill carries no
+// negative implication (vs the previous behavior of warning "Not on Luma
+// yet" which is no longer accurate).
 function LumaPill({ registered }: { registered: boolean | undefined }) {
-  if (registered) {
-    return (
-      <span
-        className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400"
-        title="Matched to a registration in the latest Luma export"
-      >
-        ✓ On Luma
-      </span>
-    );
-  }
+  if (!registered) return null;
   return (
     <span
-      className="inline-flex items-center rounded-full border border-rose-500/30 bg-rose-500/10 px-2 py-0.5 text-xs font-semibold text-rose-700 dark:text-rose-400"
-      title="No matching Luma registration found (by email or GitHub login)"
+      className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400"
+      title="Matched to a registration in the latest Luma export"
     >
-      ⚠ Not on Luma yet
+      ✓ On Luma
+    </span>
+  );
+}
+
+function PartifulPill({ registered }: { registered: boolean | undefined }) {
+  if (!registered) return null;
+  return (
+    <span
+      className="inline-flex items-center rounded-full border border-violet-500/30 bg-violet-500/10 px-2 py-0.5 text-xs font-semibold text-violet-700 dark:text-violet-400"
+      title="Matched to a Going RSVP in the latest Partiful export"
+    >
+      ✓ On Partiful
     </span>
   );
 }
@@ -82,6 +90,7 @@ type LeaderboardEntry = {
   willBeLate?: boolean;
   queuingForSpot?: boolean;
   lumaRegistered?: boolean;
+  partifulRegistered?: boolean;
   isCohort1?: boolean;
   attendingConfirmed?: boolean;
   attendingConfirmedAt?: string | null;
@@ -111,6 +120,7 @@ type LeaderboardResponse = {
     willBeLate: boolean;
     queuingForSpot: boolean;
     lumaRegistered: boolean;
+    partifulRegistered?: boolean;
     attendingConfirmed?: boolean;
     attendingConfirmedAt?: string | null;
     attendanceRank?: number | null;
@@ -574,6 +584,7 @@ function SportsHack2026SignupPageInner() {
                             </span>
                           ) : null}
                           <LumaPill registered={data.me?.lumaRegistered} />
+                          <PartifulPill registered={data.me?.partifulRegistered} />
                         </div>
                         {myRank != null && (
                           <p className="mt-1 text-neutral-700 dark:text-neutral-300">
@@ -592,21 +603,15 @@ function SportsHack2026SignupPageInner() {
                             {tier.detail}
                           </p>
                         ) : null}
-                        {data.me && !data.me.lumaRegistered ? (
-                          <p className="mt-3 rounded-lg border border-rose-500/30 bg-rose-500/5 px-3 py-2 text-xs text-rose-700 dark:text-rose-300">
-                            <strong>You&apos;re not on the Luma list yet.</strong>{" "}
-                            Website signup alone won&apos;t get you through the door —{" "}
-                            <a
-                              href={SPORTS_HACK_2026_LUMA_URL}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="underline font-medium"
-                            >
-                              RSVP on Luma now
-                            </a>
-                            .
-                          </p>
-                        ) : null}
+                        {/*
+                          Previously rendered a rose-colored "You're not on the
+                          Luma list yet" warning here. Dropped 2026-05-24 along
+                          with the rest of the Luma-prominence: the website
+                          signup is now the source of truth, so being absent
+                          from Luma is informational, not a problem. Luma /
+                          Partiful pills above still surface presence when it
+                          exists.
+                        */}
                       </div>
                       <div className="flex gap-3 shrink-0">
                         <button
@@ -1339,6 +1344,7 @@ function SportsHack2026SignupPageInner() {
                                   </span>
                                 ) : null}
                                 <LumaPill registered={row.lumaRegistered} />
+                                <PartifulPill registered={row.partifulRegistered} />
                               </div>
                             </td>
                           </tr>

--- a/lib/hackathon-leaderboard-snapshot.ts
+++ b/lib/hackathon-leaderboard-snapshot.ts
@@ -68,7 +68,16 @@ export interface LeaderboardEntry {
   checkedIn: boolean;
   willBeLate: boolean;
   queuingForSpot: boolean;
+  /**
+   * External-RSVP indicators. Sourced from each `hackathonLumaRegistrants`
+   * doc's `rsvpSource` field (written by `sync-may26-partiful-and-luma.ts`
+   * as `"partiful" | "luma" | "partiful+luma"`). Both flags can be true at
+   * the same time when an attendee RSVP'd on both external lists. Per the
+   * 2026-05-24 product call, the public page treats these as interest
+   * signals only — the website signup is the source of truth.
+   */
   lumaRegistered: boolean;
+  partifulRegistered: boolean;
   /** True when the email matches a Cohort-1 application (status pending/admitted). */
   isCohort1: boolean;
   /**
@@ -277,6 +286,7 @@ export async function buildLeaderboardPayload(
     willBeLate: boolean;
     queuingForSpot: boolean;
     lumaRegistered: boolean;
+    partifulRegistered: boolean;
     attendingConfirmedAt: number | null;
     attendingConfirmedBy: "user" | "admin" | null;
   }[] = [];
@@ -350,6 +360,7 @@ export async function buildLeaderboardPayload(
       willBeLate: data.willBeLate === true,
       queuingForSpot: data.queuingForSpot === true,
       lumaRegistered: false, // flipped true below when the Luma loop finds a match
+      partifulRegistered: false, // same — flipped true based on rsvpSource on the matched Luma doc
       attendingConfirmedAt: data.attendingConfirmedAt
         ? signedUpAtToMs(data.attendingConfirmedAt)
         : null,
@@ -406,8 +417,30 @@ export async function buildLeaderboardPayload(
     confirmedAt: number | null;
     frozenRank: number | null;
     frozenPrCount: number | null;
+    lumaRegistered: boolean;
+    partifulRegistered: boolean;
   };
   const lumaRows: LumaRow[] = [];
+
+  // The collection is named `hackathonLumaRegistrants` for historical reasons,
+  // but as of 2026-05-24 it also holds Partiful "Going" rows merged in by
+  // sync-may26-partiful-and-luma.ts. Each doc carries `rsvpSource: "partiful"
+  // | "luma" | "partiful+luma"`. Map that into a pair of booleans so the
+  // signup page can show "On Luma" / "On Partiful" / both as separate
+  // indicators next to each attendee.
+  function readExternalSources(rsvpSource: unknown): {
+    luma: boolean;
+    partiful: boolean;
+  } {
+    if (typeof rsvpSource !== "string") {
+      // Pre-sync-script docs may lack rsvpSource; treat as Luma since that
+      // was the only source historically. Backfilled correctly on the next
+      // sync run.
+      return { luma: true, partiful: false };
+    }
+    const parts = new Set(rsvpSource.split("+").map((s) => s.trim().toLowerCase()));
+    return { luma: parts.has("luma"), partiful: parts.has("partiful") };
+  }
 
   for (const doc of lumaSnap.docs) {
     const d = doc.data();
@@ -415,13 +448,19 @@ export async function buildLeaderboardPayload(
     const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
     if (judgeEmails.has(email) || declinedEmails.has(email)) continue;
 
+    const sources = readExternalSources(d.rsvpSource);
+
     const matchIdx = websiteEmails.has(email)
       ? emailToRowIdx.get(email)
       : (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase()))
         ? ghLoginToRowIdx.get(ghLogin.toLowerCase())
         : undefined;
     if (matchIdx !== undefined) {
-      rows[matchIdx].lumaRegistered = true;
+      // OR-merge — a website user can be on both lists, and each gets
+      // sticky once seen. A second pass with a single-source doc won't
+      // clear a flag set by an earlier pass.
+      if (sources.luma) rows[matchIdx].lumaRegistered = true;
+      if (sources.partiful) rows[matchIdx].partifulRegistered = true;
       if (rows[matchIdx].confirmedAt == null && d.confirmedAt) {
         rows[matchIdx].confirmedAt = signedUpAtToMs(d.confirmedAt);
       }
@@ -447,6 +486,8 @@ export async function buildLeaderboardPayload(
       confirmedAt: d.confirmedAt ? signedUpAtToMs(d.confirmedAt) : null,
       frozenRank: typeof d.frozenRank === "number" ? d.frozenRank : null,
       frozenPrCount: typeof d.frozenPrCount === "number" ? d.frozenPrCount : null,
+      lumaRegistered: sources.luma,
+      partifulRegistered: sources.partiful,
     });
   }
 
@@ -477,6 +518,7 @@ export async function buildLeaderboardPayload(
     willBeLate: boolean;
     queuingForSpot: boolean;
     lumaRegistered: boolean;
+    partifulRegistered: boolean;
     isCohort1: boolean;
     attendingConfirmedAt: number | null;
     attendingConfirmedBy: "user" | "admin" | null;
@@ -501,6 +543,7 @@ export async function buildLeaderboardPayload(
       willBeLate: r.willBeLate,
       queuingForSpot: r.queuingForSpot,
       lumaRegistered: r.lumaRegistered,
+      partifulRegistered: r.partifulRegistered,
       isCohort1: email ? cohort1Emails.has(email) : false,
       attendingConfirmedAt: r.attendingConfirmedAt,
       attendingConfirmedBy: r.attendingConfirmedBy,
@@ -521,7 +564,8 @@ export async function buildLeaderboardPayload(
       checkedInAt: null,
       willBeLate: false,
       queuingForSpot: false,
-      lumaRegistered: true,
+      lumaRegistered: lr.lumaRegistered,
+      partifulRegistered: lr.partifulRegistered,
       isCohort1: email ? cohort1Emails.has(email) : false,
       // Luma-only rows have no website user account, so they cannot click
       // "Confirm attending" on the site. They acquire attendingConfirmedAt
@@ -635,6 +679,7 @@ export async function buildLeaderboardPayload(
         willBeLate: u.willBeLate,
         queuingForSpot: u.queuingForSpot,
         lumaRegistered: u.lumaRegistered,
+        partifulRegistered: u.partifulRegistered,
         isCohort1: u.isCohort1,
         attendingConfirmed,
         attendingConfirmedAt:
@@ -666,6 +711,7 @@ export async function buildLeaderboardPayload(
       willBeLate: u.willBeLate,
       queuingForSpot: u.queuingForSpot,
       lumaRegistered: u.lumaRegistered,
+      partifulRegistered: u.partifulRegistered,
       isCohort1: u.isCohort1,
       attendingConfirmed,
       attendingConfirmedAt:
@@ -753,6 +799,7 @@ export async function readSnapshot(
     willBeLate: e.willBeLate === true,
     queuingForSpot: e.queuingForSpot === true,
     lumaRegistered: e.lumaRegistered === true,
+    partifulRegistered: e.partifulRegistered === true,
     isCohort1: e.isCohort1 === true,
     attendingConfirmed: e.attendingConfirmed === true,
     attendingConfirmedAt:


### PR DESCRIPTION
## Summary

Two shifts requested today:

1. **Public event page stops telling people to register on Luma.** Website signup becomes the source of truth — claim a spot + confirm attendance there to be on the door list and in the credit-band ranking.
2. **Each attendee row shows Luma AND/OR Partiful as separate side-by-side indicator pills** so admins and attendees can see at a glance which external lists someone is on. Previously only Luma was tracked.

## Public page (`app/hackathons/sports-hack-2026/page.tsx`)
- Removed "RSVP on Luma →" secondary CTA
- Replaced amber "must register on both" callout with green website-first copy
- Cleaned "How to win a Cursor credit" — dropped "Luma approves your registration"
- Replaced right-sidebar LumaEmbed iframe with a compact "Get on the list" card whose primary CTA is the website signup; Luma demoted to a footnote under "External RSVPs (optional)"

## Snapshot lib (`lib/hackathon-leaderboard-snapshot.ts`)
- New `partifulRegistered: boolean` field on `LeaderboardEntry`, alongside existing `lumaRegistered`
- Reads each `hackathonLumaRegistrants` doc's `rsvpSource` field (already written today by `sync-may26-partiful-and-luma.ts` as `"partiful" | "luma" | "partiful+luma"`)
- OR-merges the flags onto each row — both can be true simultaneously
- Luma-only synthesized rows now respect actual source (a Partiful-only person no longer shows up as `lumaRegistered: true`)
- `readSnapshot` hydrator defaults `partifulRegistered: false` for old snapshots

## Signup page (`app/hackathons/sports-hack-2026/signup/page.tsx`)
- `LumaPill` collapsed: only renders when `registered === true`. The "⚠ Not on Luma yet" warning was load-bearing under the old "must be on both" model — no longer accurate, removed
- New `PartifulPill` (violet) with the same opt-in render rule
- Both pills appear on each leaderboard row + on the user's own "You are signed up" card
- Removed the rose "You're not on the Luma list yet / RSVP on Luma now" warning from the user's signup card

## API route + tests
- `me` payload extended with `partifulRegistered`
- One existing test inverted: previously asserted the warning showed when `me.lumaRegistered === false`; now asserts the warning does NOT show

## Test plan
- [x] 180/180 tests pass in `sports-hack|hackathon-leaderboard|signup`
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Post-deploy: load `/hackathons/sports-hack-2026` → expect no "RSVP on Luma" button, no "must register on both" callout, sidebar shows "Get on the list" with website CTA
- [ ] Post-deploy: load `/hackathons/sports-hack-2026/signup` → expect leaderboard rows to show emerald "✓ On Luma" + violet "✓ On Partiful" pills (separately or both, depending on what each attendee is on)
- [ ] Spot-check: an attendee with only a Partiful RSVP should show only the Partiful pill (not the Luma one) — previously they'd have been mislabeled as on Luma

🤖 Generated with [Claude Code](https://claude.com/claude-code)