### PR TITLE
refactor(scripts): shared campaign/backfill harness (Phase 1 of deep refactor)

### DIFF
--- a/scripts/_lib/README.md
+++ b/scripts/_lib/README.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-License-Identifier: GPL-3.0-only
+Copyright (C) 2026 Cursor Boston
+-->
+
+# `scripts/_lib` — shared harness for one-off scripts
+
+Before this existed, every `send-*` script re-implemented the same ~150 lines of
+boilerplate (env loading, `escapeHtml`, `sleep`, CLI flag parsing, a recipient
+query, a dry-run preview, and a throttled send loop with per-recipient
+try/catch + an idempotency stamp). Backfill/seed/sync scripts likewise
+re-implemented batched writes and the `--dry-run`/`--apply` branch.
+
+These modules own that boilerplate so a script only supplies what is actually
+unique to it.
+
+## Modules
+
+| Module | Use it for |
+| --- | --- |
+| `script-utils.ts` | `loadEnv()`, `escapeHtml()`, `sleep()`, `parseSendArgs()`, `parseDbArgs()`, `requireFirebaseEnv()`, `requireMailgunEnv()` |
+| `campaign-runner.ts` | `runEmailCampaign()` — the full `send-*` lifecycle |
+| `db-runner.ts` | `runBackfill()` — batched Firestore writes for `backfill-*`/`seed-*`/`sync-*` |
+| `cohort1-recipients.ts` | domain helper: load admitted cohort-1 applicants by idempotency stamp |
+
+> **Import order matters.** `loadEnv()` (or any env-reading import) must run
+> before modules that read `process.env` at import time. Put
+> `import { loadEnv, ... } from "./_lib/script-utils"; loadEnv();` at the very
+> top, before importing `../lib/*`.
+
+## Writing a new email campaign
+
+```ts
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+// ...domain imports...
+
+interface Recipient { email: string; firstName: string; /* ... */ }
+
+function buildEmail(r: Recipient): EmailContent {
+  // return { subject, html, text }  (add `from` for a per-campaign sender)
+}
+
+async function main() {
+  await runEmailCampaign<Recipient>({
+    args: parseSendArgs(),
+    name: "My campaign",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: async ({ db, args }) => { /* query + filter */ },
+    onSent: (r, { db }) => { /* optional idempotency stamp */ },
+    // beforeSend, throttleMs, previewMode, progressEvery are optional
+  });
+}
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+Worked examples in `scripts/`:
+
+- `send-cohort-admittance.ts` — per-recipient user lookup + `--force`/`--only-email`
+- `send-cohort1-week3-*.ts` — share `cohort1-recipients.ts` for the recipient filter
+- `send-may26-event-morning.ts` — multi-collection dedup, `from` override, `beforeSend`
+
+## Writing a new backfill/seed/sync
+
+```ts
+import { loadEnv, parseDbArgs } from "./_lib/script-utils";
+loadEnv();
+import { runBackfill, type WriteOp } from "./_lib/db-runner";
+
+await runBackfill({
+  args: parseDbArgs(process.argv.slice(2), ["--write"]),
+  name: "my backfill",
+  load: async ({ db }) => { /* return the docs/items to process */ },
+  process: (item): WriteOp | null => /* a write op, or null to skip */,
+});
+```
+
+Worked example: `backfill-attending-confirmed-by.ts`.
+
+## Scope note
+
+The pre-existing dated one-off `send-*` scripts (e.g. `send-broadcast-2026-05-*`,
+`send-cohort1-week2-*`) were executed once and archived; they were intentionally
+**not** migrated, since rewriting executed-once templates is churn with no payoff.
+New scripts and re-runnable ones should use this harness.

--- a/scripts/_lib/campaign-runner.ts
+++ b/scripts/_lib/campaign-runner.ts
@@ -1,0 +1,157 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Email-campaign harness for the `scripts/send-*` one-off scripts.
+ *
+ * Each send script previously inlined ~150 lines of identical boilerplate:
+ * env validation, recipient query, dry-run preview, a throttled send loop with
+ * per-recipient try/catch + progress logging, and an optional post-send
+ * idempotency stamp. This module owns all of that; a script only has to supply
+ * `loadRecipients` + `buildEmail` (+ an optional `onSent` stamp writer).
+ *
+ * Sender overrides go through the per-call `from` field on the returned email
+ * content or the `MAILGUN_FROM` env var — never by editing `lib/mailgun.ts`.
+ */
+import type { Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "../../lib/firebase-admin";
+import { sendEmail } from "../../lib/mailgun";
+import {
+  requireFirebaseEnv,
+  requireMailgunEnv,
+  sleep,
+  type SendArgs,
+} from "./script-utils";
+
+export interface EmailContent {
+  subject: string;
+  html: string;
+  text: string;
+  /** Optional per-message sender override (defaults to MAILGUN_FROM). */
+  from?: string;
+}
+
+export interface RunEmailCampaignOptions<R> {
+  /** Parsed CLI flags (see parseSendArgs). */
+  args: SendArgs;
+  /** Human label for logs, e.g. "Cohort 1 Week 3 reminder". */
+  name: string;
+  /**
+   * Optional pre-send side effect (e.g. `syncMailgunSuppressions(db)`). Runs
+   * once after env validation, only on a real send (not dry-run), before
+   * recipients are loaded.
+   */
+  beforeSend?: (ctx: { db: Firestore }) => Promise<unknown>;
+  /** Query + filter recipients. Receives the live db handle and parsed args. */
+  loadRecipients: (ctx: { db: Firestore; args: SendArgs }) => Promise<R[]>;
+  /** Address used for sending, dedupe, and logging. */
+  getEmail: (r: R) => string;
+  /** Build the subject/html/text for one recipient. */
+  buildEmail: (r: R) => EmailContent;
+  /**
+   * Optional post-send write (idempotency stamp). Runs after a successful send,
+   * inside the same loop, before the throttle delay. Failures here are logged
+   * but do not abort the run.
+   */
+  onSent?: (r: R, ctx: { db: Firestore }) => Promise<unknown>;
+  /** Delay between sends in ms (default 450). */
+  throttleMs?: number;
+  /** Which body to print in the dry-run sample preview (default "html"). */
+  previewMode?: "html" | "text";
+  /** Log progress every N sends (default 25). */
+  progressEvery?: number;
+}
+
+export interface CampaignResult {
+  total: number;
+  sent: number;
+  failed: number;
+}
+
+/**
+ * Run an email campaign end-to-end. Validates env, loads recipients, prints a
+ * dry-run preview (and returns) when `args.dryRun`, otherwise sends with
+ * throttling, per-recipient error isolation, and an optional idempotency stamp.
+ */
+export async function runEmailCampaign<R>(
+  opts: RunEmailCampaignOptions<R>
+): Promise<CampaignResult> {
+  const {
+    args,
+    name,
+    beforeSend,
+    loadRecipients,
+    getEmail,
+    buildEmail,
+    onSent,
+    throttleMs = 450,
+    previewMode = "html",
+    progressEvery = 25,
+  } = opts;
+
+  requireFirebaseEnv();
+  if (args.send) requireMailgunEnv();
+
+  const db = getAdminDb();
+  if (!db) {
+    throw new Error("Firebase Admin not configured (getAdminDb returned null).");
+  }
+
+  if (args.send && beforeSend) await beforeSend({ db });
+
+  console.log(`\n[${name}] loading recipients…`);
+  const recipients = await loadRecipients({ db, args });
+  console.log(`[${name}] recipients to email: ${recipients.length}`);
+
+  if (args.dryRun) {
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`\nSample to: ${getEmail(sample)}`);
+      console.log(`Subject: ${subject}`);
+      if (previewMode === "text") {
+        console.log(`\n---- text preview ----\n${text}`);
+      } else {
+        console.log(
+          `\n---- HTML preview (first 1800 chars) ----\n${html.slice(0, 1800)}\n…`
+        );
+      }
+    } else {
+      console.log("\n(no recipients matched — nothing to send)");
+    }
+    console.log(`\n--dry-run: no emails sent and no writes.`);
+    return { total: recipients.length, sent: 0, failed: 0 };
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const email = getEmail(r);
+    const { subject, html, text, from } = buildEmail(r);
+    try {
+      await sendEmail({ to: email, subject, html, text, from });
+      if (onSent) {
+        try {
+          await onSent(r, { db });
+        } catch (stampErr) {
+          console.error(`  [stamp-failed] ${email}`, stampErr);
+        }
+      }
+      sent++;
+      if (sent % progressEvery === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${email}`, e);
+    }
+    await sleep(throttleMs);
+  }
+
+  console.log(`\n[${name}] done. Sent ${sent}, failed ${failed}.`);
+  return { total: recipients.length, sent, failed };
+}

--- a/scripts/_lib/cohort1-recipients.ts
+++ b/scripts/_lib/cohort1-recipients.ts
@@ -1,0 +1,106 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Shared recipient loading for the Cohort 1 send-* scripts.
+ *
+ * Every `send-cohort1-*` script walked the summer-cohort collection with the
+ * identical "admitted, in cohort-1, not yet stamped, optional --only-email"
+ * filter and the same skip-counter logging. That block lived (byte-identical)
+ * in 4+ scripts; it lives here once now. Each campaign differs only in its
+ * idempotency stamp field and email template.
+ */
+import { FieldValue, type Firestore } from "firebase-admin/firestore";
+import { SUMMER_COHORT_COLLECTION } from "../../lib/summer-cohort";
+import type { SendArgs } from "./script-utils";
+
+export interface Cohort1Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+/**
+ * Load admitted cohort-1 applicants not yet stamped with `stampField`, honoring
+ * `--force` (ignore stamp) and `--only-email`. Logs per-reason skip counts.
+ */
+export async function loadAdmittedCohort1Recipients(
+  ctx: { db: Firestore; args: SendArgs },
+  stampField: string
+): Promise<Cohort1Recipient[]> {
+  const { db, args } = ctx;
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Cohort1Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+  let skippedOnlyEmailFilter = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [key: string]: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!args.force && d[stampField]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    if (args.onlyEmail && d.email.trim().toLowerCase() !== args.onlyEmail) {
+      skippedOnlyEmailFilter++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(
+    `Eligible (admitted cohort-1${args.onlyEmail ? `, --only-email=${args.onlyEmail}` : ""}, not yet emailed): ${recipients.length}`
+  );
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${stampField}): ${skippedAlreadyEmailed}`);
+  if (args.onlyEmail) {
+    console.log(`Skipped — --only-email filter: ${skippedOnlyEmailFilter}`);
+  }
+  return recipients;
+}
+
+/** Write the idempotency stamp for a cohort-1 recipient after a successful send. */
+export function stampCohort1(
+  db: Firestore,
+  applicationId: string,
+  stampField: string
+): Promise<unknown> {
+  return db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .doc(applicationId)
+    .update({ [stampField]: FieldValue.serverTimestamp() });
+}

--- a/scripts/_lib/db-runner.ts
+++ b/scripts/_lib/db-runner.ts
@@ -1,0 +1,122 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Firestore backfill/seed harness for the `scripts/{seed,backfill,sync}-*`
+ * one-off scripts.
+ *
+ * Owns the parts those scripts kept re-implementing: env validation, the
+ * `--dry-run` vs `--apply` branch, idempotency-skip counting, batched writes
+ * with the 500-op Firestore cap (default chunk 400), and a summary line.
+ *
+ * A caller supplies `load` (the documents/items to walk) and `process` (turn
+ * one item into zero or more writes, or skip it).
+ */
+import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+import { getAdminDb } from "../../lib/firebase-admin";
+import { requireFirebaseEnv, type DbArgs } from "./script-utils";
+
+export type WriteMode = "set" | "merge" | "update" | "delete";
+
+export interface WriteOp {
+  ref: DocumentReference;
+  /** Required for set/merge/update; ignored for delete. */
+  data?: Record<string, unknown>;
+  mode: WriteMode;
+}
+
+export interface RunBackfillOptions<T> {
+  args: DbArgs;
+  name: string;
+  /** Fetch the items to process (doc snapshots, refs, rows — caller's choice). */
+  load: (ctx: { db: Firestore; args: DbArgs }) => Promise<T[]>;
+  /**
+   * Turn one item into zero or more writes. Return `null` (or `[]`) to skip the
+   * item — skips are counted and reported separately from writes.
+   */
+  process: (item: T, ctx: { db: Firestore }) => WriteOp[] | WriteOp | null;
+  /** Max ops per committed batch (default 400; Firestore hard cap is 500). */
+  batchSize?: number;
+}
+
+export interface BackfillResult {
+  total: number;
+  written: number;
+  skipped: number;
+}
+
+/**
+ * Walk a set of items, compute writes for each, and commit them in batches
+ * (or just report them, under `--dry-run`).
+ */
+export async function runBackfill<T>(
+  opts: RunBackfillOptions<T>
+): Promise<BackfillResult> {
+  const { args, name, load, process: processItem, batchSize = 400 } = opts;
+
+  requireFirebaseEnv();
+  const db = getAdminDb();
+  if (!db) {
+    throw new Error("Firebase Admin not configured (getAdminDb returned null).");
+  }
+
+  console.log(`\n[${name}] loading items…`);
+  const items = await load({ db, args });
+  console.log(`[${name}] items: ${items.length}`);
+
+  const ops: WriteOp[] = [];
+  let skipped = 0;
+  for (const item of items) {
+    const result = processItem(item, { db });
+    if (!result) {
+      skipped++;
+      continue;
+    }
+    const list = Array.isArray(result) ? result : [result];
+    if (list.length === 0) {
+      skipped++;
+      continue;
+    }
+    ops.push(...list);
+  }
+
+  console.log(
+    `[${name}] writes queued: ${ops.length} | items skipped: ${skipped}`
+  );
+
+  if (args.dryRun) {
+    console.log(`\n--dry-run: no writes committed.`);
+    for (const op of ops.slice(0, 5)) {
+      console.log(`  would ${op.mode}: ${op.ref.path}`);
+    }
+    if (ops.length > 5) console.log(`  …and ${ops.length - 5} more`);
+    return { total: items.length, written: 0, skipped };
+  }
+
+  let written = 0;
+  for (let i = 0; i < ops.length; i += batchSize) {
+    const chunk = ops.slice(i, i + batchSize);
+    const batch = db.batch();
+    for (const op of chunk) {
+      if (op.mode === "delete") {
+        batch.delete(op.ref);
+      } else if (op.mode === "set") {
+        batch.set(op.ref, op.data ?? {});
+      } else if (op.mode === "merge") {
+        batch.set(op.ref, op.data ?? {}, { merge: true });
+      } else {
+        batch.update(op.ref, op.data ?? {});
+      }
+    }
+    await batch.commit();
+    written += chunk.length;
+    console.log(`  committed ${written}/${ops.length}`);
+  }
+
+  console.log(`\n[${name}] done. Wrote ${written}, skipped ${skipped}.`);
+  return { total: items.length, written, skipped };
+}

--- a/scripts/_lib/script-utils.ts
+++ b/scripts/_lib/script-utils.ts
@@ -1,0 +1,117 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Shared helpers for the one-off scripts in `scripts/`.
+ *
+ * These collapse boilerplate that was previously copy-pasted into every
+ * `send-*` / `seed-*` / `backfill-*` / `sync-*` script: env loading, env
+ * validation, HTML escaping, throttling, and CLI flag parsing.
+ *
+ * Import order note: `loadEnv()` must run before any module that reads
+ * `process.env` at import time (e.g. `../lib/firebase-admin`). Call it at the
+ * very top of a script, before those imports.
+ */
+import { loadEnvConfig } from "@next/env";
+
+/** Load `.env.local` etc. from the repo root. Call first, before lib imports. */
+export function loadEnv(): void {
+  loadEnvConfig(process.cwd());
+}
+
+/** Escape the five HTML-significant characters for safe interpolation. */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Resolve after `ms` milliseconds. Used to throttle Mailgun/Firestore loops. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Throw with a clear message if Firebase Admin credentials are absent.
+ * Mirrors the `getAdminDb() === null` check every script used to inline.
+ */
+export function requireFirebaseEnv(): void {
+  if (
+    !process.env.FIREBASE_SERVICE_ACCOUNT_JSON &&
+    !process.env.GOOGLE_APPLICATION_CREDENTIALS
+  ) {
+    throw new Error(
+      "Firebase Admin not configured: set FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS."
+    );
+  }
+}
+
+/** Throw if Mailgun send credentials are absent. Only needed for `--send`. */
+export function requireMailgunEnv(): void {
+  if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+    throw new Error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+  }
+}
+
+/**
+ * Standard send-script CLI flags.
+ *
+ * Requires exactly one of `--dry-run` / `--send`. Also recognizes the optional
+ * `--force` (re-send to already-stamped recipients) and `--only-email=foo@bar`
+ * (restrict to a single address) flags that several scripts had grown ad hoc.
+ */
+export interface SendArgs {
+  dryRun: boolean;
+  send: boolean;
+  force: boolean;
+  onlyEmail: string | null;
+}
+
+export function parseSendArgs(argv: string[] = process.argv.slice(2)): SendArgs {
+  const dryRun = argv.includes("--dry-run");
+  const send = argv.includes("--send");
+  if (dryRun === send) {
+    // both or neither
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  const onlyArg = argv.find((a) => a.startsWith("--only-email="));
+  return {
+    dryRun,
+    send,
+    force: argv.includes("--force"),
+    onlyEmail: onlyArg
+      ? onlyArg.slice("--only-email=".length).trim().toLowerCase()
+      : null,
+  };
+}
+
+/**
+ * Standard db-script CLI flags: requires exactly one of `--dry-run` / `--apply`.
+ * `--apply` is the canonical "really write" flag (aliased from `--write`/`--send`
+ * in older scripts); pass `writeAliases` to accept legacy spellings.
+ */
+export interface DbArgs {
+  dryRun: boolean;
+  apply: boolean;
+  force: boolean;
+}
+
+export function parseDbArgs(
+  argv: string[] = process.argv.slice(2),
+  writeAliases: string[] = ["--apply", "--write", "--send"]
+): DbArgs {
+  const apply = writeAliases.some((flag) => argv.includes(flag));
+  const dryRun = argv.includes("--dry-run") || !apply;
+  if (dryRun && apply) {
+    console.error(`Specify exactly one of: --dry-run | ${writeAliases[0]}`);
+    process.exit(1);
+  }
+  return { dryRun, apply, force: argv.includes("--force") };
+}

--- a/scripts/backfill-attending-confirmed-by.ts
+++ b/scripts/backfill-attending-confirmed-by.ts
@@ -24,93 +24,71 @@
  *
  * Optional: --event=<id> restricts to one event. Default: all events.
  */
-import { loadEnvConfig } from "@next/env";
-loadEnvConfig(process.cwd());
+import { loadEnv, parseDbArgs } from "./_lib/script-utils";
+loadEnv();
 
-import { getAdminDb } from "../lib/firebase-admin";
+import { runBackfill, type WriteOp } from "./_lib/db-runner";
+import type { QueryDocumentSnapshot } from "firebase-admin/firestore";
 
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  const dryRun = args.includes("--dry-run");
-  const write = args.includes("--write");
-  const eventArg = args.find((a) => a.startsWith("--event="));
+  const args = parseDbArgs(process.argv.slice(2), ["--write"]);
+  const eventArg = process.argv.find((a) => a.startsWith("--event="));
   const eventFilter = eventArg ? eventArg.slice("--event=".length) : null;
 
-  if ((dryRun && write) || (!dryRun && !write)) {
-    console.error("Specify exactly one of: --dry-run | --write");
-    process.exit(1);
-  }
-
-  const db = getAdminDb();
-  if (!db) {
-    console.error(
-      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
-    );
-    process.exit(1);
-  }
-
-  let query: FirebaseFirestore.Query = db.collection("hackathonEventSignups");
-  if (eventFilter) {
-    query = query.where("eventId", "==", eventFilter);
-    console.log(`Filtering to eventId="${eventFilter}"`);
-  }
-  const snap = await query.get();
-  console.log(`Total signup docs scanned: ${snap.size}`);
-
-  let alreadyTagged = 0;
-  let noConfirmAt = 0;
-  let toBackfill: { id: string; eventId: string }[] = [];
-
-  for (const doc of snap.docs) {
-    const data = doc.data();
-    if (!data.attendingConfirmedAt) {
-      noConfirmAt++;
-      continue;
-    }
-    if (data.attendingConfirmedBy === "user" || data.attendingConfirmedBy === "admin") {
-      alreadyTagged++;
-      continue;
-    }
-    toBackfill.push({ id: doc.id, eventId: data.eventId ?? "?" });
-  }
-
-  console.log(`Already tagged:           ${alreadyTagged}`);
-  console.log(`No attendingConfirmedAt:  ${noConfirmAt}`);
-  console.log(`Would backfill to "user": ${toBackfill.length}`);
-
-  if (toBackfill.length > 0) {
-    const byEvent = new Map<string, number>();
-    for (const r of toBackfill) byEvent.set(r.eventId, (byEvent.get(r.eventId) ?? 0) + 1);
-    console.log("\nBy event:");
-    for (const [eid, n] of [...byEvent].sort((a, b) => b[1] - a[1])) {
-      console.log(`  ${eid.padEnd(28)} ${n}`);
-    }
-  }
-
-  if (dryRun) {
-    console.log("\n--dry-run: no writes.");
-    return;
-  }
-
-  let updated = 0;
-  let failed = 0;
-  for (const r of toBackfill) {
-    try {
-      await db
-        .collection("hackathonEventSignups")
-        .doc(r.id)
-        .update({ attendingConfirmedBy: "user" });
-      updated++;
-      if (updated % 25 === 0) {
-        console.log(`  Progress: ${updated}/${toBackfill.length}`);
+  await runBackfill<QueryDocumentSnapshot>({
+    args,
+    name: "attendingConfirmedBy backfill",
+    load: async ({ db }) => {
+      let query: FirebaseFirestore.Query = db.collection("hackathonEventSignups");
+      if (eventFilter) {
+        query = query.where("eventId", "==", eventFilter);
+        console.log(`Filtering to eventId="${eventFilter}"`);
       }
-    } catch (e) {
-      failed++;
-      console.error(`  [fail] ${r.id}`, e);
-    }
-  }
+      const snap = await query.get();
+      console.log(`Total signup docs scanned: ${snap.size}`);
 
-  console.log(`\nDone. Updated ${updated}, failed ${failed}.`);
+      let alreadyTagged = 0;
+      let noConfirmAt = 0;
+      const toBackfill: QueryDocumentSnapshot[] = [];
+      for (const doc of snap.docs) {
+        const data = doc.data();
+        if (!data.attendingConfirmedAt) {
+          noConfirmAt++;
+          continue;
+        }
+        if (
+          data.attendingConfirmedBy === "user" ||
+          data.attendingConfirmedBy === "admin"
+        ) {
+          alreadyTagged++;
+          continue;
+        }
+        toBackfill.push(doc);
+      }
+
+      console.log(`Already tagged:           ${alreadyTagged}`);
+      console.log(`No attendingConfirmedAt:  ${noConfirmAt}`);
+      console.log(`Would backfill to "user": ${toBackfill.length}`);
+
+      if (toBackfill.length > 0) {
+        const byEvent = new Map<string, number>();
+        for (const doc of toBackfill) {
+          const eid = (doc.data().eventId as string) ?? "?";
+          byEvent.set(eid, (byEvent.get(eid) ?? 0) + 1);
+        }
+        console.log("\nBy event:");
+        for (const [eid, n] of [...byEvent].sort((a, b) => b[1] - a[1])) {
+          console.log(`  ${eid.padEnd(28)} ${n}`);
+        }
+      }
+      return toBackfill;
+    },
+    process: (doc): WriteOp => ({
+      ref: doc.ref,
+      mode: "update",
+      data: { attendingConfirmedBy: "user" },
+    }),
+  });
 }
 
 main().catch((e) => {

--- a/scripts/send-cohort-admittance.ts
+++ b/scripts/send-cohort-admittance.ts
@@ -14,12 +14,11 @@
  * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
  * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
  */
-import { loadEnvConfig } from "@next/env";
-loadEnvConfig(process.cwd());
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
 
 import { FieldValue } from "firebase-admin/firestore";
-import { getAdminDb } from "../lib/firebase-admin";
-import { sendEmail } from "../lib/mailgun";
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
 import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
 import {
   SUMMER_COHORT_COLLECTION,
@@ -27,14 +26,6 @@ import {
   isValidCohortId,
   type SummerCohortId,
 } from "../lib/summer-cohort";
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 interface Admit {
   uid: string;
@@ -46,11 +37,7 @@ interface Admit {
 
 const PAGE_URL = "https://cursorboston.com/summer-cohort";
 
-function buildEmail(admit: Admit): {
-  subject: string;
-  html: string;
-  text: string;
-} {
+function buildEmail(admit: Admit): EmailContent {
   const first = escapeHtml(admit.name?.split(" ")[0]?.trim() || "there");
   const unsubUrl = buildUnsubscribeUrl(admit.email);
   const cohortLabels = admit.cohorts
@@ -164,106 +151,63 @@ Unsubscribe: ${unsubUrl}`;
   return { subject, html, text };
 }
 
-async function sleep(ms: number) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
 async function main() {
-  const args = process.argv.slice(2);
-  const dryRun = args.includes("--dry-run");
-  const send = args.includes("--send");
-  if (dryRun === send) {
-    console.error("Specify exactly one of: --dry-run | --send");
-    process.exit(1);
-  }
-  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
-    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
-    process.exit(1);
-  }
+  const args = parseSendArgs();
 
-  const db = getAdminDb();
-  if (!db) {
-    console.error("Firebase Admin not configured");
-    process.exit(1);
-  }
+  await runEmailCampaign<Admit>({
+    args,
+    name: "Summer cohort admittance",
+    getEmail: (a) => a.email,
+    buildEmail,
+    loadRecipients: async ({ db }) => {
+      const snap = await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .where("status", "==", "admitted")
+        .get();
+      console.log(`Admitted applicants: ${snap.size}`);
 
-  const snap = await db
-    .collection(SUMMER_COHORT_COLLECTION)
-    .where("status", "==", "admitted")
-    .get();
+      const queue: Admit[] = [];
+      let alreadyEmailed = 0;
+      for (const doc of snap.docs) {
+        const data = doc.data();
+        if (!args.force && data.admittanceEmailedAt) {
+          alreadyEmailed++;
+          continue;
+        }
+        const email = (data.email || "").toString().trim();
+        if (!email || !email.includes("@")) continue;
+        if (args.onlyEmail && email.toLowerCase() !== args.onlyEmail) continue;
+        const cohorts = (Array.isArray(data.cohorts) ? data.cohorts : []).filter(
+          isValidCohortId
+        ) as SummerCohortId[];
+        if (cohorts.length === 0) continue;
 
-  console.log(`Admitted applicants: ${snap.size}`);
+        let hasDiscord = false;
+        const uid = (data.userId || doc.id).toString();
+        if (uid) {
+          const userSnap = await db.collection("users").doc(uid).get();
+          hasDiscord = Boolean(userSnap.data()?.discord?.id);
+        }
 
-  const queue: Admit[] = [];
-  let alreadyEmailed = 0;
-  for (const doc of snap.docs) {
-    const data = doc.data();
-    if (data.admittanceEmailedAt) {
-      alreadyEmailed++;
-      continue;
-    }
-    const email = (data.email || "").toString().trim();
-    if (!email || !email.includes("@")) continue;
-    const cohorts = (Array.isArray(data.cohorts) ? data.cohorts : []).filter(
-      isValidCohortId
-    ) as SummerCohortId[];
-    if (cohorts.length === 0) continue;
-
-    let hasDiscord = false;
-    const uid = (data.userId || doc.id).toString();
-    if (uid) {
-      const userSnap = await db.collection("users").doc(uid).get();
-      hasDiscord = Boolean(userSnap.data()?.discord?.id);
-    }
-
-    queue.push({
-      uid,
-      name: typeof data.name === "string" ? data.name : "",
-      email,
-      cohorts,
-      hasDiscord,
-    });
-  }
-
-  console.log(`To email now: ${queue.length} | Already emailed: ${alreadyEmailed}`);
-
-  if (dryRun) {
-    const sample = queue[0];
-    if (sample) {
-      const { subject, html } = buildEmail(sample);
-      console.log(`\nSample to: ${sample.email} (${sample.name || "(no name)"})`);
-      console.log(`Discord connected: ${sample.hasDiscord}`);
-      console.log(`Subject: ${subject}`);
-      console.log(`\n---- HTML preview (first 1800 chars) ----\n${html.slice(0, 1800)}\n…`);
-    } else {
-      console.log("\n(no admits to email — either none in 'admitted' status, or all already emailed)");
-    }
-    console.log(`\n--dry-run: no emails sent and no writes.`);
-    return;
-  }
-
-  let sent = 0;
-  let failed = 0;
-  for (const admit of queue) {
-    const { subject, html, text } = buildEmail(admit);
-    try {
-      await sendEmail({ to: admit.email, subject, html, text });
-      await db.collection(SUMMER_COHORT_COLLECTION).doc(admit.uid).set(
-        { admittanceEmailedAt: FieldValue.serverTimestamp() },
-        { merge: true }
-      );
-      sent++;
-      if (sent % 10 === 0) {
-        console.log(`  Progress: ${sent}/${queue.length}`);
+        queue.push({
+          uid,
+          name: typeof data.name === "string" ? data.name : "",
+          email,
+          cohorts,
+          hasDiscord,
+        });
       }
-    } catch (e) {
-      failed++;
-      console.error(`Failed: ${admit.email}`, e);
-    }
-    await sleep(450);
-  }
 
-  console.log(`\nDone. Sent ${sent}, failed ${failed}, already-emailed ${alreadyEmailed}.`);
+      console.log(`To email now: ${queue.length} | Already emailed: ${alreadyEmailed}`);
+      return queue;
+    },
+    onSent: (a, { db }) =>
+      db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(a.uid)
+        .set({ admittanceEmailedAt: FieldValue.serverTimestamp() }, { merge: true }),
+    progressEvery: 10,
+  });
 }
 
 main().catch((e) => {

--- a/scripts/send-cohort1-week3-apology.ts
+++ b/scripts/send-cohort1-week3-apology.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Apology note (Fri May 29, 2026) to every admitted Cohort 1 applicant:
+ * Roger missed the Week 3 voting call. Short, warm, sincere — "sorry,
+ * heck of a week, see you Monday." No Zoom block (Monday's link TBD).
+ *
+ * Idempotent via `cohort1Week3ApologyEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week3-apology.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week3-apology.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-cohort1-week3-apology.ts --send
+ *   npx tsx scripts/send-cohort1-week3-apology.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import {
+  loadAdmittedCohort1Recipients,
+  stampCohort1,
+  type Cohort1Recipient,
+} from "./_lib/cohort1-recipients";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+
+const STAMP_FIELD = "cohort1Week3ApologyEmailedAt";
+
+function buildEmail(r: Cohort1Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "My apologies, folks — see you Monday";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>I owe you an apology — I missed it again tonight. It was one heck of a week, and I&apos;m sorry I couldn&apos;t be there with you.</p>
+
+<p>Thank you to everyone who shipped and showed up to present. I&apos;ll catch up on what you built.</p>
+
+<p>I&apos;ll be on with you <strong>Monday night</strong> to talk through what&apos;s next — and as I mentioned, the format&apos;s switching up. See you then.</p>
+
+<p>My apologies again, and thank you for your patience.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+I owe you an apology — I missed it again tonight. It was one heck of a week, and I'm sorry I couldn't be there with you.
+
+Thank you to everyone who shipped and showed up to present. I'll catch up on what you built.
+
+I'll be on with you Monday night to talk through what's next — and as I mentioned, the format's switching up. See you then.
+
+My apologies again, and thank you for your patience.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Cohort1Recipient>({
+    args,
+    name: "Cohort 1 Week 3 apology",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: (ctx) => loadAdmittedCohort1Recipients(ctx, STAMP_FIELD),
+    onSent: (r, { db }) => stampCohort1(db, r.applicationId, STAMP_FIELD),
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week3-mkt-deadline.ts
+++ b/scripts/send-cohort1-week3-mkt-deadline.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Deadline-day broadcast (Fri May 29, 2026) to every admitted Cohort 1
+ * applicant: Week 3 (Vibe Marketing Build) PRs are due today by 5pm EST.
+ * Roger merges everything that's in by 6pm, then we get on Zoom for the
+ * voting call. Roger can't stay on long today but leaves the room open so
+ * the cohort can present and pick the winner themselves. Heads-up that
+ * Monday's call kicks off Week 4 — and the format is switching up.
+ *
+ * Idempotent via `cohort1Week3MktDeadlineEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week3-mkt-deadline.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week3-mkt-deadline.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-cohort1-week3-mkt-deadline.ts --send
+ *   npx tsx scripts/send-cohort1-week3-mkt-deadline.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import {
+  loadAdmittedCohort1Recipients,
+  stampCohort1,
+  type Cohort1Recipient,
+} from "./_lib/cohort1-recipients";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week3MktDeadlineEmailedAt";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93655364421";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/93655364421";
+const ZOOM_MEETING_ID = "936 5536 4421";
+const ZOOM_ONE_TAP_1 = "+13126266799,,93655364421# US (Chicago)";
+const ZOOM_ONE_TAP_2 = "+16468769923,,93655364421# US (New York)";
+
+function buildEmail(r: Cohort1Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Week 3 PRs due 5pm today — Zoom at 6, you pick the winner 🚀";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Today&apos;s the day for the Week 3 vibe marketing build.</strong> Get your platform PR&apos;d by <strong>5pm EST today</strong> and you&apos;re in. I&apos;ll make sure everything that&apos;s in by then is <strong>merged by 6pm</strong>, so it&apos;s live on the cohort page in time for the call.</p>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the Week 3 tab + submit →
+  </a>
+</p>
+
+<h3 style="margin-top:22px;margin-bottom:10px;">Tonight on Zoom — 6pm EST</h3>
+<p>Heads up: I can&apos;t be on the call too long today. But I&apos;m going to <strong>leave the room open</strong> — so once everyone&apos;s on, go ahead and <strong>present your builds and decide as a cohort who wins</strong>. This one&apos;s yours to run. Hear each other out, vote, crown a winner.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>Zoom — tonight, Fri May 29 · 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">
+    Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a>
+  </p>
+  <p style="margin:0 0 6px 0;">
+    Meeting ID: <strong>${ZOOM_MEETING_ID}</strong>
+  </p>
+  <p style="margin:0;color:#555;font-size:13px;">
+    One-tap mobile: ${escapeHtml(ZOOM_ONE_TAP_1)} · ${escapeHtml(ZOOM_ONE_TAP_2)}
+  </p>
+</div>
+
+<h3 style="margin-top:22px;margin-bottom:10px;">Monday night — Week 4 kickoff</h3>
+<p>Then <strong>Monday night I&apos;ll be on</strong> to walk through next week&apos;s tasks. Quick teaser: <strong>it&apos;s switching up.</strong> Different format from the last three weeks — more on that Monday.</p>
+
+<p>Ship it. See you at 6.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Today's the day for the Week 3 vibe marketing build. Get your platform PR'd by 5pm EST today and you're in. I'll make sure everything that's in by then is merged by 6pm, so it's live on the cohort page in time for the call.
+
+Open the Week 3 tab + submit: ${COHORT_URL}
+
+TONIGHT ON ZOOM — 6PM EST
+I can't be on the call too long today. But I'm going to leave the room open — so once everyone's on, go ahead and present your builds and decide as a cohort who wins. This one's yours to run. Hear each other out, vote, crown a winner.
+
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+  One-tap mobile: ${ZOOM_ONE_TAP_1} · ${ZOOM_ONE_TAP_2}
+
+MONDAY NIGHT — WEEK 4 KICKOFF
+Then Monday night I'll be on to walk through next week's tasks. Quick teaser: it's switching up. Different format from the last three weeks — more on that Monday.
+
+Ship it. See you at 6.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Cohort1Recipient>({
+    args,
+    name: "Cohort 1 Week 3 marketing deadline",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: (ctx) => loadAdmittedCohort1Recipients(ctx, STAMP_FIELD),
+    onSent: (r, { db }) => stampCohort1(db, r.applicationId, STAMP_FIELD),
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week3-mkt-reminder.ts
+++ b/scripts/send-cohort1-week3-mkt-reminder.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Deadline-day REMINDER (Fri May 29, 2026) to every admitted Cohort 1
+ * applicant: short nudge that Week 3 (Vibe Marketing Build) PRs close at
+ * 5pm EST today, with the 6pm voting-call Zoom. Sent after the morning
+ * send-cohort1-week3-mkt-deadline.ts blast.
+ *
+ * Idempotent via `cohort1Week3MktReminderEmailedAt` (separate from the
+ * morning send's `cohort1Week3MktDeadlineEmailedAt`). `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week3-mkt-reminder.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week3-mkt-reminder.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-cohort1-week3-mkt-reminder.ts --send
+ *   npx tsx scripts/send-cohort1-week3-mkt-reminder.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import {
+  loadAdmittedCohort1Recipients,
+  stampCohort1,
+  type Cohort1Recipient,
+} from "./_lib/cohort1-recipients";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week3MktReminderEmailedAt";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93655364421";
+const ZOOM_CHAT_URL = "https://bentley.zoom.us/launch/jc/93655364421";
+const ZOOM_MEETING_ID = "936 5536 4421";
+
+function buildEmail(r: Cohort1Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Reminder: Week 3 PRs close at 5pm EST today ⏰";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Quick reminder — get your Week 3 vibe marketing submission PR&apos;d by 5pm EST today.</strong> Everything that&apos;s in by 5 gets merged and is live on the cohort page in time for tonight&apos;s call. Don&apos;t leave it to the last minute.</p>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#0284c7;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the Week 3 tab + submit →
+  </a>
+</p>
+
+<p style="margin-top:18px;">Then we&apos;re on Zoom at <strong>6pm EST</strong> to present and pick a winner — the room&apos;s yours to run tonight.</p>
+
+<div style="border:1px solid #d1d5db;border-radius:8px;padding:16px;margin:20px 0;background:#f9fafb;font-size:14px;color:#111;">
+  <p style="margin:0 0 10px 0;"><strong>Zoom — tonight, Fri May 29 · 6:00 pm EST</strong></p>
+  <p style="margin:0 0 6px 0;">Join: <a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a></p>
+  <p style="margin:0 0 6px 0;">Meeting chat: <a href="${escapeHtml(ZOOM_CHAT_URL)}">${escapeHtml(ZOOM_CHAT_URL)}</a></p>
+  <p style="margin:0;">Meeting ID: <strong>${ZOOM_MEETING_ID}</strong></p>
+</div>
+
+<p>Ship it. 🚀</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick reminder — get your Week 3 vibe marketing submission PR'd by 5pm EST today. Everything that's in by 5 gets merged and is live on the cohort page in time for tonight's call. Don't leave it to the last minute.
+
+Open the Week 3 tab + submit: ${COHORT_URL}
+
+Then we're on Zoom at 6pm EST to present and pick a winner — the room's yours to run tonight.
+
+ZOOM — TONIGHT, FRI MAY 29 · 6:00 PM EST
+  Join: ${ZOOM_URL}
+  Meeting chat: ${ZOOM_CHAT_URL}
+  Meeting ID: ${ZOOM_MEETING_ID}
+
+Ship it.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Cohort1Recipient>({
+    args,
+    name: "Cohort 1 Week 3 marketing reminder",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: (ctx) => loadAdmittedCohort1Recipients(ctx, STAMP_FIELD),
+    onSent: (r, { db }) => stampCohort1(db, r.applicationId, STAMP_FIELD),
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week3-mkt-t20m.ts
+++ b/scripts/send-cohort1-week3-mkt-t20m.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * T-20m FINAL CALL (Fri May 29, 2026) to every admitted Cohort 1 applicant:
+ * ~20 minutes left to PR the Week 3 (Vibe Marketing Build) submission before
+ * the 5pm EST cutoff. Short, urgent. Sent after the morning blast
+ * (send-cohort1-week3-mkt-deadline.ts) and the midday reminder
+ * (send-cohort1-week3-mkt-reminder.ts).
+ *
+ * Idempotent via `cohort1Week3MktT20mEmailedAt` (separate stamp). `--force`
+ * re-sends. `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week3-mkt-t20m.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week3-mkt-t20m.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-cohort1-week3-mkt-t20m.ts --send
+ *   npx tsx scripts/send-cohort1-week3-mkt-t20m.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import {
+  loadAdmittedCohort1Recipients,
+  stampCohort1,
+  type Cohort1Recipient,
+} from "./_lib/cohort1-recipients";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const STAMP_FIELD = "cohort1Week3MktT20mEmailedAt";
+
+const ZOOM_URL = "https://bentley.zoom.us/j/93655364421";
+const ZOOM_MEETING_ID = "936 5536 4421";
+
+function buildEmail(r: Cohort1Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "⏰ 20 minutes left — get your Week 3 PR in NOW";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p style="font-size:18px;"><strong>This is it — about 20 minutes until the 5pm EST cutoff.</strong> If your Week 3 vibe marketing project isn&apos;t PR&apos;d yet, open the PR <strong>now</strong>. Anything in by 5 gets merged and is live for tonight&apos;s 6pm call.</p>
+
+<div style="border:2px solid #b91c1c;border-radius:8px;padding:14px;margin:18px 0;background:#fef2f2;color:#7f1d1d;text-align:center;">
+  <p style="margin:0;font-size:17px;font-weight:700;">PR by 5:00 PM EST. Don&apos;t miss it.</p>
+</div>
+
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#b91c1c;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:700;">
+    Submit your Week 3 PR now →
+  </a>
+</p>
+
+<p style="margin-top:18px;">Then see you on Zoom at <strong>6pm EST</strong> to present and pick the winner:<br/>
+<a href="${escapeHtml(ZOOM_URL)}">${escapeHtml(ZOOM_URL)}</a> · Meeting ID <strong>${ZOOM_MEETING_ID}</strong></p>
+
+<p>Go go go. 🚀</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+THIS IS IT — about 20 minutes until the 5pm EST cutoff. If your Week 3 vibe marketing project isn't PR'd yet, open the PR NOW. Anything in by 5 gets merged and is live for tonight's 6pm call.
+
+>>> PR by 5:00 PM EST. Don't miss it. <<<
+
+Submit your Week 3 PR now: ${COHORT_URL}
+
+Then see you on Zoom at 6pm EST to present and pick the winner:
+  ${ZOOM_URL}  ·  Meeting ID ${ZOOM_MEETING_ID}
+
+Go go go.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Cohort1Recipient>({
+    args,
+    name: "Cohort 1 Week 3 marketing T-20m",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: (ctx) => loadAdmittedCohort1Recipients(ctx, STAMP_FIELD),
+    onSent: (r, { db }) => stampCohort1(db, r.applicationId, STAMP_FIELD),
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-contact-list-email.ts
+++ b/scripts/send-contact-list-email.ts
@@ -11,25 +11,16 @@
  * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
  * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
  */
-import { loadEnvConfig } from "@next/env";
-loadEnvConfig(process.cwd());
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
 
-import { getAdminDb } from "../lib/firebase-admin";
-import { sendEmail } from "../lib/mailgun";
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
 import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
 import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
 
 // ---------------------------------------------------------------------------
 // Email template
 // ---------------------------------------------------------------------------
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 interface ContactData {
   email: string;
@@ -42,11 +33,7 @@ interface ContactData {
   }[];
 }
 
-function buildEmail(contact: ContactData): {
-  subject: string;
-  html: string;
-  text: string;
-} {
+function buildEmail(contact: ContactData): EmailContent {
   const first = escapeHtml(
     contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
   );
@@ -134,120 +121,61 @@ Unsubscribe: ${unsubUrl}`;
 // Main
 // ---------------------------------------------------------------------------
 
-async function sleep(ms: number) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
 async function main() {
-  const args = process.argv.slice(2);
-  const dryRun = args.includes("--dry-run");
-  const send = args.includes("--send");
+  await runEmailCampaign<ContactData>({
+    args: parseSendArgs(),
+    name: "Event-contacts announcement",
+    progressEvery: 50,
+    getEmail: (c) => c.email,
+    buildEmail,
+    // Mirror Mailgun bounces + complaints onto eventContacts.unsubscribed
+    // before reading the list. No-op if MAILGUN_PRIVATE_API_KEY is unset.
+    beforeSend: ({ db }) => syncMailgunSuppressions(db),
+    loadRecipients: async ({ db }) => {
+      console.log("Loading contacts from eventContacts…");
+      const snap = await db.collection("eventContacts").get();
+      console.log(`Total contacts: ${snap.size}`);
 
-  if ((dryRun && send) || (!dryRun && !send)) {
-    console.error("Specify exactly one of: --dry-run | --send");
-    process.exit(1);
-  }
+      const contacts: ContactData[] = [];
+      let skippedUnsubscribed = 0;
+      let skippedDeclinedOnly = 0;
 
-  if (send) {
-    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
-      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
-      process.exit(1);
-    }
-  }
+      for (const doc of snap.docs) {
+        const data = doc.data();
 
-  const db = getAdminDb();
-  if (!db) {
-    console.error(
-      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
-    );
-    process.exit(1);
-  }
+        // Skip unsubscribed contacts
+        if (data.unsubscribed === true) {
+          skippedUnsubscribed++;
+          continue;
+        }
 
-  // Mirror Mailgun bounces + complaints onto eventContacts.unsubscribed
-  // before reading the list. No-op if MAILGUN_PRIVATE_API_KEY is unset.
-  await syncMailgunSuppressions(db);
+        const events: ContactData["events"] = (data.events || []).map(
+          (e: { eventName?: string; checkedIn?: boolean; approvalStatus?: string }) => ({
+            eventName: e.eventName || "",
+            checkedIn: e.checkedIn || false,
+            approvalStatus: e.approvalStatus || "",
+          })
+        );
 
-  console.log("Loading contacts from eventContacts…");
-  const snap = await db.collection("eventContacts").get();
-  console.log(`Total contacts: ${snap.size}`);
+        // Count declined-only for reporting but still include them
+        if (events.length > 0 && events.every((e) => e.approvalStatus === "declined")) {
+          skippedDeclinedOnly++;
+        }
 
-  const contacts: ContactData[] = [];
-  let skippedUnsubscribed = 0;
-  let skippedDeclinedOnly = 0;
-
-  for (const doc of snap.docs) {
-    const data = doc.data();
-
-    // Skip unsubscribed contacts
-    if (data.unsubscribed === true) {
-      skippedUnsubscribed++;
-      continue;
-    }
-
-    const events: ContactData["events"] = (data.events || []).map(
-      (e: { eventName?: string; checkedIn?: boolean; approvalStatus?: string }) => ({
-        eventName: e.eventName || "",
-        checkedIn: e.checkedIn || false,
-        approvalStatus: e.approvalStatus || "",
-      })
-    );
-
-    // Count declined-only for reporting but still include them
-    if (events.length > 0 && events.every((e) => e.approvalStatus === "declined")) {
-      skippedDeclinedOnly++;
-    }
-
-    contacts.push({
-      email: data.email || doc.id,
-      name: data.name || "",
-      firstName: data.firstName || "",
-      events,
-    });
-  }
-
-  console.log(
-    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed} | Declined-only (still included): ${skippedDeclinedOnly}`
-  );
-
-  if (dryRun) {
-    console.log("\n--dry-run: no emails sent.\n");
-
-    // Show sample
-    const sample = contacts[0];
-    if (sample) {
-      const { subject, html } = buildEmail(sample);
-      console.log(`Sample email to: ${sample.email}`);
-      console.log(`Subject: ${subject}`);
-      console.log(`Events: ${sample.events.map((e) => e.eventName).join(", ")}`);
-      console.log(`\nHTML preview:\n---\n${html.slice(0, 600)}…\n---`);
-    }
-
-    console.log(`\nWould send to ${contacts.length} contacts.`);
-    return;
-  }
-
-  // Send emails
-  let sent = 0;
-  let failed = 0;
-
-  for (const contact of contacts) {
-    const { subject, html, text } = buildEmail(contact);
-    try {
-      await sendEmail({ to: contact.email, subject, html, text });
-      sent++;
-      if (sent % 50 === 0) {
-        console.log(`  Progress: ${sent}/${contacts.length}`);
+        contacts.push({
+          email: data.email || doc.id,
+          name: data.name || "",
+          firstName: data.firstName || "",
+          events,
+        });
       }
-    } catch (e) {
-      failed++;
-      console.error(`Failed: ${contact.email}`, e);
-    }
-    await sleep(450);
-  }
 
-  console.log(
-    `\nDone. Sent ${sent}, failed ${failed}, skipped ${skippedUnsubscribed + skippedDeclinedOnly}.`
-  );
+      console.log(
+        `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed} | Declined-only (still included): ${skippedDeclinedOnly}`
+      );
+      return contacts;
+    },
+  });
 }
 
 main().catch((e) => {

--- a/scripts/send-may26-event-morning.ts
+++ b/scripts/send-may26-event-morning.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Morning-of broadcast for the May 26 Sports Hack — sent at ~7:30am ET
+ * 2026-05-26, doors at 9am / event start 10am. Same content as the prior
+ * evening blast (send-may26-event-today.ts), refreshed for "this morning"
+ * timing and sent from "Cursor Boston" rather than "Roger".
+ *
+ * Audience: same union as the evening send. Stamps a separate field
+ * (`sportsHack2026EventMorningEmailedAt`) so this fires independently
+ * of the evening's `sportsHack2026EventTodayEmailedAt`.
+ *
+ * Usage:
+ *   npx tsx scripts/send-may26-event-morning.ts --dry-run
+ *   npx tsx scripts/send-may26-event-morning.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-may26-event-morning.ts --send
+ *   npx tsx scripts/send-may26-event-morning.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { FieldValue } from "firebase-admin/firestore";
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import {
+  getDeclinedEmailsForEvent,
+  getJudgeEmailsForEvent,
+} from "../lib/hackathon-event-signup";
+import {
+  SPORTS_HACK_2026_EVENT_ID,
+  SPORTS_HACK_2026_NAME,
+} from "../lib/sports-hack-2026";
+
+const EVENT_ID = SPORTS_HACK_2026_EVENT_ID;
+const STAMP_FIELD = "sportsHack2026EventMorningEmailedAt";
+
+const FROM_ADDRESS = "Cursor Boston <roger@cursorboston.com>";
+
+interface Recipient {
+  email: string;
+  firstName: string;
+  source: "website" | "luma";
+  sourceDocId: string;
+}
+
+function firstNameFrom(s: string | null | undefined): string {
+  if (!s) return "";
+  return s.trim().split(/\s+/)[0] ?? "";
+}
+
+function buildEmail(r: Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = "Sports Hack this morning — doors at 9, EAT FIRST, see you at Hult";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Good morning ${first},</p>
+
+<p><strong>${escapeHtml(SPORTS_HACK_2026_NAME)}</strong> is in a few hours at Hult International, Cambridge. Quick refresher so you arrive ready.</p>
+
+<div style="border:2px solid #b91c1c;border-radius:8px;padding:14px;margin:18px 0;background:#fef2f2;color:#7f1d1d;text-align:center;">
+  <p style="margin:0;font-size:18px;font-weight:700;">EAT + GRAB COFFEE BEFORE YOU COME.</p>
+  <p style="margin:6px 0 0 0;font-size:14px;">No coffee or food in the AM. Pizza + drinks arrive around 2:30pm — plan ahead if you need to eat before then.</p>
+</div>
+
+<h3 style="margin-top:22px;margin-bottom:10px;">When to arrive</h3>
+<ul style="padding-left:20px;">
+  <li style="margin-bottom:8px;"><strong>Check-in opens at 9am.</strong> Event starts at 10am. Aim for 9–9:45 — earlier is better.</li>
+  <li style="margin-bottom:8px;">200-person venue. Don&apos;t cut it close.</li>
+</ul>
+
+<h3 style="margin-top:22px;margin-bottom:10px;">The day</h3>
+<ol style="padding-left:20px;">
+  <li style="margin-bottom:8px;"><strong>10am — talk from Antonio Mele</strong> (London School of Economics).</li>
+  <li style="margin-bottom:8px;"><strong>Hackathon sprint</strong> — build for two hours after the talk.</li>
+  <li style="margin-bottom:8px;"><strong>Submit your project</strong> → you get a <strong>Cursor credit link</strong>. Everyone who submits gets one.</li>
+  <li style="margin-bottom:8px;"><strong>~2:30pm — pizza + drinks.</strong></li>
+  <li style="margin-bottom:8px;"><strong>6 winners total: 3 AI-judged + 3 human-judge picked.</strong> Winners announced at 4pm.</li>
+</ol>
+
+<h3 style="margin-top:22px;margin-bottom:10px;">Bring</h3>
+<ul style="padding-left:20px;">
+  <li style="margin-bottom:6px;">Laptop, charger, whatever you need to build (your own infra — no shared machines).</li>
+  <li style="margin-bottom:6px;">Coffee + something to eat <strong>before you walk in</strong>.</li>
+</ul>
+
+<p style="margin-top:22px;">See you in a few hours.</p>
+
+<p>— Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you registered for the Cursor Boston May 26 event on Luma, Partiful, or the website.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a>
+</p>
+</body></html>`;
+
+  const text = `Good morning ${firstText},
+
+${SPORTS_HACK_2026_NAME} is in a few hours at Hult International, Cambridge. Quick refresher so you arrive ready.
+
+⚠️ EAT + GRAB COFFEE BEFORE YOU COME.
+No coffee or food in the AM. Pizza + drinks arrive around 2:30pm —
+plan ahead if you need to eat before then.
+
+WHEN TO ARRIVE
+  - Check-in opens at 9am. Event starts at 10am. Aim for 9–9:45 — earlier is better.
+  - 200-person venue. Don't cut it close.
+
+THE DAY
+  1. 10am — talk from Antonio Mele (London School of Economics).
+  2. Hackathon sprint — build for two hours after the talk.
+  3. Submit your project → you get a Cursor credit link. Everyone who submits gets one.
+  4. ~2:30pm — pizza + drinks.
+  5. 6 winners total: 3 AI-judged + 3 human-judge picked. Winners announced at 4pm.
+
+BRING
+  - Laptop, charger, whatever you need to build (your own infra — no shared machines).
+  - Coffee + something to eat BEFORE you walk in.
+
+See you in a few hours.
+
+— Cursor Boston
+roger@cursorboston.com
+
+---
+You're receiving this because you registered for the Cursor Boston May 26 event on Luma, Partiful, or the website.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text, from: FROM_ADDRESS };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Recipient>({
+    args,
+    name: "May 26 Sports Hack morning-of",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    beforeSend: ({ db }) => syncMailgunSuppressions(db),
+    loadRecipients: async ({ db }) => {
+      const signupSnap = await db
+        .collection("hackathonEventSignups")
+        .where("eventId", "==", EVENT_ID)
+        .get();
+      const websiteUserIds = signupSnap.docs
+        .map((d) => d.data().userId as string | undefined)
+        .filter((u): u is string => Boolean(u));
+      const userMap = new Map<string, FirebaseFirestore.DocumentData>();
+      for (let i = 0; i < websiteUserIds.length; i += 10) {
+        const chunk = websiteUserIds.slice(i, i + 10);
+        const refs = chunk.map((id) => db.collection("users").doc(id));
+        const snaps = await db.getAll(...refs);
+        for (const s of snaps) if (s.exists) userMap.set(s.id, s.data() ?? {});
+      }
+      console.log(`Website signups (${EVENT_ID}): ${signupSnap.size}`);
+
+      const lumaSnap = await db
+        .collection("hackathonLumaRegistrants")
+        .where("eventId", "==", EVENT_ID)
+        .get();
+      console.log(`Luma+Partiful registrants (${EVENT_ID}): ${lumaSnap.size}`);
+
+      const ecSnap = await db.collection("eventContacts").get();
+      const unsubscribedEmails = new Set<string>();
+      for (const doc of ecSnap.docs) {
+        if (doc.data().unsubscribed === true) {
+          const e = (doc.data().email || doc.id).toString().trim().toLowerCase();
+          if (e) unsubscribedEmails.add(e);
+        }
+      }
+      console.log(`Unsubscribed emails (global): ${unsubscribedEmails.size}`);
+
+      const judgeEmails = getJudgeEmailsForEvent(EVENT_ID);
+      const declinedEmails = getDeclinedEmailsForEvent(EVENT_ID);
+
+      const recipients: Recipient[] = [];
+      const seenEmails = new Set<string>();
+      const websiteGithubLogins = new Set<string>();
+
+      let skippedAlreadyEmailed = 0;
+      let skippedOnlyEmailFilter = 0;
+      let skippedJudgeOrDeclined = 0;
+      let skippedUnsubscribed = 0;
+      let skippedNoEmail = 0;
+
+      for (const doc of signupSnap.docs) {
+        const data = doc.data();
+        const userId = data.userId as string | undefined;
+        if (!userId) { skippedNoEmail++; continue; }
+        const profile = userMap.get(userId) ?? {};
+        const email =
+          typeof profile.email === "string" ? profile.email.trim().toLowerCase() : null;
+        if (!email) { skippedNoEmail++; continue; }
+        if (judgeEmails.has(email) || declinedEmails.has(email)) { skippedJudgeOrDeclined++; continue; }
+        if (unsubscribedEmails.has(email)) { skippedUnsubscribed++; continue; }
+        if (!args.force && data[STAMP_FIELD]) { skippedAlreadyEmailed++; continue; }
+        if (args.onlyEmail && email !== args.onlyEmail) { skippedOnlyEmailFilter++; continue; }
+        seenEmails.add(email);
+        const ghLogin =
+          profile.github && typeof profile.github === "object"
+            ? (profile.github as { login?: string }).login ?? null
+            : null;
+        if (ghLogin) websiteGithubLogins.add(ghLogin.toLowerCase());
+        recipients.push({
+          email,
+          firstName: firstNameFrom(
+            typeof profile.displayName === "string" ? profile.displayName : "",
+          ),
+          source: "website",
+          sourceDocId: doc.id,
+        });
+      }
+
+      for (const doc of lumaSnap.docs) {
+        const d = doc.data();
+        const email = (d.email as string | undefined)?.trim().toLowerCase() ?? "";
+        if (!email) { skippedNoEmail++; continue; }
+        if (judgeEmails.has(email) || declinedEmails.has(email)) { skippedJudgeOrDeclined++; continue; }
+        if (unsubscribedEmails.has(email)) { skippedUnsubscribed++; continue; }
+        if (seenEmails.has(email)) continue;
+        const ghLogin = typeof d.githubLogin === "string" ? d.githubLogin : null;
+        if (ghLogin && websiteGithubLogins.has(ghLogin.toLowerCase())) continue;
+        if (!args.force && d[STAMP_FIELD]) { skippedAlreadyEmailed++; continue; }
+        if (args.onlyEmail && email !== args.onlyEmail) { skippedOnlyEmailFilter++; continue; }
+        seenEmails.add(email);
+        recipients.push({
+          email,
+          firstName: firstNameFrom(typeof d.name === "string" ? d.name : ""),
+          source: "luma",
+          sourceDocId: doc.id,
+        });
+      }
+
+      console.log(`\nRecipients: ${recipients.length}${args.onlyEmail ? ` (--only-email=${args.onlyEmail})` : ""}`);
+      const wsCount = recipients.filter((r) => r.source === "website").length;
+      console.log(`  Website-signup recipients:        ${wsCount}`);
+      console.log(`  Luma/Partiful-only recipients:    ${recipients.length - wsCount}`);
+      console.log(`Skipped — judge/declined:           ${skippedJudgeOrDeclined}`);
+      console.log(`Skipped — unsubscribed:             ${skippedUnsubscribed}`);
+      console.log(`Skipped — no email:                 ${skippedNoEmail}`);
+      console.log(`Skipped — already emailed (stamp):  ${skippedAlreadyEmailed}`);
+      if (args.onlyEmail) console.log(`Skipped — --only-email filter:      ${skippedOnlyEmailFilter}`);
+      return recipients;
+    },
+    onSent: (r, { db }) =>
+      db
+        .collection(
+          r.source === "website" ? "hackathonEventSignups" : "hackathonLumaRegistrants"
+        )
+        .doc(r.sourceDocId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() }),
+  });
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What

Phase 1 of the deep refactoring effort. Introduces `scripts/_lib/` — a shared harness that collapses the ~150 lines of boilerplate every one-off script previously copy-pasted — and migrates a representative set of scripts onto it.

### New harness (`scripts/_lib/`)
- **`script-utils.ts`** — `loadEnv`, `escapeHtml`, `sleep`, `parseSendArgs`/`parseDbArgs`, `requireFirebaseEnv`/`requireMailgunEnv`. `escapeHtml`/`sleep` were byte-identical in ~100% of send scripts.
- **`campaign-runner.ts`** — `runEmailCampaign()`: env validation → recipient load → dry-run preview → throttled send loop with per-recipient error isolation → optional `beforeSend` (e.g. suppression sync) + `onSent` (idempotency stamp).
- **`db-runner.ts`** — `runBackfill()`: batched Firestore writes honoring the 500-op cap, `--dry-run`/`--apply` branch, skip counting.
- **`cohort1-recipients.ts`** — domain helper for the "admitted cohort-1, stamp-gated, `--force`/`--only-email`" filter that was duplicated across 4+ cohort-1 scripts.
- **`README.md`** — usage + scope notes.

### Migrated as worked examples (every variant covered)
- `send-cohort-admittance.ts` — per-recipient Discord lookup, re-runnable
- `send-cohort1-week3-{apology,mkt-deadline,mkt-reminder,mkt-t20m}.ts` — share `cohort1-recipients.ts`
- `send-may26-event-morning.ts` — multi-collection dedup, `from:` override, `beforeSend` suppression sync
- `backfill-attending-confirmed-by.ts` — now uses `db-runner` (upgraded from one-at-a-time to batched writes)

## Why
The analysis flagged ~9,000 LOC of near-identical boilerplate across 55–60 `send-*` scripts as the single biggest duplication hotspot. This lands the abstraction and proves it across the working-tree scripts; future scripts and re-runnable ones use it.

## Scope
The pre-existing **dated one-off** send scripts (`send-broadcast-2026-*`, `send-cohort1-week2-*`, the `send-may26-*` series, etc.) were executed once and archived — they are intentionally **not** migrated, since rewriting executed-once templates is churn with no payoff. Documented in `scripts/_lib/README.md`.

## Verification
- `npx tsc --noEmit` — **0 errors** project-wide
- `eslint` — clean on all changed files
- Pre-commit hook (tsc + eslint --fix + GPL headers) passed
- Each migrated script run with read-only `--dry-run` against live collections; recipient totals and per-reason skip counts match the pre-refactor logic (e.g. admittance: 93 admitted / 91 already-emailed / 2 to-send; may26: 109 website + 311 Luma deduped → 103).

Scripts are not part of the production bundle, so this carries no runtime risk to the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)