### PR TITLE
docs(open-source): document develop as the default pull request base

### DIFF
--- a/__tests__/app/open-source/page.test.tsx
+++ b/__tests__/app/open-source/page.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ *
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import OpenSourcePage from "@/app/open-source/page";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) {
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    );
+  };
+});
+
+describe("OpenSourcePage", () => {
+  it("lists where pull requests should be opened", () => {
+    render(<OpenSourcePage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Where to open your PR", level: 3 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Open a pull request against develop \(not main\)/i)
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("develop").length).toBeGreaterThan(0);
+    expect(screen.getByText("game-contributions")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "submission branches" })
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/SUBMISSION_BRANCHES.md"
+    );
+  });
+});

--- a/app/open-source/page.tsx
+++ b/app/open-source/page.tsx
@@ -52,7 +52,41 @@ const STEPS = [
   },
   {
     title: "Submit PR",
-    description: "Open a pull request and get feedback from maintainers.",
+    description:
+      "Open a pull request against develop (not main) and get feedback from maintainers.",
+  },
+] as const;
+
+/** Mirrors the routing table in .github/CONTRIBUTING.md (Where to PR). */
+const PR_TARGETS = [
+  {
+    when: "Standard code, bug fix, feature, or docs",
+    branch: "develop",
+  },
+  {
+    when: "PyData hackathon notebook",
+    branch: "pydata-2026-submissions",
+  },
+  {
+    when: "Hack-a-Sprint showcase project",
+    branch: "hack-a-sprint-2026-submissions",
+  },
+  {
+    when: "Summer cohort 1 week N submission",
+    branch:
+      "c1w1pm-submission / c1w2comms-submission / c1w3mkt-submission / c1w4edu-submission / c1w5startup-submission / c1w6oss-submission",
+  },
+  {
+    when: "Summer cohort 2 vote-format week N submission",
+    branch: "c2w1pm-submission / c2w2comms-submission / c2w3mkt-submission",
+  },
+  {
+    when: "Game-mode content (units, artifacts, lore)",
+    branch: "game-contributions",
+  },
+  {
+    when: "Maintainer application",
+    branch: "maintainer-application",
   },
 ] as const;
 
@@ -164,6 +198,74 @@ export default function OpenSourcePage() {
               </li>
             ))}
           </ol>
+
+          <div className="mt-10 overflow-x-auto rounded-lg border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+            <h3 className="mb-2 text-center text-lg font-semibold text-neutral-950 dark:text-white">
+              Where to open your PR
+            </h3>
+            <p className="mb-4 text-center text-sm text-neutral-600 dark:text-neutral-400">
+              Most contributions target{" "}
+              <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">
+                develop
+              </code>
+              . Change the base branch only for the submission targets below.
+              Do not open contributor PRs against{" "}
+              <code className="rounded bg-neutral-100 px-1 py-0.5 text-xs dark:bg-neutral-800">
+                main
+              </code>
+              .
+            </p>
+            <table className="w-full min-w-[36rem] border-collapse text-left text-sm">
+              <caption className="sr-only">
+                Pull request base branch for each kind of contribution
+              </caption>
+              <thead>
+                <tr className="border-b border-neutral-200 dark:border-neutral-800">
+                  <th
+                    scope="col"
+                    className="pb-2 pr-4 font-semibold text-neutral-950 dark:text-white"
+                  >
+                    If you&apos;re doing this
+                  </th>
+                  <th
+                    scope="col"
+                    className="pb-2 font-semibold text-neutral-950 dark:text-white"
+                  >
+                    Base branch
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {PR_TARGETS.map((row) => (
+                  <tr
+                    key={row.branch}
+                    className="border-b border-neutral-100 last:border-0 dark:border-neutral-800"
+                  >
+                    <td className="py-2 pr-4 text-neutral-600 dark:text-neutral-400">
+                      {row.when}
+                    </td>
+                    <td className="py-2">
+                      <code className="break-all text-xs text-emerald-800 dark:text-emerald-300">
+                        {row.branch}
+                      </code>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="mt-4 text-center text-sm text-neutral-600 dark:text-neutral-400">
+              Full routing notes:{" "}
+              <a
+                href="https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/docs/SUBMISSION_BRANCHES.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-700 hover:text-emerald-600 dark:text-emerald-300"
+              >
+                submission branches
+              </a>
+              .
+            </p>
+          </div>
 
           <div className="mt-10 flex flex-wrap justify-center gap-4">
             <a


### PR DESCRIPTION
## Description
Adds the contribution-guide routing table to `/open-source` so first-time contributors (and agents pointed at that page) can see that most PRs target `develop`, not `main`, and which long-lived submission branches to use otherwise.

The table matches [.github/CONTRIBUTING.md](https://github.com/rogerSuperBuilderAlpha/cursor-boston/blob/develop/.github/CONTRIBUTING.md#where-to-pr--submission-branch-routing). The Submit PR step now also says to open against `develop`.

**Base branch:** `develop`

## Type of Change
- [x] Documentation update

## How Has This Been Tested?
- [x] Tested locally
- `npm run lint` (changed files pass `eslint --max-warnings=0`)
- `npm run type-check`
- `npm test -- __tests__/app/open-source/page.test.tsx __tests__/app/open-source/roadmap-explorer.test.tsx __tests__/app/pages-gap-fill-wave-3.test.tsx`

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes

Made with [Cursor](https://cursor.com)