### PR TITLE
release: develop→main — @grpc/grpc-js 1.14.4 security fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2940,9 +2940,9 @@
       }
     },
     "node_modules/@google-cloud/pubsub/node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13573,9 +13573,9 @@
       }
     },
     "node_modules/google-gax/node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
Release of `develop` → `main`. Single security fix, lockfile-only.

## Included
- **#1608** — fix(deps): bump @grpc/grpc-js to 1.14.4 — resolves 2 high-severity Dependabot alerts (malformed compressed-message / malformed-request server crash); transitive bump 1.14.3→1.14.4 via google-gax and @google-cloud/pubsub (@Ludwitt)

## Verification
- `npm audit` → 0 vulnerabilities
- `npm run build` passed
- Full CI green on #1608 (DCO, lint/typecheck, tests, E2E, CodeQL, dependency-review)
- No app/UI surface (package-lock.json only), so no visual QA loop applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)