### PR TITLE
refactor(game): foundational dedup — unit-stack helpers + collections (Phase 4 steps 1-2)

### DIFF
--- a/__tests__/lib/game/unit-stack.test.ts
+++ b/__tests__/lib/game/unit-stack.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ *
+ * Canonical UnitStack arithmetic helpers, extracted from the four modules that
+ * each had their own copy.
+ */
+import {
+  sumStack,
+  emptyStack,
+  addStacks,
+  subtractStack,
+  stackHasAtLeast,
+  isValidUnitStack,
+} from "@/lib/game/unit-stack";
+
+describe("unit-stack", () => {
+  it("sumStack totals all three arms", () => {
+    expect(sumStack({ ground: 2, siege: 3, air: 5 })).toBe(10);
+    expect(sumStack(emptyStack())).toBe(0);
+  });
+
+  it("emptyStack is a fresh zero stack", () => {
+    expect(emptyStack()).toEqual({ ground: 0, siege: 0, air: 0 });
+  });
+
+  it("addStacks sums component-wise", () => {
+    expect(addStacks({ ground: 1, siege: 2, air: 3 }, { ground: 4, siege: 5, air: 6 })).toEqual(
+      { ground: 5, siege: 7, air: 9 }
+    );
+  });
+
+  it("subtractStack floors each arm at zero", () => {
+    expect(subtractStack({ ground: 5, siege: 1, air: 0 }, { ground: 2, siege: 3, air: 4 })).toEqual(
+      { ground: 3, siege: 0, air: 0 }
+    );
+  });
+
+  it("stackHasAtLeast requires coverage in every arm", () => {
+    const have = { ground: 5, siege: 5, air: 5 };
+    expect(stackHasAtLeast(have, { ground: 5, siege: 5, air: 5 })).toBe(true);
+    expect(stackHasAtLeast(have, { ground: 6, siege: 0, air: 0 })).toBe(false);
+  });
+
+  it("isValidUnitStack rejects non-integer, negative, and malformed stacks", () => {
+    expect(isValidUnitStack({ ground: 1, siege: 2, air: 3 })).toBe(true);
+    expect(isValidUnitStack({ ground: 1.5, siege: 2, air: 3 })).toBe(false);
+    expect(isValidUnitStack({ ground: -1, siege: 2, air: 3 })).toBe(false);
+    expect(isValidUnitStack({ ground: 1, siege: 2 })).toBe(false);
+    expect(isValidUnitStack(null)).toBe(false);
+    expect(isValidUnitStack("nope")).toBe(false);
+  });
+});

--- a/lib/game/armageddon-resolve.ts
+++ b/lib/game/armageddon-resolve.ts
@@ -41,6 +41,10 @@ import { getAdminDb } from "@/lib/firebase-admin";
 import { logger } from "@/lib/logger";
 import { makeSeededRng } from "./combat";
 import {
+  GAME_COLLECTIONS as COLLECTIONS,
+  WORLD_META_DOC,
+} from "./data-access/collections";
+import {
   SEAL_COUNT,
   TOP_BY_TILES_SNAPSHOT_COUNT,
   WINNER_COUNT,
@@ -60,18 +64,6 @@ import type {
   GameWorldMeta,
   SealRecord,
 } from "./types";
-
-const COLLECTIONS = {
-  PLAYERS: "game_players",
-  TILES: "game_tiles",
-  ATTACKS: "game_attacks",
-  WORLD_META: "game_world_meta",
-  ARTIFACTS: "game_artifacts",
-  INTEL_EFFECTS: "game_intel_effects",
-  COMMUNITY_EVENTS: "game_community_events",
-  ARMAGEDDON_EVENTS: "game_armageddon_events",
-} as const;
-const WORLD_META_DOC = "singleton";
 
 /** Firestore batched-write limit is 500; leave headroom. */
 const BATCH_SIZE = 400;

--- a/lib/game/combat.ts
+++ b/lib/game/combat.ts
@@ -34,6 +34,10 @@ import type {
   UnitStack,
   UnitType,
 } from "./types";
+import { addStacks, emptyStack, sumStack } from "./unit-stack";
+
+// Re-exported for backward compatibility with prior `./combat` import sites.
+export { addStacks };
 
 const UNIT_TYPES: readonly UnitType[] = ["ground", "siege", "air"] as const;
 
@@ -660,14 +664,6 @@ export function attributeAttackerLosses(args: {
 // empty — handy because pieces of code outside combat.ts will start needing
 // to sum SUPER+BASE.
 /** @internal */
-export function addStacks(a: UnitStack, b: UnitStack): UnitStack {
-  return {
-    ground: a.ground + b.ground,
-    siege: a.siege + b.siege,
-    air: a.air + b.air,
-  };
-}
-
 export function computeTileCapacity(
   landType: LandType,
   caste: Caste | null,
@@ -709,14 +705,6 @@ export function makeSeededRng(seed: string): () => number {
     t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };
-}
-
-function sumStack(s: UnitStack): number {
-  return s.ground + s.siege + s.air;
-}
-
-function emptyStack(): UnitStack {
-  return { ground: 0, siege: 0, air: 0 };
 }
 
 function clampStackToCapacity(

--- a/lib/game/data-access/collections.ts
+++ b/lib/game/data-access/collections.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Canonical Firestore collection names + well-known doc ids for the game.
+ *
+ * `COLLECTIONS` was previously redeclared in three modules (data-server,
+ * npc-weekly, armageddon-resolve) as overlapping subsets — a drift hazard. This
+ * is the single source of truth (the union of all three); each importer aliases
+ * it back to `COLLECTIONS` and references only the keys it needs.
+ */
+export const GAME_COLLECTIONS = {
+  PLAYERS: "game_players",
+  TILES: "game_tiles",
+  ATTACKS: "game_attacks",
+  WORLD_META: "game_world_meta",
+  ARTIFACTS: "game_artifacts",
+  // Intel effects: per-target debuffs/passives applied by spells, read inside
+  // attack resolution.
+  INTEL_EFFECTS: "game_intel_effects",
+  // Community feed: append-only event log of player actions (joins, caste
+  // picks, attacks, milestones). Read by the dashboard's CommunityPanel.
+  // Writes are Admin-SDK only.
+  COMMUNITY_EVENTS: "game_community_events",
+  // Community chat: free-form messages from authenticated players, moderated by
+  // author or by an admin (delete-only).
+  COMMUNITY_MESSAGES: "game_community_messages",
+  // End-game / Armageddon hall-of-fame: one doc per past Armageddon (doc id =
+  // seasonNumber). Persisted before the wipe so the record survives even if the
+  // resolver crashes mid-batch.
+  ARMAGEDDON_EVENTS: "game_armageddon_events",
+  // Zero-turn gameplay: queued battle plans that execute at next weekly grant.
+  // Owned by player; writes Admin-SDK only.
+  ORDER_QUEUE: "game_order_queue",
+} as const;
+
+/** The singleton world-meta document id. */
+export const WORLD_META_DOC = "singleton";

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -22,6 +22,13 @@ import {
   resolveAttack,
   rollSpellEffectiveness,
 } from "./combat";
+import {
+  addStacks as addStack,
+  isValidUnitStack,
+  stackHasAtLeast,
+  subtractStack,
+  sumStack,
+} from "./unit-stack";
 import { ARTIFACTS_BY_ID, SPELLS_BY_ID } from "./content";
 import {
   ARMAGEDDON_TILE_GATE,
@@ -1967,49 +1974,9 @@ export async function chooseCasteServer(
   });
 }
 
-function sumStack(s: UnitStack): number {
-  return s.ground + s.siege + s.air;
-}
-
-function addStack(a: UnitStack, b: UnitStack): UnitStack {
-  return {
-    ground: a.ground + b.ground,
-    siege: a.siege + b.siege,
-    air: a.air + b.air,
-  };
-}
-
-function subtractStack(a: UnitStack, b: UnitStack): UnitStack {
-  return {
-    ground: Math.max(0, a.ground - b.ground),
-    siege: Math.max(0, a.siege - b.siege),
-    air: Math.max(0, a.air - b.air),
-  };
-}
-
-function stackHasAtLeast(have: UnitStack, need: UnitStack): boolean {
-  return (
-    have.ground >= need.ground &&
-    have.siege >= need.siege &&
-    have.air >= need.air
-  );
-}
-
-function isValidUnitStack(s: unknown): s is UnitStack {
-  if (!s || typeof s !== "object") return false;
-  const obj = s as Record<string, unknown>;
-  return (
-    typeof obj.ground === "number" &&
-    typeof obj.siege === "number" &&
-    typeof obj.air === "number" &&
-    obj.ground >= 0 &&
-    obj.siege >= 0 &&
-    obj.air >= 0 &&
-    Number.isInteger(obj.ground) &&
-    Number.isInteger(obj.siege) &&
-    Number.isInteger(obj.air)
-  );
-}
+// Unit-stack arithmetic (sumStack/addStack/subtractStack/stackHasAtLeast/
+// isValidUnitStack) lives in ./unit-stack — see the import above. `addStack`
+// is the local alias for the canonical `addStacks`.
 
 // Counts the player's tiles by land type. Done OUTSIDE the build/attack
 // transactions because Firestore txns can't query — the count is at most one

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -23,6 +23,10 @@ import {
   rollSpellEffectiveness,
 } from "./combat";
 import {
+  GAME_COLLECTIONS as COLLECTIONS,
+  WORLD_META_DOC,
+} from "./data-access/collections";
+import {
   addStacks as addStack,
   isValidUnitStack,
   stackHasAtLeast,
@@ -728,30 +732,6 @@ export class GameLastStandNoThreatError extends Error {
     this.name = "GameLastStandNoThreatError";
   }
 }
-
-const COLLECTIONS = {
-  PLAYERS: "game_players",
-  TILES: "game_tiles",
-  ATTACKS: "game_attacks",
-  WORLD_META: "game_world_meta",
-  ARTIFACTS: "game_artifacts",
-  // Community feed: append-only event log of player actions (joins,
-  // caste picks, attacks, milestones). Read by the dashboard's
-  // CommunityPanel. Writes are Admin-SDK only.
-  COMMUNITY_EVENTS: "game_community_events",
-  // Community chat: free-form messages from authenticated players,
-  // moderated by author or by an admin (delete-only).
-  COMMUNITY_MESSAGES: "game_community_messages",
-  // End-game / Armageddon hall-of-fame: one doc per past Armageddon
-  // (doc id = seasonNumber). Persisted before the wipe so the record
-  // survives even if the resolver crashes mid-batch.
-  ARMAGEDDON_EVENTS: "game_armageddon_events",
-  // Zero-turn gameplay: queued battle plans that execute at next weekly
-  // grant. Owned by player; writes Admin-SDK only.
-  ORDER_QUEUE: "game_order_queue",
-} as const;
-
-const WORLD_META_DOC = "singleton";
 
 // Land types you can distribute a tile to. "unassigned" is allowed so the
 // player can revert a tile back (and pay 1 turn for the privilege); they

--- a/lib/game/discord-game.ts
+++ b/lib/game/discord-game.ts
@@ -12,6 +12,7 @@
 
 import { sendDiscordNotification } from "@/lib/discord";
 import { logger } from "@/lib/logger";
+import { sumStack } from "./unit-stack";
 import type { Caste, GameAttack } from "./types";
 
 const CASTE_COLOR: Record<Caste, number> = {
@@ -24,10 +25,6 @@ const CASTE_COLOR: Record<Caste, number> = {
 
 function gameWebhookUrl(): string | null {
   return process.env.GAME_DISCORD_WEBHOOK_URL?.trim() || null;
-}
-
-function sumStack(s: { ground: number; siege: number; air: number }): number {
-  return s.ground + s.siege + s.air;
 }
 
 /** @internal */

--- a/lib/game/npc-weekly.ts
+++ b/lib/game/npc-weekly.ts
@@ -32,6 +32,7 @@ import {
   weekStartIsoForRollover,
 } from "./turns";
 import { computeTileCapacity, makeSeededRng } from "./combat";
+import { sumStack } from "./unit-stack";
 import { getSpellForCasteAndType } from "./content";
 import { rebuildWorldSnapshotServer } from "./world-snapshot";
 import type {
@@ -86,9 +87,6 @@ function personaForUid(uid: string): Persona {
   return PERSONAS[PERSONA_NAMES[djb2(uid) % PERSONA_NAMES.length]!];
 }
 
-function sumStack(s: UnitStack): number {
-  return s.ground + s.siege + s.air;
-}
 
 interface AttackCandidate {
   sourceTileId: string;

--- a/lib/game/npc-weekly.ts
+++ b/lib/game/npc-weekly.ts
@@ -32,6 +32,7 @@ import {
   weekStartIsoForRollover,
 } from "./turns";
 import { computeTileCapacity, makeSeededRng } from "./combat";
+import { GAME_COLLECTIONS as COLLECTIONS } from "./data-access/collections";
 import { sumStack } from "./unit-stack";
 import { getSpellForCasteAndType } from "./content";
 import { rebuildWorldSnapshotServer } from "./world-snapshot";
@@ -41,11 +42,6 @@ import type {
   UnitStack,
   UnitType,
 } from "./types";
-
-const COLLECTIONS = {
-  PLAYERS: "game_players",
-  TILES: "game_tiles",
-} as const;
 
 const ATTACK_HARD_CAP = 15;
 

--- a/lib/game/unit-stack.ts
+++ b/lib/game/unit-stack.ts
@@ -1,0 +1,72 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Canonical helpers for `UnitStack` arithmetic.
+ *
+ * `sumStack` was previously defined byte-identically in four files
+ * (data-server, combat, npc-weekly, discord-game) and `addStack`/`addStacks`
+ * in two more — drifting copies of the same trivial math. They live here once
+ * now. Note `zero-turn.ts` keeps its own `addStack(a, delta: Partial<UnitStack>)`
+ * deliberately: that is a partial-delta merge with different semantics, not this
+ * two-full-stacks addition.
+ */
+import type { UnitStack } from "./types";
+
+/** Total unit count across all three arms. */
+export function sumStack(s: UnitStack): number {
+  return s.ground + s.siege + s.air;
+}
+
+/** A fresh zero stack. */
+export function emptyStack(): UnitStack {
+  return { ground: 0, siege: 0, air: 0 };
+}
+
+/** Component-wise sum of two full stacks. */
+export function addStacks(a: UnitStack, b: UnitStack): UnitStack {
+  return {
+    ground: a.ground + b.ground,
+    siege: a.siege + b.siege,
+    air: a.air + b.air,
+  };
+}
+
+/** Component-wise subtraction, floored at zero per arm. */
+export function subtractStack(a: UnitStack, b: UnitStack): UnitStack {
+  return {
+    ground: Math.max(0, a.ground - b.ground),
+    siege: Math.max(0, a.siege - b.siege),
+    air: Math.max(0, a.air - b.air),
+  };
+}
+
+/** True when `have` covers `need` in every arm. */
+export function stackHasAtLeast(have: UnitStack, need: UnitStack): boolean {
+  return (
+    have.ground >= need.ground &&
+    have.siege >= need.siege &&
+    have.air >= need.air
+  );
+}
+
+/** Runtime guard: a non-negative integer stack on all three arms. */
+export function isValidUnitStack(s: unknown): s is UnitStack {
+  if (!s || typeof s !== "object") return false;
+  const obj = s as Record<string, unknown>;
+  return (
+    typeof obj.ground === "number" &&
+    typeof obj.siege === "number" &&
+    typeof obj.air === "number" &&
+    obj.ground >= 0 &&
+    obj.siege >= 0 &&
+    obj.air >= 0 &&
+    Number.isInteger(obj.ground) &&
+    Number.isInteger(obj.siege) &&
+    Number.isInteger(obj.air)
+  );
+}


### PR DESCRIPTION
## What
The first two **foundational, low-risk** extractions in decomposing the 7,865-line `lib/game/data-server.ts`. Two atomic commits:

1. **`lib/game/unit-stack.ts`** — canonical `UnitStack` arithmetic (`sumStack`, `emptyStack`, `addStacks`, `subtractStack`, `stackHasAtLeast`, `isValidUnitStack`). `sumStack` was byte-identical in 4 files, the two-stack add in 2.
2. **`lib/game/data-access/collections.ts`** — single source of truth for Firestore collection names (`GAME_COLLECTIONS` + `WORLD_META_DOC`), previously redeclared as overlapping subsets in 3 modules.

Both are pure dedup with no semantic change. They establish `lib/game/data-access/` as the home for the upcoming (riskier, separately-PR'd) repository + attack-resolution extractions.

## How (behavior-preserving)
- `data-server.ts` imports both, aliasing `addStacks as addStack` and `GAME_COLLECTIONS as COLLECTIONS` so call sites don't churn.
- `combat.ts` re-exports `addStacks` for prior `./combat` importers.
- `npc-weekly.ts` / `discord-game.ts` drop local `sumStack`; `npc-weekly`/`armageddon-resolve` drop local `COLLECTIONS`.
- **`zero-turn.ts` untouched** — its `addStack(a, delta: Partial<UnitStack>)` is a partial-delta merge with different semantics.

## Verification
- Full game suite: **1460 tests / 72 suites green**
- New `unit-stack.test.ts` (6 tests)
- `tsc --noEmit` clean; pre-commit hook (tsc + eslint --fix + GPL) passed on each commit

The high-risk extractions (data-access read/write repositories, splitting the 1,148-line `attackTileServer`) will each be their own PR, verified against this same suite — keeping regressions bisectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)