### PR TITLE
refactor(lib): centralize GitHub API headers (Phase 5)

### DIFF
--- a/lib/github-api-helpers.ts
+++ b/lib/github-api-helpers.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Shared GitHub REST/Search API helpers.
+ *
+ * The request-header builder was previously copy-pasted as `githubHeaders()` /
+ * `searchHeaders()` / inline objects across five `github-*` modules, and the
+ * search-pagination constants in two of them. Centralized here.
+ */
+
+/**
+ * Standard GitHub API request headers. Adds a `Bearer` token from
+ * `GITHUB_TOKEN` when present (raises the rate limit); anonymous otherwise.
+ */
+export function getGithubApiHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/** Max results per Search API page (GitHub's ceiling). */
+export const GITHUB_SEARCH_PER_PAGE = 100;
+
+/** GitHub Search returns at most the first 1000 matches (10 × 100). */
+export const GITHUB_SEARCH_MAX_PAGES = 10;

--- a/lib/github-merged-pr-count.ts
+++ b/lib/github-merged-pr-count.ts
@@ -7,6 +7,11 @@
 
 import { unstable_cache } from "next/cache";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import {
+  getGithubApiHeaders as searchHeaders,
+  GITHUB_SEARCH_PER_PAGE as SEARCH_PER_PAGE,
+  GITHUB_SEARCH_MAX_PAGES as SEARCH_MAX_PAGES,
+} from "@/lib/github-api-helpers";
 import { fetchWithTimeout } from "@/lib/http-fetch";
 import { logger } from "@/lib/logger";
 
@@ -19,20 +24,6 @@ function sleep(ms: number): Promise<void> {
 type SearchIssueItem = {
   user?: { login?: string } | null;
 };
-
-const SEARCH_PER_PAGE = 100;
-/** GitHub search only returns the first 1000 matches. */
-const SEARCH_MAX_PAGES = 10;
-
-function searchHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) headers.Authorization = `Bearer ${token}`;
-  return headers;
-}
 
 /**
  * Uncached bulk merged-PR search. Exported so node scripts (which don't run

--- a/lib/github-merged-pr-reconcile.ts
+++ b/lib/github-merged-pr-reconcile.ts
@@ -8,6 +8,11 @@
 import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import {
+  getGithubApiHeaders as githubHeaders,
+  GITHUB_SEARCH_PER_PAGE as SEARCH_PER_PAGE,
+  GITHUB_SEARCH_MAX_PAGES as SEARCH_MAX_PAGES,
+} from "@/lib/github-api-helpers";
 import { logger } from "@/lib/logger";
 
 type SearchMergedPrItem = {
@@ -20,21 +25,7 @@ type SearchMergedPrItem = {
   user?: { login?: string } | null;
 };
 
-const SEARCH_PER_PAGE = 100;
-const SEARCH_MAX_PAGES = 10;
 const BATCH_WRITE_LIMIT = 400;
-
-function githubHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-  return headers;
-}
 
 /** @internal */
 export async function fetchMergedPullRequestsForAuthor(

--- a/lib/github-open-pr-review-status.ts
+++ b/lib/github-open-pr-review-status.ts
@@ -6,6 +6,7 @@
  */
 
 import { getGithubRepoPair } from "@/lib/github-recent-merged-prs";
+import { getGithubApiHeaders as githubHeaders } from "@/lib/github-api-helpers";
 import { logger } from "@/lib/logger";
 
 export type OpenPrWithReviewSummary = {
@@ -29,16 +30,6 @@ type ReviewItem = {
   state?: unknown;
   submitted_at?: unknown | null;
 };
-
-function githubHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) headers.Authorization = `Bearer ${token}`;
-  return headers;
-}
 
 function summarizeReviews(
   reviews: ReviewItem[],

--- a/lib/github-recent-merged-prs.ts
+++ b/lib/github-recent-merged-prs.ts
@@ -5,6 +5,7 @@
  * See LICENSE file for details.
  */
 
+import { getGithubApiHeaders } from "@/lib/github-api-helpers";
 import { logger } from "@/lib/logger";
 
 const DEFAULT_OWNER = "rogerSuperBuilderAlpha";
@@ -72,7 +73,6 @@ export async function fetchRecentMergedPullRequests(
 ): Promise<{ prs: MergedPullRequestSummary[]; repoUrl: string; error?: boolean }> {
   const { owner, repo } = getGithubRepoPair();
   const repoUrl = `https://github.com/${owner}/${repo}`;
-  const token = process.env.GITHUB_TOKEN;
   const url = new URL(
     `https://api.github.com/repos/${owner}/${repo}/pulls`
   );
@@ -83,11 +83,7 @@ export async function fetchRecentMergedPullRequests(
 
   try {
     const res = await fetch(url.toString(), {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
+      headers: getGithubApiHeaders(),
       next: { revalidate: 300 },
     });
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -8,6 +8,7 @@
 import { createHmac, timingSafeEqual } from "crypto";
 import { FieldValue } from "firebase-admin/firestore";
 import { getGithubRepoPair } from "./github-recent-merged-prs";
+import { getGithubApiHeaders } from "./github-api-helpers";
 import { getAdminDb } from "./firebase-admin";
 import { logger } from "./logger";
 
@@ -105,14 +106,7 @@ export async function fetchPullRequestChangedFilenames(
   prNumber: number
 ): Promise<string[]> {
   const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`;
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
+  const headers = getGithubApiHeaders();
   try {
     const res = await fetch(url, { headers });
     if (!res.ok) return [];


### PR DESCRIPTION
## What
Phase 5 (lib cluster cleanup). Extracts the duplicated GitHub API request-header builder into `lib/github-api-helpers.ts`:
- `getGithubApiHeaders()` — was copy-pasted as `githubHeaders()` / `searchHeaders()` / inline objects across **5** `github-*` modules.
- `GITHUB_SEARCH_PER_PAGE` / `GITHUB_SEARCH_MAX_PAGES` — were duplicated in 2 modules.

Each consumer imports them aliased to its prior local names, so call sites don't change.

## Behavior-preserving
Identical header keys/values and constants. Verified: github test suites **86/86 (5 suites)**, `tsc --noEmit` + eslint clean.

## Scope note
The other Phase-5 ideas are intentionally left out of this PR:
- **`console.*` → `logger`**: ~53 sites, but many are *intentional* (firebase-admin startup diagnostics, documented build-log `console.warn`s in pydata/sports-hack submissions that surface in Vercel deploy output, jsdoc examples). A blanket sweep would be noisy and risk behavior/level-filtering changes — not worth bundling here.
- **`hackathon-asprint-2026/` module grouping** (8 flat files → module + `doc-ids.ts`): a larger move touching many import sites; deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)