### PR TITLE
test(questions): cover empty states and tag filter a11y

### DIFF
--- a/__tests__/components/questions/QuestionsListing.test.tsx
+++ b/__tests__/components/questions/QuestionsListing.test.tsx
@@ -80,4 +80,82 @@ describe("QuestionsListing", () => {
       );
     });
   });
+
+  it("renders the unfiltered empty state with ask CTA for signed-in users", async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/questions/vote")) {
+        return { ok: true, json: async () => ({ userVotes: {} }) };
+      }
+      if (url.startsWith("/api/questions")) {
+        return { ok: true, json: async () => ({ questions: [], nextCursor: null }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }) as typeof fetch;
+
+    render(<QuestionsListing />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No questions yet/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Be the first to ask/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Ask a Question/i }),
+    ).toHaveAttribute("href", "/questions/ask");
+  });
+
+  it("renders the filtered empty state with clear filter action", async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/questions/vote")) {
+        return { ok: true, json: async () => ({ userVotes: {} }) };
+      }
+      if (url.startsWith("/api/questions")) {
+        return { ok: true, json: async () => ({ questions: [], nextCursor: null }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }) as typeof fetch;
+
+    render(<QuestionsListing />);
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/Search questions/i),
+      "missing topic",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/No matches found/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/No results for 'missing topic'/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /Clear filter/i }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/Search questions/i)).toHaveValue("");
+    });
+  });
+
+  it("prompts signed-out users to sign in from the unfiltered empty state", async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/questions")) {
+        return { ok: true, json: async () => ({ questions: [], nextCursor: null }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }) as typeof fetch;
+
+    render(<QuestionsListing />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No questions yet/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("link", { name: /Sign in to ask/i })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+  });
 });

--- a/components/questions/TagFilter.tsx
+++ b/components/questions/TagFilter.tsx
@@ -34,6 +34,7 @@ export function TagFilter({
     <div className="flex flex-wrap gap-2">
       <button
         type="button"
+        aria-pressed={!activeTag}
         onClick={() => onTagChange("")}
         className={[
           "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
@@ -49,6 +50,7 @@ export function TagFilter({
         <button
           key={tag}
           type="button"
+          aria-pressed={tag === activeTag}
           onClick={() => onTagChange(tag === activeTag ? "" : tag)}
           className={[
             "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",


### PR DESCRIPTION
## Summary

Completes the remaining acceptance criteria for #579 by adding focused component tests for the questions list empty states (unfiltered, filtered, and signed-out CTA) and improving tag filter accessibility with \ria-pressed\ on filter chips.

## Changes

- Add Tests for unfiltered empty state with Ask Question CTA
- Add Tests for filtered empty state with clear-filter action
- Add Tests for signed-out empty state sign-in link
- TagFilter: expose pressed state via \ria-pressed\ on All/tag chips

## Testing

- [x] \
pm test -- __tests__/components/questions/QuestionsListing.test.tsx\
- [x] Pre-commit \	sc --noEmit\ and ESLint pass

Closes #579

Made with [Cursor](https://cursor.com)