### PR TITLE
release: develop→main — ws 8 override + license-checker fix (Security Scanning green)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       # License compliance check (matches transitive licenses in production deps)
       - name: Check license compliance
         run: |
-          npx license-checker --production --excludePackages "@cursor/sdk@1.0.17;@cursor/sdk-darwin-arm64@1.0.17;@cursor/sdk-darwin-x64@1.0.17;@cursor/sdk-linux-arm64@1.0.17;@cursor/sdk-linux-x64@1.0.17;@cursor/sdk-win32-x64@1.0.17" --onlyAllow "MIT;MIT*;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;0BSD;BlueOak-1.0.0;GPL-3.0-only;GPL-3.0-or-later;Hippocratic-2.1;MPL-2.0;LGPL-3.0-or-later;(BSD-3-Clause OR GPL-2.0);MIT AND ISC" --summary
+          npx license-checker --production --excludePackages "@cursor/sdk@1.0.19;@cursor/sdk-darwin-arm64@1.0.19;@cursor/sdk-darwin-x64@1.0.19;@cursor/sdk-linux-arm64@1.0.19;@cursor/sdk-linux-x64@1.0.19;@cursor/sdk-win32-x64@1.0.19" --onlyAllow "MIT;MIT*;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Unlicense;0BSD;BlueOak-1.0.0;GPL-3.0-only;GPL-3.0-or-later;Hippocratic-2.1;MPL-2.0;LGPL-3.0-or-later;(BSD-3-Clause OR GPL-2.0);MIT AND ISC" --summary
 
       # Secrets scanning with gitleaks
       - name: Run Gitleaks

--- a/package-lock.json
+++ b/package-lock.json
@@ -15944,28 +15944,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -24158,17 +24136,17 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -202,7 +202,8 @@
     "hono": "^4.12.16",
     "tar": "^7.5.16",
     "undici": "^6.27.0",
-    "protobufjs": "^7.6.4"
+    "protobufjs": "^7.6.4",
+    "ws": "^8.18.3"
   },
   "lint-staged": {
     "**/*.{ts,tsx}": [


### PR DESCRIPTION
Release of `develop` → `main`. Completes the security cleanup — **CI Security Scanning is now fully green** (0 high advisories + license compliance passing).

## Included
- **#1629** — fix(deps): override `ws` to 8.x (clears the final high-sev advisory, GHSA-96hv-2xvq-fx4p, via firebase-tools) + ci(security): bump stale `@cursor/sdk*` license-checker excludes 1.0.17 → 1.0.19 (@Ludwitt)

## Why two fixes
- **npm audit**: ws 7.5.10 was the last high; forced to 8.21.0 via override. **High advisories: 1 → 0.**
- **license compliance**: was latent — the Security Scanning job always exited at the audit step first. Once audit passed, the license step ran and failed because #1623's `@cursor/sdk` 1.0.17→1.0.19 bump left the version-pinned excludes stale. Fixed the pins.

## Validation
- ✅ CI on #1629 fully green: **Security Scanning**, Firestore rules tests + E2E (emulator runs firebase-tools under ws 8), Test, Lint/Type Check, CodeQL, Build, DCO
- ✅ `firebase --version` loads + runs under ws 8 (15.22.0)
- ✅ `npm run build` clean
- The Firestore deploy workflow uses HTTPS REST (not websockets), so it's unaffected by the ws bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)