### PR TITLE
release: 2026-05-25 (late) — react-is 19 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "qrcode": "^1.5.4",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-is": "^18.3.1",
+        "react-is": "^19.2.6",
         "react-leaflet": "^5.0.0",
         "react-leaflet-cluster": "^4.1.3",
         "react-markdown": "^10.1.0",
@@ -21262,9 +21262,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT"
     },
     "node_modules/react-is-18": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "qrcode": "^1.5.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-is": "^18.3.1",
+    "react-is": "^19.2.6",
     "react-leaflet": "^5.0.0",
     "react-leaflet-cluster": "^4.1.3",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary

Promotes one Dependabot commit from \`develop\` to \`main\`.

## Included PRs

- **#1477** \`deps(deps): Bump react-is from 18.3.1 to 19.2.6\` — @dependabot. Major bump; react-is is a transitive dep (no direct imports in app code), v19 API is mostly stable. Re-merged after #1475 (react 18.2→18.3) cleared the conflict via \`@dependabot recreate\`.

## Local verification

- Skipped per maintainer call — diff is a single transitive-dep version bump. \`npm run build\` and CI on #1477 were both green prior to merge.

## Test plan

- [x] CI on #1477 green: Build, Lint+Typecheck, Test, E2E, CodeQL, Firestore rules, dependency-review
- [ ] Post-merge: keep an eye on pages that use heavy 3rd-party React components (charts, transitions) for any silent regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)