### PR TITLE
docs(reviews): mark ARCHITECTURE.md as shipped (P1-16, DOC-P0-1 ✅)

### DIFF
--- a/docs/DOCUMENTATION_REVIEW.md
+++ b/docs/DOCUMENTATION_REVIEW.md
@@ -30,7 +30,7 @@ Companion to [`OPENSOURCE_REVIEW.md`](OPENSOURCE_REVIEW.md). That review treats 
 
 ### Top 5 gaps (full list at [§ Recommendations](#recommendations))
 
-1. **No `docs/ARCHITECTURE.md`** — flagged in [OPENSOURCE_REVIEW.md P1-16](OPENSOURCE_REVIEW.md#prioritized-backlog) (2026-05-06), still missing. Exemplar: [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md). **P0.**
+1. ~~**No `docs/ARCHITECTURE.md`**~~ — ✅ **RESOLVED 2026-05-18** (commit `67292eb`). 216-line synthesis covering subsystem map, data flow, and deployment topology. Exemplar followed: [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md).
 2. **Issue templates are markdown, not YAML forms.** `bug_report.md` + `feature_request.md` last touched 2026-01-27 (>3 months stale). Compare to [vercel/next.js's YAML forms with dropdowns + required fields](https://github.com/vercel/next.js/tree/canary/.github/ISSUE_TEMPLATE). YAML forms produce more triagable reports. **P1.**
 3. **No docs style guide.** Without one, voice and tone drift as contributors land docs. Compare to [vercel/next.js/contributing/docs/writing-style-guide.md](https://github.com/vercel/next.js/blob/canary/contributing/docs/writing-style-guide.md) (bans "easy"/"just", mandates second-person, lists component vocabulary). **P1.**
 4. **`docs/` is flat — Diátaxis isn't surfaced.** 22 files in one directory; the quadrant mapping lives in `docs/README.md` text rather than folder structure. Compare to [Astro's `docs/src/content/docs/{tutorial,guides,recipes,reference}`](https://github.com/withastro/docs/tree/main/src/content/docs) or [Stripe's four-tab top nav](https://docs.stripe.com/). **P1.**
@@ -157,11 +157,11 @@ REFERENCE — exhaustive facts            EXPLANATION — concept-first prose
 ├── docs/SUPPLY_CHAIN.md (partial)      ├── docs/OPENSOURCE_REVIEW.md
 ├── docs/USER_GUIDE.md                  ├── docs/DOCUMENTATION_REVIEW.md (this file)
 ├── docs/SUBMISSION_BRANCHES.md         ├── docs/generals/LORE.md
-├── docs/BRANCH_PROTECTION.md           ├── .github/GOVERNANCE.md
-├── docs/generals/{UNITS,SPELLS,...}    └── .github/DCO.md
-├── CHANGELOG.md                        
-├── MAINTAINERS.md                      MISSING — explanation quadrant gap
-├── .github/{SECURITY,CODE_OF_CONDUCT,  └── docs/ARCHITECTURE.md
+├── docs/BRANCH_PROTECTION.md           ├── docs/ARCHITECTURE.md (added 2026-05-18)
+├── docs/generals/{UNITS,SPELLS,...}    ├── .github/GOVERNANCE.md
+├── CHANGELOG.md                        └── .github/DCO.md
+├── MAINTAINERS.md
+├── .github/{SECURITY,CODE_OF_CONDUCT,
 │   SUPPORT,TRADEMARK,ACCESSIBILITY,
 │   DESIGN}.md
 └── README.md (partial — also Tutorial)
@@ -180,7 +180,7 @@ REFERENCE — exhaustive facts            EXPLANATION — concept-first prose
 ### Quadrant-vs-quadrant gaps
 
 - **Tutorial quadrant is thin** — only 3 docs. Compare to [Astro's tutorial series](https://docs.astro.build/en/tutorial/0-introduction/) (12-part build-your-first-blog walkthrough). A platform with 9 subsystems warrants ≥1 tutorial per major subsystem (e.g., "build your first community-feature project end-to-end") not just per-role onboarding.
-- **Explanation quadrant lacks `ARCHITECTURE.md`** — 6 ADRs cover individual decisions but no synthesis. Exemplar: [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md) — single page, subsystem map, data flow, deployment topology. **P0 doc gap.**
+- ~~**Explanation quadrant lacks `ARCHITECTURE.md`**~~ — ✅ **RESOLVED 2026-05-18** (`67292eb`). `docs/ARCHITECTURE.md` now provides the synthesis the 6 ADRs lacked: single-page subsystem map, data flow, deployment topology. Modeled on the [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md) exemplar.
 - **Reference quadrant strong but uneven** — `API.md` is current and dense; `docs/generals/*` is exemplary; `DEVELOPMENT.md` mixes reference + how-to.
 
 ---
@@ -299,7 +299,7 @@ Cited in the May review as "the highest-quality contributor onboarding I've seen
 
 | Path | Why | Exemplar |
 |---|---|---|
-| `docs/ARCHITECTURE.md` | Single-page synthesis: subsystem map, data flow (auth → Firestore → API → client), deployment topology. ADRs cover individual decisions; this is the synthesis. | [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md) |
+| ~~`docs/ARCHITECTURE.md`~~ ✅ shipped 2026-05-18 | Single-page synthesis: subsystem map, data flow (auth → Firestore → API → client), deployment topology. ADRs cover individual decisions; this is the synthesis. | [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md) |
 | `ROADMAP.md` (root) | Currently buried in `.github/ACTIVE_ISSUES.md` which is excellent content but non-discoverable. Promote the same content to root `ROADMAP.md` and link it from README's roadmap line. | [TanStack/query roadmap](https://github.com/TanStack/query/discussions/categories/roadmap) |
 | `docs/rfcs/` (folder + README) | Forward-looking proposal flow for substantial changes. ADRs are post-hoc; RFCs are upstream. | [rust-lang/rfcs](https://github.com/rust-lang/rfcs), [reactjs/rfcs](https://github.com/reactjs/rfcs) |
 | `docs/STYLE_GUIDE.md` (or `.github/DOCS_STYLE_GUIDE.md`) | Bans "easy"/"just"/"simply", mandates second-person ("you/your"), defines product vocabulary (Cursor vs Cursor Boston vs the platform), code-block conventions. Without it, voice drifts. | [vercel/next.js/contributing/docs/writing-style-guide.md](https://github.com/vercel/next.js/blob/canary/contributing/docs/writing-style-guide.md) |
@@ -391,7 +391,7 @@ For each Diátaxis quadrant, the specific thing the exemplar does that we don't.
 
 **What Rust does:** the Rustonomicon is a 200-page concept-first explanation of unsafe Rust, deliberately separated from the reference and tutorial. Single purpose: explain hard concepts in narrative prose.
 
-**What we don't:** our explanation quadrant is ADRs + the security post-mortem + LORE.md. Missing: a narrative explanation of *how the platform works at the architecture level* — that's `docs/ARCHITECTURE.md`.
+**What we now have:** our explanation quadrant is ADRs + the security post-mortem + LORE.md + `docs/ARCHITECTURE.md` (added 2026-05-18) — the narrative explanation of *how the platform works at the architecture level*.
 
 ### ADRs → [adr.github.io / MADR](https://adr.github.io/madr/)
 
@@ -421,7 +421,7 @@ Effort estimates: **S** = a few hours, **M** = 1-3 days, **L** = a week+.
 
 | # | Action | File(s) | Effort | Exemplar |
 |---|---|---|---|---|
-| DOC-P0-1 | Write `docs/ARCHITECTURE.md` — single-page synthesis: subsystem map, data flow, deployment topology, cross-links to ADRs. | new `docs/ARCHITECTURE.md` | S | [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md) |
+| DOC-P0-1 | ✅ **DONE 2026-05-18** (`67292eb`). ~~Write `docs/ARCHITECTURE.md` — single-page synthesis: subsystem map, data flow, deployment topology, cross-links to ADRs.~~ | `docs/ARCHITECTURE.md` (216 lines) | S | [supabase/supabase/ARCHITECTURE.md](https://github.com/supabase/supabase/blob/master/ARCHITECTURE.md) |
 | DOC-P0-2 | Rewrite both issue templates as YAML forms with required fields + area dropdown. Re-author and remove the markdown originals. | `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.{md→yml}`; add `3-game-design-proposal.yml` | S | [vercel/next.js/.github/ISSUE_TEMPLATE](https://github.com/vercel/next.js/tree/canary/.github/ISSUE_TEMPLATE) |
 | DOC-P0-3 | Document API.md provenance — add a "How this file is generated" header. If hand-maintained, decide whether to auto-generate (drift risk at 178 paths is high). | `docs/API.md` | S | [Next.js App Router reference](https://nextjs.org/docs/app/api-reference) |
 | DOC-P0-4 | Resolve CHANGELOG / `v0.1.0` tag mismatch — CHANGELOG references a tag `git tag` doesn't show. Either push the tag (see [OPENSOURCE_REVIEW.md P1-12](OPENSOURCE_REVIEW.md#prioritized-backlog)) or amend the CHANGELOG. Currently misleading. | `CHANGELOG.md` or `git tag v0.1.0` | S | [Tailwind CSS releases](https://github.com/tailwindlabs/tailwindcss/releases) |

--- a/docs/OPENSOURCE_REVIEW.md
+++ b/docs/OPENSOURCE_REVIEW.md
@@ -47,7 +47,7 @@ The companion [`DOCUMENTATION_REVIEW.md`](DOCUMENTATION_REVIEW.md) extends Dim 9
 | 6 | Testing, Reliability & Observability | 🔴 RED | 🔴 RED (unchanged) | **No Sentry/OpenTelemetry/Pino/Winston dependencies** (P0-5 still ❌, single highest-leverage open item). Firestore rules tests still 8 cases / 274 lines (P1-11 ❌). No `coverageThreshold` block in jest.config (P1-14 ❌). E2E still smoke-only — 6 specs in `e2e/smoke/` (P1-15 ❌). |
 | 7 | Accessibility & Inclusive UX | 🟡 YELLOW | 🟡 YELLOW (unchanged) | a11y rules still `warn` not `error` (P1-9 ❌); no `@axe-core/playwright` in package.json (P1-10 ❌). |
 | 8 | Release Engineering & Provenance | 🟡 YELLOW | 🟡 YELLOW | Still **0 git tags / 0 GitHub releases** (P1-12 ❌). CHANGELOG references v0.1.0 (2026-01-27) but the tag doesn't exist on the remote — misleading. Sigstore pipeline remains unvalidated. |
-| 9 | Documentation & Onboarding | 🟢 GREEN | 🟢 GREEN | Doc count 60 → 61; freshness sustained. `ARCHITECTURE.md` still missing (P1-16 ❌). See [DOCUMENTATION_REVIEW.md](DOCUMENTATION_REVIEW.md) for the dedicated audit. |
+| 9 | Documentation & Onboarding | 🟢 GREEN | 🟢 GREEN | Doc count 60 → 61; freshness sustained. `ARCHITECTURE.md` shipped 2026-05-18 (P1-16 ✅). See [DOCUMENTATION_REVIEW.md](DOCUMENTATION_REVIEW.md) for the dedicated audit. |
 
 ### Session 1 backlog reconciliation
 
@@ -83,7 +83,7 @@ P0/P1/P2 items from [Session 1 § Prioritized backlog](#prioritized-backlog), wi
 | P1-13 | Sweep 81 `as any` / `as unknown as` | ❌ Regressed | Count: 85 (was 81). Code shipped with new casts faster than old ones were removed. |
 | P1-14 | Raise + enforce Jest coverage thresholds | ❌ | No `coverageThreshold` block in jest config found. |
 | P1-15 | E2E happy-paths (signup, community post, mentorship request, game turn) | ❌ | `e2e/` still has only `smoke/` — 6 specs (auth-pages, hackathons, homepage, legal-pages, navigation, public-pages). No happy-path specs for the four flows. |
-| P1-16 | Write `docs/ARCHITECTURE.md` | ❌ | File does not exist. |
+| P1-16 | Write `docs/ARCHITECTURE.md` | ✅ | Shipped 2026-05-18 (`67292eb`) — 216 lines, subsystem map + data flow + deployment topology. |
 | P1-17 | MAINTAINERS.md lists humans | ✅ | 4 humans listed with roles + dates. |
 | P1-18 | Path-scoped CODEOWNERS | ✅ | `.github/CODEOWNERS` has per-area primaries (Neha → components/analytics; Brad → middleware/sanitize/rate-limit; Aaron → Footer/partners/GET_STARTED/FIRST_CONTRIBUTION; Roger → governance/game). |
 
@@ -196,9 +196,9 @@ For each dimension, the question is: *what does the gold-standard exemplar do he
 
 **What Supabase does:** single-page architectural overview — what each subsystem is, how they connect, where data flows, deployment topology, when to add a new subsystem vs extend an existing one.
 
-**Gap:** No `docs/ARCHITECTURE.md` (P1-16 unchanged). Six ADRs cover individual decisions but no synthesis. Three new substantial subsystems shipped since May (PR Studio, zero-turn gameplay, Armageddon) without ADRs.
+**Gap:** ~~No `docs/ARCHITECTURE.md`~~ ✅ resolved 2026-05-18 (`67292eb`) — 216-line synthesis now present (P1-16 ✅, DOC-P0-1 done). Six ADRs cover individual decisions; `ARCHITECTURE.md` is the synthesis. Three new substantial subsystems shipped since May (PR Studio, zero-turn gameplay, Armageddon) still without ADRs.
 
-**Action:** Write `docs/ARCHITECTURE.md` (DOC-P0-1). Backfill ADR-0007 (account-deletion model) and ADR-0008 (Community Maintainer track).
+**Action:** Backfill ADR-0007 (account-deletion model) and ADR-0008 (Community Maintainer track).
 
 #### Dim 6 — Testing, Reliability & Observability → benchmark vs [Sentry's Next.js integration](https://docs.sentry.io/platforms/javascript/guides/nextjs/) + [tRPC's e2e + coverage gates](https://github.com/trpc/trpc/blob/main/.github/workflows/main.yml)
 
@@ -230,7 +230,7 @@ For each dimension, the question is: *what does the gold-standard exemplar do he
 
 #### Dim 9 — Documentation → benchmark vs [DOCUMENTATION_REVIEW.md](DOCUMENTATION_REVIEW.md)
 
-Handed off to the dedicated companion review. Summary: doc surface is broad and fresh (61 files, ~30 touched in last 30 days), but Diátaxis isn't surfaced in folder structure, no `ARCHITECTURE.md`, no RFC process, issue templates are stale markdown rather than YAML forms, no docs style guide, no All Contributors integration. See DOCUMENTATION_REVIEW.md § Recommendations for the full doc backlog (4 P0, 10 P1, 8 P2).
+Handed off to the dedicated companion review. Summary: doc surface is broad and fresh (61 files, ~30 touched in last 30 days), but Diátaxis isn't surfaced in folder structure, no RFC process, issue templates are stale markdown rather than YAML forms, no docs style guide, no All Contributors integration. (`ARCHITECTURE.md` shipped 2026-05-18.) See DOCUMENTATION_REVIEW.md § Recommendations for the full doc backlog (4 P0, 10 P1, 8 P2).
 
 ### New findings (not in Session 1)
 
@@ -258,7 +258,7 @@ The full executable plan lives in [REVIEW_ACTION_PLAN.md § Phase 5](REVIEW_ACTI
 | Carried | P0-1 — Actual collaborator onboarding (vs paper-only); commit-concentration recovery | M |
 | Carried | P0-2 — Code-Review = 1/10 must move to ≥ 5 (10/20 changesets reviewed) | S (process) |
 | Carried | P0-5 — Sentry + structured logging (REVIEW_ACTION_PLAN.md §2.1 is the runbook) | S-M |
-| New | DOC-P0-1 — Write `docs/ARCHITECTURE.md` | S |
+| New | ~~DOC-P0-1 — Write `docs/ARCHITECTURE.md`~~ ✅ done 2026-05-18 (`67292eb`) | S |
 | New | DOC-P0-2 — Rewrite issue templates as YAML forms | S |
 | New | DOC-P0-3 — Document `API.md` provenance + regen command | S |
 | New | DOC-P0-4 — Resolve CHANGELOG v0.1.0 tag mismatch (push the tag, or amend CHANGELOG) | S |


### PR DESCRIPTION
## Summary

`docs/ARCHITECTURE.md` was added on 2026-05-18 in commit 67292eb (216 lines — subsystem map, data flow, deployment topology), but the two review documents written the same day (`docs/OPENSOURCE_REVIEW.md` and `docs/DOCUMENTATION_REVIEW.md`) were never updated to reflect it. Six days later, they still list the file as missing in several places, which makes the review backlogs misleading for anyone scanning open work.

This PR brings the stale ❌ statuses up to date — no content claims change, only the "still missing" lines.

## Changes

**`docs/OPENSOURCE_REVIEW.md`** (4 spots)
- Dim 9 row in the score table: `❌` → `✅` with commit ref
- P1-16 backlog status: `❌` → `✅` with file size + scope
- Dim 5 narrative ("Gap: No `ARCHITECTURE.md`") marked resolved
- Updated prioritized backlog: DOC-P0-1 entry marked done
- Dim 9 summary line: removed stale "no `ARCHITECTURE.md`" claim

**`docs/DOCUMENTATION_REVIEW.md`** (6 spots)
- Top-5 gaps entry #1 marked resolved
- ASCII quadrant map: moved `ARCHITECTURE.md` from "MISSING" column to Explanation quadrant
- Quadrant-vs-quadrant bullet ("Explanation quadrant lacks…") marked resolved
- Surface-area "Missing — recommend creating" table: ARCHITECTURE row marked shipped
- Rustonomicon comparison narrative updated ("What we now have")
- Recommendations table DOC-P0-1: marked done with commit ref

Session 1 historical findings (lines 625+ in OPENSOURCE_REVIEW.md) are preserved intact — those are a snapshot of the original audit and shouldn't be retconned.

## Test plan

- [x] DCO sign-off included
- [x] Pre-commit GPL-header hook clean
- [x] All ARCHITECTURE.md exemplar links to `supabase/supabase` retained — they document what the doc was modeled on
- [ ] Markdown table cells with \`~~strikethrough~~ ✅\` render as expected in the GitHub diff preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)