### PR TITLE
test(security): add fast-check property tests for parsing surfaces

### DIFF
--- a/__tests__/lib/security-properties.test.ts
+++ b/__tests__/lib/security-properties.test.ts
@@ -1,0 +1,447 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Property-based tests for the security-sensitive parsing surfaces.
+ *
+ * These assert invariants that must hold for *every* input, not just the
+ * hand-picked examples covered by the example-based suites alongside this
+ * file. Each property states something a caller depends on for safety —
+ * "a sanitized doc ID can never contain a path separator" — rather than the
+ * weaker "arbitrary input does not throw".
+ *
+ * Surfaces covered:
+ *   - lib/sanitize.ts    text / name / URL / Firestore doc ID normalization
+ *   - lib/client-ip.ts   proxy header parsing
+ *   - lib/github.ts      HMAC webhook signature verification
+ *   - lib/api-schemas/   Zod request-boundary validation
+ */
+
+import { createHmac } from "crypto";
+import fc from "fast-check";
+
+import {
+  sanitizeText,
+  sanitizeName,
+  sanitizeUrl,
+  sanitizeDocId,
+  isValidHackathonId,
+} from "@/lib/sanitize";
+import { getClientIp } from "@/lib/client-ip";
+import { PaginationQuerySchema } from "@/lib/api-schemas/common";
+
+/* ------------------------------------------------------------------ */
+/*  lib/github requires a little setup                                 */
+/* ------------------------------------------------------------------ */
+
+// The module snapshots GITHUB_WEBHOOK_SECRET at import time, so the env var
+// has to be assigned before the require() below. Its Firestore and logger
+// imports are stubbed purely so the module loads —  verifyWebhookSignature
+// itself touches neither.
+const WEBHOOK_SECRET = "property-test-webhook-secret";
+process.env.GITHUB_WEBHOOK_SECRET = WEBHOOK_SECRET;
+
+jest.mock("@/lib/firebase-admin", () => ({ getAdminDb: () => null }));
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    logError: jest.fn(),
+  },
+}));
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => "SERVER_TS",
+    increment: (n: number) => n,
+  },
+}));
+
+const { verifyWebhookSignature } = require("@/lib/github") as typeof import("@/lib/github");
+
+/* ------------------------------------------------------------------ */
+/*  Arbitraries                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Strings biased toward the characters these functions exist to handle:
+ * control bytes, whitespace variants, path separators, and protocol
+ * prefixes. Plain `fc.string()` rarely generates a NUL byte or "../".
+ */
+const messyString = fc
+  .array(
+    fc.oneof(
+      fc.string({ maxLength: 6 }),
+      fc.constantFrom(
+        " ",
+        "\u0000", // NUL
+        "\u0007", // BEL
+        "\u001F", // unit separator - top of the stripped control range
+        "\u007F", // DEL
+        "\t",
+        "\r",
+        "\n",
+        "\u00A0", // non-breaking space
+        "<",
+        ">",
+        "&",
+        '"',
+        "'",
+        "/",
+        "\\",
+        "..",
+        ".",
+        "javascript:",
+        "data:",
+        "file:",
+        "http://",
+        "https://"
+      )
+    ),
+    { maxLength: 24 }
+  )
+  .map((parts) => parts.join(""));
+
+/** A syntactically valid IPv4 address — no commas, no whitespace. */
+const ipv4 = fc
+  .tuple(fc.nat(255), fc.nat(255), fc.nat(255), fc.nat(255))
+  .map(([a, b, c, d]) => `${a}.${b}.${c}.${d}`);
+
+function requestWith(headers: Record<string, string>): Request {
+  return new Request("https://example.com/api/test", { headers });
+}
+
+/* ------------------------------------------------------------------ */
+/*  sanitizeText                                                       */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeText — properties", () => {
+  it("is idempotent: sanitizing twice equals sanitizing once", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        const once = sanitizeText(input);
+        expect(sanitizeText(once)).toBe(once);
+      })
+    );
+  });
+
+  it("never leaves a stripped control character in the output", () => {
+    // Matches exactly the class the implementation removes, plus \t and \r
+    // which it folds into spaces. \n is deliberately preserved.
+    fc.assert(
+      fc.property(messyString, (input) => {
+        expect(sanitizeText(input)).not.toMatch(
+          /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\t\r]/
+        );
+      })
+    );
+  });
+
+  it("never returns a string with leading or trailing whitespace", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        const output = sanitizeText(input);
+        expect(output).toBe(output.trim());
+      })
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  sanitizeName                                                       */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeName — properties", () => {
+  it("only ever emits characters from the allowed set", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        expect(sanitizeName(input)).toMatch(/^[A-Za-z0-9 \-_.]*$/);
+      })
+    );
+  });
+
+  it("never emits two consecutive spaces", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        expect(sanitizeName(input)).not.toMatch(/ {2}/);
+      })
+    );
+  });
+
+  it("is idempotent", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        const once = sanitizeName(input);
+        expect(sanitizeName(once)).toBe(once);
+      })
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  sanitizeUrl                                                        */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeUrl — properties", () => {
+  it("never returns a URL outside the http/https schemes", () => {
+    // The security-critical one: a `javascript:` or `data:` URL reaching an
+    // href would be an XSS vector. Non-null output must always be http(s).
+    fc.assert(
+      fc.property(messyString, (input) => {
+        const output = sanitizeUrl(input);
+        if (output !== null) {
+          expect(output).toMatch(/^https?:\/\//);
+        }
+      })
+    );
+  });
+
+  it("rejects every javascript: and data: URL regardless of casing or padding", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("javascript", "JavaScript", "JAVASCRIPT", "data", "DATA", "file", "vbscript"),
+        fc.string({ maxLength: 20 }),
+        fc.nat(4),
+        (scheme, rest, padding) => {
+          const candidate = `${" ".repeat(padding)}${scheme}:${rest}`;
+          expect(sanitizeUrl(candidate)).toBeNull();
+        }
+      )
+    );
+  });
+
+  it("is idempotent on the URLs it accepts", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        const once = sanitizeUrl(input);
+        if (once !== null) {
+          expect(sanitizeUrl(once)).toBe(once);
+        }
+      })
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  sanitizeDocId                                                      */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeDocId — properties", () => {
+  it("never returns an ID containing a Firestore path separator", () => {
+    // A "/" in a doc ID would let caller-supplied input escape into a
+    // different collection path.
+    fc.assert(
+      fc.property(messyString, (input) => {
+        const output = sanitizeDocId(input);
+        if (output !== null) {
+          expect(output).not.toContain("/");
+        }
+      })
+    );
+  });
+
+  it("non-null results always satisfy the documented ID format and length cap", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        const output = sanitizeDocId(input);
+        if (output !== null) {
+          expect(output).toMatch(/^[A-Za-z0-9_-]+$/);
+          expect(output.length).toBeGreaterThan(0);
+          expect(output.length).toBeLessThanOrEqual(1500);
+        }
+      })
+    );
+  });
+
+  it("rejects the Firestore-reserved '.' and '..' identifiers", () => {
+    expect(sanitizeDocId(".")).toBeNull();
+    expect(sanitizeDocId("..")).toBeNull();
+  });
+
+  it("rejects anything longer than the 1500-character cap", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1501, max: 2000 }), (length) => {
+        expect(sanitizeDocId("a".repeat(length))).toBeNull();
+      })
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isValidHackathonId                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("isValidHackathonId — properties", () => {
+  it("only accepts IDs free of uppercase and path separators", () => {
+    fc.assert(
+      fc.property(messyString, (input) => {
+        if (isValidHackathonId(input)) {
+          expect(input).not.toMatch(/[A-Z]/);
+          expect(input).not.toContain("/");
+          expect(input).not.toContain("\\");
+        }
+      })
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  getClientIp                                                        */
+/* ------------------------------------------------------------------ */
+
+describe("getClientIp — properties", () => {
+  const originalHops = process.env.TRUSTED_PROXY_HOPS;
+
+  beforeEach(() => {
+    // Pin the hop count so the X-Forwarded-For selection is deterministic.
+    delete process.env.TRUSTED_PROXY_HOPS;
+  });
+
+  afterAll(() => {
+    if (originalHops === undefined) {
+      delete process.env.TRUSTED_PROXY_HOPS;
+    } else {
+      process.env.TRUSTED_PROXY_HOPS = originalHops;
+    }
+  });
+
+  it("never returns an empty or untrimmed value", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), fc.string({ maxLength: 40 }), (xff, cf) => {
+        const result = getClientIp(
+          requestWith({ "x-forwarded-for": xff, "cf-connecting-ip": cf })
+        );
+        expect(result.length).toBeGreaterThan(0);
+        expect(result).toBe(result.trim());
+      })
+    );
+  });
+
+  it("returns 'unknown' when no forwarding header carries a value", () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[ \t]*$/), (blank) => {
+        expect(getClientIp(requestWith({ "x-forwarded-for": blank }))).toBe("unknown");
+      })
+    );
+  });
+
+  it("never leaks the whole X-Forwarded-For list — it selects one entry", () => {
+    // The default of one trusted hop means the right-most address wins; the
+    // caller-controlled left-hand entries must never be returned verbatim.
+    fc.assert(
+      fc.property(fc.array(ipv4, { minLength: 1, maxLength: 8 }), (addresses) => {
+        const result = getClientIp(
+          requestWith({ "x-forwarded-for": addresses.join(", ") })
+        );
+        expect(result).not.toContain(",");
+        expect(addresses).toContain(result);
+        expect(result).toBe(addresses[addresses.length - 1]);
+      })
+    );
+  });
+
+  it("strips the brackets from a bracketed IPv6 literal", () => {
+    fc.assert(
+      fc.property(fc.constantFrom("::1", "2001:db8::1", "fe80::1"), (addr) => {
+        expect(getClientIp(requestWith({ "x-vercel-forwarded-for": `[${addr}]` }))).toBe(addr);
+      })
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  verifyWebhookSignature                                             */
+/* ------------------------------------------------------------------ */
+
+function signPayload(payload: string, secret = WEBHOOK_SECRET): string {
+  return "sha256=" + createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+describe("verifyWebhookSignature — properties", () => {
+  it("accepts a correctly computed signature for any payload", () => {
+    fc.assert(
+      fc.property(messyString, (payload) => {
+        expect(verifyWebhookSignature(payload, signPayload(payload))).toBe(true);
+      })
+    );
+  });
+
+  it("never throws, whatever the attacker puts in the signature header", () => {
+    // Regression guard: comparing buffers of differing length used to throw
+    // out of timingSafeEqual, turning a bad signature into a 500 instead of
+    // the intended 401. Wrong-length signatures are exactly what property
+    // generation produces in bulk.
+    fc.assert(
+      fc.property(messyString, fc.option(messyString, { nil: null }), (payload, signature) => {
+        expect(() => verifyWebhookSignature(payload, signature)).not.toThrow();
+      })
+    );
+  });
+
+  it("rejects every signature that is not the exact expected digest", () => {
+    fc.assert(
+      fc.property(messyString, messyString, (payload, forged) => {
+        fc.pre(forged !== signPayload(payload));
+        expect(verifyWebhookSignature(payload, forged)).toBe(false);
+      })
+    );
+  });
+
+  it("rejects a signature computed with the wrong secret", () => {
+    fc.assert(
+      fc.property(messyString, fc.string({ minLength: 1, maxLength: 32 }), (payload, otherSecret) => {
+        fc.pre(otherSecret !== WEBHOOK_SECRET);
+        expect(verifyWebhookSignature(payload, signPayload(payload, otherSecret))).toBe(false);
+      })
+    );
+  });
+
+  it("rejects a valid signature replayed against a different payload", () => {
+    fc.assert(
+      fc.property(messyString, messyString, (payload, otherPayload) => {
+        fc.pre(payload !== otherPayload);
+        expect(verifyWebhookSignature(otherPayload, signPayload(payload))).toBe(false);
+      })
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Zod request boundary                                               */
+/* ------------------------------------------------------------------ */
+
+describe("PaginationQuerySchema — properties", () => {
+  it("never throws on arbitrary query input", () => {
+    fc.assert(
+      fc.property(
+        fc.record(
+          { limit: fc.option(messyString, { nil: undefined }), cursor: fc.option(messyString, { nil: undefined }) },
+          { requiredKeys: [] }
+        ),
+        (query) => {
+          expect(() => PaginationQuerySchema.safeParse(query)).not.toThrow();
+        }
+      )
+    );
+  });
+
+  it("only accepts a `limit` that is entirely digits", () => {
+    fc.assert(
+      fc.property(messyString, (limit) => {
+        const result = PaginationQuerySchema.safeParse({ limit });
+        if (result.success) {
+          expect(limit).toMatch(/^\d+$/);
+        }
+      })
+    );
+  });
+
+  it("accepts every all-digit limit", () => {
+    fc.assert(
+      fc.property(fc.nat(100000), (n) => {
+        expect(PaginationQuerySchema.safeParse({ limit: String(n) }).success).toBe(true);
+      })
+    );
+  });
+});

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -14,6 +14,29 @@ Why these specific targets:
   resolve to a valid `http(s)`/null result, doc IDs always match the
   Firestore charset).
 
+## Relationship to the fast-check property tests
+
+`__tests__/lib/security-properties.test.ts` covers overlapping ground with
+`sanitize.fuzz.ts`. The two are complementary rather than redundant, for two
+reasons:
+
+- **Different trigger.** This workflow only runs on PRs that touch
+  `lib/sanitize.ts`, `fuzz/**`, `.clusterfuzzlite/**`, or its own YAML. The
+  Jest property tests run on *every* PR, so a refactor elsewhere that breaks a
+  sanitizer invariant is caught immediately rather than at the next fuzz run.
+- **Different reach.** The fuzzer goes deeper on `lib/sanitize.ts` — byte-level
+  coverage-guided search finds inputs a generator would not. The property tests
+  go wider: they also cover proxy-header parsing (`lib/client-ip.ts`), HMAC
+  webhook signature verification (`lib/github.ts`), and Zod request boundaries,
+  none of which have fuzz targets.
+
+The property tests also assert relational invariants a single-pass fuzz harness
+cannot express — idempotence (`f(f(x)) === f(x)`), replay resistance, and
+"rejects everything except the one correct digest".
+
+If you add a fuzz target for a surface the property tests already cover, keep
+both and note the split here.
+
 How to add a new target:
 
 1. Create `fuzz/<name>.fuzz.ts` that exports `fuzz(data: Buffer)`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
+        "fast-check": "^4.9.0",
         "firebase-tools": "^15.24.0",
         "globals": "^17.7.0",
         "husky": "^8.0.3",
@@ -11716,6 +11717,46 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unused-imports": "^4.4.1",
+    "fast-check": "^4.9.0",
     "firebase-tools": "^15.24.0",
     "globals": "^17.7.0",
     "husky": "^8.0.3",


### PR DESCRIPTION
## Description

Adds fast-check property tests for the security-sensitive parsing surfaces named in the issue. `fast-check` fits the existing Jest setup, so no new test runner is introduced.

Per the issue's ask, these assert **real invariants** rather than "arbitrary input does not throw" — idempotence, charset containment, replay resistance, and "rejects everything except the one correct digest".

Closes #1420

### Surfaces covered

| Module | Properties |
|---|---|
| `lib/sanitize.ts` | Idempotence of text/name/URL normalization; names never contain a double space; the Firestore-reserved `.` and `..` doc IDs are rejected; hackathon IDs never carry uppercase or a path separator |
| `lib/client-ip.ts` | Result is always non-empty and trimmed; never leaks the whole `X-Forwarded-For` list (selects one entry); strips brackets from IPv6 literals |
| `lib/github.ts` | `verifyWebhookSignature` never throws on a malformed signature; rejects wrong-secret and replayed signatures; accepts only the exact expected digest |
| `lib/api-schemas/common.ts` | `PaginationQuerySchema` accepts a `limit` only when it is entirely digits |

26 properties total, in one new file: `__tests__/lib/security-properties.test.ts`.

### These are not vacuous — verified by mutation

The webhook properties are a regression guard for the malformed-signature crash fixed in #1423, where comparing buffers of differing length threw out of `timingSafeEqual` and turned a bad signature into a 500 instead of a 401. Deleting that length guard from `lib/github.ts` again **fails two of these properties**. Property generation produces wrong-length signatures in bulk, which is exactly the input class that triggered the original bug.

## Overlap with the existing fuzz harness — please read

`fuzz/sanitize.fuzz.ts` already asserts several `lib/sanitize.ts` invariants (control characters, name charset, URL protocol, doc-ID charset). Flagging this up front rather than letting it be discovered in review.

I kept the overlap deliberately, for two reasons, and documented the split in `fuzz/README.md`:

- **Different trigger.** `.github/workflows/fuzz.yml` only runs on PRs touching `lib/sanitize.ts`, `fuzz/**`, `.clusterfuzzlite/**`, or its own YAML. These tests run on every PR, so a refactor elsewhere that breaks a sanitizer invariant is caught immediately rather than at the next fuzz run.
- **Different reach.** The fuzzer goes deeper on one file via coverage-guided byte-level search. The property tests go wider: `lib/client-ip.ts`, `lib/github.ts`, and the Zod boundary have **no fuzz target at all**. They also express relational invariants — idempotence, replay resistance — that a single-pass harness cannot.

Happy to trim the duplicated sanitize properties if you would rather keep the two harnesses strictly disjoint. That is a one-commit change.

### On the Scorecard framing in the issue

The issue cites `Fuzzing: 0` as motivation. I have not verified that score, and `fuzz.yml` already runs ClusterFuzzLite, which Scorecard also recognizes — so the score may already be non-zero. I am not claiming this PR moves it. The claim here is narrower and checkable: three security-relevant surfaces had no property coverage, and now do.

## Type of Change

- [x] New feature (non-breaking change which adds functionality) — test coverage only, no runtime code changed

## How Has This Been Tested?

- [x] Tested locally

```
npx jest --config config/jest.config.js __tests__/lib/security-properties.test.ts
  → 26 passed

npm test
  → 655 suites, 7720 tests, all passing

npm run type-check   → clean
npm run lint         → 0 new warnings (this file contributes none)
```

Mutation check, to confirm the properties actually bite:

```
# temporarily remove the length guard in verifyWebhookSignature
npx jest --config config/jest.config.js __tests__/lib/security-properties.test.ts
  → 2 failed, 24 passed
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**New dependency:** `fast-check@^4.9.0`, added as a `devDependency` — never bundled into the shipped app. The issue names this library specifically. The lockfile diff is purely additive (41 insertions, 0 deletions) and adds only `fast-check` and its `pure-rand` dependency; I regenerated it with npm 11 to match how the existing lockfile was written, so no unrelated `libc` metadata churn appears in the diff.

**Test environment:** the file uses the `@jest-environment node` docblock, matching `__tests__/lib/client-ip.test.ts`. `createHmac` is unavailable under jsdom.

**No license header:** `REUSE.toml` already covers `**.ts` project-wide, so the new file relies on that declaration like the rest of `__tests__/`.
