### PR TITLE
refactor(ui): standardize QuestionDetail date (Phase 3 follow-up)

### DIFF
--- a/components/questions/QuestionDetail.tsx
+++ b/components/questions/QuestionDetail.tsx
@@ -15,6 +15,7 @@ import type { Question, Answer, VoteType } from "@/types/questions";
 import type { CookbookEntry } from "@/types/cookbook";
 import { AnswerCard } from "./AnswerCard";
 import { AnswerComposer } from "./AnswerComposer";
+import { formatShortDate } from "@/lib/format-helpers";
 
 function timeAgo(dateStr: string): string {
   const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
@@ -25,7 +26,7 @@ function timeAgo(dateStr: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 30) return `${days}d ago`;
-  return new Date(dateStr).toLocaleDateString();
+  return formatShortDate(dateStr);
 }
 
 async function fetchIdToken(firebaseUser: import("firebase/auth").User) {
@@ -70,6 +71,7 @@ export function QuestionDetail({
   }, [user]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch-on-mount; setUserVotes runs after the awaited fetch, not synchronously
     fetchVotes();
   }, [fetchVotes]);
 


### PR DESCRIPTION
## What
Completes the question-card date standardization deferred from #1574. `QuestionDetail`'s >30-day fallback now uses `formatShortDate` (matching `AnswerCard`/`QuestionCard`) instead of the locale-default `toLocaleDateString`.

## The lint warning it was blocked on
`QuestionDetail` carried a **pre-existing** `react-hooks/set-state-in-effect` warning on `useEffect(() => fetchVotes(), …)` that trips the repo's `--max-warnings=0` pre-commit gate. It's a **false positive** — `fetchVotes` is async and `setUserVotes` runs *after* the awaited fetch, not synchronously — so it's suppressed with a justified `eslint-disable-next-line`, not restructured.

## Verification
- `tsc --noEmit` 0 errors; `eslint --max-warnings=0` clean; question suites **24/24**.
- Visual change is identical to the AnswerCard/QuestionCard date change already QA'd in #1574.

## Stacked
Base **#1574** (needs `lib/format-helpers.ts`). Retargets to `develop` once #1574 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)