### PR TITLE
fix(deps): bump @grpc/grpc-js to 1.14.4 (2 high-sev CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2940,9 +2940,9 @@
       }
     },
     "node_modules/@google-cloud/pubsub/node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13573,9 +13573,9 @@
       }
     },
     "node_modules/google-gax/node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
Resolves the two open high-severity Dependabot alerts (#105, #106) on the default branch.

## What
`@grpc/grpc-js` had two high-severity advisories in range `>=1.14.0 <1.14.4`:
- A malformed **compressed** message can crash a client/server
- A malformed **request** can crash a server

Both affected transitive copies bump `1.14.3 → 1.14.4`:
- via `firebase-admin` → `@google-cloud/firestore` → `google-gax`
- via `firebase-tools` → `@google-cloud/pubsub`

The `1.9.16` copy under `@firebase/firestore` is **not** in the vulnerable range and is untouched.

## Verification
- Lockfile-only change (`package.json` unchanged — patch bump within existing semver ranges)
- `npm audit` → 0 vulnerabilities
- `npm run build` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)