### PR TITLE
fix(api): add ts-rest contract for /api/commentary route

### DIFF
--- a/app/api/commentary/route.ts
+++ b/app/api/commentary/route.ts
@@ -7,14 +7,7 @@
 
 import { NextResponse } from "next/server";
 
-type CommentaryRequest = {
-  event?: string;
-  homeTeam?: string;
-  targetTeam?: string;
-  mode?: "glaze" | "roast" | string;
-  intensity?: string;
-  persona?: string;
-};
+import { CommentaryBody } from "@/lib/api-schemas/commentary";
 
 const glazeLines = [
   "Boston is playing with main character energy right now. That possession had receipts.",
@@ -29,7 +22,9 @@ const roastLines = [
 ];
 
 export async function POST(request: Request) {
-  const body = (await request.json().catch(() => ({}))) as CommentaryRequest;
+  const raw = await request.json().catch(() => ({}));
+  const parsed = CommentaryBody.safeParse(raw);
+  const body = parsed.success ? parsed.data : {};
   const isGlaze = body.mode === "glaze";
   const lines = isGlaze ? glazeLines : roastLines;
   const selected = lines[Math.floor(Math.random() * lines.length)];

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**186 paths, 223 operations across 35 areas.**
+**187 paths, 224 operations across 36 areas.**
 
 ---
 
@@ -402,6 +402,12 @@ _Talk-submission moderation queue._
 |--------|----------|------|-------------|
 | GET | `/api/talks/submission/moderate` | Yes | Admin: list talk submissions (paginated by status, or three-bucket default) |
 | POST | `/api/talks/submission/moderate` | Yes | Admin: approve a talk submission or mark it delivered |
+
+## Commentary
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/api/commentary` | No | Generate live glaze/roast sports commentary |
 
 ## Cursor
 

--- a/lib/api-schemas/commentary.ts
+++ b/lib/api-schemas/commentary.ts
@@ -1,0 +1,63 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Commentary-area API contract. Backs the live "trash talk" sports
+ * commentary demo (glaze / roast lines for a home vs. target team). The
+ * endpoint is a mock generator — all request fields are optional and the
+ * handler falls back to Celtics-vs-Knicks defaults.
+ */
+
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+
+import { ApiErrorSchema } from "./common";
+
+const c = initContract();
+
+export const CommentaryBody = z
+  .object({
+    event: z.string().optional(),
+    homeTeam: z.string().optional(),
+    targetTeam: z.string().optional(),
+    mode: z.string().optional(),
+    intensity: z.string().optional(),
+    persona: z.string().optional(),
+  })
+  .passthrough()
+  .openapi("CommentaryBody");
+
+const CommentaryResponse = z
+  .object({
+    commentary: z.string(),
+    sentiment: z.enum(["glaze", "roast"]),
+    crowdEnergy: z.number(),
+    event: z.string(),
+    targetTeam: z.string(),
+    persona: z.string(),
+    intensity: z.string(),
+    homeTeam: z.string(),
+  })
+  .openapi("CommentaryResponse");
+
+export const commentaryContract = c.router(
+  {
+    generate: {
+      method: "POST",
+      path: "/api/commentary",
+      summary: "Generate live glaze/roast sports commentary",
+      body: CommentaryBody,
+      responses: {
+        200: CommentaryResponse,
+        400: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: { errorCodes: ["VALIDATION_ERROR", "SERVER_ERROR"] as const },
+    },
+  },
+  { pathPrefix: "", strictStatusCodes: true }
+);

--- a/lib/api-schemas/index.ts
+++ b/lib/api-schemas/index.ts
@@ -23,6 +23,7 @@ import { authContract } from "./auth";
 import { badgesContract } from "./badges";
 import { certificateContract } from "./certificate";
 import { cfpContract } from "./cfp";
+import { commentaryContract } from "./commentary";
 import { communityContract } from "./community";
 import { cookbookContract } from "./cookbook";
 import { cursorContract } from "./cursor";
@@ -62,6 +63,7 @@ export const apiContract = c.router({
   badges: badgesContract,
   certificate: certificateContract,
   cfp: cfpContract,
+  commentary: commentaryContract,
   community: communityContract,
   cookbook: cookbookContract,
   cursor: cursorContract,

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -133,7 +133,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (223 endpoints)
+## API (224 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -408,6 +408,10 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
 
     GET    /api/talks/submission/moderate [Yes] — Admin: list talk submissions (paginated by status, or three-bucket default)
     POST   /api/talks/submission/moderate [Yes] — Admin: approve a talk submission or mark it delivered
+
+### Commentary
+
+    POST   /api/commentary — Generate live glaze/roast sports commentary
 
 ### Cursor
 


### PR DESCRIPTION
PR #1470 merged `app/api/commentary/route.ts` without a contract import, which breaks the `check:route-contracts` build gate (caught in local prod verification before the develop→main release).

This adds a `commentary` contract, registers it in the root `apiContract`, validates the POST body in the handler, and regenerates `API.md` + `llms.txt`. Local `npm run build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)