### PR TITLE
refactor(ui): extract shared Modal shell from 5 hand-rolled modals

### DIFF
--- a/app/(auth)/profile/_components/EditProfileModal.tsx
+++ b/app/(auth)/profile/_components/EditProfileModal.tsx
@@ -7,12 +7,12 @@
 
 "use client";
 
-import { useRef, useState, useEffect, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useRef, useState } from "react";
 import Image from "next/image";
 import { User } from "firebase/auth";
 import Avatar from "@/components/Avatar";
 import { FormInput } from "@/components/ui/FormField";
-import { CloseIcon } from "@/components/icons";
+import { Modal } from "@/components/ui/Modal";
 
 interface EditProfileModalProps {
   user: User;
@@ -22,43 +22,11 @@ interface EditProfileModalProps {
 
 export function EditProfileModal({ user, onSave, onClose }: EditProfileModalProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const modalRef = useRef<HTMLDivElement>(null);
   const [editName, setEditName] = useState(user.displayName || "");
   const [selectedPhoto, setSelectedPhoto] = useState<File | null>(null);
   const [photoPreview, setPhotoPreview] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Move focus into modal on mount
-  useEffect(() => {
-    const firstFocusable = modalRef.current?.querySelector<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    firstFocusable?.focus();
-  }, []);
-
-  const handleKeyDown = (e: ReactKeyboardEvent) => {
-    if (e.key === "Escape") {
-      onClose();
-    }
-    if (e.key === "Tab") {
-      const modal = modalRef.current;
-      if (!modal) return;
-      const focusable = modal.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    }
-  };
 
   const handlePhotoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -84,33 +52,20 @@ export function EditProfileModal({ user, onSave, onClose }: EditProfileModalProp
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="edit-profile-title"
-      onKeyDown={handleKeyDown}
+    <Modal
+      isOpen
+      onClose={onClose}
+      size="md"
+      titleId="edit-profile-title"
+      panelScroll={false}
     >
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
-
-      {/* Modal */}
-      <div ref={modalRef} className="relative bg-neutral-900 border border-neutral-800 rounded-2xl p-6 md:p-8 max-w-md w-full shadow-2xl">
-        <button
-          onClick={onClose}
-          className="absolute top-4 right-4 text-neutral-400 hover:text-white transition-colors p-1 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-          aria-label="Close"
-        >
-          <CloseIcon />
-        </button>
-
         <h2 id="edit-profile-title" className="text-xl font-bold text-white mb-6">
           Edit Profile
         </h2>
 
         {/* Photo Upload */}
         <div className="mb-6">
-          <label className="block text-sm font-medium text-neutral-400 mb-3">Profile Photo</label>
+          <label htmlFor="photo-upload" className="block text-sm font-medium text-neutral-400 mb-3">Profile Photo</label>
           <div className="flex items-center gap-4">
             <div className="shrink-0">
               {photoPreview ? (
@@ -170,7 +125,6 @@ export function EditProfileModal({ user, onSave, onClose }: EditProfileModalProp
             {isSaving ? "Saving..." : "Save Changes"}
           </button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/app/summer-cohort/_components/SetupReadinessModal.tsx
+++ b/app/summer-cohort/_components/SetupReadinessModal.tsx
@@ -13,8 +13,8 @@ import {
   CircleAlert,
   ExternalLink,
   Laptop,
-  X,
 } from "lucide-react";
+import { Modal } from "@/components/ui/Modal";
 
 const ALC_URL = "https://ludwitt.com/alc";
 
@@ -69,7 +69,6 @@ export function SetupReadinessModal({
   const [isOpen, setIsOpen] = useState(false);
   const [devEnvSubmitting, setDevEnvSubmitting] = useState(false);
   const [devEnvError, setDevEnvError] = useState<string | null>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleConfirmDevEnv = useCallback(async () => {
     setDevEnvSubmitting(true);
@@ -104,51 +103,15 @@ export function SetupReadinessModal({
     setIsOpen(false);
   }, []);
 
-  useEffect(() => {
-    if (isOpen) {
-      closeButtonRef.current?.focus();
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isOpen]);
-
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen) handleClose();
-    };
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isOpen, handleClose]);
-
-  if (!isOpen) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="setup-readiness-title"
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="lg"
+      titleId="setup-readiness-title"
+      panelScroll={false}
+      closeButtonLabel="Close readiness check"
     >
-      <div
-        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
-        onClick={handleClose}
-        aria-hidden="true"
-      />
-
-      <div className="relative w-full max-w-lg rounded-2xl border border-neutral-800 bg-neutral-900 p-6 shadow-2xl md:p-8">
-        <button
-          ref={closeButtonRef}
-          onClick={handleClose}
-          className="absolute right-4 top-4 rounded-lg p-1 text-neutral-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-          aria-label="Close readiness check"
-        >
-          <X className="h-5 w-5" strokeWidth={2.25} aria-hidden="true" />
-        </button>
-
         <h2
           id="setup-readiness-title"
           className="pr-8 text-xl font-bold text-white md:text-2xl"
@@ -231,8 +194,7 @@ export function SetupReadinessModal({
         >
           I&apos;ll come back to this
         </button>
-      </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/components/ProfileRequirementsModal.tsx
+++ b/components/ProfileRequirementsModal.tsx
@@ -7,11 +7,12 @@
 
 "use client";
 
-import { useState, useEffect, useCallback, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import Link from "next/link";
 import Avatar from "@/components/Avatar";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
+import { Modal } from "@/components/ui/Modal";
 
 export type RequirementType =
   | "isPublic"
@@ -404,8 +405,6 @@ export default function ProfileRequirementsModal({
     }
   };
 
-  if (!isOpen) return null;
-
   // Filter to only show incomplete requirements
   const incompleteRequirements = requirements.filter(
     (req) => !getRequirementStatus(req)
@@ -415,78 +414,29 @@ export default function ProfileRequirementsModal({
   );
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="profile-requirements-title"
-      onKeyDown={(e: ReactKeyboardEvent) => {
-        if (e.key === "Escape") {
-          onClose();
-        }
-        if (e.key === "Tab") {
-          const modal = e.currentTarget.querySelector("[data-modal-content]");
-          if (!modal) return;
-          const focusable = modal.querySelectorAll<HTMLElement>(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-          );
-          if (focusable.length === 0) return;
-          const first = focusable[0];
-          const last = focusable[focusable.length - 1];
-          if (e.shiftKey && document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          } else if (!e.shiftKey && document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
-        }
-      }}
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      titleId="profile-requirements-title"
+      padded={false}
+      panelScroll={false}
+      backdropClassName="bg-black/70 backdrop-blur-sm"
+      className="overflow-hidden"
+      closeButtonLabel="Close modal"
     >
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-        onClick={onClose}
-        aria-hidden="true"
-      />
-
-      {/* Modal */}
-      <div data-modal-content className="relative w-full max-w-lg bg-neutral-900 border border-neutral-800 rounded-2xl shadow-2xl overflow-hidden">
         {/* Header */}
         <div className="p-6 border-b border-neutral-800">
-          <div className="flex items-start justify-between">
-            <div className="flex items-center gap-3">
-              <Avatar
-                src={profile?.photoURL}
-                name={profile?.displayName}
-                size={48}
-              />
-              <div>
-                <h2 id="profile-requirements-title" className="text-xl font-bold text-white">{title}</h2>
-                <p className="text-sm text-neutral-400">{description}</p>
-              </div>
+          <div className="flex items-center gap-3 pr-10">
+            <Avatar
+              src={profile?.photoURL}
+              name={profile?.displayName}
+              size={48}
+            />
+            <div>
+              <h2 id="profile-requirements-title" className="text-xl font-bold text-white">{title}</h2>
+              <p className="text-sm text-neutral-400">{description}</p>
             </div>
-            <button
-              onClick={onClose}
-              className="text-neutral-400 hover:text-white transition-colors p-1 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-              aria-label="Close modal"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
-            </button>
           </div>
         </div>
 
@@ -641,7 +591,6 @@ export default function ProfileRequirementsModal({
             )}
           </div>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/components/SummerCohortModal.tsx
+++ b/components/SummerCohortModal.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { DiscordIcon } from "@/components/icons";
+import { Modal } from "@/components/ui/Modal";
 import {
   SUMMER_COHORTS,
   SUMMER_COHORT_IMMERSION,
@@ -44,8 +45,6 @@ export default function SummerCohortModal() {
   const [isOpen, setIsOpen] = useState(false);
   // null = not yet known; true/false = resolved.
   const [hasApplied, setHasApplied] = useState<boolean | null>(null);
-  const modalRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
   // Prevent double-resolves from racing each other.
   const appliedResolvedRef = useRef(false);
 
@@ -120,18 +119,6 @@ export default function SummerCohortModal() {
     return () => window.removeEventListener(SUMMER_COHORT_OPEN_EVENT, handleOpen);
   }, [hasApplied]);
 
-  useEffect(() => {
-    if (isOpen) {
-      closeButtonRef.current?.focus();
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isOpen]);
-
   const handleClose = useCallback(() => {
     try {
       localStorage.setItem(SUMMER_COHORT_LOCALSTORAGE_KEY, todayKey());
@@ -141,16 +128,6 @@ export default function SummerCohortModal() {
     setIsOpen(false);
   }, []);
 
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen) {
-        handleClose();
-      }
-    };
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isOpen, handleClose]);
-
   // Open cohorts only — what a brand new applicant can actually join.
   // Closed cohorts still render in the list (greyed) so the modal accurately
   // reflects the program shape, but the CTAs target the open cohort.
@@ -158,8 +135,6 @@ export default function SummerCohortModal() {
     () => SUMMER_COHORTS.find((c) => !c.signupsClosed) ?? null,
     []
   );
-
-  if (!isOpen) return null;
 
   // CTA strategy:
   //   - Already applied        → "View your cohort" (single primary)
@@ -175,44 +150,13 @@ export default function SummerCohortModal() {
   const headlineCohortLabel = openCohort?.label ?? "Cursor Boston Summer Cohort";
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="summer-cohort-title"
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="md"
+      titleId="summer-cohort-title"
+      closeButtonLabel="Close summer cohort message"
     >
-      <div
-        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
-        onClick={handleClose}
-        aria-hidden="true"
-      />
-
-      <div
-        ref={modalRef}
-        className="relative bg-neutral-900 border border-neutral-800 rounded-2xl p-6 md:p-8 max-w-md w-full shadow-2xl max-h-[90vh] overflow-y-auto"
-      >
-        <button
-          ref={closeButtonRef}
-          onClick={handleClose}
-          className="absolute top-4 right-4 text-neutral-400 hover:text-white transition-colors p-1 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-          aria-label="Close summer cohort message"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M18 6L6 18M6 6l12 12" />
-          </svg>
-        </button>
-
         <div className="text-center">
           <div className="w-16 h-16 bg-emerald-500/15 rounded-full flex items-center justify-center mx-auto mb-4">
             <svg
@@ -488,7 +432,6 @@ export default function SummerCohortModal() {
             Maybe later
           </button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/components/feed/RepostModal.tsx
+++ b/components/feed/RepostModal.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { Modal } from "@/components/ui/Modal";
 import type { Message } from "@/types/feed";
 
 interface RepostModalProps {
@@ -31,24 +31,22 @@ export function RepostModal({
   minLength = 100,
   maxLength = 500,
 }: RepostModalProps) {
-  const { containerRef } = useFocusTrap<HTMLDivElement>({
-    onEscape: onCancel,
-  });
   const trimmed = comment.trim();
   const isValid = trimmed.length >= minLength && trimmed.length <= maxLength;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
-      role="dialog"
-      aria-modal="true"
+    <Modal
+      isOpen
+      onClose={onCancel}
+      size="lg"
+      ariaLabel="Repost with comment"
+      panelScroll={false}
+      padded={false}
+      defaultPanelChrome={false}
+      className="rounded-xl border border-neutral-800 bg-neutral-900 p-6"
+      backdropClassName="bg-black/70 backdrop-blur-none"
+      showCloseButton={false}
     >
-      <div
-        ref={containerRef}
-        data-modal-content
-        tabIndex={-1}
-        className="bg-neutral-900 rounded-xl p-6 border border-neutral-800 max-w-lg w-full"
-      >
         <h3 className="text-lg font-semibold text-white mb-4">Repost with comment</h3>
         <div className="bg-neutral-800 rounded-lg p-4 mb-4">
           <div className="flex items-center gap-2 mb-2">
@@ -92,7 +90,6 @@ export function RepostModal({
             {posting ? "Reposting..." : "Repost"}
           </button>
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,240 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { CloseIcon } from "@/components/icons";
+import { cn } from "@/lib/utils";
+
+type ModalSize = "sm" | "md" | "lg" | "xl";
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-2xl",
+};
+
+const FOCUSABLE_SELECTOR =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), iframe, [contenteditable="true"], [tabindex]:not([tabindex="-1"])';
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((el) => el.getAttribute("aria-hidden") !== "true");
+}
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Width of the centered panel. Default "md". */
+  size?: ModalSize;
+  /**
+   * id of the heading element rendered inside the modal. When set, the modal
+   * receives `aria-labelledby={titleId}`. Provide either this or `ariaLabel`.
+   */
+  titleId?: string;
+  /**
+   * Accessible label for the dialog itself. Use when no visible heading is
+   * available (rare — prefer `titleId` so screen readers announce the
+   * actual modal heading).
+   */
+  ariaLabel?: string;
+  /** Extra classes appended to the panel. */
+  className?: string;
+  /**
+   * Backdrop classes. When omitted, defaults to a semi-opaque blurred backdrop
+   * (`bg-black/80 backdrop-blur-sm`). When provided, REPLACES the defaults
+   * — pass the full background/blur treatment you want.
+   */
+  backdropClassName?: string;
+  /** Default true. Pass false for callers that own their own padding/layout. */
+  padded?: boolean;
+  /** Default true. Pass false for callers that own panel rounding/shadow. */
+  defaultPanelChrome?: boolean;
+  /**
+   * Default true. When true the panel scrolls internally up to ~90vh so tall
+   * content stays reachable on small viewports. Pass false when the caller
+   * manages its own scroll region (e.g. an internal scroll container).
+   */
+  panelScroll?: boolean;
+  /** Show the corner close-X button. Default true. */
+  showCloseButton?: boolean;
+  /** Accessible label for the corner close-X. Default "Close". */
+  closeButtonLabel?: string;
+  /** Dismiss when the backdrop is clicked. Default true. */
+  closeOnBackdropClick?: boolean;
+  /** Dismiss on Escape key. Default true. */
+  closeOnEsc?: boolean;
+  /** Lock body scroll while the modal is open. Default true. */
+  lockBodyScroll?: boolean;
+  children: ReactNode;
+}
+
+function handleTabTrap(e: KeyboardEvent, panel: HTMLElement) {
+  if (e.key !== "Tab") return;
+  const focusable = getFocusable(panel);
+  if (focusable.length === 0) {
+    e.preventDefault();
+    panel.focus({ preventScroll: true });
+    return;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active =
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+  if (!active || !panel.contains(active)) {
+    e.preventDefault();
+    (e.shiftKey ? last : first).focus({ preventScroll: true });
+    return;
+  }
+  if (e.shiftKey && active === first) {
+    e.preventDefault();
+    last.focus({ preventScroll: true });
+  } else if (!e.shiftKey && active === last) {
+    e.preventDefault();
+    first.focus({ preventScroll: true });
+  }
+}
+
+/**
+ * Shared modal shell. Owns the backdrop, focus management, ESC/click dismissal,
+ * body scroll-lock, and the corner close-X. Renders nothing when closed.
+ *
+ * The caller renders the dialog content — header, body, footer — as children.
+ * The shell intentionally does not impose a header/footer structure because
+ * existing modals diverge on layout; `padded={false}` opts out of the default
+ * panel padding so callers can section the panel themselves.
+ *
+ * Keyboard behavior:
+ *   - Escape: handled via a document-level listener so it dismisses even
+ *     when focus has drifted outside the dialog subtree.
+ *   - Tab / Shift+Tab: trapped within the panel via a native keydown
+ *     listener on the outer dialog — wraps focus at the boundary.
+ *
+ * On open, focus moves into the panel (first focusable, falling back to the
+ * panel itself). On close/unmount the previously-focused element is restored.
+ */
+export function Modal({
+  isOpen,
+  onClose,
+  size = "md",
+  titleId,
+  ariaLabel,
+  className,
+  backdropClassName,
+  padded = true,
+  defaultPanelChrome = true,
+  panelScroll = true,
+  showCloseButton = true,
+  closeButtonLabel = "Close",
+  closeOnBackdropClick = true,
+  closeOnEsc = true,
+  lockBodyScroll = true,
+  children,
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const panel = panelRef.current;
+    if (panel) {
+      const [first] = getFocusable(panel);
+      (first ?? panel).focus({ preventScroll: true });
+    }
+    return () => {
+      previouslyFocusedRef.current?.focus({ preventScroll: true });
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !lockBodyScroll) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [isOpen, lockBodyScroll]);
+
+  useEffect(() => {
+    if (!isOpen || !closeOnEsc) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen, closeOnEsc, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const dialog = dialogRef.current;
+    const panel = panelRef.current;
+    if (!dialog || !panel) return;
+    const handler = (e: KeyboardEvent) => handleTabTrap(e, panel);
+    dialog.addEventListener("keydown", handler);
+    return () => dialog.removeEventListener("keydown", handler);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-label={titleId ? undefined : ariaLabel}
+    >
+      <div
+        className={cn(
+          "absolute inset-0",
+          backdropClassName ?? "bg-black/80 backdrop-blur-sm",
+        )}
+        onClick={closeOnBackdropClick ? onClose : undefined}
+        aria-hidden="true"
+      />
+
+      <div
+        ref={panelRef}
+        data-modal-content
+        tabIndex={-1}
+        className={cn(
+          "relative w-full",
+          SIZE_CLASS[size],
+          defaultPanelChrome &&
+            "rounded-2xl border border-neutral-800 bg-neutral-900 shadow-2xl",
+          padded && "p-6 md:p-8",
+          panelScroll && "max-h-[90vh] overflow-y-auto",
+          className,
+        )}
+      >
+        {showCloseButton ? (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={closeButtonLabel}
+            className="absolute right-4 top-4 rounded-lg p-1 text-neutral-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            <CloseIcon size={20} />
+          </button>
+        ) : null}
+
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `components/ui/Modal.tsx` owns backdrop, focus management (initial focus + restore-on-close + Tab trap), ESC dismissal (via document-level listener so focus-drift to body still closes), body scroll-lock, and the corner close-X.
- Migrated 5 modals onto it: `SummerCohortModal`, `ProfileRequirementsModal`, `EditProfileModal`, `SetupReadinessModal`, `RepostModal`. Each call site keeps its own header/body/footer; only the shell collapses.
- Net diff: ~257 lines removed across call sites, ~245-line shell added. Bigger payoff is consistency — these modals were diverging on which of {focus-trap, scroll-lock, ESC source, click-outside dismissal} they implemented.

## Why
The audit on `develop` surfaced this as the highest-ROI refactor in the redundancy pass — not because of LOC but because of correctness drift:

| Modal | Focus trap | Scroll lock | ESC source |
|---|---|---|---|
| SummerCohort | ❌ none | ✅ | document listener |
| ProfileRequirements | hand-rolled inline | ❌ | React onKeyDown on dialog |
| EditProfile | hand-rolled inline | ❌ | React onKeyDown on dialog |
| SetupReadiness | ❌ none | ✅ | document listener |
| Repost | `useFocusTrap` hook | ❌ | container listener |

After this PR all five behave the same way: Tab is trapped, ESC dismisses from anywhere, body scroll is locked, and previously-focused element is restored on close.

## Out of scope
- `SportsHackConfirmAttendanceModal` (`components/hackathons/`) was in the original audit list but is actually a `fixed bottom-right` toast/nudge, not a centered overlay. Forcing it through the shell would be the wrong primitive. Left alone.
- `EntryDetailModal` (cookbook) is the other consumer of `useFocusTrap` and isn't in the duplication group — left untouched.

## Drive-by
Fixed a pre-existing `jsx-a11y/label-has-associated-control` warning on the \"Profile Photo\" label in `EditProfileModal` (added `htmlFor=\"photo-upload\"`) so the file passes `lint-staged --max-warnings=0`.

## Test plan
- [x] `npm run type-check` clean
- [x] `npx eslint --max-warnings=0` clean on all 6 touched files
- [x] Full jest suite: 7,672 / 7,672 pass (8 modal suites green: 93 / 93)
- [ ] **Manual QA — needs reviewer pass:** open each of the 5 modals in dev and verify:
  - opens centered, backdrop blurs/dims
  - Tab cycles within the modal, Shift+Tab cycles backward, both wrap at boundaries
  - ESC dismisses
  - clicking the backdrop dismisses
  - close-X dismisses
  - body scroll is locked while open, restored on close
  - focus returns to the trigger element after close
- [ ] **Visual regression** for ProfileRequirementsModal (the layout shifted slightly — the inline header close-X was removed in favor of the panel's corner close-X; both were top-right but the corner one sits a few px further out)

## Follow-ups (not in this PR)
The audit identified 7 more refactor groups behind this one — submission cards, AI judge score badge, event hero strip, empty-state card, status pills, the `ValidatedInput`-bypass forms, and avatar-row consistency. Filing as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)