### PR TITLE
test(e2e): add Playwright smoke coverage for the cookbook

### DIFF
--- a/e2e/smoke/cookbook.spec.ts
+++ b/e2e/smoke/cookbook.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const COHORT_MODAL_STORAGE_KEY =
+  'cursor-boston-summer-cohort-modal-shown-date';
+
+async function suppressAutoDialogs(page: Page) {
+  await page.addInitScript((key) => {
+    localStorage.setItem(key, new Date().toISOString().slice(0, 10));
+  }, COHORT_MODAL_STORAGE_KEY);
+}
+
+test.describe('Cookbook', () => {
+  test('renders the cookbook header', async ({ page }) => {
+    await suppressAutoDialogs(page);
+    await page.goto('/cookbook');
+
+    await expect(
+      page.getByRole('heading', { name: /Prompt & Rules Cookbook/i })
+    ).toBeVisible();
+
+    await expect(
+      page.getByText(/A recipe book for AI-native coding/i).first()
+    ).toBeVisible();
+  });
+
+  test('add-a-prompt accordion expands to the anonymous sign-in prompt', async ({
+    page,
+  }) => {
+    await suppressAutoDialogs(page);
+    await page.goto('/cookbook');
+
+    const toggle = page.getByRole('button', {
+      name: /Add a Prompt or Rule/i,
+    });
+    await expect(toggle).toBeVisible();
+
+    await expect(
+      page.getByText('Sign in to submit a prompt or rule.')
+    ).toBeHidden();
+
+    await toggle.click();
+
+    await expect(
+      page.getByText('Sign in to submit a prompt or rule.')
+    ).toBeVisible();
+    const signInLink = page
+      .getByText('Sign in to submit a prompt or rule.')
+      .locator('..')
+      .getByRole('link', { name: 'Sign In' });
+    await expect(signInLink).toHaveAttribute('href', '/login?redirect=/cookbook');
+  });
+
+  test('renders search and filter controls with accessible labels', async ({
+    page,
+  }) => {
+    await suppressAutoDialogs(page);
+    await page.goto('/cookbook');
+
+    const search = page.getByLabel('Search');
+    await expect(search).toBeVisible();
+    await expect(search).toHaveAttribute('type', 'search');
+    await expect(search).toHaveAttribute(
+      'placeholder',
+      /Search title, description, tags/
+    );
+
+    const category = page.getByLabel('Category');
+    await expect(category).toBeVisible();
+    expect(await category.locator('option').count()).toBeGreaterThan(1);
+
+    const worksWith = page.getByLabel('Works with');
+    await expect(worksWith).toBeVisible();
+    expect(await worksWith.locator('option').count()).toBeGreaterThan(1);
+
+    const sort = page.getByLabel('Sort by');
+    await expect(sort).toBeVisible();
+    await expect(sort.locator('option')).toContainText([
+      'Top rated',
+      'Newest',
+      'Oldest',
+    ]);
+  });
+
+  test('searching locks the sort control to newest', async ({ page }) => {
+    await suppressAutoDialogs(page);
+    await page.goto('/cookbook');
+
+    const sort = page.getByLabel('Sort by');
+    await expect(sort).toBeEnabled();
+
+    await page.getByLabel('Search').fill('prompt');
+
+    await expect(sort).toBeDisabled();
+    await expect(sort).toHaveAttribute('aria-disabled', 'true');
+    await expect(
+      page.getByText(/Sort uses newest first while searching/i)
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #1695

## Summary

Adds functional Playwright smoke coverage for the cookbook, which previously had none — `e2e/smoke/public-pages.spec.ts` only asserted that `/cookbook` renders a heading.

New `e2e/smoke/cookbook.spec.ts` (4 tests), following the existing smoke conventions (public pages, no auth, no seeded data):

- Header renders (title + tagline)
- "Add a Prompt or Rule" accordion expands to the anonymous sign-in prompt with the correct `/login?redirect=/cookbook` link
- Search / category / works-with / sort controls render with accessible labels and expected options
- Typing a search query locks the sort control to newest (`disabled` + `aria-disabled` + helper text)

## Why it's safe

- Every assertion is deterministic client-side — CI runs the e2e job with placeholder Firebase env vars and no live backend, so there are no data- or network-dependent assertions.
- Uses accessible-name queries (`getByRole` / `getByLabel`) per the smoke suite convention.
- Reuses the established `addInitScript` pattern from `e2e/dark-mode.spec.ts` to suppress the auto-opening cohort dialog.

## Verification

- `npm run lint` — pass (no findings in new file)
- `npm run type-check` — pass
- `npx playwright test e2e/smoke/cookbook.spec.ts` — 4/4 passed locally against a production build (`next build` + `next start`)
- Full local e2e run: 36 passed (the only failure was the pre-existing `navigation.spec.ts` click-through test, which passes in isolation and is unrelated to this change)