### PR TITLE
release: 2026-05-27 — Discord signup fix, sports-hack + cohort Week 2/3 submissions, tooling

### DIFF
--- a/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
+++ b/__tests__/app/hackathons/sports-hack-2026/signup/page.test.tsx
@@ -386,7 +386,11 @@ describe("Sports Hack 2026 signup page", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Connect Discord/i })).toHaveAttribute(
       "href",
-      "/api/discord/authorize",
+      expect.stringContaining("/api/discord/authorize?returnTo="),
+    );
+    expect(screen.getByRole("link", { name: /Join Discord first/i })).toHaveAttribute(
+      "href",
+      "https://discord.gg/Wsncg8YYqc",
     );
     expect(screen.getByRole("button", { name: /Complete requirements/i })).toBeDisabled();
     // 1/4 requirements met (isPublic only)

--- a/__tests__/components/ProfileRequirementsModal.deep.test.tsx
+++ b/__tests__/components/ProfileRequirementsModal.deep.test.tsx
@@ -322,7 +322,11 @@ describe("ProfileRequirementsModal deep", () => {
     ).toHaveAttribute("href", "/api/github/authorize");
     expect(screen.getByRole("link", { name: /Connect Discord/i })).toHaveAttribute(
       "href",
-      "/api/discord/authorize",
+      expect.stringContaining("/api/discord/authorize?returnTo="),
+    );
+    expect(screen.getByRole("link", { name: /Join Discord first/i })).toHaveAttribute(
+      "href",
+      "https://discord.gg/Wsncg8YYqc",
     );
   });
 

--- a/app/events/cursor-boston-sports-hack-2026/page.tsx
+++ b/app/events/cursor-boston-sports-hack-2026/page.tsx
@@ -165,7 +165,7 @@ function Hero({ event }: { event: EventRecord | null }) {
             href={SIGNUP_URL}
             className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400"
           >
-            Claim your participation spot →
+            View signup list and rank →
           </Link>
           <a
             href={SPORTS_HACK_2026_LUMA_URL}
@@ -198,18 +198,19 @@ function HowToWinCredits() {
         <ol className="grid gap-4 md:grid-cols-3">
           <Step
             num={1}
-            title="Claim your spot on the site"
+            title="Use the website signup list"
             body={
               <>
-                Sign up at{" "}
+                The list at{" "}
                 <Link
                   href={SIGNUP_URL}
                   className="text-emerald-600 hover:text-emerald-500 dark:text-emerald-400 underline"
                 >
                   /hackathons/sports-hack-2026/signup
                 </Link>
-                . Required even if you&apos;re already on Luma — this is the
-                list we rank from.
+                {" "}
+                is the ranking source for participants. It is separate from
+                Luma registration, which controls event admission.
               </>
             }
           />

--- a/app/hackathons/hack-a-sprint-2026/signup/page.tsx
+++ b/app/hackathons/hack-a-sprint-2026/signup/page.tsx
@@ -13,9 +13,15 @@ import { useAuth } from "@/contexts/AuthContext";
 import { GitHubIcon, DiscordIcon } from "@/components/icons";
 import { trackEvent } from "@/lib/analytics";
 import {
+  EventSignupDiscordConnectLink,
+  EventSignupDiscordJoinHint,
+  EventSignupDiscordMissingCopy,
+} from "@/components/events/EventSignupDiscordRequirement";
+import {
   CURSOR_CREDIT_TOP_N,
 } from "@/lib/hackathon-event-signup";
 import { HACK_A_SPRINT_2026_EVENT_ID } from "@/lib/hackathon-showcase";
+import { getHackathonEventSignupReturnTo } from "@/lib/event-signup-discord";
 
 type EntryStatus = "confirmed" | "waitlisted";
 
@@ -91,6 +97,7 @@ export default function HackASprint2026SignupPage() {
 
   const eventId = HACK_A_SPRINT_2026_EVENT_ID;
   const apiUrl = `/api/hackathons/events/${eventId}/signup`;
+  const signupReturnTo = getHackathonEventSignupReturnTo(eventId);
 
   const trackAuthCta = (cta: "sign_in" | "create_account") => {
     void trackEvent(
@@ -658,7 +665,7 @@ export default function HackASprint2026SignupPage() {
                         <p className="text-xs text-neutral-500 dark:text-neutral-400">
                           {profile.hasDiscord && profile.discordUsername
                             ? <>Connected as <span className="text-emerald-600 dark:text-emerald-400">@{profile.discordUsername}</span></>
-                            : "Required so organizers can reach you"}
+                            : <EventSignupDiscordMissingCopy />}
                         </p>
                       </div>
                     </div>
@@ -668,15 +675,12 @@ export default function HackASprint2026SignupPage() {
                         @{profile.discordUsername}
                       </span>
                     ) : (
-                      <a
-                        href="/api/discord/authorize"
-                        className="inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-4 py-2 text-sm font-medium text-white hover:bg-[#4752C4] transition-colors"
-                      >
-                        <DiscordIcon size={16} />
-                        Connect Discord
-                      </a>
+                      <EventSignupDiscordConnectLink returnTo={signupReturnTo} />
                     )}
                   </div>
+                  {!profile.hasDiscord ? (
+                    <EventSignupDiscordJoinHint className="-mt-1 ml-12 text-xs text-neutral-500 dark:text-neutral-400" />
+                  ) : null}
 
                   {/* Show Discord on profile */}
                   {(() => {

--- a/app/hackathons/sports-hack-2026/signup/page.tsx
+++ b/app/hackathons/sports-hack-2026/signup/page.tsx
@@ -16,6 +16,11 @@ import { SportsHack2026EventNav } from "@/components/hackathons/SportsHack2026Ev
 import { trackEvent } from "@/lib/analytics";
 import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
 import {
+  EventSignupDiscordConnectLink,
+  EventSignupDiscordJoinHint,
+  EventSignupDiscordMissingCopy,
+} from "@/components/events/EventSignupDiscordRequirement";
+import {
   SPORTS_HACK_2026_ATTENDANCE_LIMIT,
   SPORTS_HACK_2026_CAPACITY,
   SPORTS_HACK_2026_EVENT_ID,
@@ -23,6 +28,7 @@ import {
   getSportsHack2026RankTier,
   type SportsHack2026RankTone,
 } from "@/lib/sports-hack-2026";
+import { getHackathonEventSignupReturnTo } from "@/lib/event-signup-discord";
 
 const SPORTS_HACK_RETURN_TO = "/hackathons/sports-hack-2026/signup";
 
@@ -51,6 +57,8 @@ const TONE_BANNER_CLASS: Record<SportsHack2026RankTone, string> = {
 // pills are rendered only when present; the absence of a pill carries no
 // negative implication (vs the previous behavior of warning "Not on Luma
 // yet" which is no longer accurate).
+const SIGNUP_RETURN_TO = getHackathonEventSignupReturnTo(SPORTS_HACK_2026_EVENT_ID);
+
 function LumaPill({ registered }: { registered: boolean | undefined }) {
   if (!registered) return null;
   return (
@@ -1032,7 +1040,7 @@ function SportsHack2026SignupPageInner() {
                               </span>
                             </>
                           ) : (
-                            "Required so organizers can reach you"
+                            <EventSignupDiscordMissingCopy />
                           )}
                         </p>
                       </div>
@@ -1042,15 +1050,12 @@ function SportsHack2026SignupPageInner() {
                         <DiscordIcon size={16} />@{profile.discordUsername}
                       </span>
                     ) : (
-                      <a
-                        href="/api/discord/authorize"
-                        className="inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-4 py-2 text-sm font-medium text-white hover:bg-[#4752C4] transition-colors"
-                      >
-                        <DiscordIcon size={16} />
-                        Connect Discord
-                      </a>
+                      <EventSignupDiscordConnectLink returnTo={SIGNUP_RETURN_TO} />
                     )}
                   </div>
+                  {!profile.hasDiscord ? (
+                    <EventSignupDiscordJoinHint className="-mt-1 ml-12 text-xs text-neutral-500 dark:text-neutral-400" />
+                  ) : null}
 
                   {/* Show Discord on profile */}
                   <ShowDiscordRow

--- a/components/ProfileRequirementsModal.tsx
+++ b/components/ProfileRequirementsModal.tsx
@@ -13,6 +13,10 @@ import Link from "next/link";
 import Avatar from "@/components/Avatar";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
 import { Modal } from "@/components/ui/Modal";
+import {
+  EventSignupDiscordConnectLink,
+  EventSignupDiscordJoinHint,
+} from "@/components/events/EventSignupDiscordRequirement";
 
 export type RequirementType =
   | "isPublic"
@@ -76,6 +80,7 @@ interface ProfileRequirementsModalProps {
   requirements: RequirementType[];
   title?: string;
   description?: string;
+  returnTo?: string;
 }
 
 export default function ProfileRequirementsModal({
@@ -85,6 +90,7 @@ export default function ProfileRequirementsModal({
   requirements,
   title = "Complete Your Profile",
   description = "Please complete the following requirements to continue.",
+  returnTo,
 }: ProfileRequirementsModalProps) {
   const { user, refreshUserProfile } = useAuth();
   const [profile, setProfile] = useState<ProfileStatus | null>(null);
@@ -93,6 +99,11 @@ export default function ProfileRequirementsModal({
   const [displayNameInput, setDisplayNameInput] = useState("");
   const [editingDisplayName, setEditingDisplayName] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const discordReturnTo =
+    returnTo ??
+    (typeof window === "undefined"
+      ? undefined
+      : `${window.location.pathname}${window.location.search}`);
 
   const fetchProfile = useCallback(async () => {
     if (!user) return;
@@ -323,13 +334,10 @@ export default function ProfileRequirementsModal({
           );
         }
         return (
-          <a
-            href="/api/discord/authorize"
+          <EventSignupDiscordConnectLink
+            returnTo={discordReturnTo}
             className="px-4 py-2 bg-[#5865F2] hover:bg-[#4752C4] text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2"
-          >
-            <DiscordIcon size={16} />
-            Connect Discord
-          </a>
+          />
         );
 
       case "hasDisplayName":
@@ -466,39 +474,41 @@ export default function ProfileRequirementsModal({
                   {incompleteRequirements.map((req) => {
                     const config = REQUIREMENT_CONFIGS[req];
                     return (
-                      <div
-                        key={req}
-                        className="flex items-center justify-between p-4 bg-neutral-800/50 border border-neutral-700 rounded-xl"
-                      >
-                        <div className="flex items-center gap-3">
-                          <div className="w-8 h-8 bg-amber-500/10 rounded-full flex items-center justify-center">
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              width="16"
-                              height="16"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              className="text-amber-400"
-                            >
-                              <circle cx="12" cy="12" r="10" />
-                              <line x1="12" y1="8" x2="12" y2="12" />
-                              <line x1="12" y1="16" x2="12.01" y2="16" />
-                            </svg>
+                      <div key={req} className="space-y-2">
+                        <div className="flex items-center justify-between p-4 bg-neutral-800/50 border border-neutral-700 rounded-xl">
+                          <div className="flex items-center gap-3">
+                            <div className="w-8 h-8 bg-amber-500/10 rounded-full flex items-center justify-center">
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                className="text-amber-400"
+                              >
+                                <circle cx="12" cy="12" r="10" />
+                                <line x1="12" y1="8" x2="12" y2="12" />
+                                <line x1="12" y1="16" x2="12.01" y2="16" />
+                              </svg>
+                            </div>
+                            <div>
+                              <p className="text-white font-medium text-sm">
+                                {config.label}
+                              </p>
+                              <p className="text-neutral-400 text-xs">
+                                {config.description}
+                              </p>
+                            </div>
                           </div>
-                          <div>
-                            <p className="text-white font-medium text-sm">
-                              {config.label}
-                            </p>
-                            <p className="text-neutral-400 text-xs">
-                              {config.description}
-                            </p>
-                          </div>
+                          {renderRequirementAction(req)}
                         </div>
-                        {renderRequirementAction(req)}
+                        {req === "hasDiscord" ? (
+                          <EventSignupDiscordJoinHint className="px-4 text-xs text-neutral-400" />
+                        ) : null}
                       </div>
                     );
                   })}

--- a/components/events/EventSignupDiscordRequirement.tsx
+++ b/components/events/EventSignupDiscordRequirement.tsx
@@ -1,0 +1,58 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import {
+  CURSOR_BOSTON_DISCORD_INVITE_URL,
+  getDiscordAuthorizeUrl,
+} from "@/lib/event-signup-discord";
+import { DiscordIcon } from "@/components/icons";
+
+export function EventSignupDiscordMissingCopy() {
+  return (
+    <>
+      Join the Cursor Boston Discord first, then connect so we can verify
+      membership.
+    </>
+  );
+}
+
+export function EventSignupDiscordJoinHint({
+  className = "text-xs text-neutral-500 dark:text-neutral-400",
+}: {
+  className?: string;
+}) {
+  return (
+    <p className={className}>
+      Not in the server yet?{" "}
+      <a
+        href={CURSOR_BOSTON_DISCORD_INVITE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-emerald-600 underline hover:text-emerald-500 dark:text-emerald-400"
+      >
+        Join Discord first
+      </a>
+      , then come back and connect your account.
+    </p>
+  );
+}
+
+export function EventSignupDiscordConnectLink({
+  returnTo,
+  className = "inline-flex items-center gap-2 rounded-lg bg-[#5865F2] px-4 py-2 text-sm font-medium text-white hover:bg-[#4752C4] transition-colors",
+}: {
+  returnTo?: string | null;
+  className?: string;
+}) {
+  return (
+    <a href={getDiscordAuthorizeUrl(returnTo)} className={className}>
+      <DiscordIcon size={16} />
+      Connect Discord
+    </a>
+  );
+}
+

--- a/content/summer-cohort/c1/w2-comms/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w2-comms/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie.cursorboston.com",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Maintaining Jackie as cohort PM tool. This week: wired live GitHub API data for all 6 weeks, shipped Weeks 4-6 cohort views with correct format variations (no vote on W4/W6, Demoing state on W5), added full timestamps to submission cards, and added task delete + due date labels to the personal tracker.",
+  "competeForWin": false
+}

--- a/content/summer-cohort/c1/w3-vibe-marketing/submissions/ProductChameleon.json
+++ b/content/summer-cohort/c1/w3-vibe-marketing/submissions/ProductChameleon.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "ProductChameleon",
+  "name": "Ying Chen",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocKiyNwdAKbCeA2qDYkQP6oH_ukbVnK2gG9tBY4kXJyx0EiDgg=s96-c",
+  "repoUrl": "https://github.com/ProductChameleon/jackie",
+  "liveUrl": "https://jackie.cursorboston.com",
+  "loomUrl": "https://www.loom.com/share/b1592d208a3f4b37ada0f5517f29666f",
+  "pitch": "Opened Jackie as a contributor-friendly open source repo this week. Shipped README, CONTRIBUTING.md with local setup instructions, and seeded 3 labeled issues (good first issue) so cohort members can co-build Jackie. The repo is live at github.com/ProductChameleon/jackie -- come build with me.",
+  "competeForWin": false
+}

--- a/lib/event-signup-discord.ts
+++ b/lib/event-signup-discord.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+export const CURSOR_BOSTON_DISCORD_INVITE_URL = "https://discord.gg/Wsncg8YYqc";
+
+export function getHackathonEventSignupReturnTo(eventId: string): string {
+  return `/hackathons/${eventId}/signup`;
+}
+
+export function getDiscordAuthorizeUrl(returnTo?: string | null): string {
+  if (!returnTo) return "/api/discord/authorize";
+  return `/api/discord/authorize?returnTo=${encodeURIComponent(returnTo)}`;
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -20505,7 +20505,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/scripts/send-broadcast-2026-05-26.ts
+++ b/scripts/send-broadcast-2026-05-26.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * General broadcast to all eventContacts (2026-05-26 evening).
+ *
+ * Sent the evening after the Boston Tech Week Sports Hack at Hult.
+ * Three beats:
+ *   1. Thanks — the Sports Hack today was a knockout
+ *   2. Want to host an event with us? Reply.
+ *   3. New essay from Roger: The Death of the University Degree
+ *
+ * Mirrors send-broadcast-2026-05-07.ts mechanics: pulls from eventContacts,
+ * skips unsubscribed, syncs Mailgun suppressions first, HMAC unsubscribe link.
+ *
+ * Usage:
+ *   npx tsx scripts/send-broadcast-2026-05-26.ts --dry-run
+ *   npx tsx scripts/send-broadcast-2026-05-26.ts --send
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN, UNSUBSCRIBE_SECRET
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const SUBMISSIONS_URL =
+  "https://www.cursorboston.com/events/cursor-boston-sports-hack-2026";
+const SUBSTACK_URL =
+  "https://rogerhuntphdcand.substack.com/p/the-death-of-the-university-degree";
+const REPO_URL = "https://github.com/rogerSuperBuilderAlpha/cursor-boston";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+}
+
+function buildEmail(contact: ContactData): { subject: string; html: string; text: string } {
+  const first = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there",
+  );
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  const subject = "Thanks for a knockout Sports Hack — and a new essay";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Today was a <strong>total knockout</strong>. Thank you to everyone who showed up at the Boston Tech Week Sports Hack at Hult — builders, mentors, sponsors, and the crew making sure the wifi held up. The room was electric, the submissions kept landing all afternoon, and the demos were genuinely impressive.</p>
+
+<p>If you want to see what got built, the submission board is here: <a href="${SUBMISSIONS_URL}">${SUBMISSIONS_URL}</a>. Every project is open source.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">Want to host an event with us?</h3>
+
+<p>If you&apos;ve been thinking about running a hackathon, workshop, or evening build at your company, school, or space — <strong>reply to this email</strong>. We&apos;ll figure it out. The Sports Hack was the fourth event we&apos;ve done this month and we have the playbook dialed in: registration, judging, sponsorship, AI scoring, the works. You bring the audience and the room; we&apos;ll bring the format.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;">New essay — The Death of the University Degree</h3>
+
+<p>I wrote a piece this week on what AI-native tooling is doing to the credentialing model that most of higher ed still runs on. If you care about how people learn to build now — and where the signal of "this person can ship" actually comes from — give it a read:</p>
+
+<p><a href="${SUBSTACK_URL}" style="display:inline-block;margin:8px 0;padding:12px 22px;background:#111;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">Read: The Death of the University Degree</a></p>
+
+<p>Reply with thoughts, pushback, or quotes from your own experience — I&apos;m collecting reactions.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="font-size:12px;color:#888;margin-top:24px;border-top:1px solid #e5e5e5;padding-top:16px;">You&apos;re receiving this because you registered for a Cursor Boston event. <a href="${unsubUrl}" style="color:#888;">Unsubscribe</a> at any time.<br/>
+<small>Repo: <a href="${REPO_URL}" style="color:#888;">${REPO_URL}</a></small></p>
+</body></html>`;
+
+  const text = `Hi ${first},
+
+Today was a TOTAL KNOCKOUT. Thank you to everyone who showed up at the Boston Tech Week Sports Hack at Hult — builders, mentors, sponsors, and the crew making sure the wifi held up. The room was electric, the submissions kept landing all afternoon, and the demos were genuinely impressive.
+
+If you want to see what got built, the submission board is here:
+${SUBMISSIONS_URL}
+
+Every project is open source.
+
+WANT TO HOST AN EVENT WITH US?
+
+If you've been thinking about running a hackathon, workshop, or evening build at your company, school, or space — reply to this email. We'll figure it out. The Sports Hack was the fourth event we've done this month and we have the playbook dialed in: registration, judging, sponsorship, AI scoring, the works. You bring the audience and the room; we'll bring the format.
+
+NEW ESSAY — THE DEATH OF THE UNIVERSITY DEGREE
+
+I wrote a piece this week on what AI-native tooling is doing to the credentialing model that most of higher ed still runs on. If you care about how people learn to build now — and where the signal of "this person can ship" actually comes from — give it a read:
+
+${SUBSTACK_URL}
+
+Reply with thoughts, pushback, or quotes from your own experience — I'm collecting reactions.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you registered for a Cursor Boston event.
+Unsubscribe: ${unsubUrl}
+Repo: ${REPO_URL}
+`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS).",
+    );
+    process.exit(1);
+  }
+
+  await syncMailgunSuppressions(db);
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    contacts.push({
+      email: data.email || doc.id,
+      name: data.name || "",
+      firstName: data.firstName || "",
+    });
+  }
+
+  console.log(`Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = contacts[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview (first 1800 chars) ---");
+      console.log(html.slice(0, 1800));
+      console.log("\n--- Text preview (first 1200 chars) ---");
+      console.log(text.slice(0, 1200));
+    }
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 50 === 0) {
+        console.log(`  Progress: ${sent}/${contacts.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/treasure-hunt-add-unassigned-codes.ts
+++ b/scripts/treasure-hunt-add-unassigned-codes.ts
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Add never-assigned Cursor referral codes to the treasure-hunt prize pool.
+ *
+ * Use case: an event distribution (e.g. sports-hack-2026) pre-printed N
+ * referral codes for a credit band, but only M < N attendees met the
+ * submission requirement. The remaining N - M codes were never emailed
+ * to anyone — they're free to hide behind website puzzles.
+ *
+ * Unlike scripts/treasure-hunt-build-pool.ts (which sources from
+ * hackathonCreditCodes assigned by rank), this script takes a flat JSON
+ * array of referral URLs + an offset of how many were already used.
+ *
+ * Each unused URL is verified against Cursor's referral API (matching the
+ * existing pool builder) before landing in treasureHuntPrizes with status
+ * = "available" and originalAssignee = null.
+ *
+ * Usage:
+ *   npx tsx scripts/treasure-hunt-add-unassigned-codes.ts \
+ *     --codes /tmp/sports-hack-2026-credits.json \
+ *     --used 31 \
+ *     --source sports-hack-2026-leftovers \
+ *     --dry-run
+ *
+ *   npx tsx scripts/treasure-hunt-add-unassigned-codes.ts \
+ *     --codes /tmp/sports-hack-2026-credits.json \
+ *     --used 31 \
+ *     --source sports-hack-2026-leftovers \
+ *     --write
+ *
+ * Flags:
+ *   --codes <path>   JSON file: array of referral URL strings
+ *   --used <n>       Number of leading URLs in the file already distributed
+ *   --source <tag>   Free-form label stored on each prize doc for auditing
+ *   --skip-verify    Don't hit Cursor's API (faster; skip only for fresh codes)
+ *   --dry-run        Plan only — no Firestore writes
+ *   --write          Commit the inserts
+ */
+import { readFileSync } from "fs";
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+
+const REFERRAL_REGEX = /https?:\/\/cursor\.com\/referral\?code=([A-Z0-9]+)/i;
+const CHECK_ENDPOINT = "https://cursor.com/api/dashboard/check-referral-code";
+const CHECK_DELAY_MS = 500;
+
+type ReferralStatus = "active" | "redeemed" | "unknown";
+
+async function checkReferral(code: string, retries = 3): Promise<ReferralStatus> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      if (attempt > 0) await new Promise((r) => setTimeout(r, CHECK_DELAY_MS * attempt));
+      const res = await fetch(CHECK_ENDPOINT, {
+        method: "POST",
+        headers: {
+          accept: "*/*",
+          "content-type": "application/json",
+          origin: "https://cursor.com",
+          referer: `https://cursor.com/referral?code=${code}`,
+          "user-agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+        },
+        body: JSON.stringify({ referralCode: code }),
+      });
+      if (res.status === 200) {
+        const json = (await res.json()) as Record<string, unknown>;
+        if (json && typeof json === "object" && "isValid" in json) {
+          const v = json as { isValid: boolean; userIsEligible?: boolean };
+          return v.isValid && v.userIsEligible ? "active" : "redeemed";
+        }
+        if (json && Object.keys(json).length === 0) return "redeemed";
+        const title = (json as { metadata?: { title?: string } })?.metadata?.title?.toLowerCase() ?? "";
+        if (title.includes("already been used") || title.includes("expired")) return "redeemed";
+        return "unknown";
+      }
+      if (res.status === 500 && attempt < retries - 1) continue;
+      return "unknown";
+    } catch {
+      if (attempt < retries - 1) continue;
+      return "unknown";
+    }
+  }
+  return "unknown";
+}
+
+function parseArgs(argv: string[]) {
+  const get = (flag: string): string | null => {
+    const i = argv.indexOf(flag);
+    return i >= 0 && argv[i + 1] ? argv[i + 1]! : null;
+  };
+  const dryRun = argv.includes("--dry-run");
+  const write = argv.includes("--write");
+  const skipVerify = argv.includes("--skip-verify");
+  const codesPath = get("--codes");
+  const usedRaw = get("--used");
+  const source = get("--source");
+
+  if ((dryRun && write) || (!dryRun && !write)) {
+    console.error("Specify exactly one of: --dry-run | --write");
+    process.exit(1);
+  }
+  if (!codesPath) {
+    console.error("--codes <path-to-json-array> required");
+    process.exit(1);
+  }
+  if (!source) {
+    console.error("--source <tag> required (free-form audit label)");
+    process.exit(1);
+  }
+  const used = usedRaw ? Number.parseInt(usedRaw, 10) : 0;
+  if (Number.isNaN(used) || used < 0) {
+    console.error("--used must be a non-negative integer");
+    process.exit(1);
+  }
+  return { dryRun, write, skipVerify, codesPath, used, source };
+}
+
+async function main(): Promise<void> {
+  const { dryRun, skipVerify, codesPath, used, source } = parseArgs(
+    process.argv.slice(2),
+  );
+
+  let urls: string[];
+  try {
+    const raw = readFileSync(codesPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.some((x) => typeof x !== "string")) {
+      console.error("Codes file must be a JSON array of URL strings.");
+      process.exit(1);
+    }
+    urls = parsed as string[];
+  } catch (e) {
+    console.error(`Cannot read codes file: ${codesPath}`, e);
+    process.exit(1);
+  }
+
+  console.log(`Loaded ${urls.length} URL(s) from ${codesPath}`);
+  console.log(`Marked as already used: ${used}`);
+  if (used > urls.length) {
+    console.error(`--used (${used}) exceeds total URL count (${urls.length}).`);
+    process.exit(1);
+  }
+
+  const remaining = urls.slice(used);
+  console.log(`Leftover to add to pool: ${remaining.length}`);
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS).",
+    );
+    process.exit(1);
+  }
+  const col = db.collection("treasureHuntPrizes");
+
+  type Candidate = { url: string; code: string };
+  const candidates: Candidate[] = [];
+  const skippedMalformed: string[] = [];
+  for (const url of remaining) {
+    const match = url.match(REFERRAL_REGEX);
+    if (!match) {
+      skippedMalformed.push(url);
+      continue;
+    }
+    candidates.push({ url, code: match[1]!.toUpperCase() });
+  }
+  if (skippedMalformed.length > 0) {
+    console.warn(`[warn] Skipped ${skippedMalformed.length} URL(s) that don't match the referral pattern.`);
+  }
+
+  // Dedupe against codes already in the pool — don't double-insert.
+  const existing = new Set<string>();
+  const existSnap = await col.get();
+  for (const doc of existSnap.docs) {
+    existing.add(doc.id);
+  }
+  const fresh = candidates.filter((c) => !existing.has(c.code));
+  const duplicates = candidates.filter((c) => existing.has(c.code));
+  if (duplicates.length > 0) {
+    console.log(`Already in pool (will skip): ${duplicates.length}`);
+  }
+  console.log(`To verify + insert: ${fresh.length}`);
+
+  let toInsert: Array<Candidate & { status: ReferralStatus }>;
+  if (skipVerify) {
+    toInsert = fresh.map((c) => ({ ...c, status: "active" as const }));
+    console.log("[info] --skip-verify: trusting all leftovers as active.");
+  } else {
+    console.log(`\nVerifying ${fresh.length} code(s) against Cursor's referral API...`);
+    const verified: Array<Candidate & { status: ReferralStatus }> = [];
+    for (let i = 0; i < fresh.length; i++) {
+      const c = fresh[i]!;
+      const status = await checkReferral(c.code);
+      console.log(`  [${i + 1}/${fresh.length}] ${c.code} → ${status}`);
+      verified.push({ ...c, status });
+      if (i < fresh.length - 1) await new Promise((r) => setTimeout(r, CHECK_DELAY_MS));
+    }
+    toInsert = verified;
+  }
+
+  const active = toInsert.filter((v) => v.status === "active");
+  const redeemed = toInsert.filter((v) => v.status === "redeemed");
+  const unknown = toInsert.filter((v) => v.status === "unknown");
+
+  console.log(
+    `\nResult: ${active.length} active | ${redeemed.length} already redeemed | ${unknown.length} unknown (skipped)`,
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no Firestore writes. Would insert:");
+    for (const a of active) {
+      console.log(`  ${a.code}`);
+    }
+    return;
+  }
+
+  if (active.length === 0) {
+    console.log("Nothing to write.");
+    return;
+  }
+
+  const batch = db.batch();
+  for (const a of active) {
+    batch.set(col.doc(a.code), {
+      code: a.code,
+      creditUrl: a.url,
+      originalAssignee: {
+        email: null,
+        name: null,
+        uid: null,
+        role: null,
+      },
+      status: "available",
+      claimedByUid: null,
+      claimedByEmail: null,
+      claimedPath: null,
+      claimedAt: null,
+      emailSentAt: null,
+      source,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  }
+  await batch.commit();
+  console.log(`\nWrote ${active.length} prize doc(s) to treasureHuntPrizes (source=${source}).`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/sports-hack-2026-submissions/pothirendirahul/meta.json
+++ b/sports-hack-2026-submissions/pothirendirahul/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "FanPulse FIFA AI",
+  "description": "FanPulse FIFA AI helps football fans rediscover past matches through personalized AI storytelling, top highlights, hidden insights, trivia, and shareable social content. The MVP uses a 3-agent pipeline and supports OpenAI with mock fallback; it is not deployed yet.",
+  "displayName": "Rahul Pothirendi",
+  "videoUrl": "https://www.loom.com/share/08b18241d60d49c6b23a962dac11efdd",
+  "repoUrl": "https://github.com/Pothirendirahul/fanpulse-fifa",
+  "deployedUrl": "",
+  "tags": ["ai", "football", "fan-engagement", "sports", "fastapi", "openai"]
+}

--- a/sports-hack-2026-submissions/shivz3232/meta.json
+++ b/sports-hack-2026-submissions/shivz3232/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "CoachCam AI - A free-throw form analyzer",
+  "description": "CoachCam AI helps beginner basketball players improve their free throw form by analyzing a short phone video and giving instant visual + coaching feedback.",
+  "displayName": "Shivu & Prathamesh",
+  "videoUrl": "https://northeastern.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=c8336990-28fe-41e5-b189-b456013142a8",
+  "repoUrl": "https://github.com/Shivz3232/free-throw-analyzer",
+  "deployedUrl": "https://free-throw-analyzer.vercel.app/",
+  "tags": ["basketball", "pose-estimation", "next.js"],
+  "collaborators": [
+    { "displayName": "Shivu", "githubHandle": "shivz3232" },
+    { "displayName": "Prathmesh", "githubHandle": "prathmeshb15" }
+  ]
+}


### PR DESCRIPTION
## Release contents

### Code changes
- **#1495** — fix: event signup Discord requirement flow. Adds `EventSignupDiscordRequirement` component + `lib/event-signup-discord.ts` helper so the Discord OAuth round-trips back to the signup page after auth. Thanks @nebullii.
- **chore(deps)** — install missing `eslint-plugin-unused-imports`. PR #1489 added it to package.json + wired into eslint.config.mjs but never committed the lockfile update; this catches the lockfile up so `npm ci` and pre-commit hooks work on fresh checkouts.
- **chore(scripts)** — May 26 evening broadcast script + a generic `treasure-hunt-add-unassigned-codes.ts` companion to `treasure-hunt-build-pool.ts` for seeding never-assigned referral codes into the puzzle pool.

### sports-hack-2026 submissions (bulk-promoted via #1546)
- **#1508** — shivz3232 + prathmeshb15: CoachCam AI (free-throw form analyzer)
- **#1544** — Pothirendirahul: FanPulse FIFA AI (re-submission with corrected Loom URL after #1526 was reverted)

### Summer cohort 1 contributions (bulk-promoted via #1542, #1543)
- **#1466** — ProductChameleon (Jackie): c1 Week 2 (comms) update — live GitHub API, weeks 4-6 views, timestamps, task improvements
- **#1469** — ProductChameleon (Jackie): c1 Week 3 (vibe-marketing) update — open source repo setup, README, CONTRIBUTING, seeded issues

## Verification
- `npm run build` clean (191/191 pages, only the pre-existing protobufjs warning + pre-existing pydata-skipped notices)
- `npm start` smoke-tested locally on :3100 against the sports-hack-2026 event page (new cards rendering), the cohort Week 2 / Week 3 pages, and the sports-hack signup page (Discord flow fix).

Signed-off-by: Ludwitt <ludwitt@ludwitt.com>