### PR TITLE
fix(summer-cohort): default dashboard to active week

### DIFF
--- a/__tests__/app/summer-cohort/page.admitted.test.tsx
+++ b/__tests__/app/summer-cohort/page.admitted.test.tsx
@@ -79,6 +79,10 @@ function setupSummerCohortFetch(intakeCompleted = false) {
 }
 
 describe("summer-cohort page admitted", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     localStorage.clear();
     mockUseAuth.mockReturnValue({
@@ -127,5 +131,26 @@ describe("summer-cohort page admitted", () => {
       expect(screen.queryByText(/Why did you join the program/i)).not.toBeInTheDocument();
       expect(screen.getByText(/You're in! Welcome to Cohort 1/i)).toBeInTheDocument();
     });
+  });
+
+  it("defaults to the current active week tab when intake is completed", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-05-20T15:00:00.000Z"));
+    setupSummerCohortFetch(true);
+
+    const Page = (await import("@/app/summer-cohort/page")).default;
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Status: Admitted/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("tab", { name: /week 2/i })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    expect(
+      screen.getByRole("heading", { name: /Communications Build/i })
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/lib/summer-cohort.test.ts
+++ b/__tests__/lib/summer-cohort.test.ts
@@ -1,4 +1,5 @@
 import {
+  getCurrentCohortTab,
   SUMMER_COHORTS,
   SUMMER_COHORT_COLLECTION,
   SUMMER_COHORT_DEMO_DAY,
@@ -117,5 +118,37 @@ describe("lib/summer-cohort isValidCohortId", () => {
     expect(isValidCohortId(1)).toBe(false);
     expect(isValidCohortId({ id: "cohort-1" })).toBe(false);
     expect(isValidCohortId(["cohort-1"])).toBe(false);
+  });
+});
+
+describe("lib/summer-cohort getCurrentCohortTab", () => {
+  it("returns the active cohort-1 week during a week window", () => {
+    expect(getCurrentCohortTab("cohort-1", new Date("2026-05-20T15:00:00.000Z"))).toBe(
+      "week-2"
+    );
+  });
+
+  it("treats kickoff and deadline boundaries as inclusive", () => {
+    expect(getCurrentCohortTab("cohort-1", new Date("2026-05-25T22:00:00.000Z"))).toBe(
+      "week-3"
+    );
+    expect(getCurrentCohortTab("cohort-1", new Date("2026-05-29T21:00:00.000Z"))).toBe(
+      "week-3"
+    );
+  });
+
+  it("falls back to default tab when outside all windows", () => {
+    expect(getCurrentCohortTab("cohort-1", new Date("2026-05-31T12:00:00.000Z"))).toBe(
+      "week-1"
+    );
+    expect(getCurrentCohortTab("cohort-2", new Date("2026-06-20T12:00:00.000Z"))).toBe(
+      "week-1"
+    );
+  });
+
+  it("supports cohort-2 week routing", () => {
+    expect(getCurrentCohortTab("cohort-2", new Date("2026-07-21T12:00:00.000Z"))).toBe(
+      "week-4"
+    );
   });
 });

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -26,10 +26,10 @@ import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnec
 import { useDiscordConnection } from "@/app/(auth)/profile/_hooks/useDiscordConnection";
 import {
   SUMMER_COHORTS,
-  SUMMER_COHORT_C1_DEFAULT_TAB,
   SUMMER_COHORT_GOAL_PER_COHORT,
   SUMMER_COHORT_IMMERSION,
   SUMMER_COHORT_RETURN_TO,
+  getCurrentCohortTab,
   getPrimarySummerCohort,
   getSummerCohortRuntime,
   isValidCohortId,
@@ -513,15 +513,6 @@ function SummerCohortPageInner() {
     () => Date.now() < new Date("2026-05-23T04:00:00Z").getTime()
   );
 
-  const [activeTab, setActiveTab] = useState<CohortTabId>(
-    SUMMER_COHORT_C1_DEFAULT_TAB
-  );
-  // Tracks the cohorts for which we've already auto-switched the user to the
-  // intake-survey tab on first land. Per-cohort so switching to a different
-  // cohort with its own incomplete survey nudges them once, but a user who
-  // explicitly navigates away within a cohort isn't yanked back.
-  const autoSwitchedToSurveyRef = useRef<Set<SummerCohortId>>(new Set());
-
   // Primary cohort = the user's "home" cohort if they're admitted to one
   // (or both — cohort-1 wins as the active run). Used as the default
   // selection for the top-level cohort switcher.
@@ -538,6 +529,15 @@ function SummerCohortPageInner() {
   const selectedCohort: SummerCohortId = isValidCohortId(urlCohort)
     ? urlCohort
     : primaryCohort ?? "cohort-1";
+
+  const [activeTab, setActiveTab] = useState<CohortTabId>(() =>
+    getCurrentCohortTab(selectedCohort)
+  );
+  // Tracks the cohorts for which we've already auto-switched the user to the
+  // intake-survey tab on first land. Per-cohort so switching to a different
+  // cohort with its own incomplete survey nudges them once, but a user who
+  // explicitly navigates away within a cohort isn't yanked back.
+  const autoSwitchedToSurveyRef = useRef<Set<SummerCohortId>>(new Set());
 
   const openEditDetails = useCallback(() => {
     setEditingDetails(true);
@@ -653,15 +653,21 @@ function SummerCohortPageInner() {
     setActiveTab("intake-survey");
   }, [intakeStatus, application, selectedCohort]);
 
+  // When cohort changes, start from that cohort's currently active week tab.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- cohort switch should reset default week tab
+    setActiveTab(getCurrentCohortTab(selectedCohort));
+  }, [selectedCohort]);
+
   // If the survey was the active tab and the user just submitted it (status
   // flipped to "completed" → tab disappears), snap to the default tab so we
   // don't leave them staring at an empty panel.
   useEffect(() => {
     if (intakeStatus === "completed" && activeTab === "intake-survey") {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- post-submit cleanup
-      setActiveTab(SUMMER_COHORT_C1_DEFAULT_TAB);
+      setActiveTab(getCurrentCohortTab(selectedCohort));
     }
-  }, [intakeStatus, activeTab]);
+  }, [intakeStatus, activeTab, selectedCohort]);
 
   // Handle OAuth callbacks landed on this page.
   useEffect(() => {

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -492,6 +492,32 @@ export const SUMMER_COHORT_C1_WEEK_6 = {
 /** Default tab when an admitted cohort-1 user lands on /summer-cohort. */
 export const SUMMER_COHORT_C1_DEFAULT_TAB = "week-1" as const;
 
+export type SummerCohortWeekTab =
+  | "week-1"
+  | "week-2"
+  | "week-3"
+  | "week-4"
+  | "week-5"
+  | "week-6";
+
+export interface SummerCohortWeekDateWindow {
+  readonly week: 1 | 2 | 3 | 4 | 5 | 6;
+  readonly tab: SummerCohortWeekTab;
+  /** ISO timestamp in UTC for deterministic week routing. */
+  readonly kickoffAt: string;
+  /** ISO timestamp in UTC. Inclusive boundary when present. */
+  readonly deadlineAt?: string;
+}
+
+export const SUMMER_COHORT_C1_WEEK_WINDOWS: readonly SummerCohortWeekDateWindow[] = [
+  { week: 1, tab: "week-1", kickoffAt: "2026-05-11T22:00:00.000Z", deadlineAt: "2026-05-15T21:00:00.000Z" },
+  { week: 2, tab: "week-2", kickoffAt: "2026-05-18T22:00:00.000Z", deadlineAt: "2026-05-22T21:00:00.000Z" },
+  { week: 3, tab: "week-3", kickoffAt: "2026-05-25T22:00:00.000Z", deadlineAt: "2026-05-29T21:00:00.000Z" },
+  { week: 4, tab: "week-4", kickoffAt: "2026-06-01T22:00:00.000Z", deadlineAt: "2026-06-05T21:00:00.000Z" },
+  { week: 5, tab: "week-5", kickoffAt: "2026-06-08T22:00:00.000Z", deadlineAt: "2026-06-12T22:00:00.000Z" },
+  { week: 6, tab: "week-6", kickoffAt: "2026-06-15T22:00:00.000Z", deadlineAt: "2026-06-20T03:59:59.999Z" },
+] as const;
+
 export const SUMMER_COHORT_PHILOSOPHY =
   "The cohort succeeds or fails as a cohort. Goal: every participant lands a job offer. The tools each cohort builds are how they market themselves to hiring partners and the world.";
 
@@ -585,6 +611,15 @@ export const SUMMER_COHORT_C2_WEEK_6 = {
 /** Default tab when an admitted cohort-2 user lands on /summer-cohort. */
 export const SUMMER_COHORT_C2_DEFAULT_TAB = "week-1" as const;
 
+export const SUMMER_COHORT_C2_WEEK_WINDOWS: readonly SummerCohortWeekDateWindow[] = [
+  { week: 1, tab: "week-1", kickoffAt: "2026-06-29T22:00:00.000Z", deadlineAt: "2026-07-03T21:00:00.000Z" },
+  { week: 2, tab: "week-2", kickoffAt: "2026-07-06T22:00:00.000Z", deadlineAt: "2026-07-10T21:00:00.000Z" },
+  { week: 3, tab: "week-3", kickoffAt: "2026-07-13T22:00:00.000Z", deadlineAt: "2026-07-17T21:00:00.000Z" },
+  { week: 4, tab: "week-4", kickoffAt: "2026-07-20T22:00:00.000Z", deadlineAt: "2026-07-24T21:00:00.000Z" },
+  { week: 5, tab: "week-5", kickoffAt: "2026-07-27T22:00:00.000Z", deadlineAt: "2026-07-31T22:00:00.000Z" },
+  { week: 6, tab: "week-6", kickoffAt: "2026-08-03T22:00:00.000Z", deadlineAt: "2026-08-08T03:59:59.999Z" },
+] as const;
+
 // ---------------------------------------------------------------------------
 // Cohort runtime — single accessor that the page + week panels read from so
 // the UI is the same shape for either cohort and only the dates / branches /
@@ -668,4 +703,45 @@ export function getPrimarySummerCohort(
   if (cohorts.includes("cohort-1")) return "cohort-1";
   if (cohorts.includes("cohort-2")) return "cohort-2";
   return null;
+}
+
+const SUMMER_COHORT_DEFAULT_TAB_BY_ID: Readonly<Record<SummerCohortId, SummerCohortWeekTab>> =
+  {
+    "cohort-1": SUMMER_COHORT_C1_DEFAULT_TAB,
+    "cohort-2": SUMMER_COHORT_C2_DEFAULT_TAB,
+  };
+
+const SUMMER_COHORT_WEEK_WINDOWS_BY_ID: Readonly<
+  Record<SummerCohortId, readonly SummerCohortWeekDateWindow[]>
+> = {
+  "cohort-1": SUMMER_COHORT_C1_WEEK_WINDOWS,
+  "cohort-2": SUMMER_COHORT_C2_WEEK_WINDOWS,
+};
+
+/**
+ * Maps a cohort + current time to the active week tab.
+ * Falls back to the cohort's default tab when outside all week windows.
+ */
+export function getCurrentCohortTab(
+  cohortId: SummerCohortId,
+  now: Date = new Date()
+): SummerCohortWeekTab {
+  const windows = SUMMER_COHORT_WEEK_WINDOWS_BY_ID[cohortId];
+  const nowMs = now.getTime();
+
+  for (let index = 0; index < windows.length; index += 1) {
+    const current = windows[index];
+    const startMs = Date.parse(current.kickoffAt);
+    const endMs = current.deadlineAt
+      ? Date.parse(current.deadlineAt)
+      : index < windows.length - 1
+        ? Date.parse(windows[index + 1].kickoffAt) - 1
+        : Number.POSITIVE_INFINITY;
+
+    if (nowMs >= startMs && nowMs <= endMs) {
+      return current.tab;
+    }
+  }
+
+  return SUMMER_COHORT_DEFAULT_TAB_BY_ID[cohortId];
 }


### PR DESCRIPTION
## Summary
- add machine-readable weekly date windows for each summer cohort
- add `getCurrentCohortTab(cohortId, now)` to map current date to active week tab
- update `/summer-cohort` page to default and reset to the current active week while preserving intake-survey override behavior
- add helper and page tests for week selection and boundary behavior

## Test plan
- [x] npm run test -- __tests__/lib/summer-cohort.test.ts __tests__/app/summer-cohort/page.admitted.test.tsx
- [x] npx eslint app/summer-cohort/page.tsx lib/summer-cohort.ts __tests__/lib/summer-cohort.test.ts __tests__/app/summer-cohort/page.admitted.test.tsx
- [x] npm run type-check

Made with [Cursor](https://cursor.com)