### PR TITLE
Release: opportunities location terminology (#1577)

### DIFF
--- a/__tests__/app/opportunities/opportunity-listings.test.tsx
+++ b/__tests__/app/opportunities/opportunity-listings.test.tsx
@@ -86,7 +86,7 @@ describe("OpportunityListings", () => {
   it("filters listings by work mode", () => {
     render(<OpportunityListings opportunities={opportunities} />);
 
-    fireEvent.change(screen.getByLabelText("Filter by work mode"), {
+    fireEvent.change(screen.getByLabelText("Filter by location"), {
       target: { value: "remote" },
     });
 
@@ -94,7 +94,7 @@ describe("OpportunityListings", () => {
     expect(screen.getByText("AI Product Engineer")).toBeInTheDocument();
     expect(screen.getByText("Showing 1 of 2 listings.")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Filter by work mode"), {
+    fireEvent.change(screen.getByLabelText("Filter by location"), {
       target: { value: "in-person" },
     });
 

--- a/app/opportunities/_components/OpportunityListings.tsx
+++ b/app/opportunities/_components/OpportunityListings.tsx
@@ -262,7 +262,7 @@ export function OpportunityListings({
               </label>
 
               <label className="block">
-                <span className="sr-only">Filter by work mode</span>
+                <span className="sr-only">Filter by location</span>
                 <select
                   value={workMode}
                   onChange={(event) =>
@@ -270,7 +270,7 @@ export function OpportunityListings({
                   }
                   className="h-11 w-full rounded-lg border border-neutral-200 bg-white px-3 text-sm text-neutral-950 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white"
                 >
-                  <option value="all">All modes</option>
+                  <option value="all">All locations</option>
                   <option value="remote">Remote</option>
                   <option value="in-person">Boston area</option>
                 </select>


### PR DESCRIPTION
Develop → main release.

## Included PRs
- **#1577** — feat(opportunities): use location terminology in work mode filter — thanks @jangel19 (Jordi Lopez)

## Verification
- Local production build (`npm run build`) succeeded.
- `npm start` served the build; /opportunities renders "Filter by location" / "All locations" as expected; homepage + /opportunities return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)