### PR TITLE
release: develop → main 2026-08-24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,13 @@ Notes:
 - `score.json` is **maintainer-authored**, not contributor-authored. Reject any PR that includes a `score.json` written by the contributor — they don't get to score themselves.
 - If `ANTHROPIC_API_KEY` isn't available locally, you can run the scorer against the merged folder later, but score every submission before announcing winners — the "Best Submission" prize is decided from these scores.
 - A PyData submission without `score.json` will still render on the event page (the badge just won't appear), but it is **ineligible for "Best Submission"** until scored.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/__tests__/lib/client-ip.property.test.ts
+++ b/__tests__/lib/client-ip.property.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Property-based coverage (fast-check) for getClientIp.
+ *
+ * Invariants under test (issue #1420):
+ *  - Totality: arbitrary attacker-controlled header values never throw
+ *    and always yield a non-empty string.
+ *  - Precedence: a present x-vercel-forwarded-for wins over any
+ *    x-forwarded-for content.
+ *  - Trusted-hop selection: with the default single trusted hop, the
+ *    rightmost x-forwarded-for entry (the proxy-written observation) is
+ *    selected, never the client-supplied left side.
+ *  - Normalization: bracketed IPv6 literals are unbracketed.
+ */
+
+import fc from "fast-check";
+import { getClientIp } from "@/lib/client-ip";
+
+function requestWithHeaders(headers: Record<string, string>): Request {
+  const filtered = Object.fromEntries(
+    Object.entries(headers).filter(([, value]) => value !== undefined)
+  );
+  return new Request("https://example.com/api/x", { headers: filtered });
+}
+
+// Header-legal arbitrary values: printable ASCII (fetch rejects other bytes).
+const headerValue = fc.stringMatching(/^[\x20-\x7e]{0,120}$/);
+
+// A single plausible IP-ish token with no comma, space, or brackets.
+const ipToken = fc.oneof(
+  fc.ipV4(),
+  fc.ipV6().map((ip) => ip),
+  fc.stringMatching(/^[a-zA-Z0-9.:_-]{1,40}$/)
+);
+
+describe("getClientIp properties", () => {
+  const originalTrustedProxyHops = process.env.TRUSTED_PROXY_HOPS;
+
+  beforeEach(() => {
+    delete process.env.TRUSTED_PROXY_HOPS;
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (originalTrustedProxyHops === undefined) {
+      delete process.env.TRUSTED_PROXY_HOPS;
+    } else {
+      process.env.TRUSTED_PROXY_HOPS = originalTrustedProxyHops;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it("never throws and always returns a non-empty string for arbitrary header values", () => {
+    fc.assert(
+      fc.property(
+        headerValue,
+        headerValue,
+        headerValue,
+        (vercel, forwarded, cloudflare) => {
+          const request = requestWithHeaders({
+            "x-vercel-forwarded-for": vercel,
+            "x-forwarded-for": forwarded,
+            "cf-connecting-ip": cloudflare,
+          });
+          const result = getClientIp(request);
+          expect(typeof result).toBe("string");
+          expect(result.length).toBeGreaterThan(0);
+        }
+      )
+    );
+  });
+
+  it("prefers x-vercel-forwarded-for over any x-forwarded-for content", () => {
+    fc.assert(
+      fc.property(fc.ipV4(), headerValue, (vercelIp, forwarded) => {
+        const request = requestWithHeaders({
+          "x-vercel-forwarded-for": vercelIp,
+          "x-forwarded-for": forwarded,
+        });
+        expect(getClientIp(request)).toBe(vercelIp);
+      })
+    );
+  });
+
+  it("selects the rightmost x-forwarded-for entry under the default trusted hop", () => {
+    fc.assert(
+      fc.property(
+        fc.array(ipToken, { minLength: 1, maxLength: 6 }),
+        (addresses) => {
+          const request = requestWithHeaders({
+            "x-forwarded-for": addresses.join(", "),
+          });
+          expect(getClientIp(request)).toBe(addresses[addresses.length - 1]);
+        }
+      )
+    );
+  });
+
+  it("unbrackets IPv6 literals from any source header", () => {
+    fc.assert(
+      fc.property(fc.ipV6(), (ip) => {
+        const request = requestWithHeaders({
+          "x-vercel-forwarded-for": `[${ip}]`,
+        });
+        expect(getClientIp(request)).toBe(ip);
+      })
+    );
+  });
+
+  it("falls back to \"unknown\" only when no header yields an address", () => {
+    const request = requestWithHeaders({});
+    expect(getClientIp(request)).toBe("unknown");
+  });
+});

--- a/__tests__/lib/github-webhook-signature.property.test.ts
+++ b/__tests__/lib/github-webhook-signature.property.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Property-based coverage (fast-check) for verifyWebhookSignature.
+ *
+ * Invariants under test (issue #1420):
+ *  - No throwing: arbitrary signature input — any unicode string, any
+ *    length — returns a boolean; malformed input is an unauthorized
+ *    result, never a server error path.
+ *  - Soundness: the only accepted signature for a payload is the exact
+ *    "sha256=" + HMAC-SHA256 hex digest under the configured secret.
+ *  - Completeness: the correct digest is always accepted.
+ *
+ * The module caches GITHUB_WEBHOOK_SECRET at import time, so the env var
+ * is set first and the module is loaded via jest.isolateModules.
+ */
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: jest.fn(),
+}));
+
+jest.mock("@/lib/github-recent-merged-prs", () => ({
+  getGithubRepoPair: () => ({ owner: "test-owner", repo: "test-repo" }),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => "SERVER_TS",
+    increment: (n: number) => `INCREMENT(${n})`,
+  },
+}));
+
+import fc from "fast-check";
+import { createHmac } from "crypto";
+
+const SECRET = "property-test-webhook-secret";
+
+function expectedSignature(payload: string): string {
+  return "sha256=" + createHmac("sha256", SECRET).update(payload).digest("hex");
+}
+
+let verifyWebhookSignature: (
+  payload: string,
+  signature: string | null
+) => boolean;
+
+beforeAll(() => {
+  process.env.GITHUB_WEBHOOK_SECRET = SECRET;
+  jest.isolateModules(() => {
+    ({ verifyWebhookSignature } = require("@/lib/github"));
+  });
+});
+
+afterAll(() => {
+  delete process.env.GITHUB_WEBHOOK_SECRET;
+});
+
+describe("verifyWebhookSignature properties", () => {
+  it("returns a boolean and never throws for arbitrary payload/signature pairs", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.string({ unit: "binary", maxLength: 200 }),
+        (payload, signature) => {
+          const result = verifyWebhookSignature(payload, signature);
+          expect(typeof result).toBe("boolean");
+        }
+      )
+    );
+  });
+
+  it("rejects every signature that is not the exact expected digest", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.string({ unit: "binary", maxLength: 200 }),
+        (payload, signature) => {
+          fc.pre(signature !== expectedSignature(payload));
+          expect(verifyWebhookSignature(payload, signature)).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("accepts the correct digest for any payload", () => {
+    fc.assert(
+      fc.property(fc.string(), (payload) => {
+        expect(verifyWebhookSignature(payload, expectedSignature(payload))).toBe(
+          true
+        );
+      })
+    );
+  });
+
+  it("rejects any single-character corruption of the correct signature", () => {
+    const hexChars = "0123456789abcdef";
+    fc.assert(
+      fc.property(
+        fc.string(),
+        // Position within the 64-char hex digest (after the "sha256=" prefix).
+        fc.nat({ max: 63 }),
+        fc.nat({ max: 15 }),
+        (payload, digestIndex, replacementIndex) => {
+          const valid = expectedSignature(payload);
+          const index = "sha256=".length + digestIndex;
+          const replacement = hexChars[replacementIndex];
+          fc.pre(valid[index] !== replacement);
+          const corrupted =
+            valid.slice(0, index) + replacement + valid.slice(index + 1);
+          expect(verifyWebhookSignature(payload, corrupted)).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("rejects every truncation or extension of the correct signature without throwing", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.integer({ min: -70, max: 70 }),
+        (payload, delta) => {
+          fc.pre(delta !== 0);
+          const valid = expectedSignature(payload);
+          const malformed =
+            delta < 0 ? valid.slice(0, delta) : valid + "0".repeat(delta);
+          expect(verifyWebhookSignature(payload, malformed)).toBe(false);
+        }
+      )
+    );
+  });
+});

--- a/__tests__/lib/link-fragment-hunt.test.ts
+++ b/__tests__/lib/link-fragment-hunt.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+import {
+  LINK_FRAGMENT_PUZZLES,
+  assembleReferralUrl,
+  getLinkFragmentReferralCode,
+  getLinkFragmentSlices,
+  listLinkFragmentPuzzles,
+  signLinkFragmentToken,
+  verifyLinkFragmentToken,
+} from "@/lib/link-fragment-hunt";
+
+describe("link-fragment-hunt", () => {
+  beforeEach(() => {
+    delete process.env.LINK_FRAGMENT_HUNT_CODE;
+  });
+
+  it("exposes six puzzles in index order", () => {
+    const puzzles = listLinkFragmentPuzzles();
+    expect(puzzles).toHaveLength(6);
+    expect(puzzles.map((p) => p.index)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("splits the default code into six 2-char fragments", () => {
+    expect(getLinkFragmentReferralCode()).toBe("HULTSUMMER26");
+    expect(getLinkFragmentSlices()).toEqual(["HU", "LT", "SU", "MM", "ER", "26"]);
+  });
+
+  it("verifies puzzle answers case-insensitively", () => {
+    expect(LINK_FRAGMENT_PUZZLES["about-beantown"].verify("Beantown")).toBe(true);
+    expect(LINK_FRAGMENT_PUZZLES["events-perks"].verify("4")).toBe(true);
+    expect(LINK_FRAGMENT_PUZZLES["hult-guest"].verify("Shiv Jethi")).toBe(true);
+    expect(LINK_FRAGMENT_PUZZLES["about-beantown"].verify("wrong")).toBe(false);
+  });
+
+  it("signs and verifies fragment tokens", () => {
+    const token = signLinkFragmentToken("about-beantown", "LT");
+    expect(verifyLinkFragmentToken("about-beantown", "LT", token)).toBe(true);
+    expect(verifyLinkFragmentToken("about-beantown", "HU", token)).toBe(false);
+  });
+
+  it("assembles a full referral URL from valid tokens", () => {
+    const tokens = Object.fromEntries(
+      listLinkFragmentPuzzles().map((p) => [
+        p.id,
+        signLinkFragmentToken(p.id, getLinkFragmentSlices()[p.index]!),
+      ])
+    );
+    const result = assembleReferralUrl(tokens);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe(
+        "https://cursor.com/referral?code=HULTSUMMER26"
+      );
+    }
+  });
+});

--- a/__tests__/lib/sanitize.property.test.ts
+++ b/__tests__/lib/sanitize.property.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Property-based coverage (fast-check) for the input sanitizers.
+ *
+ * Invariants under test (issue #1420) — real output guarantees, not just
+ * "does not throw":
+ *  - sanitizeText: strips the control characters it names, normalizes
+ *    tabs/CRs to spaces, trims, and is idempotent.
+ *  - sanitizeName: output only ever contains the allowed character class,
+ *    with no doubled whitespace, and is idempotent.
+ *  - sanitizeUrl: output is null or an http(s) URL in normalized form —
+ *    normalization is a fixed point.
+ *  - sanitizeDocId: output is null or a ≤1500-char [A-Za-z0-9_-]+ string
+ *    accepted unchanged when fed back in.
+ *  - isValidHackathonId: total over arbitrary strings.
+ */
+
+import fc from "fast-check";
+import {
+  sanitizeText,
+  sanitizeName,
+  sanitizeUrl,
+  sanitizeDocId,
+  isValidHackathonId,
+} from "@/lib/sanitize";
+
+// Arbitrary unicode strings, biased toward the characters the sanitizers act on.
+const noisyString = fc.oneof(
+  fc.string({ unit: "binary", maxLength: 300 }),
+  fc.stringMatching(/^[\x00-\x1f\x7f a-zA-Z0-9<>&"'._\-\t\r\n]{0,300}$/)
+);
+
+describe("sanitizeText properties", () => {
+  it("never leaves stripped control characters, tabs, or CRs in the output", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeText(input);
+        expect(output).not.toMatch(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\t\r]/);
+      })
+    );
+  });
+
+  it("always trims surrounding whitespace", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeText(input);
+        expect(output).toBe(output.trim());
+      })
+    );
+  });
+
+  it("is idempotent", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const once = sanitizeText(input);
+        expect(sanitizeText(once)).toBe(once);
+      })
+    );
+  });
+});
+
+describe("sanitizeName properties", () => {
+  it("only ever emits the documented character class, single-spaced and trimmed", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeName(input);
+        expect(output).toMatch(/^$|^[a-zA-Z0-9\-_.]+( [a-zA-Z0-9\-_.]+)*$/);
+      })
+    );
+  });
+
+  it("is idempotent", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const once = sanitizeName(input);
+        expect(sanitizeName(once)).toBe(once);
+      })
+    );
+  });
+});
+
+describe("sanitizeUrl properties", () => {
+  const urlish = fc.oneof(
+    noisyString,
+    fc.webUrl(),
+    fc
+      .tuple(
+        fc.constantFrom("http", "https", "javascript", "data", "ftp", "file"),
+        fc.string({ maxLength: 50 })
+      )
+      .map(([scheme, rest]) => `${scheme}:${rest}`)
+  );
+
+  it("returns null or a parseable http(s) URL", () => {
+    fc.assert(
+      fc.property(urlish, (input) => {
+        const output = sanitizeUrl(input);
+        if (output === null) return;
+        const parsed = new URL(output);
+        expect(["http:", "https:"]).toContain(parsed.protocol);
+      })
+    );
+  });
+
+  it("normalized output is a fixed point", () => {
+    fc.assert(
+      fc.property(urlish, (input) => {
+        const output = sanitizeUrl(input);
+        fc.pre(output !== null);
+        expect(sanitizeUrl(output as string)).toBe(output);
+      })
+    );
+  });
+});
+
+describe("sanitizeDocId properties", () => {
+  it("returns null or a bounded id in the documented character class", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeDocId(input);
+        if (output === null) return;
+        expect(output).toMatch(/^[a-zA-Z0-9_-]+$/);
+        expect(output.length).toBeLessThanOrEqual(1500);
+      })
+    );
+  });
+
+  it("accepts its own output unchanged", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        const output = sanitizeDocId(input);
+        fc.pre(output !== null);
+        expect(sanitizeDocId(output as string)).toBe(output);
+      })
+    );
+  });
+
+  it("rejects every string longer than 1500 characters after trimming", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1501, maxLength: 1600, unit: fc.constantFrom("a", "B", "3", "-", "_") }),
+        (input) => {
+          expect(sanitizeDocId(input)).toBeNull();
+        }
+      )
+    );
+  });
+});
+
+describe("isValidHackathonId properties", () => {
+  it("is total over arbitrary strings and returns a boolean", () => {
+    fc.assert(
+      fc.property(noisyString, (input) => {
+        expect(typeof isValidHackathonId(input)).toBe("boolean");
+      })
+    );
+  });
+
+  it("accepts every well-formed virtual-YYYY-MM id", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 9999 }),
+        fc.integer({ min: 0, max: 99 }),
+        (year, month) => {
+          const id = `virtual-${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}`;
+          expect(isValidHackathonId(id)).toBe(true);
+        }
+      )
+    );
+  });
+});

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -8,6 +8,7 @@
 import { Metadata } from "next";
 import Logo from "@/components/Logo";
 import { DiscordIcon } from "@/components/icons";
+import { HuntSourceComment } from "@/components/hunt/HuntSourceComment";
 
 export const metadata: Metadata = {
   title: "About",
@@ -77,6 +78,7 @@ const accelerators = [
 export default function AboutPage() {
   return (
     <main className="flex flex-col">
+      <HuntSourceComment text="Link hunt: Beantown wasn't built in a day." />
       {/* Hero */}
       <section className="py-16 md:py-24 px-6 border-b border-neutral-200 dark:border-neutral-800">
         <div className="max-w-4xl mx-auto text-center">

--- a/app/api/hunt/link-fragment/assemble/route.ts
+++ b/app/api/hunt/link-fragment/assemble/route.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  assembleReferralUrl,
+  linkFragmentHuntEnabled,
+  type LinkFragmentPuzzleId,
+} from "@/lib/link-fragment-hunt";
+import { huntContract } from "@/lib/api-schemas/hunt";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  try {
+    if (!linkFragmentHuntEnabled()) {
+      return NextResponse.json({ ok: false, reason: "disabled" }, { status: 403 });
+    }
+
+    const parsed = huntContract.linkFragmentAssemble.body.safeParse(
+      await request.json().catch(() => ({}))
+    );
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, reason: "validation_error" },
+        { status: 400 }
+      );
+    }
+
+    const result = assembleReferralUrl(
+      parsed.data.tokens as Partial<Record<LinkFragmentPuzzleId, string>>
+    );
+    if (!result.ok) {
+      return NextResponse.json({ ok: false, reason: result.reason }, { status: 400 });
+    }
+
+    return NextResponse.json({ ok: true, url: result.url });
+  } catch (e) {
+    console.error("[hunt/link-fragment/assemble]", e);
+    return NextResponse.json({ ok: false, reason: "server_error" }, { status: 500 });
+  }
+}

--- a/app/api/hunt/link-fragment/verify/route.ts
+++ b/app/api/hunt/link-fragment/verify/route.ts
@@ -1,0 +1,68 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getLinkFragmentPuzzle,
+  getLinkFragmentSlices,
+  linkFragmentHuntEnabled,
+  signLinkFragmentToken,
+  type LinkFragmentPuzzleId,
+} from "@/lib/link-fragment-hunt";
+import { huntContract } from "@/lib/api-schemas/hunt";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  try {
+    if (!linkFragmentHuntEnabled()) {
+      return NextResponse.json({ ok: false, reason: "disabled" }, { status: 403 });
+    }
+
+    const parsed = huntContract.linkFragmentVerify.body.safeParse(
+      await request.json().catch(() => ({}))
+    );
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, reason: "validation_error" },
+        { status: 400 }
+      );
+    }
+
+    const puzzle = getLinkFragmentPuzzle(parsed.data.puzzleId);
+    if (!puzzle) {
+      return NextResponse.json({ ok: false, reason: "unknown_puzzle" }, { status: 404 });
+    }
+
+    if (!puzzle.verify(parsed.data.answer)) {
+      return NextResponse.json({ ok: false, reason: "wrong_answer" });
+    }
+
+    const slices = getLinkFragmentSlices();
+    const fragment = slices[puzzle.index];
+    if (!fragment) {
+      return NextResponse.json({ ok: false, reason: "server_error" }, { status: 500 });
+    }
+
+    const token = signLinkFragmentToken(
+      puzzle.id as LinkFragmentPuzzleId,
+      fragment
+    );
+
+    return NextResponse.json({
+      ok: true,
+      puzzleId: puzzle.id,
+      fragment,
+      index: puzzle.index,
+      token,
+    });
+  } catch (e) {
+    console.error("[hunt/link-fragment/verify]", e);
+    return NextResponse.json({ ok: false, reason: "server_error" }, { status: 500 });
+  }
+}

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
   getLumaCheckoutHref,
 } from "@/lib/luma-event";
 import { PYDATA_2026_EVENT_SLUG } from "@/lib/pydata-2026";
+import { HuntSourceComment } from "@/components/hunt/HuntSourceComment";
 
 // Type definitions for event data
 interface AgendaItem {
@@ -241,6 +242,9 @@ export default async function EventPage({
 
   return (
     <div className="flex flex-col">
+      {slug === "cursor-boston-hult-summer-hackathon-2026" && (
+        <HuntSourceComment text="Link hunt: who from Cursor joins at 2:30 PM? First and last name." />
+      )}
       {/* JSON-LD */}
       <script
         type="application/ld+json"

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import eventsData from "@/content/events.json";
 import { EventsBrowse } from "@/components/events/EventsBrowse";
 import { PydataLockedBanner } from "@/components/events/PydataLockedBanner";
+import { HuntSourceComment } from "@/components/hunt/HuntSourceComment";
 import { todayYmdInListingTz } from "@/lib/events-calendar-buckets";
 import { EventsData } from "@/types/events";
 
@@ -165,6 +166,7 @@ export default async function EventsPage({
 
   return (
     <main className="flex flex-col">
+      <HuntSourceComment text="Link hunt: count the Hult Summer Hackathon perks (digits only)." />
       {eventsJsonLd.map((event, index) => (
         <script
           key={index}

--- a/app/hunt/link/page.tsx
+++ b/app/hunt/link/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { Metadata } from "next";
+import { LinkFragmentAssembler } from "@/components/hunt/LinkFragmentAssembler";
+
+export const metadata: Metadata = {
+  title: "Link Fragment Hunt",
+  robots: { index: false, follow: false },
+};
+
+export default function LinkFragmentHuntPage() {
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-16">
+      <h1 className="text-3xl font-bold">Complete the link</h1>
+      <p className="mt-3 text-zinc-400">
+        Cursor Boston × Hult Summer Hackathon attendees: the referral URL you
+        received is missing its code. Hunt six fragments across the site, then
+        paste them together here.
+      </p>
+      <div className="mt-10">
+        <LinkFragmentAssembler />
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import AppShell from "@/components/AppShell";
 import SummerCohortModal from "@/components/SummerCohortModal";
 import LumaCheckoutTracker from "@/components/LumaCheckoutTracker";
 import { KonamiListener } from "@/components/hunt/KonamiListener";
+import { LinkFragmentOrchestrator } from "@/components/hunt/LinkFragmentOrchestrator";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ToastProvider } from "@/components/Toast";
@@ -129,6 +130,7 @@ export default function RootLayout({
               <SummerCohortModal />
               <LumaCheckoutTracker />
               <KonamiListener />
+              <LinkFragmentOrchestrator />
             </ToastProvider>
           </AuthProvider>
         </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import Logo from "@/components/Logo";
 import { DiscordIcon } from "@/components/icons";
+import { HuntSourceComment } from "@/components/hunt/HuntSourceComment";
 
 export const metadata: Metadata = {
   title: "Cursor Boston - AI Coding Community",
@@ -179,6 +180,7 @@ export default function Home() {
     <div className="flex flex-col">
       {/* Hero Section */}
       <section className="py-16 md:py-24 px-6">
+        <HuntSourceComment text="Link hunt: seven beats on the logo unlock the first fragment." />
         <div className="max-w-4xl mx-auto text-center">
           <Logo size="heroHome" className="mx-auto mb-6" priority />
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground mb-4 tracking-tight">

--- a/app/summer-cohort/page.tsx
+++ b/app/summer-cohort/page.tsx
@@ -22,6 +22,7 @@ import { Sun } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { DiscordIcon, GitHubIcon } from "@/components/icons";
 import { SectionHelp } from "@/components/SectionHelp";
+import { HuntSourceComment } from "@/components/hunt/HuntSourceComment";
 import { useGithubConnection } from "@/app/(auth)/profile/_hooks/useGithubConnection";
 import { useDiscordConnection } from "@/app/(auth)/profile/_hooks/useDiscordConnection";
 import {
@@ -885,6 +886,7 @@ function SummerCohortPageInner() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 md:px-6 md:py-14">
+      <HuntSourceComment text="Link hunt: the Cambridge school on 1 Education St (one word)." />
       {/* Hult transition banner — every cohort surface signals the launch. */}
       <section className="mb-8 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-5 dark:bg-emerald-500/10">
         <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">

--- a/components/hunt/HuntSourceComment.tsx
+++ b/components/hunt/HuntSourceComment.tsx
@@ -1,0 +1,17 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/** Renders an HTML comment into the page for view-source puzzle clues. */
+export function HuntSourceComment({ text }: { text: string }) {
+  return (
+    <div
+      className="hidden"
+      aria-hidden
+      dangerouslySetInnerHTML={{ __html: `<!-- ${text} -->` }}
+    />
+  );
+}

--- a/components/hunt/LinkFragmentAssembler.tsx
+++ b/components/hunt/LinkFragmentAssembler.tsx
@@ -1,0 +1,213 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  LINK_FRAGMENT_COUNT,
+  LINK_FRAGMENT_REFERRAL_BASE,
+  listLinkFragmentPuzzles,
+  type LinkFragmentPuzzle,
+} from "@/lib/link-fragment-hunt";
+import {
+  LINK_FRAGMENT_UPDATED_EVENT,
+  readStoredFragments,
+  storedFragmentMap,
+  writeStoredFragment,
+  type StoredLinkFragment,
+} from "@/components/hunt/link-fragment-storage";
+
+export function LinkFragmentAssembler() {
+  const puzzles = useMemo(() => listLinkFragmentPuzzles(), []);
+  const [stored, setStored] = useState<Partial<Record<string, StoredLinkFragment>>>(
+    () => storedFragmentMap()
+  );
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [fullUrl, setFullUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    function syncStored() {
+      setStored(storedFragmentMap());
+    }
+    window.addEventListener(LINK_FRAGMENT_UPDATED_EVENT, syncStored);
+    return () => window.removeEventListener(LINK_FRAGMENT_UPDATED_EVENT, syncStored);
+  }, []);
+
+  const foundCount = puzzles.filter((p) => stored[p.id]).length;
+  const allFound = foundCount >= LINK_FRAGMENT_COUNT;
+  const maskedCode = puzzles
+    .map((p) => stored[p.id]?.fragment ?? "??")
+    .join("");
+
+  useEffect(() => {
+    if (!allFound) return;
+
+    const tokens = Object.fromEntries(
+      puzzles.map((p) => [p.id, stored[p.id]!.token])
+    );
+
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch("/api/hunt/link-fragment/assemble", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tokens }),
+      });
+      const j = (await res.json()) as { ok?: boolean; url?: string };
+      if (!cancelled && j.ok && j.url) setFullUrl(j.url);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [allFound, puzzles, stored]);
+
+  const displayUrl = allFound ? fullUrl : null;
+
+  async function submitPuzzle(puzzle: LinkFragmentPuzzle) {
+    const answer = (answers[puzzle.id] || "").trim();
+    if (!answer) return;
+
+    setSubmitting(puzzle.id);
+    setErrors((e) => ({ ...e, [puzzle.id]: "" }));
+    try {
+      const res = await fetch("/api/hunt/link-fragment/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ puzzleId: puzzle.id, answer }),
+      });
+      const j = (await res.json()) as {
+        ok?: boolean;
+        reason?: string;
+        fragment?: string;
+        token?: string;
+        index?: number;
+      };
+      if (j.ok && j.token && j.fragment && typeof j.index === "number") {
+        writeStoredFragment({
+          puzzleId: puzzle.id,
+          fragment: j.fragment,
+          token: j.token,
+          index: j.index,
+        });
+        setAnswers((a) => ({ ...a, [puzzle.id]: "" }));
+        setStored(storedFragmentMap());
+      } else {
+        const msg =
+          j.reason === "wrong_answer"
+            ? "Not quite — keep exploring the site."
+            : "Could not verify. Try again.";
+        setErrors((e) => ({ ...e, [puzzle.id]: msg }));
+      }
+    } catch {
+      setErrors((e) => ({ ...e, [puzzle.id]: "Network error." }));
+    } finally {
+      setSubmitting(null);
+    }
+  }
+
+  async function copyUrl(url: string) {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-5">
+        <p className="text-sm text-zinc-400">
+          You were given the start of a link. Six pairs of characters are hidden
+          across cursorboston.com — solve each puzzle to reveal them.
+        </p>
+        <p className="mt-4 font-mono text-lg tracking-widest text-emerald-400 break-all">
+          {LINK_FRAGMENT_REFERRAL_BASE}
+          <span className="text-amber-300">{maskedCode}</span>
+        </p>
+        <p className="mt-2 text-xs text-zinc-500">
+          {foundCount} / {LINK_FRAGMENT_COUNT} fragments found
+          {readStoredFragments().some((f) => f.puzzleId === "home-pulse")
+            ? ""
+            : " · one unlocks from an interaction on the home page"}
+        </p>
+        {displayUrl && (
+          <div className="mt-5 rounded-lg border border-emerald-800/50 bg-emerald-950/30 p-4">
+            <p className="text-sm font-medium text-emerald-300">Full link</p>
+            <p className="mt-2 font-mono text-sm text-emerald-100 break-all">{displayUrl}</p>
+            <button
+              type="button"
+              onClick={() => void copyUrl(displayUrl)}
+              className="mt-3 rounded bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-emerald-500"
+            >
+              {copied ? "Copied!" : "Copy link"}
+            </button>
+          </div>
+        )}
+      </section>
+
+      <div className="grid gap-4">
+        {puzzles.map((puzzle) => {
+          const found = stored[puzzle.id];
+          return (
+            <article
+              key={puzzle.id}
+              className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-5"
+            >
+              <h2 className="text-lg font-semibold">
+                {puzzle.emoji} {puzzle.title}
+              </h2>
+              <p className="mt-2 text-sm text-zinc-400">{puzzle.hint}</p>
+              <p className="mt-1 text-xs text-zinc-500">
+                Clue lives on{" "}
+                <code className="text-zinc-400">{puzzle.page}</code>
+              </p>
+
+              {found ? (
+                <p className="mt-4 font-mono text-emerald-400">
+                  Fragment {puzzle.index + 1}: {found.fragment}
+                </p>
+              ) : (
+                <form
+                  className="mt-4 flex flex-col gap-2 sm:flex-row"
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    void submitPuzzle(puzzle);
+                  }}
+                >
+                  <input
+                    type="text"
+                    value={answers[puzzle.id] || ""}
+                    onChange={(e) =>
+                      setAnswers((a) => ({ ...a, [puzzle.id]: e.target.value }))
+                    }
+                    placeholder="Your answer"
+                    className="flex-1 rounded border border-zinc-700 bg-zinc-950 px-3 py-2 font-mono text-sm"
+                    autoComplete="off"
+                    spellCheck={false}
+                  />
+                  <button
+                    type="submit"
+                    disabled={submitting === puzzle.id}
+                    className="rounded bg-amber-500 px-4 py-2 text-sm font-semibold text-zinc-900 hover:bg-amber-400 disabled:opacity-50"
+                  >
+                    {submitting === puzzle.id ? "Checking…" : "Submit"}
+                  </button>
+                  {errors[puzzle.id] && (
+                    <p className="text-sm text-rose-400 sm:basis-full">{errors[puzzle.id]}</p>
+                  )}
+                </form>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/hunt/LinkFragmentOrchestrator.tsx
+++ b/components/hunt/LinkFragmentOrchestrator.tsx
@@ -1,0 +1,95 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { useToast } from "@/components/Toast";
+import {
+  readStoredFragments,
+  writeStoredFragment,
+} from "@/components/hunt/link-fragment-storage";
+
+const LOGO_CLICK_TARGET = 7;
+const LOGO_CLICK_WINDOW_MS = 4000;
+
+async function verifyPuzzle(puzzleId: string, answer: string) {
+  const res = await fetch("/api/hunt/link-fragment/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ puzzleId, answer }),
+  });
+  return (await res.json()) as {
+    ok?: boolean;
+    reason?: string;
+    puzzleId?: string;
+    fragment?: string;
+    index?: number;
+    token?: string;
+  };
+}
+
+/**
+ * Sitewide listener for interaction-based link-fragment puzzles (e.g. home logo taps).
+ */
+export function LinkFragmentOrchestrator() {
+  const pathname = usePathname();
+  const { success } = useToast();
+  const clickTimes = useRef<number[]>([]);
+  const unlocking = useRef(false);
+
+  const unlockHomePulse = useCallback(async () => {
+    if (unlocking.current) return;
+    const already = readStoredFragments().some((f) => f.puzzleId === "home-pulse");
+    if (already) return;
+
+    unlocking.current = true;
+    try {
+      const j = await verifyPuzzle("home-pulse", "seven-beats");
+      if (j.ok && j.token && j.fragment && typeof j.index === "number") {
+        writeStoredFragment({
+          puzzleId: "home-pulse",
+          fragment: j.fragment,
+          token: j.token,
+          index: j.index,
+        });
+        success({
+          title: `Fragment ${j.index + 1} unlocked: ${j.fragment}`,
+        });
+      }
+    } finally {
+      unlocking.current = false;
+    }
+  }, [success]);
+
+  useEffect(() => {
+    if (pathname !== "/") return;
+
+    function onLogoClick(e: MouseEvent) {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      const img = target.closest('img[alt="Cursor Boston"]');
+      if (!img) return;
+
+      const now = Date.now();
+      clickTimes.current = clickTimes.current
+        .filter((t) => now - t < LOGO_CLICK_WINDOW_MS)
+        .concat(now);
+
+      if (clickTimes.current.length >= LOGO_CLICK_TARGET) {
+        clickTimes.current = [];
+        void unlockHomePulse();
+      }
+    }
+
+    document.addEventListener("click", onLogoClick);
+    return () => document.removeEventListener("click", onLogoClick);
+  }, [pathname, unlockHomePulse]);
+
+  return null;
+}

--- a/components/hunt/link-fragment-storage.ts
+++ b/components/hunt/link-fragment-storage.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import type { LinkFragmentPuzzleId } from "@/lib/link-fragment-hunt";
+
+export const LINK_FRAGMENT_STORAGE_KEY = "cb-link-fragment-hunt-v1";
+export const LINK_FRAGMENT_UPDATED_EVENT = "cb-link-fragments-updated";
+
+export type StoredLinkFragment = {
+  puzzleId: LinkFragmentPuzzleId;
+  fragment: string;
+  token: string;
+  index: number;
+};
+
+export function readStoredFragments(): StoredLinkFragment[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(LINK_FRAGMENT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as StoredLinkFragment[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeStoredFragment(entry: StoredLinkFragment): void {
+  if (typeof window === "undefined") return;
+  const existing = readStoredFragments().filter((f) => f.puzzleId !== entry.puzzleId);
+  existing.push(entry);
+  existing.sort((a, b) => a.index - b.index);
+  window.localStorage.setItem(LINK_FRAGMENT_STORAGE_KEY, JSON.stringify(existing));
+  window.dispatchEvent(new CustomEvent(LINK_FRAGMENT_UPDATED_EVENT));
+}
+
+export function storedFragmentMap(): Partial<
+  Record<LinkFragmentPuzzleId, StoredLinkFragment>
+> {
+  const map: Partial<Record<LinkFragmentPuzzleId, StoredLinkFragment>> = {};
+  for (const f of readStoredFragments()) {
+    map[f.puzzleId] = f;
+  }
+  return map;
+}

--- a/lib/api-schemas/hunt.ts
+++ b/lib/api-schemas/hunt.ts
@@ -28,6 +28,19 @@ const SubmitBody = z
   })
   .openapi("HuntPathSubmitBody");
 
+const LinkFragmentVerifyBody = z
+  .object({
+    puzzleId: z.string().min(1),
+    answer: z.string().min(1),
+  })
+  .openapi("HuntLinkFragmentVerifyBody");
+
+const LinkFragmentAssembleBody = z
+  .object({
+    tokens: z.record(z.string(), z.string()),
+  })
+  .openapi("HuntLinkFragmentAssembleBody");
+
 export const huntContract = c.router(
   {
     status: {
@@ -83,6 +96,42 @@ export const huntContract = c.router(
           "RATE_LIMITED",
           "SERVER_ERROR",
         ] as const,
+      },
+    },
+    linkFragmentVerify: {
+      method: "POST",
+      path: "/api/hunt/link-fragment/verify",
+      summary: "Verify a link-fragment puzzle answer",
+      body: LinkFragmentVerifyBody,
+      responses: {
+        200: PassthroughOk,
+        400: ApiErrorSchema,
+        403: ApiErrorSchema,
+        404: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: [
+          "VALIDATION_ERROR",
+          "FORBIDDEN",
+          "NOT_FOUND",
+          "SERVER_ERROR",
+        ] as const,
+      },
+    },
+    linkFragmentAssemble: {
+      method: "POST",
+      path: "/api/hunt/link-fragment/assemble",
+      summary: "Assemble a referral URL from signed fragment tokens",
+      body: LinkFragmentAssembleBody,
+      responses: {
+        200: PassthroughOk,
+        400: ApiErrorSchema,
+        403: ApiErrorSchema,
+        500: ApiErrorSchema,
+      },
+      metadata: {
+        errorCodes: ["VALIDATION_ERROR", "FORBIDDEN", "SERVER_ERROR"] as const,
       },
     },
   },

--- a/lib/link-fragment-hunt.ts
+++ b/lib/link-fragment-hunt.ts
@@ -1,0 +1,207 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Six-puzzle scavenger hunt: each solved puzzle reveals a 2-character slice of
+ * a Cursor referral code. Fragments are returned only from the verify API with
+ * an HMAC token; the full code never ships in client bundles.
+ */
+
+export const LINK_FRAGMENT_COUNT = 6;
+export const LINK_FRAGMENT_REFERRAL_BASE = "https://cursor.com/referral?code=";
+
+export type LinkFragmentPuzzleId =
+  | "home-pulse"
+  | "about-beantown"
+  | "events-perks"
+  | "cohort-campus"
+  | "hult-guest"
+  | "opensource-reader";
+
+export type LinkFragmentPuzzle = {
+  id: LinkFragmentPuzzleId;
+  /** Pathname where the clue lives (exact or prefix). */
+  page: string;
+  emoji: string;
+  title: string;
+  hint: string;
+  verify: (answer: string) => boolean;
+  index: number;
+};
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, "");
+}
+
+function safeEqualLower(a: string, b: string): boolean {
+  const an = normalize(a);
+  const bn = normalize(b);
+  if (an.length !== bn.length) return false;
+  return timingSafeEqual(Buffer.from(an), Buffer.from(bn));
+}
+
+function huntSecret(): string {
+  return (
+    process.env.LINK_FRAGMENT_HUNT_SECRET?.trim() ||
+    process.env.UNSUBSCRIBE_SECRET?.trim() ||
+    "link-fragment-hunt-dev-secret-32b"
+  );
+}
+
+/** 12-character referral code, split into six 2-char fragments. */
+export function getLinkFragmentReferralCode(): string {
+  const code = (process.env.LINK_FRAGMENT_HUNT_CODE || "HULTSUMMER26").trim();
+  if (!/^[A-Za-z0-9]{12}$/.test(code)) {
+    throw new Error(
+      "LINK_FRAGMENT_HUNT_CODE must be exactly 12 alphanumeric characters."
+    );
+  }
+  return code.toUpperCase();
+}
+
+export function getLinkFragmentSlices(): string[] {
+  const code = getLinkFragmentReferralCode();
+  return Array.from({ length: LINK_FRAGMENT_COUNT }, (_, i) =>
+    code.slice(i * 2, i * 2 + 2)
+  );
+}
+
+export function signLinkFragmentToken(
+  puzzleId: LinkFragmentPuzzleId,
+  fragment: string
+): string {
+  return createHmac("sha256", huntSecret())
+    .update(`link-frag|${puzzleId}|${fragment}`)
+    .digest("base64url");
+}
+
+export function verifyLinkFragmentToken(
+  puzzleId: LinkFragmentPuzzleId,
+  fragment: string,
+  token: string
+): boolean {
+  const expected = signLinkFragmentToken(puzzleId, fragment);
+  try {
+    const a = Buffer.from(token);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+export function assembleReferralUrl(
+  tokens: Partial<Record<LinkFragmentPuzzleId, string>>
+): { ok: true; url: string } | { ok: false; reason: string } {
+  const puzzles = listLinkFragmentPuzzles();
+  const slices = getLinkFragmentSlices();
+  let code = "";
+
+  for (const puzzle of puzzles) {
+    const token = tokens[puzzle.id];
+    if (!token) {
+      return { ok: false, reason: "missing_fragment" };
+    }
+    const fragment = slices[puzzle.index];
+    if (!fragment || !verifyLinkFragmentToken(puzzle.id, fragment, token)) {
+      return { ok: false, reason: "invalid_token" };
+    }
+    code += fragment;
+  }
+
+  return { ok: true, url: `${LINK_FRAGMENT_REFERRAL_BASE}${code}` };
+}
+
+export const LINK_FRAGMENT_PUZZLES: Record<
+  LinkFragmentPuzzleId,
+  LinkFragmentPuzzle
+> = {
+  "home-pulse": {
+    id: "home-pulse",
+    page: "/",
+    emoji: "💓",
+    title: "The Seven Beats",
+    hint:
+      "On the home page, the logo remembers old arcade rhythms. Seven quick taps " +
+      "within a few seconds unlock the first pair of characters.",
+    verify: (answer) => safeEqualLower(answer, "seven-beats"),
+    index: 0,
+  },
+  "about-beantown": {
+    id: "about-beantown",
+    page: "/about",
+    emoji: "🫘",
+    title: "Beantown Roots",
+    hint:
+      "View source on the About page. A comment whispers the city's nickname — " +
+      "submit it here.",
+    verify: (answer) => safeEqualLower(answer, "beantown"),
+    index: 1,
+  },
+  "events-perks": {
+    id: "events-perks",
+    page: "/events",
+    emoji: "🍕",
+    title: "Perk Counter",
+    hint:
+      "The Hult Summer Hackathon lists its perks on the Events page. How many? " +
+      "Digits only.",
+    verify: (answer) => safeEqualLower(answer, "4"),
+    index: 2,
+  },
+  "cohort-campus": {
+    id: "cohort-campus",
+    page: "/summer-cohort",
+    emoji: "🎓",
+    title: "Campus on Education St",
+    hint:
+      "Summer cohort copy points at a Cambridge business school. Submit the " +
+      "school's short name (one word).",
+    verify: (answer) => safeEqualLower(answer, "hult"),
+    index: 3,
+  },
+  "hult-guest": {
+    id: "hult-guest",
+    page: "/events/cursor-boston-hult-summer-hackathon-2026",
+    emoji: "✨",
+    title: "The 2:30 Guest",
+    hint:
+      "On the Hult hackathon event page, find who joins at 2:30 PM from Cursor. " +
+      "Submit their first and last name.",
+    verify: (answer) => safeEqualLower(answer, "shivjethi"),
+    index: 4,
+  },
+  "opensource-reader": {
+    id: "opensource-reader",
+    page: "/open-source",
+    emoji: "💻",
+    title: "The Code Reader",
+    hint:
+      "Open Source page source names a snake_case function that resolves 2026 " +
+      "credits. Submit that function name.",
+    verify: (answer) =>
+      safeEqualLower(answer, "resolve_hack_a_sprint_2026_credit_for_user"),
+    index: 5,
+  },
+};
+
+export function listLinkFragmentPuzzles(): LinkFragmentPuzzle[] {
+  return Object.values(LINK_FRAGMENT_PUZZLES).sort((a, b) => a.index - b.index);
+}
+
+export function getLinkFragmentPuzzle(
+  id: string
+): LinkFragmentPuzzle | null {
+  return LINK_FRAGMENT_PUZZLES[id as LinkFragmentPuzzleId] ?? null;
+}
+
+export function linkFragmentHuntEnabled(): boolean {
+  return process.env.LINK_FRAGMENT_HUNT_ENABLED !== "false";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-unused-imports": "^4.4.1",
+        "fast-check": "^4.9.0",
         "firebase-tools": "^15.27.0",
         "globals": "^17.11.0",
         "husky": "^8.0.3",
@@ -11831,6 +11832,46 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unused-imports": "^4.4.1",
+    "fast-check": "^4.9.0",
     "firebase-tools": "^15.27.0",
     "globals": "^17.11.0",
     "husky": "^8.0.3",

--- a/scripts/send-hult-summer-hackathon-2026-credits.ts
+++ b/scripts/send-hult-summer-hackathon-2026-credits.ts
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+/**
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Copyright (C) 2026 Cursor Boston
+ * This file is part of Cursor Boston, licensed under GPL-3.0.
+ * See LICENSE file for details.
+ */
+
+/**
+ * Cursor Boston × Hult Summer Hackathon (Aug 24, 2026) — send Cursor credit
+ * redemption links to attendees who checked in on Luma.
+ *
+ * Credits are assigned in check-in order (earliest `checked_in_at` first).
+ * One unique link per checked-in guest from the credits JSON file.
+ *
+ * Usage:
+ *   npx tsx scripts/send-hult-summer-hackathon-2026-credits.ts --dry-run
+ *   npx tsx scripts/send-hult-summer-hackathon-2026-credits.ts --dry-run --only-email=you@example.com
+ *   npx tsx scripts/send-hult-summer-hackathon-2026-credits.ts --send
+ *
+ * Optional flags:
+ *   --csv <path>       Luma guest export (default: scripts/_data/hult-summer-hackathon-2026-guests-2026-08-24.csv)
+ *   --credits <path>   JSON array of redemption URLs (default: scripts/_data/hult-summer-hackathon-2026-credits.json)
+ *   --force            Re-send even if already logged in the idempotency file
+ *   --allow-unsubscribed  Include unsubscribed addresses (manual override)
+ *   --emails=a@x.com,b@y.com  Send only to these addresses (comma-separated)
+ *
+ * Requires: FIREBASE_SERVICE_ACCOUNT_JSON
+ * For --send: MAILGUN_API_KEY, MAILGUN_DOMAIN, UNSUBSCRIBE_SECRET
+ */
+import { existsSync, readFileSync, appendFileSync } from "fs";
+import { join } from "path";
+import { loadEnv, escapeHtml, parseSendArgs, type SendArgs } from "./_lib/script-utils";
+loadEnv();
+
+import { getAdminDb } from "../lib/firebase-admin";
+import { sendEmail } from "../lib/mailgun";
+import { syncMailgunSuppressions } from "../lib/mailgun-suppressions";
+import { buildUnsubscribeUrl } from "../lib/unsubscribe-token";
+
+const EVENT_NAME = "Cursor Boston × Hult Summer Hackathon";
+const EVENT_PAGE = "https://www.cursorboston.com/events/cursor-boston-hult-summer-hackathon-2026";
+const FROM = "Roger <roger@cursorboston.com>";
+const CREDIT_AMOUNT = "$50";
+
+const DATA_DIR = join(__dirname, "_data");
+const DEFAULT_CSV = join(DATA_DIR, "hult-summer-hackathon-2026-guests-2026-08-24.csv");
+const DEFAULT_CREDITS = join(DATA_DIR, "hult-summer-hackathon-2026-credits.json");
+const CAMPAIGN = "hult-summer-hackathon-2026-credits";
+const ALREADY_SENT_JSON = join(DATA_DIR, `${CAMPAIGN}-already-sent.json`);
+const SENT_LOG = join(DATA_DIR, `${CAMPAIGN}-sent.log`);
+
+interface Recipient {
+  email: string;
+  firstName: string;
+  name: string;
+  checkedInAt: string;
+  creditUrl: string;
+}
+
+function parseCsv(content: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (content[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+    } else if (c === "\r") {
+      // ignore
+    } else if (c === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += c;
+    }
+  }
+  row.push(field);
+  if (row.some((c) => c.length > 0)) rows.push(row);
+  if (rows.length < 2) return [];
+  const header = rows[0]!.map((h) => h.trim());
+  const out: Record<string, string>[] = [];
+  for (let r = 1; r < rows.length; r++) {
+    const obj: Record<string, string> = {};
+    for (let j = 0; j < header.length; j++) {
+      obj[header[j]!] = (rows[r]![j] ?? "").trim();
+    }
+    out.push(obj);
+  }
+  return out;
+}
+
+function loadAlreadySent(): Set<string> {
+  const set = new Set<string>();
+  if (existsSync(ALREADY_SENT_JSON)) {
+    try {
+      for (const e of JSON.parse(readFileSync(ALREADY_SENT_JSON, "utf8")) as string[]) {
+        set.add(e.trim().toLowerCase());
+      }
+    } catch {
+      /* ignore malformed seed */
+    }
+  }
+  if (existsSync(SENT_LOG)) {
+    for (const line of readFileSync(SENT_LOG, "utf8").split("\n")) {
+      const e = line.trim().toLowerCase();
+      if (e) set.add(e);
+    }
+  }
+  return set;
+}
+
+function parseCli(argv: string[]): SendArgs & {
+  csvPath: string;
+  creditsPath: string;
+  allowUnsubscribed: boolean;
+  emails: string[] | null;
+} {
+  const args = parseSendArgs(argv);
+  const csvIdx = argv.indexOf("--csv");
+  const creditsIdx = argv.indexOf("--credits");
+  const emailsArg = argv.find((a) => a.startsWith("--emails="));
+  return {
+    ...args,
+    csvPath: csvIdx >= 0 ? argv[csvIdx + 1] ?? DEFAULT_CSV : DEFAULT_CSV,
+    creditsPath:
+      creditsIdx >= 0 ? argv[creditsIdx + 1] ?? DEFAULT_CREDITS : DEFAULT_CREDITS,
+    allowUnsubscribed: argv.includes("--allow-unsubscribed"),
+    emails: emailsArg
+      ? emailsArg
+          .slice("--emails=".length)
+          .split(",")
+          .map((e) => e.trim().toLowerCase())
+          .filter(Boolean)
+      : null,
+  };
+}
+
+function loadCreditUrls(path: string): string[] {
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed) || parsed.some((x) => typeof x !== "string")) {
+    throw new Error("Credits file must be a JSON array of URL strings.");
+  }
+  return parsed as string[];
+}
+
+function buildEmail(r: Recipient): { subject: string; html: string; text: string } {
+  const first = escapeHtml(r.firstName || r.name.split(" ")[0] || "there");
+  const firstText = r.firstName || r.name.split(" ")[0] || "there";
+  const creditLink = escapeHtml(r.creditUrl);
+  const unsubUrl = buildUnsubscribeUrl(r.email);
+
+  const subject = `Your Cursor credit — ${EVENT_NAME}`;
+
+  const html = `<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;line-height:1.6;color:#111;max-width:640px;">
+<p>Hi ${first},</p>
+
+<p>Thanks for checking in at the <strong>${escapeHtml(EVENT_NAME)}</strong> on Monday! As promised, here is your <strong>${CREDIT_AMOUNT} Cursor credit</strong>.</p>
+
+<p><strong>Redeem your credit here:</strong></p>
+<p><a href="${creditLink}" style="display:inline-block;margin:8px 0;padding:12px 22px;background:#10b981;color:#fff;text-decoration:none;border-radius:8px;font-weight:600;">Redeem Cursor credit</a></p>
+<p style="font-size:14px;color:#555;word-break:break-all;">${creditLink}</p>
+
+<p>Event page: <a href="${escapeHtml(EVENT_PAGE)}">${escapeHtml(EVENT_PAGE)}</a></p>
+
+<p>Reply if anything looks off, or to share what you built.</p>
+
+<p>— Roger<br/>
+<a href="mailto:roger@cursorboston.com">roger@cursorboston.com</a></p>
+
+<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e5e5;font-size:12px;color:#888;">
+You&apos;re receiving this because you checked in at the ${escapeHtml(EVENT_NAME)} on August 24, 2026.<br/>
+<a href="${escapeHtml(unsubUrl)}" style="color:#888;">Unsubscribe from emails</a>
+</p>
+</body></html>`;
+
+  const text = `Hi ${firstText},
+
+Thanks for checking in at the ${EVENT_NAME} on Monday! As promised, here is your ${CREDIT_AMOUNT} Cursor credit.
+
+Redeem your credit here:
+${r.creditUrl}
+
+Event page: ${EVENT_PAGE}
+
+Reply if anything looks off, or to share what you built.
+
+— Roger
+roger@cursorboston.com
+
+---
+You're receiving this because you checked in at the ${EVENT_NAME} on August 24, 2026.
+Unsubscribe: ${unsubUrl}
+`;
+
+  return { subject, html, text };
+}
+
+async function loadRecipients(args: ReturnType<typeof parseCli>): Promise<Recipient[]> {
+  const db = getAdminDb();
+  if (!db) {
+    throw new Error("Firebase Admin not configured.");
+  }
+
+  let raw = readFileSync(args.csvPath, "utf8");
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+  const rows = parseCsv(raw);
+  console.log(`Luma CSV: ${rows.length} rows from ${args.csvPath}`);
+
+  const creditUrls = loadCreditUrls(args.creditsPath);
+  console.log(`Credits: ${creditUrls.length} link(s) from ${args.creditsPath}`);
+
+  const ec = await db.collection("eventContacts").get();
+  const unsubbed = new Set<string>();
+  for (const d of ec.docs) {
+    const data = d.data();
+    const email = (typeof data.email === "string" ? data.email : d.id).toLowerCase();
+    if (data.unsubscribed === true) unsubbed.add(email);
+  }
+
+  const checkedIn = rows
+    .filter((r) => {
+      const status = (r.approval_status || "").toLowerCase();
+      return status === "approved" && !!(r.checked_in_at || "").trim();
+    })
+    .map((r) => {
+      const email = (r.email || "").trim().toLowerCase();
+      const firstName = (r.first_name || "").trim();
+      const name = (r.name || "").trim() || [firstName, (r.last_name || "").trim()].filter(Boolean).join(" ");
+      return {
+        email,
+        firstName,
+        name,
+        checkedInAt: (r.checked_in_at || "").trim(),
+      };
+    })
+    .filter((r) => r.email.includes("@") && !r.email.endsWith("@anysphere.co"))
+    .sort((a, b) => a.checkedInAt.localeCompare(b.checkedInAt));
+
+  const seen = new Set<string>();
+  const deduped = checkedIn.filter((r) => {
+    if (seen.has(r.email)) return false;
+    seen.add(r.email);
+    return true;
+  });
+
+  let skippedUnsub = 0;
+  const eligible = deduped.filter((r) => {
+    if (!args.allowUnsubscribed && unsubbed.has(r.email)) {
+      skippedUnsub++;
+      return false;
+    }
+    return true;
+  });
+
+  const alreadySent = args.force ? new Set<string>() : loadAlreadySent();
+  let skippedAlreadySent = 0;
+  const pending = eligible.filter((r) => {
+    if (alreadySent.has(r.email)) {
+      skippedAlreadySent++;
+      return false;
+    }
+    return true;
+  });
+
+  let skippedOnlyEmail = 0;
+  let filtered = pending;
+  if (args.onlyEmail) {
+    const before = filtered.length;
+    filtered = filtered.filter((r) => r.email === args.onlyEmail);
+    skippedOnlyEmail = before - filtered.length;
+  }
+  if (args.emails) {
+    const allow = new Set(args.emails);
+    const before = filtered.length;
+    filtered = filtered.filter((r) => allow.has(r.email));
+    skippedOnlyEmail += before - filtered.length;
+  }
+
+  const creditIndexByEmail = new Map(
+    deduped.map((r, i) => [r.email, i] as const),
+  );
+
+  if (creditUrls.length < filtered.length) {
+    console.warn(
+      `[warn] Only ${creditUrls.length} credit link(s) for ${filtered.length} recipient(s). The last ${filtered.length - creditUrls.length} won't get a link.`,
+    );
+  }
+
+  const recipients: Recipient[] = filtered
+    .map((r) => ({
+      ...r,
+      creditUrl: creditUrls[creditIndexByEmail.get(r.email) ?? -1] ?? "",
+    }))
+    .filter((r) => r.creditUrl);
+
+  console.log(
+    `Checked in: ${checkedIn.length} | deduped: ${deduped.length} | unsub skipped: ${skippedUnsub} | already-sent skipped: ${skippedAlreadySent}` +
+      (args.onlyEmail || args.emails ? ` | address filter excluded: ${skippedOnlyEmail}` : ""),
+  );
+  console.log(`Recipients to email: ${recipients.length}`);
+
+  const pad = (s: string, n: number) => s.slice(0, n).padEnd(n);
+  console.log(`\n${pad("Checked in", 22)} ${pad("Email", 36)} ${pad("Credit", 12)}`);
+  console.log("-".repeat(72));
+  for (const r of recipients) {
+    console.log(`${pad(r.checkedInAt, 22)} ${pad(r.email, 36)} ASSIGNED`);
+  }
+
+  return recipients;
+}
+
+async function main() {
+  const args = parseCli(process.argv.slice(2));
+
+  if (args.send) {
+    if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
+      console.error("For --send, set MAILGUN_API_KEY and MAILGUN_DOMAIN.");
+      process.exit(1);
+    }
+    const db = getAdminDb();
+    if (!db) {
+      console.error("Firebase Admin not configured.");
+      process.exit(1);
+    }
+    await syncMailgunSuppressions(db);
+  }
+
+  const recipients = await loadRecipients(args);
+  if (recipients.length === 0) {
+    console.log("Nothing to send.");
+    return;
+  }
+
+  if (args.dryRun) {
+    const sample = recipients[0]!;
+    const { subject, text } = buildEmail(sample);
+    console.log(`\nSample email to: ${sample.email}`);
+    console.log(`Subject: ${subject}`);
+    console.log("\n--- Text ---");
+    console.log(text);
+    console.log("\n--dry-run: no emails sent.");
+    return;
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const r of recipients) {
+    const { subject, html, text } = buildEmail(r);
+    try {
+      await sendEmail({
+        from: FROM,
+        to: r.email,
+        subject,
+        html,
+        text,
+      });
+      appendFileSync(SENT_LOG, `${r.email}\n`);
+      sent++;
+      console.log(`  [ok] ${r.email}`);
+    } catch (e) {
+      failed++;
+      console.error(`  [fail] ${r.email}`, e);
+    }
+    await new Promise((res) => setTimeout(res, 450));
+  }
+
+  console.log(`\nDone. Sent ${sent}, failed ${failed}.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Link-fragment puzzle hunt at `/hunt/link` — six sitewide puzzles reveal Cursor referral code fragments
- Maintainer script to email Hult Summer Hackathon checked-in guests their credit links
- Hunt API routes with ts-rest contracts

## Test plan
- [x] `npm run build` passes locally
- [x] `__tests__/lib/link-fragment-hunt.test.ts` passes
- [ ] Verify `/hunt/link` on production after deploy
- [ ] Set `LINK_FRAGMENT_HUNT_CODE` in Vercel to a real unused referral code


Made with [Cursor](https://cursor.com)