### PR TITLE
Release: send scripts + dependency bumps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,13 +38,13 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: '/language:${{ matrix.language }}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.100.1",
+        "@anthropic-ai/sdk": "^0.102.0",
         "@commitlint/cli": "^21.0.2",
         "@commitlint/config-conventional": "^21.0.2",
         "@eslint/compat": "^2.1.0",
@@ -71,7 +71,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
-        "firebase-tools": "^15.19.0",
+        "firebase-tools": "^15.19.1",
         "globals": "^17.6.0",
         "husky": "^8.0.3",
         "jest": "^30.4.2",
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.100.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
-      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12547,9 +12547,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "15.19.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.19.0.tgz",
-      "integrity": "sha512-ZcbyqbYkn+e7rsFVhurbkmeuzkxGBqhmrU1A+V3mzO8yfqsQLBU4MSqfez7Lkmk6LRu8Vl9uXOoDTlzQ2ej9rw==",
+      "version": "15.19.1",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.19.1.tgz",
+      "integrity": "sha512-r3BslVykVe0MwvyGf4+oLOcX38vjgEfu2YypfvaQdIW08j505h1mfJrHJGGMmKRAPuvlf35FSekNG9cOfoyh/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@testing-library/user-event": "^14.5.1",
         "@types/jest": "^30.0.0",
         "@types/leaflet": "^1.9.21",
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.2",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -6701,9 +6701,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^30.0.0",
     "@types/leaflet": "^1.9.21",
-    "@types/node": "^25.9.1",
+    "@types/node": "^25.9.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.100.1",
+    "@anthropic-ai/sdk": "^0.102.0",
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
     "@eslint/compat": "^2.1.0",
@@ -136,7 +136,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unused-imports": "^4.4.1",
-    "firebase-tools": "^15.19.0",
+    "firebase-tools": "^15.19.1",
     "globals": "^17.6.0",
     "husky": "^8.0.3",
     "jest": "^30.4.2",

--- a/scripts/send-cohort1-discord-tonight.ts
+++ b/scripts/send-cohort1-discord-tonight.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-off heads-up to every admitted Cohort 1 applicant: we're meeting on
+ * Discord TONIGHT at 6:00 pm EST. Topic: what it looks like and means to plug
+ * an ed-tech tool into Ludwitt. Moving to Discord so a single point of failure
+ * (a flaky host connection) doesn't break the session flow.
+ *
+ * Idempotent via `cohort1DiscordTonightEmailedAt`.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-discord-tonight.ts --dry-run
+ *   npx tsx scripts/send-cohort1-discord-tonight.ts --send
+ *   npx tsx scripts/send-cohort1-discord-tonight.ts --send --force
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const DISCORD_URL = "https://discord.gg/Wsncg8YYqc";
+const STAMP_FIELD = "cohort1DiscordTonightEmailedAt";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = "Tonight on Discord — 6 pm EST";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Let's meet on Discord tonight at 6:00 pm EST.</strong></p>
+
+<p>We're running this one on Discord on purpose — that way if my connection hiccups, me screwing up doesn't take the whole session down with it. The flow keeps going either way.</p>
+
+<h3 style="margin-top:28px;margin-bottom:8px;font-size:16px;">What we'll talk about</h3>
+<p>What it looks like — and what it actually means — to plug an ed-tech tool into <strong>Ludwitt</strong>. Come with questions.</p>
+
+<h3 style="margin-top:28px;margin-bottom:8px;font-size:16px;">How to join</h3>
+<p>You should already be in the Cursor Boston Discord (the invite's all over the site). Hop into the voice channel at 6. If you somehow aren't in yet:</p>
+<p>
+  <a href="${DISCORD_URL}" style="display:inline-block;background:#5865F2;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Join the Discord →
+  </a>
+</p>
+
+<p>See you at 6.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.firstName?.trim() || "there"},
+
+Let's meet on Discord tonight at 6:00 pm EST.
+
+We're running this one on Discord on purpose — that way if my connection hiccups, me screwing up doesn't take the whole session down with it. The flow keeps going either way.
+
+WHAT WE'LL TALK ABOUT
+What it looks like — and what it actually means — to plug an ed-tech tool into Ludwitt. Come with questions.
+
+HOW TO JOIN
+You should already be in the Cursor Boston Discord (the invite's all over the site). Hop into the voice channel at 6. If you somehow aren't in yet:
+${DISCORD_URL}
+
+See you at 6.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(`Eligible recipients (admitted cohort-1, not yet emailed): ${recipients.length}`);
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed (${STAMP_FIELD}): ${skippedAlreadyEmailed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nRecipient count: ${recipients.length}`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(250);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week4-edu-deadline.ts
+++ b/scripts/send-cohort1-week4-edu-deadline.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Deadline-day broadcast (Fri Jun 5, 2026) to every admitted Cohort 1
+ * applicant: Week 4 (Ludwitt Education Tool) is due TODAY by 5pm EST.
+ *
+ * Two steps:
+ *   1. Submit the tool through the creator portal at https://www.ludwitt.com/creator
+ *      — this is the step that counts.
+ *   2. Open a PR to cursorboston (c1w4edu-submission branch) reporting your move,
+ *      so it shows on the cohort page.
+ *
+ * Idempotent via `cohort1Week4EduDeadlineEmailedAt`. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week4-edu-deadline.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week4-edu-deadline.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-cohort1-week4-edu-deadline.ts --send
+ *   npx tsx scripts/send-cohort1-week4-edu-deadline.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import {
+  loadAdmittedCohort1Recipients,
+  stampCohort1,
+  type Cohort1Recipient,
+} from "./_lib/cohort1-recipients";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const CREATOR_PORTAL_URL = "https://www.ludwitt.com/creator";
+const STAMP_FIELD = "cohort1Week4EduDeadlineEmailedAt";
+
+function buildEmail(r: Cohort1Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Week 4 due TODAY 5pm — ship your Ludwitt education tool 🎓";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Week 4 — your Ludwitt education tool — is due today by 5pm EST.</strong> This is the week that pays you back: every tool that ships and merges earns its author a revenue share as users spend Ludwitt credits through it.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;font-size:16px;">Two steps to be counted</h3>
+<ol style="padding-left:20px;margin-top:4px;">
+  <li style="margin-bottom:10px;">
+    <strong>Submit on Ludwitt — this is the one that counts.</strong> Go through the creator portal and submit your tool:
+    <br/>
+    <a href="${CREATOR_PORTAL_URL}" style="display:inline-block;margin-top:8px;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+      Submit on the Ludwitt creator portal →
+    </a>
+  </li>
+  <li style="margin-bottom:4px;">
+    <strong>Open a PR to cursorboston</strong> for Week 4 with your project (the <code>c1w4edu-submission</code> branch). The PR reports your move so it shows up on the cohort page — but the Ludwitt submission is what actually counts.
+  </li>
+</ol>
+
+<p style="margin-top:16px;">
+  <a href="${COHORT_URL}" style="color:#0284c7;font-weight:600;">Open the Week 4 tab on the cohort page →</a>
+</p>
+
+<div style="border:1px solid #fde68a;border-radius:8px;padding:14px 16px;margin:20px 0;background:#fffbeb;font-size:14px;color:#111;">
+  <strong>⏰ Deadline: today, Fri Jun 5 · 5:00 pm EST.</strong> We batch-merge qualifying tools through the weekend, so get it in by 5.
+</div>
+
+<p>Even a small, focused tool counts — ship it, submit it on Ludwitt, and PR it. Questions? Just reply.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Week 4 — your Ludwitt education tool — is due today by 5pm EST. This is the week that pays you back: every tool that ships and merges earns its author a revenue share as users spend Ludwitt credits through it.
+
+TWO STEPS TO BE COUNTED
+  1. Submit on Ludwitt — this is the one that counts. Go through the creator portal and submit your tool:
+     ${CREATOR_PORTAL_URL}
+  2. Open a PR to cursorboston for Week 4 with your project (the c1w4edu-submission branch). The PR reports your move so it shows on the cohort page — but the Ludwitt submission is what actually counts.
+
+Open the Week 4 tab on the cohort page: ${COHORT_URL}
+
+⏰ DEADLINE: today, Fri Jun 5 · 5:00 pm EST. We batch-merge qualifying tools through the weekend, so get it in by 5.
+
+Even a small, focused tool counts — ship it, submit it on Ludwitt, and PR it. Questions? Just reply.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Cohort1Recipient>({
+    args,
+    name: "Cohort 1 Week 4 education-tool deadline",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: (ctx) => loadAdmittedCohort1Recipients(ctx, STAMP_FIELD),
+    onSent: (r, { db }) => stampCohort1(db, r.applicationId, STAMP_FIELD),
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week4-followup.ts
+++ b/scripts/send-cohort1-week4-followup.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Follow-up nudge to every admitted Cohort 1 applicant for their Week 4 work.
+ * Separate from the deadline-day blast (`send-cohort1-week4-edu-deadline.ts`):
+ * this one re-states the two concrete deliverables and asks the stragglers to
+ * close them out.
+ *
+ * Two deliverables:
+ *   1. Integrate your app into Ludwitt via the creator portal
+ *      (https://www.ludwitt.com/creator) — this is the step that counts and the
+ *      one that earns you a revenue share.
+ *   2. Open an overview PR to cursorboston (c1w4edu-submission branch) describing
+ *      what you built, so it shows on the cohort page.
+ *
+ * Idempotent via its own stamp field `cohort1Week4FollowupEmailedAt`, so it
+ * sends independently of the earlier deadline email. `--force` re-sends.
+ * `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week4-followup.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week4-followup.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-cohort1-week4-followup.ts --send
+ *   npx tsx scripts/send-cohort1-week4-followup.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import {
+  loadAdmittedCohort1Recipients,
+  stampCohort1,
+  type Cohort1Recipient,
+} from "./_lib/cohort1-recipients";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const CREATOR_PORTAL_URL = "https://www.ludwitt.com/creator";
+const STAMP_FIELD = "cohort1Week4FollowupEmailedAt";
+
+function buildEmail(r: Cohort1Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Week 4: integrate your app into Ludwitt + send the overview PR";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick follow-up on <strong>Week 4</strong>. If you haven't closed it out yet, there are just two things left to do — and they're the ones that pay you back, since every app integrated into Ludwitt earns its author a revenue share as users spend credits through it.</p>
+
+<h3 style="margin-top:24px;margin-bottom:8px;font-size:16px;">Two things to wrap up</h3>
+<ol style="padding-left:20px;margin-top:4px;">
+  <li style="margin-bottom:10px;">
+    <strong>Integrate your app into Ludwitt — this is the one that counts.</strong> Go through the creator portal and connect your tool:
+    <br/>
+    <a href="${CREATOR_PORTAL_URL}" style="display:inline-block;margin-top:8px;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+      Integrate on the Ludwitt creator portal →
+    </a>
+  </li>
+  <li style="margin-bottom:4px;">
+    <strong>Open an overview PR to cursorboston</strong> on the <code>c1w4edu-submission</code> branch — a short write-up of what you built and how it plugs into Ludwitt. The PR is what makes your work show up on the cohort page.
+  </li>
+</ol>
+
+<p style="margin-top:16px;">
+  <a href="${COHORT_URL}" style="color:#0284c7;font-weight:600;">Open the Week 4 tab on the cohort page →</a>
+</p>
+
+<p style="margin-top:20px;">Even a small, focused tool counts — integrate it into Ludwitt and send the overview PR. Stuck on either step? Just reply and I'll help you over the line.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Quick follow-up on Week 4. If you haven't closed it out yet, there are just two things left to do — and they're the ones that pay you back, since every app integrated into Ludwitt earns its author a revenue share as users spend credits through it.
+
+TWO THINGS TO WRAP UP
+  1. Integrate your app into Ludwitt — this is the one that counts. Go through the creator portal and connect your tool:
+     ${CREATOR_PORTAL_URL}
+  2. Open an overview PR to cursorboston on the c1w4edu-submission branch — a short write-up of what you built and how it plugs into Ludwitt. The PR is what makes your work show up on the cohort page.
+
+Open the Week 4 tab on the cohort page: ${COHORT_URL}
+
+Even a small, focused tool counts — integrate it into Ludwitt and send the overview PR. Stuck on either step? Just reply and I'll help you over the line.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Cohort1Recipient>({
+    args,
+    name: "Cohort 1 Week 4 follow-up (Ludwitt integration + overview PR)",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: (ctx) => loadAdmittedCohort1Recipients(ctx, STAMP_FIELD),
+    onSent: (r, { db }) => stampCohort1(db, r.applicationId, STAMP_FIELD),
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-week5-startup.ts
+++ b/scripts/send-cohort1-week5-startup.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Week 5 kickoff to every admitted Cohort 1 applicant.
+ *
+ * Two beats:
+ *   1. Celebrate Week 4 — a bunch of apps got connected into Ludwitt, and as a
+ *      thank-you everyone got $5 of Ludwitt credit added to their account for
+ *      their apps.
+ *   2. Week 5 is "Create a startup." Deliverables: a pitch deck AND a full,
+ *      production application that real users can actually use. PR the writeup
+ *      to cursorboston on the `c1w5startup-submission` branch so it shows on the
+ *      cohort page.
+ *
+ * Idempotent via its own stamp field `cohort1Week5StartupEmailedAt`. `--force`
+ * re-sends. `--only-email=foo@bar` restricts to a single recipient.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-week5-startup.ts --dry-run
+ *   npx tsx scripts/send-cohort1-week5-startup.ts --send --only-email=rhunt@bentley.edu
+ *   npx tsx scripts/send-cohort1-week5-startup.ts --send
+ *   npx tsx scripts/send-cohort1-week5-startup.ts --send --force
+ */
+import { loadEnv, escapeHtml, parseSendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { runEmailCampaign, type EmailContent } from "./_lib/campaign-runner";
+import {
+  loadAdmittedCohort1Recipients,
+  stampCohort1,
+  type Cohort1Recipient,
+} from "./_lib/cohort1-recipients";
+import { buildUnsubscribeUrl, buildWithdrawUrl } from "../lib/unsubscribe-token";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const LUDWITT_URL = "https://www.ludwitt.com";
+const STAMP_FIELD = "cohort1Week5StartupEmailedAt";
+
+function buildEmail(r: Cohort1Recipient): EmailContent {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const firstText = r.firstName?.trim() || "there";
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-1");
+
+  const subject = "Week 5: build a startup 🚀 (+ $5 Ludwitt credit is in your account)";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p><strong>Week 4 was a hit.</strong> A bunch of you got real apps connected into Ludwitt — genuinely great work. As a thank-you, <strong>we've added $5 of Ludwitt credit to everyone's account</strong> for the apps you shipped. It's already there; go spend it.</p>
+
+<div style="border:1px solid #a7f3d0;border-radius:8px;padding:14px 16px;margin:20px 0;background:#ecfdf5;font-size:14px;color:#065f46;">
+  💸 <strong>$5 of Ludwitt credit has been added to your account.</strong> <a href="${LUDWITT_URL}" style="color:#047857;font-weight:600;">Open Ludwitt →</a>
+</div>
+
+<h3 style="margin-top:28px;margin-bottom:8px;font-size:16px;">This week: create a startup 🚀</h3>
+<p>Week 5 is the big one. Take what you've built and turn it into a company. By the end of the week you should have:</p>
+<ul style="padding-left:20px;margin-top:4px;">
+  <li style="margin-bottom:8px;"><strong>A pitch deck</strong> — the story: problem, solution, who it's for, why now, and where it goes.</li>
+  <li style="margin-bottom:8px;"><strong>A full production application</strong> — not a prototype. Something real users can sign up for and actually use today.</li>
+</ul>
+
+<h3 style="margin-top:24px;margin-bottom:8px;font-size:16px;">How to submit</h3>
+<p>Open a PR to cursorboston on the <code>c1w5startup-submission</code> branch with your deck and a link to the live app, so it shows up on the cohort page.</p>
+
+<p style="margin-top:16px;">
+  <a href="${COHORT_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the Week 5 tab on the cohort page →
+  </a>
+</p>
+
+<p style="margin-top:20px;">Ship something you'd actually put your name on. Stuck on scope, the deck, or going live? Just reply — happy to help you shape it.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you&apos;re admitted to Cohort 1 of the Cursor Boston summer cohort.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a> · <a href="${escapeHtml(withdrawUrl)}" style="color:#888;">Withdraw from Cohort 1</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Week 4 was a hit. A bunch of you got real apps connected into Ludwitt — genuinely great work. As a thank-you, we've added $5 of Ludwitt credit to everyone's account for the apps you shipped. It's already there; go spend it.
+
+💸 $5 of Ludwitt credit has been added to your account. Open Ludwitt: ${LUDWITT_URL}
+
+THIS WEEK: CREATE A STARTUP 🚀
+Week 5 is the big one. Take what you've built and turn it into a company. By the end of the week you should have:
+  1. A pitch deck — the story: problem, solution, who it's for, why now, and where it goes.
+  2. A full production application — not a prototype. Something real users can sign up for and actually use today.
+
+HOW TO SUBMIT
+Open a PR to cursorboston on the c1w5startup-submission branch with your deck and a link to the live app, so it shows up on the cohort page.
+
+Open the Week 5 tab on the cohort page: ${COHORT_URL}
+
+Ship something you'd actually put your name on. Stuck on scope, the deck, or going live? Just reply — happy to help you shape it.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you're admitted to Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe from emails: ${unsubUrl}
+Withdraw from Cohort 1:  ${withdrawUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = parseSendArgs();
+
+  await runEmailCampaign<Cohort1Recipient>({
+    args,
+    name: "Cohort 1 Week 5 startup kickoff (+ $5 Ludwitt credit)",
+    previewMode: "text",
+    getEmail: (r) => r.email,
+    buildEmail,
+    loadRecipients: (ctx) => loadAdmittedCohort1Recipients(ctx, STAMP_FIELD),
+    onSent: (r, { db }) => stampCohort1(db, r.applicationId, STAMP_FIELD),
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-game-digest-2026-06-03.ts
+++ b/scripts/send-game-digest-2026-06-03.ts
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * One-off "This Week in the World" game digest to the full community
+ * (eventContacts), respecting unsubscribes + Mailgun suppressions.
+ *
+ * Content is a recap of the last 7 days in the tile-strategy game: kingdoms
+ * that grew big, new heroes that emerged, and the state of the war. Figures
+ * are pulled from live game data (see the dry-run note in the chat that
+ * generated this) as of 2026-06-03.
+ *
+ * Usage:
+ *   npx tsx scripts/send-game-digest-2026-06-03.ts --dry-run
+ *   npx tsx scripts/send-game-digest-2026-06-03.ts --send
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const GAME_URL = "https://cursorboston.com/game";
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+
+// Per-recipient Cohort 2 state, derived from their summer-cohort application:
+//   "in"       — applied (pending or admitted) and not withdrawn → we're
+//                admitting everyone who's applied; official confirmation lands
+//                the weekend after June 19.
+//   "comeback" — previously withdrew → warm re-invite.
+//   "apply"    — no Cohort 2 application on file → invite to apply.
+type Cohort2State = "in" | "comeback" | "apply";
+
+interface ContactData {
+  email: string;
+  name: string;
+  firstName: string;
+  c2: Cohort2State;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// Dynamic Cohort 2 opener, keyed off the recipient's application state. The
+// official admission weekend is after June 19, so applicants are told they're
+// in with that confirmation date — no promises beyond it.
+function cohort2BlockHtml(state: Cohort2State): string {
+  if (state === "in") {
+    return `<div style="background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;padding:14px 16px;margin:0 0 20px;">
+<p style="margin:0;"><strong>🎉 You're in for Cohort 2.</strong> We're admitting everyone who's applied so far — you're on the list. We'll send official confirmation and next steps the weekend after <strong>June 19</strong>. Nothing to do right now but get ready.</p>
+</div>`;
+  }
+  if (state === "comeback") {
+    return `<div style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:8px;padding:14px 16px;margin:0 0 20px;">
+<p style="margin:0;"><strong>The door's still open for Cohort 2.</strong> We saw you stepped back earlier — if the timing works better now, we'd love to have you. Re-apply and you're in; we send official confirmations the weekend after <strong>June 19</strong>. <a href="${COHORT_URL}" style="color:#2563eb;">Rejoin Cohort 2 →</a></p>
+</div>`;
+  }
+  return `<div style="background:#fffbeb;border:1px solid #fde68a;border-radius:8px;padding:14px 16px;margin:0 0 20px;">
+<p style="margin:0;"><strong>Cohort 2 is filling up — want in?</strong> Applications are open now, and we're admitting applicants on a rolling basis with official decisions the weekend after <strong>June 19</strong>. If you've been meaning to join, now's the time. <a href="${COHORT_URL}" style="color:#b45309;">Apply for Cohort 2 →</a></p>
+</div>`;
+}
+
+function cohort2BlockText(state: Cohort2State): string {
+  if (state === "in") {
+    return `YOU'RE IN FOR COHORT 2
+We're admitting everyone who's applied so far — you're on the list. We'll send official confirmation and next steps the weekend after June 19. Nothing to do right now but get ready.
+`;
+  }
+  if (state === "comeback") {
+    return `THE DOOR'S STILL OPEN FOR COHORT 2
+We saw you stepped back earlier — if the timing works better now, we'd love to have you. Re-apply and you're in; we send official confirmations the weekend after June 19.
+Rejoin: ${COHORT_URL}
+`;
+  }
+  return `COHORT 2 IS FILLING UP — WANT IN?
+Applications are open now, and we're admitting applicants on a rolling basis with official decisions the weekend after June 19. If you've been meaning to join, now's the time.
+Apply: ${COHORT_URL}
+`;
+}
+
+function buildEmail(contact: ContactData): { subject: string; html: string; text: string } {
+  const first = escapeHtml(
+    contact.firstName?.trim() || contact.name?.split(" ")[0]?.trim() || "there"
+  );
+  const unsubUrl = buildUnsubscribeUrl(contact.email);
+
+  const subject = "This Week in the World — kingdoms rise, 42 heroes emerge ⚔️";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+${cohort2BlockHtml(contact.c2)}
+
+<p>Now — the world has been busy. Here's your weekly dispatch from the front, what shifted across the map over the last seven days.</p>
+
+<h3 style="margin-top:28px;margin-bottom:8px;font-size:16px;">🏰 The biggest kingdoms</h3>
+<p>The map is held by <strong>74 rulers</strong> (24 of you, plus 50 NPC warbands) across <strong>7,166 tiles</strong>. The largest realms right now:</p>
+<ol style="padding-left:20px;margin-top:4px;">
+  <li style="margin-bottom:4px;"><strong>Ulysses</strong> (red) — <strong>469 tiles</strong>, far and away the largest realm in the world</li>
+  <li style="margin-bottom:4px;"><strong>Roger Man v2</strong> (black) — 305 tiles, and the most battle-hardened ruler standing (41 wins)</li>
+  <li style="margin-bottom:4px;"><strong>Potato Defender</strong> (blue) — 197 tiles and 30 victories, holding a contested frontier</li>
+  <li style="margin-bottom:4px;"><strong>Captain Lighthouse</strong> (blue) — 189 tiles</li>
+  <li style="margin-bottom:4px;"><strong>Julylu None</strong> (black) — 178 tiles, with a standing army of 250</li>
+</ol>
+<p style="font-size:13px;color:#555;">Also climbing fast: IngeniousGeneral, Dark Shadow, and Ass-Kicker — the latter only joined this week and already holds 125 tiles.</p>
+
+<h3 style="margin-top:28px;margin-bottom:8px;font-size:16px;">🦸 New heroes have emerged</h3>
+<p><strong>42 new heroes</strong> walked onto the map this week — siege-lords, sky-knights, raiders and supply-captains. A few who rallied to player banners:</p>
+<ul style="padding-left:20px;margin-top:4px;">
+  <li style="margin-bottom:4px;"><strong>Brown Magic</strong> drew three to the white banner — <em>Father Esmond</em>, <em>Lord Tomas</em>, and <em>Knight-Lector Storne</em>.</li>
+  <li style="margin-bottom:4px;"><strong>Roger Man v2</strong> raised <em>The Echo of Vask</em>, a raid-specialist of the black caste.</li>
+  <li style="margin-bottom:4px;"><strong>Julylu None</strong> gained <em>Wraith-Captain Sehl</em> and <em>Halrik Twice-Buried</em>.</li>
+  <li style="margin-bottom:4px;"><strong>Captain Lighthouse</strong> took <em>Captain Whitewing</em>; <strong>Potato Defender</strong> took <em>Sky-Knight Henrik</em>.</li>
+</ul>
+<p style="font-size:13px;color:#555;">Not all of them will live long: five heroes were already slain in battle this week, including Vurn the Reluctant and the short-lived Hrolfgar Again.</p>
+
+<h3 style="margin-top:28px;margin-bottom:8px;font-size:16px;">⚔️ The state of the war</h3>
+<p>It was a bloody week: <strong>1,049 attacks</strong> were launched and <strong>91 tiles changed hands</strong>. Much of that churn is the NPC warbands grinding against each other along the borders — Bram Hollowwind, Captain Idriel and Khorvath were the most relentless conquerors — so there's open territory and weakened neighbors out there for anyone ready to push.</p>
+
+<p style="margin-top:20px;">
+  <a href="${GAME_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Check your kingdom →
+  </a>
+</p>
+
+<p>Your turns are waiting. See you on the map.</p>
+
+<p>— The Cursor Boston team</p>
+
+<p style="font-size:12px;color:#888;margin-top:24px;border-top:1px solid #e5e5e5;padding-top:16px;">
+You're receiving this because you registered for a Cursor Boston event. <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a> at any time.
+</p>
+</body></html>`;
+
+  const text = `Hi ${first},
+
+${cohort2BlockText(contact.c2)}
+Now — the world has been busy. Here's your weekly dispatch from the front, what shifted across the map over the last seven days.
+
+THE BIGGEST KINGDOMS
+The map is held by 74 rulers (24 of you, plus 50 NPC warbands) across 7,166 tiles. The largest realms right now:
+  1. Ulysses (red) — 469 tiles, far and away the largest realm in the world
+  2. Roger Man v2 (black) — 305 tiles, and the most battle-hardened ruler standing (41 wins)
+  3. Potato Defender (blue) — 197 tiles and 30 victories, holding a contested frontier
+  4. Captain Lighthouse (blue) — 189 tiles
+  5. Julylu None (black) — 178 tiles, with a standing army of 250
+Also climbing fast: IngeniousGeneral, Dark Shadow, and Ass-Kicker — the latter only joined this week and already holds 125 tiles.
+
+NEW HEROES HAVE EMERGED
+42 new heroes walked onto the map this week — siege-lords, sky-knights, raiders and supply-captains. A few who rallied to player banners:
+  - Brown Magic drew three to the white banner: Father Esmond, Lord Tomas, and Knight-Lector Storne.
+  - Roger Man v2 raised The Echo of Vask, a raid-specialist of the black caste.
+  - Julylu None gained Wraith-Captain Sehl and Halrik Twice-Buried.
+  - Captain Lighthouse took Captain Whitewing; Potato Defender took Sky-Knight Henrik.
+Not all of them will live long: five heroes were already slain in battle this week, including Vurn the Reluctant and the short-lived Hrolfgar Again.
+
+THE STATE OF THE WAR
+It was a bloody week: 1,049 attacks were launched and 91 tiles changed hands. Much of that churn is the NPC warbands grinding against each other along the borders — Bram Hollowwind, Captain Idriel and Khorvath were the most relentless conquerors — so there's open territory and weakened neighbors out there for anyone ready to push.
+
+Check your kingdom: ${GAME_URL}
+
+Your turns are waiting. See you on the map.
+
+— The Cursor Boston team
+
+---
+You're receiving this because you registered for a Cursor Boston event.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  // Mirror Mailgun bounces/complaints into eventContacts.unsubscribed first.
+  if (send) {
+    console.log("Syncing Mailgun suppressions…");
+    await syncMailgunSuppressions(db);
+  }
+
+  // Map each email -> Cohort 2 application state, so the opener is dynamic.
+  console.log("Loading Cohort 2 application states…");
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const c2ByEmail = new Map<string, Cohort2State>();
+  for (const doc of appsSnap.docs) {
+    const x = doc.data() as Record<string, unknown>;
+    const cohorts = Array.isArray(x.cohorts) ? (x.cohorts as string[]) : [];
+    if (!cohorts.includes("cohort-2")) continue;
+    const email = String(x.email ?? "").trim().toLowerCase();
+    if (!email) continue;
+    const status = String(x.status ?? "");
+    // Admitting everyone who's applied → pending + admitted both read as "in".
+    const state: Cohort2State = status === "withdrawn" ? "comeback" : "in";
+    // If someone has multiple rows, prefer "in" over "comeback".
+    if (c2ByEmail.get(email) !== "in") c2ByEmail.set(email, state);
+  }
+
+  console.log("Loading contacts from eventContacts…");
+  const snap = await db.collection("eventContacts").get();
+  console.log(`Total contacts: ${snap.size}`);
+
+  const contacts: ContactData[] = [];
+  let skippedUnsubscribed = 0;
+  let skippedNoEmail = 0;
+  const stateTally: Record<Cohort2State, number> = { in: 0, comeback: 0, apply: 0 };
+  for (const doc of snap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+    if (data.unsubscribed === true) {
+      skippedUnsubscribed++;
+      continue;
+    }
+    const email = (data.email as string) || doc.id;
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    const c2 = c2ByEmail.get(email.trim().toLowerCase()) ?? "apply";
+    stateTally[c2]++;
+    contacts.push({
+      email,
+      name: (data.name as string) || "",
+      firstName: (data.firstName as string) || "",
+      c2,
+    });
+  }
+
+  console.log(
+    `Eligible: ${contacts.length} | Skipped unsubscribed: ${skippedUnsubscribed} | Skipped no-email: ${skippedNoEmail}`
+  );
+  console.log(
+    `Cohort 2 openers — in: ${stateTally.in} | comeback: ${stateTally.comeback} | apply: ${stateTally.apply}`
+  );
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const { subject } = buildEmail(contacts[0] ?? { email: "x@y.com", name: "", firstName: "", c2: "apply" });
+    console.log(`Subject (all recipients): ${subject}\n`);
+    // Show the full email for each of the three Cohort 2 opener variants.
+    for (const state of ["in", "comeback", "apply"] as Cohort2State[]) {
+      const example =
+        contacts.find((c) => c.c2 === state) ??
+        ({ email: `${state}@example.com`, name: "Sample Person", firstName: "Sample", c2: state } as ContactData);
+      const { html, text } = buildEmail(example);
+      console.log(`\n========================================================`);
+      console.log(`VARIANT: c2="${state}"   (example recipient: ${example.email})`);
+      console.log(`========================================================`);
+      console.log("--- HTML ---");
+      console.log(html);
+      console.log("\n--- Text ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${contacts.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const contact of contacts) {
+    const { subject, html, text } = buildEmail(contact);
+    try {
+      await sendEmail({ to: contact.email, subject, html, text });
+      sent++;
+      if (sent % 50 === 0) console.log(`  Progress: ${sent}/${contacts.length}`);
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${contact.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}, skipped unsubscribed ${skippedUnsubscribed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Release of `develop` → `main`. Carries 4 PRs — no app/UI changes (scripts, dependencies, CI only):

| PR | Title | Author |
|----|-------|--------|
| #1601 | chore(scripts): add Cohort 1 send-* email campaign scripts | maintainer |
| #1600 | deps(deps-dev): bump @types/node 25.9.1 → 25.9.2 | @dependabot |
| #1598 | ci(deps): bump github/codeql-action 4.36.1 → 4.36.2 | @dependabot |
| #1604 | chore(deps): bump @anthropic-ai/sdk 0.100.1 → 0.102.0 + firebase-tools 15.19.0 → 15.19.1 | maintainer |

### Verification
- [x] `npm run build` succeeded locally
- [x] No UI surface in this delta — visual QA N/A (only `scripts/`, `package.json`/lock, `.github/workflows/codeql.yml`)
- [x] All four PRs passed full CI before merge to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)