### PR TITLE
feat(ui): replace auth spinner with skeleton on talks submit

### DIFF
--- a/__tests__/app/talks/submit-page.test.tsx
+++ b/__tests__/app/talks/submit-page.test.tsx
@@ -64,7 +64,8 @@ describe("SubmitTalkPage", () => {
   it("renders a loading skeleton while auth is loading", () => {
     setAuth({ loading: true });
     const { container } = render(<SubmitTalkPage />);
-    expect(container.querySelector(".animate-spin")).toBeTruthy();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
   });
 
   it("renders the sign-in gate when no user is present", () => {

--- a/app/talks/submit/page.tsx
+++ b/app/talks/submit/page.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthContext";
+import { AuthFormSkeleton } from "@/components/skeletons/AuthFormSkeleton";
 import { submitTalkProposal, TalkSubmission } from "@/lib/submissions";
 import Link from "next/link";
 
@@ -126,11 +127,7 @@ export default function SubmitTalkPage() {
   };
 
   if (authLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-white"></div>
-      </div>
-    );
+    return <AuthFormSkeleton />;
   }
 
   if (!user) {


### PR DESCRIPTION
## Description
Replace the auth-loading spinner on `/talks/submit` with the existing `AuthFormSkeleton` component — same pattern as login/signup. Improves perceived loading UX while auth state is checked. No behaviour change.

**Base branch:** Open PRs against **`develop`** (default). Only release PRs use **`develop` → `main`**.

Fixes #1703

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Accessibility improvement

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested locally (visual check of loading state)
- [ ] Tested on mobile devices
- [ ] Tested accessibility (keyboard navigation, screen readers)
- [ ] Tested authentication flows
- [ ] Tested form submissions
- [x] Updated `submit-page.test.tsx` loading-state assertion

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A — skeleton reuses existing auth form placeholder pattern.

## Additional Notes
Hult cohort Week 6 · @Studmuffin01. Claim comment posted on #1703 before coding.