### PR TITLE
Fix event signup Discord requirement flow

### DIFF
--- a/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
@@ -386,7 +386,11 @@ describe("Sports Hack 2026 signup page", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Connect Discord/i })).toHaveAttribute(
       "href",
-      "/api/discord/authorize",
+      expect.stringContaining("/api/discord/authorize?returnTo="),
+    );
+    expect(screen.getByRole("link", { name: /Join Discord first/i })).toHaveAttribute(
+      "href",
+      "https://discord.gg/Wsncg8YYqc",
     );
     expect(screen.getByRole("button", { name: /Complete requirements/i })).toBeDisabled();
     // 1/4 requirements met (isPublic only)

--- a/__tests__/components/ProfileRequirementsModal.deep.test.tsx
+++ b/__tests__/components/ProfileRequirementsModal.deep.test.tsx
@@ -322,7 +322,11 @@ describe("ProfileRequirementsModal deep", () => {
     ).toHaveAttribute("href", "/api/github/authorize");
     expect(screen.getByRole("link", { name: /Connect Discord/i })).toHaveAttribute(
       "href",
-      "/api/discord/authorize",
+      expect.stringContaining("/api/discord/authorize?returnTo="),
+    );
+    expect(screen.getByRole("link", { name: /Join Discord first/i })).toHaveAttribute(
+      "href",
+      "https://discord.gg/Wsncg8YYqc",
     );
   });
 

--- a/app/events/cursor-boston-sports-hack-2026/page.tsx
+++ b/app/events/cursor-boston-sports-hack-2026/page.tsx
@@ -165,7 +165,7 @@ function Hero({ event }: { event: EventRecord | null }) {
             href={SIGNUP_URL}
             className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
           >
-            Claim your participation spot →
+            View signup list and rank →
           </Link>
           <a
             href={SPORTS_HACK_2026_LUMA_URL}
@@ -198,18 +198,19 @@ function HowToWinCredits() {
         <ol className="grid gap-4 md:grid-cols-3">
           <Step
             num={1}
-            title="Claim your spot on the site"
+            title="Use the website signup list"
             body={
               <>
-                Sign up at{" "}
+                The list at{" "}
                 <Link
                   href={SIGNUP_URL}
                   className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
                 >
                   /hackathons/sports-hack-2026/signup
                 </Link>
-                . Required even if you&apos;re already on Luma — this is the
-                list we rank from.
+                {" "}
+                is the ranking source for participants. It is separate from
+                Luma registration, which controls event admission.
               </>
             }
           />

--- a/app/hackathons/hack-a-sprint-2026/signup/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/signup/page.tsx
@@ -13,9 +13,15 @@ import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
 import { trackEvent } from "@/lib/analytics";
 import {
+  EventSignupDiscordConnectLink,
+  EventSignupDiscordJoinHint,
+  EventSignupDiscordMissingCopy,
+} from "@/components/events/EventSignupDiscordRequirement";
+import {
   CURSOR_CREDIT_TOP_N,
 } from "@/lib/hackathon-event-signup";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
+import { getHackathonEventSignupReturnTo } from "@/lib/event-signup-discord";
 
 type EntryStatus = "confirmed" | "waitlisted";
 
@@ -91,6 +97,7 @@ export default function HackASprint2026SignupPage() {
 
   const eventId = HACK_A_SPRINT_2026_EVENT_ID;
   const apiUrl = `/api/hackathons/events/${eventId}/signup`;
+  const signupReturnTo = getHackathonEventSignupReturnTo(eventId);
 
   const trackAuthCta = (cta: "sign_in" | "create_account") => {
     void trackEvent(
@@ -658,7 +665,7 @@ export default function HackASprint2026SignupPage() {
                         <p className="text-xs text-neutral-500 dark:text-neutral-400">
                           {profile.hasDiscord && profile.discordUsername
                             ? <>Connected as <span className="text-emerald-600 dark:text-emerald-400">@{profile.discordUsername}</span></>
-                            : "Required so organizers can reach you"}
+                            : <EventSignupDiscordMissingCopy />}
                         </p>
                       </div>
                     </div>
@@ -668,15 +675,12 @@ export default function HackASprint2026SignupPage() {
                         @{profile.discordUsername}
                       </span>
                     ) : (
-                      <a
-                        href="/api/discord/authorize"
-                        className="inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-4 py-2 text-sm font-medium text-white hover:bg-[#4752C4] transition-colors"
-                      >
-                        <DiscordIcon size={16} />
-                        Connect Discord
-                      </a>
+                      <EventSignupDiscordConnectLink returnTo={signupReturnTo} />
                     )}
                   </div>
+                  {!profile.hasDiscord ? (
+                    <EventSignupDiscordJoinHint className="-mt-1 ml-12 text-xs text-neutral-500 dark:text-neutral-400" />
+                  ) : null}
 
                   {/* Show Discord on profile */}
                   {(() => {

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -16,6 +16,11 @@ import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026Ev
 import { trackEvent } from "@/lib/analytics";
 import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
 import {
+  EventSignupDiscordConnectLink,
+  EventSignupDiscordJoinHint,
+  EventSignupDiscordMissingCopy,
+} from "@/components/events/EventSignupDiscordRequirement";
+import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
@@ -23,6 +28,7 @@ import {
   getSportsHack2026RankTier,
   type SportsHack2026RankTone,
 } from "@/lib/sports-hack-2026";
+import { getHackathonEventSignupReturnTo } from "@/lib/event-signup-discord";
 
 const SPORTS_HACK_RETURN_TO = "/hackathons/sports-hack-2026/signup";
 
@@ -51,6 +57,8 @@ const TONE_BANNER_CLASS: Record<SportsHack2026RankTone, string> = {
 // pills are rendered only when present; the absence of a pill carries no
 // negative implication (vs the previous behavior of warning "Not on Luma
 // yet" which is no longer accurate).
+const SIGNUP_RETURN_TO = getHackathonEventSignupReturnTo(SPORTS_HACK_2026_EVENT_ID);
+
 function LumaPill({ registered }: { registered: boolean | undefined }) {
   if (!registered) return null;
   return (
@@ -1032,7 +1040,7 @@ function SportsHack2026SignupPageInner() {
                               </span>
                             </>
                           ) : (
-                            "Required so organizers can reach you"
+                            <EventSignupDiscordMissingCopy />
                           )}
                         </p>
                       </div>
@@ -1042,15 +1050,12 @@ function SportsHack2026SignupPageInner() {
                         <DiscordIcon size={16} />@{profile.discordUsername}
                       </span>
                     ) : (
-                      <a
-                        href="/api/discord/authorize"
-                        className="inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-4 py-2 text-sm font-medium text-white hover:bg-[#4752C4] transition-colors"
-                      >
-                        <DiscordIcon size={16} />
-                        Connect Discord
-                      </a>
+                      <EventSignupDiscordConnectLink returnTo={SIGNUP_RETURN_TO} />
                     )}
                   </div>
+                  {!profile.hasDiscord ? (
+                    <EventSignupDiscordJoinHint className="-mt-1 ml-12 text-xs text-neutral-500 dark:text-neutral-400" />
+                  ) : null}
 
                   {/* Show Discord on profile */}
                   <ShowDiscordRow

--- a/components/ProfileRequirementsModal.tsx
+++ b/components/ProfileRequirementsModal.tsx
@@ -13,6 +13,10 @@ import Link from "next/link";
 import Avatar from "@/components/Avatar";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
 import { Modal } from "@/components/ui/Modal";
+import {
+  EventSignupDiscordConnectLink,
+  EventSignupDiscordJoinHint,
+} from "@/components/events/EventSignupDiscordRequirement";
 
 export type RequirementType =
   | "isPublic"
@@ -76,6 +80,7 @@ interface ProfileRequirementsModalProps {
   requirements: RequirementType[];
   title?: string;
   description?: string;
+  returnTo?: string;
 }
 
 export default function ProfileRequirementsModal({
@@ -85,6 +90,7 @@ export default function ProfileRequirementsModal({
   requirements,
   title = "Complete Your Profile",
   description = "Please complete the following requirements to continue.",
+  returnTo,
 }: ProfileRequirementsModalProps) {
   const { user, refreshUserProfile } = useAuth();
   const [profile, setProfile] = useState<ProfileStatus | null>(null);
@@ -93,6 +99,11 @@ export default function ProfileRequirementsModal({
   const [displayNameInput, setDisplayNameInput] = useState("");
   const [editingDisplayName, setEditingDisplayName] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const discordReturnTo =
+    returnTo ??
+    (typeof window === "undefined"
+      ? undefined
+      : `${window.location.pathname}${window.location.search}`);
 
   const fetchProfile = useCallback(async () => {
     if (!user) return;
@@ -323,13 +334,10 @@ export default function ProfileRequirementsModal({
           );
         }
         return (
-          <a
-            href="/api/discord/authorize"
+          <EventSignupDiscordConnectLink
+            returnTo={discordReturnTo}
             className="px-4 py-2 bg-[#5865F2] hover:bg-[#4752C4] text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2"
-          >
-            <DiscordIcon size={16} />
-            Connect Discord
-          </a>
+          />
         );
 
       case "hasDisplayName":
@@ -466,39 +474,41 @@ export default function ProfileRequirementsModal({
                   {incompleteRequirements.map((req) => {
                     const config = REQUIREMENT_CONFIGS[req];
                     return (
-                      <div
-                        key={req}
-                        className="flex items-center justify-between p-4 bg-neutral-800/50 border border-neutral-700 rounded-xl"
-                      >
-                        <div className="flex items-center gap-3">
-                          <div className="w-8 h-8 bg-amber-500/10 rounded-full flex items-center justify-center">
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              width="16"
-                              height="16"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              className="text-amber-400"
-                            >
-                              <circle cx="12" cy="12" r="10" />
-                              <line x1="12" y1="8" x2="12" y2="12" />
-                              <line x1="12" y1="16" x2="12.01" y2="16" />
-                            </svg>
+                      <div key={req} className="space-y-2">
+                        <div className="flex items-center justify-between p-4 bg-neutral-800/50 border border-neutral-700 rounded-xl">
+                          <div className="flex items-center gap-3">
+                            <div className="w-8 h-8 bg-amber-500/10 rounded-full flex items-center justify-center">
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                className="text-amber-400"
+                              >
+                                <circle cx="12" cy="12" r="10" />
+                                <line x1="12" y1="8" x2="12" y2="12" />
+                                <line x1="12" y1="16" x2="12.01" y2="16" />
+                              </svg>
+                            </div>
+                            <div>
+                              <p className="text-white font-medium text-sm">
+                                {config.label}
+                              </p>
+                              <p className="text-neutral-400 text-xs">
+                                {config.description}
+                              </p>
+                            </div>
                           </div>
-                          <div>
-                            <p className="text-white font-medium text-sm">
-                              {config.label}
-                            </p>
-                            <p className="text-neutral-400 text-xs">
-                              {config.description}
-                            </p>
-                          </div>
+                          {renderRequirementAction(req)}
                         </div>
-                        {renderRequirementAction(req)}
+                        {req === "hasDiscord" ? (
+                          <EventSignupDiscordJoinHint className="px-4 text-xs text-neutral-400" />
+                        ) : null}
                       </div>
                     );
                   })}

--- a/components/events/EventSignupDiscordRequirement.tsx
+++ b/components/events/EventSignupDiscordRequirement.tsx
@@ -1,0 +1,58 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  CURSOR_BOSTON_DISCORD_INVITE_URL,
+  getDiscordAuthorizeUrl,
+} from "@/lib/event-signup-discord";
+import { DiscordIcon } from "@/components/icons";
+
+export function EventSignupDiscordMissingCopy() {
+  return (
+    <>
+      Join the Cursor Boston Discord first, then connect so we can verify
+      membership.
+    </>
+  );
+}
+
+export function EventSignupDiscordJoinHint({
+  className = "text-xs text-neutral-500 dark:text-neutral-400",
+}: {
+  className?: string;
+}) {
+  return (
+    <p className={className}>
+      Not in the server yet?{" "}
+      <a
+        href={CURSOR_BOSTON_DISCORD_INVITE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-emerald-600 underline hover:text-emerald-500 dark:text-emerald-400"
+      >
+        Join Discord first
+      </a>
+      , then come back and connect your account.
+    </p>
+  );
+}
+
+export function EventSignupDiscordConnectLink({
+  returnTo,
+  className = "inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-4 py-2 text-sm font-medium text-white hover:bg-[#4752C4] transition-colors",
+}: {
+  returnTo?: string | null;
+  className?: string;
+}) {
+  return (
+    <a href={getDiscordAuthorizeUrl(returnTo)} className={className}>
+      <DiscordIcon size={16} />
+      Connect Discord
+    </a>
+  );
+}
+

--- a/lib/event-signup-discord.ts
+++ b/lib/event-signup-discord.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export const CURSOR_BOSTON_DISCORD_INVITE_URL = "https://discord.gg/Wsncg8YYqc";
+
+export function getHackathonEventSignupReturnTo(eventId: string): string {
+  return `/hackathons/${eventId}/signup`;
+}
+
+export function getDiscordAuthorizeUrl(returnTo?: string | null): string {
+  if (!returnTo) return "/api/discord/authorize";
+  return `/api/discord/authorize?returnTo=${encodeURIComponent(returnTo)}`;
+}
+


### PR DESCRIPTION
## Summary
- add shared event signup Discord helpers/components for join-first guidance and return-aware auth links
- apply the flow to current hackathon signup pages and the generic profile requirements modal
- clarify Sports Hack event copy so website signup ranking is not described as claiming admission

Fixes #1492

## Validation
- npm run lint
- npm run type-check
- npm test -- --runTestsByPath __tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx __tests__/app/hackathons/hack-a-sprint-2026/signup/page.test.tsx __tests__/components/ProfileRequirementsModal.deep.test.tsx --runInBand
- npm run build with local dummy UNSUBSCRIBE_SECRET