### PR TITLE
docs(sports-hack): submit hwillGIT — BeatM ROAST MODE AI trash talk battle cards

### DIFF
--- a/sports-hack-2026-submissions/hwillGIT/meta.json
+++ b/sports-hack-2026-submissions/hwillGIT/meta.json
@@ -1,10 +1,10 @@
 {
-  "title": "RTRevenue — Blockchain Revenue-Share Marketplace for Small Business Financing",
-  "description": "A blockchain-powered marketplace connecting small businesses with individual investors through revenue-share agreements. Businesses get fair financing; investors get 5-7% yield. Smart contracts automate distributions; real-time integrations verify revenue.",
+  "title": "BeatM ROAST MODE — AI Trash Talk Battle Cards for DFS Lineups",
+  "description": "Enter two DFS lineups, get AI-generated trash talk battle cards. Claude roasts both sides with stat context, crowd predictions, and shareable cards. Built for BeatM's social-first DFS thesis — because winning is sweeter when your crew knows about it.",
   "displayName": "Mike Williams",
   "videoUrl": "",
-  "repoUrl": "https://github.com/hwillGIT/rtrevenue-workspace",
+  "repoUrl": "https://github.com/hwillGIT/beatm-roast",
   "deployedUrl": "",
-  "tags": ["fintech", "revenue-sharing", "blockchain", "small-business", "investing", "reg-cf"],
+  "tags": ["beatm", "dfs", "ai-roast", "social", "claude-ai", "next-js"],
   "collaborators": []
 }

--- a/sports-hack-2026-submissions/hwillGIT/meta.json
+++ b/sports-hack-2026-submissions/hwillGIT/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "RTRevenue — Blockchain Revenue-Share Marketplace for Small Business Financing",
+  "description": "A blockchain-powered marketplace connecting small businesses with individual investors through revenue-share agreements. Businesses get fair financing; investors get 5-7% yield. Smart contracts automate distributions; real-time integrations verify revenue.",
+  "displayName": "Mike Williams",
+  "videoUrl": "",
+  "repoUrl": "https://github.com/hwillGIT/rtrevenue-workspace",
+  "deployedUrl": "",
+  "tags": ["fintech", "revenue-sharing", "blockchain", "small-business", "investing", "reg-cf"],
+  "collaborators": []
+}

--- a/sports-hack-2026-submissions/hwillGIT/meta.json
+++ b/sports-hack-2026-submissions/hwillGIT/meta.json
@@ -1,10 +1,17 @@
 {
-  "title": "BeatM ROAST MODE — AI Trash Talk Battle Cards for DFS Lineups",
-  "description": "Enter two DFS lineups, get AI-generated trash talk battle cards. Claude roasts both sides with stat context, crowd predictions, and shareable cards. Built for BeatM's social-first DFS thesis — because winning is sweeter when your crew knows about it.",
+  "title": "BeatM ROAST MODE - AI Trash Talk Battle Cards for DFS Lineups",
+  "description": "Enter two DFS lineups, get AI-generated trash talk battle cards. Claude roasts both sides with stat context, crowd predictions, and shareable cards. Built for BeatMs social-first DFS thesis.",
   "displayName": "Mike Williams",
   "videoUrl": "",
   "repoUrl": "https://github.com/hwillGIT/beatm-roast",
   "deployedUrl": "",
-  "tags": ["beatm", "dfs", "ai-roast", "social", "claude-ai", "next-js"],
+  "tags": [
+    "beatm",
+    "dfs",
+    "ai-roast",
+    "social",
+    "claude-ai",
+    "next-js"
+  ],
   "collaborators": []
 }

--- a/sports-hack-2026-submissions/hwillGIT/score.json
+++ b/sports-hack-2026-submissions/hwillGIT/score.json
@@ -1,0 +1,9 @@
+{
+  "ai": {
+    "score": 4,
+    "rationale": "Creative niche idea — AI-generated trash-talk battle cards for two DFS lineups, tied to a real-product thesis (BeatM) — and the pitch is specific enough to picture the UX. Loses heavily on completeness: both videoUrl AND deployedUrl are empty, so there's no way to verify the project actually shipped, and the brief explicitly required a live URL + explainer video. With either of those filled in this lands in the 6-7 range; with both missing it can't break into the solid tier.",
+    "model": "claude-opus-4-7",
+    "scoredAt": "2026-05-26T18:54:00.000Z",
+    "scorerVersion": 2
+  }
+}


### PR DESCRIPTION
## Sports Hack 2026 Submission — hwillGIT

**Project:** BeatM ROAST MODE — AI Trash Talk Battle Cards for DFS Lineups

**What I built:** An AI-powered social trash talk battle card generator built directly for BeatM's social-first DFS thesis. Enter two DFS lineups → Claude generates personalized trash talk for both sides with stat context, crowd prediction percentage, and a shareable card URL. Because winning is sweeter when your crew knows about it.

**Stack:** Next.js 14 · Tailwind · Claude API (claude-haiku-4-5) · BallDontLie sports data · Vercel

### Checklist
- [x] Folder named after GitHub handle (`sports-hack-2026-submissions/hwillGIT/`)
- [x] `meta.json` present and valid — BeatM ROAST MODE
- [x] No API keys or secrets committed
- [ ] `videoUrl` — **to be updated before 4 PM ET deadline**
- [ ] `deployedUrl` — **to be updated before 4 PM ET deadline**

> ⚠️ **Note:** `videoUrl` and `deployedUrl` will be added once the build is complete and Loom is recorded.