### PR TITLE
feat(cohort): Hult Cohort Developer Program launch popup, banner + announcement email scripts

### DIFF
--- a/__tests__/components/SummerCohortModal.test.tsx
+++ b/__tests__/components/SummerCohortModal.test.tsx
@@ -61,8 +61,20 @@ describe("SummerCohortModal", () => {
   it("auto-opens on first visit (no localStorage flag for today)", async () => {
     render(<SummerCohortModal />);
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
-    // Logged-out new visitor sees the cohort-targeted headline.
-    expect(screen.getByRole("heading", { name: /Join Cohort 2/i })).toBeInTheDocument();
+    // Every visitor sees the Hult launch headline.
+    expect(
+      screen.getByRole("heading", { name: /Hult Cohort Developer Program/i })
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the Hult launch message and July 9 start date", async () => {
+    render(<SummerCohortModal />);
+    await screen.findByRole("dialog");
+    expect(screen.getByText(/Launching soon/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Hult International Business School/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Thursday, July 9/i)).toBeInTheDocument();
   });
 
   it("does not auto-open if today's date is already stored", () => {
@@ -72,10 +84,10 @@ describe("SummerCohortModal", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("does not auto-open on suppressed pathnames (/summer-cohort)", () => {
+  it("now auto-opens on /summer-cohort (Hult transition surfaces it everywhere)", async () => {
     mockUsePathname.mockReturnValue("/summer-cohort");
     render(<SummerCohortModal />);
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
   });
 
   it("does not auto-open on /contribute/game-art", () => {
@@ -95,18 +107,10 @@ describe("SummerCohortModal", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("renders both cohort rows; cohort 1 marked Closed", async () => {
+  it("logged-out users get a Create-account-and-register primary CTA pointing to /signup with redirect", async () => {
     render(<SummerCohortModal />);
     await screen.findByRole("dialog");
-    expect(screen.getByText("Cohort 1")).toBeInTheDocument();
-    expect(screen.getByText("Cohort 2")).toBeInTheDocument();
-    expect(screen.getByText("Closed")).toBeInTheDocument();
-  });
-
-  it("logged-out users get a Create-account-and-apply primary CTA pointing to /signup with redirect", async () => {
-    render(<SummerCohortModal />);
-    await screen.findByRole("dialog");
-    const cta = screen.getByRole("link", { name: /create account.*apply/i });
+    const cta = screen.getByRole("link", { name: /create account.*register/i });
     expect(cta).toHaveAttribute(
       "href",
       "/signup?redirect=%2Fsummer-cohort"
@@ -123,26 +127,6 @@ describe("SummerCohortModal", () => {
     );
   });
 
-  it("includes the May 26 immersion link as an external link", async () => {
-    render(<SummerCohortModal />);
-    await screen.findByRole("dialog");
-    const link = screen.getByRole("link", {
-      name: /Hult \/ Cursor Boston immersion/i,
-    });
-    expect(link).toHaveAttribute("href", expect.stringContaining("luma.com"));
-    expect(link).toHaveAttribute("target", "_blank");
-    expect(link).toHaveAttribute("rel", "noopener noreferrer");
-  });
-
-  it("includes the designer-contribute internal link", async () => {
-    render(<SummerCohortModal />);
-    await screen.findByRole("dialog");
-    const link = screen.getByRole("link", {
-      name: /Contribute art to the game/i,
-    });
-    expect(link).toHaveAttribute("href", "/contribute/game-art");
-  });
-
   it("renders the explore-the-community footer chips (Discord, Events, PR Ideas)", async () => {
     render(<SummerCohortModal />);
     await screen.findByRole("dialog");
@@ -154,7 +138,7 @@ describe("SummerCohortModal", () => {
     expect(screen.getByRole("link", { name: /pr ideas/i })).toHaveAttribute("href", "/pr-ideas");
   });
 
-  it("logged-in user without an application gets a single Apply CTA (no Create-account button)", async () => {
+  it("logged-in user without an application gets a Register-for-Cohort-2 CTA (no Create-account button)", async () => {
     const fakeUser = {
       getIdToken: jest.fn().mockResolvedValue("fake-token"),
     } as unknown as {
@@ -171,19 +155,20 @@ describe("SummerCohortModal", () => {
 
     render(<SummerCohortModal />);
     await waitFor(() => {
-      expect(screen.getByRole("link", { name: /^apply/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /register for cohort 2/i })
+      ).toBeInTheDocument();
     });
-    expect(screen.getByRole("link", { name: /^apply/i })).toHaveAttribute(
-      "href",
-      "/summer-cohort"
-    );
+    expect(
+      screen.getByRole("link", { name: /register for cohort 2/i })
+    ).toHaveAttribute("href", "/summer-cohort");
     // Logged-in path no longer surfaces the create-account fork.
     expect(
       screen.queryByRole("link", { name: /create account/i })
     ).not.toBeInTheDocument();
   });
 
-  it("swaps CTA to View-your-cohort when the user has already applied", async () => {
+  it("shows a registered confirmation (no register CTA) when the user has already applied", async () => {
     const fakeUser = {
       getIdToken: jest.fn().mockResolvedValue("fake-token"),
     } as unknown as {
@@ -200,13 +185,15 @@ describe("SummerCohortModal", () => {
 
     render(<SummerCohortModal />);
     await waitFor(() => {
+      // Match without the apostrophe (rendered as a curly &rsquo;).
       expect(
-        screen.getByRole("link", { name: /View your cohort/i })
+        screen.getByText(/registered for Cohort 2/i)
       ).toBeInTheDocument();
     });
+    // Registered users no longer see a register/apply CTA.
     expect(
-      screen.getByRole("link", { name: /View your cohort/i })
-    ).toHaveAttribute("href", "/summer-cohort");
+      screen.queryByRole("link", { name: /register for cohort 2/i })
+    ).not.toBeInTheDocument();
   });
 
   it("closes and writes today's date on close", async () => {
@@ -214,7 +201,7 @@ describe("SummerCohortModal", () => {
     render(<SummerCohortModal />);
     await screen.findByRole("dialog");
     await user.click(
-      screen.getByRole("button", { name: /close summer cohort/i })
+      screen.getByRole("button", { name: /close cohort announcement/i })
     );
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       SUMMER_COHORT_LOCALSTORAGE_KEY,

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -885,6 +885,53 @@ function SummerCohortPageInner() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      {/* Hult transition banner — every cohort surface signals the launch. */}
+      <section className="mb-8 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-5 dark:bg-emerald-500/10">
+        <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+          Launching soon
+        </p>
+        <h2 className="mt-1 text-lg font-bold md:text-xl">
+          The Hult Cohort Developer Program
+        </h2>
+        <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+          Cursor Boston has teamed up with{" "}
+          <span className="font-medium text-neutral-900 dark:text-neutral-100">
+            Hult International Business School
+          </span>
+          —Cohort 2 is becoming the inaugural pilot of the new Hult Cohort
+          Developer Program. We&rsquo;re putting the finishing touches on the new
+          platform; lots more info is coming over the next two weeks.
+        </p>
+        <p className="mt-3 inline-flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-1.5 text-sm font-semibold text-emerald-800 dark:text-emerald-200">
+          Be ready to start: Thursday, July 9
+        </p>
+        {application ? (
+          <p className="mt-3 flex items-start gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-300">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="mt-0.5 shrink-0"
+              aria-hidden="true"
+            >
+              <path d="M20 6L9 17l-5-5" />
+            </svg>
+            You&rsquo;re registered — you&rsquo;ll receive all the email updates from
+            Cursor Boston as we finalize the details. Nothing else to do right now.
+          </p>
+        ) : (
+          <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-300">
+            Register for Cohort 2 below to lock in your spot in the pilot and get
+            every update by email.
+          </p>
+        )}
+      </section>
       {showTabs ? (
         <SetupReadinessModal
           cohortLabel={runtime.label}

--- a/components/SummerCohortModal.tsx
+++ b/components/SummerCohortModal.tsx
@@ -7,20 +7,21 @@
 
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { DiscordIcon } from "@/components/icons";
 import { Modal } from "@/components/ui/Modal";
 import {
-  SUMMER_COHORTS,
-  SUMMER_COHORT_IMMERSION,
   SUMMER_COHORT_LOCALSTORAGE_KEY,
   SUMMER_COHORT_OPEN_EVENT,
   SUMMER_COHORT_RETURN_TO,
   SUMMER_COHORT_VIEW_TO,
 } from "@/lib/summer-cohort";
+
+// Tentative kickoff for the Hult Cohort Developer Program pilot (Cohort 2).
+const START_LABEL = "Thursday, July 9";
 
 function todayKey(): string {
   return new Date().toISOString().slice(0, 10);
@@ -28,15 +29,16 @@ function todayKey(): string {
 
 // Pages that already cover the modal's content — don't auto-pop on top of
 // them. Manual dispatch of SUMMER_COHORT_OPEN_EVENT still works.
+// NOTE: /summer-cohort is intentionally NOT suppressed during the Hult
+// transition — every cohort surface should surface the launch message.
 const SUPPRESS_AUTO_OPEN_PREFIXES = [
-  "/summer-cohort",
   "/contribute/game-art",
   "/login",
   "/signup",
 ];
 
 // Cap the wait for the "have you applied?" fetch before opening anyway.
-// Keeps the modal snappy if the API is slow; the CTA defaults to "Apply".
+// Keeps the modal snappy if the API is slow; the CTA defaults to "register".
 const APPLIED_FETCH_TIMEOUT_MS = 600;
 
 export default function SummerCohortModal() {
@@ -128,26 +130,13 @@ export default function SummerCohortModal() {
     setIsOpen(false);
   }, []);
 
-  // Open cohorts only — what a brand new applicant can actually join.
-  // Closed cohorts still render in the list (greyed) so the modal accurately
-  // reflects the program shape, but the CTAs target the open cohort.
-  const openCohort = useMemo(
-    () => SUMMER_COHORTS.find((c) => !c.signupsClosed) ?? null,
-    []
-  );
-
-  // CTA strategy:
-  //   - Already applied        → "View your cohort" (single primary)
-  //   - Logged in, not applied → "Apply" (single primary, jumps to form)
-  //   - Logged out             → "Create account & apply" (primary)
-  //                              + small "Already have an account? Sign in"
-  const applyHref = hasApplied ? SUMMER_COHORT_VIEW_TO : SUMMER_COHORT_RETURN_TO;
-  const signedInPrimaryLabel = hasApplied ? "View your cohort" : "Apply";
+  const isLoggedOut = !user && !authLoading;
+  const isRegistered = hasApplied === true;
+  // Registered users land on their details/view; everyone else heads to the
+  // apply form, which still registers them for Cohort 2.
+  const registerHref = isRegistered ? SUMMER_COHORT_VIEW_TO : SUMMER_COHORT_RETURN_TO;
   const newUserPrimaryHref = `/signup?redirect=${encodeURIComponent(SUMMER_COHORT_RETURN_TO)}`;
   const newUserSecondaryHref = `/login?redirect=${encodeURIComponent(SUMMER_COHORT_RETURN_TO)}`;
-  const isLoggedOut = !user && !authLoading;
-  // Modal headline reflects the next cohort actually open for signups.
-  const headlineCohortLabel = openCohort?.label ?? "Cursor Boston Summer Cohort";
 
   return (
     <Modal
@@ -155,126 +144,90 @@ export default function SummerCohortModal() {
       onClose={handleClose}
       size="md"
       titleId="summer-cohort-title"
-      closeButtonLabel="Close summer cohort message"
+      closeButtonLabel="Close cohort announcement"
     >
-        <div className="text-center">
-          <div className="w-16 h-16 bg-emerald-500/15 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="32"
-              height="32"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.75"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-emerald-400"
-              aria-hidden="true"
-            >
-              <circle cx="12" cy="12" r="4" />
-              <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-            </svg>
-          </div>
-
-          <h2
-            id="summer-cohort-title"
-            className="text-2xl font-bold text-white mb-2"
+      <div className="text-center">
+        <div className="w-16 h-16 bg-emerald-500/15 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-emerald-400"
+            aria-hidden="true"
           >
-            {hasApplied
-              ? "Cursor Boston Summer Cohort"
-              : `Join ${headlineCohortLabel}`}
-          </h2>
-          <p className="text-neutral-400 mb-6">
-            {hasApplied
-              ? "Two six-week sessions to build with Cursor alongside other Boston developers, founders, and students."
-              : openCohort
-                ? `Six weeks building with Cursor alongside other Boston developers, founders, and students. Kicks off ${openCohort.startLabel}.`
-                : "Two six-week sessions to build with Cursor alongside other Boston developers, founders, and students."}
-          </p>
+            <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+            <path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+            <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+          </svg>
+        </div>
 
-          <ul className="space-y-2 mb-6 text-left">
-            {SUMMER_COHORTS.map((cohort) => {
-              const closed = cohort.signupsClosed === true;
-              return (
-                <li
-                  key={cohort.id}
-                  className={`flex items-center justify-between gap-3 px-4 py-3 rounded-lg border ${
-                    closed
-                      ? "bg-neutral-900/40 border-neutral-800 opacity-70"
-                      : "bg-neutral-800/60 border-neutral-700"
-                  }`}
-                >
-                  <span
-                    className={`text-sm font-semibold ${
-                      closed ? "text-neutral-400" : "text-white"
-                    }`}
-                  >
-                    {cohort.label}
-                  </span>
-                  <span className="flex items-center gap-2">
-                    <span
-                      className={`text-xs ${
-                        closed ? "text-neutral-500" : "text-neutral-300"
-                      }`}
-                    >
-                      {cohort.startLabel} – {cohort.endLabel}
-                    </span>
-                    {closed ? (
-                      <span className="text-[10px] uppercase tracking-wide font-semibold px-2 py-0.5 rounded-full border border-neutral-700 text-neutral-400">
-                        Closed
-                      </span>
-                    ) : null}
-                  </span>
-                </li>
-              );
-            })}
-          </ul>
+        <p className="text-xs uppercase tracking-wider text-emerald-400 font-semibold mb-2">
+          Launching soon
+        </p>
+        <h2 id="summer-cohort-title" className="text-2xl font-bold text-white mb-3">
+          The Hult Cohort Developer Program
+        </h2>
+        <p className="text-neutral-400 mb-5">
+          Cursor Boston has teamed up with{" "}
+          <span className="text-neutral-200 font-medium">
+            Hult International Business School
+          </span>
+          —Cohort 2 is becoming the inaugural pilot of the new Hult Cohort
+          Developer Program. We&rsquo;re putting the finishing touches on the new
+          platform, and lots more info is coming over the next two weeks.
+        </p>
 
-          {/* Primary CTA. Logged-out new visitors get the create-account
-              path so they don't have to discover the "Sign up" link buried
-              at the bottom of /login. */}
-          {isLoggedOut ? (
-            <>
-              <Link
-                href={newUserPrimaryHref}
-                onClick={handleClose}
-                className="flex items-center justify-center gap-2 w-full px-4 py-3 bg-emerald-500 text-white rounded-lg font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+        <div className="mb-6 px-4 py-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10">
+          <span className="block text-xs uppercase tracking-wide text-emerald-300 font-semibold">
+            Be ready to start
+          </span>
+          <span className="block text-lg font-bold text-white">{START_LABEL}</span>
+        </div>
+
+        {isRegistered ? (
+          <div className="px-4 py-4 rounded-lg border border-emerald-500/30 bg-emerald-500/10 text-left">
+            <p className="flex items-start gap-2 text-emerald-200 font-semibold">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="shrink-0 mt-0.5 text-emerald-400"
+                aria-hidden="true"
               >
-                Create account &amp; apply
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M5 12h14M13 5l7 7-7 7" />
-                </svg>
-              </Link>
-              <p className="mt-3 text-xs text-neutral-400">
-                Already have an account?{" "}
-                <Link
-                  href={newUserSecondaryHref}
-                  onClick={handleClose}
-                  className="font-semibold text-emerald-400 hover:text-emerald-300 underline-offset-2 hover:underline"
-                >
-                  Sign in
-                </Link>
-              </p>
-            </>
-          ) : (
+                <path d="M20 6L9 17l-5-5" />
+              </svg>
+              You&rsquo;re registered for Cohort 2.
+            </p>
+            <p className="mt-2 text-sm text-neutral-300">
+              Nothing else to do right now — you&rsquo;ll receive all the email
+              updates from Cursor Boston as we finalize the details. Just be ready
+              to start on {START_LABEL}.
+            </p>
+          </div>
+        ) : isLoggedOut ? (
+          <>
+            <p className="text-sm text-neutral-300 mb-3">
+              Register for Cohort 2 to lock in your spot in the pilot and get
+              every update by email.
+            </p>
             <Link
-              href={applyHref}
+              href={newUserPrimaryHref}
               onClick={handleClose}
               className="flex items-center justify-center gap-2 w-full px-4 py-3 bg-emerald-500 text-white rounded-lg font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
             >
-              {signedInPrimaryLabel}
+              Create account &amp; register
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
@@ -290,148 +243,121 @@ export default function SummerCohortModal() {
                 <path d="M5 12h14M13 5l7 7-7 7" />
               </svg>
             </Link>
-          )}
+            <p className="mt-3 text-xs text-neutral-400">
+              Already have an account?{" "}
+              <Link
+                href={newUserSecondaryHref}
+                onClick={handleClose}
+                className="font-semibold text-emerald-400 hover:text-emerald-300 underline-offset-2 hover:underline"
+              >
+                Sign in
+              </Link>
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-neutral-300 mb-3">
+              Register for Cohort 2 so you receive all the email updates and your
+              spot in the pilot is confirmed.
+            </p>
+            <Link
+              href={registerHref}
+              onClick={handleClose}
+              className="flex items-center justify-center gap-2 w-full px-4 py-3 bg-emerald-500 text-white rounded-lg font-semibold hover:bg-emerald-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+            >
+              Register for Cohort 2
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14M13 5l7 7-7 7" />
+              </svg>
+            </Link>
+          </>
+        )}
 
-          <div className="mt-5 space-y-2 text-left">
+        {/* Community-discovery footer — folks who want to lurk first still get
+            a path into Discord, Events, and the PR-ideas explorer. */}
+        <div className="mt-6 pt-5 border-t border-neutral-800">
+          <p className="text-xs uppercase tracking-wider text-neutral-500 font-semibold mb-3 text-left">
+            Or just explore the community
+          </p>
+          <div className="grid grid-cols-3 gap-2">
             <a
-              href={SUMMER_COHORT_IMMERSION.lumaUrl}
+              href="https://discord.gg/Wsncg8YYqc"
               target="_blank"
               rel="noopener noreferrer"
-              onClick={handleClose}
-              className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-neutral-800 bg-neutral-800/40 hover:bg-neutral-800/70 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+              className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 rounded-lg border border-neutral-800 bg-neutral-800/30 hover:bg-neutral-800/60 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]"
             >
-              <span className="min-w-0">
-                <span className="block text-xs uppercase tracking-wide text-emerald-400 font-semibold">
-                  {SUMMER_COHORT_IMMERSION.label}
-                </span>
-                <span className="block text-sm text-white truncate">
-                  {SUMMER_COHORT_IMMERSION.title}
-                </span>
-              </span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="text-neutral-400 shrink-0"
-                aria-hidden="true"
-              >
-                <path d="M7 17L17 7M7 7h10v10" />
-              </svg>
+              <DiscordIcon size={18} className="text-[#7983f5]" />
+              <span className="text-xs font-medium text-neutral-200">Discord</span>
             </a>
-
             <Link
-              href="/contribute/game-art"
+              href="/events"
               onClick={handleClose}
-              className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-neutral-800 bg-neutral-800/40 hover:bg-neutral-800/70 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+              className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 rounded-lg border border-neutral-800 bg-neutral-800/30 hover:bg-neutral-800/60 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
             >
-              <span className="min-w-0">
-                <span className="block text-xs uppercase tracking-wide text-violet-300 font-semibold">
-                  Designers
-                </span>
-                <span className="block text-sm text-white truncate">
-                  Contribute art to the game
-                </span>
-              </span>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
+                width="18"
+                height="18"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className="text-neutral-400 shrink-0"
+                className="text-neutral-300"
                 aria-hidden="true"
               >
-                <path d="M5 12h14M13 5l7 7-7 7" />
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
               </svg>
+              <span className="text-xs font-medium text-neutral-200">Events</span>
+            </Link>
+            <Link
+              href="/pr-ideas"
+              onClick={handleClose}
+              className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 rounded-lg border border-neutral-800 bg-neutral-800/30 hover:bg-neutral-800/60 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-neutral-300"
+                aria-hidden="true"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                <path d="M9 9h6v6H9z" />
+              </svg>
+              <span className="text-xs font-medium text-neutral-200">PR Ideas</span>
             </Link>
           </div>
-
-          {/* Community-discovery footer — replaces the old standalone
-              welcome modal. Compact chips so the cohort CTA stays the
-              hero, but folks who want to lurk first still get a path
-              into Discord, Events, and the PR-ideas explorer. */}
-          <div className="mt-6 pt-5 border-t border-neutral-800">
-            <p className="text-xs uppercase tracking-wider text-neutral-500 font-semibold mb-3 text-left">
-              Or just explore the community
-            </p>
-            <div className="grid grid-cols-3 gap-2">
-              <a
-                href="https://discord.gg/Wsncg8YYqc"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 rounded-lg border border-neutral-800 bg-neutral-800/30 hover:bg-neutral-800/60 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5865F2]"
-              >
-                <DiscordIcon size={18} className="text-[#7983f5]" />
-                <span className="text-xs font-medium text-neutral-200">Discord</span>
-              </a>
-              <Link
-                href="/events"
-                onClick={handleClose}
-                className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 rounded-lg border border-neutral-800 bg-neutral-800/30 hover:bg-neutral-800/60 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="text-neutral-300"
-                  aria-hidden="true"
-                >
-                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-                  <line x1="16" y1="2" x2="16" y2="6" />
-                  <line x1="8" y1="2" x2="8" y2="6" />
-                  <line x1="3" y1="10" x2="21" y2="10" />
-                </svg>
-                <span className="text-xs font-medium text-neutral-200">Events</span>
-              </Link>
-              <Link
-                href="/pr-ideas"
-                onClick={handleClose}
-                className="flex flex-col items-center justify-center gap-1.5 px-2 py-3 rounded-lg border border-neutral-800 bg-neutral-800/30 hover:bg-neutral-800/60 hover:border-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="text-neutral-300"
-                  aria-hidden="true"
-                >
-                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                  <path d="M9 9h6v6H9z" />
-                </svg>
-                <span className="text-xs font-medium text-neutral-200">PR Ideas</span>
-              </Link>
-            </div>
-          </div>
-
-          <button
-            onClick={handleClose}
-            className="mt-4 text-neutral-500 hover:text-neutral-300 text-sm transition-colors focus-visible:outline-none focus-visible:text-white focus-visible:underline"
-          >
-            Maybe later
-          </button>
         </div>
+
+        <button
+          onClick={handleClose}
+          className="mt-4 text-neutral-500 hover:text-neutral-300 text-sm transition-colors focus-visible:outline-none focus-visible:text-white focus-visible:underline"
+        >
+          Maybe later
+        </button>
+      </div>
     </Modal>
   );
 }

--- a/scripts/count-cohort2-signups.ts
+++ b/scripts/count-cohort2-signups.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Read-only: count Cohort 2 signups (docs whose `cohorts` includes "cohort-2")
+ * broken down by status. No writes.
+ *
+ *   npx tsx scripts/count-cohort2-signups.ts
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { SUMMER_COHORT_COLLECTION } from "../lib/summer-cohort";
+
+async function main(): Promise<void> {
+  const db = getAdminDb();
+  if (!db) {
+    console.error("Firebase Admin not configured.");
+    process.exit(1);
+  }
+
+  const snap = await db.collection(SUMMER_COHORT_COLLECTION).get();
+  let totalDocs = 0;
+  let cohort2 = 0;
+  const byStatus: Record<string, number> = {};
+
+  for (const doc of snap.docs) {
+    totalDocs++;
+    const d = doc.data() as { cohorts?: string[]; status?: string };
+    const cohorts = Array.isArray(d.cohorts) ? d.cohorts : [];
+    if (!cohorts.includes("cohort-2")) continue;
+    cohort2++;
+    const status = d.status ?? "pending";
+    byStatus[status] = (byStatus[status] ?? 0) + 1;
+  }
+
+  console.log(`Collection scanned: ${SUMMER_COHORT_COLLECTION} (${totalDocs} total docs)`);
+  console.log(`\nCohort 2 signups (cohorts includes "cohort-2"): ${cohort2}`);
+  console.log(`\nBreakdown by status:`);
+  for (const [status, n] of Object.entries(byStatus).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${status.padEnd(12)} ${n}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort1-hult-c2-invite.ts
+++ b/scripts/send-cohort1-hult-c2-invite.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Send the Hult / Cohort 2 announcement to Cohort 1 participants who are NOT
+ * registered for Cohort 2, with a call-to-action to sign up for Cohort 2 on
+ * cursorboston.com so they keep getting updates. Same core news as
+ * send-cohort2-hult-announcement.ts, but the "your spot carries over"
+ * logistics are replaced with a sign-up CTA (these people are not enrolled).
+ *
+ * Filters:
+ *   - cohorts includes "cohort-1" AND does NOT include "cohort-2"
+ *   - status === "admitted" (skips withdrawn/etc — i.e. actual participants)
+ *
+ * Idempotency:
+ *   - on successful send, stamps `cohort1HultC2InviteEmailedAt` on the
+ *     application doc; re-runs skip anyone already stamped (override with --force).
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort1-hult-c2-invite.ts --dry-run
+ *   npx tsx scripts/send-cohort1-hult-c2-invite.ts --send
+ *   npx tsx scripts/send-cohort1-hult-c2-invite.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION, isValidCohortId } from "../lib/summer-cohort";
+
+const SUBJECT =
+  "Big news for Cohort 2 — we've teamed up with Hult International Business School";
+const SIGNUP_URL = "https://cursorboston.com/summer-cohort";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  name: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.name?.split(" ")[0]?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Some big news from Cursor Boston — and a chance for you to be part of what&rsquo;s next.</p>
+
+<p style="margin:16px 0;padding:14px 16px;background:#ecfdf5;border-left:4px solid #10b981;border-radius:6px;">
+  <strong>Cursor Boston is teaming up with Hult International Business School — and Cohort 2 will run as the inaugural pilot of the new Hult Cohort Developer Program.</strong>
+</p>
+
+<p>You were part of <strong>Cohort 1</strong> — thank you. Cohort 2 is shaping up to be bigger and more ambitious, and we&rsquo;d love to have you in it.</p>
+
+<p><strong>What&rsquo;s in it:</strong></p>
+
+<ul>
+  <li><strong>A bigger, more ambitious program.</strong> The pilot brings together 300+ students and professionals in a learning environment built for the agentic economy — building real software with AI, collaborating in public through GitHub, reviewing peers&rsquo; work, and making real product decisions.</li>
+  <li><strong>Led by Professor Anusha Vissapragada</strong>, academic director for Computer Science for Business at Hult Boston — recently named by <em>Poets&amp;Quants</em> as one of the 50 Best Undergraduate Business Professors of 2025.</li>
+  <li><strong>A certificate of completion from both Hult and Cursor Boston</strong> when you finish.</li>
+  <li><strong>A pathway to college credit.</strong> This summer pilot lays the groundwork for the fall semester, where students will be able to take a cohort for actual college credit.</li>
+  <li><strong>Job placement support.</strong> We&rsquo;re building a team of placement specialists to help participants find roles during and after the program. More on this soon.</li>
+</ul>
+
+<p style="margin:18px 0;padding:14px 16px;background:#eff6ff;border-left:4px solid #3b82f6;border-radius:6px;">
+  <strong>You&rsquo;re not registered for Cohort 2 yet.</strong> Sign up on Cursor Boston to join Cohort 2 and keep getting updates — we&rsquo;re now planning to kick off <strong>Thursday, July 9</strong>, with lots of detail coming over the next two weeks.
+</p>
+
+<p style="margin-top:20px;">
+  <a href="${SIGNUP_URL}" style="display:inline-block;background:#10b981;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Sign up for Cohort 2 →</a>
+</p>
+<p style="font-size:14px;color:#6b7280;"><a href="${SIGNUP_URL}" style="color:#065f46;">${SIGNUP_URL}</a></p>
+
+<p>Thank you for being part of Cursor Boston — we&rsquo;d love to build with you again.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&rsquo;re receiving this because you were a Cohort 1 participant.<br/>
+Don&rsquo;t want any emails from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a>.
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+Some big news from Cursor Boston — and a chance for you to be part of what's next.
+
+CURSOR BOSTON IS TEAMING UP WITH HULT INTERNATIONAL BUSINESS SCHOOL — and Cohort 2 will run as the inaugural pilot of the new Hult Cohort Developer Program.
+
+You were part of Cohort 1 — thank you. Cohort 2 is shaping up to be bigger and more ambitious, and we'd love to have you in it.
+
+WHAT'S IN IT:
+
+- A bigger, more ambitious program. The pilot brings together 300+ students and professionals in a learning environment built for the agentic economy — building real software with AI, collaborating in public through GitHub, reviewing peers' work, and making real product decisions.
+- Led by Professor Anusha Vissapragada, academic director for Computer Science for Business at Hult Boston — recently named by Poets&Quants as one of the 50 Best Undergraduate Business Professors of 2025.
+- A certificate of completion from both Hult and Cursor Boston when you finish.
+- A pathway to college credit. This summer pilot lays the groundwork for the fall semester, where students will be able to take a cohort for actual college credit.
+- Job placement support. We're building a team of placement specialists to help participants find roles during and after the program. More on this soon.
+
+YOU'RE NOT REGISTERED FOR COHORT 2 YET. Sign up on Cursor Boston to join Cohort 2 and keep getting updates — we're now planning to kick off THURSDAY, JULY 9, with lots of detail coming over the next two weeks.
+
+Sign up for Cohort 2: ${SIGNUP_URL}
+
+Thank you for being part of Cursor Boston — we'd love to build with you again.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you were a Cohort 1 participant.
+Unsubscribe from emails: ${unsubUrl}`;
+
+  return { subject: SUBJECT, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  const force = args.includes("--force");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Loading applications from ${SUMMER_COHORT_COLLECTION}…`);
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotAdmitted = 0;
+  let skippedNotC1 = 0;
+  let skippedInC2 = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    const cohorts = Array.isArray(data.cohorts)
+      ? data.cohorts.filter(isValidCohortId)
+      : [];
+    if (!cohorts.includes("cohort-1")) {
+      skippedNotC1++;
+      continue;
+    }
+    if (cohorts.includes("cohort-2")) {
+      skippedInC2++;
+      continue;
+    }
+    if (data.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!force && data.cohort1HultC2InviteEmailedAt) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+
+    recipients.push({
+      applicationId: doc.id,
+      email,
+      name: typeof data.name === "string" ? data.name : "",
+    });
+  }
+
+  console.log(
+    `Eligible to email: ${recipients.length} | already emailed: ${skippedAlreadyEmailed} | not admitted: ${skippedNotAdmitted} | already in cohort-2: ${skippedInC2} | not cohort-1: ${skippedNotC1} | no email: ${skippedNoEmail}`
+  );
+
+  if (recipients.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, text } = buildEmail(sample);
+      console.log("============================================================");
+      console.log("SAMPLE");
+      console.log("============================================================");
+      console.log(`To:      ${sample.email} (${sample.name || "(no name)"})`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- TEXT BODY ----\n${text}\n`);
+    }
+    console.log("All recipients:");
+    for (const r of recipients) console.log(`  ${r.email.padEnd(40)} ${r.name}`);
+    console.log(`\nWould send to ${recipients.length} cohort-1 (not cohort-2) admits.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const recipient of recipients) {
+    const { subject, html, text } = buildEmail(recipient);
+    try {
+      await sendEmail({ to: recipient.email, subject, html, text });
+      sent++;
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(recipient.applicationId).set(
+        { cohort1HultC2InviteEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${recipient.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/send-cohort2-hult-announcement.ts
+++ b/scripts/send-cohort2-hult-announcement.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Announce to Cohort 2 admits that Cursor Boston has teamed up with Hult
+ * International Business School and Cohort 2 will run as the inaugural pilot of
+ * the Hult Cohort Developer Program. Communicates: new tentative start date
+ * (Thu, Jul 9, moved from Jun 29), dual Hult + Cursor Boston certificate, fall
+ * college-credit pathway, forthcoming job-placement support, and that lots more
+ * detail is coming over the next two weeks. Deliberately does NOT include the
+ * pilot website URL (not public yet).
+ *
+ * Filters:
+ *   - cohort-2 only (must include "cohort-2" in `cohorts`)
+ *   - status === "admitted" (skips pending/withdrawn/rejected/waitlist)
+ *
+ * Idempotency:
+ *   - on successful send, stamps `cohort2HultAnnouncementEmailedAt` on the
+ *     application doc; re-runs skip anyone already stamped (override with --force).
+ *
+ * Usage:
+ *   npx tsx scripts/send-cohort2-hult-announcement.ts --dry-run
+ *   npx tsx scripts/send-cohort2-hult-announcement.ts --send
+ *   npx tsx scripts/send-cohort2-hult-announcement.ts --send --force
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN
+ */
+import { loadEnvConfig } from "@next/env";
+loadEnvConfig(process.cwd());
+
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+import { SUMMER_COHORT_COLLECTION, isValidCohortId } from "../lib/summer-cohort";
+
+const SUBJECT =
+  "Big news for Cohort 2 — we've teamed up with Hult International Business School";
+
+interface Recipient {
+  applicationId: string;
+  email: string;
+  name: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.name?.split(" ")[0]?.trim() || "there");
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Some big news, and we&rsquo;re genuinely excited to share it.</p>
+
+<p style="margin:16px 0;padding:14px 16px;background:#ecfdf5;border-left:4px solid #10b981;border-radius:6px;">
+  <strong>Cursor Boston is teaming up with Hult International Business School — and Cohort 2 will run as the inaugural pilot of the new Hult Cohort Developer Program.</strong> You&rsquo;re part of the very first group to go through it.
+</p>
+
+<p><strong>What this means for you:</strong></p>
+
+<ul>
+  <li><strong>A bigger, more ambitious program.</strong> The pilot brings together 300+ students and professionals in a learning environment built for the agentic economy — building real software with AI, collaborating in public through GitHub, reviewing peers&rsquo; work, and making real product decisions. The core of what you signed up for stays exactly the same; it&rsquo;s just getting a lot more behind it.</li>
+  <li><strong>Led by Professor Anusha Vissapragada</strong>, academic director for Computer Science for Business at Hult Boston — recently named by <em>Poets&amp;Quants</em> as one of the 50 Best Undergraduate Business Professors of 2025.</li>
+  <li><strong>A certificate of completion from both Hult and Cursor Boston</strong> when you finish.</li>
+  <li><strong>A pathway to college credit.</strong> This summer pilot lays the groundwork for the fall semester, where students will be able to take a cohort for actual college credit.</li>
+  <li><strong>Job placement support.</strong> We&rsquo;re building a team of placement specialists to help participants find roles during and after the program. More on this soon.</li>
+</ul>
+
+<p><strong>A couple of logistics:</strong></p>
+
+<ul>
+  <li><strong>New start date:</strong> we&rsquo;re now planning to kick off <strong>Thursday, July 9</strong> (moved from the original June 29). We&rsquo;ll confirm the final schedule shortly.</li>
+  <li><strong>Nothing you need to do right now.</strong> Your spot carries over automatically.</li>
+  <li><strong>Lots of information is on the way.</strong> Over the <strong>next two weeks</strong> we&rsquo;ll be sending details on the schedule, the platform, onboarding, the certificate, and everything else you&rsquo;ll need to hit the ground running.</li>
+</ul>
+
+<p>Thank you for being part of this — you&rsquo;re joining at the start of something that&rsquo;s about to get a lot bigger.</p>
+
+<p>— Roger &amp; Cursor Boston<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a><br/>
+<a href="https://cursorboston.com">https://cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&rsquo;re receiving this because you&rsquo;re an admitted Cohort 2 participant.<br/>
+Don&rsquo;t want any emails from us? <a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe</a> (this just stops emails; it doesn&rsquo;t remove you from the cohort).
+</p>
+</body></html>`;
+
+  const text = `Hi ${r.name?.split(" ")[0]?.trim() || "there"},
+
+Some big news, and we're genuinely excited to share it.
+
+CURSOR BOSTON IS TEAMING UP WITH HULT INTERNATIONAL BUSINESS SCHOOL — and Cohort 2 will run as the inaugural pilot of the new Hult Cohort Developer Program. You're part of the very first group to go through it.
+
+WHAT THIS MEANS FOR YOU:
+
+- A bigger, more ambitious program. The pilot brings together 300+ students and professionals in a learning environment built for the agentic economy — building real software with AI, collaborating in public through GitHub, reviewing peers' work, and making real product decisions. The core of what you signed up for stays exactly the same; it's just getting a lot more behind it.
+- Led by Professor Anusha Vissapragada, academic director for Computer Science for Business at Hult Boston — recently named by Poets&Quants as one of the 50 Best Undergraduate Business Professors of 2025.
+- A certificate of completion from both Hult and Cursor Boston when you finish.
+- A pathway to college credit. This summer pilot lays the groundwork for the fall semester, where students will be able to take a cohort for actual college credit.
+- Job placement support. We're building a team of placement specialists to help participants find roles during and after the program. More on this soon.
+
+A COUPLE OF LOGISTICS:
+
+- New start date: we're now planning to kick off THURSDAY, JULY 9 (moved from the original June 29). We'll confirm the final schedule shortly.
+- Nothing you need to do right now. Your spot carries over automatically.
+- Lots of information is on the way. Over the next two weeks we'll be sending details on the schedule, the platform, onboarding, the certificate, and everything else you'll need to hit the ground running.
+
+Thank you for being part of this — you're joining at the start of something that's about to get a lot bigger.
+
+— Roger & Cursor Boston
+roger@cursorboston.com
+https://cursorboston.com
+
+You're receiving this because you're an admitted Cohort 2 participant.
+Unsubscribe from emails (doesn't remove you from the cohort): ${unsubUrl}`;
+
+  return { subject: SUBJECT, html, text };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const send = args.includes("--send");
+  const force = args.includes("--force");
+
+  if ((dryRun && send) || (!dryRun && !send)) {
+    console.error("Specify exactly one of: --dry-run | --send");
+    process.exit(1);
+  }
+  if (send && (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN)) {
+    console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+    process.exit(1);
+  }
+
+  const db = getAdminDb();
+  if (!db) {
+    console.error(
+      "Firebase Admin not configured (FIREBASE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS)."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Loading applications from ${SUMMER_COHORT_COLLECTION}…`);
+  const snap = await db
+    .collection(SUMMER_COHORT_COLLECTION)
+    .orderBy("createdAt", "asc")
+    .get();
+
+  const recipients: Recipient[] = [];
+  let skippedNotAdmitted = 0;
+  let skippedNotCohort2 = 0;
+  let skippedAlreadyEmailed = 0;
+  let skippedNoEmail = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const email = (data.email || "").toString().trim();
+    if (!email || !email.includes("@")) {
+      skippedNoEmail++;
+      continue;
+    }
+    const cohorts = Array.isArray(data.cohorts)
+      ? data.cohorts.filter(isValidCohortId)
+      : [];
+    if (!cohorts.includes("cohort-2")) {
+      skippedNotCohort2++;
+      continue;
+    }
+    if (data.status !== "admitted") {
+      skippedNotAdmitted++;
+      continue;
+    }
+    if (!force && data.cohort2HultAnnouncementEmailedAt) {
+      skippedAlreadyEmailed++;
+      continue;
+    }
+
+    recipients.push({
+      applicationId: doc.id,
+      email,
+      name: typeof data.name === "string" ? data.name : "",
+    });
+  }
+
+  console.log(
+    `Eligible to email: ${recipients.length} | already emailed: ${skippedAlreadyEmailed} | not admitted: ${skippedNotAdmitted} | not cohort-2: ${skippedNotCohort2} | no email: ${skippedNoEmail}`
+  );
+
+  if (recipients.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log("\n--dry-run: no emails sent.\n");
+    const sample = recipients[0];
+    if (sample) {
+      const { subject, html, text } = buildEmail(sample);
+      console.log("============================================================");
+      console.log("SAMPLE");
+      console.log("============================================================");
+      console.log(`To:      ${sample.email} (${sample.name || "(no name)"})`);
+      console.log(`Subject: ${subject}`);
+      console.log(`\n---- TEXT BODY ----\n${text}\n`);
+      console.log(`---- HTML PREVIEW (first 1800 chars) ----\n${html.slice(0, 1800)}\n…`);
+    }
+    console.log(`\nWould send to ${recipients.length} cohort-2 admits.`);
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const recipient of recipients) {
+    const { subject, html, text } = buildEmail(recipient);
+    try {
+      await sendEmail({ to: recipient.email, subject, html, text });
+      sent++;
+      await db.collection(SUMMER_COHORT_COLLECTION).doc(recipient.applicationId).set(
+        { cohort2HultAnnouncementEmailedAt: FieldValue.serverTimestamp() },
+        { merge: true }
+      );
+      if (sent % 10 === 0) {
+        console.log(`  Progress: ${sent}/${recipients.length}`);
+      }
+    } catch (e) {
+      failed++;
+      console.error(`Failed: ${recipient.email}`, e);
+    }
+    await sleep(450);
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Transitions the public cohort surfaces to the new **Hult Cohort Developer Program** pilot (Cohort 2), and adds the operational email scripts used to announce it.

## UI
- **`components/SummerCohortModal.tsx`** — repurposed the site-wide auto-popping modal into the Hult launch announcement (tentative start **Thu, Jul 9**). Stateful:
  - Not registered → **Register for Cohort 2** CTA (routes to the existing apply form, which still registers them).
  - Logged out → **Create account & register**.
  - Already registered → **"You're registered — you'll get email updates"** confirmation (no CTA).
  - Un-suppressed on `/summer-cohort` so the cohort page shows it too (game-art/login/signup stay suppressed). Removed stale May 26 immersion link + two-cohort list; kept Discord/Events/PR-Ideas explore row.
- **`app/summer-cohort/page.tsx`** — added a matching launch banner with the same registered/not-registered split.
- **Apply flow untouched** — still registers users for Cohort 2.
- Updated `SummerCohortModal` tests for the new copy/states (16/16 pass; all summer-cohort page tests still green).

## Scripts (operational)
- `scripts/count-cohort2-signups.ts` — read-only signup count by status.
- `scripts/send-cohort2-hult-announcement.ts` — Hult announcement to cohort-2 admits (idempotent).
- `scripts/send-cohort1-hult-c2-invite.ts` — same news to cohort-1 alumni not in cohort-2, with a sign-up CTA (idempotent).

## Verification
- `npm run build` ✅ clean
- Reviewed locally via `npm start` (modal + banner, all three states)
- Jest: modal + summer-cohort page suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)