### PR TITLE
feat(events): add on-site RSVP with capacity and waitlist

### DIFF
--- a/__tests__/app/api/events/[eventId]/rsvp/route.test.ts
+++ b/__tests__/app/api/events/[eventId]/rsvp/route.test.ts
@@ -1,0 +1,144 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ *
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { DELETE, GET, POST } from "@/app/api/events/[eventId]/rsvp/route";
+import {
+  cancelEventRsvp,
+  createEventRsvp,
+  getEventRsvpSnapshot,
+} from "@/lib/event-rsvp";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+jest.mock("@/lib/logger", () => ({
+  logger: { logError: jest.fn() },
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: jest.fn(() => ({ success: true })),
+  getClientIdentifier: () => "test-client",
+}));
+
+jest.mock("@/lib/server-auth", () => ({
+  getVerifiedUser: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/event-rsvp", () => ({
+  getEventRsvpSnapshot: jest.fn(),
+  createEventRsvp: jest.fn(),
+  cancelEventRsvp: jest.fn(),
+}));
+
+const mockGetVerifiedUser = getVerifiedUser as jest.MockedFunction<typeof getVerifiedUser>;
+const mockGetSnapshot = getEventRsvpSnapshot as jest.MockedFunction<typeof getEventRsvpSnapshot>;
+const mockCreate = createEventRsvp as jest.MockedFunction<typeof createEventRsvp>;
+const mockCancel = cancelEventRsvp as jest.MockedFunction<typeof cancelEventRsvp>;
+const { checkRateLimit } = jest.requireMock("@/lib/rate-limit") as {
+  checkRateLimit: jest.Mock;
+};
+
+const snapshot = {
+  capacity: 50,
+  confirmedCount: 1,
+  waitlistCount: 0,
+  remaining: 49,
+  myStatus: "confirmed" as const,
+  waitlistPosition: null,
+};
+
+function makeContext(eventId: string) {
+  return { params: Promise.resolve({ eventId }) };
+}
+
+function makeRequest(method: string, body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/events/cafe-cursor-boston-2026/rsvp", {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("GET /api/events/[eventId]/rsvp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRateLimit.mockReturnValue({ success: true });
+    mockGetVerifiedUser.mockResolvedValue(null);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    checkRateLimit.mockReturnValue({ success: false, retryAfter: 30 });
+    const res = await GET(makeRequest("GET"), makeContext("cafe-cursor-boston-2026"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for an invalid event id", async () => {
+    const res = await GET(makeRequest("GET"), makeContext("bad id!"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns public counts without auth", async () => {
+    mockGetSnapshot.mockResolvedValue({ configured: true, snapshot: { ...snapshot, myStatus: "none" } });
+    const res = await GET(makeRequest("GET"), makeContext("cafe-cursor-boston-2026"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.confirmedCount).toBe(1);
+    expect(body.myStatus).toBe("none");
+  });
+});
+
+describe("POST /api/events/[eventId]/rsvp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await POST(makeRequest("POST", {}), makeContext("cafe-cursor-boston-2026"));
+    expect(res.status).toBe(401);
+  });
+
+  it("creates an RSVP for the signed-in user", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1" } as never);
+    mockCreate.mockResolvedValue({ configured: true, snapshot });
+    const res = await POST(makeRequest("POST", {}), makeContext("cafe-cursor-boston-2026"));
+    expect(res.status).toBe(200);
+    expect(mockCreate).toHaveBeenCalledWith("cafe-cursor-boston-2026", "u1");
+    const body = await res.json();
+    expect(body.myStatus).toBe("confirmed");
+  });
+});
+
+describe("DELETE /api/events/[eventId]/rsvp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRateLimit.mockReturnValue({ success: true });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetVerifiedUser.mockResolvedValue(null);
+    const res = await DELETE(makeRequest("DELETE"), makeContext("cafe-cursor-boston-2026"));
+    expect(res.status).toBe(401);
+  });
+
+  it("cancels an RSVP", async () => {
+    mockGetVerifiedUser.mockResolvedValue({ uid: "u1" } as never);
+    mockCancel.mockResolvedValue({
+      configured: true,
+      snapshot: { ...snapshot, confirmedCount: 0, remaining: 50, myStatus: "none" },
+    });
+    const res = await DELETE(makeRequest("DELETE"), makeContext("cafe-cursor-boston-2026"));
+    expect(res.status).toBe(200);
+    expect(mockCancel).toHaveBeenCalledWith("cafe-cursor-boston-2026", "u1");
+  });
+});

--- a/__tests__/app/events/slug-page.test.tsx
+++ b/__tests__/app/events/slug-page.test.tsx
@@ -75,6 +75,10 @@ jest.mock("@/components/events/CoworkingSlots", () => ({
   default: () => null,
 }));
 
+jest.mock("@/components/events/EventRsvpCard", () => ({
+  EventRsvpCard: () => null,
+}));
+
 import EventPage, {
   generateMetadata,
   generateStaticParams,

--- a/__tests__/components/events/EventRsvpCard.test.tsx
+++ b/__tests__/components/events/EventRsvpCard.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ *
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { EventRsvpCard } from "@/components/events/EventRsvpCard";
+import { useAuth } from "@/contexts/AuthContext";
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response);
+}
+
+describe("EventRsvpCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: null } as never);
+    global.fetch = jest.fn(() =>
+      jsonResponse({
+        success: true,
+        configured: true,
+        capacity: 50,
+        confirmedCount: 12,
+        waitlistCount: 0,
+        remaining: 38,
+        myStatus: "none",
+        waitlistPosition: null,
+      })
+    ) as jest.Mock;
+  });
+
+  it("shows capacity counts and a sign-in CTA when logged out", async () => {
+    render(
+      <EventRsvpCard eventId="cafe-cursor-boston-2026" eventSlug="cafe-cursor-boston" capacity={50} />
+    );
+
+    expect(await screen.findByText("12/50")).toBeInTheDocument();
+    const login = screen.getByRole("link", { name: "Sign in to RSVP" });
+    expect(login).toHaveAttribute("href", "/login?redirect=%2Fevents%2Fcafe-cursor-boston");
+  });
+
+  it("RSVPs when the signed-in user clicks the button", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { getIdToken: jest.fn().mockResolvedValue("token") },
+    } as never);
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          success: true,
+          configured: true,
+          capacity: 50,
+          confirmedCount: 12,
+          waitlistCount: 0,
+          remaining: 38,
+          myStatus: "none",
+          waitlistPosition: null,
+        })
+      )
+      .mockImplementationOnce(() =>
+        jsonResponse({
+          success: true,
+          configured: true,
+          capacity: 50,
+          confirmedCount: 13,
+          waitlistCount: 0,
+          remaining: 37,
+          myStatus: "confirmed",
+          waitlistPosition: null,
+        })
+      );
+
+    render(
+      <EventRsvpCard eventId="cafe-cursor-boston-2026" eventSlug="cafe-cursor-boston" capacity={50} />
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "RSVP — confirmed spot" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("You have a confirmed spot.")).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/events/cafe-cursor-boston-2026/rsvp",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});

--- a/__tests__/lib/event-rsvp-core.test.ts
+++ b/__tests__/lib/event-rsvp-core.test.ts
@@ -1,0 +1,94 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ *
+ * @jest-environment node
+ */
+
+import {
+  deriveRsvpSnapshot,
+  eventRsvpDocId,
+  eventSupportsOnSiteRsvp,
+  getOnSiteRsvpEvent,
+} from "@/lib/event-rsvp-core";
+
+describe("deriveRsvpSnapshot", () => {
+  it("confirms the first N RSVPs and waitlists the rest in createdAt order", () => {
+    const active = [
+      { userId: "a", createdAtMs: 30 },
+      { userId: "b", createdAtMs: 10 },
+      { userId: "c", createdAtMs: 20 },
+    ];
+    expect(deriveRsvpSnapshot(active, 2, "b")).toEqual({
+      capacity: 2,
+      confirmedCount: 2,
+      waitlistCount: 1,
+      remaining: 0,
+      myStatus: "confirmed",
+      waitlistPosition: null,
+    });
+    expect(deriveRsvpSnapshot(active, 2, "a")).toEqual({
+      capacity: 2,
+      confirmedCount: 2,
+      waitlistCount: 1,
+      remaining: 0,
+      myStatus: "waitlisted",
+      waitlistPosition: 1,
+    });
+  });
+
+  it("returns none when the user has not RSVPed", () => {
+    expect(deriveRsvpSnapshot([], 50, "u1").myStatus).toBe("none");
+    expect(deriveRsvpSnapshot([], 50, null).remaining).toBe(50);
+  });
+});
+
+describe("eventSupportsOnSiteRsvp", () => {
+  it("rejects specialized hackathon and PyData slugs even if flagged", () => {
+    expect(
+      eventSupportsOnSiteRsvp({
+        slug: "cursor-boston-pydata-2026",
+        capacity: 150,
+        onSiteRsvp: true,
+      })
+    ).toBe(false);
+    expect(
+      eventSupportsOnSiteRsvp({
+        slug: "cursor-boston-sports-hack-2026",
+        capacity: 119,
+        onSiteRsvp: true,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts opted-in catalog events with capacity", () => {
+    expect(
+      eventSupportsOnSiteRsvp({
+        slug: "cafe-cursor-boston",
+        capacity: 50,
+        onSiteRsvp: true,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("getOnSiteRsvpEvent", () => {
+  it("resolves the Cafe Cursor catalog event", () => {
+    const event = getOnSiteRsvpEvent("cafe-cursor-boston-2026");
+    expect(event?.slug).toBe("cafe-cursor-boston");
+    expect(event?.capacity).toBe(50);
+  });
+
+  it("returns null for specialized events", () => {
+    expect(getOnSiteRsvpEvent("cursor-boston-pydata-2026")).toBeNull();
+  });
+});
+
+describe("eventRsvpDocId", () => {
+  it("namespaces the document by event and user", () => {
+    expect(eventRsvpDocId("cafe-cursor-boston-2026", "uid-1")).toBe(
+      "cafe-cursor-boston-2026__uid-1"
+    );
+  });
+});

--- a/app/api/events/[eventId]/rsvp/route.ts
+++ b/app/api/events/[eventId]/rsvp/route.ts
@@ -1,0 +1,155 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { eventsContract } from "@/lib/api-schemas/events";
+import {
+  cancelEventRsvp,
+  createEventRsvp,
+  getEventRsvpSnapshot,
+} from "@/lib/event-rsvp";
+import { logger } from "@/lib/logger";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
+import { sanitizeDocId } from "@/lib/sanitize";
+import { getVerifiedUser } from "@/lib/server-auth";
+
+// @contracts: eventsContract.rsvpGet, eventsContract.rsvpPost, eventsContract.rsvpDelete (lib/api-schemas/events.ts)
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 20 };
+
+interface RouteContext {
+  params: Promise<{ eventId: string }>;
+}
+
+function jsonSnapshot(
+  payload: Awaited<ReturnType<typeof getEventRsvpSnapshot>>,
+  extra: Record<string, unknown> = {}
+) {
+  if ("error" in payload) {
+    return NextResponse.json({ error: payload.error }, { status: 400 });
+  }
+  return NextResponse.json({
+    success: true,
+    configured: payload.configured,
+    ...payload.snapshot,
+    ...extra,
+  });
+}
+
+async function parseEventId(context: RouteContext): Promise<string | null> {
+  const { eventId } = await context.params;
+  return sanitizeDocId(eventId);
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`event-rsvp-get:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateResult.retryAfter || 60) },
+        }
+      );
+    }
+
+    const eventId = await parseEventId(context);
+    if (!eventId) {
+      return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+    }
+
+    const user = await getVerifiedUser(request);
+    const payload = await getEventRsvpSnapshot(eventId, user?.uid ?? null);
+    return jsonSnapshot(payload);
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/events/[eventId]/rsvp", area: "events" });
+    return NextResponse.json({ error: "Failed to load RSVP status" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`event-rsvp-post:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateResult.retryAfter || 60) },
+        }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const eventId = await parseEventId(context);
+    if (!eventId) {
+      return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+    }
+
+    let body: unknown = {};
+    const contentType = request.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      try {
+        body = await request.json();
+      } catch {
+        return NextResponse.json({ error: "Invalid JSON in request body" }, { status: 400 });
+      }
+    }
+    const parsed = eventsContract.rsvpPost.body.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const payload = await createEventRsvp(eventId, user.uid);
+    return jsonSnapshot(payload);
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/events/[eventId]/rsvp", area: "events" });
+    return NextResponse.json({ error: "Failed to RSVP" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  try {
+    const clientId = getClientIdentifier(request as unknown as Request);
+    const rateResult = checkRateLimit(`event-rsvp-delete:${clientId}`, RATE_LIMIT);
+    if (!rateResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests", retryAfterSeconds: rateResult.retryAfter },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateResult.retryAfter || 60) },
+        }
+      );
+    }
+
+    const user = await getVerifiedUser(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const eventId = await parseEventId(context);
+    if (!eventId) {
+      return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+    }
+
+    const payload = await cancelEventRsvp(eventId, user.uid);
+    return jsonSnapshot(payload);
+  } catch (error) {
+    logger.logError(error, { endpoint: "/api/events/[eventId]/rsvp", area: "events" });
+    return NextResponse.json({ error: "Failed to cancel RSVP" }, { status: 500 });
+  }
+}

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -12,6 +12,8 @@ import { notFound } from "next/navigation";
 import eventsData from "@/content/events.json";
 import type { EventsData } from "@/types/events";
 import CoworkingSlots from "@/components/events/CoworkingSlots";
+import { EventRsvpCard } from "@/components/events/EventRsvpCard";
+import { eventSupportsOnSiteRsvp } from "@/lib/event-rsvp-core";
 import {
   getLumaCheckoutEventId,
   getLumaCheckoutHref,
@@ -78,6 +80,7 @@ interface Event {
   lumaCheckoutEventId?: string;
   registrationRequired: boolean;
   capacity?: number;
+  onSiteRsvp?: boolean;
   perks?: string[];
   topics?: string[];
   agenda?: AgendaItem[];
@@ -425,6 +428,13 @@ export default async function EventPage({
                 </a>
               </div>
             )}
+            {eventSupportsOnSiteRsvp(event) && typeof event.capacity === "number" ? (
+              <EventRsvpCard
+                eventId={event.id}
+                eventSlug={event.slug}
+                capacity={event.capacity}
+              />
+            ) : null}
           </div>
         </div>
       </section>

--- a/components/events/EventRsvpCard.tsx
+++ b/components/events/EventRsvpCard.tsx
@@ -1,0 +1,209 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import type { EventRsvpSnapshot } from "@/lib/event-rsvp-core";
+
+interface EventRsvpCardProps {
+  eventId: string;
+  eventSlug: string;
+  capacity: number;
+}
+
+type RsvpPayload = EventRsvpSnapshot & {
+  success?: boolean;
+  configured?: boolean;
+  error?: string;
+};
+
+const emptySnapshot = (capacity: number): EventRsvpSnapshot => ({
+  capacity,
+  confirmedCount: 0,
+  waitlistCount: 0,
+  remaining: capacity,
+  myStatus: "none",
+  waitlistPosition: null,
+});
+
+export function EventRsvpCard({ eventId, eventSlug, capacity }: EventRsvpCardProps) {
+  const { user } = useAuth();
+  const requestKey = `${eventId}:${user?.uid ?? ""}`;
+  const [snapshot, setSnapshot] = useState<EventRsvpSnapshot>(emptySnapshot(capacity));
+  const [configured, setConfigured] = useState(true);
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const loading = loadedFor !== requestKey;
+
+  const applyPayload = useCallback((data: RsvpPayload) => {
+    setSnapshot({
+      capacity: data.capacity,
+      confirmedCount: data.confirmedCount,
+      waitlistCount: data.waitlistCount,
+      remaining: data.remaining,
+      myStatus: data.myStatus,
+      waitlistPosition: data.waitlistPosition ?? null,
+    });
+    setConfigured(data.configured !== false);
+  }, []);
+
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        const headers: Record<string, string> = {};
+        if (user) {
+          headers.Authorization = `Bearer ${await user.getIdToken()}`;
+        }
+        const res = await fetch(`/api/events/${eventId}/rsvp`, { headers, signal });
+        const data = (await res.json()) as RsvpPayload;
+        if (signal?.aborted) return;
+        if (!res.ok) {
+          setError(data.error || "Failed to load RSVP status");
+          return;
+        }
+        setError(null);
+        applyPayload(data);
+      } catch (err) {
+        if (signal?.aborted) return;
+        console.error("Error loading event RSVP:", err);
+        setError("Failed to load RSVP status");
+      } finally {
+        if (!signal?.aborted) setLoadedFor(requestKey);
+      }
+    },
+    [applyPayload, eventId, requestKey, user]
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount, state set inside async callback
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  async function mutate(method: "POST" | "DELETE") {
+    if (!user) {
+      setError("Please sign in to RSVP.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/events/${eventId}/rsvp`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: method === "POST" ? JSON.stringify({}) : undefined,
+      });
+      const data = (await res.json()) as RsvpPayload;
+      if (!res.ok) {
+        setError(data.error || "Something went wrong");
+        return;
+      }
+      applyPayload(data);
+    } catch (err) {
+      console.error("Error updating event RSVP:", err);
+      setError("Failed to update RSVP");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const statusCopy =
+    snapshot.myStatus === "confirmed"
+      ? "You have a confirmed spot."
+      : snapshot.myStatus === "waitlisted"
+        ? `You are #${snapshot.waitlistPosition ?? "?"} on the waitlist. If someone cancels, you move up automatically.`
+        : `${snapshot.remaining} of ${snapshot.capacity} confirmed spots left.`;
+
+  return (
+    <div className="mt-6 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-5">
+      <h3 className="text-lg font-semibold text-foreground">RSVP on this site</h3>
+      <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+        First {snapshot.capacity} members are confirmed. Anyone after that joins
+        the waitlist. Luma may still be used for door entry.
+      </p>
+
+      {loading ? (
+        <div className="mt-4 h-16 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+      ) : (
+        <>
+          <dl className="mt-4 grid grid-cols-3 gap-3 text-center text-sm">
+            <div className="rounded-lg bg-white/60 p-3 dark:bg-neutral-900/60">
+              <dt className="text-neutral-500">Confirmed</dt>
+              <dd className="mt-1 text-lg font-semibold text-foreground">
+                {snapshot.confirmedCount}/{snapshot.capacity}
+              </dd>
+            </div>
+            <div className="rounded-lg bg-white/60 p-3 dark:bg-neutral-900/60">
+              <dt className="text-neutral-500">Waitlist</dt>
+              <dd className="mt-1 text-lg font-semibold text-foreground">
+                {snapshot.waitlistCount}
+              </dd>
+            </div>
+            <div className="rounded-lg bg-white/60 p-3 dark:bg-neutral-900/60">
+              <dt className="text-neutral-500">Open spots</dt>
+              <dd className="mt-1 text-lg font-semibold text-foreground">
+                {snapshot.remaining}
+              </dd>
+            </div>
+          </dl>
+
+          <p className="mt-4 text-sm text-neutral-700 dark:text-neutral-300">{statusCopy}</p>
+
+          {!configured ? (
+            <p className="mt-3 text-sm text-amber-700 dark:text-amber-400">
+              RSVPs are not stored in demo mode. Set up Firebase to persist them.
+            </p>
+          ) : null}
+
+          {error ? (
+            <p className="mt-3 text-sm text-rose-600 dark:text-rose-400" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="mt-4 flex flex-wrap gap-3">
+            {!user ? (
+              <Link
+                href={`/login?redirect=${encodeURIComponent(`/events/${eventSlug}`)}`}
+                className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+              >
+                Sign in to RSVP
+              </Link>
+            ) : snapshot.myStatus === "none" ? (
+              <button
+                type="button"
+                onClick={() => void mutate("POST")}
+                disabled={busy || !configured}
+                className="inline-flex items-center justify-center rounded-lg bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+              >
+                {busy ? "Saving…" : snapshot.remaining > 0 ? "RSVP — confirmed spot" : "Join waitlist"}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void mutate("DELETE")}
+                disabled={busy || !configured}
+                className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-semibold text-neutral-800 hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              >
+                {busy ? "Saving…" : "Cancel RSVP"}
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -251,6 +251,13 @@ service cloud.firestore {
       allow write: if false; // Only server-side writes for data integrity
     }
 
+    // On-site event RSVPs — owners can read their row; writes are Admin SDK only
+    // so capacity / waitlist order cannot be spoofed from the client.
+    match /eventRsvps/{rsvpId} {
+      allow read: if request.auth != null && request.auth.uid == resource.data.userId;
+      allow write: if false;
+    }
+
     // Mentorship - Profiles: users can create/update their own profile, authenticated users can read active profiles
     match /mentorship_profiles/{userId} {
       allow read: if request.auth != null && (resource.data.isActive == true || request.auth.uid == userId);

--- a/content/events.json
+++ b/content/events.json
@@ -26,6 +26,8 @@
       "lumaCheckoutEventId": "evt-I9VjCOaJrZx1wzk",
       "lumaEmbedSrc": "https://luma.com/embed/event/evt-I9VjCOaJrZx1wzk/simple",
       "registrationRequired": true,
+      "onSiteRsvp": true,
+      "capacity": 80,
       "perks": [
         "Lunch on us",
         "Cohort 1 demo crowd",
@@ -337,6 +339,7 @@
       "lumaUrl": "https://luma.com/u43ar9pi",
       "lumaEventId": "u43ar9pi",
       "registrationRequired": true,
+      "onSiteRsvp": true,
       "capacity": 50,
       "perks": [
         "Cursor Credits",

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 
 All endpoints are under `/api/`. Authentication uses Firebase Auth ID tokens (Bearer) or session cookies. Spec: [`/openapi.json`](https://cursorboston.com/openapi.json) · interactive: [`/api/docs`](https://cursorboston.com/api/docs).
 
-**186 paths, 223 operations across 35 areas.**
+**187 paths, 226 operations across 35 areas.**
 
 ---
 
@@ -129,6 +129,9 @@ _Coworking sessions and PyData 2026 ticketing._
 | DELETE | `/api/events/{eventId}/coworking/register` | Yes | Cancel the current user's coworking registration |
 | POST | `/api/events/{eventId}/coworking/register` | Yes | Register for a coworking session in an event |
 | GET | `/api/events/{eventId}/coworking/slots` | No | List coworking sessions with availability for an event |
+| DELETE | `/api/events/{eventId}/rsvp` | Yes | Cancel the current user's on-site RSVP (promotes the waitlist) |
+| GET | `/api/events/{eventId}/rsvp` | No | Get on-site RSVP counts and the current user's status |
+| POST | `/api/events/{eventId}/rsvp` | Yes | RSVP to an event (confirmed if under capacity, otherwise waitlisted) |
 | GET | `/api/events/pydata-2026/access` | No | Whether the signed-in user is on the 150-person PyData 2026 door list |
 | GET | `/api/events/pydata-2026/admin/list` | Yes | Admin: paginated PyData 2026 registrations with cap-vs-waitlist |
 | GET | `/api/events/pydata-2026/capacity` | No | Public PyData 2026 capacity / claimed / remaining counts |

--- a/lib/account-deletion/registry.ts
+++ b/lib/account-deletion/registry.ts
@@ -103,6 +103,7 @@ export const userOwnedCollections: ReadonlyArray<UserOwnedCollection> = [
   { collection: "hackathonJoinRequests", mode: "fieldEqualsUid", field: "fromUserId", behavior: { type: "delete" } },
   { collection: "agents", mode: "fieldEqualsUid", field: "ownerId", behavior: { type: "delete" } },
   { collection: "coworkingRegistrations", mode: "fieldEqualsUid", field: "userId", behavior: { type: "delete" } },
+  { collection: "eventRsvps", mode: "fieldEqualsUid", field: "userId", behavior: { type: "delete" } },
   { collection: "mentorship_check_ins", mode: "fieldEqualsUid", field: "authorId", behavior: { type: "delete" } },
   { collection: "cookbook_user_votes", mode: "fieldEqualsUid", field: "userId", behavior: { type: "delete" } },
   { collection: "question_votes", mode: "fieldEqualsUid", field: "userId", behavior: { type: "delete" } },

--- a/lib/api-schemas/events.ts
+++ b/lib/api-schemas/events.ts
@@ -7,8 +7,9 @@
 
 /**
  * Events API contracts. Covers the per-event coworking flow
- * (eligibility / register / slots) and the PyData 2026 ticketing surface
- * (capacity, luma cross-check, registration, admin list).
+ * (eligibility / register / slots), on-site RSVP + waitlist, and the
+ * PyData 2026 ticketing surface (capacity, luma cross-check, registration,
+ * admin list).
  */
 
 import { initContract } from "@ts-rest/core";
@@ -87,6 +88,21 @@ const CoworkingDeleteResponse = z.object({
   success: z.literal(true),
   message: z.string(),
 });
+
+const EventRsvpBody = z.object({}).openapi("EventRsvpBody");
+
+const EventRsvpSnapshotResponse = z
+  .object({
+    success: z.literal(true),
+    configured: z.boolean(),
+    capacity: z.number().int().nonnegative(),
+    confirmedCount: z.number().int().nonnegative(),
+    waitlistCount: z.number().int().nonnegative(),
+    remaining: z.number().int().nonnegative(),
+    myStatus: z.enum(["none", "confirmed", "waitlisted"]),
+    waitlistPosition: z.number().int().positive().nullable(),
+  })
+  .openapi("EventRsvpSnapshotResponse");
 
 const PydataCapacityResponse = z.object({
   capacity: z.number().int().nonnegative(),
@@ -197,6 +213,61 @@ export const eventsContract = c.router(
       },
       metadata: {
         errorCodes: ["VALIDATION_ERROR", "RATE_LIMITED", "SERVER_ERROR"] as const,
+      },
+    },
+
+    rsvpGet: {
+      method: "GET",
+      path: "/api/events/:eventId/rsvp",
+      pathParams: EventIdParam,
+      summary: "Get on-site RSVP counts and the current user's status",
+      description:
+        "Authentication optional. Unauthenticated callers still receive capacity / waitlist counts.",
+      responses: {
+        200: EventRsvpSnapshotResponse,
+        400: ApiErrorSchema,
+        429: RateLimitedErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: ["VALIDATION_ERROR", "RATE_LIMITED", "SERVER_ERROR"] as const,
+      },
+    },
+    rsvpPost: {
+      method: "POST",
+      path: "/api/events/:eventId/rsvp",
+      pathParams: EventIdParam,
+      summary: "RSVP to an event (confirmed if under capacity, otherwise waitlisted)",
+      body: EventRsvpBody,
+      responses: {
+        200: EventRsvpSnapshotResponse,
+        ...writeErrors,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "VALIDATION_ERROR",
+          "RATE_LIMITED",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+    rsvpDelete: {
+      method: "DELETE",
+      path: "/api/events/:eventId/rsvp",
+      pathParams: EventIdParam,
+      summary: "Cancel the current user's on-site RSVP (promotes the waitlist)",
+      responses: {
+        200: EventRsvpSnapshotResponse,
+        ...writeErrors,
+      },
+      metadata: {
+        errorCodes: [
+          "UNAUTHORIZED",
+          "VALIDATION_ERROR",
+          "RATE_LIMITED",
+          "SERVER_ERROR",
+        ] as const,
       },
     },
 

--- a/lib/event-rsvp-core.ts
+++ b/lib/event-rsvp-core.ts
@@ -1,0 +1,108 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Pure RSVP helpers shared by the API and the client card.
+ * Keep Firebase Admin out of this file so client components can import it.
+ */
+
+import eventsData from "@/content/events.json";
+import type { Event, EventsData } from "@/types/events";
+
+export const EVENT_RSVPS_COLLECTION = "eventRsvps";
+
+const SPECIALIZED_EVENT_SLUGS = new Set([
+  "cursor-boston-pydata-2026",
+  "cursor-boston-sports-hack-2026",
+  "cursor-boston-hack-a-sprint-2026",
+]);
+
+export type EventRsvpStatus = "none" | "confirmed" | "waitlisted";
+
+export interface EventRsvpCounts {
+  capacity: number;
+  confirmedCount: number;
+  waitlistCount: number;
+  remaining: number;
+}
+
+export interface EventRsvpSnapshot extends EventRsvpCounts {
+  myStatus: EventRsvpStatus;
+  waitlistPosition: number | null;
+}
+
+export interface ActiveRsvp {
+  userId: string;
+  createdAtMs: number;
+}
+
+function allCatalogEvents(): Event[] {
+  const data = eventsData as EventsData;
+  return [...data.upcoming, ...data.past, ...(data.oldEvents ?? [])];
+}
+
+export function findCatalogEventById(eventId: string): Event | undefined {
+  return allCatalogEvents().find((event) => event.id === eventId);
+}
+
+export function eventSupportsOnSiteRsvp(
+  event: Pick<Event, "slug" | "capacity" | "onSiteRsvp">
+): boolean {
+  return (
+    event.onSiteRsvp === true &&
+    typeof event.capacity === "number" &&
+    event.capacity > 0 &&
+    !SPECIALIZED_EVENT_SLUGS.has(event.slug)
+  );
+}
+
+export function eventRsvpDocId(eventId: string, userId: string): string {
+  return `${eventId}__${userId}`;
+}
+
+export function deriveRsvpSnapshot(
+  active: readonly ActiveRsvp[],
+  capacity: number,
+  userId: string | null
+): EventRsvpSnapshot {
+  const sorted = [...active].sort((a, b) => {
+    if (a.createdAtMs !== b.createdAtMs) return a.createdAtMs - b.createdAtMs;
+    return a.userId.localeCompare(b.userId);
+  });
+  const confirmedCount = Math.min(sorted.length, capacity);
+  const waitlistCount = Math.max(0, sorted.length - capacity);
+  const remaining = Math.max(0, capacity - confirmedCount);
+
+  let myStatus: EventRsvpStatus = "none";
+  let waitlistPosition: number | null = null;
+  if (userId) {
+    const index = sorted.findIndex((row) => row.userId === userId);
+    if (index >= 0 && index < capacity) {
+      myStatus = "confirmed";
+    } else if (index >= capacity) {
+      myStatus = "waitlisted";
+      waitlistPosition = index - capacity + 1;
+    }
+  }
+
+  return {
+    capacity,
+    confirmedCount,
+    waitlistCount,
+    remaining,
+    myStatus,
+    waitlistPosition,
+  };
+}
+
+export function getOnSiteRsvpEvent(eventId: string): Event | null {
+  const event = findCatalogEventById(eventId);
+  if (!event || !eventSupportsOnSiteRsvp(event) || typeof event.capacity !== "number") {
+    return null;
+  }
+  return event;
+}

--- a/lib/event-rsvp.ts
+++ b/lib/event-rsvp.ts
@@ -1,0 +1,166 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Firestore-backed on-site event RSVP (capacity + waitlist).
+ */
+
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  EVENT_RSVPS_COLLECTION,
+  deriveRsvpSnapshot,
+  eventRsvpDocId,
+  getOnSiteRsvpEvent,
+  type ActiveRsvp,
+  type EventRsvpSnapshot,
+} from "@/lib/event-rsvp-core";
+
+export {
+  EVENT_RSVPS_COLLECTION,
+  deriveRsvpSnapshot,
+  eventRsvpDocId,
+  eventSupportsOnSiteRsvp,
+  findCatalogEventById,
+  getOnSiteRsvpEvent,
+  type EventRsvpSnapshot,
+  type EventRsvpStatus,
+} from "@/lib/event-rsvp-core";
+
+function timestampToMs(value: unknown): number {
+  if (value instanceof Timestamp) return value.toMillis();
+  if (
+    value &&
+    typeof value === "object" &&
+    "toMillis" in value &&
+    typeof (value as Timestamp).toMillis === "function"
+  ) {
+    return (value as Timestamp).toMillis();
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+async function loadActiveRsvps(eventId: string): Promise<ActiveRsvp[]> {
+  const db = getAdminDb();
+  if (!db) return [];
+  const snap = await db
+    .collection(EVENT_RSVPS_COLLECTION)
+    .where("eventId", "==", eventId)
+    .get();
+  return snap.docs
+    .map((doc) => {
+      const data = doc.data();
+      if (data.status !== "active") return null;
+      if (typeof data.userId !== "string") return null;
+      return {
+        userId: data.userId,
+        createdAtMs: timestampToMs(data.createdAt),
+      };
+    })
+    .filter((row): row is ActiveRsvp => row !== null);
+}
+
+export async function getEventRsvpSnapshot(
+  eventId: string,
+  userId: string | null
+): Promise<{ configured: boolean; snapshot: EventRsvpSnapshot } | { error: string }> {
+  const event = getOnSiteRsvpEvent(eventId);
+  if (!event || typeof event.capacity !== "number") {
+    return { error: "On-site RSVP is not enabled for this event." };
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return {
+      configured: false,
+      snapshot: deriveRsvpSnapshot([], event.capacity, userId),
+    };
+  }
+  const active = await loadActiveRsvps(eventId);
+  return {
+    configured: true,
+    snapshot: deriveRsvpSnapshot(active, event.capacity, userId),
+  };
+}
+
+export async function createEventRsvp(
+  eventId: string,
+  userId: string
+): Promise<{ configured: boolean; snapshot: EventRsvpSnapshot } | { error: string }> {
+  const event = getOnSiteRsvpEvent(eventId);
+  if (!event || typeof event.capacity !== "number") {
+    return { error: "On-site RSVP is not enabled for this event." };
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return { error: "Event RSVP is not configured on this server." };
+  }
+
+  const docRef = db
+    .collection(EVENT_RSVPS_COLLECTION)
+    .doc(eventRsvpDocId(eventId, userId));
+  const existing = await docRef.get();
+  const alreadyActive = existing.exists && existing.data()?.status === "active";
+  if (!alreadyActive) {
+    await docRef.set({
+      eventId,
+      userId,
+      status: "active",
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  const active = await loadActiveRsvps(eventId);
+  const hasSelf = active.some((row) => row.userId === userId);
+  if (!hasSelf) {
+    active.push({ userId, createdAtMs: Date.now() });
+  }
+  return {
+    configured: true,
+    snapshot: deriveRsvpSnapshot(active, event.capacity, userId),
+  };
+}
+
+export async function cancelEventRsvp(
+  eventId: string,
+  userId: string
+): Promise<{ configured: boolean; snapshot: EventRsvpSnapshot } | { error: string }> {
+  const event = getOnSiteRsvpEvent(eventId);
+  if (!event || typeof event.capacity !== "number") {
+    return { error: "On-site RSVP is not enabled for this event." };
+  }
+  const db = getAdminDb();
+  if (!db) {
+    return { error: "Event RSVP is not configured on this server." };
+  }
+
+  const docRef = db
+    .collection(EVENT_RSVPS_COLLECTION)
+    .doc(eventRsvpDocId(eventId, userId));
+  const existing = await docRef.get();
+  if (!existing.exists || existing.data()?.status !== "active") {
+    return { error: "You do not have an active RSVP for this event." };
+  }
+
+  await docRef.set(
+    {
+      status: "cancelled",
+      updatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  const active = await loadActiveRsvps(eventId);
+  return {
+    configured: true,
+    snapshot: deriveRsvpSnapshot(
+      active.filter((row) => row.userId !== userId),
+      event.capacity,
+      userId
+    ),
+  };
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -134,7 +134,7 @@ AI agents authenticate with:
 
 Register at POST /api/agents/register to get a key.
 
-## API (223 endpoints)
+## API (226 endpoints)
 
 Machine-readable spec: https://cursorboston.com/openapi.json
 Interactive Swagger UI: https://cursorboston.com/api/docs
@@ -208,6 +208,9 @@ Interactive Swagger UI: https://cursorboston.com/api/docs
     DELETE /api/events/{eventId}/coworking/register [Yes] — Cancel the current user's coworking registration
     POST   /api/events/{eventId}/coworking/register [Yes] — Register for a coworking session in an event
     GET    /api/events/{eventId}/coworking/slots — List coworking sessions with availability for an event
+    DELETE /api/events/{eventId}/rsvp [Yes] — Cancel the current user's on-site RSVP (promotes the waitlist)
+    GET    /api/events/{eventId}/rsvp — Get on-site RSVP counts and the current user's status
+    POST   /api/events/{eventId}/rsvp [Yes] — RSVP to an event (confirmed if under capacity, otherwise waitlisted)
     GET    /api/events/pydata-2026/access — Whether the signed-in user is on the 150-person PyData 2026 door list
     GET    /api/events/pydata-2026/admin/list [Yes] — Admin: paginated PyData 2026 registrations with cap-vs-waitlist
     GET    /api/events/pydata-2026/capacity — Public PyData 2026 capacity / claimed / remaining counts

--- a/types/events.ts
+++ b/types/events.ts
@@ -85,6 +85,8 @@ export interface Event {
   venue?: Venue;
   longDescription?: string;
   capacity?: number;
+  /** Enable first-come on-site RSVP + waitlist (not used for PyData/hackathon door lists). */
+  onSiteRsvp?: boolean;
   perks?: string[];
   topics?: string[];
   agenda?: AgendaItem[];


### PR DESCRIPTION
## Description
Adds opt-in **on-site RSVP** for catalog events: members can RSVP on cursorboston.com with capacity limits and a first-come waitlist. Confirmed spots are the first N active RSVPs by `createdAt`; canceling a confirmed spot promotes the next waitlisted person automatically.

This complements Luma (door entry can still use Luma). It does **not** replace PyData, Sports Hack, or Hack-a-Sprint signup.

Enabled in `content/events.json` for:
- Cafe Cursor (`cafe-cursor-boston`, capacity 50)
- End of Cohort 1 Hack (`cursor-boston-cohort1-end-hack-2026`, capacity 80)

**Base branch:** `develop`

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Tested locally
- `npx eslint --max-warnings=0` on changed files
- `npm run type-check`
- `npm run check:route-contracts`
- `npm test --` RSVP unit tests (`event-rsvp-core`, rsvp route, `EventRsvpCard`, slug page, account-deletion registry)

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
- Collection: `eventRsvps` (Admin SDK writes only; owners can read their row)
- Included in account deletion via `userOwnedCollections`
- Without Firebase, GET reports `configured: false` and the card still shows counts
