### PR TITLE
Sports Hack 2026: arpand9 — SportsHire AI

### DIFF
--- a/sports-hack-2026-submissions/arpand9/meta.json
+++ b/sports-hack-2026-submissions/arpand9/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "SportsHire AI — MCP-native sports job marketplace",
-  "description": "Structured seeker profiles and employer-weighted scoring criteria. MCP server + REST /api/tools/* with 10 agent tools (search, rank, apply). 367 Boston-area jobs (362 scraped from WorkInSports + curated demo). AI-judge docs: AGENTS.md, docs/AI_JUDGE.md. Freemium demo on web; agents get full API access with SPORTSHIRE_AI_JUDGE=1.",
+  "description": "Structured seeker profiles and employer-weighted scoring criteria. MCP server + REST /api/tools/* with 10 agent tools (search, rank, apply). 367 Boston-area jobs (362 scraped from WorkInSports + curated demo). AI-judge docs: AGENTS.md, docs/AI_JUDGE.md. Vercel-ready Next.js deploy (docs/VERCEL.md). Freemium UI demo; agents get full API access with SPORTSHIRE_AI_JUDGE=1.",
   "displayName": "Arpan D",
   "videoUrl": "https://www.loom.com/share/f5ca7af0a83b4494ab1aacd5d4b3eeed",
   "repoUrl": "https://github.com/arpand9/sports-jobs-agent",

--- a/sports-hack-2026-submissions/arpand9/meta.json
+++ b/sports-hack-2026-submissions/arpand9/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "SportsHire AI — MCP-native sports job marketplace",
+  "description": "Structured seeker profiles and employer-weighted scoring criteria. MCP server + REST /api/tools/* with 10 agent tools (search, rank, apply). 367 Boston-area jobs (362 scraped from WorkInSports + curated demo). AI-judge docs: AGENTS.md, docs/AI_JUDGE.md. Freemium demo on web; agents get full API access with SPORTSHIRE_AI_JUDGE=1.",
+  "displayName": "Arpan D",
+  "videoUrl": "https://www.loom.com/share/YOUR_LOOM_ID",
+  "repoUrl": "https://github.com/arpand9/sports-jobs-agent",
+  "deployedUrl": "",
+  "tags": ["sports", "mcp", "jobs", "ai-agents", "matching", "boston", "hackathon"]
+}

--- a/sports-hack-2026-submissions/arpand9/meta.json
+++ b/sports-hack-2026-submissions/arpand9/meta.json
@@ -2,7 +2,7 @@
   "title": "SportsHire AI — MCP-native sports job marketplace",
   "description": "Structured seeker profiles and employer-weighted scoring criteria. MCP server + REST /api/tools/* with 10 agent tools (search, rank, apply). 367 Boston-area jobs (362 scraped from WorkInSports + curated demo). AI-judge docs: AGENTS.md, docs/AI_JUDGE.md. Freemium demo on web; agents get full API access with SPORTSHIRE_AI_JUDGE=1.",
   "displayName": "Arpan D",
-  "videoUrl": "https://www.loom.com/share/YOUR_LOOM_ID",
+  "videoUrl": "https://www.loom.com/share/f5ca7af0a83b4494ab1aacd5d4b3eeed",
   "repoUrl": "https://github.com/arpand9/sports-jobs-agent",
   "deployedUrl": "",
   "tags": ["sports", "mcp", "jobs", "ai-agents", "matching", "boston", "hackathon"]


### PR DESCRIPTION
## Summary
Hackathon submission metadata for **SportsHire AI** — MCP-native sports job marketplace.

- **Project repo:** https://github.com/arpand9/sports-jobs-agent
- **Agent docs:** AGENTS.md, docs/AI_JUDGE.md, docs/API.md
- **Data:** 367 Boston-area jobs (362 WorkInSports scrape + curated demos)
- **MCP:** 10 tools + REST `/api/tools/*` parity for AI judges

## Test plan
- [x] `meta.json` only under `sports-hack-2026-submissions/arpand9/`
- [x] Public repo linked and pushed

Made with [Cursor](https://cursor.com)