### PR TITLE
refactor(game): data-access reads layer — world-meta + lazy-regen untangle (Phase 4, step 6)

### DIFF
--- a/lib/game/data-access/tile-regen.ts
+++ b/lib/game/data-access/tile-regen.ts
@@ -1,0 +1,123 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Lazy BASE-unit regen applied on read.
+ *
+ * Extracted from data-server and split into a **pure** computation
+ * (`computeLazyBaseRegen` — no I/O, unit-testable) and the side-effecting
+ * wrappers (`applyLazyRegen` / `applyLazyRegenBatch`) that fire the
+ * non-awaited Firestore writeback. This decouples the read getters from the
+ * write path so they can live in the data-access layer without dragging
+ * mutation logic along.
+ */
+import type { Firestore, Timestamp } from "firebase-admin/firestore";
+import { applyBaseRegen, baseUnitsTarget } from "../combat";
+import { logger } from "@/lib/logger";
+import type { GamePlayer, GameTile } from "../types";
+import { GAME_COLLECTIONS as COLLECTIONS } from "./collections";
+import { adminDbOrThrow } from "./db";
+
+/**
+ * Pure BASE-regen computation for one tile. Returns the regenerated
+ * `baseUnits`/`baseRegenedAt` when regen is due, or `null` when the tile is
+ * unowned or there's nothing to regen (so the caller can skip the writeback).
+ */
+export function computeLazyBaseRegen(
+  tile: GameTile,
+  player: GamePlayer | null,
+  now: Date
+): { baseUnits: GameTile["baseUnits"]; baseRegenedAt: Date } | null {
+  if (!tile.ownerId) return null;
+  const currentBase = tile.baseUnits ?? { ground: 0, siege: 0, air: 0 };
+  const target = baseUnitsTarget({
+    landType: tile.type,
+    caste: player?.caste ?? null,
+    upgradeIds: tile.upgradeIds,
+    intrinsicBuffs: tile.intrinsicBuffs,
+    createdAt:
+      tile.createdAt instanceof Date
+        ? tile.createdAt
+        : typeof (tile.createdAt as Timestamp | undefined)?.toDate === "function"
+          ? (tile.createdAt as Timestamp).toDate()
+          : undefined,
+    activeUpgrades: player?.activeUpgrades ?? {},
+    productionSpellsActive: player?.productionSpellsActive,
+    now,
+  });
+  const baseRegenedAt =
+    tile.baseRegenedAt instanceof Date
+      ? tile.baseRegenedAt
+      : typeof (tile.baseRegenedAt as Timestamp | undefined)?.toDate ===
+          "function"
+        ? (tile.baseRegenedAt as Timestamp).toDate()
+        : tile.createdAt instanceof Date
+          ? tile.createdAt
+          : typeof (tile.createdAt as Timestamp | undefined)?.toDate ===
+              "function"
+            ? (tile.createdAt as Timestamp).toDate()
+            : now;
+  const result = applyBaseRegen({
+    currentBase,
+    target,
+    landType: tile.type,
+    baseRegenedAt,
+    now,
+  });
+  if (result.deltaUnits <= 0) return null;
+  return { baseUnits: result.baseUnits, baseRegenedAt: result.baseRegenedAt };
+}
+
+/**
+ * Apply lazy regen to one tile: computes the regen, fires a fire-and-forget
+ * Firestore writeback when there's a delta (failures logged, not awaited, so
+ * the read path stays snappy), and returns the regenerated tile in-memory.
+ */
+export function applyLazyRegen(
+  tile: GameTile,
+  player: GamePlayer | null,
+  now: Date,
+  db: Firestore
+): GameTile {
+  const regen = computeLazyBaseRegen(tile, player, now);
+  if (!regen) return tile;
+  db.collection(COLLECTIONS.TILES)
+    .doc(tile.tileId)
+    .update({
+      baseUnits: regen.baseUnits,
+      baseRegenedAt: regen.baseRegenedAt,
+    })
+    .catch((e) => {
+      logger.warn("applyLazyRegen writeback failed", {
+        tileId: tile.tileId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    });
+  return {
+    ...tile,
+    baseUnits: regen.baseUnits,
+    baseRegenedAt: regen.baseRegenedAt,
+  };
+}
+
+// In-memory + fire-and-forget Firestore writeback of BASE regen across a
+// batch of tiles. Returns the regenerated tiles. Writes only fire for tiles
+// where the BASE delta is non-zero (avoids write storms on read-heavy paths).
+// The writes are not awaited — the caller's response uses the in-memory
+// regen result; the next request reads the persisted values.
+export function applyLazyRegenBatch(
+  tiles: GameTile[],
+  player: GamePlayer | null,
+  now: Date
+): GameTile[] {
+  const db = adminDbOrThrow();
+  const out: GameTile[] = [];
+  for (const t of tiles) {
+    out.push(applyLazyRegen(t, player, now, db));
+  }
+  return out;
+}

--- a/lib/game/data-access/world-meta.ts
+++ b/lib/game/data-access/world-meta.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * World-meta singleton accessors.
+ *
+ * `defaultedWorldMeta` (the pure defaulting helper) and `getWorldMetaServer`
+ * (the read-only fetch) move here out of data-server. The transactional
+ * `readWorldMetaInTx` stays in data-server and imports `defaultedWorldMeta`
+ * back — this module holds no transaction state, so there's no cycle.
+ */
+import type { GameWorldMeta } from "../types";
+import { GAME_COLLECTIONS as COLLECTIONS, WORLD_META_DOC } from "./collections";
+import { adminDbOrThrow } from "./db";
+
+/** Fill a partial/absent world-meta doc with its documented defaults. */
+export function defaultedWorldMeta(
+  raw: Partial<GameWorldMeta> | undefined
+): GameWorldMeta {
+  return {
+    playerCount: raw?.playerCount ?? 0,
+    seasonNumber: raw?.seasonNumber ?? 1,
+    sealsBroken: raw?.sealsBroken ?? 0,
+    seals: raw?.seals ?? [],
+    armageddonState: raw?.armageddonState ?? "active",
+    armageddonStartedAt: raw?.armageddonStartedAt,
+    armageddonResolvedAt: raw?.armageddonResolvedAt,
+    lastSpawnAt: raw?.lastSpawnAt,
+    updatedAt: raw?.updatedAt,
+  };
+}
+
+/** Read-only world-meta fetch for dashboard / hall-of-fame surfacing.
+ *  Returns the defaulted shape even when the doc doesn't exist yet. */
+export async function getWorldMetaServer(): Promise<GameWorldMeta> {
+  const db = adminDbOrThrow();
+  const snap = await db
+    .collection(COLLECTIONS.WORLD_META)
+    .doc(WORLD_META_DOC)
+    .get();
+  const raw = snap.exists ? (snap.data() as Partial<GameWorldMeta>) : undefined;
+  return defaultedWorldMeta(raw);
+}

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -26,6 +26,9 @@ import {
   GAME_COLLECTIONS as COLLECTIONS,
   WORLD_META_DOC,
 } from "./data-access/collections";
+import { defaultedWorldMeta, getWorldMetaServer } from "./data-access/world-meta";
+// Re-exported so existing `@/lib/game/data-server` importers keep working.
+export { getWorldMetaServer };
 import {
   addStacks as addStack,
   isValidUnitStack,
@@ -748,20 +751,6 @@ const VALID_CASTES = new Set<Caste>(["black", "red", "white", "green", "blue"]);
 // with safe defaults. Pre-Armageddon docs (and freshly-bootstrapped envs)
 // don't have sealsBroken / armageddonState / seasonNumber set; treat
 // season as 1 and state as "active" so legacy reads behave correctly.
-function defaultedWorldMeta(raw: Partial<GameWorldMeta> | undefined): GameWorldMeta {
-  return {
-    playerCount: raw?.playerCount ?? 0,
-    seasonNumber: raw?.seasonNumber ?? 1,
-    sealsBroken: raw?.sealsBroken ?? 0,
-    seals: raw?.seals ?? [],
-    armageddonState: raw?.armageddonState ?? "active",
-    armageddonStartedAt: raw?.armageddonStartedAt,
-    armageddonResolvedAt: raw?.armageddonResolvedAt,
-    lastSpawnAt: raw?.lastSpawnAt,
-    updatedAt: raw?.updatedAt,
-  };
-}
-
 /** Refuses turn-spending actions while the world is being remade. Also
  *  refuses stale player docs (left over from a prior season after a
  *  partial wipe — should be rare since the resolver deletes them, but
@@ -792,18 +781,6 @@ async function readWorldMetaInTx(
   const snap = await tx.get(ref);
   const raw = snap.exists ? (snap.data() as Partial<GameWorldMeta>) : undefined;
   return { meta: defaultedWorldMeta(raw), ref };
-}
-
-/** Read-only world-meta fetch for dashboard / hall-of-fame surfacing.
- *  Returns the defaulted shape even when the doc doesn't exist yet. */
-export async function getWorldMetaServer(): Promise<GameWorldMeta> {
-  const db = adminDbOrThrow();
-  const snap = await db
-    .collection(COLLECTIONS.WORLD_META)
-    .doc(WORLD_META_DOC)
-    .get();
-  const raw = snap.exists ? (snap.data() as Partial<GameWorldMeta>) : undefined;
-  return defaultedWorldMeta(raw);
 }
 
 // Rolls (3% chance) for an artifact and stages a tx.set() to persist it if

--- a/lib/game/data-server.ts
+++ b/lib/game/data-server.ts
@@ -9,7 +9,6 @@ import { randomUUID } from "node:crypto";
 import type { Firestore, Timestamp, Transaction } from "firebase-admin/firestore";
 import { adminDbOrThrow } from "./data-access/db";
 import {
-  applyBaseRegen,
   applyFlyoverModifiers,
   attributeAttackerLosses,
   attributeDefenderLosses,
@@ -29,6 +28,10 @@ import {
 import { defaultedWorldMeta, getWorldMetaServer } from "./data-access/world-meta";
 // Re-exported so existing `@/lib/game/data-server` importers keep working.
 export { getWorldMetaServer };
+import {
+  applyLazyRegen,
+  applyLazyRegenBatch,
+} from "./data-access/tile-regen";
 import {
   addStacks as addStack,
   isValidUnitStack,
@@ -850,88 +853,6 @@ export async function getOwnedTilesServer(userId: string): Promise<GameTile[]> {
   const player = playerSnap.exists ? (playerSnap.data() as GamePlayer) : null;
   const tiles = snap.docs.map((d) => d.data() as GameTile);
   return applyLazyRegenBatch(tiles, player, new Date());
-}
-
-// In-memory + fire-and-forget Firestore writeback of BASE regen across a
-// batch of tiles. Returns the regenerated tiles. Writes only fire for tiles
-// where the BASE delta is non-zero (avoids write storms on read-heavy paths).
-// The writes are not awaited — the caller's response uses the in-memory
-// regen result; the next request reads the persisted values.
-function applyLazyRegenBatch(
-  tiles: GameTile[],
-  player: GamePlayer | null,
-  now: Date
-): GameTile[] {
-  const db = adminDbOrThrow();
-  const out: GameTile[] = [];
-  for (const t of tiles) {
-    out.push(applyLazyRegen(t, player, now, db));
-  }
-  return out;
-}
-
-function applyLazyRegen(
-  tile: GameTile,
-  player: GamePlayer | null,
-  now: Date,
-  db: Firestore
-): GameTile {
-  if (!tile.ownerId) return tile;
-  const currentBase = tile.baseUnits ?? { ground: 0, siege: 0, air: 0 };
-  const target = baseUnitsTarget({
-    landType: tile.type,
-    caste: player?.caste ?? null,
-    upgradeIds: tile.upgradeIds,
-    intrinsicBuffs: tile.intrinsicBuffs,
-    createdAt:
-      tile.createdAt instanceof Date
-        ? tile.createdAt
-        : typeof (tile.createdAt as Timestamp | undefined)?.toDate === "function"
-          ? (tile.createdAt as Timestamp).toDate()
-          : undefined,
-    activeUpgrades: player?.activeUpgrades ?? {},
-    productionSpellsActive: player?.productionSpellsActive,
-    now,
-  });
-  const baseRegenedAt =
-    tile.baseRegenedAt instanceof Date
-      ? tile.baseRegenedAt
-      : typeof (tile.baseRegenedAt as Timestamp | undefined)?.toDate ===
-          "function"
-        ? (tile.baseRegenedAt as Timestamp).toDate()
-        : tile.createdAt instanceof Date
-          ? tile.createdAt
-          : typeof (tile.createdAt as Timestamp | undefined)?.toDate ===
-              "function"
-            ? (tile.createdAt as Timestamp).toDate()
-            : now;
-  const result = applyBaseRegen({
-    currentBase,
-    target,
-    landType: tile.type,
-    baseRegenedAt,
-    now,
-  });
-  if (result.deltaUnits <= 0) return tile;
-  // Fire-and-forget Firestore writeback. Failures are logged inside the
-  // surrounding logger; we don't await so the read path stays snappy.
-  db.collection(COLLECTIONS.TILES)
-    .doc(tile.tileId)
-    .update({
-      baseUnits: result.baseUnits,
-      baseRegenedAt: result.baseRegenedAt,
-    })
-    .catch((e) => {
-      logger.warn("applyLazyRegen writeback failed", {
-        tileId: tile.tileId,
-        error: e instanceof Error ? e.message : String(e),
-      });
-    });
-  return {
-    ...tile,
-    baseUnits: result.baseUnits,
-    baseRegenedAt: result.baseRegenedAt,
-  };
 }
 
 // Lightweight tile fetch — uses Firestore's select() to only pull the fields


### PR DESCRIPTION
## What
Two commits extending the data-access layer, both unblocking the read getters trapped in `data-server.ts`:

**1. World-meta reader** → `data-access/world-meta.ts`
- `defaultedWorldMeta` (pure) + `getWorldMetaServer` (read-only fetch).
- data-server's transactional `readWorldMetaInTx` imports `defaultedWorldMeta` back; `getWorldMetaServer` is re-exported so external import sites are unaffected.

**2. Lazy BASE-regen untangle** → `data-access/tile-regen.ts`
- `applyLazyRegen` mixed a pure regen computation with a fire-and-forget Firestore writeback, and was *the* dependency pinning the read getters (`getOwnedTilesServer`, `getTileServer`, map queries) inside data-server.
- Split into **`computeLazyBaseRegen`** (pure, no I/O, unit-testable) + `applyLazyRegen` (pure compute + non-awaited writeback) + `applyLazyRegenBatch`. Behavior unchanged — same early-returns, same update, same in-memory return.
- data-server imports all three back; `applyBaseRegen` (used only here) dropped from its combat import.

No cycles: both modules depend only on `../combat`, `../types`, `@/lib/logger`, and `data-access/{collections,db}`.

## Behavior-preserving
Code moved verbatim (regen split preserves exact logic). Verified: game suite **1460/1460**, tsc + eslint clean. `data-server.ts` 7,444 → **7,337** (7,865 → 7,337 across the whole Phase-4 chain).

## Why this matters
The lazy-regen untangle removes the blocker that made the read getters un-extractable. Moving the getters themselves into `data-access/reads.ts` is now a clean follow-up.

## Stacked chain (6 deep)
#1567 → #1569 → #1570 → #1571 → **this**. Recommend landing bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)