### PR TITLE
release: develop→main — Cohort 2 admin/email scripts + codecov-action 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           CI: true
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info

--- a/scripts/admit-all-cohort2-pending.ts
+++ b/scripts/admit-all-cohort2-pending.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Bulk-admit every PENDING Cohort 2 application. Scoped to status === "pending"
+ * only (121 as of 2026-06-11) — already-admitted and withdrawn docs are left
+ * untouched. Differs from the Cohort 1 bulk-admit, which also swept
+ * waitlist/rejected; here the user asked to admit exactly the pending set.
+ *
+ * Idempotent: re-running is a no-op for already-admitted docs.
+ *
+ * Usage:
+ *   npx tsx scripts/admit-all-cohort2-pending.ts --dry-run
+ *   npx tsx scripts/admit-all-cohort2-pending.ts --apply
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+interface Candidate {
+  applicationId: string;
+  email: string;
+  name: string;
+  status: string;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const apply = process.argv.includes("--apply");
+  if (!dryRun && !apply) {
+    console.error("Pass --dry-run or --apply.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const snap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  const candidates: Candidate[] = [];
+  let scanned = 0;
+  let alreadyAdmitted = 0;
+  let withdrawn = 0;
+  let notCohort2 = 0;
+  const otherStatuses: Record<string, number> = {};
+
+  for (const doc of snap.docs) {
+    scanned++;
+    const d = doc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-2")) {
+      notCohort2++;
+      continue;
+    }
+    const status = d.status ?? "pending";
+    if (status === "admitted") {
+      alreadyAdmitted++;
+      continue;
+    }
+    if (status === "withdrawn") {
+      withdrawn++;
+      continue;
+    }
+    if (status !== "pending") {
+      // Leave waitlist/rejected/other untouched — user asked for the pending set only.
+      otherStatuses[status] = (otherStatuses[status] ?? 0) + 1;
+      continue;
+    }
+    candidates.push({
+      applicationId: doc.id,
+      email: (d.email ?? "").trim(),
+      name: (d.name ?? "").trim(),
+      status,
+    });
+  }
+
+  console.log(`Scanned: ${scanned}`);
+  console.log(`Not cohort-2: ${notCohort2}`);
+  console.log(`Already admitted: ${alreadyAdmitted}`);
+  console.log(`Withdrawn (skipped): ${withdrawn}`);
+  console.log(`Other non-pending statuses (skipped):`, otherStatuses);
+  console.log(`To be admitted (pending): ${candidates.length}`);
+
+  if (candidates.length > 0) {
+    console.log("\nFirst 10 candidates:");
+    for (const c of candidates.slice(0, 10)) {
+      console.log(`  ${c.status.padEnd(10)}  ${c.email.padEnd(40)}  ${c.name}`);
+    }
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no writes made.");
+    return;
+  }
+
+  let admitted = 0;
+  let failed = 0;
+  for (const c of candidates) {
+    try {
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(c.applicationId).update({
+        status: "admitted",
+        admittedAt: FieldValue.serverTimestamp(),
+        admittedVia: "bulk-cohort2-jun11",
+        statusUpdatedAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      admitted++;
+    } catch (e) {
+      failed++;
+      console.error(`Failed to admit ${c.email}:`, e);
+    }
+  }
+  console.log(`\nDone. Admitted ${admitted}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort-admittance.ts
+++ b/scripts/send-cohort-admittance.ts
@@ -154,6 +154,19 @@ Unsubscribe: ${unsubUrl}`;
 async function main() {
   const args = parseSendArgs();
 
+  // Optional: restrict to a specific admit cohort by the `admittedVia` tag
+  // (e.g. --admitted-via=bulk-cohort2-jun11) so a bulk send can target exactly
+  // one admission batch and skip unrelated stragglers / test docs.
+  const viaArg = process.argv
+    .slice(2)
+    .find((a) => a.startsWith("--admitted-via="));
+  const admittedViaFilter = viaArg
+    ? viaArg.slice("--admitted-via=".length).trim()
+    : null;
+  if (admittedViaFilter) {
+    console.log(`Filtering to admittedVia === "${admittedViaFilter}"`);
+  }
+
   await runEmailCampaign<Admit>({
     args,
     name: "Summer cohort admittance",
@@ -168,8 +181,13 @@ async function main() {
 
       const queue: Admit[] = [];
       let alreadyEmailed = 0;
+      let skippedVia = 0;
       for (const doc of snap.docs) {
         const data = doc.data();
+        if (admittedViaFilter && data.admittedVia !== admittedViaFilter) {
+          skippedVia++;
+          continue;
+        }
         if (!args.force && data.admittanceEmailedAt) {
           alreadyEmailed++;
           continue;
@@ -198,7 +216,10 @@ async function main() {
         });
       }
 
-      console.log(`To email now: ${queue.length} | Already emailed: ${alreadyEmailed}`);
+      console.log(
+        `To email now: ${queue.length} | Already emailed: ${alreadyEmailed}` +
+          (admittedViaFilter ? ` | Skipped (other admittedVia): ${skippedVia}` : "")
+      );
       return queue;
     },
     onSent: (a, { db }) =>

--- a/scripts/send-cohort1-reach-out.ts
+++ b/scripts/send-cohort1-reach-out.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Cohort 1 — "reach out if you have questions" check-in email.
+ *
+ * Roger is traveling over the next few weeks (DC this week, SF the week of
+ * Jun 15, NY the week of Jun 22) but stays fully available — this email
+ * encourages anyone who's stuck or has questions to just message him.
+ *
+ * Idempotent via `cohort1ReachOutEmailedAt` on the application doc.
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-reach-out.ts --dry-run
+ *   npx tsx scripts/send-cohort1-reach-out.ts --send
+ *   npx tsx scripts/send-cohort1-reach-out.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const CONTACT_EMAIL = "roger@cursorboston.com";
+const STAMP_FIELD = "cohort1ReachOutEmailedAt";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = "Stuck on anything? Just reach out — I'm around";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Quick check-in: if you're stuck on anything or have a question — about the build, the tooling, your track, anything — <strong>please just reach out</strong>. Don't sit on it. The fastest way to get unblocked is to message me.</p>
+
+<p>I'm doing a fair bit of travel over the next few weeks — <strong>DC this week, San Francisco the week of June 15, and New York the week of June 22</strong> — but that doesn't change anything: I'm fully available and happy to help. A different time zone is not a barrier; ping me and I'll get back to you.</p>
+
+<p>The easiest way to reach me:</p>
+<p>
+  <a href="mailto:${CONTACT_EMAIL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Email me → ${CONTACT_EMAIL}
+  </a>
+</p>
+<p style="font-size:14px;color:#6b7280;">Or drop a note in the cohort Discord channel — whatever's quickest for you.</p>
+
+<p style="margin-top:24px;">Everything you need (Discord, GitHub, intake survey) is on the cohort page:</p>
+<p>
+  <a href="${COHORT_URL}" style="display:inline-block;background:#7c3aed;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Open the cohort page →
+  </a>
+</p>
+
+<p style="margin-top:32px;">Seriously — don't be a stranger. I'd rather hear from you early than have you stuck.</p>
+
+<p>— Roger<br/>
+<a href="mailto:${CONTACT_EMAIL}">${CONTACT_EMAIL}</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You're receiving this because you're in Cohort 1 of the Cursor Boston summer cohort.<br/>
+Don't want any emails from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>.
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.firstName?.trim() || "there"},
+
+Quick check-in: if you're stuck on anything or have a question — about the build, the tooling, your track, anything — please just reach out. Don't sit on it. The fastest way to get unblocked is to message me.
+
+I'm doing a fair bit of travel over the next few weeks — DC this week, San Francisco the week of June 15, and New York the week of June 22 — but that doesn't change anything: I'm fully available and happy to help. A different time zone is not a barrier; ping me and I'll get back to you.
+
+The easiest way to reach me: ${CONTACT_EMAIL}
+Or drop a note in the cohort Discord channel — whatever's quickest for you.
+
+Everything you need (Discord, GitHub, intake survey) is on the cohort page: ${COHORT_URL}
+
+Seriously — don't be a stranger. I'd rather hear from you early than have you stuck.
+
+— Roger
+${CONTACT_EMAIL}
+
+---
+You're receiving this because you're in Cohort 1 of the Cursor Boston summer cohort.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const send = process.argv.includes("--send");
+  const force = process.argv.includes("--force");
+  if (!dryRun && !send) {
+    console.error("Pass --dry-run or --send.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  console.log("Loading cohort-1 admits...");
+  const appsSnap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotCohort1 = 0;
+  let skippedNotAdmitted = 0;
+  let skippedNoEmail = 0;
+  let skippedAlreadyEmailed = 0;
+
+  for (const appDoc of appsSnap.docs) {
+    const d = appDoc.data() as {
+      cohorts?: string[];
+      status?: string;
+      email?: string;
+      name?: string;
+      [STAMP_FIELD]?: unknown;
+    };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotCohort1++;
+      continue;
+    }
+    if (d.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!d.email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (!force && d[STAMP_FIELD]) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+    const name = d.name?.trim() || "";
+    const firstName = name.split(" ")[0] || "";
+    recipients.push({
+      applicationId: appDoc.id,
+      email: d.email.trim(),
+      firstName,
+    });
+  }
+
+  console.log(`Eligible recipients: ${recipients.length}`);
+  console.log(`Skipped — not cohort-1: ${skippedNotCohort1}`);
+  console.log(`Skipped — not admitted: ${skippedNotAdmitted}`);
+  console.log(`Skipped — no email: ${skippedNoEmail}`);
+  console.log(`Skipped — already emailed: ${skippedAlreadyEmailed}`);
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log(`Sample to: ${sample.email}`);
+      console.log(`Subject: ${subject}`);
+      console.log("\n--- HTML preview ---");
+      console.log(html);
+      console.log("\n--- Text preview ---");
+      console.log(text);
+    }
+    console.log(`\nWould send to ${recipients.length} contacts.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({ to: r.email, subject, html, text });
+      await db
+        .collection(SUMMER_COHORT_COLLECTION)
+        .doc(r.applicationId)
+        .update({ [STAMP_FIELD]: FieldValue.serverTimestamp() });
+      sent++;
+      if (sent % 25 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${r.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort2-intake-survey.ts
+++ b/scripts/send-cohort2-intake-survey.ts
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Email Cohort 2 admits asking them to fill out the intake survey, with a
+ * full reiteration of the kickoff date (Mon, Jun 29) and explicit, one-click
+ * withdraw instructions for anyone who no longer wants to participate.
+ *
+ * Filters:
+ *   - cohort-2 only (must include "cohort-2" in `cohorts`)
+ *   - status === "admitted" (skips pending/withdrawn/rejected/waitlist)
+ *   - skips anyone whose email already has a doc in summerCohortIntakeSurveys
+ *
+ * Idempotency:
+ *   - on successful send, stamps `cohort2IntakeSurveyEmailedAt` on the
+ *     application doc; re-runs skip anyone already stamped (override with --force).
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort2-intake-survey.ts --dry-run
+ *   npx tsx scripts/send-cohort2-intake-survey.ts --send
+ *   npx tsx scripts/send-cohort2-intake-survey.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import {
+  buildUnsubscribeUrl,
+  buildWithdrawUrl,
+} from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION, isValidCohortId } from "../lib/summer-cohort";
+import { SUMMER_COHORT_INTAKE_COLLECTION } from "../lib/summer-cohort-intake";
+
+const COHORT_URL = "https://cursorboston.com/summer-cohort";
+const KICKOFF = "Monday, June 29 at 6pm EST";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  name: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const first = escapeHtml(r.name?.split(" ")[0]?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+  const withdrawUrl = buildWithdrawUrl(r.email, "cohort-2");
+  const subject = "Cohort 2 starts Jun 29 — quick 5-min intake survey";
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>You&rsquo;re admitted to <strong>Cohort 2</strong> of the Cursor Boston Summer Cohort. Kickoff is <strong>${KICKOFF}</strong> on the kickoff Zoom (link sent separately closer to the date). Mark your calendar now.</p>
+
+<p>One quick ask before we get going:</p>
+
+<p style="margin:16px 0;padding:14px 16px;background:#ecfdf5;border-left:4px solid #10b981;border-radius:6px;">
+  <strong>Take the intake survey on your cohort page (~5 min).</strong><br/>
+  <a href="${COHORT_URL}" style="color:#065f46;font-weight:600;">${COHORT_URL}</a>
+</p>
+
+<p>It&rsquo;s simple — programming background, what you&rsquo;ve been using AI for, what you want out of the cohort. We&rsquo;re using it to <strong>build tools that help you ship faster, smoother, and have more fun</strong>: track progress, surface where people are getting stuck, route help to the right person, and tailor the program to who&rsquo;s actually in the room.</p>
+
+<p style="margin:16px 0;padding:12px 16px;background:#fffbeb;border-left:4px solid #f59e0b;border-radius:6px;">
+  <strong>Heads up: this is NOT a research study.</strong><br/>
+  Cursor Boston&rsquo;s research IRB is still pending. This intake is for operational use only — it&rsquo;s not part of any experimental or research project. Once IRB is approved we&rsquo;ll send a separate, fully-optional research survey; you can decide then whether you want to participate.
+</p>
+
+<p style="margin-top:20px;">
+  <a href="${COHORT_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Take the intake survey →</a>
+</p>
+
+<h3 style="margin-top:32px;margin-bottom:8px;color:#b91c1c;">Not joining anymore?</h3>
+<p>No problem — life happens. If you can no longer commit to Cohort 2, please <strong>withdraw now</strong> so we can free your spot for someone on the waitlist:</p>
+<p>
+  <a href="${escapeHtml(withdrawUrl)}" style="display:inline-block;background:#fff;color:#b91c1c;border:1px solid #b91c1c;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600;">
+    Withdraw from Cohort 2
+  </a>
+</p>
+<p style="font-size:14px;color:#6b7280;">One click — no confirmation page. You&rsquo;ll land on a &ldquo;you&rsquo;ve been withdrawn&rdquo; page. This removes you from the cohort entirely (different from the unsubscribe link below, which only stops emails). You can re-apply later if your situation changes.</p>
+
+<p style="margin-top:24px;color:#555;font-size:14px;">Reply to this email if you hit any snags. Excited to build with you.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&rsquo;re receiving this because you&rsquo;re an admitted Cohort 2 participant.<br/>
+Don&rsquo;t want any emails from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a> (different from withdrawing — this just stops emails, doesn&rsquo;t remove you from the cohort).
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+You're admitted to COHORT 2 of the Cursor Boston Summer Cohort. Kickoff is ${KICKOFF} on the kickoff Zoom (link sent separately closer to the date). Mark your calendar now.
+
+One quick ask before we get going:
+
+TAKE THE INTAKE SURVEY ON YOUR COHORT PAGE (~5 MIN):
+${COHORT_URL}
+
+It's simple — programming background, what you've been using AI for, what you want out of the cohort. We're using it to build tools that help you ship faster, smoother, and have more fun: track progress, surface where people are getting stuck, route help to the right person, and tailor the program to who's actually in the room.
+
+HEADS UP: THIS IS NOT A RESEARCH STUDY.
+Cursor Boston's research IRB is still pending. This intake is for operational use only — it's not part of any experimental or research project. Once IRB is approved we'll send a separate, fully-optional research survey; you can decide then whether you want to participate.
+
+Take the intake survey: ${COHORT_URL}
+
+NOT JOINING ANYMORE?
+No problem — life happens. If you can no longer commit to Cohort 2, please withdraw now so we can free your spot for someone on the waitlist:
+${withdrawUrl}
+
+One click — no confirmation page. This removes you from the cohort entirely (different from unsubscribing, which only stops emails). You can re-apply later if your situation changes.
+
+Reply to this email if you hit any snags. Excited to build with you.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you're an admitted Cohort 2 participant.
+Unsubscribe from emails (different from withdrawing): ${unsubUrl}`;
+
+  return { subject, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  const force = args.includes("--force"); // re-send even if previously emailed
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Loading existing intake submissions from ${SUMMER_COHORT_INTAKE_COLLECTION}…`);
+  const intakeSnap = await db.collection(SUMMER_COHORT_INTAKE_COLLECTION).get();
+  const intakeEmails = new Set<string>();
+  for (const doc of intakeSnap.docs) {
+    const email = (doc.data().email || "").toString().trim().toLowerCase();
+    if (email) intakeEmails.add(email);
+  }
+  console.log(`Existing intake submissions: ${intakeEmails.size}`);
+
+  console.log(`Loading applications from ${SUMMER_COHORT_COLLECTION}…`);
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotAdmitted = 0;
+  let skippedNotCohort2 = 0;
+  let skippedAlreadyDone = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    const cohorts = Array.isArray(data.cohorts)
+      ? data.cohorts.filter(isValidCohortId)
+      : [];
+    if (!cohorts.includes("cohort-2")) {
+      skippedNotCohort2++;
+      continue;
+    }
+    if (data.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (intakeEmails.has(email.toLowerCase())) {
+      skippedAlreadyDone++;
+      continue;
+    }
+    if (!force && data.cohort2IntakeSurveyEmailedAt) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+
+    recipients.push({
+      applicationId: doc.id,
+      email,
+      name: typeof data.name === "string" ? data.name : "",
+    });
+  }
+
+  console.log(
+    `Eligible to email: ${recipients.length} | already submitted: ${skippedAlreadyDone} | already emailed: ${skippedAlreadyEmailed} | not admitted: ${skippedNotAdmitted} | not cohort-2: ${skippedNotCohort2} | no email: ${skippedNoEmail}`
+  );
+
+  if (recipients.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log("============================================================");
+      console.log("SAMPLE");
+      console.log("============================================================");
+      console.log(`To:      ${sample.email} (${sample.name || "(no name)"})`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- TEXT BODY ----\n${text}\n`);
+      console.log(`---- HTML PREVIEW (first 2200 chars) ----\n${html.slice(0, 2200)}\n…`);
+    }
+    console.log(`\nWould send to ${recipients.length} cohort-2 admits.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const recipient of recipients) {
+    const { subject, html, text } = buildEmail(recipient);
+    try {
+      await sendEmail({ to: recipient.email, subject, html, text });
+      sent++;
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(recipient.applicationId).set(
+        { cohort2IntakeSurveyEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${recipient.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Release of `develop` → `main`. 2 commits, no app/UI changes (scripts + CI only).

## Included
- **f12a51e5** — chore(scripts): Cohort 2 admit + survey/reach-out email campaigns — adds `scripts/admit-all-cohort2-pending.ts`, `scripts/send-cohort1-reach-out.ts`, `scripts/send-cohort2-intake-survey.ts` and tweaks `scripts/send-cohort-admittance.ts` (@Ludwitt)
- **#1597** — ci(deps): bump codecov/codecov-action from 6.0.1 to 7.0.0 (@dependabot)

## Verification
- Local production build (`npm run build`) passed — all routes compiled/generated clean.
- No UI surface in this release (standalone `tsx` scripts + `.github/workflows/ci.yml`), so no visual QA loop applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)