### PR TITLE
chore(deps): bump @anthropic-ai/sdk and firebase-tools (split from #1599)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.100.1",
+        "@anthropic-ai/sdk": "^0.102.0",
         "@commitlint/cli": "^21.0.2",
         "@commitlint/config-conventional": "^21.0.2",
         "@eslint/compat": "^2.1.0",
@@ -71,7 +71,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
-        "firebase-tools": "^15.19.0",
+        "firebase-tools": "^15.19.1",
         "globals": "^17.6.0",
         "husky": "^8.0.3",
         "jest": "^30.4.2",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.100.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
-      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12547,9 +12547,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "15.19.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.19.0.tgz",
-      "integrity": "sha512-ZcbyqbYkn+e7rsFVhurbkmeuzkxGBqhmrU1A+V3mzO8yfqsQLBU4MSqfez7Lkmk6LRu8Vl9uXOoDTlzQ2ej9rw==",
+      "version": "15.19.1",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.19.1.tgz",
+      "integrity": "sha512-r3BslVykVe0MwvyGf4+oLOcX38vjgEfu2YypfvaQdIW08j505h1mfJrHJGGMmKRAPuvlf35FSekNG9cOfoyh/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.100.1",
+    "@anthropic-ai/sdk": "^0.102.0",
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
     "@eslint/compat": "^2.1.0",
@@ -136,7 +136,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unused-imports": "^4.4.1",
-    "firebase-tools": "^15.19.0",
+    "firebase-tools": "^15.19.1",
     "globals": "^17.6.0",
     "husky": "^8.0.3",
     "jest": "^30.4.2",


### PR DESCRIPTION
Lands the two safe dependency bumps from #1599 without the blocking one.

| Package | From | To |
|---|---|---|
| `@anthropic-ai/sdk` | 0.100.1 | 0.102.0 |
| `firebase-tools` | 15.19.0 | 15.19.1 |

**Excluded:** `@cursor/sdk` 1.0.17 → 1.0.18. The new `@cursor/sdk-linux-x64@1.0.18` publishes a placeholder license (`"Custom: https://www.npmjs.com/package/"`) that the Security Scanning `--onlyAllow` license gate rejects — which is why #1599 fails. Holding that bump until the upstream metadata is fixed or the license is allowlisted.

Once this merges, #1599 can be closed (Dependabot will re-open a `@cursor/sdk`-only PR on its next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)