### PR TITLE
fix(hackathons): remove rounded corners from Luma iframe wrapper

### DIFF
--- a/app/hackathons/page.tsx
+++ b/app/hackathons/page.tsx
@@ -328,14 +328,13 @@ export default function HackathonsPage() {
                     <p className="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                       Register on Luma
                     </p>
-                    <div className="overflow-hidden rounded-lg">
+                    <div className="overflow-hidden">
                       <iframe
                         src={featuredEmbedSrc}
                         title={`${featuredInPersonHackathon.title} — Luma`}
                         className="h-[min(440px,58vh)] w-full bg-white sm:h-[min(480px,62vh)]"
                         style={{
-                          border: "1px solid #bfcbda88",
-                          borderRadius: 4,
+                          border: "1px solid #bfcbda88"
                         }}
                         allow="fullscreen; payment"
                         frameBorder={0}


### PR DESCRIPTION
## Description
Remove rounded corners from the Luma iframe wrapper on the /hackathons page. The rounded-lg class on the wrapper div and borderRadius: 4 on the iframe's inline style were causing the iframe content's corners to appear clipped/cut-off, since overflow: hidden on the iframe itself cannot clip content rendered inside a cross-origin frame.

**Base branch:** Open PRs against **`develop`** (default). Only release PRs use **`develop` → `main`**.

Fixes # (no issue)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Tested locally

Navigated to /hackathons and confirmed the Luma embed no longer shows clipped corners.

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Screenshots

### Before:
<img width="1512" height="827" alt="Screenshot_2026-05-26_at_10 22 45_AM-b7de5bb6-abb8" src="https://github.com/user-attachments/assets/6d416311-47a1-428f-8628-7b64ac90ce13" />
<img width="453" height="507" alt="Screenshot_2026-05-26_at_10 22 34_AM-6a6b26a9-0612" src="https://github.com/user-attachments/assets/cec4bd83-517a-494d-9254-e9fadfac288e" />

### After:
<img width="462" height="529" alt="Screenshot 2026-05-26 at 10 27 47 AM" src="https://github.com/user-attachments/assets/9a286b86-1f6b-4e99-943d-548bcb6dfaaf" />
<img width="1512" height="828" alt="Screenshot 2026-05-26 at 10 27 56 AM" src="https://github.com/user-attachments/assets/e9081ed8-1770-4b64-8922-3fab19f3301f" />

## Additional Notes
None
