### PR TITLE
fix(unsubscribe): resolve token secret lazily (root cause of broken links)

### DIFF
--- a/__tests__/lib/unsubscribe-token.test.ts
+++ b/__tests__/lib/unsubscribe-token.test.ts
@@ -47,40 +47,40 @@ afterEach(() => {
 });
 
 describe("unsubscribe token secret resolution", () => {
+  // The secret is resolved lazily (on first token op), not at import time, so
+  // the module loads cleanly and the fail-closed throw surfaces on first use.
   it("fails closed outside development and test when no token secret is configured", () => {
-    expect(() =>
-      loadTokenModule({
-        nodeEnv: "production",
-      })
-    ).toThrow(
+    const mod = loadTokenModule({ nodeEnv: "production" });
+    expect(() => mod.generateUnsubscribeToken("user@example.com")).toThrow(
       "UNSUBSCRIBE_SECRET must be configured; refusing to generate unsubscribe or withdraw tokens with a public fallback secret."
     );
   });
 
   it("fails closed for staging-like server environments without a token secret", () => {
-    expect(() =>
-      loadTokenModule({
-        nodeEnv: "staging",
-      })
-    ).toThrow("UNSUBSCRIBE_SECRET must be configured");
+    const mod = loadTokenModule({ nodeEnv: "staging" });
+    expect(() => mod.generateUnsubscribeToken("user@example.com")).toThrow(
+      "UNSUBSCRIBE_SECRET must be configured"
+    );
   });
 
   it("ignores NEXTAUTH_SECRET for this token concern", () => {
-    expect(() =>
-      loadTokenModule({
-        env: { NEXTAUTH_SECRET: UNIT_TEST_SECRET },
-        nodeEnv: "production",
-      })
-    ).toThrow("UNSUBSCRIBE_SECRET must be configured");
+    const mod = loadTokenModule({
+      env: { NEXTAUTH_SECRET: UNIT_TEST_SECRET },
+      nodeEnv: "production",
+    });
+    expect(() => mod.generateUnsubscribeToken("user@example.com")).toThrow(
+      "UNSUBSCRIBE_SECRET must be configured"
+    );
   });
 
   it("rejects configured secrets shorter than 32 bytes", () => {
-    expect(() =>
-      loadTokenModule({
-        env: { UNSUBSCRIBE_SECRET: "short-secret" },
-        nodeEnv: "production",
-      })
-    ).toThrow("UNSUBSCRIBE_SECRET must be at least 32 bytes");
+    const mod = loadTokenModule({
+      env: { UNSUBSCRIBE_SECRET: "short-secret" },
+      nodeEnv: "production",
+    });
+    expect(() => mod.generateUnsubscribeToken("user@example.com")).toThrow(
+      "UNSUBSCRIBE_SECRET must be at least 32 bytes"
+    );
   });
 
   it("uses a 32-byte UNSUBSCRIBE_SECRET in production", () => {
@@ -104,6 +104,22 @@ describe("unsubscribe token secret resolution", () => {
       nodeEnv: "development",
     });
     expect(inDevelopment.generateUnsubscribeToken("user@example.com")).toMatch(
+      /^[a-f0-9]{64}$/
+    );
+  });
+
+  it("resolves the secret lazily — env set AFTER import is still honored", () => {
+    // Reproduces the real-world script ordering: the module is imported first
+    // (imports are hoisted), and UNSUBSCRIBE_SECRET is populated afterwards
+    // (e.g. by loadEnvConfig). Lazy resolution must pick it up, not throw.
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.UNSUBSCRIBE_SECRET;
+    setNodeEnv("production");
+    const mod = require("@/lib/unsubscribe-token") as UnsubscribeTokenModule;
+    // Env arrives only now, after the module is already loaded.
+    process.env.UNSUBSCRIBE_SECRET = UNIT_TEST_SECRET;
+    expect(mod.generateUnsubscribeToken("user@example.com")).toMatch(
       /^[a-f0-9]{64}$/
     );
   });

--- a/lib/unsubscribe-token.ts
+++ b/lib/unsubscribe-token.ts
@@ -38,12 +38,24 @@ function resolveSecret(): string {
   );
 }
 
-const SECRET = resolveSecret();
+// Resolve the secret LAZILY, on first token operation, not at import time.
+// Module imports are hoisted above any `loadEnvConfig(...)` call in a script,
+// so an import-time `resolveSecret()` ran before the env was populated and
+// threw — which is exactly what pushed the send scripts into a fragile
+// `UNSUBSCRIBE_SECRET="$(... cut ...)"` shell prefix (whose kept quotes broke
+// ~1,900 unsubscribe links). Lazy + memoized resolution lets a script call
+// loadEnvConfig() first, then generate tokens with the correctly-loaded value,
+// with no env shell-prefix needed. Memoized so the HMAC key is stable per run.
+let cachedSecret: string | null = null;
+function getSecret(): string {
+  if (cachedSecret === null) cachedSecret = resolveSecret();
+  return cachedSecret;
+}
 
 /** Generate a deterministic HMAC token for an email address. */
 /** @internal */
 export function generateUnsubscribeToken(email: string): string {
-  return createHmac("sha256", SECRET)
+  return createHmac("sha256", getSecret())
     .update(email.toLowerCase().trim())
     .digest("hex");
 }
@@ -66,10 +78,8 @@ function tokenMatches(expected: string, candidate: string): boolean {
 // already-sent links would otherwise never verify. We accept them via a
 // secondary HMAC keyed on the quoted secret. This is intentionally narrow:
 // it only matches tokens signed with `"<secret>"`, nothing else.
-const LEGACY_QUOTED_SECRET = `"${SECRET}"`;
-
 function generateLegacyQuotedToken(email: string): string {
-  return createHmac("sha256", LEGACY_QUOTED_SECRET)
+  return createHmac("sha256", `"${getSecret()}"`)
     .update(email.toLowerCase().trim())
     .digest("hex");
 }
@@ -107,7 +117,7 @@ const WITHDRAW_NS = "withdraw-cohort";
 
 /** @internal */
 export function generateWithdrawToken(email: string, cohortId: string): string {
-  return createHmac("sha256", SECRET)
+  return createHmac("sha256", getSecret())
     .update(`${WITHDRAW_NS}:${cohortId}:${email.toLowerCase().trim()}`)
     .digest("hex");
 }
@@ -138,7 +148,7 @@ const PYDATA_WITHDRAW_NS = "withdraw-pydata-2026";
 
 /** @internal */
 export function generatePydataWithdrawToken(email: string): string {
-  return createHmac("sha256", SECRET)
+  return createHmac("sha256", getSecret())
     .update(`${PYDATA_WITHDRAW_NS}:${email.toLowerCase().trim()}`)
     .digest("hex");
 }


### PR DESCRIPTION
## Root cause
The broken-unsubscribe-links incident traced to `lib/unsubscribe-token.ts` resolving `UNSUBSCRIBE_SECRET` at **import time** (`const SECRET = resolveSecret()`). ES module imports hoist above a script's `loadEnvConfig()`, so the secret resolved before env was populated and threw — which is precisely why the send scripts were run with a `UNSUBSCRIBE_SECRET="$(... cut ...)"` shell prefix whose retained quotes signed ~1,900 links with the wrong key.

## Fix
- Resolve the secret **lazily + memoized** (`getSecret()`), used by all five token generators. A script that calls `loadEnvConfig()` before generating tokens now gets the correct value with **no env shell-prefix needed**. Verified: `send-game-digest-2026-06-03.ts --dry-run`, run plainly, emits the correct (unquoted) signature (fp 47549… not 34cea…).
- Fail-closed preserved: the throw moves from import-time to first token op. Tests updated; added a test asserting env set AFTER import is still honored.

Complements the already-shipped #1589 (legacy-token verify fallback + amp; param). Together: old broken links keep working, and future sends are signed correctly.

## Verification
- Tests 30/30 (token lib + route). Typecheck + lint clean. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)