### PR TITLE
sports-hack-2026: Manideep Mallurwar — InjuryIQ

### DIFF
--- a/sports-hack-2026-submissions/manideep007-cyber/meta.json
+++ b/sports-hack-2026-submissions/manideep007-cyber/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "InjuryIQ — Athlete Recovery Risk Predictor",
+  "description": "Athletic trainers face a high-stakes daily call: should this athlete practice today? InjuryIQ takes a 5-field morning check-in (training load, sleep, soreness, days since rest, prior injuries) and returns a calibrated injury-risk score with the top 3 driving factors for that athlete today. Built on a star-schema data model with a logistic regression trained on 1,500 athlete-days.",
+  "displayName": "Manideep Mallurwar",
+  "videoUrl": "https://www.loom.com/share/55bf45d4040041a39f14b2505047ddbb",
+  "repoUrl": "https://github.com/manideep007-cyber/-injury-iq",
+  "deployedUrl": "https://injury-iq-manideep.streamlit.app",
+  "tags": ["sports-tech", "athlete-performance", "ml", "streamlit", "injury-prevention"],
+  "collaborators": []
+}


### PR DESCRIPTION
Project submission for the May 26 Cursor Boston × Hult Sports Hack at Hult International.

InjuryIQ — Athlete recovery risk predictor. Morning check-in → calibrated injury-risk score + top 3 drivers.

- Live demo: https://injury-iq-manideep.streamlit.app
- Repo: https://github.com/manideep007-cyber/-injury-iq
- Video: https://www.loom.com/share/55bf45d4040041a39f14b2505047ddbb