### PR TITLE
docs(sports-hack): FANCAST + StatsCast — Abi5678

### DIFF
--- a/sports-hack-2026-submissions/Abi5678/meta.json
+++ b/sports-hack-2026-submissions/Abi5678/meta.json
@@ -2,7 +2,7 @@
   "title": "FANCAST + StatsCast",
   "description": "Talk to a live NBA game using your voice — FANCAST uses Gemini Live native audio to answer fan questions about scores, plays, and player lines in real time. StatsCast pairs it with streaming AI analyst breakdowns and animated season stats for any player or sport.",
   "displayName": "Abishek M",
-  "videoUrl": "https://www.loom.com/share/",
+  "videoUrl": "https://youtu.be/so_uH2eHfq0",
   "repoUrl": "https://github.com/Abi5678/fancast",
   "deployedUrl": "https://shine-exorcism-dork.ngrok-free.dev",
   "tags": ["gemini-live", "nba", "voice", "real-time", "audio", "ai-analytics"],

--- a/sports-hack-2026-submissions/Abi5678/meta.json
+++ b/sports-hack-2026-submissions/Abi5678/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "FANCAST + StatsCast",
+  "description": "Talk to a live NBA game using your voice — FANCAST uses Gemini Live native audio to answer fan questions about scores, plays, and player lines in real time. StatsCast pairs it with streaming AI analyst breakdowns and animated season stats for any player or sport.",
+  "displayName": "Abishek M",
+  "videoUrl": "https://www.loom.com/share/",
+  "repoUrl": "https://github.com/Abi5678/fancast",
+  "deployedUrl": "https://shine-exorcism-dork.ngrok-free.dev",
+  "tags": ["gemini-live", "nba", "voice", "real-time", "audio", "ai-analytics"],
+  "collaborators": []
+}

--- a/sports-hack-2026-submissions/Abi5678/meta.json
+++ b/sports-hack-2026-submissions/Abi5678/meta.json
@@ -4,7 +4,7 @@
   "displayName": "Abishek M",
   "videoUrl": "https://youtu.be/so_uH2eHfq0",
   "repoUrl": "https://github.com/Abi5678/fancast",
-  "deployedUrl": "https://shine-exorcism-dork.ngrok-free.dev",
+  "deployedUrl": "https://fancast-three.vercel.app",
   "tags": ["gemini-live", "nba", "voice", "real-time", "audio", "ai-analytics"],
   "collaborators": []
 }

--- a/sports-hack-2026-submissions/Abi5678/score.json
+++ b/sports-hack-2026-submissions/Abi5678/score.json
@@ -1,0 +1,9 @@
+{
+  "ai": {
+    "score": 8,
+    "rationale": "Strong submission. Voice-first interface to a live NBA game via Gemini Live native audio is genuinely novel — most sports apps are visual-first, and conversational live-game Q&A pushes a real edge of what current models can do. Companion StatsCast layer (streaming analyst breakdowns + animated season stats) shows ambition without losing focus. All three URLs filled (YouTube + repo + stable Vercel deploy). Knocked just short of the top tier because the meta sells the experience but doesn't show how live-data integration is grounded, which is the hard part for this kind of product.",
+    "model": "claude-opus-4-7",
+    "scoredAt": "2026-05-26T19:06:00.000Z",
+    "scorerVersion": 2
+  }
+}


### PR DESCRIPTION
## FANCAST + StatsCast

**Track:** Fan & Audience Experience

**What I built:** Voice-first sports companion for live NBA games using Gemini Live native audio. Ask about scores, plays, and player lines in real time — FANCAST responds with broadcast-quality voice answers. StatsCast adds streaming AI analyst breakdowns with animated season stats for any player or sport.

**Links:**
- **Live demo:** https://fancast-three.vercel.app
- **Demo video:** https://youtu.be/so_uH2eHfq0
- **Repo:** https://github.com/Abi5678/fancast

**Tech stack:**
- Gemini 2.5 Flash Native Audio (Live API) for real-time voice
- ESPN public API for live game data (box score, play-by-play, leaders)
- Gemini Flash Lite for streaming StatsCast analysis
- FastAPI + AudioWorklet + vanilla JS, deployed on Vercel

**Submission folder:** `sports-hack-2026-submissions/Abi5678/`