### PR TITLE
c1w3-vibe-marketing: promote ProductChameleon (Jackie) Week 3 update

### DIFF
--- a/content/summer-cohort/c1/w3-vibe-marketing/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w3-vibe-marketing/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie.cursorboston.com",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Opened Jackie as a contributor-friendly open source repo this week. Shipped README, CONTRIBUTING.md with local setup instructions, and seeded 3 labeled issues (good first issue) so cohort members can co-build Jackie. The repo is live at github.com/ProductChameleon/jackie -- come build with me.",
+  "competeForWin": false
+}


### PR DESCRIPTION
Bulk-promotes Jackie's c1 Week 3 (vibe-marketing) submission update from the staging branch into develop so it renders on the cohort page.

- #1469 — maintenance: open source repo setup, README, CONTRIBUTING, seeded issues

Single file: `content/summer-cohort/c1/w3-vibe-marketing/submissions/ProductChameleon.json`.

Co-authored-by: ProductChameleon <productchameleon@gmail.com>

Signed-off-by: Ludwitt <ludwitt@ludwitt.com>