### PR TITLE
feat(cohort): promote kvarnik week 5 startup submission (BeanCounter) to develop (#1606)

### DIFF
--- a/content/summer-cohort/c1/w5-startup/submissions/kvarnik.json
+++ b/content/summer-cohort/c1/w5-startup/submissions/kvarnik.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "kvarnik",
+  "name": "Kristjan Varnik",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocIro1Ic1ruV9VCukjLPwXQuDgn43ekifN-0xuJQHqfngHZxVg=s96-c",
+  "repoUrl": "https://github.com/shapechanging-oss/bean-counter",
+  "liveUrl": "https://bean-counter-gilt.vercel.app/",
+  "deckUrl": "https://bean-counter-gilt.vercel.app/deck",
+  "pitch": "BeanCounter: compare per-serving grocery costs for whole-food, plant-based NutritionFacts.org recipes across local stores — built from real CSV price data, fully static, live in production today.",
+  "competeForWin": false
+}


### PR DESCRIPTION
Promotes the **BeanCounter** Cohort 1 Week 5 (startup track) submission from the `c1w5startup-submission` staging branch into `develop`.

Single new file — a submission manifest, no code:
- `content/summer-cohort/c1/w5-startup/submissions/kvarnik.json`

Submission by **Kristjan Varnik** (@kvarnik) — originally landed as #1606 on the submission branch. This was the one branch skipped during the last `develop → main` fast-forward sync because it carried this unmerged commit; this PR brings it into `develop` so the branch can be synced going forward.
