### PR TITLE
refactor(api): getFirstValidationError helper + community/questions dedup (Phase 2)

### DIFF
--- a/__tests__/lib/api-response.test.ts
+++ b/__tests__/lib/api-response.test.ts
@@ -9,8 +9,10 @@ import {
   apiError,
   apiSuccess,
   parseRequestBody,
+  getFirstValidationError,
   ErrorCode,
 } from "@/lib/api-response";
+import { z } from "zod";
 
 describe("ErrorCode constants", () => {
   it("exposes the 8 documented codes", () => {
@@ -91,6 +93,39 @@ describe("apiSuccess", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body).toEqual({ success: true, id: "new" });
+  });
+});
+
+describe("getFirstValidationError", () => {
+  const schema = z.object({
+    name: z.string().min(1, "name is required"),
+    age: z.number().int("age must be an integer"),
+  });
+
+  it("returns the first issue's message", () => {
+    const result = schema.safeParse({ name: "", age: 1.5 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(getFirstValidationError(result.error)).toBe("name is required");
+    }
+  });
+
+  it("uses the default fallback when there are no issues", () => {
+    const empty = { issues: [] } as unknown as z.ZodError;
+    expect(getFirstValidationError(empty)).toBe("Invalid request");
+  });
+
+  it("honours a custom fallback when there are no issues", () => {
+    const empty = { issues: [] } as unknown as z.ZodError;
+    expect(getFirstValidationError(empty, "Bad query")).toBe("Bad query");
+  });
+
+  it("matches the legacy `issues[0]?.message ?? fallback` idiom it replaced", () => {
+    const result = schema.safeParse({ name: "ok", age: 2.5 });
+    if (!result.success) {
+      const legacy = result.error.issues[0]?.message ?? "Invalid body";
+      expect(getFirstValidationError(result.error, "Invalid body")).toBe(legacy);
+    }
   });
 });
 

--- a/app/api/community/block/route.ts
+++ b/app/api/community/block/route.ts
@@ -16,6 +16,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
@@ -47,7 +48,7 @@ export async function POST(request: NextRequest) {
     const parsed = communityContract.block.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }
@@ -86,7 +87,7 @@ export async function DELETE(request: NextRequest) {
     });
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Missing targetUid" },
+        { error: getFirstValidationError(parsed.error, "Missing targetUid") },
         { status: 400 }
       );
     }

--- a/app/api/community/delete/route.ts
+++ b/app/api/community/delete/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
@@ -60,7 +61,7 @@ export async function POST(request: NextRequest) {
     const parsed = communityContract.deletePost.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/community/feed/route.ts
+++ b/app/api/community/feed/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import type { DocumentData, Firestore, QueryDocumentSnapshot } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getOptionalVerifiedUser } from "@/lib/server-auth";
@@ -136,7 +137,7 @@ export async function GET(request: NextRequest) {
     });
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid query" },
+        { error: getFirstValidationError(parsed.error, "Invalid query") },
         { status: 400 }
       );
     }

--- a/app/api/community/moderate/route.ts
+++ b/app/api/community/moderate/route.ts
@@ -19,6 +19,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser, isCurrentIdTokenRevoked } from "@/lib/server-auth";
@@ -64,7 +65,7 @@ export async function GET(request: NextRequest) {
     });
     if (!queryParsed.success) {
       return NextResponse.json(
-        { error: queryParsed.error.issues[0]?.message ?? "Invalid query" },
+        { error: getFirstValidationError(queryParsed.error, "Invalid query") },
         { status: 400 }
       );
     }
@@ -135,7 +136,7 @@ export async function POST(request: NextRequest) {
     const parsed = communityContract.moderateAction.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/community/my-reactions/route.ts
+++ b/app/api/community/my-reactions/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getClientIdentifier, checkRateLimit } from "@/lib/rate-limit";
@@ -60,7 +61,7 @@ export async function GET(request: NextRequest) {
     });
     if (!queryParsed.success) {
       return NextResponse.json(
-        { error: queryParsed.error.issues[0]?.message ?? "Invalid query" },
+        { error: getFirstValidationError(queryParsed.error, "Invalid query") },
         { status: 400 }
       );
     }

--- a/app/api/community/post/route.ts
+++ b/app/api/community/post/route.ts
@@ -10,7 +10,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { logger } from "@/lib/logger";
-import { parseRequestBody } from "@/lib/api-response";
+import { getFirstValidationError, parseRequestBody } from "@/lib/api-response";
 import { getClientIdentifier } from "@/lib/rate-limit";
 import { checkUpstashRateLimit } from "@/lib/upstash-rate-limit";
 import { sanitizeText } from "@/lib/sanitize";
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
     });
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid request body" },
+        { error: getFirstValidationError(parsed.error, "Invalid request body") },
         { status: 400 }
       );
     }

--- a/app/api/community/reaction/route.ts
+++ b/app/api/community/reaction/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
@@ -63,7 +64,7 @@ export async function POST(request: NextRequest) {
     const parsed = communityContract.reaction.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/community/reply/route.ts
+++ b/app/api/community/reply/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
@@ -68,7 +69,7 @@ export async function POST(request: NextRequest) {
     const parsed = communityContract.createReply.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/community/report/route.ts
+++ b/app/api/community/report/route.ts
@@ -15,6 +15,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
@@ -57,7 +58,7 @@ export async function POST(request: NextRequest) {
     const parsed = communityContract.report.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/community/repost/route.ts
+++ b/app/api/community/repost/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getVerifiedUser } from "@/lib/server-auth";
@@ -68,7 +69,7 @@ export async function POST(request: NextRequest) {
     const parsed = communityContract.createRepost.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/questions/[questionId]/route.ts
+++ b/app/api/questions/[questionId]/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getQuestionsService } from "@/lib/questions/service";
 import { logger } from "@/lib/logger";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
@@ -37,7 +38,7 @@ export async function GET(
     });
     if (!paramParsed.success) {
       return NextResponse.json(
-        { error: paramParsed.error.issues[0]?.message ?? "Invalid question ID" },
+        { error: getFirstValidationError(paramParsed.error, "Invalid question ID") },
         { status: 400 }
       );
     }

--- a/app/api/questions/accept/route.ts
+++ b/app/api/questions/accept/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {
   getQuestionsService,
@@ -48,7 +49,7 @@ export async function POST(request: NextRequest) {
     const parsed = questionsContract.accept.body.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/questions/answer/route.ts
+++ b/app/api/questions/answer/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {
   getQuestionsService,
@@ -49,7 +50,7 @@ export async function POST(request: NextRequest) {
     const parsed = questionsContract.answer.body.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/questions/post/route.ts
+++ b/app/api/questions/post/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getVerifiedUser } from "@/lib/server-auth";
 import { getQuestionsService } from "@/lib/questions/service";
 import { logger } from "@/lib/logger";
@@ -50,7 +51,7 @@ export async function POST(request: NextRequest) {
     const parsed = questionsContract.post.body.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getQuestionsService } from "@/lib/questions/service";
 import { logger } from "@/lib/logger";
 import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
@@ -38,7 +39,7 @@ export async function GET(request: NextRequest) {
     });
     if (!queryParsed.success) {
       return NextResponse.json(
-        { error: queryParsed.error.issues[0]?.message ?? "Invalid query" },
+        { error: getFirstValidationError(queryParsed.error, "Invalid query") },
         { status: 400 }
       );
     }

--- a/app/api/questions/vote/route.ts
+++ b/app/api/questions/vote/route.ts
@@ -7,6 +7,7 @@
 
 // @contracts: questionsContract.myVotes (lib/api-schemas/questions.ts)
 import { NextRequest, NextResponse } from "next/server";
+import { getFirstValidationError } from "@/lib/api-response";
 import { getVerifiedUser } from "@/lib/server-auth";
 import {
   getQuestionsService,
@@ -50,7 +51,7 @@ export async function POST(request: NextRequest) {
     const parsed = questionsContract.vote.body.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? "Invalid body" },
+        { error: getFirstValidationError(parsed.error, "Invalid body") },
         { status: 400 }
       );
     }

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import type { ZodError } from "zod";
 
 /**
  * Standard error codes for API responses.
@@ -70,6 +71,23 @@ export async function parseRequestBody<T = Record<string, any>>(
       { status: 400 }
     );
   }
+}
+
+/**
+ * Extract the first Zod validation message, falling back to a generic string.
+ *
+ * Replaces the `parsed.error.issues[0]?.message ?? "…"` idiom that appears in
+ * ~100 route handlers. Use after a failed `safeParse()`:
+ *
+ *   if (!parsed.success) {
+ *     return apiError(getFirstValidationError(parsed.error), 400);
+ *   }
+ */
+export function getFirstValidationError(
+  error: ZodError,
+  fallback: string = "Invalid request"
+): string {
+  return error.issues[0]?.message ?? fallback;
 }
 
 function inferErrorCode(status: number): ErrorCodeType {


### PR DESCRIPTION
## What
Phase 2 of the deep refactor. Adds `getFirstValidationError(zodError, fallback?)` to `lib/api-response.ts` and replaces the `parsed.error.issues[0]?.message ?? "…"` idiom — which the analysis found repeated ~100× across route handlers — at all **18 sites** in `app/api/community` and `app/api/questions`.

## Why
Single most-duplicated validation idiom in the API layer. Centralizing it removes the copy-paste and gives one place to evolve validation-error formatting.

## Behavior-preserving
The helper returns exactly `error.issues[0]?.message ?? fallback`, fed into the **same** `{ error }` / status shape each route already used — a unit test asserts equivalence with the legacy idiom. No response bodies change.

## Scope decision (important)
The plan's broader Phase-2 ideas — a `withAuth` wrapper and migrating routes to `apiError`/`apiSuccess` — are **deliberately excluded**, because they are **not** behavior-preserving:
- `apiError` emits a structured `{success:false, error:{message,code}}` body, but ~70% of routes return the flat `{error:"…"}` shape. Swapping them changes the response **contract**, not just the code.
- `withAuth` would likewise emit the structured 401 body and would change bad-token responses (several routes currently 500 on a thrown `verifyIdToken`, via a whole-handler try/catch).

Unifying the API response contract is a real, client-affecting change that deserves its own decision + QA — not a silent refactor. Left as an opt-in follow-up.

## Verification
- `npx tsc --noEmit` — 0 errors
- `eslint` — clean
- `__tests__/lib/api-response.test.ts` — 19/19 (4 new for `getFirstValidationError`, incl. a legacy-idiom-equivalence assertion)
- Pre-commit hook (tsc + eslint --fix + GPL headers) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)