### PR TITLE
fix(types): clarify utility return contracts (issue #590)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,6 +111,21 @@ const config = tseslint.config(
     },
   },
   {
+    // Issue #590 — keep explicit module-boundary return types on core utilities.
+    files: ["lib/utils.ts", "lib/sanitize.ts"],
+    rules: {
+      "@typescript-eslint/explicit-function-return-type": [
+        "error",
+        {
+          allowExpressions: true,
+          allowTypedFunctionExpressions: true,
+          allowHigherOrderFunctions: true,
+        },
+      ],
+      "@typescript-eslint/explicit-module-boundary-types": "error",
+    },
+  },
+  {
     // Test files use mock `next/image` shims that render a bare <img>;
     // alt-text and other a11y rules don't apply to test mocks. Keep
     // these as advisory in tests rather than blocking.

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -12,6 +12,18 @@
  * These functions should be used on all user-generated content before storage.
  */
 
+/** Normalized free-text safe for storage and JSX rendering. */
+export type SanitizedText = string;
+
+/** Normalized display name restricted to safe characters. */
+export type SanitizedName = string;
+
+/** Normalized http(s) URL, or null when invalid or disallowed. */
+export type SanitizedUrl = string | null;
+
+/** Valid Firestore document ID, or null when invalid. */
+export type SanitizedDocId = string | null;
+
 /**
  * Normalize free-text user input for storage.
  *
@@ -28,7 +40,7 @@
  * @param input - The raw string to normalize
  * @returns The normalized string, or an empty string if input is not a string
  */
-export function sanitizeText(input: string): string {
+export function sanitizeText(input: string): SanitizedText {
   if (typeof input !== "string") {
     return "";
   }
@@ -48,7 +60,7 @@ export function sanitizeText(input: string): string {
  * @param input - The raw display name to sanitize
  * @returns The sanitized name containing only alphanumeric characters, spaces, hyphens, underscores, and periods
  */
-export function sanitizeName(input: string): string {
+export function sanitizeName(input: string): SanitizedName {
   if (typeof input !== "string") {
     return "";
   }
@@ -68,7 +80,7 @@ export function sanitizeName(input: string): string {
  * @param input - The raw URL string to validate and sanitize
  * @returns The normalized URL string, or null if the URL is invalid or uses a dangerous protocol
  */
-export function sanitizeUrl(input: string): string | null {
+export function sanitizeUrl(input: string): SanitizedUrl {
   if (typeof input !== "string" || !input.trim()) {
     return null;
   }
@@ -96,7 +108,7 @@ export function sanitizeUrl(input: string): string | null {
  * @param input - The raw document ID to sanitize
  * @returns The sanitized document ID, or null if invalid or exceeds 1500 characters
  */
-export function sanitizeDocId(input: string): string | null {
+export function sanitizeDocId(input: string): SanitizedDocId {
   if (typeof input !== "string" || !input.trim()) {
     return null;
   }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,6 +7,12 @@
 
 import { Timestamp } from "firebase/firestore";
 
+/** User fields used to derive a stable display label. */
+export type DisplayNameSource = {
+  name?: string | null;
+  email?: string | null;
+};
+
 /**
  * Merge class names, filtering out falsy values.
  */
@@ -33,10 +39,7 @@ export function getInitials(name: string | null | undefined): string {
  * Get a stable display name from a user record.
  * Falls back from name -> local-part of email -> "Anonymous".
  */
-export function getDisplayName(user: {
-  name?: string | null;
-  email?: string | null;
-}): string {
+export function getDisplayName(user: DisplayNameSource): string {
   const trimmedName = user.name?.trim();
   if (trimmedName) return trimmedName;
 


### PR DESCRIPTION
## Summary

Closes #590.

On `develop`, exported functions in `lib/utils.ts` and `lib/sanitize.ts` already had explicit return types. This PR strengthens the public contract without changing runtime behavior:

- Adds `DisplayNameSource` plus named sanitize result types (`SanitizedText`, `SanitizedName`, `SanitizedUrl`, `SanitizedDocId`).
- Uses those types on exported utility signatures.
- Adds a scoped ESLint override on both files so module-boundary return types stay explicit.

## Scope

- `lib/utils.ts`
- `lib/sanitize.ts`
- `eslint.config.mjs` (scoped override only)

## Verification

- `npx eslint lib/utils.ts lib/sanitize.ts eslint.config.mjs`
- `npx jest --config config/jest.config.js __tests__/lib/utils.test.ts __tests__/lib/sanitize.test.ts` (35 passed)
- Pre-commit `tsc --noEmit` + eslint clean

## Test plan

- [x] No runtime behavior changes
- [x] Existing utils/sanitize tests pass
- [x] ESLint explicit return-type rules pass on scoped files