### PR TITLE
Release: hono dev-dependency bump (#1593)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14045,9 +14045,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Develop → main release.

## Included
- **#1593** — chore(deps-dev): bump hono 4.12.18 → 4.12.23 (lockfile-only).

## Verification
- `npm ci` clean install — 0 vulnerabilities.
- `npm run build` succeeded; `npm start` served it; /, /opportunities, /summer-cohort all 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)