### PR TITLE
refactor(ui): standardize date formats + cookbook pills (Phase 3)

### DIFF
--- a/components/badges/BadgeCard.tsx
+++ b/components/badges/BadgeCard.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useRef, useState, type KeyboardEvent, type SVGProps } from "react";
+import { formatMonthYear } from "@/lib/format-helpers";
 import type { BadgeDefinition, BadgeEligibilityResult } from "@/lib/badges/types";
 import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
 import { cn } from "@/lib/utils";
@@ -168,10 +169,7 @@ export function BadgeCard({
   const earnedDate = awardedAt ? new Date(awardedAt) : null;
   const earnedDateLabel =
     isEarned && earnedDate && !Number.isNaN(earnedDate.getTime())
-      ? earnedDate.toLocaleDateString("en-US", {
-          month: "short",
-          year: "numeric",
-        })
+      ? formatMonthYear(earnedDate)
       : null;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {

--- a/components/cookbook/CookbookEntryCard.tsx
+++ b/components/cookbook/CookbookEntryCard.tsx
@@ -129,7 +129,7 @@ export function CookbookEntryCard({
                   </span>
                 ))}
                 {worksWithMore > 0 && (
-                  <span className="px-2.5 py-1 bg-neutral-200 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs font-medium rounded-full">
+                  <span className={CLASS_GROUPS.tag.neutralStrongPill}>
                     +{worksWithMore}
                   </span>
                 )}
@@ -166,7 +166,7 @@ export function CookbookEntryCard({
                   )
                 )}
                 {tagsMore > 0 && (
-                  <span className="px-2.5 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs font-medium rounded-full">
+                  <span className={CLASS_GROUPS.tag.neutralPill}>
                     +{tagsMore}
                   </span>
                 )}

--- a/components/cookbook/EntryDetailModal.tsx
+++ b/components/cookbook/EntryDetailModal.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { CATEGORY_LABELS } from "@/lib/cookbook-labels";
+import { CLASS_GROUPS } from "@/lib/classname-constants";
 import { formatCookbookDate } from "@/lib/format-cookbook-date";
 import type { CookbookCategory, CookbookEntry } from "@/types/cookbook";
 import { PromptMarkdown } from "./PromptMarkdown";
@@ -119,7 +120,7 @@ export function EntryDetailModal({
                 <span className="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1.5 uppercase tracking-wider">
                   Category
                 </span>
-                <span className="px-2.5 py-1 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-medium rounded-full">
+                <span className={CLASS_GROUPS.tag.successPill}>
                   {CATEGORY_LABELS[entry.category as CookbookCategory] || entry.category}
                 </span>
               </div>
@@ -132,7 +133,7 @@ export function EntryDetailModal({
                     {(entry.worksWith ?? []).map((w) => (
                       <span
                         key={w}
-                        className="px-2.5 py-1 bg-neutral-200 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 text-xs font-medium rounded-full"
+                        className={CLASS_GROUPS.tag.neutralStrongPill}
                       >
                         {w}
                       </span>
@@ -149,7 +150,7 @@ export function EntryDetailModal({
                     {(entry.tags ?? []).map((tag) => (
                       <span
                         key={tag}
-                        className="px-2.5 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 text-xs font-medium rounded-full"
+                        className={CLASS_GROUPS.tag.neutralPill}
                       >
                         {tag}
                       </span>

--- a/components/events/EventsBrowse.tsx
+++ b/components/events/EventsBrowse.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import Image from "next/image";
+import { formatShortDate } from "@/lib/format-helpers";
 import Link from "next/link";
 import { useId, useMemo } from "react";
 import type { Event } from "@/types/events";
@@ -36,11 +37,7 @@ function PastStyleEventCard({ event }: { event: Event }) {
       <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-1">
         {event.date === "TBD"
           ? "Date TBD"
-          : new Date(event.date).toLocaleDateString("en-US", {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
+          : formatShortDate(event.date)}
       </p>
       <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
         {event.location}

--- a/components/home/OpenSourceFeedSection.tsx
+++ b/components/home/OpenSourceFeedSection.tsx
@@ -12,16 +12,7 @@ import {
   fetchRecentMergedPullRequests,
   getGithubRepoWebBaseUrl,
 } from "@/lib/github-recent-merged-prs";
-
-function formatMergedDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
+import { formatShortDate } from "@/lib/format-helpers";
 
 async function OpenSourceFeedContent() {
   const { prs, repoUrl, error } = await fetchRecentMergedPullRequests(8);
@@ -71,10 +62,10 @@ async function OpenSourceFeedContent() {
                 <span className="font-medium text-neutral-600 dark:text-neutral-300">
                   @{pr.authorLogin}
                 </span>
-                {formatMergedDate(pr.mergedAt) ? (
+                {formatShortDate(pr.mergedAt) ? (
                   <>
                     {" "}
-                    · merged {formatMergedDate(pr.mergedAt)}
+                    · merged {formatShortDate(pr.mergedAt)}
                   </>
                 ) : null}
               </p>

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -6,6 +6,7 @@
  */
 
 import Avatar from "@/components/Avatar";
+import { formatMonthYear } from "@/lib/format-helpers";
 import type { PublicMember } from "@/types/members";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
 import { BADGE_DEFINITIONS } from "@/lib/badges/definitions";
@@ -313,10 +314,7 @@ export function MemberCard({ member }: MemberCardProps) {
         {v?.showMemberSince && member.createdAt && typeof member.createdAt.toDate === "function" && (
           <span className="text-neutral-400 text-xs ml-auto">
             Member since{" "}
-            {member.createdAt.toDate().toLocaleDateString("en-US", {
-              month: "short",
-              year: "numeric",
-            })}
+            {formatMonthYear(member.createdAt.toDate())}
           </span>
         )}
       </div>

--- a/components/questions/AnswerCard.tsx
+++ b/components/questions/AnswerCard.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import { ThumbsUp, ThumbsDown, CheckCircle2 } from "lucide-react";
+import { formatShortDate } from "@/lib/format-helpers";
 import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
 import { cn } from "@/lib/utils";
 import type { Answer, VoteType } from "@/types/questions";
@@ -21,7 +22,7 @@ function timeAgo(dateStr: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 30) return `${days}d ago`;
-  return new Date(dateStr).toLocaleDateString();
+  return formatShortDate(dateStr);
 }
 
 export function AnswerCard({

--- a/components/questions/QuestionCard.tsx
+++ b/components/questions/QuestionCard.tsx
@@ -8,6 +8,7 @@
 "use client";
 
 import Link from "next/link";
+import { formatShortDate } from "@/lib/format-helpers";
 import { ThumbsUp, ThumbsDown, MessageSquare } from "lucide-react";
 import { CLASS_GROUPS, TAILWIND_CLASS_NAMES as TW } from "@/lib/classname-constants";
 import { cn } from "@/lib/utils";
@@ -22,7 +23,7 @@ function timeAgo(dateStr: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 30) return `${days}d ago`;
-  return new Date(dateStr).toLocaleDateString();
+  return formatShortDate(dateStr);
 }
 
 export function QuestionCard({

--- a/components/research/ResearchCard.tsx
+++ b/components/research/ResearchCard.tsx
@@ -31,18 +31,10 @@ import {
   type ResearchEntry,
   type ResearchType,
 } from "@/lib/research";
+import { formatShortDate } from "@/lib/format-helpers";
 
 interface ResearchCardProps {
   entry: ResearchEntry;
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
 }
 
 function relativeFromNow(iso: string, now: Date = new Date()): string {
@@ -54,7 +46,7 @@ function relativeFromNow(iso: string, now: Date = new Date()): string {
   if (diffDays === -1) return "yesterday";
   if (diffDays > 1 && diffDays < 30) return `in ${diffDays} days`;
   if (diffDays < -1 && diffDays > -30) return `${Math.abs(diffDays)} days ago`;
-  return formatDate(iso);
+  return formatShortDate(iso);
 }
 
 const TYPE_BADGE_STYLES: Record<ResearchType, string> = {
@@ -144,7 +136,7 @@ export function ResearchCard({ entry }: ResearchCardProps) {
       <header className="mb-2 flex items-start justify-between gap-3">
         <TypeBadge entry={entry} />
         <span className="text-xs text-neutral-500 dark:text-neutral-500">
-          {formatDate(entry.updatedAt ?? entry.postedAt)}
+          {formatShortDate(entry.updatedAt ?? entry.postedAt)}
           {entry.updatedAt ? " · updated" : ""}
         </span>
       </header>

--- a/lib/format-helpers.ts
+++ b/lib/format-helpers.ts
@@ -1,0 +1,39 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Canonical human-facing date formatters.
+ *
+ * Components previously inlined `toLocaleDateString` with five different
+ * option sets (and two different locales). These two helpers are the
+ * standardized formats; consolidating onto them deliberately unifies a few
+ * call sites (e.g. long month-names → short, default locale → en-US) so dates
+ * read consistently across the app.
+ */
+
+function toDate(value: Date | string | number): Date | null {
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** "Mar 5, 2026" — short month, day, year. The default full-date format. */
+export function formatShortDate(value: Date | string | number): string {
+  const d = toDate(value);
+  if (!d) return "";
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** "Mar 2026" — short month + year, no day. For "member since" / "earned" lines. */
+export function formatMonthYear(value: Date | string | number): string {
+  const d = toDate(value);
+  if (!d) return "";
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}


### PR DESCRIPTION
## What
Phase 3 of the deep refactor (you chose **standardize**). Two consolidations:

**Date formats** — new `lib/format-helpers.ts` with two canonical formatters; migrates 7 inline `toLocaleDateString` sites:
- `formatShortDate` ("Mar 5, 2026") — ResearchCard, EventsBrowse, OpenSourceFeed, AnswerCard, QuestionCard
- `formatMonthYear` ("Mar 2026") — MemberCard "member since", BadgeCard "earned"

**Pills** — migrates straggler inline pill strings onto the **existing** `CLASS_GROUPS.tag.*` tokens (the project's pill primitive) in the cookbook components.

## Deliberate visual changes (per "standardize")
- `/events` — long month → short ("March 5, 2026" → "Mar 5, 2026")
- `/questions` (>30-day-old dates) — locale default ("3/5/2026") → "Mar 5, 2026"
- homepage open-source feed — default locale → en-US
- `/cookbook` CookbookEntryCard tag pills — `text-neutral-500` → canonical `-600/-700` (slightly darker, matches the rest of the app)

All other migrated sites are **output-identical** (EntryDetailModal's 3 pills are byte-exact token swaps; ResearchCard/MemberCard/BadgeCard dates unchanged).

## Visual QA (CLAUDE.md gate) ✅
`npm run build` succeeded; `npm start` served `/`, `/cookbook`, `/members`, `/questions`, `/events`, `/research` (all 200); rendering confirmed in light + dark mode before commit.

## Scope note
`QuestionDetail.tsx` shares the same date pattern but carries an **unrelated pre-existing** `react-hooks/set-state-in-effect` warning that trips the repo's `--max-warnings=0` pre-commit gate the moment the file is staged. Left for a follow-up that also fixes that warning, rather than bundling unrelated lint debt here.

## Verification
- `tsc --noEmit` 0 errors; `eslint --max-warnings=0` clean; build + serve verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)