### PR TITLE
c1w2-comms: promote ProductChameleon (Jackie) Week 2 update

### DIFF
--- a/content/summer-cohort/c1/w2-comms/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie.cursorboston.com",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Maintaining Jackie as cohort PM tool. This week: wired live GitHub API data for all 6 weeks, shipped Weeks 4-6 cohort views with correct format variations (no vote on W4/W6, Demoing state on W5), added full timestamps to submission cards, and added task delete + due date labels to the personal tracker.",
+  "competeForWin": false
+}


### PR DESCRIPTION
Bulk-promotes Jackie's c1 Week 2 (comms) submission update from the staging branch into develop so it renders on the cohort page.

- #1466 — maintenance: live GitHub API, weeks 4-6 views, timestamps, task improvements

Single file: `content/summer-cohort/c1/w2-comms/submissions/ProductChameleon.json`.

Co-authored-by: ProductChameleon <productchameleon@gmail.com>

Signed-off-by: Ludwitt <ludwitt@ludwitt.com>