### PR TITLE
release: hotfix — refresh snapshot after hackathon check-in

### DIFF
--- a/app/api/hackathons/events/[eventId]/checkin/route.ts
+++ b/app/api/hackathons/events/[eventId]/checkin/route.ts
@@ -14,6 +14,7 @@ import {
   hackathonEventSignupDocId,
   isHackathonEventSignupId,
 } from "@/lib/hackathon-event-signup";
+import { refreshSnapshot } from "@/lib/hackathon-leaderboard-snapshot";
 import { checkRateLimit, getClientIdentifier, rateLimitConfigs } from "@/lib/rate-limit";
 import { hackathonsContract } from "@/lib/api-schemas/hackathons";
 
@@ -119,6 +120,13 @@ export async function POST(request: NextRequest, context: RouteContext) {
         attendingConfirmedBy: "admin",
       });
       revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+      // Rebuild the leaderboard snapshot so the admin UI reflects the new
+      // checked-in state on the next read. Without this, the admin sees a
+      // stale "unchecked" row and the checkbox visually flips back even
+      // though Firestore was updated.
+      await refreshSnapshot(eventId).catch((err) =>
+        console.warn("[checkin] refreshSnapshot failed", err),
+      );
       return NextResponse.json({ ok: true, checkedIn: true, created: true });
     }
 
@@ -151,6 +159,12 @@ export async function POST(request: NextRequest, context: RouteContext) {
       await ref.update({ checkedInAt: FieldValue.delete() });
     }
     revalidateTag(HACKATHON_SIGNUP_CACHE_TAG, { expire: 0 });
+    // Rebuild the leaderboard snapshot so the admin UI reflects the new
+    // checked-in state on the next read. Mirrors the post-write refresh in
+    // /confirm-attendance.
+    await refreshSnapshot(eventId).catch((err) =>
+      console.warn("[checkin] refreshSnapshot failed", err),
+    );
 
     return NextResponse.json({ ok: true, checkedIn });
   } catch (e) {


### PR DESCRIPTION
## Live hotfix during the May 26 Sports Hack check-in

Single-commit promotion. Admin check-in checkboxes were visually flipping back because the snapshot didn't rebuild after the Firestore write.

## Included PR

- **#1486** \`fix(hackathon checkin): refresh snapshot after write so UI catches up\` — Roger. Adds \`await refreshSnapshot(eventId)\` to both write paths in \`app/api/hackathons/events/[eventId]/checkin/route.ts\`. Mirrors the existing pattern in \`/confirm-attendance\`. Wrapped in \`.catch\` so a snapshot rebuild failure doesn't fail the check-in — Firestore is the source of truth.

## Local verification

- Typecheck clean.
- Live verified via Firestore that the underlying writes work (Leonardo Martins checkedInAt=2026-05-26T13:02:23Z) — the gap was strictly the snapshot.

## Test plan

- [ ] After deploy: open admin signup page, check someone in, refresh → checkbox stays checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)