### PR TITLE
Add Jayden Phillip to contributors list

### DIFF
--- a/.github-usernames
+++ b/.github-usernames
@@ -17,3 +17,4 @@ Join@4goodvibes.shop Kissprisonblock2018
 dungarani.j@northeastern.edu 17-jd
 scblouir+github@gmail.com samblouir
 leonarudoryuu0629@gmail.com rysat0
+jaydenphillip2008@yahoo.com jayyyW34

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,6 +30,7 @@
 | <img src="https://github.com/Kissprisonblock2018.png?size=40" width="40" height="40" alt="@Kissprisonblock2018" /> | [Kissprisonblock2018](https://github.com/Kissprisonblock2018) | 0 | 2 | 2026-02-19 |
 | <img src="https://github.com/DavidGamero.png?size=40" width="40" height="40" alt="@DavidGamero" /> | [David Gamero](https://github.com/DavidGamero) | 0 | 1 | 2026-02-16 |
 | <img src="https://github.com/randyjtorres.png?size=40" width="40" height="40" alt="@randyjtorres" /> | [Randy Torres](https://github.com/randyjtorres) | 0 | 1 | 2026-03-30 |
+| <img src="https://github.com/jayyyW34.png?size=40" width="40" height="40" alt="@jayyyW34" /> | [Jayden Phillip](https://github.com/jayyyW34) | 0 | 0 | 2026-07-02 |
 
 <!-- CONTRIBUTORS:END -->
 

--- a/.mailmap
+++ b/.mailmap
@@ -15,3 +15,5 @@ Nevi Chaudhari <nchaudhari@clarku.edu> Nevi <nchaudhari@clarku.edu>
 Nyriq Faber <64752969+riqthedev@users.noreply.github.com> riqthedev <riqthedev@gmail.com>
 
 Ray Liao <17989965+rayruizhiliao@users.noreply.github.com> Ruizhi (Ray) Liao <17989965+rayruizhiliao@users.noreply.github.com>
+
+Jayden Phillip <jaydenphillip2008@yahoo.com> jayyyW34 <jaydenphillip2008@yahoo.com>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,10 +29,11 @@
 | <img src="https://github.com/Kissprisonblock2018.png?size=40" width="40" height="40" alt="@Kissprisonblock2018" /> | [Kissprisonblock2018](https://github.com/Kissprisonblock2018) | 0 | 2 | 2026-02-19 |
 | <img src="https://github.com/DavidGamero.png?size=40" width="40" height="40" alt="@DavidGamero" /> | [David Gamero](https://github.com/DavidGamero) | 0 | 1 | 2026-02-16 |
 | <img src="https://github.com/randyjtorres.png?size=40" width="40" height="40" alt="@randyjtorres" /> | [Randy Torres](https://github.com/randyjtorres) | 0 | 1 | 2026-03-30 |
+| <img src="https://github.com/jayyyW34.png?size=40" width="40" height="40" alt="@jayyyW34" /> | [Jayden Phillip](https://github.com/jayyyW34) | 0 | 0 | 2026-07-02 |
 
 <!-- CONTRIBUTORS:END -->
 
-**25 contributors** &middot; Ranked by merged PRs &middot; _Updated 2026-04-08_
+**26 contributors** &middot; Ranked by merged PRs &middot; _Updated 2026-07-02_
 
 ---
 


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue. Include relevant motivation and context.

**Base branch:** Open PRs against **`develop`** (default). Only release PRs use **`develop` → `main`**.

Adds Jayden Phillip ([@jayyyW34](https://github.com/jayyyW34)) to the project contributors list, including the mapping files used by the auto-generator so future commits are attributed correctly.

Fixes # (issue)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Accessibility improvement

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally
- [ ] Tested on mobile devices
- [ ] Tested accessibility (keyboard navigation, screen readers)
- [ ] Tested authentication flows
- [ ] Tested form submissions

Verified the new row appears in `CONTRIBUTORS.md` and `.github/CONTRIBUTING.md` with the correct name and GitHub link.

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help explain your changes.

N/A — markdown-only contributor list update.

## Additional Notes
Also updated `.github-usernames` and `.mailmap` so `scripts/generate-contributors.sh` will keep the display name and GitHub link correct after future contributions.
