### PR TITLE
Release: Week 5 startup brief alignment + Sports Hack submission

### DIFF
--- a/app/summer-cohort/_components/Week5StartupPanel.tsx
+++ b/app/summer-cohort/_components/Week5StartupPanel.tsx
@@ -34,7 +34,7 @@ export function Week5StartupPanel({
         </span>
         <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
           <Rocket className="h-3 w-3" strokeWidth={2.25} aria-hidden="true" />
-          Open week — your call
+          Pitch deck + production app
         </span>
       </div>
       <h2 className="mt-3 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
@@ -74,37 +74,56 @@ export function Week5StartupPanel({
         </a>
       </div>
 
-      {/* What this week is */}
+      {/* What you ship this week */}
       <div className="mt-6">
         <h3 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
-          What this week is
+          What you ship this week
         </h3>
         <ul className="mt-3 space-y-3 text-sm text-neutral-700 dark:text-neutral-300">
           <li className="flex gap-3">
             <span className="text-neutral-400" aria-hidden="true">•</span>
             <span>
-              <strong>Build whatever YOU want.</strong> Your own startup
-              project. The thing you&apos;d be working on if the cohort
-              didn&apos;t exist.
+              <strong>A pitch deck.</strong> The story: problem, solution, who
+              it&apos;s for, why now, and where it goes. Tight enough to present
+              in a few minutes.
             </span>
           </li>
           <li className="flex gap-3">
             <span className="text-neutral-400" aria-hidden="true">•</span>
             <span>
-              <strong>No vote. No template. No PR to this repo.</strong> The
-              cohort tools (PM, comms, marketing) are still running — use them
-              to ship faster.
+              <strong>A full production application.</strong> Not a prototype —
+              something real users can sign up for and actually use today. Use
+              the cohort tools (PM, comms, marketing) to ship faster.
             </span>
           </li>
           <li className="flex gap-3">
             <span className="text-neutral-400" aria-hidden="true">•</span>
             <span>
-              <strong>Friday show-and-tell at {week.showAndTellLabel}.</strong>{" "}
-              Each person gets ~3 minutes. No formal pitch — just &quot;here&apos;s
-              what I built and what I&apos;m doing next.&quot; Optional.
+              <strong>Friday demo at {week.showAndTellLabel}.</strong> Present
+              your deck and walk the live app — a few minutes each.
             </span>
           </li>
         </ul>
+      </div>
+
+      {/* Submission */}
+      <div className="mt-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950/40">
+        <div className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+          How to submit
+        </div>
+        <p className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+          Open a PR to cursorboston on the{" "}
+          <a
+            href={`https://github.com/rogerSuperBuilderAlpha/cursor-boston/tree/${week.submissionBranch}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold text-emerald-700 underline decoration-emerald-400 underline-offset-2 dark:text-emerald-400"
+          >
+            <code>{week.submissionBranch}</code>
+          </a>{" "}
+          branch with your pitch deck and a link to the live app, so it shows up
+          on the cohort page.
+        </p>
       </div>
 
       {/* What good looks like */}
@@ -113,16 +132,17 @@ export function Week5StartupPanel({
           What &quot;good&quot; looks like for this week
         </div>
         <p className="mt-2 text-sm text-emerald-900/90 dark:text-emerald-200/90">
-          End the week with something you can show — a working prototype, a
-          landing page with real signups, a public alpha. The bar is &quot;I
-          shipped something I&apos;m proud of,&quot; not &quot;I won a
-          vote.&quot;
+          A production-grade app real people can sign up for and use today,
+          paired with a deck you&apos;d be comfortable putting in front of an
+          investor. The bar is &quot;this is a real startup,&quot; not &quot;I
+          have a prototype.&quot;
         </p>
       </div>
 
       <p className="mt-5 border-t border-neutral-200 pt-4 text-xs text-neutral-600 dark:border-neutral-800 dark:text-neutral-400">
-        Stuck on what to build? Bring it to office hours or post in the cohort
-        channel. The cohort is a great free pair of eyes for this.
+        Stuck on scope, the deck, or going live? Bring it to office hours or
+        post in the cohort channel. The cohort is a great free pair of eyes for
+        this.
       </p>
     </section>
   );

--- a/lib/summer-cohort.ts
+++ b/lib/summer-cohort.ts
@@ -136,7 +136,7 @@ export const SUMMER_COHORT_WEEKS: readonly SummerCohortWeek[] = [
     week: 5,
     title: "Your own startup",
     description:
-      "Build whatever you want — your own startup project for the week.",
+      "Turn your work into a real startup — ship a full production application real users can sign up for and use, plus a pitch deck telling the story. Submit both via PR.",
   },
   {
     week: 6,
@@ -486,9 +486,10 @@ export const SUMMER_COHORT_C1_WEEK_5 = {
   week: 5,
   title: "Your Own Startup",
   oneLiner:
-    "Build whatever YOU want this week — your own startup project. No vote, no submission template; bring it to the Friday call for show-and-tell.",
+    "Turn what you've built into a real startup: a pitch deck that tells the story and a full production application real users can sign up for and use today. Submit a PR with your deck and live-app link, then present at the Friday demo.",
   kickoffLabel: "Mon, Jun 8 · 6–7pm EST",
   showAndTellLabel: "Fri, Jun 12 · 6pm EST",
+  submissionBranch: "c1w5startup-submission",
 } as const;
 
 /** @internal */
@@ -617,6 +618,7 @@ export const SUMMER_COHORT_C2_WEEK_5 = {
   oneLiner: SUMMER_COHORT_C1_WEEK_5.oneLiner,
   kickoffLabel: "Mon, Jul 27 · 6–7pm EST",
   showAndTellLabel: "Fri, Jul 31 · 6pm EST",
+  submissionBranch: "c2w5startup-submission",
 } as const;
 
 /** @internal */
@@ -662,6 +664,8 @@ export interface SummerCohortWeek5 {
   readonly oneLiner: string;
   readonly kickoffLabel: string;
   readonly showAndTellLabel: string;
+  /** Submission branch contributors PR their deck + live-app link into. */
+  readonly submissionBranch: string;
 }
 
 export interface SummerCohortWeek6 {

--- a/sports-hack-2026-submissions/dhananjaykumarmv/meta.json
+++ b/sports-hack-2026-submissions/dhananjaykumarmv/meta.json
@@ -1,0 +1,13 @@
+{
+    "title": "Adertisemnet Score Card",
+    "description": "A marketing intelligence platform that generates instant brand value profiles for top athletes. Input any athlete name and get social media metrics, sponsorship history, brand fit scoring, and growth trajectory — all in one report built for brand managers, agents, and sponsors.",
+    "displayName": "Dhananjaya Kumar Mittapalli",
+    "videoUrl": "",
+    "repoUrl": "https://github.com/DhananJayKumarMV/cursor-boston-sports-hack-dhananjaykumarmv",
+    "deployedUrl": "",
+    "tags": ["langchain", "python", "sports", "ai", "fastapi", "rag"],
+    "collaborators": [
+      { "displayName": "Saiteja Reddy Gajula", "githubHandle": "Saitej0211" },
+      {"displayName": "LeoMattosMartins", "githubHandle": "LeoMattosMartins"}
+    ]
+  }

--- a/sports-hack-2026-submissions/dhananjaykumarmv/score.json
+++ b/sports-hack-2026-submissions/dhananjaykumarmv/score.json
@@ -1,0 +1,9 @@
+{
+  "ai": {
+    "score": 6,
+    "rationale": "Advertisement Score Card is a recognizably sports-tech project — an athlete brand-value and sponsorship-intelligence platform pitched sharply at a clear audience (brand managers, agents, sponsors) with concrete outputs: social metrics, sponsorship history, brand-fit scoring, and a growth trajectory. The strongest signal is genuine AI leverage: the langchain/RAG/FastAPI stack points to real retrieval-augmented analysis rather than a bolt-on. The main weakness is completeness — only the repo URL is present, with no explainer video and no live deployed URL, which falls short of the brief's ship-it-live bar.",
+    "model": "claude-opus-4-8",
+    "scoredAt": "2026-06-06T11:35:00.000Z",
+    "scorerVersion": 1
+  }
+}


### PR DESCRIPTION
Release of `develop` → `main`. Carries 2 PRs:

| PR | Title | Contributors |
|----|-------|--------------|
| #1602 | fix(summer-cohort): Week 5 = pitch deck + production app, not open week | maintainer |
| #1514 | Sports Hack 2026 submission — "Advertisement Score Card" | @DhananJayKumarMV, @Saitej0211, @LeoMattosMartins |

### Highlights

- **#1602** — Aligns the Week 5 cohort page with the brief Cohort 1 was emailed: a required **pitch deck** + a **full production application** (not a prototype), submitted via PR to `c1w5startup-submission`. Replaces the prior "open week / no PR / optional show-and-tell / prototype is fine" copy. Plumbs a per-cohort `submissionBranch` so the link is correct for C1 and C2.
- **#1514** — Sports Hack submission folder for @DhananJayKumarMV (meta.json + AI-judge score.json, 6/10).

### Verification

- [x] `npm run build` succeeded locally
- [x] `npm start` production server verified (200 on `/summer-cohort`; new Week 5 copy present in bundle, old copy removed)
- [x] Visual QA confirmed by maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)