### PR TITLE
test(security): add fast-check property coverage for parsing surfaces

### DIFF
--- a/__tests__/lib/client-ip.property.test.ts
+++ b/__tests__/lib/client-ip.property.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Property-based coverage (fast-check) for getClientIp.
+ *
+ * Invariants under test (issue #1420):
+ *  - Totality: arbitrary attacker-controlled header values never throw
+ *    and always yield a non-empty string.
+ *  - Precedence: a present x-vercel-forwarded-for wins over any
+ *    x-forwarded-for content.
+ *  - Trusted-hop selection: with the default single trusted hop, the
+ *    rightmost x-forwarded-for entry (the proxy-written observation) is
+ *    selected, never the client-supplied left side.
+ *  - Normalization: bracketed IPv6 literals are unbracketed.
+ */
+
+import fc from "fast-check";
+import { getClientIp } from "@/lib/client-ip";
+
+function requestWithHeaders(headers: Record<string, string>): Request {
+  const filtered = Object.fromEntries(
+    Object.entries(headers).filter(([, value]) => value !== undefined)
+  );
+  return new Request("https://example.com/api/x", { headers: filtered });
+}
+
+// Header-legal arbitrary values: printable ASCII (fetch rejects other bytes).
+const headerValue = fc.stringMatching(/^[\x20-\x7e]{0,120}$/);
+
+// A single plausible IP-ish token with no comma, space, or brackets.
+const ipToken = fc.oneof(
+  fc.ipV4(),
+  fc.ipV6().map((ip) => ip),
+  fc.stringMatching(/^[a-zA-Z0-9.:_-]{1,40}$/)
+);
+
+describe("getClientIp properties", () => {
+  const originalTrustedProxyHops = process.env.TRUSTED_PROXY_HOPS;
+
+  beforeEach(() => {
+    delete process.env.TRUSTED_PROXY_HOPS;
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (originalTrustedProxyHops === undefined) {
+      delete process.env.TRUSTED_PROXY_HOPS;
+    } else {
+      process.env.TRUSTED_PROXY_HOPS = originalTrustedProxyHops;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it("never throws and always returns a non-empty string for arbitrary header values", () => {
+    fc.assert(
+      fc.property(
+        headerValue,
+        headerValue,
+        headerValue,
+        (vercel, forwarded, cloudflare) => {
+          const request = requestWithHeaders({
+            "x-vercel-forwarded-for": vercel,
+            "x-forwarded-for": forwarded,
+            "cf-connecting-ip": cloudflare,
+          });
+          const result = getClientIp(request);
+          expect(typeof result).toBe("string");
+          expect(result.length).toBeGreaterThan(0);
+        }
+      )
+    );
+  });
+
+  it("prefers x-vercel-forwarded-for over any x-forwarded-for content", () => {
+    fc.assert(
+      fc.property(fc.ipV4(), headerValue, (vercelIp, forwarded) => {
+        const request = requestWithHeaders({
+          "x-vercel-forwarded-for": vercelIp,
+          "x-forwarded-for": forwarded,
+        });
+        expect(getClientIp(request)).toBe(vercelIp);
+      })
+    );
+  });
+
+  it("selects the rightmost x-forwarded-for entry under the default trusted hop", () => {
+    fc.assert(
+      fc.property(
+        fc.array(ipToken, { minLength: 1, maxLength: 6 }),
+        (addresses) => {
+          const request = requestWithHeaders({
+            "x-forwarded-for": addresses.join(", "),
+          });
+          expect(getClientIp(request)).toBe(addresses[addresses.length - 1]);
+        }
+      )
+    );
+  });
+
+  it("unbrackets IPv6 literals from any source header", () => {
+    fc.assert(
+      fc.property(fc.ipV6(), (ip) => {
+        const request = requestWithHeaders({
+          "x-vercel-forwarded-for": `[${ip}]`,
+        });
+        expect(getClientIp(request)).toBe(ip);
+      })
+    );
+  });
+
+  it("falls back to \"unknown\" only when no header yields an address", () => {
+    const request = requestWithHeaders({});
+    expect(getClientIp(request)).toBe("unknown");
+  });
+});

--- a/__tests__/lib/github-webhook-signature.property.test.ts
+++ b/__tests__/lib/github-webhook-signature.property.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Property-based coverage (fast-check) for verifyWebhookSignature.
+ *
+ * Invariants under test (issue #1420):
+ *  - No throwing: arbitrary signature input — any unicode string, any
+ *    length — returns a boolean; malformed input is an unauthorized
+ *    result, never a server error path.
+ *  - Soundness: the only accepted signature for a payload is the exact
+ *    "sha256=" + HMAC-SHA256 hex digest under the configured secret.
+ *  - Completeness: the correct digest is always accepted.
+ *
+ * The module caches GITHUB_WEBHOOK_SECRET at import time, so the env var
+ * is set first and the module is loaded via jest.isolateModules.
+ */
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: () => ({ owner: "test-owner", repo: "test-repo" }),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => "SERVER_TS",
+    increment: (n: number) => `INCREMENT(${n})`,
+  },
+}));
+
+import fc from "fast-check";
+import { createHmac } from "crypto";
+
+const SECRET = "property-test-webhook-secret";
+
+function expectedSignature(payload: string): string {
+  return "sha256=" + createHmac("sha256", SECRET).update(payload).digest("hex");
+}
+
+let verifyWebhookSignature: (
+  payload: string,
+  signature: string | null
+) => boolean;
+
+beforeAll(() => {
+  process.env.GITHUB_WEBHOOK_SECRET = SECRET;
+  jest.isolateModules(() => {
+    ({ verifyWebhookSignature } = require("@/lib/github"));
+  });
+});
+
+afterAll(() => {
+  delete process.env.GITHUB_WEBHOOK_SECRET;
+});
+
+describe("verifyWebhookSignature properties", () => {
+  it("returns a boolean and never throws for arbitrary payload/signature pairs", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.string({ unit: "binary", maxLength: 200 }),
+        (payload, signature) => {
+          const result = verifyWebhookSignature(payload, signature);
+          expect(typeof result).toBe("boolean");
+        }
+      )
+    );
+  });
+
+  it("rejects every signature that is not the exact expected digest", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.string({ unit: "binary", maxLength: 200 }),
+        (payload, signature) => {
+          fc.pre(signature !== expectedSignature(payload));
+          expect(verifyWebhookSignature(payload, signature)).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("accepts the correct digest for any payload", () => {
+    fc.assert(
+      fc.property(fc.string(), (payload) => {
+        expect(verifyWebhookSignature(payload, expectedSignature(payload))).toBe(
+          true
+        );
+      })
+    );
+  });
+
+  it("rejects any single-character corruption of the correct signature", () => {
+    const hexChars = "0123456789abcdef";
+    fc.assert(
+      fc.property(
+        fc.string(),
+        // Position within the 64-char hex digest (after the "sha256=" prefix).
+        fc.nat({ max: 63 }),
+        fc.nat({ max: 15 }),
+        (payload, digestIndex, replacementIndex) => {
+          const valid = expectedSignature(payload);
+          const index = "sha256=".length + digestIndex;
+          const replacement = hexChars[replacementIndex];
+          fc.pre(valid[index] !== replacement);
+          const corrupted =
+            valid.slice(0, index) + replacement + valid.slice(index + 1);
+          expect(verifyWebhookSignature(payload, corrupted)).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("rejects every truncation or extension of the correct signature without throwing", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.integer({ min: -70, max: 70 }),
+        (payload, delta) => {
+          fc.pre(delta !== 0);
+          const valid = expectedSignature(payload);
+          const malformed =
+            delta < 0 ? valid.slice(0, delta) : valid + "0".repeat(delta);
+          expect(verifyWebhookSignature(payload, malformed)).toBe(false);
+        }
+      )
+    );
+  });
+});

--- a/__tests__/lib/sanitize.property.test.ts
+++ b/__tests__/lib/sanitize.property.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Property-based coverage (fast-check) for the input sanitizers.
+ *
+ * Invariants under test (issue #1420) — real output guarantees, not just
+ * "does not throw":
+ *  - sanitizeText: strips the control characters it names, normalizes
+ *    tabs/CRs to spaces, trims, and is idempotent.
+ *  - sanitizeName: output only ever contains the allowed character class,
+ *    with no doubled whitespace, and is idempotent.
+ *  - sanitizeUrl: output is null or an http(s) URL in normalized form —
+ *    normalization is a fixed point.
+ *  - sanitizeDocId: output is null or a ≤1500-char [A-Za-z0-9_-]+ string
+ *    accepted unchanged when fed back in.
+ *  - isValidHackathonId: total over arbitrary strings.
+ */
+
+import fc from "fast-check";
+import {
+  sanitizeText,
+  sanitizeName,
+  sanitizeUrl,
+  sanitizeDocId,
+  isValidHackathonId,
+} from "@/lib/sanitize";
+
+// Arbitrary unicode strings, biased toward the characters the sanitizers act on.
+const noisyString = fc.oneof(
+  fc.string({ unit: "binary", maxLength: 300 }),
+  fc.stringMatching(/^[\x00-\x1f\x7f a-zA-Z0-9<>&"'._\-\t\r\n]{0,300}$/)
+);
+
+describe("sanitizeText properties", () => {
+  it("never leaves stripped control characters, tabs, or CRs in the output", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeText(input);
+        expect(output).not.toMatch(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\t\r]/);
+      })
+    );
+  });
+
+  it("always trims surrounding whitespace", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeText(input);
+        expect(output).toBe(output.trim());
+      })
+    );
+  });
+
+  it("is idempotent", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const once = sanitizeText(input);
+        expect(sanitizeText(once)).toBe(once);
+      })
+    );
+  });
+});
+
+describe("sanitizeName properties", () => {
+  it("only ever emits the documented character class, single-spaced and trimmed", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeName(input);
+        expect(output).toMatch(/^$|^[a-zA-Z0-9\-_.]+( [a-zA-Z0-9\-_.]+)*$/);
+      })
+    );
+  });
+
+  it("is idempotent", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const once = sanitizeName(input);
+        expect(sanitizeName(once)).toBe(once);
+      })
+    );
+  });
+});
+
+describe("sanitizeUrl properties", () => {
+  const urlish = fc.oneof(
+    noisyString,
+    fc.webUrl(),
+    fc
+      .tuple(
+        fc.constantFrom("http", "https", "javascript", "data", "ftp", "file"),
+        fc.string({ maxLength: 50 })
+      )
+      .map(([scheme, rest]) => `${scheme}:${rest}`)
+  );
+
+  it("returns null or a parseable http(s) URL", () => {
+    fc.assert(
+      fc.property(urlish, (input) => {
+        const output = sanitizeUrl(input);
+        if (output === null) return;
+        const parsed = new URL(output);
+        expect(["http:", "https:"]).toContain(parsed.protocol);
+      })
+    );
+  });
+
+  it("normalized output is a fixed point", () => {
+    fc.assert(
+      fc.property(urlish, (input) => {
+        const output = sanitizeUrl(input);
+        fc.pre(output !== null);
+        expect(sanitizeUrl(output as string)).toBe(output);
+      })
+    );
+  });
+});
+
+describe("sanitizeDocId properties", () => {
+  it("returns null or a bounded id in the documented character class", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeDocId(input);
+        if (output === null) return;
+        expect(output).toMatch(/^[a-zA-Z0-9_-]+$/);
+        expect(output.length).toBeLessThanOrEqual(1500);
+      })
+    );
+  });
+
+  it("accepts its own output unchanged", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeDocId(input);
+        fc.pre(output !== null);
+        expect(sanitizeDocId(output as string)).toBe(output);
+      })
+    );
+  });
+
+  it("rejects every string longer than 1500 characters after trimming", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1501, maxLength: 1600, unit: fc.constantFrom("a", "B", "3", "-", "_") }),
+        (input) => {
+          expect(sanitizeDocId(input)).toBeNull();
+        }
+      )
+    );
+  });
+});
+
+describe("isValidHackathonId properties", () => {
+  it("is total over arbitrary strings and returns a boolean", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        expect(typeof isValidHackathonId(input)).toBe("boolean");
+      })
+    );
+  });
+
+  it("accepts every well-formed virtual-YYYY-MM id", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 9999 }),
+        fc.integer({ min: 0, max: 99 }),
+        (year, month) => {
+          const id = `virtual-${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}`;
+          expect(isValidHackathonId(id)).toBe(true);
+        }
+      )
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
+        "fast-check": "^4.9.0",
         "firebase-tools": "^15.27.0",
         "globals": "^17.11.0",
         "husky": "^8.0.3",
@@ -11831,6 +11832,46 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unused-imports": "^4.4.1",
+    "fast-check": "^4.9.0",
     "firebase-tools": "^15.27.0",
     "globals": "^17.11.0",
     "husky": "^8.0.3",


### PR DESCRIPTION
## Description

Adds `fast-check` as a devDependency and property-based tests asserting real invariants on the security parsing surfaces, per the scope claimed on the issue. Three of the issue's four target areas are covered:

- **`verifyWebhookSignature`** — arbitrary, corrupted, truncated, or extended signatures return `false` without throwing; the exact HMAC digest is always accepted; any single-character corruption of a valid signature is rejected.
- **`lib/sanitize.ts`** — control-character stripping, documented character-class and length bounds, trim guarantees, and idempotence/fixed-point properties for all five exported functions.
- **`lib/client-ip.ts`** — totality over arbitrary header values, `x-vercel-forwarded-for` precedence, rightmost-entry selection under the default trusted hop, IPv6 unbracketing.

Zod API boundary coverage from the issue's list is not in this slice; I can follow up if wanted.

Addresses #1420

## Type of Change

- [x] New feature (test coverage; no runtime code changed)

## How Has This Been Tested?

- [x] Tested locally — full suite: 660/661 suites, 7735/7736 tests pass. The single failure is a pre-existing intermittent flake in `__tests__/components/questions/QuestionsListing.test.tsx` ("renders the filtered empty state") — the `No results for '...'` assertion runs outside a `waitFor` and races the debounced search; it passes and fails on an unchanged tree and is unrelated to this change (no runtime code touched). Reported separately with repro details.
- New suites: 3 suites / 22 property tests green; `tsc --noEmit` clean; `eslint --max-warnings=0` clean
- Mutation check: a seeded one-character bug in the digest construction is caught by the soundness property

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
