### PR TITLE
release: develop → main — dependency & CI bumps (#1637, #1635, #1633, #1632)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Java
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Attest SLSA build provenance for release artifacts
         id: attest
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             cursor-boston-${{ github.event.inputs.version || github.ref_name }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           CI: true
 
       - name: Setup Java (Firestore emulator)
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/sign-historical-release.yml
+++ b/.github/workflows/sign-historical-release.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Attest SLSA build provenance
         id: attest
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             cursor-boston-${{ inputs.tag }}.tar.gz

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@types/three": "^0.184.1",
         "cross-env": "^10.1.0",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "eslint-config-next": "^16.2.9",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -10937,9 +10937,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@testing-library/user-event": "^14.5.1",
         "@types/jest": "^30.0.0",
         "@types/leaflet": "^1.9.21",
-        "@types/node": "^25.9.2",
+        "@types/node": "^26.0.1",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -6618,12 +6618,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -23266,9 +23266,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "@types/three": "^0.184.1",
     "cross-env": "^10.1.0",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "eslint-config-next": "^16.2.9",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^30.0.0",
     "@types/leaflet": "^1.9.21",
-    "@types/node": "^25.9.2",
+    "@types/node": "^26.0.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-syntax-highlighter": "^15.5.13",


### PR DESCRIPTION
Release `develop` → `main`. Four dependency / CI-tooling bumps, no app or UI code changes. Local production verification passed (`npm ci` + `npm run build` + `npm start`, `/` and `/summer-cohort` both 200).

## Included PRs
- #1637 — deps(deps-dev): bump `@types/node` 25.9.2 → 26.0.1 (@dependabot)
- #1635 — deps(deps-dev): bump `eslint` 10.5.0 → 10.6.0 in the dev-dependencies group (@dependabot)
- #1633 — ci(deps): bump `actions/setup-java` 5.3.0 → 5.4.0 (@dependabot)
- #1632 — ci(deps): bump `actions/attest-build-provenance` 4.1.0 → 4.1.1 (@dependabot)

All four passed full CI on their branches and were squash-merged into `develop`.
