### PR TITLE
fix(hackathon checkin): refresh snapshot after write so UI catches up

### DIFF
--- a/app/api/hackathons/events/[eventId]/checkin/route.ts
+++ b/app/api/hackathons/events/[eventId]/checkin/route.ts
@@ -14,6 +14,7 @@ import {
   hackathonEventSignupDocId,
   isHackathonEventSignupId,
 } from "@/lib/hackathon-event-signup";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
 import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { hackathonsContract } from "@/lib/api-schemas/hackathons";
 
@@ -119,6 +120,13 @@ export async function POST(request: NextRequest, context: RouteContext) {
         attendingConfirmedBy: "admin",
       });
       revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+      // Rebuild the leaderboard snapshot so the admin UI reflects the new
+      // checked-in state on the next read. Without this, the admin sees a
+      // stale "unchecked" row and the checkbox visually flips back even
+      // though Firestore was updated.
+      await refreshSnapshot(eventId).catch((err) =>
+        console.warn("[checkin] refreshSnapshot failed", err),
+      );
       return NextResponse.json({ ok: true, checkedIn: true, created: true });
     }
 
@@ -151,6 +159,12 @@ export async function POST(request: NextRequest, context: RouteContext) {
       await ref.update({ checkedInAt: FieldValue.delete() });
     }
     revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+    // Rebuild the leaderboard snapshot so the admin UI reflects the new
+    // checked-in state on the next read. Mirrors the post-write refresh in
+    // /confirm-attendance.
+    await refreshSnapshot(eventId).catch((err) =>
+      console.warn("[checkin] refreshSnapshot failed", err),
+    );
 
     return NextResponse.json({ ok: true, checkedIn });
   } catch (e) {


### PR DESCRIPTION
## Live hotfix during the May 26 Sports Hack check-in

The admin check-in checkbox doesn't visually persist — the click writes \`checkedInAt\` to Firestore correctly, but the admin UI reads from the cached leaderboard snapshot which doesn't get rebuilt on check-in. Next read returns the stale snapshot and the checkbox flips back to unchecked.

Confirmed during the live event:
- **Leonardo Martins** was correctly checked in at 13:02:23Z in Firestore
- The admin UI continued to show him unchecked until I manually deleted + rebuilt the snapshot doc.

## Fix

Add \`await refreshSnapshot(eventId)\` after both check-in write paths (the walk-in/create branch and the normal update branch). Mirrors the post-write refresh in \`/confirm-attendance/route.ts:128\`.

Wrapped in \`.catch\` so a snapshot rebuild failure doesn't fail the check-in response — the Firestore write is the source of truth.

## Test plan

- [x] Local typecheck clean
- [ ] After merge: admin checks someone in → checkbox stays checked on next read