### PR TITLE
release: develop → main — BeanCounter cohort submission (#1643)

### DIFF
--- a/content/summer-cohort/c1/w5-startup/submissions/kvarnik.json
+++ b/content/summer-cohort/c1/w5-startup/submissions/kvarnik.json
@@ -1,0 +1,10 @@
+{
+  "githubHandle": "kvarnik",
+  "name": "Kristjan Varnik",
+  "photoUrl": "https://lh3.googleusercontent.com/a/ACg8ocIro1Ic1ruV9VCukjLPwXQuDgn43ekifN-0xuJQHqfngHZxVg=s96-c",
+  "repoUrl": "https://github.com/shapechanging-oss/bean-counter",
+  "liveUrl": "https://bean-counter-gilt.vercel.app/",
+  "deckUrl": "https://bean-counter-gilt.vercel.app/deck",
+  "pitch": "BeanCounter: compare per-serving grocery costs for whole-food, plant-based NutritionFacts.org recipes across local stores — built from real CSV price data, fully static, live in production today.",
+  "competeForWin": false
+}


### PR DESCRIPTION
Release `develop` → `main`. One content-only change since the previous release (#1642), no code.

## Included
- #1643 — feat(cohort): promote **BeanCounter** (Cohort 1 Week 5 startup submission, @kvarnik / Kristjan Varnik) to `develop` — adds `content/summer-cohort/c1/w5-startup/submissions/kvarnik.json`

Local production verification passed: `npm run build` (compiled with the new submission file) + `npm start`, `/` and `/summer-cohort` both 200.
