### PR TITLE
fix(cohort): move Cohort 2 start date to Monday, July 13

### DIFF
--- a/__tests__/components/SummerCohortModal.test.tsx
+++ b/__tests__/components/SummerCohortModal.test.tsx
@@ -67,14 +67,14 @@ describe("SummerCohortModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("surfaces the Hult launch message and July 9 start date", async () => {
+  it("surfaces the Hult launch message and July 13 start date", async () => {
     render(<SummerCohortModal />);
     await screen.findByRole("dialog");
     expect(screen.getByText(/Launching soon/i)).toBeInTheDocument();
     expect(
       screen.getByText(/Hult International Business School/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/Thursday, July 9/i)).toBeInTheDocument();
+    expect(screen.getByText(/Monday, July 13/i)).toBeInTheDocument();
   });
 
   it("does not auto-open if today's date is already stored", () => {

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -903,7 +903,7 @@ function SummerCohortPageInner() {
           platform; lots more info is coming over the next two weeks.
         </p>
         <p className="mt-3 inline-flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-1.5 text-sm font-semibold text-emerald-800 dark:text-emerald-200">
-          Be ready to start: Thursday, July 9
+          Be ready to start: Monday, July 13
         </p>
         {application ? (
           <p className="mt-3 flex items-start gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-300">

--- a/components/SummerCohortModal.tsx
+++ b/components/SummerCohortModal.tsx
@@ -20,8 +20,8 @@ import {
   SUMMER_COHORT_VIEW_TO,
 } from "@/lib/summer-cohort";
 
-// Tentative kickoff for the Hult Cohort Developer Program pilot (Cohort 2).
-const START_LABEL = "Thursday, July 9";
+// Kickoff for the Hult Cohort Developer Program pilot (Cohort 2).
+const START_LABEL = "Monday, July 13";
 
 function todayKey(): string {
   return new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
## What
Cohort 2 (Hult Developer Program pilot) was displaying **"Thursday, July 9"** as its start date on the summer-cohort page banner and the launch modal. The cohort now starts **Monday, July 13**, matching the launch announcement emails already sent to the list.

## Changes
- `app/summer-cohort/page.tsx` — "Be ready to start" banner → Monday, July 13
- `components/SummerCohortModal.tsx` — `START_LABEL` → Monday, July 13
- `__tests__/components/SummerCohortModal.test.tsx` — assertion + test name updated (16/16 pass)

## Notes
- July 13, 2026 is a Monday.
- Not touched: the week-by-week schedule in `lib/summer-cohort.ts` (`SUMMER_COHORT_C2_WEEK_WINDOWS`) still runs on the original Jun 29 timeline — a separate decision if the whole cadence shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)