### PR TITLE
Release: unsubscribe dual-verify fix (#1589)

### DIFF
--- a/__tests__/lib/unsubscribe-token.test.ts
+++ b/__tests__/lib/unsubscribe-token.test.ts
@@ -180,6 +180,28 @@ describe("verifyUnsubscribeToken", () => {
     const token = generateUnsubscribeToken("user@example.com");
     expect(verifyUnsubscribeToken("other@example.com", token)).toBe(false);
   });
+
+  it("accepts a token signed with the quote-wrapped secret (early-June 2026 blast compat)", () => {
+    // The cohort-1 Discord blast and the 2026-06-03 game digest signed links
+    // with the secret value including its surrounding double-quotes, because
+    // the send command extracted it from .env.local with `cut` (quotes kept).
+    // Those already-sent links must still verify.
+    const { verifyUnsubscribeToken } = tokens();
+    const { createHmac } = require("crypto") as typeof import("crypto");
+    const legacyToken = createHmac("sha256", `"${UNIT_TEST_SECRET}"`)
+      .update("user@example.com")
+      .digest("hex");
+    expect(verifyUnsubscribeToken("user@example.com", legacyToken)).toBe(true);
+  });
+
+  it("does not accept a quoted-secret token for the wrong email", () => {
+    const { verifyUnsubscribeToken } = tokens();
+    const { createHmac } = require("crypto") as typeof import("crypto");
+    const legacyToken = createHmac("sha256", `"${UNIT_TEST_SECRET}"`)
+      .update("user@example.com")
+      .digest("hex");
+    expect(verifyUnsubscribeToken("other@example.com", legacyToken)).toBe(false);
+  });
 });
 
 describe("buildUnsubscribeUrl", () => {

--- a/app/api/notifications/unsubscribe/route.ts
+++ b/app/api/notifications/unsubscribe/route.ts
@@ -46,9 +46,15 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  // Some mail clients / link scanners deliver the href with the literal HTML
+  // entity `&amp;` undecoded, so the second query param arrives named
+  // `amp;token` (and a forwarded/encoded link can yield `amp;email`). Fall
+  // back to those variants so a mangled separator doesn't break unsubscribe.
+  const sp = request.nextUrl.searchParams;
+  const param = (name: string) => sp.get(name) ?? sp.get(`amp;${name}`) ?? undefined;
   const parsedQuery = notificationsContract.unsubscribe.query.safeParse({
-    email: request.nextUrl.searchParams.get("email") ?? undefined,
-    token: request.nextUrl.searchParams.get("token") ?? undefined,
+    email: param("email"),
+    token: param("token"),
   });
   const email = parsedQuery.success
     ? parsedQuery.data.email?.toLowerCase().trim()

--- a/lib/unsubscribe-token.ts
+++ b/lib/unsubscribe-token.ts
@@ -58,13 +58,36 @@ function tokenMatches(expected: string, candidate: string): boolean {
   return timingSafeEqual(expectedBytes, candidateBytes);
 }
 
-/** Verify that a token matches the expected HMAC for the email. */
+// Legacy/compat secret: two send scripts in early June 2026 (the cohort-1
+// Discord blast and the 2026-06-03 game digest) signed their unsubscribe
+// links with the secret value INCLUDING its surrounding double-quotes — the
+// send command extracted UNSUBSCRIBE_SECRET from .env.local with `cut`, which
+// keeps the quotes, while the runtime (and dotenv) strip them. Those ~1,900
+// already-sent links would otherwise never verify. We accept them via a
+// secondary HMAC keyed on the quoted secret. This is intentionally narrow:
+// it only matches tokens signed with `"<secret>"`, nothing else.
+const LEGACY_QUOTED_SECRET = `"${SECRET}"`;
+
+function generateLegacyQuotedToken(email: string): string {
+  return createHmac("sha256", LEGACY_QUOTED_SECRET)
+    .update(email.toLowerCase().trim())
+    .digest("hex");
+}
+
+/**
+ * Verify that a token matches the expected HMAC for the email.
+ *
+ * Primary check uses the correctly-loaded secret. As a backward-compatible
+ * fallback we also accept tokens signed with the quote-wrapped secret (see
+ * LEGACY_QUOTED_SECRET) so unsubscribe links from the early-June 2026 blasts
+ * keep working. Both comparisons are constant-time.
+ */
 export function verifyUnsubscribeToken(
   email: string,
   token: string
 ): boolean {
-  const expected = generateUnsubscribeToken(email);
-  return tokenMatches(expected, token);
+  if (tokenMatches(generateUnsubscribeToken(email), token)) return true;
+  return tokenMatches(generateLegacyQuotedToken(email), token);
 }
 
 /** Build a full unsubscribe URL for a given email. */


### PR DESCRIPTION
Develop → main release.

## Included
- **#1589** — fix(unsubscribe): accept the legacy quote-wrapped token signature + amp; param fallback. Repairs the ~1,943 unsubscribe links from the early-June 2026 blasts (cohort-1 Discord + 2026-06-03 game digest) that were signed with the quote-kept secret. Shared UNSUBSCRIBE_SECRET unchanged, so all correctly-signed historical links keep working.

## Verification
- Unit tests 20/20 (token lib) + 9/9 (route); `npm run build` clean.
- Live E2E on the release build: legacy(broken-blast) token → status=success, correct → success, genuinely-bad → invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)