### PR TITLE
chore(docs): regenerate API.md + llms.txt after dropping /api/commentary

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**187 paths, 224 operations across 36 areas.**
+**186 paths, 223 operations across 35 areas.**
 
 ---
 
@@ -402,12 +402,6 @@ _Talk-submission moderation queue._
 |--------|----------|------|-------------|
 | GET | `/api/talks/submission/moderate` | Yes | Admin: list talk submissions (paginated by status, or three-bucket default) |
 | POST | `/api/talks/submission/moderate` | Yes | Admin: approve a talk submission or mark it delivered |
-
-## Commentary
-
-| Method | Endpoint | Auth | Description |
-|--------|----------|------|-------------|
-| POST | `/api/commentary` | No | Generate live glaze/roast sports commentary |
 
 ## Cursor
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -133,7 +133,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (224 endpoints)
+## API (223 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -408,10 +408,6 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
 
     GET    /api/talks/submission/moderate [Yes] — Admin: list talk submissions (paginated by status, or three-bucket default)
     POST   /api/talks/submission/moderate [Yes] — Admin: approve a talk submission or mark it delivered
-
-### Commentary
-
-    POST   /api/commentary — Generate live glaze/roast sports commentary
 
 ### Cursor
 


### PR DESCRIPTION
Generated-doc cleanup following #1559 (TrashTalk revert). Removes the deleted `/api/commentary` endpoint from the API reference + llms.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)