### PR TITLE
docs(sports-hack): submit t-siddharth project

### DIFF
--- a/sports-hack-2026-submissions/t-siddharth/meta.json
+++ b/sports-hack-2026-submissions/t-siddharth/meta.json
@@ -1,10 +1,16 @@
 {
-    "title": "Cricket IPL 2026 Stats Visualizer",
-    "description": "A web app that visualizes cricket IPL 2026 stats for a given player or team.",
-    "displayName": "Siddharth Tewari",
-    "videoUrl": "https://www.loom.com/share/...",
-    "repoUrl": "https://github.com/t-siddharth/cricket-stats-visualizer",
-    "deployedUrl": "https://cricket-stats-visualizer.vercel.app",
-    "tags": ["cricket", "stats", "visualization"],
-    "collaborators": []
-  }
+  "title": "Cricket IPL Career Progression Visualizer",
+  "description": "Static export of an IPL player career progression analysis notebook (2008–2025) with downloadable CSV datasets for batting, bowling, and player master records.",
+  "displayName": "Siddharth Tewari",
+  "videoUrl": "https://www.loom.com/share/...",
+  "repoUrl": "https://github.com/t-siddharth/cursor-boston/tree/sports-hack/t-siddharth/sports-hack-2026-submissions/t-siddharth",
+  "deployedUrl": "https://cricket-stats-visualizer.vercel.app",
+  "tags": [
+    "cricket",
+    "ipl",
+    "stats",
+    "visualization",
+    "notebook"
+  ],
+  "collaborators": []
+}

--- a/sports-hack-2026-submissions/t-siddharth/meta.json
+++ b/sports-hack-2026-submissions/t-siddharth/meta.json
@@ -1,0 +1,10 @@
+{
+    "title": "Cricket IPL 2026 Stats Visualizer",
+    "description": "A web app that visualizes cricket IPL 2026 stats for a given player or team.",
+    "displayName": "Siddharth Tewari",
+    "videoUrl": "https://www.loom.com/share/...",
+    "repoUrl": "https://github.com/t-siddharth/cricket-stats-visualizer",
+    "deployedUrl": "https://cricket-stats-visualizer.vercel.app",
+    "tags": ["cricket", "stats", "visualization"],
+    "collaborators": []
+  }


### PR DESCRIPTION
## Summary

- Adds `sports-hack-2026-submissions/t-siddharth/meta.json` for the Sports Hack 2026 showcase.
- Live demo: https://cricket-stats-visualizer.vercel.app (static IPL career progression notebook + CSV data hosted separately on Vercel).

## Submission metadata

| Field | Value |
|-------|-------|
| Title | Cricket IPL Career Progression Visualizer |
| Deployed | https://cricket-stats-visualizer.vercel.app |
| Repo path | `sports-hack-2026-submissions/t-siddharth/` on this branch |

## Test plan

- [ ] `meta.json` parses and folder name matches PR author handle (`t-siddharth`)
- [ ] `deployedUrl` loads in a browser
- [ ] No secrets in the PR diff (meta.json only)

**Note:** `videoUrl` is currently empty — will add a Loom link in a follow-up commit if needed before judging.

Made with [Cursor](https://cursor.com)